### PR TITLE
Lighting and other Viewer improvements

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -11,6 +11,7 @@ import { EngineStore } from "../Engines/engineStore";
 import type { AbstractScene } from "../abstractScene";
 import { Tags } from "../Misc/tags";
 import type { AnimationGroupMask } from "./animationGroupMask";
+import "./animatable";
 
 /**
  * This class defines the direct association between an animation and a target

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -9,6 +9,7 @@ import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
 import { STLFileLoaderMetadata } from "./stlFileLoader.metadata";
+import "core/Materials/standardMaterial";
 
 declare module "core/Loading/sceneLoader" {
     // eslint-disable-next-line jsdoc/require-jsdoc

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -9,7 +9,7 @@ import type { Animation } from "core/Animations/animation";
 import type { IAnimatable } from "core/Animations/animatable.interface";
 import type { IAnimationKey } from "core/Animations/animationKey";
 import { AnimationKeyInterpolation } from "core/Animations/animationKey";
-import { AnimationGroup } from "core/Animations/animationGroup";
+import type { AnimationGroup } from "core/Animations/animationGroup";
 import { Bone } from "core/Bones/bone";
 import { Skeleton } from "core/Bones/skeleton";
 import { Material } from "core/Materials/material";
@@ -1595,30 +1595,33 @@ export class GLTFLoader implements IGLTFLoader {
             return promise;
         }
 
-        this._babylonScene._blockEntityCollection = !!this._assetContainer;
-        const babylonAnimationGroup = new AnimationGroup(animation.name || `animation${animation.index}`, this._babylonScene);
-        babylonAnimationGroup._parentContainer = this._assetContainer;
-        this._babylonScene._blockEntityCollection = false;
-        animation._babylonAnimationGroup = babylonAnimationGroup;
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        return import("core/Animations/animationGroup").then(({ AnimationGroup }) => {
+            this._babylonScene._blockEntityCollection = !!this._assetContainer;
+            const babylonAnimationGroup = new AnimationGroup(animation.name || `animation${animation.index}`, this._babylonScene);
+            babylonAnimationGroup._parentContainer = this._assetContainer;
+            this._babylonScene._blockEntityCollection = false;
+            animation._babylonAnimationGroup = babylonAnimationGroup;
 
-        const promises = new Array<Promise<unknown>>();
+            const promises = new Array<Promise<unknown>>();
 
-        ArrayItem.Assign(animation.channels);
-        ArrayItem.Assign(animation.samplers);
+            ArrayItem.Assign(animation.channels);
+            ArrayItem.Assign(animation.samplers);
 
-        for (const channel of animation.channels) {
-            promises.push(
-                this._loadAnimationChannelAsync(`${context}/channels/${channel.index}`, context, animation, channel, (babylonTarget, babylonAnimation) => {
-                    babylonTarget.animations = babylonTarget.animations || [];
-                    babylonTarget.animations.push(babylonAnimation);
-                    babylonAnimationGroup.addTargetedAnimation(babylonAnimation, babylonTarget);
-                })
-            );
-        }
+            for (const channel of animation.channels) {
+                promises.push(
+                    this._loadAnimationChannelAsync(`${context}/channels/${channel.index}`, context, animation, channel, (babylonTarget, babylonAnimation) => {
+                        babylonTarget.animations = babylonTarget.animations || [];
+                        babylonTarget.animations.push(babylonAnimation);
+                        babylonAnimationGroup.addTargetedAnimation(babylonAnimation, babylonTarget);
+                    })
+                );
+            }
 
-        return Promise.all(promises).then(() => {
-            babylonAnimationGroup.normalize(0);
-            return babylonAnimationGroup;
+            return Promise.all(promises).then(() => {
+                babylonAnimationGroup.normalize(0);
+                return babylonAnimationGroup;
+            });
         });
     }
 

--- a/packages/public/@babylonjs/viewer-alpha/readme.md
+++ b/packages/public/@babylonjs/viewer-alpha/readme.md
@@ -33,7 +33,7 @@ To use the higher level `HTML3DElement` you can import the `@babylonjs/viewer` m
     <script type="module">
       import '@babylonjs/viewer';
     </script>
-    <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
+    <babylon-viewer source="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
   </body>
 </html>
 ```
@@ -46,7 +46,7 @@ If you want to use the viewer directly in a browser without any build tools, you
 <html lang="en">
   <body>
     <script type="module" src="https://unpkg.com/@babylonjs/viewer@preview/dist/babylon-viewer.esm.min.js"></script>
-    <babylon-viewer src="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
+    <babylon-viewer source="https://playground.babylonjs.com/scenes/BoomBox.glb"></babylon-viewer>
   </body>
 </html>
 ```

--- a/packages/public/@babylonjs/viewer-alpha/test/apps/web/index.html
+++ b/packages/public/@babylonjs/viewer-alpha/test/apps/web/index.html
@@ -11,8 +11,8 @@
         }
     </style>
     <body>
-        <script type="module" src="../../../dist/babylon-viewer.esm.js"></script>
-        <babylon-viewer src="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env">
+        <script type="module" src="../../../dist/babylon-viewer.esm.min.js"></script>
+        <babylon-viewer source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" environment="https://assets.babylonjs.com/environments/ulmerMuenster.env">
         </babylon-viewer>
     </body>
 </html>

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -20,7 +20,7 @@ import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { CubeTexture } from "core/Materials/Textures/cubeTexture";
 import { Texture } from "core/Materials/Textures/texture";
 import { Color4 } from "core/Maths/math.color";
-import { Scalar } from "core/Maths/math.scalar";
+import { Clamp } from "core/Maths/math.scalar.functions";
 import { Vector3 } from "core/Maths/math.vector";
 import { CreateBox } from "core/Meshes/Builders/boxBuilder";
 import { AsyncLock } from "core/Misc/asyncLock";
@@ -150,6 +150,7 @@ export class Viewer implements IDisposable {
     private readonly _autoRotationBehavior: AutoRotationBehavior;
     private readonly _renderLoopController: IDisposable;
     private _skybox: Nullable<Mesh> = null;
+    private _light: Nullable<HemisphericLight> = null;
 
     private _isDisposed = false;
 
@@ -220,7 +221,7 @@ export class Viewer implements IDisposable {
     }
 
     public set selectedAnimation(value: number) {
-        value = Math.round(Scalar.Clamp(value, -1, this.animations.length - 1));
+        value = Math.round(Clamp(value, -1, this.animations.length - 1));
         if (value !== this._selectedAnimation) {
             const startAnimation = this.isAnimationPlaying;
             if (this._activeAnimation) {
@@ -312,7 +313,7 @@ export class Viewer implements IDisposable {
     }
 
     /**
-     * Resets the model to an empty scene.
+     * Unloads the current 3D model if one is loaded.
      * @param abortSignal An optional signal that can be used to abort the reset.
      */
     public async resetModel(abortSignal?: AbortSignal): Promise<void> {
@@ -328,10 +329,10 @@ export class Viewer implements IDisposable {
         await this._loadModelLock.lockAsync(async () => {
             this._throwIfDisposedOrAborted(abortSignal, abortController.signal);
             this._details.model?.dispose();
+            this._details.model = null;
             this.selectedAnimation = -1;
 
             try {
-                this._details.model = null;
                 if (source) {
                     this._details.model = await loadAssetContainerAsync(source, this._details.scene, options);
                     this._details.model.animationGroups.forEach((group) => group.stop());
@@ -340,6 +341,7 @@ export class Viewer implements IDisposable {
                 }
 
                 this._updateCamera();
+                this._updateLight();
                 this._applyAnimationSpeed();
                 this.onModelChanged.notifyObservers();
             } catch (e) {
@@ -362,7 +364,7 @@ export class Viewer implements IDisposable {
     }
 
     /**
-     * Resets the environment to a simple hemispheric light.
+     * Unloads the current environment if one is loaded.
      * @param abortSignal An optional signal that can be used to abort the reset.
      */
     public async resetEnvironment(abortSignal?: AbortSignal): Promise<void> {
@@ -378,14 +380,12 @@ export class Viewer implements IDisposable {
         await this._loadEnvironmentLock.lockAsync(async () => {
             this._throwIfDisposedOrAborted(abortSignal, abortController.signal);
             this._environment?.dispose();
+            this._environment = null;
+            this._details.scene.autoClear = true;
 
             try {
-                this._environment = await new Promise<IDisposable>((resolve, reject) => {
-                    if (!url) {
-                        const light = new HemisphericLight("hemilight", Vector3.Up(), this._details.scene);
-                        this._details.scene.autoClear = true;
-                        resolve(light);
-                    } else {
+                if (url) {
+                    this._environment = await new Promise<IDisposable>((resolve, reject) => {
                         const cubeTexture = CubeTexture.CreateFromPrefilteredData(url, this._details.scene);
                         this._details.scene.environmentTexture = cubeTexture;
 
@@ -416,10 +416,11 @@ export class Viewer implements IDisposable {
                                 reject(new Error("Failed to load environment texture."));
                             }
                         });
-                    }
+                    });
+                }
 
-                    this.onEnvironmentChanged.notifyObservers();
-                });
+                this._updateLight();
+                this.onEnvironmentChanged.notifyObservers();
             } catch (e) {
                 this.onEnvironmentError.notifyObservers(e);
                 throw e;
@@ -474,7 +475,6 @@ export class Viewer implements IDisposable {
         this._isDisposed = true;
     }
 
-    // copy/paste from sandbox and scene helpers
     private _updateCamera(): void {
         // Enable camera's behaviors
         this._camera.useFramingBehavior = true;
@@ -520,6 +520,33 @@ export class Viewer implements IDisposable {
         this._camera.restoreStateInterpolationFactor = 0.1;
 
         updateSkybox(this._skybox, this._camera);
+    }
+
+    private _updateLight() {
+        let shouldHaveDefaultLight: boolean;
+        if (!this._details.model) {
+            shouldHaveDefaultLight = false;
+        } else {
+            const hasModelProvidedLights = this._details.model.lights.length > 0;
+            const hasImageBasedLighting = !!this._environment;
+            const hasMaterials = this._details.model.materials.length > 0;
+            const hasNonPBRMaterials = this._details.model.materials.some((material) => !(material instanceof PBRMaterial));
+
+            if (hasModelProvidedLights) {
+                shouldHaveDefaultLight = false;
+            } else {
+                shouldHaveDefaultLight = !hasImageBasedLighting || !hasMaterials || hasNonPBRMaterials;
+            }
+        }
+
+        if (shouldHaveDefaultLight) {
+            if (!this._light) {
+                this._light = new HemisphericLight("defaultLight", Vector3.Up(), this._details.scene);
+            }
+        } else {
+            this._light?.dispose();
+            this._light = null;
+        }
     }
 
     private _applyAnimationSpeed() {

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -181,7 +181,7 @@ export class Viewer implements IDisposable {
         this._autoRotationBehavior = this._camera.getBehaviorByName("AutoRotation") as AutoRotationBehavior;
 
         // Load a default light, but ignore errors as the user might be immediately loading their own environment.
-        this.resetEnvironmentAsync().catch(() => {});
+        this.resetEnvironment().catch(() => {});
 
         // TODO: render at least back ground. Maybe we can only run renderloop when a mesh is loaded. What to render until then?
         const render = () => {
@@ -307,19 +307,19 @@ export class Viewer implements IDisposable {
      * @param options The options to use when loading the model.
      * @param abortSignal An optional signal that can be used to abort the loading process.
      */
-    public async loadModelAsync(source: string | File | ArrayBufferView, options?: LoadAssetContainerOptions, abortSignal?: AbortSignal): Promise<void> {
-        await this._updateModelAsync(source, options, abortSignal);
+    public async loadModel(source: string | File | ArrayBufferView, options?: LoadAssetContainerOptions, abortSignal?: AbortSignal): Promise<void> {
+        await this._updateModel(source, options, abortSignal);
     }
 
     /**
      * Resets the model to an empty scene.
      * @param abortSignal An optional signal that can be used to abort the reset.
      */
-    public async resetModelAsync(abortSignal?: AbortSignal): Promise<void> {
-        await this._updateModelAsync(undefined, undefined, abortSignal);
+    public async resetModel(abortSignal?: AbortSignal): Promise<void> {
+        await this._updateModel(undefined, undefined, abortSignal);
     }
 
-    private async _updateModelAsync(source: string | File | ArrayBufferView | undefined, options?: LoadAssetContainerOptions, abortSignal?: AbortSignal): Promise<void> {
+    private async _updateModel(source: string | File | ArrayBufferView | undefined, options?: LoadAssetContainerOptions, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
 
         this._loadModelAbortController?.abort("New model is being loaded before previous model finished loading.");
@@ -357,19 +357,19 @@ export class Viewer implements IDisposable {
      * @param options The options to use when loading the environment.
      * @param abortSignal An optional signal that can be used to abort the loading process.
      */
-    public async loadEnvironmentAsync(url: string, options?: {}, abortSignal?: AbortSignal): Promise<void> {
-        await this._updateEnvironmentAsync(url, options, abortSignal);
+    public async loadEnvironment(url: string, options?: {}, abortSignal?: AbortSignal): Promise<void> {
+        await this._updateEnvironment(url, options, abortSignal);
     }
 
     /**
      * Resets the environment to a simple hemispheric light.
      * @param abortSignal An optional signal that can be used to abort the reset.
      */
-    public async resetEnvironmentAsync(abortSignal?: AbortSignal): Promise<void> {
-        await this._updateEnvironmentAsync(undefined, undefined, abortSignal);
+    public async resetEnvironment(abortSignal?: AbortSignal): Promise<void> {
+        await this._updateEnvironment(undefined, undefined, abortSignal);
     }
 
-    private async _updateEnvironmentAsync(url: Nullable<string | undefined>, options?: {}, abortSignal?: AbortSignal): Promise<void> {
+    private async _updateEnvironment(url: Nullable<string | undefined>, options?: {}, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
 
         this._loadEnvironmentAbortController?.abort("New environment is being loaded before previous environment finished loading.");

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -28,9 +28,6 @@ import { Observable } from "core/Misc/observable";
 import { Scene } from "core/scene";
 import { registerBuiltInLoaders } from "loaders/dynamic";
 
-// TODO: Dynamic imports?
-import "core/Animations/animatable";
-
 function createSkybox(scene: Scene, camera: Camera, environmentTexture: CubeTexture, blur: number): Mesh {
     const hdrSkybox = CreateBox("hdrSkyBox", undefined, scene);
     const hdrSkyboxMaterial = new PBRMaterial("skyBox", scene);

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -516,9 +516,9 @@ export class HTML3DElement extends LitElement {
     private async _updateModel() {
         try {
             if (this.source) {
-                await this._viewer?.loadModelAsync(this.source, { pluginExtension: this.extension ?? undefined });
+                await this._viewer?.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
             } else {
-                await this._viewer?.resetModelAsync();
+                await this._viewer?.resetModel();
             }
         } catch (error) {
             Logger.Log(error);
@@ -528,9 +528,9 @@ export class HTML3DElement extends LitElement {
     private async _updateEnv() {
         try {
             if (this.environment) {
-                await this._viewer?.loadEnvironmentAsync(this.environment);
+                await this._viewer?.loadEnvironment(this.environment);
             } else {
-                await this._viewer?.resetEnvironmentAsync();
+                await this._viewer?.resetEnvironment();
             }
         } catch (error) {
             Logger.Log(error);

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -218,7 +218,7 @@ export class HTML3DElement extends LitElement {
      * The model URL.
      */
     @property({ reflect: true })
-    public src: Nullable<string> = null;
+    public source: Nullable<string> = null;
 
     /**
      * Forces the model to be loaded with the specified extension.
@@ -232,7 +232,7 @@ export class HTML3DElement extends LitElement {
      * The environment URL.
      */
     @property({ reflect: true })
-    public env: Nullable<string> = null;
+    public environment: Nullable<string> = null;
 
     /**
      * The list of animation names for the currently loaded model.
@@ -314,11 +314,11 @@ export class HTML3DElement extends LitElement {
                 this._updateSelectedAnimation();
             }
 
-            if (changedProperties.has("src" satisfies keyof this)) {
+            if (changedProperties.has("source" satisfies keyof this)) {
                 this._updateModel();
             }
 
-            if (changedProperties.has("env" satisfies keyof this)) {
+            if (changedProperties.has("environment" satisfies keyof this)) {
                 this._updateEnv();
             }
         }
@@ -515,8 +515,8 @@ export class HTML3DElement extends LitElement {
 
     private async _updateModel() {
         try {
-            if (this.src) {
-                await this._viewer?.loadModelAsync(this.src, { pluginExtension: this.extension });
+            if (this.source) {
+                await this._viewer?.loadModelAsync(this.source, { pluginExtension: this.extension ?? undefined });
             } else {
                 await this._viewer?.resetModelAsync();
             }
@@ -527,8 +527,8 @@ export class HTML3DElement extends LitElement {
 
     private async _updateEnv() {
         try {
-            if (this.env) {
-                await this._viewer?.loadEnvironmentAsync(this.env);
+            if (this.environment) {
+                await this._viewer?.loadEnvironmentAsync(this.environment);
             } else {
                 await this._viewer?.resetEnvironmentAsync();
             }

--- a/packages/tools/viewer-alpha/test/apps/web/analyze.html
+++ b/packages/tools/viewer-alpha/test/apps/web/analyze.html
@@ -18,7 +18,7 @@
     </head>
 
     <body>
-        <babylon-viewer src="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env">
+        <babylon-viewer source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" environment="https://assets.babylonjs.com/environments/ulmerMuenster.env">
         </babylon-viewer>
         <script type="module" src="/packages/tools/viewer-alpha/dist/analyze/tools/viewer-alpha/src/index.js"></script>
     </body>

--- a/packages/tools/viewer-alpha/test/apps/web/coverage.html
+++ b/packages/tools/viewer-alpha/test/apps/web/coverage.html
@@ -18,7 +18,7 @@
     </head>
 
     <body>
-        <babylon-viewer src="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" env="https://assets.babylonjs.com/environments/ulmerMuenster.env">
+        <babylon-viewer source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" environment="https://assets.babylonjs.com/environments/ulmerMuenster.env">
         </babylon-viewer>
         <button id="saveCoverageButton" style="position: absolute; top: 10px; left: 10px" onclick="saveCoverage()">Collect Coverage</button>
         <script type="module" src="/packages/tools/viewer-alpha/dist/coverage/instrumented/tools/viewer-alpha/src/index.js"></script>

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -49,8 +49,9 @@
 
     <body ondragover="event.preventDefault()" ondrop="onDrop(event)">
         <babylon-viewer
-            src="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
-            env="https://assets.babylonjs.com/environments/ulmerMuenster.env"
+            engine="WebGL"
+            source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
+            environment="https://assets.babylonjs.com/environments/ulmerMuenster.env"
             animation-speed="1.5"
         >
             <!-- <div slot="tool-bar" style="position: absolute; top: 12px; left: 12px; width: 100px; height: 36px">
@@ -81,11 +82,11 @@
                 // Alternatively, we could just await import("/packages/tools/viewer-alpha/src/index.ts") here instead.
                 await customElements.whenDefined("babylon-viewer");
                 await new Promise((resolve) => setTimeout(resolve, 2000));
-                //viewerElement.src = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
+                //viewerElement.source = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
                 // error case
-                //viewerElement.src = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem2.glb';
+                //viewerElement.source = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem2.glb";
                 await new Promise((resolve) => setTimeout(resolve, 2000));
-                //viewerElement.src = "https://playground.babylonjs.com/scenes/BoomBox.glb";
+                //viewerElement.source = "https://playground.babylonjs.com/scenes/BoomBox.glb";
             })();
 
             async function onDrop(event) {

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -83,6 +83,7 @@
                 await customElements.whenDefined("babylon-viewer");
                 await new Promise((resolve) => setTimeout(resolve, 2000));
                 //viewerElement.source = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
+                //viewerElement.environment = "";
                 // error case
                 //viewerElement.source = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem2.glb";
                 await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -94,7 +95,7 @@
                 if (file) {
                     event.preventDefault();
                     await customElements.whenDefined("babylon-viewer");
-                    await viewerDetail.viewer.loadModelAsync(file);
+                    await viewerDetail.viewer.loadModel(file);
                 }
             }
 

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -63,17 +63,17 @@
         <script type="module" src="/packages/tools/viewer-alpha/src/index.ts"></script>
         <script>
             const viewerElement = document.querySelector("babylon-viewer");
-            let viewerDetail;
+            let viewerDetails;
             viewerElement.addEventListener(
                 "viewerready",
                 (event) => {
-                    viewerDetail = event.detail;
-                    console.log(`Viewer ready.`, viewerDetail);
+                    viewerDetails = viewerElement.viewerDetails;
+                    console.log(`Viewer ready.`, viewerDetails);
                 },
                 { once: true }
             );
             viewerElement.addEventListener("modelchange", (event) => {
-                console.log(`Model changed.`, viewerDetail);
+                console.log(`Model changed.`, viewerDetails);
             });
             let isViewerConnected = true;
 
@@ -95,7 +95,7 @@
                 if (file) {
                     event.preventDefault();
                     await customElements.whenDefined("babylon-viewer");
-                    await viewerDetail.viewer.loadModel(file);
+                    await viewerDetails.viewer.loadModel(file);
                 }
             }
 


### PR DESCRIPTION
This change includes a few improvements to the new Viewer:

1. The conditions for a default light are improved (it now considers whether there is an environment, whether the model brings in its own lights, and the models materials).
2. `ViewerDetails` is now publicly exposed from the viewer element. It used to only be available via the `viewerready` event, but this can cause challenges (particularly when using the viewer element in React) due to timing between different async operations (such as mounting and rendering a React component). Now a consumer can register for the event and also check if the viewer is already in a loaded state (via the `viewerDetails` property).
3. The `environmenterror` and `modelerror` events are now `ErrorEvents` and include the error. This is useful to be able to check and see if the error is an abort error.
4. Replaced abbreviated attributes with full names (e.g. `src` -> `source` and `env` -> `environment`). @bghgary convinced me as abbreviated names are not really used in new/modern WebAPI, but rather only in very old APIs.
5. `Async` postfixes have been removed, since generally in JS APIs it is non-standard and these APIs are all new so we don't need to disambiguate them against legacy APIs that use callbacks.
6. Switched from `Scalar.Clamp` to `Clamp`.

It also has a few changes not in the Viewer, but related:
1. `STLFileLoader` imports `StandardMaterial`.
2. `AnimationGroup` imports `Animatable`.
3. `glTFLoader` imports `AnimationGroup` dynamically (to defer the cost until we know the model has animations).