### PR TITLE
Effect: Fix infinite loop when engine is disposed

### DIFF
--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -436,6 +436,10 @@ export class Effect implements IDisposable {
     }
 
     private _isReadyInternal(): boolean {
+        if (this._engine.isDisposed) {
+            // Engine is disposed, we return true to prevent looping over the setTimeout call in _checkIsReady
+            return true;
+        }
         if (this._isReady) {
             return true;
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/effect-checkisready-infinite-loop-when-dispose-scene-with-defaultrenderingpipeline-again/53633