### PR TITLE
epsilon in sprite.vertex shader

### DIFF
--- a/packages/dev/core/src/Shaders/sprites.vertex.fx
+++ b/packages/dev/core/src/Shaders/sprites.vertex.fx
@@ -10,13 +10,16 @@ attribute vec4 color;
 uniform mat4 view;
 uniform mat4 projection;
 
+#ifdef SPRITE_APPLY_EPSILON_CORRECTION
+    uniform float epsilon;
+#endif
+
 // Output
 varying vec2 vUV;
 varying vec4 vColor;
 
 #include<fogVertexDeclaration>
 #include<logDepthDeclaration>
-
 
 #define CUSTOM_VERTEX_DEFINITIONS
 
@@ -30,6 +33,13 @@ void main(void) {
 	float angle = position.w;
 	vec2 size = vec2(options.x, options.y);
 	vec2 offset = offsets.xy;
+
+	#ifdef SPRITE_APPLY_EPSILON_CORRECTION
+		if (offset.x < 0.5) offset.x += epsilon;
+		if (offset.x>= 0.5) offset.x = 1.0- epsilon;
+		if (offset.y < 0.5) offset.y += epsilon;
+		if (offset.y >0.5) offset.y = 1.0- epsilon;
+	#endif
 
 	cornerPos = vec2(offset.x - 0.5, offset.y  - 0.5) * size;
 

--- a/packages/dev/core/src/Shaders/sprites.vertex.fx
+++ b/packages/dev/core/src/Shaders/sprites.vertex.fx
@@ -35,10 +35,10 @@ void main(void) {
 	vec2 offset = offsets.xy;
 
 	#ifdef SPRITE_APPLY_EPSILON_CORRECTION
-		if (offset.x < 0.5) offset.x += epsilon;
-		if (offset.x>= 0.5) offset.x = 1.0- epsilon;
-		if (offset.y < 0.5) offset.y += epsilon;
-		if (offset.y >0.5) offset.y = 1.0- epsilon;
+		if (offset.x == 0.) offset.x += epsilon;
+		if (offset.x == 1.) offset.x -= epsilon;
+		if (offset.y == 0.) offset.y += epsilon;
+		if (offset.y == 1.) offset.y -= epsilon;
 	#endif
 
 	cornerPos = vec2(offset.x - 0.5, offset.y  - 0.5) * size;

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -221,6 +221,13 @@ export class SpriteManager implements ISpriteManager {
         this._spriteRenderer.useLogarithmicDepth = value;
     }
 
+    public set epsilon(value: number) {
+        this._spriteRenderer.epsilon = value;
+    }
+    public get epsilon() {
+        return this._spriteRenderer.epsilon;
+    }
+
     /**
      * Blend mode use to render the particle, it can be any of
      * the static Constants.ALPHA_x properties provided in this class.

--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -131,6 +131,24 @@ export class SpriteRenderer {
         this._createEffects();
     }
 
+    private _epsilon: number;
+    public get epsilon() {
+        return this._epsilon;
+    }
+
+    public set epsilon(value: number) {
+        if (this._epsilon === value) {
+            return;
+        }
+
+        if (!this._epsilon) {
+            this._epsilon = value;
+            this._createEffects();
+        } else {
+            // has epsilon set already, no need to recreate the effect
+            this._epsilon = value;
+        }
+    }
     /** Shader language used by the material */
     protected _shaderLanguage = ShaderLanguage.GLSL;
 
@@ -147,7 +165,6 @@ export class SpriteRenderer {
     private readonly _scene: Nullable<Scene>;
 
     private readonly _capacity: number;
-    private readonly _epsilon: number;
 
     private _vertexBufferSize: number;
     private _vertexData: Float32Array;

--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -252,12 +252,14 @@ export class SpriteRenderer {
         }
 
         let defines = "";
+        const uniforms = ["view", "projection", "textureInfos", "alphaTest", "vFogInfos", "vFogColor", "logarithmicDepthConstant"];
 
         if (this._pixelPerfect) {
             defines += "#define PIXEL_PERFECT\n";
         }
         if (this._epsilon) {
             defines += "#define SPRITE_APPLY_EPSILON_CORRECTION\n";
+            uniforms.push("epsilon");
         }
         if (this._scene && this._scene.fogEnabled && this._scene.fogMode !== 0 && this._fogEnabled) {
             defines += "#define FOG\n";
@@ -265,9 +267,6 @@ export class SpriteRenderer {
         if (this._useLogarithmicDepth) {
             defines += "#define LOGARITHMICDEPTH\n";
         }
-
-        const uniforms = ["view", "projection", "textureInfos", "alphaTest", "vFogInfos", "vFogColor", "logarithmicDepthConstant"];
-        this._epsilon && uniforms.push("epsilon");
 
         this._drawWrapperBase.effect = this._engine.createEffect(
             "sprites",

--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -256,6 +256,9 @@ export class SpriteRenderer {
         if (this._pixelPerfect) {
             defines += "#define PIXEL_PERFECT\n";
         }
+        if (this._epsilon) {
+            defines += "#define SPRITE_APPLY_EPSILON_CORRECTION\n";
+        }
         if (this._scene && this._scene.fogEnabled && this._scene.fogMode !== 0 && this._fogEnabled) {
             defines += "#define FOG\n";
         }
@@ -263,10 +266,13 @@ export class SpriteRenderer {
             defines += "#define LOGARITHMICDEPTH\n";
         }
 
+        const uniforms = ["view", "projection", "textureInfos", "alphaTest", "vFogInfos", "vFogColor", "logarithmicDepthConstant"];
+        this._epsilon && uniforms.push("epsilon");
+
         this._drawWrapperBase.effect = this._engine.createEffect(
             "sprites",
             [VertexBuffer.PositionKind, "options", "offsets", "inverts", "cellInfo", VertexBuffer.ColorKind],
-            ["view", "projection", "textureInfos", "alphaTest", "vFogInfos", "vFogColor", "logarithmicDepthConstant"],
+            uniforms,
             ["diffuseSampler"],
             defines,
             undefined,
@@ -355,6 +361,10 @@ export class SpriteRenderer {
         effect.setMatrix("view", viewMatrix);
         effect.setMatrix("projection", projectionMatrix);
 
+        if (this._epsilon) {
+            effect.setFloat("epsilon", this._epsilon);
+        }
+
         // Scene Info
         if (shouldRenderFog) {
             const scene = this._scene!;
@@ -424,18 +434,6 @@ export class SpriteRenderer {
         customSpriteUpdate: Nullable<(sprite: ThinSprite, baseSize: ISize) => void>
     ): void {
         let arrayOffset = index * this._vertexBufferSize;
-
-        if (offsetX === 0) {
-            offsetX = this._epsilon;
-        } else if (offsetX === 1) {
-            offsetX = 1 - this._epsilon;
-        }
-
-        if (offsetY === 0) {
-            offsetY = this._epsilon;
-        } else if (offsetY === 1) {
-            offsetY = 1 - this._epsilon;
-        }
 
         if (customSpriteUpdate) {
             customSpriteUpdate(sprite, baseSize);


### PR DESCRIPTION
https://forum.babylonjs.com/t/sprites-render-pixels-from-cell-next-to-it/53630

#YCY2IL#2229

Implementation of @Popov72 's suggestion:  
> My opinion is that what "fixes" the problem is the epsilon applied to the uv coordinates, not the fact we don't use instancing. It happens that in instanced mode, epsilon is not applied, which is why you have to revert to non-instanced mode, but it looks like a bug to me, because it means the output for sprites may be different depending on your computer/browser (if it supports instancing or not). So, I would fix this problem by applying the epsilon in instanced mode too.
> 
> It can't be done the same way than in the non-instanced mode (which is probably why it wasn't implemented), but you could do it roughly like this:
> 
> * add a uniform to the shader, to pass the epsilon value (feel free to use the names you want for the define/uniform!):
> 
> ```glsl
> #ifdef SPRITE_APPLY_EPSILON_CORRECTION
>     uniform float epsilon;
> #endif
> ```
> 
> * apply the epsilon:
> 
> ```glsl
>     ...
>     vec2 offset = offsets.xy;
>     #ifdef SPRITE_APPLY_EPSILON_CORRECTION
>         if (offset.x == 0.) offset.x += epsilon;
>         if (offset.x == 1.) offset.x -= epsilon;
>         if (offset.y == 0.) offset.y += epsilon;
>         if (offset.y == 1.) offset.y -= epsilon;
>     #endif
>     ...
> ```
> 
> * in the JS code, define `SPRITE_APPLY_EPSILON_CORRECTION` when in instanced mode, and pass the value of epsilon to the shader
> 
> I think that should do it.
