### PR TITLE
Color from hex

### DIFF
--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -782,15 +782,7 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
      * @returns a new Color3 object
      */
     public static FromHexString(hex: string): Color3 {
-        if (hex.substring(0, 1) !== "#" || hex.length !== 7) {
-            return new Color3(0, 0, 0);
-        }
-
-        const r = parseInt(hex.substring(1, 3), 16);
-        const g = parseInt(hex.substring(3, 5), 16);
-        const b = parseInt(hex.substring(5, 7), 16);
-
-        return Color3.FromInts(r, g, b);
+        return new Color3(0, 0, 0).fromHexString(hex)
     }
 
     /**
@@ -1711,12 +1703,7 @@ export class Color4 implements Tensor<Tuple<number, 4>, IColor4Like>, IColor4Lik
             return new Color4(0.0, 0.0, 0.0, 0.0);
         }
 
-        const r = parseInt(hex.substring(1, 3), 16);
-        const g = parseInt(hex.substring(3, 5), 16);
-        const b = parseInt(hex.substring(5, 7), 16);
-        const a = hex.length === 9 ? parseInt(hex.substring(7, 9), 16) : 255;
-
-        return Color4.FromInts(r, g, b, a);
+        return new Color4(0.0, 0.0, 0.0, 1.0).fromHexString(hex);
     }
 
     /**

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -590,6 +590,23 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
     }
 
     /**
+     * Updates the Color3 rgb values from the string containing valid hexadecimal values
+     * @param hex defines a string containing valid hexadecimal values
+     * @returns the current Color3 object
+     */
+    public fromHexString(hex: string): this {
+        if (hex.substring(0, 1) !== "#" || hex.length !== 7) {
+            return this
+        }
+
+        this.r = parseInt(hex.substring(1, 3), 16);
+        this.g = parseInt(hex.substring(3, 5), 16);
+        this.b = parseInt(hex.substring(5, 7), 16);
+
+        return this;
+    }
+
+    /**
      * Converts current color in rgb space to HSV values
      * @returns a new color3 representing the HSV values
      */
@@ -1581,6 +1598,34 @@ export class Color4 implements Tensor<Tuple<number, 4>, IColor4Like>, IColor4Lik
 
         const intA = Math.round(this.a * 255);
         return "#" + ToHex(intR) + ToHex(intG) + ToHex(intB) + ToHex(intA);
+    }
+
+    /**
+     * Updates the Color4 rgba values from the string containing valid hexadecimal values.
+     *
+     * A valid hex string is either in the format #RRGGBB or #RRGGBBAA.
+     *
+     * When a hex string without alpha is passed, the resulting Color4 keeps
+     * its previous alpha value.
+     *
+     * An invalid string does not modify this object
+     *
+     * @param hex defines a string containing valid hexadecimal values
+     * @returns the current updated Color4 object
+     */
+    public fromHexString(hex: string): this {
+        if (hex.substring(0, 1) !== "#" || (hex.length !== 9 && hex.length !== 7)) {
+            return this;
+        }
+
+        this.r = parseInt(hex.substring(1, 3), 16);
+        this.g = parseInt(hex.substring(3, 5), 16);
+        this.b = parseInt(hex.substring(5, 7), 16);
+        if (hex.length === 9) {
+            this.a = parseInt(hex.substring(7, 9), 16);
+        }
+
+        return this;
     }
 
     /**

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -599,9 +599,9 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
             return this;
         }
 
-        this.r = parseInt(hex.substring(1, 3), 16);
-        this.g = parseInt(hex.substring(3, 5), 16);
-        this.b = parseInt(hex.substring(5, 7), 16);
+        this.r = parseInt(hex.substring(1, 3), 16) / 255;
+        this.g = parseInt(hex.substring(3, 5), 16) / 255;
+        this.b = parseInt(hex.substring(5, 7), 16) / 255;
 
         return this;
     }
@@ -1610,11 +1610,11 @@ export class Color4 implements Tensor<Tuple<number, 4>, IColor4Like>, IColor4Lik
             return this;
         }
 
-        this.r = parseInt(hex.substring(1, 3), 16);
-        this.g = parseInt(hex.substring(3, 5), 16);
-        this.b = parseInt(hex.substring(5, 7), 16);
+        this.r = parseInt(hex.substring(1, 3), 16) / 255;
+        this.g = parseInt(hex.substring(3, 5), 16) / 255;
+        this.b = parseInt(hex.substring(5, 7), 16) / 255;
         if (hex.length === 9) {
-            this.a = parseInt(hex.substring(7, 9), 16);
+            this.a = parseInt(hex.substring(7, 9), 16) / 255;
         }
 
         return this;

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -596,7 +596,7 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
      */
     public fromHexString(hex: string): this {
         if (hex.substring(0, 1) !== "#" || hex.length !== 7) {
-            return this
+            return this;
         }
 
         this.r = parseInt(hex.substring(1, 3), 16);
@@ -782,7 +782,7 @@ export class Color3 implements Tensor<Tuple<number, 3>, IColor3Like>, IColor3Lik
      * @returns a new Color3 object
      */
     public static FromHexString(hex: string): Color3 {
-        return new Color3(0, 0, 0).fromHexString(hex)
+        return new Color3(0, 0, 0).fromHexString(hex);
     }
 
     /**


### PR DESCRIPTION
Added instance methods to the `Color3` and `Color4` objects for filling the object with the hex values. The static methods now re-use that method to reduce code duplication.
This allows us to re-use color object instances when we need to parse hex values and therefore reduces GC.