### PR TITLE
Improve viewer camera framing (and other small fixes)

### DIFF
--- a/packages/dev/core/src/Meshes/meshUtils.ts
+++ b/packages/dev/core/src/Meshes/meshUtils.ts
@@ -169,6 +169,10 @@ export function computeMaxExtents(
     const updateMaxExtents = (): void => {
         for (let i = 0; i < meshes.length; i++) {
             const mesh = meshes[i];
+            const positions = mesh.getVerticesData(VertexBuffer.PositionKind);
+            if (!positions) {
+                continue;
+            }
 
             const worldMatrix = mesh.computeWorldMatrix(true);
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -520,7 +520,7 @@ export class Viewer implements IDisposable {
         this._camera.lowerRadiusLimit = radius * 0.01;
         this._camera.wheelPrecision = 100 / radius;
         this._camera.alpha = Math.PI / 2;
-        this._camera.beta = Math.PI / 2;
+        this._camera.beta = Math.PI / 2.4;
         this._camera.radius = radius;
         this._camera.minZ = radius * 0.01;
         this._camera.maxZ = radius * 1000;

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -508,7 +508,7 @@ export class Viewer implements IDisposable {
             const worldSize = worldExtents.max.subtract(worldExtents.min);
             const worldCenter = worldExtents.min.add(worldSize.scale(0.5));
 
-            radius = worldSize.length() * 1.2;
+            radius = worldSize.length() * 1.1;
 
             if (!isFinite(radius)) {
                 radius = 1;

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -192,12 +192,7 @@ export class Viewer implements IDisposable {
 
         // TODO: render at least back ground. Maybe we can only run renderloop when a mesh is loaded. What to render until then?
         const render = () => {
-            const scene = this._details.scene;
-            const engine = scene.getEngine();
-
-            engine.beginFrame();
-            scene.render();
-            engine.endFrame();
+            this._details.scene.render();
             if (this.isAnimationPlaying) {
                 this.onAnimationProgressChanged.notifyObservers();
                 this._autoRotationBehavior.resetLastInteractionTime();

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -29,8 +29,6 @@ import { Observable } from "core/Misc/observable";
 import { Scene } from "core/scene";
 import { registerBuiltInLoaders } from "loaders/dynamic";
 
-//import "core/Rendering/boundingBoxRenderer";
-
 function throwIfAborted(...abortSignals: (Nullable<AbortSignal> | undefined)[]): void {
     for (const signal of abortSignals) {
         signal?.throwIfAborted();
@@ -344,8 +342,6 @@ export class Viewer implements IDisposable {
                     });
                     this.selectedAnimation = 0;
                     this._details.model.addAllToScene();
-
-                    this._details.model.meshes.forEach((mesh) => (mesh.showBoundingBox = true));
                 }
 
                 this._updateCamera();

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -64,14 +64,10 @@
         <script>
             const viewerElement = document.querySelector("babylon-viewer");
             let viewerDetails;
-            viewerElement.addEventListener(
-                "viewerready",
-                (event) => {
-                    viewerDetails = viewerElement.viewerDetails;
-                    console.log(`Viewer ready.`, viewerDetails);
-                },
-                { once: true }
-            );
+            viewerElement.addEventListener("viewerready", (event) => {
+                viewerDetails = viewerElement.viewerDetails;
+                console.log(`Viewer ready.`, viewerDetails);
+            });
             viewerElement.addEventListener("modelchange", (event) => {
                 console.log(`Model changed.`, viewerDetails);
             });


### PR DESCRIPTION
The main change here is to improve camera framing via:
1. Using the new `computeMaxExtents` helper from @bghgary to take into account animation. This significantly improves the framing for models with significant translation in animations. Note this also includes a small bug fix in `computeMaxExtents` where it did not handle the case of a mesh with no verts.
2. When models have animations, set the selected `AnimationGroup` to frame 0. This ensures it is within the camera framing computed for the model + animation.
3. Change the camera to looking down at a slight angle to the object.
4. Reduce the framing scalar from 1.2 to 1.1 to fit a bit better.

There are a couple other Viewer fixes included in this PR as well:
1. Remove the redundant `beginFrame` and `endFrame` calls. They are already called in `_renderLoop` and they mess up frame time calculations and break some behavior (like animating the camera back to its initial pose upon double click).
2. If an async operation (like loading an environment or model) was correctly started while the viewer was not disposed, but then the viewer is disposed while the async operation is still running, the async operation should be aborted and throw and abort error rather than a disposed error. A disposed error is indicative of a programming error, which this is not. We need this to be accurate for consumers who need to be able to tell the difference between an unexpected error and an expected error.