### PR TITLE
Moving BabylonFileParser out of the scene

### DIFF
--- a/packages/dev/core/src/Audio/audioSceneComponent.ts
+++ b/packages/dev/core/src/Audio/audioSceneComponent.ts
@@ -5,16 +5,17 @@ import { Matrix, Vector3 } from "../Maths/math.vector";
 import type { ISceneSerializableComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
 import { Scene } from "../scene";
-import { AbstractScene } from "../abstractScene";
+import type { AbstractScene } from "../abstractScene";
 import type { AssetContainer } from "../assetContainer";
 
 import "./audioEngine";
 import { PrecisionDate } from "../Misc/precisionDate";
 import { EngineStore } from "../Engines/engineStore";
 import { AbstractEngine } from "core/Engines/abstractEngine";
+import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
 
 // Adds the parser to the scene parsers.
-AbstractScene.AddParser(SceneComponentConstants.NAME_AUDIO, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
+AddParser(SceneComponentConstants.NAME_AUDIO, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
     // TODO: add sound
     let loadedSounds: Sound[] = [];
     let loadedSound: Sound;

--- a/packages/dev/core/src/Layers/effectLayerSceneComponent.ts
+++ b/packages/dev/core/src/Layers/effectLayerSceneComponent.ts
@@ -9,8 +9,10 @@ import { EffectLayer } from "./effectLayer";
 import { AbstractScene } from "../abstractScene";
 import type { AssetContainer } from "../assetContainer";
 import { EngineStore } from "../Engines/engineStore";
+import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+
 // Adds the parser to the scene parsers.
-AbstractScene.AddParser(SceneComponentConstants.NAME_EFFECTLAYER, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
+AddParser(SceneComponentConstants.NAME_EFFECTLAYER, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
     if (parsedData.effectLayers) {
         if (!container.effectLayers) {
             container.effectLayers = [] as EffectLayer[];

--- a/packages/dev/core/src/LensFlares/lensFlareSystemSceneComponent.ts
+++ b/packages/dev/core/src/LensFlares/lensFlareSystemSceneComponent.ts
@@ -7,8 +7,10 @@ import { SceneComponentConstants } from "../sceneComponent";
 import { AbstractScene } from "../abstractScene";
 import type { AssetContainer } from "../assetContainer";
 import { LensFlareSystem } from "./lensFlareSystem";
+import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+
 // Adds the parser to the scene parsers.
-AbstractScene.AddParser(SceneComponentConstants.NAME_LENSFLARESYSTEM, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
+AddParser(SceneComponentConstants.NAME_LENSFLARESYSTEM, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
     // Lens flares
     if (parsedData.lensFlareSystems !== undefined && parsedData.lensFlareSystems !== null) {
         if (!container.lensFlareSystems) {

--- a/packages/dev/core/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
@@ -5,9 +5,11 @@ import { ShadowGenerator } from "./shadowGenerator";
 import { CascadedShadowGenerator } from "./cascadedShadowGenerator";
 import type { ISceneSerializableComponent } from "../../sceneComponent";
 import { SceneComponentConstants } from "../../sceneComponent";
-import { AbstractScene } from "../../abstractScene";
+import type { AbstractScene } from "../../abstractScene";
+import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+
 // Adds the parser to the scene parsers.
-AbstractScene.AddParser(SceneComponentConstants.NAME_SHADOWGENERATOR, (parsedData: any, scene: Scene) => {
+AddParser(SceneComponentConstants.NAME_SHADOWGENERATOR, (parsedData: any, scene: Scene) => {
     // Shadows
     if (parsedData.shadowGenerators !== undefined && parsedData.shadowGenerators !== null) {
         for (let index = 0, cache = parsedData.shadowGenerators.length; index < cache; index++) {

--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -17,7 +17,6 @@ import { AnimationGroup } from "../../Animations/animationGroup";
 import { Light } from "../../Lights/light";
 import { SceneComponentConstants } from "../../sceneComponent";
 import { SceneLoader } from "../../Loading/sceneLoader";
-import { AbstractScene } from "../../abstractScene";
 import { AssetContainer } from "../../assetContainer";
 import { ActionManager } from "../../Actions/actionManager";
 import type { IParticleSystem } from "../../Particles/IParticleSystem";
@@ -31,6 +30,7 @@ import { GetClass } from "../../Misc/typeStore";
 import { Tools } from "../../Misc/tools";
 import { PostProcess } from "../../PostProcesses/postProcess";
 import { SpriteManager } from "core/Sprites/spriteManager";
+import { GetIndividualParser, Parse } from "./babylonFileParser.function";
 
 /** @internal */
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-var
@@ -558,7 +558,7 @@ const loadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError
             g._loadedUniqueId = "";
         });
 
-        AbstractScene.Parse(parsedData, scene, container, rootUrl);
+        Parse(parsedData, scene, container, rootUrl);
 
         // Actions (scene) Done last as it can access other objects.
         for (index = 0, cache = scene.meshes.length; index < cache; index++) {
@@ -893,7 +893,7 @@ SceneLoader.RegisterPlugin({
 
             // Particles
             if (parsedData.particleSystems !== undefined && parsedData.particleSystems !== null) {
-                const parser = AbstractScene.GetIndividualParser(SceneComponentConstants.NAME_PARTICLESYSTEM);
+                const parser = GetIndividualParser(SceneComponentConstants.NAME_PARTICLESYSTEM);
                 if (parser) {
                     for (let index = 0, cache = parsedData.particleSystems.length; index < cache; index++) {
                         const parsedParticleSystem = parsedData.particleSystems[index];

--- a/packages/dev/core/src/Loading/Plugins/babylonFileParser.function.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileParser.function.ts
@@ -1,0 +1,84 @@
+import type { AssetContainer } from "core/assetContainer";
+import type { Scene } from "core/scene";
+import type { Nullable } from "core/types";
+
+/**
+ * Defines how the parser contract is defined.
+ * These parsers are used to parse a list of specific assets (like particle systems, etc..)
+ */
+export type BabylonFileParser = (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => void;
+
+/**
+ * Defines how the individual parser contract is defined.
+ * These parser can parse an individual asset
+ */
+export type IndividualBabylonFileParser = (parsedData: any, scene: Scene, rootUrl: string) => any;
+
+/**
+ * Stores the list of available parsers in the application.
+ */
+const _BabylonFileParsers: { [key: string]: BabylonFileParser } = {};
+
+/**
+ * Stores the list of available individual parsers in the application.
+ */
+const _IndividualBabylonFileParsers: { [key: string]: IndividualBabylonFileParser } = {};
+
+/**
+ * Adds a parser in the list of available ones
+ * @param name Defines the name of the parser
+ * @param parser Defines the parser to add
+ */
+export function AddParser(name: string, parser: BabylonFileParser): void {
+    _BabylonFileParsers[name] = parser;
+}
+
+/**
+ * Gets a general parser from the list of available ones
+ * @param name Defines the name of the parser
+ * @returns the requested parser or null
+ */
+export function GetParser(name: string): Nullable<BabylonFileParser> {
+    if (_BabylonFileParsers[name]) {
+        return _BabylonFileParsers[name];
+    }
+
+    return null;
+}
+
+/**
+ * Adds n individual parser in the list of available ones
+ * @param name Defines the name of the parser
+ * @param parser Defines the parser to add
+ */
+export function AddIndividualParser(name: string, parser: IndividualBabylonFileParser): void {
+    _IndividualBabylonFileParsers[name] = parser;
+}
+
+/**
+ * Gets an individual parser from the list of available ones
+ * @param name Defines the name of the parser
+ * @returns the requested parser or null
+ */
+export function GetIndividualParser(name: string): Nullable<IndividualBabylonFileParser> {
+    if (_IndividualBabylonFileParsers[name]) {
+        return _IndividualBabylonFileParsers[name];
+    }
+
+    return null;
+}
+
+/**
+ * Parser json data and populate both a scene and its associated container object
+ * @param jsonData Defines the data to parse
+ * @param scene Defines the scene to parse the data for
+ * @param container Defines the container attached to the parsing sequence
+ * @param rootUrl Defines the root url of the data
+ */
+export function Parse(jsonData: any, scene: Scene, container: AssetContainer, rootUrl: string): void {
+    for (const parserName in _BabylonFileParsers) {
+        if (Object.prototype.hasOwnProperty.call(_BabylonFileParsers, parserName)) {
+            _BabylonFileParsers[parserName](jsonData, scene, container, rootUrl);
+        }
+    }
+}

--- a/packages/dev/core/src/Loading/Plugins/index.ts
+++ b/packages/dev/core/src/Loading/Plugins/index.ts
@@ -1,1 +1,2 @@
 export * from "./babylonFileLoader";
+export * from "./babylonFileParser.function";

--- a/packages/dev/core/src/Particles/particleSystemComponent.ts
+++ b/packages/dev/core/src/Particles/particleSystemComponent.ts
@@ -1,7 +1,6 @@
 import { Mesh } from "../Meshes/mesh";
 import type { IParticleSystem } from "./IParticleSystem";
 import { GPUParticleSystem } from "./gpuParticleSystem";
-import { AbstractScene } from "../abstractScene";
 import type { Effect } from "../Materials/effect";
 import { ParticleSystem } from "./particleSystem";
 import type { Scene } from "../scene";
@@ -10,10 +9,11 @@ import type { AssetContainer } from "../assetContainer";
 import type { EffectFallbacks } from "../Materials/effectFallbacks";
 import { AbstractEngine } from "../Engines/abstractEngine";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
+import { AddParser, AddIndividualParser, GetIndividualParser } from "core/Loading/Plugins/babylonFileParser.function";
 
 // Adds the parsers to the scene parsers.
-AbstractScene.AddParser(SceneComponentConstants.NAME_PARTICLESYSTEM, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
-    const individualParser = AbstractScene.GetIndividualParser(SceneComponentConstants.NAME_PARTICLESYSTEM);
+AddParser(SceneComponentConstants.NAME_PARTICLESYSTEM, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
+    const individualParser = GetIndividualParser(SceneComponentConstants.NAME_PARTICLESYSTEM);
 
     if (!individualParser) {
         return;
@@ -28,7 +28,7 @@ AbstractScene.AddParser(SceneComponentConstants.NAME_PARTICLESYSTEM, (parsedData
     }
 });
 
-AbstractScene.AddIndividualParser(SceneComponentConstants.NAME_PARTICLESYSTEM, (parsedParticleSystem: any, scene: Scene, rootUrl: string) => {
+AddIndividualParser(SceneComponentConstants.NAME_PARTICLESYSTEM, (parsedParticleSystem: any, scene: Scene, rootUrl: string) => {
     if (parsedParticleSystem.activeParticleCount) {
         const ps = GPUParticleSystem.Parse(parsedParticleSystem, scene, rootUrl);
         return ps;

--- a/packages/dev/core/src/Rendering/subSurfaceSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/subSurfaceSceneComponent.ts
@@ -3,11 +3,11 @@ import { Scene } from "../scene";
 import type { ISceneSerializableComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
 import { SubSurfaceConfiguration } from "./subSurfaceConfiguration";
-import { AbstractScene } from "../abstractScene";
 import { Color3 } from "../Maths/math.color";
+import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
 
 // Adds the parser to the scene parsers.
-AbstractScene.AddParser(SceneComponentConstants.NAME_SUBSURFACE, (parsedData: any, scene: Scene) => {
+AddParser(SceneComponentConstants.NAME_SUBSURFACE, (parsedData: any, scene: Scene) => {
     // Diffusion profiles
     if (parsedData.ssDiffusionProfileColors !== undefined && parsedData.ssDiffusionProfileColors !== null) {
         scene.enableSubSurfaceForPrePass();

--- a/packages/dev/core/src/abstractScene.ts
+++ b/packages/dev/core/src/abstractScene.ts
@@ -1,11 +1,9 @@
-import type { Scene } from "./scene";
 import type { Nullable } from "./types";
 import type { AbstractMesh } from "./Meshes/abstractMesh";
 import type { TransformNode } from "./Meshes/transformNode";
 import type { Geometry } from "./Meshes/geometry";
 import type { Skeleton } from "./Bones/skeleton";
 import type { MorphTargetManager } from "./Morph/morphTargetManager";
-import type { AssetContainer } from "./assetContainer";
 import type { IParticleSystem } from "./Particles/IParticleSystem";
 import type { AnimationGroup } from "./Animations/animationGroup";
 import type { BaseTexture } from "./Materials/Textures/baseTexture";
@@ -20,92 +18,11 @@ import type { Animation } from "./Animations/animation";
 import { RegisterClass } from "./Misc/typeStore";
 
 /**
- * Defines how the parser contract is defined.
- * These parsers are used to parse a list of specific assets (like particle systems, etc..)
- */
-export type BabylonFileParser = (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => void;
-
-/**
- * Defines how the individual parser contract is defined.
- * These parser can parse an individual asset
- */
-export type IndividualBabylonFileParser = (parsedData: any, scene: Scene, rootUrl: string) => any;
-
-/**
  * Base class of the scene acting as a container for the different elements composing a scene.
  * This class is dynamically extended by the different components of the scene increasing
  * flexibility and reducing coupling
  */
 export abstract class AbstractScene {
-    /**
-     * Stores the list of available parsers in the application.
-     */
-    private static _BabylonFileParsers: { [key: string]: BabylonFileParser } = {};
-
-    /**
-     * Stores the list of available individual parsers in the application.
-     */
-    private static _IndividualBabylonFileParsers: { [key: string]: IndividualBabylonFileParser } = {};
-
-    /**
-     * Adds a parser in the list of available ones
-     * @param name Defines the name of the parser
-     * @param parser Defines the parser to add
-     */
-    public static AddParser(name: string, parser: BabylonFileParser): void {
-        this._BabylonFileParsers[name] = parser;
-    }
-
-    /**
-     * Gets a general parser from the list of available ones
-     * @param name Defines the name of the parser
-     * @returns the requested parser or null
-     */
-    public static GetParser(name: string): Nullable<BabylonFileParser> {
-        if (this._BabylonFileParsers[name]) {
-            return this._BabylonFileParsers[name];
-        }
-
-        return null;
-    }
-
-    /**
-     * Adds n individual parser in the list of available ones
-     * @param name Defines the name of the parser
-     * @param parser Defines the parser to add
-     */
-    public static AddIndividualParser(name: string, parser: IndividualBabylonFileParser): void {
-        this._IndividualBabylonFileParsers[name] = parser;
-    }
-
-    /**
-     * Gets an individual parser from the list of available ones
-     * @param name Defines the name of the parser
-     * @returns the requested parser or null
-     */
-    public static GetIndividualParser(name: string): Nullable<IndividualBabylonFileParser> {
-        if (this._IndividualBabylonFileParsers[name]) {
-            return this._IndividualBabylonFileParsers[name];
-        }
-
-        return null;
-    }
-
-    /**
-     * Parser json data and populate both a scene and its associated container object
-     * @param jsonData Defines the data to parse
-     * @param scene Defines the scene to parse the data for
-     * @param container Defines the container attached to the parsing sequence
-     * @param rootUrl Defines the root url of the data
-     */
-    public static Parse(jsonData: any, scene: Scene, container: AssetContainer, rootUrl: string): void {
-        for (const parserName in this._BabylonFileParsers) {
-            if (Object.prototype.hasOwnProperty.call(this._BabylonFileParsers, parserName)) {
-                this._BabylonFileParsers[parserName](jsonData, scene, container, rootUrl);
-            }
-        }
-    }
-
     /**
      * Gets the list of root nodes (ie. nodes with no parent)
      */


### PR DESCRIPTION
In preparation for CoreScene, I'm removing unnecessary code out of AbstractScene.

This will be flagged as breaking changes but as it is purely internal I envision no problem