### PR TITLE
Store camera state

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -527,6 +527,7 @@ export class Viewer implements IDisposable {
         this._camera.wheelDeltaPercentage = 0.01;
         this._camera.pinchDeltaPercentage = 0.01;
         this._camera.restoreStateInterpolationFactor = 0.1;
+        this._camera.storeState();
 
         updateSkybox(this._skybox, this._camera);
     }


### PR DESCRIPTION
Not sure how this got missed for so long, but we weren't actually storing the camera state after doing the framing, so restoring the stored camera state (e.g. double click) was restoring to the wrong camera pose.