### PR TITLE
Remove AbstractScene

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -8,10 +8,10 @@ import { Observable } from "../Misc/observable";
 import type { Nullable } from "../types";
 import { EngineStore } from "../Engines/engineStore";
 
-import type { AbstractScene } from "../abstractScene";
 import { Tags } from "../Misc/tags";
 import type { AnimationGroupMask } from "./animationGroupMask";
 import "./animatable";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 /**
  * This class defines the direct association between an animation and a target
@@ -84,7 +84,7 @@ export class AnimationGroup implements IDisposable {
     private _shouldStart = true;
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /**
      * Gets or sets the unique id of the node

--- a/packages/dev/core/src/Audio/audioSceneComponent.ts
+++ b/packages/dev/core/src/Audio/audioSceneComponent.ts
@@ -5,7 +5,6 @@ import { Matrix, Vector3 } from "../Maths/math.vector";
 import type { ISceneSerializableComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
 import { Scene } from "../scene";
-import type { AbstractScene } from "../abstractScene";
 import type { AssetContainer } from "../assetContainer";
 
 import "./audioEngine";
@@ -13,6 +12,7 @@ import { PrecisionDate } from "../Misc/precisionDate";
 import { EngineStore } from "../Engines/engineStore";
 import { AbstractEngine } from "core/Engines/abstractEngine";
 import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 // Adds the parser to the scene parsers.
 AddParser(SceneComponentConstants.NAME_AUDIO, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
@@ -43,17 +43,12 @@ AddParser(SceneComponentConstants.NAME_AUDIO, (parsedData: any, scene: Scene, co
     loadedSounds = [];
 });
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * The list of sounds used in the scene.
          */
         sounds: Nullable<Array<Sound>>;
-    }
-}
-
-declare module "../scene" {
-    export interface Scene {
         /**
          * @internal
          * Backing field
@@ -382,7 +377,7 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
      * Adds all the elements from the container to the scene
      * @param container the container holding the elements
      */
-    public addFromContainer(container: AbstractScene): void {
+    public addFromContainer(container: IAssetContainer): void {
         if (!container.sounds) {
             return;
         }
@@ -398,7 +393,7 @@ export class AudioSceneComponent implements ISceneSerializableComponent {
      * @param container contains the elements to remove
      * @param dispose if the removed element should be disposed (default: false)
      */
-    public removeFromContainer(container: AbstractScene, dispose = false): void {
+    public removeFromContainer(container: IAssetContainer, dispose = false): void {
         if (!container.sounds) {
             return;
         }

--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -15,7 +15,7 @@ import { Logger } from "../Misc/logger";
 import { DeepCopier } from "../Misc/deepCopier";
 import type { IInspectable } from "../Misc/iInspectable";
 import type { IAnimatable } from "../Animations/animatable.interface";
-import type { AbstractScene } from "../abstractScene";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 /**
  * Class used to handle skinning animations
@@ -64,7 +64,7 @@ export class Skeleton implements IAnimatable {
     public _hasWaitingData: Nullable<boolean> = null;
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /**
      * Specifies if the skeleton should be serialized

--- a/packages/dev/core/src/IAssetContainer.ts
+++ b/packages/dev/core/src/IAssetContainer.ts
@@ -132,7 +132,7 @@ export interface IAssetContainer {
     /**
      * The list of sound added to the scene
      */
-    sounds: Sound[];
+    sounds: Nullable<Sound[]>;
 
     /**
      * The list of effect layers added to the scene

--- a/packages/dev/core/src/IAssetContainer.ts
+++ b/packages/dev/core/src/IAssetContainer.ts
@@ -15,63 +15,67 @@ import type { Light } from "./Lights/light";
 import type { Node } from "./node";
 import type { PostProcess } from "./PostProcesses/postProcess";
 import type { Animation } from "./Animations/animation";
-import { RegisterClass } from "./Misc/typeStore";
-
+import type { Sound } from "./Audio/sound";
+import type { Layer } from "./Layers/layer";
+import type { EffectLayer } from "./Layers/effectLayer";
+import type { ReflectionProbe } from "./Probes/reflectionProbe";
+import type { LensFlareSystem } from "./LensFlares/lensFlareSystem";
+import type { ProceduralTexture } from "./Materials/Textures/Procedurals/proceduralTexture";
 /**
- * Base class of the scene acting as a container for the different elements composing a scene.
+ * Interface defining container for the different elements composing a scene.
  * This class is dynamically extended by the different components of the scene increasing
  * flexibility and reducing coupling
  */
-export abstract class AbstractScene {
+export interface IAssetContainer {
     /**
      * Gets the list of root nodes (ie. nodes with no parent)
      */
-    public rootNodes: Node[] = [];
+    rootNodes: Node[];
 
     /** All of the cameras added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras
      */
-    public cameras: Camera[] = [];
+    cameras: Camera[];
 
     /**
      * All of the lights added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction
      */
-    public lights: Light[] = [];
+    lights: Light[];
 
     /**
      * All of the (abstract) meshes added to this scene
      */
-    public meshes: AbstractMesh[] = [];
+    meshes: AbstractMesh[];
 
     /**
      * The list of skeletons added to the scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/bonesSkeletons
      */
-    public skeletons: Skeleton[] = [];
+    skeletons: Skeleton[];
 
     /**
      * All of the particle systems added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_system_intro
      */
-    public particleSystems: IParticleSystem[] = [];
+    particleSystems: IParticleSystem[];
 
     /**
      * Gets a list of Animations associated with the scene
      */
-    public animations: Animation[] = [];
+    animations: Animation[];
 
     /**
      * All of the animation groups added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/animation/groupAnimations
      */
-    public animationGroups: AnimationGroup[] = [];
+    animationGroups: AnimationGroup[];
 
     /**
      * All of the multi-materials added to this scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/multiMaterials
      */
-    public multiMaterials: MultiMaterial[] = [];
+    multiMaterials: MultiMaterial[];
 
     /**
      * All of the materials added to this scene
@@ -80,18 +84,18 @@ export abstract class AbstractScene {
      * Note also that the order of the Material within the array is not significant and might change.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/materials_introduction
      */
-    public materials: Material[] = [];
+    materials: Material[];
 
     /**
      * The list of morph target managers added to the scene
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/dynamicMeshMorph
      */
-    public morphTargetManagers: MorphTargetManager[] = [];
+    morphTargetManagers: MorphTargetManager[];
 
     /**
      * The list of geometries used in the scene.
      */
-    public geometries: Geometry[] = [];
+    geometries: Geometry[];
 
     /**
      * All of the transform nodes added to this scene
@@ -100,52 +104,63 @@ export abstract class AbstractScene {
      * Note also that the order of the TransformNode within the array is not significant and might change.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/transform_node
      */
-    public transformNodes: TransformNode[] = [];
+    transformNodes: TransformNode[];
 
     /**
      * ActionManagers available on the scene.
      * @deprecated
      */
-    public actionManagers: AbstractActionManager[] = [];
+    actionManagers: AbstractActionManager[];
 
     /**
      * Textures to keep.
      */
-    public textures: BaseTexture[] = [];
+    textures: BaseTexture[];
 
-    /** @internal */
-    protected _environmentTexture: Nullable<BaseTexture> = null;
     /**
      * Texture used in all pbr material as the reflection texture.
      * As in the majority of the scene they are the same (exception for multi room and so on),
      * this is easier to reference from here than from all the materials.
      */
-    public get environmentTexture(): Nullable<BaseTexture> {
-        return this._environmentTexture;
-    }
-
-    public set environmentTexture(value: Nullable<BaseTexture>) {
-        this._environmentTexture = value;
-    }
+    environmentTexture: Nullable<BaseTexture>;
 
     /**
      * The list of postprocesses added to the scene
      */
-    public postProcesses: PostProcess[] = [];
+    postProcesses: PostProcess[];
+
+    /**
+     * The list of sound added to the scene
+     */
+    sounds: Sound[];
+
+    /**
+     * The list of effect layers added to the scene
+     */
+    effectLayers: EffectLayer[];
+
+    /**
+     * The list of layers added to the scene
+     */
+    layers: Layer[];
+
+    /**
+     * The list of reflection probes added to the scene
+     */
+    reflectionProbes: ReflectionProbe[];
+
+    /**
+     * The list of lens flare system added to the scene
+     */
+    lensFlareSystems: LensFlareSystem[];
+
+    /**
+     * The list of procedural textures added to the scene
+     */
+    proceduralTextures: ProceduralTexture[];
 
     /**
      * @returns all meshes, lights, cameras, transformNodes and bones
      */
-    public getNodes(): Array<Node> {
-        let nodes: Node[] = [];
-        nodes = nodes.concat(this.meshes);
-        nodes = nodes.concat(this.lights);
-        nodes = nodes.concat(this.cameras);
-        nodes = nodes.concat(this.transformNodes); // dummies
-        this.skeletons.forEach((skeleton) => (nodes = nodes.concat(skeleton.bones)));
-        return nodes;
-    }
+    getNodes(): Array<Node>;
 }
-
-// Register Class Name
-RegisterClass("BABYLON.AbstractScene", AbstractScene);

--- a/packages/dev/core/src/Layers/effectLayerSceneComponent.ts
+++ b/packages/dev/core/src/Layers/effectLayerSceneComponent.ts
@@ -1,15 +1,15 @@
 import { Camera } from "../Cameras/camera";
-import type { Scene } from "../scene";
+import { Scene } from "../scene";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import type { ISceneSerializableComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
 import { EffectLayer } from "./effectLayer";
-import { AbstractScene } from "../abstractScene";
 import type { AssetContainer } from "../assetContainer";
 import { EngineStore } from "../Engines/engineStore";
 import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 // Adds the parser to the scene parsers.
 AddParser(SceneComponentConstants.NAME_EFFECTLAYER, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
@@ -25,8 +25,8 @@ AddParser(SceneComponentConstants.NAME_EFFECTLAYER, (parsedData: any, scene: Sce
     }
 });
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * The list of effect layers (highlights/glow) added to the scene
          * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/highlightLayer
@@ -49,7 +49,7 @@ declare module "../abstractScene" {
     }
 }
 
-AbstractScene.prototype.removeEffectLayer = function (toRemove: EffectLayer): number {
+Scene.prototype.removeEffectLayer = function (toRemove: EffectLayer): number {
     const index = this.effectLayers.indexOf(toRemove);
     if (index !== -1) {
         this.effectLayers.splice(index, 1);
@@ -58,7 +58,7 @@ AbstractScene.prototype.removeEffectLayer = function (toRemove: EffectLayer): nu
     return index;
 };
 
-AbstractScene.prototype.addEffectLayer = function (newEffectLayer: EffectLayer): void {
+Scene.prototype.addEffectLayer = function (newEffectLayer: EffectLayer): void {
     this.effectLayers.push(newEffectLayer);
 };
 
@@ -142,7 +142,7 @@ export class EffectLayerSceneComponent implements ISceneSerializableComponent {
      * Adds all the elements from the container to the scene
      * @param container the container holding the elements
      */
-    public addFromContainer(container: AbstractScene): void {
+    public addFromContainer(container: IAssetContainer): void {
         if (!container.effectLayers) {
             return;
         }
@@ -156,7 +156,7 @@ export class EffectLayerSceneComponent implements ISceneSerializableComponent {
      * @param container contains the elements to remove
      * @param dispose if the removed element should be disposed (default: false)
      */
-    public removeFromContainer(container: AbstractScene, dispose?: boolean): void {
+    public removeFromContainer(container: IAssetContainer, dispose?: boolean): void {
         if (!container.effectLayers) {
             return;
         }

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -2,7 +2,7 @@
 import { serialize } from "../Misc/decorators";
 import type { Nullable } from "../types";
 import type { Camera } from "../Cameras/camera";
-import type { Scene } from "../scene";
+import { Scene } from "../scene";
 import { Vector2 } from "../Maths/math.vector";
 import { VertexBuffer } from "../Buffers/buffer";
 import type { SubMesh } from "../Meshes/subMesh";
@@ -15,7 +15,6 @@ import { Material } from "../Materials/material";
 import type { PostProcess } from "../PostProcesses/postProcess";
 import { BlurPostProcess } from "../PostProcesses/blurPostProcess";
 import { EffectLayer } from "./effectLayer";
-import { AbstractScene } from "../abstractScene";
 import { Constants } from "../Engines/constants";
 import { RegisterClass } from "../Misc/typeStore";
 import { Color4 } from "../Maths/math.color";
@@ -26,8 +25,8 @@ import { SerializationHelper } from "../Misc/decorators.serialization";
 import { GetExponentOfTwo } from "../Misc/tools.functions";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * Return the first glow layer of the scene with a given name.
          * @param name The name of the glow layer to look for.
@@ -37,7 +36,7 @@ declare module "../abstractScene" {
     }
 }
 
-AbstractScene.prototype.getGlowLayerByName = function (name: string): Nullable<GlowLayer> {
+Scene.prototype.getGlowLayerByName = function (name: string): Nullable<GlowLayer> {
     for (let index = 0; index < this.effectLayers?.length; index++) {
         if (this.effectLayers[index].name === name && this.effectLayers[index].getEffectName() === GlowLayer.EffectName) {
             return (<any>this.effectLayers[index]) as GlowLayer;

--- a/packages/dev/core/src/Layers/highlightLayer.ts
+++ b/packages/dev/core/src/Layers/highlightLayer.ts
@@ -4,7 +4,7 @@ import type { Observer } from "../Misc/observable";
 import { Observable } from "../Misc/observable";
 import type { Nullable } from "../types";
 import type { Camera } from "../Cameras/camera";
-import type { Scene } from "../scene";
+import { Scene } from "../scene";
 import { Vector2 } from "../Maths/math.vector";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { VertexBuffer } from "../Buffers/buffer";
@@ -20,7 +20,6 @@ import { PostProcess } from "../PostProcesses/postProcess";
 import { PassPostProcess } from "../PostProcesses/passPostProcess";
 import { BlurPostProcess } from "../PostProcesses/blurPostProcess";
 import { EffectLayer } from "./effectLayer";
-import { AbstractScene } from "../abstractScene";
 import { Constants } from "../Engines/constants";
 import { Logger } from "../Misc/logger";
 import { RegisterClass } from "../Misc/typeStore";
@@ -30,8 +29,8 @@ import { SerializationHelper } from "../Misc/decorators.serialization";
 import { GetExponentOfTwo } from "../Misc/tools.functions";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * Return a the first highlight layer of the scene with a given name.
          * @param name The name of the highlight layer to look for.
@@ -41,7 +40,7 @@ declare module "../abstractScene" {
     }
 }
 
-AbstractScene.prototype.getHighlightLayerByName = function (name: string): Nullable<HighlightLayer> {
+Scene.prototype.getHighlightLayerByName = function (name: string): Nullable<HighlightLayer> {
     for (let index = 0; index < this.effectLayers?.length; index++) {
         if (this.effectLayers[index].name === name && this.effectLayers[index].getEffectName() === HighlightLayer.EffectName) {
             return (<any>this.effectLayers[index]) as HighlightLayer;

--- a/packages/dev/core/src/Layers/layerSceneComponent.ts
+++ b/packages/dev/core/src/Layers/layerSceneComponent.ts
@@ -5,11 +5,11 @@ import type { ISceneComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
 import type { Layer } from "./layer";
 import type { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
-import type { AbstractScene } from "../abstractScene";
 import { EngineStore } from "../Engines/engineStore";
+import type { IAssetContainer } from "core/IAssetContainer";
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * The list of layers (background and foreground) of the scene
          */
@@ -160,7 +160,7 @@ export class LayerSceneComponent implements ISceneComponent {
      * Adds all the elements from the container to the scene
      * @param container the container holding the elements
      */
-    public addFromContainer(container: AbstractScene): void {
+    public addFromContainer(container: IAssetContainer): void {
         if (!container.layers) {
             return;
         }
@@ -174,7 +174,7 @@ export class LayerSceneComponent implements ISceneComponent {
      * @param container contains the elements to remove
      * @param dispose if the removed element should be disposed (default: false)
      */
-    public removeFromContainer(container: AbstractScene, dispose = false): void {
+    public removeFromContainer(container: IAssetContainer, dispose = false): void {
         if (!container.layers) {
             return;
         }

--- a/packages/dev/core/src/LensFlares/lensFlareSystemSceneComponent.ts
+++ b/packages/dev/core/src/LensFlares/lensFlareSystemSceneComponent.ts
@@ -1,13 +1,13 @@
 import { Tools } from "../Misc/tools";
 import type { Nullable } from "../types";
 import type { Camera } from "../Cameras/camera";
-import type { Scene } from "../scene";
+import { Scene } from "../scene";
 import type { ISceneSerializableComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
-import { AbstractScene } from "../abstractScene";
 import type { AssetContainer } from "../assetContainer";
 import { LensFlareSystem } from "./lensFlareSystem";
 import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 // Adds the parser to the scene parsers.
 AddParser(SceneComponentConstants.NAME_LENSFLARESYSTEM, (parsedData: any, scene: Scene, container: AssetContainer, rootUrl: string) => {
@@ -25,8 +25,8 @@ AddParser(SceneComponentConstants.NAME_LENSFLARESYSTEM, (parsedData: any, scene:
     }
 });
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * The list of lens flare system added to the scene
          * @see https://doc.babylonjs.com/features/featuresDeepDive/environment/lenseFlare
@@ -70,7 +70,7 @@ declare module "../abstractScene" {
     }
 }
 
-AbstractScene.prototype.getLensFlareSystemByName = function (name: string): Nullable<LensFlareSystem> {
+Scene.prototype.getLensFlareSystemByName = function (name: string): Nullable<LensFlareSystem> {
     for (let index = 0; index < this.lensFlareSystems.length; index++) {
         if (this.lensFlareSystems[index].name === name) {
             return this.lensFlareSystems[index];
@@ -80,7 +80,7 @@ AbstractScene.prototype.getLensFlareSystemByName = function (name: string): Null
     return null;
 };
 
-AbstractScene.prototype.getLensFlareSystemById = function (id: string): Nullable<LensFlareSystem> {
+Scene.prototype.getLensFlareSystemById = function (id: string): Nullable<LensFlareSystem> {
     for (let index = 0; index < this.lensFlareSystems.length; index++) {
         if (this.lensFlareSystems[index].id === id) {
             return this.lensFlareSystems[index];
@@ -90,11 +90,11 @@ AbstractScene.prototype.getLensFlareSystemById = function (id: string): Nullable
     return null;
 };
 
-AbstractScene.prototype.getLensFlareSystemByID = function (id: string): Nullable<LensFlareSystem> {
+Scene.prototype.getLensFlareSystemByID = function (id: string): Nullable<LensFlareSystem> {
     return this.getLensFlareSystemById(id);
 };
 
-AbstractScene.prototype.removeLensFlareSystem = function (toRemove: LensFlareSystem): number {
+Scene.prototype.removeLensFlareSystem = function (toRemove: LensFlareSystem): number {
     const index = this.lensFlareSystems.indexOf(toRemove);
     if (index !== -1) {
         this.lensFlareSystems.splice(index, 1);
@@ -102,7 +102,7 @@ AbstractScene.prototype.removeLensFlareSystem = function (toRemove: LensFlareSys
     return index;
 };
 
-AbstractScene.prototype.addLensFlareSystem = function (newLensFlareSystem: LensFlareSystem): void {
+Scene.prototype.addLensFlareSystem = function (newLensFlareSystem: LensFlareSystem): void {
     this.lensFlareSystems.push(newLensFlareSystem);
 };
 
@@ -152,7 +152,7 @@ export class LensFlareSystemSceneComponent implements ISceneSerializableComponen
      * Adds all the elements from the container to the scene
      * @param container the container holding the elements
      */
-    public addFromContainer(container: AbstractScene): void {
+    public addFromContainer(container: IAssetContainer): void {
         if (!container.lensFlareSystems) {
             return;
         }
@@ -166,7 +166,7 @@ export class LensFlareSystemSceneComponent implements ISceneSerializableComponen
      * @param container contains the elements to remove
      * @param dispose if the removed element should be disposed (default: false)
      */
-    public removeFromContainer(container: AbstractScene, dispose?: boolean): void {
+    public removeFromContainer(container: IAssetContainer, dispose?: boolean): void {
         if (!container.lensFlareSystems) {
             return;
         }

--- a/packages/dev/core/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
@@ -5,8 +5,8 @@ import { ShadowGenerator } from "./shadowGenerator";
 import { CascadedShadowGenerator } from "./cascadedShadowGenerator";
 import type { ISceneSerializableComponent } from "../../sceneComponent";
 import { SceneComponentConstants } from "../../sceneComponent";
-import type { AbstractScene } from "../../abstractScene";
 import { AddParser } from "core/Loading/Plugins/babylonFileParser.function";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 // Adds the parser to the scene parsers.
 AddParser(SceneComponentConstants.NAME_SHADOWGENERATOR, (parsedData: any, scene: Scene) => {
@@ -87,7 +87,7 @@ export class ShadowGeneratorSceneComponent implements ISceneSerializableComponen
      * @param container the container holding the elements
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public addFromContainer(container: AbstractScene): void {
+    public addFromContainer(container: IAssetContainer): void {
         // Nothing To Do Here. (directly attached to a light)
     }
 
@@ -97,7 +97,7 @@ export class ShadowGeneratorSceneComponent implements ISceneSerializableComponen
      * @param dispose if the removed element should be disposed (default: false)
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public removeFromContainer(container: AbstractScene, dispose?: boolean): void {
+    public removeFromContainer(container: IAssetContainer, dispose?: boolean): void {
         // Nothing To Do Here. (directly attached to a light)
     }
 

--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTextureSceneComponent.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTextureSceneComponent.ts
@@ -5,8 +5,8 @@ import { SceneComponentConstants } from "../../../sceneComponent";
 
 import type { ProceduralTexture } from "./proceduralTexture";
 
-declare module "../../../abstractScene" {
-    export interface AbstractScene {
+declare module "../../../scene" {
+    export interface Scene {
         /**
          * The list of procedural textures added to the scene
          * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/proceduralTextures

--- a/packages/dev/core/src/Materials/Textures/baseTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/baseTexture.ts
@@ -13,10 +13,10 @@ import { RandomGUID } from "../../Misc/guid";
 import "../../Misc/fileTools";
 import type { AbstractEngine } from "../../Engines/abstractEngine";
 import { ThinTexture } from "./thinTexture";
-import type { AbstractScene } from "../../abstractScene";
 
 import type { Animation } from "../../Animations/animation";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 /**
  * Base class of all the textures in babylon.
@@ -503,7 +503,7 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
     }
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     protected _loadingError: boolean = false;
     protected _errorObject?: {

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -24,7 +24,6 @@ import { DrawWrapper } from "./drawWrapper";
 import { MaterialStencilState } from "./materialStencilState";
 import { ScenePerformancePriority } from "../scene";
 import type { Scene } from "../scene";
-import type { AbstractScene } from "../abstractScene";
 import type {
     MaterialPluginDisposed,
     MaterialPluginIsReadyForSubMesh,
@@ -52,6 +51,7 @@ import type { InstancedMesh } from "../Meshes/instancedMesh";
 import { BindSceneUniformBuffer } from "./materialHelper.functions";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import { ShaderLanguage } from "./shaderLanguage";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 declare let BABYLON: any;
 
@@ -865,7 +865,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     public meshMap: Nullable<{ [id: string]: AbstractMesh | undefined }> = null;
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /** @internal */
     public _dirtyCallbacks: { [code: number]: () => void };

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -16,7 +16,6 @@ import { Tools } from "../Misc/tools";
 import { Tags } from "../Misc/tags";
 import type { DataBuffer } from "../Buffers/dataBuffer";
 import { extractMinAndMax } from "../Maths/math.functions";
-import type { AbstractScene } from "../abstractScene";
 import { EngineStore } from "../Engines/engineStore";
 import { useOpenGLOrientationForUV } from "../Compat/compatibilityOptions";
 
@@ -25,6 +24,7 @@ import type { Buffer } from "../Buffers/buffer";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { ThinEngine } from "../Engines/thinEngine";
 import { CopyFloatData } from "../Buffers/bufferUtils";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 /**
  * Class used to store geometry data (vertex buffers + index buffer)
@@ -86,7 +86,7 @@ export class Geometry implements IGetSetVerticesData {
     private _positionsCache: Vector3[] = [];
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /**
      *  Gets or sets the Bias Vector to apply on the bounding elements (box/sphere), the max extend is computed as v += v * bias.x + bias.y, the min is computed as v -= v * bias.x + bias.y

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -9,7 +9,7 @@ import { MorphTarget } from "./morphTarget";
 import { Constants } from "../Engines/constants";
 import type { Effect } from "../Materials/effect";
 import { RawTexture2DArray } from "../Materials/Textures/rawTexture2DArray";
-import type { AbstractScene } from "../abstractScene";
+import type { IAssetContainer } from "core/IAssetContainer";
 /**
  * This class is used to deform meshes using morphing between different targets
  * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/morphTargets
@@ -49,7 +49,7 @@ export class MorphTargetManager implements IDisposable {
     public _morphTargetTextureIndices: Float32Array;
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /** @internal */
     public _targetStoreTexture: Nullable<RawTexture2DArray>;

--- a/packages/dev/core/src/PostProcesses/postProcess.ts
+++ b/packages/dev/core/src/PostProcesses/postProcess.ts
@@ -15,7 +15,6 @@ import { serialize, serializeAsColor4 } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import { GetClass, RegisterClass } from "../Misc/typeStore";
 import { DrawWrapper } from "../Materials/drawWrapper";
-import type { AbstractScene } from "../abstractScene";
 import type { RenderTargetWrapper } from "../Engines/renderTargetWrapper";
 import { ShaderLanguage } from "../Materials/shaderLanguage";
 
@@ -26,6 +25,7 @@ import type { PrePassRenderer } from "../Rendering/prePassRenderer";
 import type { PrePassEffectConfiguration } from "../Rendering/prePassEffectConfiguration";
 import { AbstractEngine } from "../Engines/abstractEngine";
 import { GetExponentOfTwo } from "../Misc/tools.functions";
+import type { IAssetContainer } from "core/IAssetContainer";
 
 declare module "../Engines/abstractEngine" {
     export interface AbstractEngine {
@@ -224,7 +224,7 @@ export class PostProcess {
     public static ForceGLSL = false;
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     private static _CustomShaderCodeProcessing: { [postProcessName: string]: PostProcessCustomShaderCodeProcessing } = {};
 

--- a/packages/dev/core/src/Probes/reflectionProbe.ts
+++ b/packages/dev/core/src/Probes/reflectionProbe.ts
@@ -4,13 +4,13 @@ import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { Matrix, Vector3 } from "../Maths/math.vector";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { Nullable } from "../types";
-import { AbstractScene } from "../abstractScene";
-import type { Scene } from "../scene";
+import { Scene } from "../scene";
 import { Constants } from "../Engines/constants";
 import type { UniformBuffer } from "../Materials/uniformBuffer";
+import type { IAssetContainer } from "core/IAssetContainer";
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /**
          * The list of reflection probes added to the scene
          * @see https://doc.babylonjs.com/features/featuresDeepDive/environment/reflectionProbes
@@ -32,7 +32,7 @@ declare module "../abstractScene" {
     }
 }
 
-AbstractScene.prototype.removeReflectionProbe = function (toRemove: ReflectionProbe): number {
+Scene.prototype.removeReflectionProbe = function (toRemove: ReflectionProbe): number {
     if (!this.reflectionProbes) {
         return -1;
     }
@@ -45,7 +45,7 @@ AbstractScene.prototype.removeReflectionProbe = function (toRemove: ReflectionPr
     return index;
 };
 
-AbstractScene.prototype.addReflectionProbe = function (newReflectionProbe: ReflectionProbe): void {
+Scene.prototype.addReflectionProbe = function (newReflectionProbe: ReflectionProbe): void {
     if (!this.reflectionProbes) {
         this.reflectionProbes = [];
     }
@@ -81,7 +81,7 @@ export class ReflectionProbe {
     public metadata: any = null;
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /**
      * Creates a new reflection probe

--- a/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderer.ts
+++ b/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderer.ts
@@ -18,8 +18,8 @@ import { FluidRenderingObjectCustomParticles } from "./fluidRenderingObjectCusto
 import { FluidRenderingDepthTextureCopy } from "./fluidRenderingDepthTextureCopy";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-declare module "../../abstractScene" {
-    export interface AbstractScene {
+declare module "../../scene" {
+    export interface Scene {
         /** @internal (Backing field) */
         _fluidRenderer: Nullable<FluidRenderer>;
 

--- a/packages/dev/core/src/Rendering/prePassRendererSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/prePassRendererSceneComponent.ts
@@ -12,8 +12,8 @@ import type { Camera } from "../Cameras/camera";
 import type { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import type { PrePassRenderTarget } from "../Materials/Textures/prePassRenderTarget";
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /** @internal (Backing field) */
         _prePassRenderer: Nullable<PrePassRenderer>;
 

--- a/packages/dev/core/src/Rendering/subSurfaceSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/subSurfaceSceneComponent.ts
@@ -20,8 +20,8 @@ AddParser(SceneComponentConstants.NAME_SUBSURFACE, (parsedData: any, scene: Scen
     }
 });
 
-declare module "../abstractScene" {
-    export interface AbstractScene {
+declare module "../scene" {
+    export interface Scene {
         /** @internal (Backing field) */
         _subSurfaceConfiguration: Nullable<SubSurfaceConfiguration>;
 

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -149,7 +149,7 @@ export class AbstractAssetContainer implements IAssetContainer {
     /**
      * The list of sounds
      */
-    public sounds: Sound[] = [];
+    public sounds: Nullable<Sound[]> = null;
 
     /**
      * The list of effect layers added to the scene

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -1,4 +1,3 @@
-import { AbstractScene } from "./abstractScene";
 import type { Scene } from "./scene";
 import { Mesh } from "./Meshes/mesh";
 import { TransformNode } from "./Meshes/transformNode";
@@ -18,11 +17,183 @@ import { InstancedMesh } from "./Meshes/instancedMesh";
 import { Light } from "./Lights/light";
 import { Camera } from "./Cameras/camera";
 import { Tools } from "./Misc/tools";
+import type { IParticleSystem } from "./Particles/IParticleSystem";
+import type { IAssetContainer } from "./IAssetContainer";
+import type { Animation } from "./Animations/animation";
+import type { MorphTargetManager } from "./Morph/morphTargetManager";
+import type { Geometry } from "./Meshes/geometry";
+import type { AbstractActionManager } from "./Actions/abstractActionManager";
+import type { BaseTexture } from "./Materials/Textures/baseTexture";
+import type { PostProcess } from "./PostProcesses/postProcess";
+import type { Sound } from "./Audio/sound";
+import type { Layer } from "./Layers/layer";
+import type { EffectLayer } from "./Layers";
+import type { ReflectionProbe } from "./Probes/reflectionProbe";
+import type { LensFlareSystem } from "./LensFlares/lensFlareSystem";
+import type { ProceduralTexture } from "./Materials/Textures/Procedurals/proceduralTexture";
+
+/**
+ * Root class for AssetContainer and KeepAssets
+ */
+export class AbstractAssetContainer implements IAssetContainer {
+    /**
+     * Gets the list of root nodes (ie. nodes with no parent)
+     */
+    public rootNodes: Node[] = [];
+
+    /** All of the cameras added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras
+     */
+    public cameras: Camera[] = [];
+
+    /**
+     * All of the lights added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction
+     */
+    public lights: Light[] = [];
+
+    /**
+     * All of the (abstract) meshes added to this scene
+     */
+    public meshes: AbstractMesh[] = [];
+
+    /**
+     * The list of skeletons added to the scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/bonesSkeletons
+     */
+    public skeletons: Skeleton[] = [];
+
+    /**
+     * All of the particle systems added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_system_intro
+     */
+    public particleSystems: IParticleSystem[] = [];
+
+    /**
+     * Gets a list of Animations associated with the scene
+     */
+    public animations: Animation[] = [];
+
+    /**
+     * All of the animation groups added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/animation/groupAnimations
+     */
+    public animationGroups: AnimationGroup[] = [];
+
+    /**
+     * All of the multi-materials added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/multiMaterials
+     */
+    public multiMaterials: MultiMaterial[] = [];
+
+    /**
+     * All of the materials added to this scene
+     * In the context of a Scene, it is not supposed to be modified manually.
+     * Any addition or removal should be done using the addMaterial and removeMaterial Scene methods.
+     * Note also that the order of the Material within the array is not significant and might change.
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/materials_introduction
+     */
+    public materials: Material[] = [];
+
+    /**
+     * The list of morph target managers added to the scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/dynamicMeshMorph
+     */
+    public morphTargetManagers: MorphTargetManager[] = [];
+
+    /**
+     * The list of geometries used in the scene.
+     */
+    public geometries: Geometry[] = [];
+
+    /**
+     * All of the transform nodes added to this scene
+     * In the context of a Scene, it is not supposed to be modified manually.
+     * Any addition or removal should be done using the addTransformNode and removeTransformNode Scene methods.
+     * Note also that the order of the TransformNode within the array is not significant and might change.
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/transform_node
+     */
+    public transformNodes: TransformNode[] = [];
+
+    /**
+     * ActionManagers available on the scene.
+     * @deprecated
+     */
+    public actionManagers: AbstractActionManager[] = [];
+
+    /**
+     * Textures to keep.
+     */
+    public textures: BaseTexture[] = [];
+
+    /** @internal */
+    protected _environmentTexture: Nullable<BaseTexture> = null;
+    /**
+     * Texture used in all pbr material as the reflection texture.
+     * As in the majority of the scene they are the same (exception for multi room and so on),
+     * this is easier to reference from here than from all the materials.
+     */
+    public get environmentTexture(): Nullable<BaseTexture> {
+        return this._environmentTexture;
+    }
+
+    public set environmentTexture(value: Nullable<BaseTexture>) {
+        this._environmentTexture = value;
+    }
+
+    /**
+     * The list of postprocesses added to the scene
+     */
+    public postProcesses: PostProcess[] = [];
+
+    /**
+     * The list of sounds
+     */
+    public sounds: Sound[] = [];
+
+    /**
+     * The list of effect layers added to the scene
+     */
+    public effectLayers: EffectLayer[] = [];
+
+    /**
+     * The list of layers added to the scene
+     */
+    public layers: Layer[] = [];
+
+    /**
+     * The list of reflection probes added to the scene
+     */
+    public reflectionProbes: ReflectionProbe[];
+
+    /**
+     * The list of lens flare systems added to the scene
+     */
+    public lensFlareSystems: LensFlareSystem[];
+
+    /**
+     * The list of procedural textures added to the scene
+     */
+    public proceduralTextures: ProceduralTexture[];
+
+    /**
+     * @returns all meshes, lights, cameras, transformNodes and bones
+     */
+    public getNodes(): Array<Node> {
+        let nodes: Node[] = [];
+        nodes = nodes.concat(this.meshes);
+        nodes = nodes.concat(this.lights);
+        nodes = nodes.concat(this.cameras);
+        nodes = nodes.concat(this.transformNodes); // dummies
+        this.skeletons.forEach((skeleton) => (nodes = nodes.concat(skeleton.bones)));
+        return nodes;
+    }
+}
 
 /**
  * Set of assets to keep when moving a scene into an asset container.
  */
-export class KeepAssets extends AbstractScene {}
+export class KeepAssets extends AbstractAssetContainer {}
 
 /**
  * Class used to store the output of the AssetContainer.instantiateAllMeshesToScene function
@@ -67,7 +238,7 @@ export class InstantiatedEntries {
 /**
  * Container with a set of assets that can be added or removed from a scene.
  */
-export class AssetContainer extends AbstractScene {
+export class AssetContainer extends AbstractAssetContainer {
     private _wasAddedToScene = false;
     private _onContextRestoredObserver: Nullable<Observer<AbstractEngine>>;
 
@@ -87,12 +258,7 @@ export class AssetContainer extends AbstractScene {
             return;
         }
         this.scene = scene;
-        this["sounds"] = [];
-        this["effectLayers"] = [];
-        this["layers"] = [];
-        this["lensFlareSystems"] = [];
         this["proceduralTextures"] = [];
-        this["reflectionProbes"] = [];
 
         scene.onDisposeObservable.add(() => {
             if (!this._wasAddedToScene) {

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -164,7 +164,7 @@ export class AbstractAssetContainer implements IAssetContainer {
     /**
      * The list of reflection probes added to the scene
      */
-    public reflectionProbes: ReflectionProbe[];
+    public reflectionProbes: ReflectionProbe[] = [];
 
     /**
      * The list of lens flare systems added to the scene

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -27,7 +27,7 @@ import type { BaseTexture } from "./Materials/Textures/baseTexture";
 import type { PostProcess } from "./PostProcesses/postProcess";
 import type { Sound } from "./Audio/sound";
 import type { Layer } from "./Layers/layer";
-import type { EffectLayer } from "./Layers";
+import type { EffectLayer } from "./Layers/effectLayer";
 import type { ReflectionProbe } from "./Probes/reflectionProbe";
 import type { LensFlareSystem } from "./LensFlares/lensFlareSystem";
 import type { ProceduralTexture } from "./Materials/Textures/Procedurals/proceduralTexture";

--- a/packages/dev/core/src/index.ts
+++ b/packages/dev/core/src/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-internal-modules */
-export * from "./abstractScene";
 export * from "./Actions/index";
 export * from "./Animations/index";
 export * from "./assetContainer";

--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -11,7 +11,6 @@ import { EngineStore } from "./Engines/engineStore";
 import { _WarnImport } from "./Misc/devTools";
 import type { AbstractActionManager } from "./Actions/abstractActionManager";
 import type { IInspectable } from "./Misc/iInspectable";
-import type { AbstractScene } from "./abstractScene";
 import type { IAccessibilityTag } from "./IAccessibilityTag";
 import type { AnimationRange } from "./Animations/animationRange";
 import type { AnimationPropertiesOverride } from "./Animations/animationPropertiesOverride";
@@ -19,6 +18,7 @@ import type { AbstractMesh } from "./Meshes/abstractMesh";
 import type { Animation } from "./Animations/animation";
 import type { Animatable } from "./Animations/animatable";
 import { SerializationHelper } from "./Misc/decorators.serialization";
+import type { IAssetContainer } from "./IAssetContainer";
 
 /**
  * Defines how a node can be built from a string name.
@@ -164,7 +164,7 @@ export class Node implements IBehaviorAware<Node> {
     }
 
     /** @internal */
-    public _parentContainer: Nullable<AbstractScene> = null;
+    public _parentContainer: Nullable<IAssetContainer> = null;
 
     /**
      * Gets a list of Animations associated with the node

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -90,7 +90,7 @@ import { PointerPickingConfiguration } from "./Inputs/pointerPickingConfiguratio
 import { Logger } from "./Misc/logger";
 import type { AbstractEngine } from "./Engines/abstractEngine";
 import { RegisterClass } from "./Misc/typeStore";
-import { IAssetContainer } from "./IAssetContainer";
+import type { IAssetContainer } from "./IAssetContainer";
 
 /**
  * Define an interface for all classes that will hold resources
@@ -1765,8 +1765,6 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
      * @param options defines the scene options
      */
     constructor(engine: AbstractEngine, options?: SceneOptions) {
-        super();
-
         this.activeCameras = [] as Camera[];
 
         const fullOptions = {

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -12,7 +12,6 @@ import { Tags } from "./Misc/tags";
 import type { Vector2, Vector4 } from "./Maths/math.vector";
 import { Vector3, Matrix, TmpVectors } from "./Maths/math.vector";
 import type { IParticleSystem } from "./Particles/IParticleSystem";
-import { AbstractScene } from "./abstractScene";
 import { ImageProcessingConfiguration } from "./Materials/imageProcessingConfiguration";
 import { UniformBuffer } from "./Materials/uniformBuffer";
 import { PickingInfo } from "./Collisions/pickingInfo";
@@ -91,6 +90,7 @@ import { PointerPickingConfiguration } from "./Inputs/pointerPickingConfiguratio
 import { Logger } from "./Misc/logger";
 import type { AbstractEngine } from "./Engines/abstractEngine";
 import { RegisterClass } from "./Misc/typeStore";
+import { IAssetContainer } from "./IAssetContainer";
 
 /**
  * Define an interface for all classes that will hold resources
@@ -142,7 +142,7 @@ export const enum ScenePerformancePriority {
  * Represents a scene to be rendered by the engine.
  * @see https://doc.babylonjs.com/features/featuresDeepDive/scene
  */
-export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHolder {
+export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     /** The fog is deactivated */
     public static readonly FOGMODE_NONE = Constants.FOGMODE_NONE;
     /** The fog density is following an exponential function */
@@ -222,28 +222,6 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * The material properties need to be setup according to the type of texture in use.
      */
     public environmentBRDFTexture: BaseTexture;
-
-    /**
-     * Texture used in all pbr material as the reflection texture.
-     * As in the majority of the scene they are the same (exception for multi room and so on),
-     * this is easier to reference from here than from all the materials.
-     */
-    public override get environmentTexture(): Nullable<BaseTexture> {
-        return this._environmentTexture;
-    }
-    /**
-     * Texture used in all pbr material as the reflection texture.
-     * As in the majority of the scene they are the same (exception for multi room and so on),
-     * this is easier to set here than in all the materials.
-     */
-    public override set environmentTexture(value: Nullable<BaseTexture>) {
-        if (this._environmentTexture === value) {
-            return;
-        }
-
-        this._environmentTexture = value;
-        this.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
-    }
 
     /**
      * Intensity of the environment in all pbr material.
@@ -384,6 +362,138 @@ export class Scene extends AbstractScene implements IAnimatable, IClipPlanesHold
      * Gets or sets the active clipplane 6
      */
     public clipPlane6: Nullable<Plane>;
+
+    /**
+     * Gets the list of root nodes (ie. nodes with no parent)
+     */
+    public rootNodes: Node[] = [];
+
+    /** All of the cameras added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras
+     */
+    public cameras: Camera[] = [];
+
+    /**
+     * All of the lights added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction
+     */
+    public lights: Light[] = [];
+
+    /**
+     * All of the (abstract) meshes added to this scene
+     */
+    public meshes: AbstractMesh[] = [];
+
+    /**
+     * The list of skeletons added to the scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/bonesSkeletons
+     */
+    public skeletons: Skeleton[] = [];
+
+    /**
+     * All of the particle systems added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/particles/particle_system/particle_system_intro
+     */
+    public particleSystems: IParticleSystem[] = [];
+
+    /**
+     * Gets a list of Animations associated with the scene
+     */
+    public animations: Animation[] = [];
+
+    /**
+     * All of the animation groups added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/animation/groupAnimations
+     */
+    public animationGroups: AnimationGroup[] = [];
+
+    /**
+     * All of the multi-materials added to this scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/multiMaterials
+     */
+    public multiMaterials: MultiMaterial[] = [];
+
+    /**
+     * All of the materials added to this scene
+     * In the context of a Scene, it is not supposed to be modified manually.
+     * Any addition or removal should be done using the addMaterial and removeMaterial Scene methods.
+     * Note also that the order of the Material within the array is not significant and might change.
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/materials/using/materials_introduction
+     */
+    public materials: Material[] = [];
+
+    /**
+     * The list of morph target managers added to the scene
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/dynamicMeshMorph
+     */
+    public morphTargetManagers: MorphTargetManager[] = [];
+
+    /**
+     * The list of geometries used in the scene.
+     */
+    public geometries: Geometry[] = [];
+
+    /**
+     * All of the transform nodes added to this scene
+     * In the context of a Scene, it is not supposed to be modified manually.
+     * Any addition or removal should be done using the addTransformNode and removeTransformNode Scene methods.
+     * Note also that the order of the TransformNode within the array is not significant and might change.
+     * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/parent_pivot/transform_node
+     */
+    public transformNodes: TransformNode[] = [];
+
+    /**
+     * ActionManagers available on the scene.
+     * @deprecated
+     */
+    public actionManagers: AbstractActionManager[] = [];
+
+    /**
+     * Textures to keep.
+     */
+    public textures: BaseTexture[] = [];
+
+    /** @internal */
+    protected _environmentTexture: Nullable<BaseTexture> = null;
+    /**
+     * Texture used in all pbr material as the reflection texture.
+     * As in the majority of the scene they are the same (exception for multi room and so on),
+     * this is easier to reference from here than from all the materials.
+     */
+    public get environmentTexture(): Nullable<BaseTexture> {
+        return this._environmentTexture;
+    }
+    /**
+     * Texture used in all pbr material as the reflection texture.
+     * As in the majority of the scene they are the same (exception for multi room and so on),
+     * this is easier to set here than in all the materials.
+     */
+    public set environmentTexture(value: Nullable<BaseTexture>) {
+        if (this._environmentTexture === value) {
+            return;
+        }
+
+        this._environmentTexture = value;
+        this.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+    }
+
+    /**
+     * The list of postprocesses added to the scene
+     */
+    public postProcesses: PostProcess[] = [];
+
+    /**
+     * @returns all meshes, lights, cameras, transformNodes and bones
+     */
+    public getNodes(): Array<Node> {
+        let nodes: Node[] = [];
+        nodes = nodes.concat(this.meshes);
+        nodes = nodes.concat(this.lights);
+        nodes = nodes.concat(this.cameras);
+        nodes = nodes.concat(this.transformNodes); // dummies
+        this.skeletons.forEach((skeleton) => (nodes = nodes.concat(skeleton.bones)));
+        return nodes;
+    }
 
     /**
      * Gets or sets a boolean indicating if animations are enabled

--- a/packages/dev/core/src/sceneComponent.ts
+++ b/packages/dev/core/src/sceneComponent.ts
@@ -2,7 +2,6 @@ import type { Scene } from "./scene";
 import type { SmartArrayNoDuplicate } from "./Misc/smartArray";
 import type { Nullable } from "./types";
 import type { PickingInfo } from "./Collisions/pickingInfo";
-import type { AbstractScene } from "./abstractScene";
 import type { IPointerEvent } from "./Events/deviceInputEvents";
 
 import type { Mesh } from "./Meshes/mesh";
@@ -11,6 +10,7 @@ import type { Camera } from "./Cameras/camera";
 import type { AbstractMesh } from "./Meshes/abstractMesh";
 import type { SubMesh } from "./Meshes/subMesh";
 import type { RenderTargetTexture } from "./Materials/Textures/renderTargetTexture";
+import type { IAssetContainer } from "./IAssetContainer";
 
 /**
  * Groups all the scene component constants in one place to ease maintenance.
@@ -147,14 +147,14 @@ export interface ISceneSerializableComponent extends ISceneComponent {
      * Adds all the elements from the container to the scene
      * @param container the container holding the elements
      */
-    addFromContainer(container: AbstractScene): void;
+    addFromContainer(container: IAssetContainer): void;
 
     /**
      * Removes all the elements in the container from the scene
      * @param container contains the elements to remove
      * @param dispose if the removed element should be disposed (default: false)
      */
-    removeFromContainer(container: AbstractScene, dispose?: boolean): void;
+    removeFromContainer(container: IAssetContainer, dispose?: boolean): void;
 
     /**
      * Serializes the component data to the specified json object


### PR DESCRIPTION
AbstractScene was an internal class used to share data definition between Scene and AssetContainer. It was misleading and used to extend Scene (and this AssetContainer for no reason)

