### PR TITLE
Decal: Misc fixes for decal management

### DIFF
--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -266,6 +266,14 @@ export class ShaderMaterial extends PushMaterial {
     }
 
     /**
+     * Remove a texture from the material.
+     * @param name Define the name of the texture to remove
+     */
+    public removeTexture(name: string): void {
+        delete this._textures[name];
+    }
+
+    /**
      * Set a texture array in the shader.
      * @param name Define the name of the uniform sampler array as defined in the shader
      * @param textures Define the list of textures to bind to this sampler


### PR DESCRIPTION
See https://forum.babylonjs.com/t/user-texture-for-decalmap/53777

I've also simplified the use of `renderTexture` so that users don't have to call `isReady()` themselves. However, as calling `isReady()` can be time-consuming, it's possible to disable this feature in cases where the user knows everything is ready and doesn't need to double-check every time.