### PR TITLE
added floatarray stride mode for points

### DIFF
--- a/packages/dev/core/src/Meshes/Builders/greasedLineBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/greasedLineBuilder.ts
@@ -78,6 +78,19 @@ export const enum GreasedLineMeshWidthDistribution {
 }
 
 /**
+ * Options for converting the points to the internal number[][] format used by GreasedLine
+ */
+export interface GreasedLinePointsOptions {
+    /**
+     * If defined and a Float32Array is used for the points parameter,
+     * it will create multiple disconnected lines.
+     * This parameter defines how many entries from the array to use for one line.
+     * One entry = 3 float values.
+     */
+    floatArrayStride?: number;
+}
+
+/**
  * Material options for GreasedLineBuilder
  */
 export interface GreasedLineMaterialBuilderOptions extends GreasedLineMaterialOptions {
@@ -98,6 +111,10 @@ export interface GreasedLineMaterialBuilderOptions extends GreasedLineMaterialOp
  * Line mesh options for GreasedLineBuilder
  */
 export interface GreasedLineMeshBuilderOptions extends GreasedLineMeshOptions {
+    /**
+     * Options for converting the points.
+     */
+    pointsOptions?: GreasedLinePointsOptions;
     /**
      * Distribution of the widths if the width table contains fewer entries than needed. Defaults to GreasedLineMeshWidthDistribution.WIDTH_DISTRIBUTION_START
      * @see CompleteGreasedLineWidthTable
@@ -149,7 +166,7 @@ export function CreateGreasedLine(name: string, options: GreasedLineMeshBuilderO
     scene = <Scene>(scene ?? EngineStore.LastCreatedScene);
 
     let instance;
-    const allPoints = GreasedLineTools.ConvertPoints(options.points);
+    const allPoints = GreasedLineTools.ConvertPoints(options.points, options.pointsOptions);
 
     options.widthDistribution = options.widthDistribution ?? GreasedLineMeshWidthDistribution.WIDTH_DISTRIBUTION_START;
     if (options.ribbonOptions) {

--- a/packages/dev/core/src/Misc/greasedLineTools.ts
+++ b/packages/dev/core/src/Misc/greasedLineTools.ts
@@ -46,13 +46,12 @@ export class GreasedLineTools {
             if (options?.floatArrayStride) {
                 const positions: number[][] = [];
                 const stride = options.floatArrayStride * 3;
-                let linePoints = [];
                 for (let i = 0; i < points.length; i += stride) {
+                    const linePoints = new Array(stride); // Pre-allocate memory for the line
                     for (let j = 0; j < stride; j++) {
-                        linePoints.push(points[i + j]);
+                        linePoints[j] = points[i + j];
                     }
                     positions.push(linePoints);
-                    linePoints = [];
                 }
                 return positions;
             } else {

--- a/packages/dev/core/src/Misc/greasedLineTools.ts
+++ b/packages/dev/core/src/Misc/greasedLineTools.ts
@@ -11,6 +11,7 @@ import { RawTexture } from "../Materials/Textures/rawTexture";
 import type { Scene } from "../scene";
 import { Engine } from "../Engines/engine";
 import { GreasedLineMaterialDefaults } from "../Materials/GreasedLine/greasedLineMaterialDefaults";
+import type { GreasedLinePointsOptions } from "../Meshes/Builders/greasedLineBuilder";
 
 /**
  * Tool functions for GreasedLine
@@ -19,9 +20,10 @@ export class GreasedLineTools {
     /**
      * Converts GreasedLinePoints to number[][]
      * @param points GreasedLinePoints
+     * @param options GreasedLineToolsConvertPointsOptions
      * @returns number[][] with x, y, z coordinates of the points, like [[x, y, z, x, y, z, ...], [x, y, z, ...]]
      */
-    public static ConvertPoints(points: GreasedLinePoints): number[][] {
+    public static ConvertPoints(points: GreasedLinePoints, options?: GreasedLinePointsOptions): number[][] {
         if (points.length && Array.isArray(points) && typeof points[0] === "number") {
             return [<number[]>points];
         } else if (points.length && Array.isArray(points[0]) && typeof points[0][0] === "number") {
@@ -41,12 +43,27 @@ export class GreasedLineTools {
             });
             return positions;
         } else if (points instanceof Float32Array) {
-            return [Array.from(points)];
+            if (options?.floatArrayStride) {
+                const positions: number[][] = [];
+                const stride = options.floatArrayStride * 3;
+                let linePoints = [];
+                for (let i = 0; i < points.length; i += stride) {
+                    for (let j = 0; j < stride; j++) {
+                        linePoints.push(points[i + j]);
+                    }
+                    positions.push(linePoints);
+                    linePoints = [];
+                }
+                return positions;
+            } else {
+                return [Array.from(points)];
+            }
         } else if (points.length && points[0] instanceof Float32Array) {
             const positions: number[][] = [];
             points.forEach((p) => {
                 positions.push(Array.from(p as Float32Array));
             });
+
             return positions;
         }
 


### PR DESCRIPTION
User can provide a flat Float32Array as points coordinates and set a stride option to draw separate lines.

https://forum.babylonjs.com/t/low-level-havok-debug-lines-visualization/53484/41?u=roland

#TCURLI#3