### PR TITLE
dont sync bbinfo fix

### DIFF
--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -203,7 +203,7 @@ export abstract class GreasedLineBaseMesh extends Mesh {
             this._updateColorPointers();
         }
         this._createVertexBuffers(this._options.ribbonOptions?.smoothShading);
-        this.refreshBoundingInfo();
+        !this.doNotSyncBoundingInfo && this.refreshBoundingInfo();
 
         this.greasedLineMaterial?.updateLazy();
     }

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts
@@ -201,7 +201,7 @@ export class GreasedLineMesh extends GreasedLineBaseMesh {
                 this._updateColorPointers();
             }
             this._createVertexBuffers();
-            this.refreshBoundingInfo();
+            !this.doNotSyncBoundingInfo && this.refreshBoundingInfo();
         }
     }
 

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.ts
@@ -206,7 +206,7 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
 
         if (!this._lazy) {
             this._createVertexBuffers();
-            this.refreshBoundingInfo();
+            !this.doNotSyncBoundingInfo && this.refreshBoundingInfo();
         }
     }
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/greasedline-mesh-doesnt-respect-donotsyncboundinginfo/53829