### PR TITLE
Spritemap

### DIFF
--- a/packages/dev/core/src/Shaders/spriteMap.fragment.fx
+++ b/packages/dev/core/src/Shaders/spriteMap.fragment.fx
@@ -72,17 +72,28 @@ void main(){
         vec2 ratio = frameData[2].xy / frameData[0].zw;
 
         //rotated
-        if (frameData[2].z == 1.){
+        #ifdef FR_CW
+            if (frameData[2].z == 1.){
+                tileUV.xy = tileUV.yx;
+            } else {
+                tileUV.xy = fract(tUV).xy;
+            }
             #ifdef FLIPU
                 tileUV.y = 1.0 - tileUV.y;
             #endif
-            tileUV.xy = tileUV.yx;
-        } else {
-            tileUV.xy = fract(tUV).xy;
-            #ifdef FLIPU
-                tileUV.y = 1.0 - tileUV.y;
-            #endif
-        }
+        #else
+            if (frameData[2].z == 1.){
+                #ifdef FLIPU
+                    tileUV.y = 1.0 - tileUV.y;
+                #endif
+                tileUV.xy = tileUV.yx;
+            } else {
+                tileUV.xy = fract(tUV).xy;
+                #ifdef FLIPU
+                    tileUV.y = 1.0 - tileUV.y;
+                #endif
+            }
+        #endif
 
 
         vec4 nc = texture2D(spriteSheet, tileUV * frameSize+offset);

--- a/packages/dev/core/src/Shaders/spriteMap.fragment.fx
+++ b/packages/dev/core/src/Shaders/spriteMap.fragment.fx
@@ -70,16 +70,20 @@ void main(){
         vec2 frameSize = (frameData[0].zw) / spriteMapSize;
         vec2 offset = frameData[0].xy * sheetUnits;
         vec2 ratio = frameData[2].xy / frameData[0].zw;
-
+        
         //rotated
         if (frameData[2].z == 1.){
+            #ifdef FLIPU
+                tileUV.y = 1.0 - tileUV.y;
+            #endif
             tileUV.xy = tileUV.yx;
         } else {
-            tileUV.xy = fract(tUV).xy;
+            tileUV.xy = 1.0 - fract(tUV).xy;
+            #ifdef FLIPU
+                tileUV.y = 1.0 - tileUV.y;
+            #endif
         }
-        #ifdef FLIPU
-            tileUV.y = 1.0 - tileUV.y;
-        #endif
+
 
         vec4 nc = texture2D(spriteSheet, tileUV * frameSize+offset);
         if (i == 0){

--- a/packages/dev/core/src/Shaders/spriteMap.fragment.fx
+++ b/packages/dev/core/src/Shaders/spriteMap.fragment.fx
@@ -95,7 +95,6 @@ void main(){
             }
         #endif
 
-
         vec4 nc = texture2D(spriteSheet, tileUV * frameSize+offset);
         if (i == 0){
             color = nc;

--- a/packages/dev/core/src/Shaders/spriteMap.fragment.fx
+++ b/packages/dev/core/src/Shaders/spriteMap.fragment.fx
@@ -70,7 +70,7 @@ void main(){
         vec2 frameSize = (frameData[0].zw) / spriteMapSize;
         vec2 offset = frameData[0].xy * sheetUnits;
         vec2 ratio = frameData[2].xy / frameData[0].zw;
-        
+
         //rotated
         if (frameData[2].z == 1.){
             #ifdef FLIPU
@@ -78,7 +78,7 @@ void main(){
             #endif
             tileUV.xy = tileUV.yx;
         } else {
-            tileUV.xy = 1.0 - fract(tUV).xy;
+            tileUV.xy = fract(tUV).xy;
             #ifdef FLIPU
                 tileUV.y = 1.0 - tileUV.y;
             #endif

--- a/packages/dev/core/src/Shaders/spriteMap.fragment.fx
+++ b/packages/dev/core/src/Shaders/spriteMap.fragment.fx
@@ -42,9 +42,7 @@ mat4 getFrameData(float frameID){
 void main(){
     vec4 color = vec4(0.);
     vec2 tileUV = fract(tUV);
-    #ifdef FLIPU
-        tileUV.y = 1.0 - tileUV.y;
-    #endif
+
 
     vec2 tileID = floor(tUV);
     vec2 sheetUnits = 1. / spriteMapSize;
@@ -56,16 +54,13 @@ void main(){
         #define LAYER_ID_SWITCH
 
         vec4 animationData = TEXTUREFUNC(animationMap, vec2((frameID + 0.5) / spriteCount, 0.), 0.);
-
         if(animationData.y > 0.) {
-
             mt = mod(time*animationData.z, 1.0);
             for(float f = 0.; f < MAX_ANIMATION_FRAMES; f++){
                 if(animationData.y > mt){
                     frameID = animationData.x;
                     break;
                 }
-
                 animationData = TEXTUREFUNC(animationMap, vec2((frameID + 0.5) / spriteCount, aFrameSteps * f), 0.);
             }
         }
@@ -79,7 +74,12 @@ void main(){
         //rotated
         if (frameData[2].z == 1.){
             tileUV.xy = tileUV.yx;
+        } else {
+            tileUV.xy = fract(tUV).xy;
         }
+        #ifdef FLIPU
+            tileUV.y = 1.0 - tileUV.y;
+        #endif
 
         vec4 nc = texture2D(spriteSheet, tileUV * frameSize+offset);
         if (i == 0){

--- a/packages/dev/core/src/Shaders/spriteMap.vertex.fx
+++ b/packages/dev/core/src/Shaders/spriteMap.vertex.fx
@@ -9,17 +9,17 @@ attribute vec2 uv;
 varying vec3 vPosition;
 varying vec2 vUV;
 varying vec2 tUV;
-varying vec2 stageUnits;
-varying vec2 levelUnits;
-varying vec2 tileID;
+// varying vec2 stageUnits;
+// varying vec2 levelUnits;
+// varying vec2 tileID;
 
 // Uniforms
 uniform float time;
 uniform mat4 worldViewProjection;
 
-uniform vec2 outputSize;
+// uniform vec2 outputSize;
 uniform vec2 stageSize;
-uniform vec2 spriteMapSize;
+// uniform vec2 spriteMapSize;
 
 uniform float stageScale;
 

--- a/packages/dev/core/src/Sprites/spriteMap.ts
+++ b/packages/dev/core/src/Sprites/spriteMap.ts
@@ -14,6 +14,11 @@ import "../Shaders/spriteMap.fragment";
 import "../Shaders/spriteMap.vertex";
 import { Constants } from "core/Engines/constants";
 
+export enum SpriteMapFrameRotationDirection {
+    CCW = 0,
+    CW = 1,
+}
+
 /**
  * Defines the basic options interface of a SpriteMap
  */
@@ -62,6 +67,12 @@ export interface ISpriteMapOptions {
      * Vector3 scalar of the global RGB values of the SpriteMap.
      */
     colorMultiply?: Vector3;
+
+    /**
+     * Rotation direction of the frame by 90 degrees.
+     * Applied when the the frame's "rotated" parameter is true.
+     */
+    frameRotationDirection?: SpriteMapFrameRotationDirection;
 }
 
 /**
@@ -210,6 +221,10 @@ export class SpriteMap implements ISpriteMap {
 
         const defines = [];
         defines.push("#define LAYERS " + options.layerCount);
+
+        if (options?.frameRotationDirection === SpriteMapFrameRotationDirection.CW) {
+            defines.push("#define FR_CW");
+        }
 
         if (options.flipU) {
             defines.push("#define FLIPU");

--- a/packages/dev/core/src/Sprites/spriteMap.ts
+++ b/packages/dev/core/src/Sprites/spriteMap.ts
@@ -302,6 +302,16 @@ export class SpriteMap implements ISpriteMap {
     }
 
     /**
+     * Returns the index of the frame for a given filename
+     * @param name filename of the frame
+     * @returns index of the frame
+     */
+    public getTileIdxByName(name: string): number {
+        const idx = this.atlasJSON.frames.findIndex((f) => f.filename === name);
+        return idx;
+    }
+
+    /**
      * Returns tileID location
      * @returns Vector2 the cell position ID
      */

--- a/packages/dev/core/src/Sprites/spriteMap.ts
+++ b/packages/dev/core/src/Sprites/spriteMap.ts
@@ -71,6 +71,7 @@ export interface ISpriteMapOptions {
     /**
      * Rotation direction of the frame by 90 degrees.
      * Applied when the the frame's "rotated" parameter is true.
+     * Default is CCW.
      */
     frameRotationDirection?: SpriteMapFrameRotationDirection;
 }


### PR DESCRIPTION
Fixing rotation of sprites in multiple layers.
https://forum.babylonjs.com/t/unexpected-rotation-on-multi-layered-spritemap/53668/5

#YCY2IL#2273

The tile in the right bottom corner in layer 0 must be brown and rotated however the torch musn't be rotated.