### PR TITLE
WebGPU: Fix buffer memory leak

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuBufferManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuBufferManager.ts
@@ -53,8 +53,9 @@ export class WebGPUBufferManager {
 
     public createBuffer(viewOrSize: ArrayBufferView | number, flags: GPUBufferUsageFlags, label?: string): WebGPUDataBuffer {
         const isView = (viewOrSize as ArrayBufferView).byteLength !== undefined;
-        const buffer = this.createRawBuffer(viewOrSize, flags, undefined, label);
-        const dataBuffer = new WebGPUDataBuffer(buffer);
+        const dataBuffer = new WebGPUDataBuffer();
+        const labelId = "DataBufferUniqueId=" + dataBuffer.uniqueId;
+        dataBuffer.buffer = this.createRawBuffer(viewOrSize, flags, undefined, label ? labelId + "-" + label : labelId);
         dataBuffer.references = 1;
         dataBuffer.capacity = isView ? (viewOrSize as ArrayBufferView).byteLength : (viewOrSize as number);
         dataBuffer.engineId = this._engine.uniqueId;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuPipelineContext.ts
@@ -134,6 +134,7 @@ export class WebGPUPipelineContext implements IPipelineContext {
             return;
         }
 
+        this.uniformBuffer?.dispose();
         this.uniformBuffer = new UniformBuffer(this.engine, undefined, undefined, "leftOver-" + this._name);
 
         for (const leftOverUniform of this.shaderProcessingContext.leftOverUniforms) {

--- a/packages/dev/core/src/Engines/index.ts
+++ b/packages/dev/core/src/Engines/index.ts
@@ -23,6 +23,7 @@ export * from "./WebGPU/webgpuCacheBindGroups";
 export * from "./WebGPU/webgpuCacheSampler";
 export * from "./WebGPU/webgpuDrawContext";
 export * from "./WebGPU/webgpuRenderTargetWrapper";
+export * from "./WebGPU/webgpuShaderProcessor";
 export * from "./WebGPU/webgpuTintWASM";
 export * from "./WebGL/webGL2ShaderProcessors";
 export * from "./nativeEngine";

--- a/packages/dev/core/src/Meshes/WebGPU/webgpuDataBuffer.ts
+++ b/packages/dev/core/src/Meshes/WebGPU/webgpuDataBuffer.ts
@@ -8,10 +8,16 @@ export class WebGPUDataBuffer extends DataBuffer {
     // Used to make sure the buffer is not recreated twice after a context loss/restoration
     public engineId = -1;
 
-    public constructor(resource: GPUBuffer, capacity = 0) {
+    public set buffer(buffer: Nullable<GPUBuffer>) {
+        this._buffer = buffer;
+    }
+
+    public constructor(resource?: GPUBuffer, capacity = 0) {
         super();
         this.capacity = capacity;
-        this._buffer = resource;
+        if (resource) {
+            this._buffer = resource;
+        }
     }
 
     public override get underlyingResource(): any {


### PR DESCRIPTION
I've also improved debugging a little by adding the buffer identifier to the buffer label. And I've exported `WebGPUShaderProcessor`, so we can access `BABYLON.WebGPUShaderProcessor.LeftOvertUBOName` from a PG (or anywhere else!).