### PR TITLE
Enable aggressive performance priority in viewer

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -26,7 +26,7 @@ import { CreateBox } from "core/Meshes/Builders/boxBuilder";
 import { computeMaxExtents } from "core/Meshes/meshUtils";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Observable } from "core/Misc/observable";
-import { Scene } from "core/scene";
+import { Scene, ScenePerformancePriority } from "core/scene";
 import { registerBuiltInLoaders } from "loaders/dynamic";
 
 function throwIfAborted(...abortSignals: (Nullable<AbortSignal> | undefined)[]): void {
@@ -179,6 +179,7 @@ export class Viewer implements IDisposable {
             scene: new Scene(this._engine),
             model: null,
         };
+        this._details.scene.performancePriority = ScenePerformancePriority.Aggressive;
         this._details.scene.clearColor = finalOptions.backgroundColor;
         this._camera = new ArcRotateCamera("camera1", 0, 0, 1, Vector3.Zero(), this._details.scene);
         this._camera.attachControl();

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -61,6 +61,7 @@ export class HTML3DElement extends LitElement {
 
         .full-size {
             display: block;
+            position: relative;
             width: 100%;
             height: 100%;
         }


### PR DESCRIPTION
This sets the viewer scene to use aggressive performance priority. I can see this improve performance for some models, and some of the effects of this (e.g. setting `alwaysSelectAsActiveMesh` on every mesh) are needed for upcoming enablement of WebGPU snapshot rendering mode in the viewer anyway.

I also tacked on one small css change that ensures the toolbar shows up in the right place when the viewer does not take up the full screen.