### PR TITLE
Remove use of RegisterClass

### DIFF
--- a/packages/dev/core/src/Actions/action.ts
+++ b/packages/dev/core/src/Actions/action.ts
@@ -2,7 +2,6 @@ import { Observable } from "../Misc/observable";
 import { Vector2, Vector3 } from "../Maths/math.vector";
 import { Color3, Color4 } from "../Maths/math.color";
 import type { Condition } from "./condition";
-import { RegisterClass } from "../Misc/typeStore";
 import type { AbstractActionManager } from "./abstractActionManager";
 import type { Nullable } from "../types";
 import type { Material } from "../Materials/material";
@@ -321,5 +320,3 @@ export class Action implements IAction {
         };
     };
 }
-
-RegisterClass("BABYLON.Action", Action);

--- a/packages/dev/core/src/Actions/condition.ts
+++ b/packages/dev/core/src/Actions/condition.ts
@@ -1,5 +1,4 @@
 import { Action } from "./action";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { ActionManager } from "./actionManager";
 
@@ -287,7 +286,3 @@ export class StateCondition extends Condition {
         });
     }
 }
-
-RegisterClass("BABYLON.ValueCondition", ValueCondition);
-RegisterClass("BABYLON.PredicateCondition", PredicateCondition);
-RegisterClass("BABYLON.StateCondition", StateCondition);

--- a/packages/dev/core/src/Actions/directActions.ts
+++ b/packages/dev/core/src/Actions/directActions.ts
@@ -3,7 +3,6 @@ import { Vector3 } from "../Maths/math.vector";
 import { Action } from "./action";
 import type { Condition } from "./condition";
 import { Constants } from "../Engines/constants";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { ActionEvent } from "./actionEvent";
 
@@ -567,15 +566,3 @@ export class SetParentAction extends Action {
         );
     }
 }
-
-RegisterClass("BABYLON.SetParentAction", SetParentAction);
-RegisterClass("BABYLON.ExecuteCodeAction", ExecuteCodeAction);
-RegisterClass("BABYLON.DoNothingAction", DoNothingAction);
-RegisterClass("BABYLON.StopAnimationAction", StopAnimationAction);
-RegisterClass("BABYLON.PlayAnimationAction", PlayAnimationAction);
-RegisterClass("BABYLON.IncrementValueAction", IncrementValueAction);
-RegisterClass("BABYLON.SetValueAction", SetValueAction);
-RegisterClass("BABYLON.SetStateAction", SetStateAction);
-RegisterClass("BABYLON.SetParentAction", SetParentAction);
-RegisterClass("BABYLON.SwitchBooleanAction", SwitchBooleanAction);
-RegisterClass("BABYLON.CombineAction", CombineAction);

--- a/packages/dev/core/src/Actions/directAudioActions.ts
+++ b/packages/dev/core/src/Actions/directAudioActions.ts
@@ -1,6 +1,5 @@
 import { Action } from "./action";
 import type { Condition } from "./condition";
-import { RegisterClass } from "../Misc/typeStore";
 import type { Sound } from "../Audio/sound";
 
 /**
@@ -92,6 +91,3 @@ export class StopSoundAction extends Action {
         );
     }
 }
-
-RegisterClass("BABYLON.PlaySoundAction", PlaySoundAction);
-RegisterClass("BABYLON.StopSoundAction", StopSoundAction);

--- a/packages/dev/core/src/Actions/interpolateValueAction.ts
+++ b/packages/dev/core/src/Actions/interpolateValueAction.ts
@@ -6,7 +6,6 @@ import { Observable } from "../Misc/observable";
 import { Color3 } from "../Maths/math.color";
 import { Vector3, Matrix, Quaternion } from "../Maths/math.vector";
 import { Animation } from "../Animations/animation";
-import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This defines an action responsible to change the value of a property
@@ -157,5 +156,3 @@ export class InterpolateValueAction extends Action {
         );
     }
 }
-
-RegisterClass("BABYLON.InterpolateValueAction", InterpolateValueAction);

--- a/packages/dev/core/src/Animations/animation.ts
+++ b/packages/dev/core/src/Animations/animation.ts
@@ -4,7 +4,6 @@ import { Color3, Color4 } from "../Maths/math.color";
 import { Hermite, Lerp } from "../Maths/math.scalar.functions";
 import type { DeepImmutable, Nullable } from "../types";
 import type { Scene } from "../scene";
-import { RegisterClass } from "../Misc/typeStore";
 import type { IAnimationKey } from "./animationKey";
 import { AnimationKeyInterpolation } from "./animationKey";
 import { AnimationRange } from "./animationRange";
@@ -1633,5 +1632,4 @@ export class Animation {
     public static CreateFromSnippetAsync = Animation.ParseFromSnippetAsync;
 }
 
-RegisterClass("BABYLON.Animation", Animation);
 Node._AnimationRangeFactory = (name: string, from: number, to: number) => new AnimationRange(name, from, to);

--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -11,7 +11,6 @@ import type { ISoundOptions } from "./Interfaces/ISoundOptions";
 import { EngineStore } from "../Engines/engineStore";
 import type { IAudioEngine } from "./Interfaces/IAudioEngine";
 import type { Observer } from "../Misc/observable";
-import { RegisterClass } from "../Misc/typeStore";
 import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
@@ -1327,6 +1326,3 @@ export class Sound {
         }
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.Sound", Sound);

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -17,7 +17,6 @@ import type { ArcRotateCameraMouseWheelInput } from "../Cameras/Inputs/arcRotate
 import { ArcRotateCameraInputsManager } from "../Cameras/arcRotateCameraInputsManager";
 import { Epsilon } from "../Maths/math.constants";
 import { Tools } from "../Misc/tools";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 import type { TransformNode } from "core/Meshes/transformNode";
@@ -1416,6 +1415,3 @@ export class ArcRotateCamera extends TargetCamera {
         return "ArcRotateCamera";
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.ArcRotateCamera", ArcRotateCamera);

--- a/packages/dev/core/src/Cameras/flyCamera.ts
+++ b/packages/dev/core/src/Cameras/flyCamera.ts
@@ -9,7 +9,6 @@ import { FlyCameraInputsManager } from "./flyCameraInputsManager";
 import type { FlyCameraMouseInput } from "../Cameras/Inputs/flyCameraMouseInput";
 import type { FlyCameraKeyboardInput } from "../Cameras/Inputs/flyCameraKeyboardInput";
 import { Tools } from "../Misc/tools";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 import { AbstractEngine } from "core/Engines/abstractEngine";
@@ -452,6 +451,3 @@ export class FlyCamera extends TargetCamera {
         return "FlyCamera";
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.FlyCamera", FlyCamera);

--- a/packages/dev/core/src/Cameras/followCamera.ts
+++ b/packages/dev/core/src/Cameras/followCamera.ts
@@ -7,7 +7,6 @@ import { TmpVectors, Vector3 } from "../Maths/math.vector";
 import { Node } from "../node";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { FollowCameraInputsManager } from "./followCameraInputsManager";
-import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("FollowCamera", (name, scene) => {
     return () => new FollowCamera(name, Vector3.Zero(), scene);
@@ -309,7 +308,3 @@ export class ArcFollowCamera extends TargetCamera {
         return "ArcFollowCamera";
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.FollowCamera", FollowCamera);
-RegisterClass("BABYLON.ArcFollowCamera", ArcFollowCamera);

--- a/packages/dev/core/src/Cameras/freeCamera.ts
+++ b/packages/dev/core/src/Cameras/freeCamera.ts
@@ -8,7 +8,6 @@ import { FreeCameraInputsManager } from "./freeCameraInputsManager";
 import type { FreeCameraMouseInput } from "../Cameras/Inputs/freeCameraMouseInput";
 import type { FreeCameraKeyboardMoveInput } from "../Cameras/Inputs/freeCameraKeyboardMoveInput";
 import { Tools } from "../Misc/tools";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { Collider } from "../Collisions/collider";
 import { AbstractEngine } from "core/Engines/abstractEngine";
@@ -455,6 +454,3 @@ export class FreeCamera extends TargetCamera {
         return "FreeCamera";
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.FreeCamera", FreeCamera);

--- a/packages/dev/core/src/Compute/computeShader.ts
+++ b/packages/dev/core/src/Compute/computeShader.ts
@@ -4,7 +4,6 @@ import type { Scene } from "../scene";
 import type { Nullable } from "../types";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
-import { RegisterClass } from "../Misc/typeStore";
 import type { ComputeEffect, IComputeEffectCreationOptions, IComputeShaderPath } from "./computeEffect";
 import type { ComputeBindingMapping } from "../Engines/Extensions/engine.computeShader";
 import { ComputeBindingType } from "../Engines/Extensions/engine.computeShader";
@@ -522,5 +521,3 @@ export class ComputeShader {
         return (buffer as DataBuffer).underlyingResource !== undefined;
     }
 }
-
-RegisterClass("BABYLON.ComputeShader", ComputeShader);

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -16,7 +16,6 @@ import type { PostProcess } from "../PostProcesses/postProcess";
 import { BlurPostProcess } from "../PostProcesses/blurPostProcess";
 import { EffectLayer } from "./effectLayer";
 import { Constants } from "../Engines/constants";
-import { RegisterClass } from "../Misc/typeStore";
 import { Color4 } from "../Maths/math.color";
 import type { PBRMaterial } from "../Materials/PBR/pbrMaterial";
 
@@ -748,5 +747,3 @@ export class GlowLayer extends EffectLayer {
         return gl;
     }
 }
-
-RegisterClass("BABYLON.GlowLayer", GlowLayer);

--- a/packages/dev/core/src/Layers/highlightLayer.ts
+++ b/packages/dev/core/src/Layers/highlightLayer.ts
@@ -22,7 +22,6 @@ import { BlurPostProcess } from "../PostProcesses/blurPostProcess";
 import { EffectLayer } from "./effectLayer";
 import { Constants } from "../Engines/constants";
 import { Logger } from "../Misc/logger";
-import { RegisterClass } from "../Misc/typeStore";
 import { Color4, Color3 } from "../Maths/math.color";
 
 import { SerializationHelper } from "../Misc/decorators.serialization";
@@ -978,5 +977,3 @@ export class HighlightLayer extends EffectLayer {
         return hl;
     }
 }
-
-RegisterClass("BABYLON.HighlightLayer", HighlightLayer);

--- a/packages/dev/core/src/Lights/directionalLight.ts
+++ b/packages/dev/core/src/Lights/directionalLight.ts
@@ -7,7 +7,6 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Light } from "./light";
 import { ShadowLight } from "./shadowLight";
 import type { Effect } from "../Materials/effect";
-import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_1", (name, scene) => {
     return () => new DirectionalLight(name, Vector3.Zero(), scene);
@@ -354,6 +353,3 @@ export class DirectionalLight extends ShadowLight {
         defines["DIRLIGHT" + lightIndex] = true;
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.DirectionalLight", DirectionalLight);

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -7,7 +7,6 @@ import { Node } from "../node";
 import type { Effect } from "../Materials/effect";
 import { Light } from "./light";
 import type { IShadowGenerator } from "./Shadows/shadowGenerator";
-import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_3", (name, scene) => {
     return () => new HemisphericLight(name, Vector3.Zero(), scene);
@@ -129,6 +128,3 @@ export class HemisphericLight extends Light {
         defines["HEMILIGHT" + lightIndex] = true;
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.HemisphericLight", HemisphericLight);

--- a/packages/dev/core/src/Lights/pointLight.ts
+++ b/packages/dev/core/src/Lights/pointLight.ts
@@ -6,7 +6,6 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Light } from "./light";
 import { ShadowLight } from "./shadowLight";
 import type { Effect } from "../Materials/effect";
-import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_0", (name, scene) => {
     return () => new PointLight(name, Vector3.Zero(), scene);
@@ -216,6 +215,3 @@ export class PointLight extends ShadowLight {
         defines["POINTLIGHT" + lightIndex] = true;
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.PointLight", PointLight);

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -11,7 +11,6 @@ import { ShadowLight } from "./shadowLight";
 import { Texture } from "../Materials/Textures/texture";
 import type { ProceduralTexture } from "../Materials/Textures/Procedurals/proceduralTexture";
 import type { Camera } from "../Cameras/camera";
-import { RegisterClass } from "../Misc/typeStore";
 
 Node.AddNodeConstructor("Light_Type_2", (name, scene) => {
     return () => new SpotLight(name, Vector3.Zero(), Vector3.Zero(), 0, 0, scene);
@@ -475,6 +474,3 @@ export class SpotLight extends ShadowLight {
         defines["PROJECTEDLIGHTTEXTURE" + lightIndex] = this.projectionTexture && this.projectionTexture.isReady() ? true : false;
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.SpotLight", SpotLight);

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -22,7 +22,6 @@ import { Texture } from "../../Materials/Textures/texture";
 import type { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture";
 import type { IShadowLight } from "../../Lights/shadowLight";
 import { Constants } from "../../Engines/constants";
-import { RegisterClass } from "../../Misc/typeStore";
 import { MaterialFlags } from "../materialFlags";
 import { Color3 } from "../../Maths/math.color";
 
@@ -1363,5 +1362,3 @@ export class BackgroundMaterial extends PushMaterial {
         return SerializationHelper.Parse(() => new BackgroundMaterial(source.name, scene), source, scene, rootUrl);
     }
 }
-
-RegisterClass("BABYLON.BackgroundMaterial", BackgroundMaterial);

--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
@@ -9,7 +9,6 @@ import { SerializationHelper } from "../../Misc/decorators.serialization";
 import { VertexBuffer } from "../../Buffers/buffer";
 import { MaterialDefines } from "../../Materials/materialDefines";
 import { PushMaterial } from "../../Materials/pushMaterial";
-import { RegisterClass } from "../../Misc/typeStore";
 import { addClipPlaneUniforms, bindClipPlane } from "../clipPlaneMaterialHelper";
 import { Camera } from "core/Cameras/camera";
 
@@ -307,5 +306,3 @@ export class GaussianSplattingMaterial extends PushMaterial {
         return SerializationHelper.Parse(() => new GaussianSplattingMaterial(source.name, scene), source, scene, rootUrl);
     }
 }
-
-RegisterClass("BABYLON.GaussianSplattingMaterial", GaussianSplattingMaterial);

--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterial.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterial.ts
@@ -10,7 +10,6 @@ import type { Material } from "../material";
 import { MaterialDefines } from "../materialDefines";
 import type { AbstractMesh } from "../../Meshes/abstractMesh";
 import type { BaseTexture } from "../Textures/baseTexture";
-import { RegisterClass } from "../../Misc/typeStore";
 import type { GreasedLineMaterialOptions, IGreasedLineMaterial } from "./greasedLineMaterialInterfaces";
 import { GreasedLineMeshColorDistributionType, GreasedLineMeshColorMode } from "./greasedLineMaterialInterfaces";
 import { GreasedLineMaterialDefaults } from "./greasedLineMaterialDefaults";
@@ -731,5 +730,3 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase implements IGr
         dest.markAllDefinesAsDirty();
     }
 }
-
-RegisterClass(`BABYLON.${GreasedLinePluginMaterial.GREASED_LINE_MATERIAL_NAME}`, GreasedLinePluginMaterial);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/clipPlanesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/clipPlanesBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Effect } from "../../../effect";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import type { Mesh } from "../../../../Meshes/mesh";
@@ -152,5 +151,3 @@ export class ClipPlanesBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ClipPlanesBlock", ClipPlanesBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
@@ -7,7 +7,6 @@ import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines, NodeMaterial } from "../../nodeMaterial";
 import type { BaseTexture } from "../../../Textures/baseTexture";
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { Texture } from "../../../Textures/texture";
 import type { Scene } from "../../../../scene";
 import type { InputBlock } from "../Input/inputBlock";
@@ -312,5 +311,3 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.CurrentScreenBlock", CurrentScreenBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/fogBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/fogBlock.ts
@@ -9,7 +9,6 @@ import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnect
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import { InputBlock } from "../Input/inputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 
 import { GetFogState } from "core/Materials/materialHelper.functions";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -199,5 +198,3 @@ export class FogBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.FogBlock", FogBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/imageSourceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/imageSourceBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Nullable } from "../../../../types";
 import { Texture } from "../../../Textures/texture";
 import { Constants } from "../../../../Engines/constants";
@@ -185,5 +184,3 @@ export class ImageSourceBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.ImageSourceBlock", ImageSourceBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -11,7 +11,6 @@ import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { InputBlock } from "../Input/inputBlock";
 import type { Light } from "../../../../Lights/light";
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Scene } from "../../../../scene";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 
@@ -472,5 +471,3 @@ export class LightBlock extends NodeMaterialBlock {
         this._setTarget();
     }
 }
-
-RegisterClass("BABYLON.LightBlock", LightBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -9,7 +9,6 @@ import { NodeMaterial } from "../../nodeMaterial";
 import type { Effect } from "../../../effect";
 import type { Mesh } from "../../../../Meshes/mesh";
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Scene } from "../../../../scene";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
@@ -606,5 +605,3 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
         this._setTarget();
     }
 }
-
-RegisterClass("BABYLON.ReflectionTextureBaseBlock", ReflectionTextureBaseBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBlock.ts
@@ -3,7 +3,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { NodeMaterial } from "../../nodeMaterial";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { ReflectionTextureBaseBlock } from "./reflectionTextureBaseBlock";
@@ -203,5 +202,3 @@ export class ReflectionTextureBlock extends ReflectionTextureBaseBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ReflectionTextureBlock", ReflectionTextureBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/sceneDepthBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/sceneDepthBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { BaseTexture } from "../../../Textures/baseTexture";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Scene } from "../../../../scene";
 import type { InputBlock } from "../Input/inputBlock";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
@@ -288,5 +287,3 @@ export class SceneDepthBlock extends NodeMaterialBlock {
         this.force32itsFloat = serializationObject.force32itsFloat;
     }
 }
-
-RegisterClass("BABYLON.SceneDepthBlock", SceneDepthBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -10,7 +10,6 @@ import { NodeMaterial } from "../../nodeMaterial";
 import { InputBlock } from "../Input/inputBlock";
 import type { Effect } from "../../../effect";
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { Texture } from "../../../Textures/texture";
 import type { Scene } from "../../../../scene";
 import { NodeMaterialModes } from "../../Enums/nodeMaterialModes";
@@ -715,5 +714,3 @@ export class TextureBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.TextureBlock", TextureBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/TBNBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/TBNBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
@@ -216,5 +215,3 @@ export class TBNBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.TBNBlock", TBNBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/derivativeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/derivativeBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**
@@ -80,5 +79,3 @@ export class DerivativeBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.DerivativeBlock", DerivativeBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/discardBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/discardBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 /**
  * Block used to discard a pixel if a value is smaller than a cutoff
  */
@@ -55,5 +54,3 @@ export class DiscardBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.DiscardBlock", DiscardBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragCoordBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragCoordBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**
@@ -111,5 +110,3 @@ export class FragCoordBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.FragCoordBlock", FragCoordBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragDepthBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragDepthBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { Logger } from "core/Misc/logger";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 /**
@@ -75,5 +74,3 @@ export class FragDepthBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.FragDepthBlock", FragDepthBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Scene } from "../../../../scene";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines, NodeMaterial } from "../../nodeMaterial";
@@ -203,5 +202,3 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
         this.useLogarithmicDepth = serializationObject.useLogarithmicDepth ?? false;
     }
 }
-
-RegisterClass("BABYLON.FragmentOutputBlock", FragmentOutputBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/frontFacingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/frontFacingBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { ShaderLanguage } from "../../../../Materials/shaderLanguage";
 /**
  * Block used to test if the fragment shader is front facing
@@ -51,5 +50,3 @@ export class FrontFacingBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.FrontFacingBlock", FrontFacingBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/heightToNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/heightToNormalBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import type { Scene } from "../../../../scene";
 import { Logger } from "../../../../Misc/logger";
@@ -189,5 +188,3 @@ export class HeightToNormalBlock extends NodeMaterialBlock {
         this.automaticNormalizationTangent = serializationObject.automaticNormalizationTangent;
     }
 }
-
-RegisterClass("BABYLON.HeightToNormalBlock", HeightToNormalBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
@@ -7,7 +7,6 @@ import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import type { Effect } from "../../../effect";
 import type { Mesh } from "../../../../Meshes/mesh";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Scene } from "../../../../scene";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 
@@ -222,5 +221,3 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
         this.convertInputToLinearSpace = serializationObject.convertInputToLinearSpace ?? true;
     }
 }
-
-RegisterClass("BABYLON.ImageProcessingBlock", ImageProcessingBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { Mesh } from "../../../../Meshes/mesh";
@@ -445,5 +444,3 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         this.useObjectSpaceNormalMap = !!serializationObject.useObjectSpaceNormalMap;
     }
 }
-
-RegisterClass("BABYLON.PerturbNormalBlock", PerturbNormalBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/prePassOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/prePassOutputBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**
@@ -214,5 +213,3 @@ export class PrePassOutputBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.PrePassOutputBlock", PrePassOutputBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSizeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSizeBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Effect } from "../../../effect";
 import type { Scene } from "../../../../scene";
 import { ShaderLanguage } from "../../../../Materials/shaderLanguage";
@@ -96,5 +95,3 @@ export class ScreenSizeBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ScreenSizeBlock", ScreenSizeBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSpaceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSpaceBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { NodeMaterial } from "../../nodeMaterial";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { InputBlock } from "../Input/inputBlock";
@@ -124,5 +123,3 @@ export class ScreenSpaceBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ScreenSpaceBlock", ScreenSpaceBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/shadowMapBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/shadowMapBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**
@@ -160,5 +159,3 @@ export class ShadowMapBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ShadowMapBlock", ShadowMapBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/twirlBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/twirlBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { Vector2 } from "../../../../Maths/math.vector";
 
@@ -139,5 +138,3 @@ export class TwirlBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.TwirlBlock", TwirlBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -10,7 +10,7 @@ import type { Scene } from "../../../../scene";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { GetClass, RegisterClass } from "../../../../Misc/typeStore";
+import { GetClass } from "../../../../Misc/typeStore";
 import { Color3, Color4, TmpColors } from "../../../../Maths/math";
 import { AnimatedInputBlockTypes } from "./animatedInputBlockTypes";
 import { Observable } from "../../../../Misc/observable";
@@ -884,5 +884,3 @@ export class InputBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.InputBlock", InputBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/prePassTextureBlock.ts
@@ -5,7 +5,6 @@ import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockCon
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { NodeMaterial } from "../../nodeMaterial";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import { Constants } from "../../../../Engines/constants";
@@ -284,5 +283,3 @@ export class PrePassTextureBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.PrePassTextureBlock", PrePassTextureBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
@@ -4,7 +4,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import { TBNBlock } from "../Fragment/TBNBlock";
@@ -240,5 +239,3 @@ export class AnisotropyBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.AnisotropyBlock", AnisotropyBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/clearCoatBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/clearCoatBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
@@ -424,5 +423,3 @@ export class ClearCoatBlock extends NodeMaterialBlock {
         this.remapF0OnInterfaceChange = serializationObject.remapF0OnInterfaceChange ?? true;
     }
 }
-
-RegisterClass("BABYLON.ClearCoatBlock", ClearCoatBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/iridescenceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/iridescenceBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
@@ -163,5 +162,3 @@ export class IridescenceBlock extends NodeMaterialBlock {
         super._deserialize(serializationObject, scene, rootUrl);
     }
 }
-
-RegisterClass("BABYLON.IridescenceBlock", IridescenceBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -9,7 +9,6 @@ import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { InputBlock } from "../Input/inputBlock";
 import type { Light } from "../../../../Lights/light";
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { Effect } from "../../../effect";
 import type { Mesh } from "../../../../Meshes/mesh";
@@ -1526,5 +1525,3 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         this._setTarget();
     }
 }
-
-RegisterClass("BABYLON.PBRMetallicRoughnessBlock", PBRMetallicRoughnessBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/reflectionBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/reflectionBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnect
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import { ReflectionTextureBaseBlock } from "../Dual/reflectionTextureBaseBlock";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
@@ -506,5 +505,3 @@ export class ReflectionBlock extends ReflectionTextureBaseBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.ReflectionBlock", ReflectionBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnect
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
@@ -409,5 +408,3 @@ export class RefractionBlock extends NodeMaterialBlock {
         this.useThicknessAsDepth = !!serializationObject.useThicknessAsDepth;
     }
 }
-
-RegisterClass("BABYLON.RefractionBlock", RefractionBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/sheenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/sheenBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
@@ -228,5 +227,3 @@ export class SheenBlock extends NodeMaterialBlock {
         this.linkSheenWithAlbedo = serializationObject.linkSheenWithAlbedo;
     }
 }
-
-RegisterClass("BABYLON.SheenBlock", SheenBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/subSurfaceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/subSurfaceBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
@@ -287,5 +286,3 @@ export class SubSurfaceBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.SubSurfaceBlock", SubSurfaceBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Particle/particleBlendMultiplyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Particle/particleBlendMultiplyBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 
 /**
  * Block used for the particle blend multiply section
@@ -89,5 +88,3 @@ export class ParticleBlendMultiplyBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ParticleBlendMultiplyBlock", ParticleBlendMultiplyBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Particle/particleRampGradientBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Particle/particleRampGradientBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 
 /**
  * Block used for the particle ramp gradient section
@@ -87,5 +86,3 @@ export class ParticleRampGradientBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ParticleRampGradientBlock", ParticleRampGradientBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Particle/particleTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Particle/particleTextureBlock.ts
@@ -8,7 +8,6 @@ import type { NodeMaterialDefines, NodeMaterial } from "../../nodeMaterial";
 import { InputBlock } from "../Input/inputBlock";
 import type { BaseTexture } from "../../../Textures/baseTexture";
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { Texture } from "../../../Textures/texture";
 import type { Scene } from "../../../../scene";
 
@@ -217,5 +216,3 @@ export class ParticleTextureBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.ParticleTextureBlock", ParticleTextureBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Teleport/teleportInBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Teleport/teleportInBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
@@ -150,5 +149,3 @@ export class NodeMaterialTeleportInBlock extends NodeMaterialBlock {
         this._endpoints = [];
     }
 }
-
-RegisterClass("BABYLON.NodeMaterialTeleportInBlock", NodeMaterialTeleportInBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Teleport/teleportOutBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Teleport/teleportOutBlock.ts
@@ -1,5 +1,4 @@
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { NodeMaterialTeleportInBlock } from "./teleportInBlock";
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
@@ -150,5 +149,3 @@ export class NodeMaterialTeleportOutBlock extends NodeMaterialBlock {
         this._tempEntryPointUniqueId = serializationObject.entryPoint;
     }
 }
-
-RegisterClass("BABYLON.NodeMaterialTeleportOutBlock", NodeMaterialTeleportOutBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/bonesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/bonesBlock.ts
@@ -9,7 +9,6 @@ import type { Effect } from "../../../effect";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import { InputBlock } from "../Input/inputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 
 import type { EffectFallbacks } from "../../../effectFallbacks";
 import { BindBonesParameters, PrepareDefinesForBones } from "../../../materialHelper.functions";
@@ -211,5 +210,3 @@ export class BonesBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.BonesBlock", BonesBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/instancesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/instancesBlock.ts
@@ -7,7 +7,6 @@ import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { InputBlock } from "../Input/inputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { SubMesh } from "../../../../Meshes/subMesh";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
@@ -201,5 +200,3 @@ export class InstancesBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.InstancesBlock", InstancesBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/lightInformationBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/lightInformationBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Nullable } from "../../../../types";
 import type { Scene } from "../../../../scene";
 import type { Effect } from "../../../effect";
@@ -248,5 +247,3 @@ export class LightInformationBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.LightInformationBlock", LightInformationBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -9,7 +9,6 @@ import type { Effect } from "../../../effect";
 import type { Mesh } from "../../../../Meshes/mesh";
 import { VertexBuffer } from "../../../../Buffers/buffer";
 import { InputBlock } from "../Input/inputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 
 import { BindMorphTargetParameters, PrepareDefinesForMorphTargets } from "../../../materialHelper.functions";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -374,5 +373,3 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MorphTargetsBlock", MorphTargetsBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/vertexOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/vertexOutputBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Immutable } from "../../../../types";
 
 import type { FragmentOutputBlock } from "../Fragment/fragmentOutputBlock";
@@ -79,5 +78,3 @@ export class VertexOutputBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.VertexOutputBlock", VertexOutputBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/addBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/addBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { BaseMathBlock } from "./baseMathBlock";
 
 /**
@@ -32,5 +31,3 @@ export class AddBlock extends BaseMathBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.AddBlock", AddBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/arcTan2Block.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/arcTan2Block.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 /**
  * Block used to compute arc tangent of 2 values
@@ -61,5 +60,3 @@ export class ArcTan2Block extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ArcTan2Block", ArcTan2Block);

--- a/packages/dev/core/src/Materials/Node/Blocks/biPlanarBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/biPlanarBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { TriPlanarBlock } from "./triPlanarBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBlockConnectionPointTypes";
 import { ShaderLanguage } from "../../../Materials/shaderLanguage";
@@ -110,5 +109,3 @@ export class BiPlanarBlock extends TriPlanarBlock {
         `;
     }
 }
-
-RegisterClass("BABYLON.BiPlanarBlock", BiPlanarBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/clampBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/clampBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../Decorators/nodeDecorator";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -92,5 +91,3 @@ export class ClampBlock extends NodeMaterialBlock {
         this.maximum = serializationObject.maximum;
     }
 }
-
-RegisterClass("BABYLON.ClampBlock", ClampBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/cloudBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/cloudBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../Decorators/nodeDecorator";
 import type { Scene } from "../../../scene";
 import { ShaderLanguage } from "../../../Materials/shaderLanguage";
@@ -227,5 +226,3 @@ export class CloudBlock extends NodeMaterialBlock {
         this.octaves = serializationObject.octaves;
     }
 }
-
-RegisterClass("BABYLON.CloudBlock", CloudBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/colorConverterBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorConverterBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**
@@ -211,5 +210,3 @@ export class ColorConverterBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ColorConverterBlock", ColorConverterBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 
 /**
@@ -197,5 +196,3 @@ export class ColorMergerBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.ColorMergerBlock", ColorMergerBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/colorSplitterBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorSplitterBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 /**
  * Block used to expand a Color3/4 into 4 outputs (one for each component)
@@ -131,5 +130,3 @@ export class ColorSplitterBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ColorSplitterBlock", ColorSplitterBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/conditionalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/conditionalBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 
 /**
@@ -189,5 +188,3 @@ export class ConditionalBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.ConditionalBlock", ConditionalBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/crossBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/crossBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to apply a cross product between 2 vectors
  */
@@ -68,5 +67,3 @@ export class CrossBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.CrossBlock", CrossBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/curveBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/curveBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
@@ -342,5 +341,3 @@ export class CurveBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.CurveBlock", CurveBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/customBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/customBlock.ts
@@ -2,7 +2,6 @@ import { NodeMaterialBlock } from "../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 import type { Nullable } from "../../../types";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
@@ -189,5 +188,3 @@ export class CustomBlock extends NodeMaterialBlock {
         return null;
     }
 }
-
-RegisterClass("BABYLON.CustomBlock", CustomBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/desaturateBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/desaturateBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to desaturate a color
  */
@@ -69,5 +68,3 @@ export class DesaturateBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.DesaturateBlock", DesaturateBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/distanceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/distanceBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the distance between 2 values
  */
@@ -66,5 +65,3 @@ export class DistanceBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.DistanceBlock", DistanceBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/divideBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/divideBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { BaseMathBlock } from "./baseMathBlock";
 
 /**
@@ -32,5 +31,3 @@ export class DivideBlock extends BaseMathBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.DivideBlock", DivideBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/dotBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/dotBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to apply a dot product between 2 vectors
  */
@@ -65,5 +64,3 @@ export class DotBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.DotBlock", DotBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/elbowBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/elbowBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used as a pass through
  */
@@ -80,5 +79,3 @@ export class ElbowBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ElbowBlock", ElbowBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/fresnelBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/fresnelBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { InputBlock } from "./Input/inputBlock";
 import type { NodeMaterial } from "../nodeMaterial";
 
@@ -106,5 +105,3 @@ export class FresnelBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.FresnelBlock", FresnelBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/gradientBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/gradientBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { Color3 } from "../../../Maths/math.color";
 import type { Scene } from "../../../scene";
 import { Observable } from "../../../Misc/observable";
@@ -194,5 +193,3 @@ export class GradientBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.GradientBlock", GradientBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/lengthBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/lengthBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the length of a vector
  */
@@ -54,5 +53,3 @@ export class LengthBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.LengthBlock", LengthBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/lerpBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/lerpBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to lerp between 2 values
  */
@@ -74,5 +73,3 @@ export class LerpBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.LerpBlock", LerpBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/loopBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/loopBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialConnectionPointDirection } from "../nodeMaterialBlockConnectionPoint";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "core/Decorators/nodeDecorator";
 import type { Scene } from "core/scene";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -141,5 +140,3 @@ export class LoopBlock extends NodeMaterialBlock {
         this.iterations = serializationObject.iterations;
     }
 }
-
-RegisterClass("BABYLON.LoopBlock", LoopBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/matrixBuilderBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/matrixBuilderBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { InputBlock } from "./Input/inputBlock";
 import { Vector4 } from "../../../Maths/math.vector";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -113,5 +112,3 @@ export class MatrixBuilderBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MatrixBuilder", MatrixBuilderBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/matrixDeterminantBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/matrixDeterminantBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 /**
  * Block used to compute the determinant of a matrix
@@ -53,5 +52,3 @@ export class MatrixDeterminantBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MatrixDeterminantBlock", MatrixDeterminantBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/matrixTransposeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/matrixTransposeBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 /**
  * Block used to transpose a matrix
@@ -53,5 +52,3 @@ export class MatrixTransposeBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MatrixTransposeBlock", MatrixTransposeBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/maxBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/maxBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the max of 2 values
  */
@@ -62,5 +61,3 @@ export class MaxBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MaxBlock", MaxBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/meshAttributeExistsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/meshAttributeExistsBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { InputBlock } from "./Input/inputBlock";
 import { MorphTargetsBlock } from "./Vertex/morphTargetsBlock";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../Decorators/nodeDecorator";
@@ -214,5 +213,3 @@ export class MeshAttributeExistsBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.MeshAttributeExistsBlock", MeshAttributeExistsBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/minBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/minBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the min of 2 values
  */
@@ -62,5 +61,3 @@ export class MinBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MinBlock", MinBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/modBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/modBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 /**
  * Block used to compute value of one parameter modulo another
@@ -69,5 +68,3 @@ export class ModBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ModBlock", ModBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/multiplyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/multiplyBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { BaseMathBlock } from "./baseMathBlock";
 
 /**
@@ -32,5 +31,3 @@ export class MultiplyBlock extends BaseMathBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.MultiplyBlock", MultiplyBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/nLerpBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/nLerpBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to normalize lerp between 2 values
  */
@@ -75,5 +74,3 @@ export class NLerpBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.NLerpBlock", NLerpBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/negateBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/negateBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get negative version of a value (i.e. x * -1)
  */
@@ -53,5 +52,3 @@ export class NegateBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.NegateBlock", NegateBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/normalBlendBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/normalBlendBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to blend normals
  */
@@ -82,5 +81,3 @@ export class NormalBlendBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.NormalBlendBlock", NormalBlendBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/normalizeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/normalizeBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to normalize a vector
  */
@@ -57,5 +56,3 @@ export class NormalizeBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.NormalizeBlock", NormalizeBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/oneMinusBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/oneMinusBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the opposite (1 - x) of a value
  */
@@ -54,6 +53,3 @@ export class OneMinusBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.OneMinusBlock", OneMinusBlock);
-RegisterClass("BABYLON.OppositeBlock", OneMinusBlock); // Backward compatibility

--- a/packages/dev/core/src/Materials/Node/Blocks/posterizeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/posterizeBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 /**
  * Block used to posterize a value
@@ -69,5 +68,3 @@ export class PosterizeBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.PosterizeBlock", PosterizeBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/powBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/powBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the value of the first parameter raised to the power of the second
  */
@@ -62,5 +61,3 @@ export class PowBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.PowBlock", PowBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/randomNumberBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/randomNumberBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 import "../../../Shaders/ShadersInclude/helperFunctions";
 
@@ -65,5 +64,3 @@ export class RandomNumberBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.RandomNumberBlock", RandomNumberBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/reciprocalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/reciprocalBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the reciprocal (1 / x) of a value
  */
@@ -57,5 +56,3 @@ export class ReciprocalBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ReciprocalBlock", ReciprocalBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/reflectBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/reflectBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the reflected vector from a direction and a normal
  */
@@ -72,5 +71,3 @@ export class ReflectBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ReflectBlock", ReflectBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/refractBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/refractBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to get the refracted vector from a direction and a normal
  */
@@ -82,5 +81,3 @@ export class RefractBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.RefractBlock", RefractBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/remapBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/remapBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { Vector2 } from "../../../Maths/math.vector";
 import type { Scene } from "../../../scene";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../Decorators/nodeDecorator";
@@ -133,5 +132,3 @@ export class RemapBlock extends NodeMaterialBlock {
         this.targetRange = Vector2.FromArray(serializationObject.targetRange);
     }
 }
-
-RegisterClass("BABYLON.RemapBlock", RemapBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/replaceColorBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/replaceColorBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to replace a color by another one
  */
@@ -90,5 +89,3 @@ export class ReplaceColorBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ReplaceColorBlock", ReplaceColorBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/rotate2dBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/rotate2dBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { InputBlock } from "./Input/inputBlock";
 
 /**
@@ -73,5 +72,3 @@ export class Rotate2dBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.Rotate2dBlock", Rotate2dBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/scaleBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/scaleBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to scale a vector by a float
  */
@@ -61,5 +60,3 @@ export class ScaleBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ScaleBlock", ScaleBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/simplexPerlin3DBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/simplexPerlin3DBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { ShaderLanguage } from "../../../Materials/shaderLanguage";
 /**
  * block used to Generate a Simplex Perlin 3d Noise Pattern
@@ -136,5 +135,3 @@ export class SimplexPerlin3DBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.SimplexPerlin3DBlock", SimplexPerlin3DBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/smoothStepBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/smoothStepBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to smooth step a value
  */
@@ -72,5 +71,3 @@ export class SmoothStepBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.SmoothStepBlock", SmoothStepBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/stepBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/stepBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 /**
  * Block used to step a value
  */
@@ -59,5 +58,3 @@ export class StepBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.StepBlock", StepBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/storageReadBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/storageReadBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialConnectionPointDirection, type NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { LoopBlock } from "./loopBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../nodeMaterialConnectionPointCustomObject";
 /**
@@ -67,5 +66,3 @@ export class StorageReadBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.StorageReadBlock", StorageReadBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/storageWriteBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/storageWriteBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialConnectionPointDirection, type NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { LoopBlock } from "./loopBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../nodeMaterialConnectionPointCustomObject";
 /**
@@ -79,5 +78,3 @@ export class StorageWriteBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.StorageWriteBlock", StorageWriteBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/subtractBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/subtractBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { BaseMathBlock } from "./baseMathBlock";
 
 /**
@@ -32,5 +31,3 @@ export class SubtractBlock extends BaseMathBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.SubtractBlock", SubtractBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/transformBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/transformBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 import type { InputBlock } from "./Input/inputBlock";
 import type { AbstractMesh } from "../../../Meshes/abstractMesh";
@@ -190,5 +189,3 @@ export class TransformBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.TransformBlock", TransformBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.ts
@@ -9,7 +9,6 @@ import type { NodeMaterialDefines } from "../nodeMaterial";
 import { NodeMaterial } from "../nodeMaterial";
 import type { Effect } from "../../effect";
 import type { Nullable } from "../../../types";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { Texture } from "../../Textures/texture";
 import type { Scene } from "../../../scene";
 import { Constants } from "../../../Engines/constants";
@@ -563,5 +562,3 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.TriPlanarBlock", TriPlanarBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/trigonometryBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/trigonometryBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 
 /**
@@ -204,5 +203,3 @@ export class TrigonometryBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.TrigonometryBlock", TrigonometryBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/vectorMergerBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/vectorMergerBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 
 /**
@@ -338,5 +337,3 @@ export class VectorMergerBlock extends NodeMaterialBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.VectorMergerBlock", VectorMergerBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/vectorSplitterBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/vectorSplitterBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 /**
  * Block used to expand a Vector3/4 into 4 outputs (one for each component)
@@ -174,5 +173,3 @@ export class VectorSplitterBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.VectorSplitterBlock", VectorSplitterBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/viewDirectionBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/viewDirectionBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { NodeMaterial } from "../nodeMaterial";
 import { NodeMaterialSystemValues } from "../Enums/nodeMaterialSystemValues";
 import { InputBlock } from "./Input/inputBlock";
@@ -76,5 +75,3 @@ export class ViewDirectionBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.ViewDirectionBlock", ViewDirectionBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/voronoiNoiseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/voronoiNoiseBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /**
@@ -133,5 +132,3 @@ export class VoronoiNoiseBlock extends NodeMaterialBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.VoronoiNoiseBlock", VoronoiNoiseBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/waveBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/waveBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 
 /**
@@ -102,5 +101,3 @@ export class WaveBlock extends NodeMaterialBlock {
         this.kind = serializationObject.kind;
     }
 }
-
-RegisterClass("BABYLON.WaveBlock", WaveBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/worleyNoise3DBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/worleyNoise3DBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../Enums/nodeMaterialBloc
 import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { Scene } from "../../../scene";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../Decorators/nodeDecorator";
 import { ShaderLanguage } from "../../../Materials/shaderLanguage";
@@ -302,5 +301,3 @@ export class WorleyNoise3DBlock extends NodeMaterialBlock {
         this.manhattanDistance = serializationObject.manhattanDistance;
     }
 }
-
-RegisterClass("BABYLON.WorleyNoise3DBlock", WorleyNoise3DBlock);

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -25,7 +25,7 @@ import { TransformBlock } from "./Blocks/transformBlock";
 import { VertexOutputBlock } from "./Blocks/Vertex/vertexOutputBlock";
 import { FragmentOutputBlock } from "./Blocks/Fragment/fragmentOutputBlock";
 import { InputBlock } from "./Blocks/Input/inputBlock";
-import { GetClass, RegisterClass } from "../../Misc/typeStore";
+import { GetClass } from "../../Misc/typeStore";
 import { serialize } from "../../Misc/decorators";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
 import type { TextureBlock } from "./Blocks/Dual/textureBlock";
@@ -2631,5 +2631,3 @@ export class NodeMaterial extends PushMaterial {
         return newMaterial;
     }
 }
-
-RegisterClass("BABYLON.NodeMaterial", NodeMaterial);

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.ts
@@ -7,7 +7,6 @@ import type { ImageProcessingConfiguration } from "../../Materials/imageProcessi
 import type { ColorCurves } from "../../Materials/colorCurves";
 import type { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { PBRBaseMaterial } from "./pbrBaseMaterial";
-import { RegisterClass } from "../../Misc/typeStore";
 import { Material } from "../material";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
 
@@ -841,5 +840,3 @@ export class PBRMaterial extends PBRBaseMaterial {
         return material;
     }
 }
-
-RegisterClass("BABYLON.PBRMaterial", PBRMaterial);

--- a/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
@@ -4,7 +4,6 @@ import type { Scene } from "../../scene";
 import type { Color3 } from "../../Maths/math.color";
 import type { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { PBRBaseSimpleMaterial } from "./pbrBaseSimpleMaterial";
-import { RegisterClass } from "../../Misc/typeStore";
 import type { Nullable } from "../../types";
 
 /**
@@ -146,5 +145,3 @@ export class PBRMetallicRoughnessMaterial extends PBRBaseSimpleMaterial {
         return material;
     }
 }
-
-RegisterClass("BABYLON.PBRMetallicRoughnessMaterial", PBRMetallicRoughnessMaterial);

--- a/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
@@ -3,7 +3,6 @@ import type { Scene } from "../../scene";
 import type { Color3 } from "../../Maths/math.color";
 import type { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { PBRBaseSimpleMaterial } from "./pbrBaseSimpleMaterial";
-import { RegisterClass } from "../../Misc/typeStore";
 import type { Nullable } from "../../types";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
 
@@ -143,5 +142,3 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
         return material;
     }
 }
-
-RegisterClass("BABYLON.PBRSpecularGlossinessMaterial", PBRSpecularGlossinessMaterial);

--- a/packages/dev/core/src/Materials/Textures/Procedurals/noiseProceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/noiseProceduralTexture.ts
@@ -3,7 +3,6 @@ import type { Scene } from "../../../scene";
 import { EngineStore } from "../../../Engines/engineStore";
 import type { Texture } from "../../../Materials/Textures/texture";
 import { ProceduralTexture } from "./proceduralTexture";
-import { RegisterClass } from "../../../Misc/typeStore";
 
 import "../../../Shaders/noise.fragment";
 
@@ -135,5 +134,3 @@ export class NoiseProceduralTexture extends ProceduralTexture {
         return texture;
     }
 }
-
-RegisterClass("BABYLON.NoiseProceduralTexture", NoiseProceduralTexture);

--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
@@ -16,7 +16,6 @@ import { RenderTargetTexture } from "../../../Materials/Textures/renderTargetTex
 import { ProceduralTextureSceneComponent } from "./proceduralTextureSceneComponent";
 
 import type { DataBuffer } from "../../../Buffers/dataBuffer";
-import { RegisterClass } from "../../../Misc/typeStore";
 import type { NodeMaterial } from "../../Node/nodeMaterial";
 import type { TextureSize } from "../../../Materials/Textures/textureCreationOptions";
 import { EngineStore } from "../../../Engines/engineStore";
@@ -849,5 +848,3 @@ export class ProceduralTexture extends Texture {
         super.dispose();
     }
 }
-
-RegisterClass("BABYLON.ProceduralTexture", ProceduralTexture);

--- a/packages/dev/core/src/Materials/Textures/colorGradingTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/colorGradingTexture.ts
@@ -4,7 +4,6 @@ import { Matrix } from "../../Maths/math.vector";
 import type { InternalTexture } from "../../Materials/Textures/internalTexture";
 import { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { Constants } from "../../Engines/constants";
-import { RegisterClass } from "../../Misc/typeStore";
 import type { AbstractEngine } from "../../Engines/abstractEngine";
 
 /**
@@ -307,5 +306,3 @@ export class ColorGradingTexture extends BaseTexture {
         return serializationObject;
     }
 }
-
-RegisterClass("BABYLON.ColorGradingTexture", ColorGradingTexture);

--- a/packages/dev/core/src/Materials/Textures/cubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/cubeTexture.ts
@@ -6,7 +6,7 @@ import { Matrix, TmpVectors, Vector3 } from "../../Maths/math.vector";
 import { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { Texture } from "../../Materials/Textures/texture";
 import { Constants } from "../../Engines/constants";
-import { GetClass, RegisterClass } from "../../Misc/typeStore";
+import { GetClass } from "../../Misc/typeStore";
 import type { AbstractEngine } from "../../Engines/abstractEngine";
 import { Observable } from "../../Misc/observable";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
@@ -584,5 +584,3 @@ export class CubeTexture extends BaseTexture {
 }
 
 Texture._CubeTextureParser = CubeTexture.Parse;
-// Some exporters relies on Tools.Instantiate
-RegisterClass("BABYLON.CubeTexture", CubeTexture);

--- a/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
@@ -6,7 +6,6 @@ import { Texture } from "../../Materials/Textures/texture";
 import { Constants } from "../../Engines/constants";
 import { GetCubeMapTextureData } from "../../Misc/HighDynamicRange/hdr";
 import { CubeMapToSphericalPolynomialTools } from "../../Misc/HighDynamicRange/cubemapToSphericalPolynomial";
-import { RegisterClass } from "../../Misc/typeStore";
 import { Observable } from "../../Misc/observable";
 import { Tools } from "../../Misc/tools";
 import { ToGammaSpace } from "../../Maths/math.constants";
@@ -415,5 +414,3 @@ export class HDRCubeTexture extends BaseTexture {
         return serializationObject;
     }
 }
-
-RegisterClass("BABYLON.HDRCubeTexture", HDRCubeTexture);

--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -4,7 +4,7 @@ import type { Nullable } from "../../types";
 import { Matrix, TmpVectors, Vector3 } from "../../Maths/math.vector";
 import { BaseTexture } from "../../Materials/Textures/baseTexture";
 import { Constants } from "../../Engines/constants";
-import { GetClass, RegisterClass } from "../../Misc/typeStore";
+import { GetClass } from "../../Misc/typeStore";
 import { _WarnImport } from "../../Misc/devTools";
 import type { IInspectable } from "../../Misc/iInspectable";
 import type { AbstractEngine } from "../../Engines/abstractEngine";
@@ -1212,5 +1212,4 @@ export class Texture extends BaseTexture {
 }
 
 // References the dependencies.
-RegisterClass("BABYLON.Texture", Texture);
 SerializationHelper._TextureParser = Texture.Parse;

--- a/packages/dev/core/src/Materials/Textures/videoTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/videoTexture.ts
@@ -11,7 +11,6 @@ import type { WebGPUEngine } from "core/Engines";
 import "../../Engines/Extensions/engine.videoTexture";
 import "../../Engines/Extensions/engine.dynamicTexture";
 import { serialize } from "core/Misc/decorators";
-import { RegisterClass } from "core/Misc/typeStore";
 
 function removeSource(video: HTMLVideoElement): void {
     // Remove any <source> elements, etc.
@@ -603,5 +602,3 @@ Texture._CreateVideoTexture = (
 ) => {
     return new VideoTexture(name, src, scene, generateMipMaps, invertY, samplingMode, settings, onError, format);
 };
-// Some exporters relies on Tools.Instantiate
-RegisterClass("BABYLON.VideoTexture", VideoTexture);

--- a/packages/dev/core/src/Materials/imageProcessingConfiguration.ts
+++ b/packages/dev/core/src/Materials/imageProcessingConfiguration.ts
@@ -11,7 +11,6 @@ import { Mix } from "../Misc/tools.functions";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import type { IImageProcessingConfigurationDefines } from "./imageProcessingConfiguration.defines";
 import { PrepareSamplersForImageProcessing, PrepareUniformsForImageProcessing } from "./imageProcessingConfiguration.functions";
-import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This groups together the common properties used for image processing either in direct forward pass
@@ -644,6 +643,3 @@ export class ImageProcessingConfiguration {
 
 // References the dependencies.
 SerializationHelper._ImageProcessingConfigurationParser = ImageProcessingConfiguration.Parse;
-
-// Register Class Name
-RegisterClass("BABYLON.ImageProcessingConfiguration", ImageProcessingConfiguration);

--- a/packages/dev/core/src/Materials/material.decalMapConfiguration.ts
+++ b/packages/dev/core/src/Materials/material.decalMapConfiguration.ts
@@ -10,7 +10,6 @@ import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type { UniformBuffer } from "./uniformBuffer";
 import type { PBRBaseMaterial } from "./PBR/pbrBaseMaterial";
 import type { StandardMaterial } from "./standardMaterial";
-import { RegisterClass } from "core/Misc/typeStore";
 import { BindTextureMatrix, PrepareDefinesForMergedUV } from "./materialHelper.functions";
 
 /**
@@ -145,5 +144,3 @@ export class DecalMapConfiguration extends MaterialPluginBase {
         };
     }
 }
-
-RegisterClass("BABYLON.DecalMapConfiguration", DecalMapConfiguration);

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -16,7 +16,6 @@ import type { Material } from "./material";
 import type { BaseTexture } from "./Textures/baseTexture";
 import type { RenderTargetTexture } from "./Textures/renderTargetTexture";
 import { SerializationHelper } from "../Misc/decorators.serialization";
-import { RegisterClass } from "../Misc/typeStore";
 import { ShaderLanguage } from "./shaderLanguage";
 
 /**
@@ -327,6 +326,3 @@ export class MaterialPluginBase {
         SerializationHelper.Parse(() => this, source, scene, rootUrl);
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.MaterialPluginBase", MaterialPluginBase);

--- a/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
+++ b/packages/dev/core/src/Materials/meshDebugPluginMaterial.ts
@@ -6,7 +6,6 @@ import type { FloatArray, Nullable } from "../types";
 import { MaterialDefines } from "./materialDefines";
 import type { PBRBaseMaterial } from "./PBR/pbrBaseMaterial";
 import type { StandardMaterial } from "./standardMaterial";
-import { RegisterClass } from "../Misc/typeStore";
 import { Color3 } from "core/Maths/math";
 import type { Mesh } from "core/Meshes/mesh";
 import { Logger } from "core/Misc/logger";
@@ -798,5 +797,3 @@ export class MeshDebugPluginMaterial extends MaterialPluginBase {
         return rollback;
     }
 }
-
-RegisterClass("BABYLON.MeshDebugPluginMaterial", MeshDebugPluginMaterial);

--- a/packages/dev/core/src/Materials/multiMaterial.ts
+++ b/packages/dev/core/src/Materials/multiMaterial.ts
@@ -5,7 +5,6 @@ import type { SubMesh } from "../Meshes/subMesh";
 import type { BaseTexture } from "../Materials/Textures/baseTexture";
 import { Material } from "../Materials/material";
 import { Tags } from "../Misc/tags";
-import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * A multi-material is used to apply different materials to different parts of the same object without the need of
@@ -268,5 +267,3 @@ export class MultiMaterial extends Material {
         return multiMaterial;
     }
 }
-
-RegisterClass("BABYLON.MultiMaterial", MultiMaterial);

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -9,7 +9,6 @@ import { VertexBuffer } from "../Buffers/buffer";
 import type { BaseTexture } from "../Materials/Textures/baseTexture";
 import { Texture } from "../Materials/Textures/texture";
 import type { Effect, IEffectCreationOptions, IShaderPath } from "./effect";
-import { RegisterClass } from "../Misc/typeStore";
 import { Color3, Color4 } from "../Maths/math.color";
 import { EffectFallbacks } from "./effectFallbacks";
 import { WebRequest } from "../Misc/webRequest";
@@ -1867,5 +1866,3 @@ export class ShaderMaterial extends PushMaterial {
      */
     public static CreateFromSnippetAsync = ShaderMaterial.ParseFromSnippetAsync;
 }
-
-RegisterClass("BABYLON.ShaderMaterial", ShaderMaterial);

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -28,7 +28,6 @@ import type { BaseTexture } from "../Materials/Textures/baseTexture";
 import { Texture } from "../Materials/Textures/texture";
 import type { CubeTexture } from "../Materials/Textures/cubeTexture";
 import type { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
-import { RegisterClass } from "../Misc/typeStore";
 import { MaterialFlags } from "./materialFlags";
 
 import { Constants } from "../Engines/constants";
@@ -2198,8 +2197,6 @@ export class StandardMaterial extends PushMaterial {
         MaterialFlags.FresnelEnabled = value;
     }
 }
-
-RegisterClass("BABYLON.StandardMaterial", StandardMaterial);
 
 Scene.DefaultMaterialFactory = (scene: Scene) => {
     return new StandardMaterial("default material", scene);

--- a/packages/dev/core/src/Maths/math.color.ts
+++ b/packages/dev/core/src/Maths/math.color.ts
@@ -1,5 +1,4 @@
 import { BuildArray } from "../Misc/arrayTools";
-import { RegisterClass } from "../Misc/typeStore";
 import type { DeepImmutable, FloatArray, Tuple } from "../types";
 import { Epsilon, ToGammaSpace, ToLinearSpace } from "./math.constants";
 import type { IColor3Like, IColor4Like } from "./math.like";
@@ -1893,6 +1892,3 @@ export class TmpColors {
     public static Color3: Color3[] = BuildArray(3, Color3.Black);
     public static Color4: Color4[] = BuildArray(3, () => new Color4(0, 0, 0, 0));
 }
-
-RegisterClass("BABYLON.Color3", Color3);
-RegisterClass("BABYLON.Color4", Color4);

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -3,7 +3,6 @@ import { Epsilon } from "./math.constants";
 import type { Viewport } from "./math.viewport";
 import type { DeepImmutable, Nullable, FloatArray, float, Tuple } from "../types";
 import { BuildTuple } from "../Misc/arrayTools";
-import { RegisterClass } from "../Misc/typeStore";
 import type { Plane } from "./math.plane";
 import { PerformanceConfigurator } from "../Engines/performanceConfigurator";
 import { EngineStore } from "../Engines/engineStore";
@@ -8901,10 +8900,5 @@ export class TmpVectors {
     /** 8 temp Matrices at once should be enough */
     public static Matrix = BuildTuple(8, Matrix.Identity);
 }
-
-RegisterClass("BABYLON.Vector2", Vector2);
-RegisterClass("BABYLON.Vector3", Vector3);
-RegisterClass("BABYLON.Vector4", Vector4);
-RegisterClass("BABYLON.Matrix", Matrix);
 
 const mtxConvertNDCToHalfZRange = Matrix.FromValues(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0.5, 0, 0, 0, 0.5, 1);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { VertexData } from "../../../mesh.vertexData";
@@ -153,5 +152,3 @@ export class InstantiateBlock extends InstantiateBaseBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.InstantiateBlock", InstantiateBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateLinearBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateLinearBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { Matrix, Quaternion, Vector3 } from "../../../../Maths/math.vector";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
@@ -118,5 +117,3 @@ export class InstantiateLinearBlock extends InstantiateBaseBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.InstantiateLinearBlock", InstantiateLinearBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnFacesBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnFacesBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -319,5 +318,3 @@ export class InstantiateOnFacesBlock extends NodeGeometryBlock implements INodeG
         }
     }
 }
-
-RegisterClass("BABYLON.InstantiateOnFacesBlock", InstantiateOnFacesBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnVerticesBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnVerticesBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -281,5 +280,3 @@ export class InstantiateOnVerticesBlock extends NodeGeometryBlock implements INo
         }
     }
 }
-
-RegisterClass("BABYLON.InstantiateOnVerticesBlock", InstantiateOnVerticesBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnVolumeBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateOnVolumeBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -344,5 +343,3 @@ export class InstantiateOnVolumeBlock extends NodeGeometryBlock implements INode
         }
     }
 }
-
-RegisterClass("BABYLON.InstantiateOnVolumeBlock", InstantiateOnVolumeBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateRadialBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Instances/instantiateRadialBlock.ts
@@ -1,5 +1,4 @@
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { Matrix, Quaternion, Vector3 } from "../../../../Maths/math.vector";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
@@ -167,5 +166,3 @@ export class InstantiateRadialBlock extends InstantiateBaseBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.InstantiateRadialBlock", InstantiateRadialBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Matrices/alignBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Matrices/alignBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { Matrix, Vector3 } from "../../../../Maths/math.vector";
@@ -67,5 +66,3 @@ export class AlignBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.AlignBlock", AlignBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Matrices/rotationXBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Matrices/rotationXBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
@@ -59,5 +58,3 @@ export class RotationXBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.RotationXBlock", RotationXBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Matrices/rotationYBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Matrices/rotationYBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
@@ -59,5 +58,3 @@ export class RotationYBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.RotationYBlock", RotationYBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Matrices/rotationZBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Matrices/rotationZBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
@@ -59,5 +58,3 @@ export class RotationZBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.RotationZBlock", RotationZBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Matrices/scalingBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Matrices/scalingBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
@@ -60,5 +59,3 @@ export class ScalingBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.ScalingBlock", ScalingBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Matrices/translationBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Matrices/translationBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
@@ -60,5 +59,3 @@ export class TranslationBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.TranslationBlock", TranslationBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Set/setColorsBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Set/setColorsBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -182,5 +181,3 @@ export class SetColorsBlock extends NodeGeometryBlock implements INodeGeometryEx
         }
     }
 }
-
-RegisterClass("BABYLON.SetColorsBlock", SetColorsBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Set/setMaterialIDBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Set/setMaterialIDBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { VertexDataMaterialInfo, type VertexData } from "../../../../Meshes/mesh.vertexData";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
@@ -118,5 +117,3 @@ export class SetMaterialIDBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.SetMaterialIDBlock", SetMaterialIDBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Set/setNormalsBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Set/setNormalsBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -166,5 +165,3 @@ export class SetNormalsBlock extends NodeGeometryBlock implements INodeGeometryE
         }
     }
 }
-
-RegisterClass("BABYLON.SetNormalsBlock", SetNormalsBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Set/setPositionsBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Set/setPositionsBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -254,5 +253,3 @@ export class SetPositionsBlock extends NodeGeometryBlock implements INodeGeometr
         }
     }
 }
-
-RegisterClass("BABYLON.SetPositionsBlock", SetPositionsBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Set/setTangentsBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Set/setTangentsBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -166,5 +165,3 @@ export class SetTangentsBlock extends NodeGeometryBlock implements INodeGeometry
         }
     }
 }
-
-RegisterClass("BABYLON.SetTangentsBlock", SetTangentsBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Set/setUVsBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Set/setUVsBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import type { INodeGeometryExecutionContext } from "../../Interfaces/nodeGeometryExecutionContext";
@@ -205,5 +204,3 @@ export class SetUVsBlock extends NodeGeometryBlock implements INodeGeometryExecu
         }
     }
 }
-
-RegisterClass("BABYLON.SetUVsBlock", SetUVsBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/boxBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/boxBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { CreateSegmentedBoxVertexData } from "core/Meshes/Builders/boxBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
 
@@ -215,5 +214,3 @@ export class BoxBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.BoxBlock", BoxBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/capsuleBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/capsuleBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Vector3 } from "../../../../Maths/math.vector";
 import { CreateCapsuleVertexData } from "core/Meshes/Builders/capsuleBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
@@ -149,5 +148,3 @@ export class CapsuleBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.CapsuleBlock", CapsuleBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/cylinderBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/cylinderBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Vector4 } from "../../../../Maths/math.vector";
 import { CreateCylinderVertexData } from "core/Meshes/Builders/cylinderBuilder";
 import type { Color4 } from "../../../../Maths/math.color";
@@ -191,5 +190,3 @@ export class CylinderBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.CylinderBlock", CylinderBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/discBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/discBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Vector4 } from "../../../../Maths/math.vector";
 import { CreateDiscVertexData } from "core/Meshes/Builders/discBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
@@ -129,5 +128,3 @@ export class DiscBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.DiscBlock", DiscBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/gridBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/gridBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { CreateGroundVertexData } from "../../../Builders/groundBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
 
@@ -145,5 +144,3 @@ export class GridBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.GridBlock", GridBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/icoSphereBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/icoSphereBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Vector4 } from "../../../../Maths/math.vector";
 import { CreateIcoSphereVertexData } from "core/Meshes/Builders/icoSphereBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
@@ -151,5 +150,3 @@ export class IcoSphereBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.IcoSphereBlock", IcoSphereBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/meshBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/meshBlock.ts
@@ -1,7 +1,6 @@
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Mesh } from "../../../../Meshes/mesh";
 import { VertexData } from "../../../../Meshes/mesh.vertexData";
 import type { Nullable } from "../../../../types";
@@ -134,5 +133,3 @@ export class MeshBlock extends NodeGeometryBlock {
         this.reverseWindingOrder = serializationObject.reverseWindingOrder;
     }
 }
-
-RegisterClass("BABYLON.MeshBlock", MeshBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/nullBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/nullBlock.ts
@@ -1,7 +1,6 @@
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../../Misc/typeStore";
 
 /**
  * Defines a block used to generate a null geometry data
@@ -44,5 +43,3 @@ export class NullBlock extends NodeGeometryBlock {
         this.vector._storedValue = null;
     }
 }
-
-RegisterClass("BABYLON.NullBlock", NullBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/planeBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/planeBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { Matrix } from "../../../../Maths/math.vector";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
 import { CreateGroundVertexData } from "core/Meshes/Builders/groundBuilder";
@@ -186,5 +185,3 @@ export class PlaneBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.PlaneBlock", PlaneBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/sphereBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/sphereBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Vector4 } from "../../../../Maths/math.vector";
 import { CreateSphereVertexData } from "core/Meshes/Builders/sphereBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
@@ -170,5 +169,3 @@ export class SphereBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.SphereBlock", SphereBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Sources/torusBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Sources/torusBlock.ts
@@ -3,7 +3,6 @@ import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
 import type { NodeGeometryBuildState } from "../../nodeGeometryBuildState";
 import { GeometryInputBlock } from "../geometryInputBlock";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Vector4 } from "../../../../Maths/math.vector";
 import { CreateTorusVertexData } from "core/Meshes/Builders/torusBuilder";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../../Decorators/nodeDecorator";
@@ -129,5 +128,3 @@ export class TorusBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.TorusBlock", TorusBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Teleport/teleportInBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Teleport/teleportInBlock.ts
@@ -1,5 +1,4 @@
 import type { Nullable } from "core/types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
@@ -149,5 +148,3 @@ export class TeleportInBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.TeleportInBlock", TeleportInBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Teleport/teleportOutBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Teleport/teleportOutBlock.ts
@@ -1,5 +1,4 @@
 import type { Nullable } from "../../../../types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../../nodeGeometryBlockConnectionPoint";
@@ -129,5 +128,3 @@ export class TeleportOutBlock extends NodeGeometryBlock {
         this._tempEntryPointUniqueId = serializationObject.entryPoint;
     }
 }
-
-RegisterClass("BABYLON.TeleportOutBlock", TeleportOutBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Textures/geometryTextureBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Textures/geometryTextureBlock.ts
@@ -1,5 +1,4 @@
 import type { Nullable } from "core/types";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { INodeGeometryTextureData } from "../../Interfaces/nodeGeometryTextureData";
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
@@ -202,5 +201,3 @@ export class GeometryTextureBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.GeometryTextureBlock", GeometryTextureBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/Textures/geometryTextureFetchBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/Textures/geometryTextureFetchBlock.ts
@@ -1,5 +1,4 @@
 import { Vector4, type Vector2 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../../Enums/nodeGeometryConnectionPointTypes";
 import type { INodeGeometryTextureData } from "../../Interfaces/nodeGeometryTextureData";
 import { NodeGeometryBlock } from "../../nodeGeometryBlock";
@@ -182,5 +181,3 @@ export class GeometryTextureFetchBlock extends NodeGeometryBlock {
         this.clampCoordinates = serializationObject.clampCoordinates;
     }
 }
-
-RegisterClass("BABYLON.GeometryTextureFetchBlock", GeometryTextureFetchBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/booleanGeometryBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/booleanGeometryBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { VertexData } from "../../mesh.vertexData";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
@@ -171,5 +170,3 @@ export class BooleanGeometryBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.BooleanGeometryBlock", BooleanGeometryBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/boundingBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/boundingBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { extractMinAndMax } from "../../../Maths/math.functions";
 
@@ -74,5 +73,3 @@ export class BoundingBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.BoundingBlock", BoundingBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/computeNormalsBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/computeNormalsBlock.ts
@@ -1,5 +1,4 @@
 import { VertexData } from "core/Meshes/mesh.vertexData";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -57,5 +56,3 @@ export class ComputeNormalsBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.ComputeNormalsBlock", ComputeNormalsBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/conditionBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/conditionBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../Decorators/nodeDecorator";
@@ -194,5 +193,3 @@ export class ConditionBlock extends NodeGeometryBlock {
         this.test = serializationObject.test;
     }
 }
-
-RegisterClass("BABYLON.ConditionBlock", ConditionBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/debugBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/debugBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2ToFixed, Vector3ToFixed, Vector4ToFixed } from "../../../Maths/math.vector.functions";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -101,5 +100,3 @@ export class DebugBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.DebugBlock", DebugBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryArcTan2Block.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryArcTan2Block.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -90,5 +89,3 @@ export class GeometryArcTan2Block extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.GeometryArcTan2Block", GeometryArcTan2Block);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryClampBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryClampBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../Decorators/nodeDecorator";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
@@ -111,5 +110,3 @@ export class GeometryClampBlock extends NodeGeometryBlock {
         this.maximum = serializationObject.maximum;
     }
 }
-
-RegisterClass("BABYLON.GeometryClampBlock", GeometryClampBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryCollectionBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryCollectionBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import {} from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { VertexData } from "../../mesh.vertexData";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryCollectionBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryCollectionBlock.ts
@@ -1,6 +1,6 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
+import {} from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { VertexData } from "../../mesh.vertexData";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
@@ -190,5 +190,3 @@ export class GeometryCollectionBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.GeometryCollectionBlock", GeometryCollectionBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryCrossBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryCrossBlock.ts
@@ -1,5 +1,4 @@
 import { Vector3 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -85,5 +84,3 @@ export class GeometryCrossBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryCrossBlock", GeometryCrossBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryCurveBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryCurveBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -310,5 +309,3 @@ export class GeometryCurveBlock extends NodeGeometryBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.GeometryCurveBlock", GeometryCurveBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryDesaturateBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryDesaturateBlock.ts
@@ -1,5 +1,4 @@
 import { Vector3 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -69,5 +68,3 @@ export class GeometryDesaturateBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryDesaturateBlock", GeometryDesaturateBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryDistanceBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryDistanceBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -73,5 +72,3 @@ export class GeometryDistanceBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryDistanceBlock", GeometryDistanceBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryDotBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryDotBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -72,5 +71,3 @@ export class GeometryDotBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryDotBlock", GeometryDotBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryElbowBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryElbowBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -60,5 +59,3 @@ export class GeometryElbowBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.GeometryElbowBlock", GeometryElbowBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryInfoBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryInfoBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { VertexData } from "../../mesh.vertexData";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
@@ -113,5 +112,3 @@ export class GeometryInfoBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.GeometryInfoBlock", GeometryInfoBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryInputBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryInputBlock.ts
@@ -2,7 +2,7 @@ import { Observable } from "../../../Misc/observable";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { GetClass, RegisterClass } from "../../../Misc/typeStore";
+import { GetClass } from "../../../Misc/typeStore";
 import { Matrix, Vector2, Vector3, Vector4 } from "../../../Maths/math.vector";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import { NodeGeometryContextualSources } from "../Enums/nodeGeometryContextualSources";
@@ -305,5 +305,3 @@ export class GeometryInputBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.GeometryInputBlock", GeometryInputBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryInterceptorBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryInterceptorBlock.ts
@@ -1,5 +1,4 @@
 import { Observable } from "core/Misc/observable";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -70,5 +69,3 @@ export class GeometryInterceptorBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.GeometryInterceptorBlock", GeometryInterceptorBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryLengthBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryLengthBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -58,5 +57,3 @@ export class GeometryLengthBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryLengthBlock", GeometryLengthBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryLerpBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryLerpBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
@@ -100,5 +99,3 @@ export class GeometryLerpBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryLerpBlock", GeometryLerpBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryModBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryModBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -91,5 +90,3 @@ export class GeometryModBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryModBlock", GeometryModBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryNLerpBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryNLerpBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -114,5 +113,3 @@ export class GeometryNLerpBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryNLerpBlock", GeometryNLerpBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryOptimizeBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryOptimizeBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -183,5 +182,3 @@ export class GeometryOptimizeBlock extends NodeGeometryBlock {
         this.optimizeFaces = serializationObject.optimizeFaces;
     }
 }
-
-RegisterClass("BABYLON.GeometryOptimizeBlock", GeometryOptimizeBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryOutputBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryOutputBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import type { VertexData } from "core/Meshes/mesh.vertexData";
@@ -50,5 +49,3 @@ export class GeometryOutputBlock extends NodeGeometryBlock {
         this._vertexData = state.vertexData;
     }
 }
-
-RegisterClass("BABYLON.GeometryOutputBlock", GeometryOutputBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryPosterizeBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryPosterizeBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "../../../Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -107,5 +106,3 @@ export class GeometryPosterizeBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryPosterizeBlock", GeometryPosterizeBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryPowBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryPowBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -90,5 +89,3 @@ export class GeometryPowBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryPowBlock", GeometryPowBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryReplaceColorBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryReplaceColorBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -97,5 +96,3 @@ export class GeometryReplaceColorBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryReplaceColorBlock", GeometryReplaceColorBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryRotate2dBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryRotate2dBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -65,5 +64,3 @@ export class GeometryRotate2dBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryRotate2dBlock", GeometryRotate2dBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometrySmoothStepBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometrySmoothStepBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -101,5 +100,3 @@ export class GeometrySmoothStepBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometrySmoothStepBlock", GeometrySmoothStepBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryStepBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryStepBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -93,5 +92,3 @@ export class GeometryStepBlock extends NodeGeometryBlock {
         return this;
     }
 }
-
-RegisterClass("BABYLON.GeometryStepBlock", GeometryStepBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryTransformBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryTransformBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { Matrix, Vector2, Vector3, Vector4 } from "../../../Maths/math.vector";
 import type { VertexData } from "../../../Meshes/mesh.vertexData";
@@ -178,5 +177,3 @@ export class GeometryTransformBlock extends NodeGeometryBlock {
         }
     }
 }
-
-RegisterClass("BABYLON.GeometryTransformBlock", GeometryTransformBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/geometryTrigonometryBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/geometryTrigonometryBlock.ts
@@ -1,5 +1,4 @@
 import type { Nullable } from "../../../types";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -286,5 +285,3 @@ export class GeometryTrigonometryBlock extends NodeGeometryBlock {
         return codeString;
     }
 }
-
-RegisterClass("BABYLON.GeometryTrigonometryBlock", GeometryTrigonometryBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/intFloatConverterBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/intFloatConverterBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -91,5 +90,3 @@ export class IntFloatConverterBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.IntFloatConverterBlock", IntFloatConverterBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/mapRangeBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/mapRangeBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -105,5 +104,3 @@ export class MapRangeBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.MapRangeBlock", MapRangeBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/mappingBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/mappingBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import { PropertyTypeForEdition, editableInPropertyPage } from "../../../Decorators/nodeDecorator";
@@ -175,5 +174,3 @@ export class MappingBlock extends NodeGeometryBlock {
         this.mapping = serializationObject.mapping;
     }
 }
-
-RegisterClass("BABYLON.MappingBlock", MappingBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/mathBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/mathBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import { Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
@@ -338,5 +337,3 @@ export class MathBlock extends NodeGeometryBlock {
         this.operation = serializationObject.operation;
     }
 }
-
-RegisterClass("BABYLON.MathBlock", MathBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/matrixComposeBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/matrixComposeBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import type { Matrix } from "core/Maths/math.vector";
@@ -67,5 +66,3 @@ export class MatrixComposeBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.MatrixComposeBlock", MatrixComposeBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/mergeGeometryBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/mergeGeometryBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { VertexData } from "../../../Meshes/mesh.vertexData";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
@@ -162,5 +161,3 @@ export class MergeGeometryBlock extends NodeGeometryBlock {
         this.evaluateContext = serializationObject.evaluateContext;
     }
 }
-
-RegisterClass("BABYLON.MergeGeometryBlock", MergeGeometryBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/noiseBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/noiseBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { Vector3 } from "../../../Maths/math.vector";
 import { Clamp } from "../../../Maths/math.scalar.functions";
@@ -211,5 +210,3 @@ export class NoiseBlock extends NodeGeometryBlock {
         };
     }
 }
-
-RegisterClass("BABYLON.NoiseBlock", NoiseBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/normalizeVectorBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/normalizeVectorBlock.ts
@@ -1,4 +1,3 @@
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -58,5 +57,3 @@ export class NormalizeVectorBlock extends NodeGeometryBlock {
         this.output._storedFunction = (state) => this.input.getConnectedValue(state).normalize();
     }
 }
-
-RegisterClass("BABYLON.NormalizeVectorBlock", NormalizeVectorBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/randomBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/randomBlock.ts
@@ -1,6 +1,5 @@
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import type { NodeGeometryBuildState } from "../nodeGeometryBuildState";
 import { GeometryInputBlock } from "./geometryInputBlock";
@@ -203,5 +202,3 @@ export class RandomBlock extends NodeGeometryBlock {
         this.lockMode = serializationObject.lockMode;
     }
 }
-
-RegisterClass("BABYLON.RandomBlock", RandomBlock);

--- a/packages/dev/core/src/Meshes/Node/Blocks/vectorConverterBlock.ts
+++ b/packages/dev/core/src/Meshes/Node/Blocks/vectorConverterBlock.ts
@@ -1,5 +1,4 @@
 import { Vector2, Vector3, Vector4 } from "../../../Maths/math.vector";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeGeometryBlockConnectionPointTypes } from "../Enums/nodeGeometryConnectionPointTypes";
 import { NodeGeometryBlock } from "../nodeGeometryBlock";
 import type { NodeGeometryConnectionPoint } from "../nodeGeometryBlockConnectionPoint";
@@ -295,5 +294,3 @@ export class VectorConverterBlock extends NodeGeometryBlock {
         wOutput._storedFunction = (state) => getData(state).w;
     }
 }
-
-RegisterClass("BABYLON.VectorConverterBlock", VectorConverterBlock);

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -35,7 +35,6 @@ import { Epsilon } from "../Maths/math.constants";
 import type { Plane } from "../Maths/math.plane";
 import { Axis } from "../Maths/math.axis";
 import type { IParticleSystem } from "../Particles/IParticleSystem";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { Ray } from "../Culling/ray";
 import type { Collider } from "../Collisions/collider";
@@ -2795,5 +2794,3 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
         return this._scene.particleSystems.filter((particleSystem) => particleSystem.emitter === this);
     }
 }
-
-RegisterClass("BABYLON.AbstractMesh", AbstractMesh);

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -15,7 +15,6 @@ import type { Light } from "../Lights/light";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Tools } from "../Misc/tools";
 import type { ThinEngine } from "../Engines/thinEngine";
-import { RegisterClass } from "../Misc/typeStore";
 
 Mesh._instancedMeshFactory = (name: string, mesh: Mesh): InstancedMesh => {
     const instance = new InstancedMesh(name, mesh);
@@ -824,6 +823,3 @@ Mesh.prototype._disposeInstanceSpecificData = function () {
 
     this.instancedBuffers = {};
 };
-
-// Register Class Name
-RegisterClass("BABYLON.InstancedMesh", InstancedMesh);

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -33,7 +33,7 @@ import type { Skeleton } from "../Bones/skeleton";
 import { Constants } from "../Engines/constants";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import { Logger } from "../Misc/logger";
-import { GetClass, RegisterClass } from "../Misc/typeStore";
+import { GetClass } from "../Misc/typeStore";
 import { _WarnImport } from "../Misc/devTools";
 import { SceneComponentConstants } from "../sceneComponent";
 import { MeshLODLevel } from "./meshLODLevel";
@@ -5519,5 +5519,3 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         throw new Error("Import MeshBuilder to populate this function");
     }
 }
-
-RegisterClass("BABYLON.Mesh", Mesh);

--- a/packages/dev/core/src/Misc/typeStore.ts
+++ b/packages/dev/core/src/Misc/typeStore.ts
@@ -1,4 +1,7 @@
 /** @internal */
+
+import { ExtractClass } from "core/contextHelper";
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _RegisteredTypes: { [key: string]: Object } = {};
 
@@ -13,6 +16,13 @@ export function RegisterClass(className: string, type: Object) {
  * @internal
  */
 export function GetClass(fqdn: string): any {
+    // First try to extract
+    const extracted = ExtractClass(fqdn.replace("BABYLON.", ""));
+    if (extracted) {
+        return extracted;
+    }
+
+    // Fallback to registered types (if user has registered them)
     return _RegisteredTypes[fqdn];
 }
 

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -24,7 +24,6 @@ import type { HemisphericParticleEmitter } from "./EmitterTypes/hemisphericParti
 import type { SphereDirectedParticleEmitter, SphereParticleEmitter } from "./EmitterTypes/sphereParticleEmitter";
 import type { CylinderDirectedParticleEmitter, CylinderParticleEmitter } from "./EmitterTypes/cylinderParticleEmitter";
 import type { ConeDirectedParticleEmitter, ConeParticleEmitter } from "./EmitterTypes/coneParticleEmitter";
-import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * This represents the base class for particle system in Babylon.
@@ -829,6 +828,3 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         throw new Error("Method not implemented.");
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.BaseParticleSystem", BaseParticleSystem);

--- a/packages/dev/core/src/Particles/computeShaderParticleSystem.ts
+++ b/packages/dev/core/src/Particles/computeShaderParticleSystem.ts
@@ -12,7 +12,6 @@ import { Constants } from "../Engines/constants";
 import { UniformBufferEffectCommonAccessor } from "../Materials/uniformBufferEffectCommonAccessor";
 import type { ComputeBindingMapping } from "../Engines/Extensions/engine.computeShader";
 import type { Effect } from "../Materials/effect";
-import { RegisterClass } from "../Misc/typeStore";
 
 import "../ShadersWGSL/gpuUpdateParticles.compute";
 
@@ -189,5 +188,3 @@ export class ComputeShaderParticleSystem implements IGPUParticleSystemPlatform {
         this._renderVertexBuffers.length = 0;
     }
 }
-
-RegisterClass("BABYLON.ComputeShaderParticleSystem", ComputeShaderParticleSystem);

--- a/packages/dev/core/src/Particles/webgl2ParticleSystem.ts
+++ b/packages/dev/core/src/Particles/webgl2ParticleSystem.ts
@@ -10,7 +10,6 @@ import type { DataArray, Nullable } from "../types";
 import type { DataBuffer } from "../Buffers/dataBuffer";
 import { UniformBufferEffectCommonAccessor } from "../Materials/uniformBufferEffectCommonAccessor";
 import { Constants } from "../Engines/constants";
-import { RegisterClass } from "../Misc/typeStore";
 
 import "../Shaders/gpuUpdateParticles.fragment";
 import "../Shaders/gpuUpdateParticles.vertex";
@@ -300,5 +299,3 @@ export class WebGL2ParticleSystem implements IGPUParticleSystemPlatform {
         return vao;
     }
 }
-
-RegisterClass("BABYLON.WebGL2ParticleSystem", WebGL2ParticleSystem);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -24,7 +24,6 @@ import { PostProcessRenderPipeline } from "../../../PostProcesses/RenderPipeline
 import { PostProcessRenderEffect } from "../../../PostProcesses/RenderPipeline/postProcessRenderEffect";
 import { DepthOfFieldEffect, DepthOfFieldEffectBlurLevel } from "../../../PostProcesses/depthOfFieldEffect";
 import { BloomEffect } from "../../../PostProcesses/bloomEffect";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { EngineStore } from "../../../Engines/engineStore";
 import { Tools } from "core/Misc/tools";
 
@@ -868,5 +867,3 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
         return SerializationHelper.Parse(() => new DefaultRenderingPipeline(source._name, source._name._hdr, scene), source, scene, rootUrl);
     }
 }
-
-RegisterClass("BABYLON.DefaultRenderingPipeline", DefaultRenderingPipeline);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -11,7 +11,6 @@ import { PostProcessRenderPipeline } from "../../../PostProcesses/RenderPipeline
 import { PostProcessRenderEffect } from "../../../PostProcesses/RenderPipeline/postProcessRenderEffect";
 import { PassPostProcess } from "../../../PostProcesses/passPostProcess";
 import type { Scene } from "../../../scene";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { EngineStore } from "../../../Engines/engineStore";
 import { SSAO2Configuration } from "../../../Rendering/ssao2Configuration";
 import type { PrePassRenderer } from "../../../Rendering/prePassRenderer";
@@ -722,5 +721,3 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
         );
     }
 }
-
-RegisterClass("BABYLON.SSAO2RenderingPipeline", SSAO2RenderingPipeline);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssrRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssrRenderingPipeline.ts
@@ -8,7 +8,6 @@ import { PostProcess } from "../../postProcess";
 import { PostProcessRenderPipeline } from "../postProcessRenderPipeline";
 import { PostProcessRenderEffect } from "../postProcessRenderEffect";
 import type { Scene } from "../../../scene";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { ScreenSpaceReflections2Configuration } from "../../../Rendering/screenSpaceReflections2Configuration";
 import type { PrePassRenderer } from "../../../Rendering/prePassRenderer";
 import { GeometryBufferRenderer } from "../../../Rendering/geometryBufferRenderer";
@@ -1309,5 +1308,3 @@ export class SSRRenderingPipeline extends PostProcessRenderPipeline {
         return SerializationHelper.Parse(() => new SSRRenderingPipeline(source._name, scene, source._ratio), source, scene, rootUrl);
     }
 }
-
-RegisterClass("BABYLON.SSRRenderingPipeline", SSRRenderingPipeline);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/standardRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/standardRenderingPipeline.ts
@@ -20,7 +20,6 @@ import type { DirectionalLight } from "../../../Lights/directionalLight";
 import type { GeometryBufferRenderer } from "../../../Rendering/geometryBufferRenderer";
 
 import { Constants } from "../../../Engines/constants";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { MotionBlurPostProcess } from "../../motionBlurPostProcess";
 import { ScreenSpaceReflectionPostProcess } from "../../screenSpaceReflectionPostProcess";
 
@@ -1684,5 +1683,3 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
      */
     public static LuminanceSteps: number = 6;
 }
-
-RegisterClass("BABYLON.StandardRenderingPipeline", StandardRenderingPipeline);

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/taaRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/taaRenderingPipeline.ts
@@ -7,7 +7,6 @@ import { PostProcess } from "../../postProcess";
 import { PostProcessRenderPipeline } from "../postProcessRenderPipeline";
 import { PostProcessRenderEffect } from "../postProcessRenderEffect";
 import type { Scene } from "../../../scene";
-import { RegisterClass } from "../../../Misc/typeStore";
 import { Constants } from "../../../Engines/constants";
 import type { Nullable } from "../../../types";
 import { PassPostProcess } from "core/PostProcesses/passPostProcess";
@@ -385,5 +384,3 @@ export class TAARenderingPipeline extends PostProcessRenderPipeline {
         return SerializationHelper.Parse(() => new TAARenderingPipeline(source._name, scene, source._ratio), source, scene, rootUrl);
     }
 }
-
-RegisterClass("BABYLON.TAARenderingPipeline", TAARenderingPipeline);

--- a/packages/dev/core/src/PostProcesses/anaglyphPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/anaglyphPostProcess.ts
@@ -3,7 +3,6 @@ import type { PostProcessOptions } from "./postProcess";
 import { PostProcess } from "./postProcess";
 import type { Camera } from "../Cameras/camera";
 import type { Effect } from "../Materials/effect";
-import { RegisterClass } from "../Misc/typeStore";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
@@ -49,5 +48,3 @@ export class AnaglyphPostProcess extends PostProcess {
         super._gatherImports(useWebGPU, list);
     }
 }
-
-RegisterClass("BABYLON.AnaglyphPostProcess", AnaglyphPostProcess);

--- a/packages/dev/core/src/PostProcesses/blackAndWhitePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blackAndWhitePostProcess.ts
@@ -4,7 +4,6 @@ import type { Camera } from "../Cameras/camera";
 import type { Effect } from "../Materials/effect";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import type { Nullable } from "../types";
@@ -79,5 +78,3 @@ export class BlackAndWhitePostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.BlackAndWhitePostProcess", BlackAndWhitePostProcess);

--- a/packages/dev/core/src/PostProcesses/bloomMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/bloomMergePostProcess.ts
@@ -6,7 +6,6 @@ import type { Effect } from "../Materials/effect";
 import type { Camera } from "../Cameras/camera";
 import { Constants } from "../Engines/constants";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 
 /**
@@ -78,5 +77,3 @@ export class BloomMergePostProcess extends PostProcess {
         super._gatherImports(useWebGPU, list);
     }
 }
-
-RegisterClass("BABYLON.BloomMergePostProcess", BloomMergePostProcess);

--- a/packages/dev/core/src/PostProcesses/blurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blurPostProcess.ts
@@ -7,7 +7,6 @@ import type { Camera } from "../Cameras/camera";
 import type { Effect } from "../Materials/effect";
 import { Texture } from "../Materials/Textures/texture";
 import { Constants } from "../Engines/constants";
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize, serializeAsVector2 } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -353,5 +352,3 @@ export class BlurPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.BlurPostProcess", BlurPostProcess);

--- a/packages/dev/core/src/PostProcesses/chromaticAberrationPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/chromaticAberrationPostProcess.ts
@@ -7,7 +7,6 @@ import type { Camera } from "../Cameras/camera";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { Constants } from "../Engines/constants";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -148,5 +147,3 @@ export class ChromaticAberrationPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.ChromaticAberrationPostProcess", ChromaticAberrationPostProcess);

--- a/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
@@ -7,7 +7,6 @@ import type { Camera } from "../Cameras/camera";
 import { Logger } from "../Misc/logger";
 import { Constants } from "../Engines/constants";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
 
@@ -121,5 +120,3 @@ export class CircleOfConfusionPostProcess extends PostProcess {
         this._depthTexture = value;
     }
 }
-
-RegisterClass("BABYLON.CircleOfConfusionPostProcess", CircleOfConfusionPostProcess);

--- a/packages/dev/core/src/PostProcesses/colorCorrectionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/colorCorrectionPostProcess.ts
@@ -5,7 +5,6 @@ import { Texture } from "../Materials/Textures/texture";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { Camera } from "../Cameras/camera";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import type { Nullable } from "../types";
@@ -101,5 +100,3 @@ export class ColorCorrectionPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.ColorCorrectionPostProcess", ColorCorrectionPostProcess);

--- a/packages/dev/core/src/PostProcesses/convolutionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/convolutionPostProcess.ts
@@ -6,7 +6,6 @@ import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { Effect } from "../Materials/effect";
 import { Constants } from "../Engines/constants";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -119,5 +118,3 @@ export class ConvolutionPostProcess extends PostProcess {
      */
     public static GaussianKernel = [0, 1, 0, 1, 1, 1, 0, 1, 0];
 }
-
-RegisterClass("BABYLON.ConvolutionPostProcess", ConvolutionPostProcess);

--- a/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
@@ -7,7 +7,6 @@ import type { PostProcess, PostProcessOptions } from "./postProcess";
 import { BlurPostProcess } from "./blurPostProcess";
 import type { Scene } from "../scene";
 import { Constants } from "../Engines/constants";
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
 
@@ -92,5 +91,3 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
         });
     }
 }
-
-RegisterClass("BABYLON.DepthOfFieldBlurPostProcess", DepthOfFieldBlurPostProcess);

--- a/packages/dev/core/src/PostProcesses/displayPassPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/displayPassPostProcess.ts
@@ -4,7 +4,6 @@ import type { PostProcessOptions } from "./postProcess";
 import { PostProcess } from "./postProcess";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
 import type { Scene } from "../scene";
@@ -66,5 +65,3 @@ export class DisplayPassPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.DisplayPassPostProcess", DisplayPassPostProcess);

--- a/packages/dev/core/src/PostProcesses/extractHighlightsPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/extractHighlightsPostProcess.ts
@@ -8,7 +8,6 @@ import { ToGammaSpace } from "../Maths/math.constants";
 import { Constants } from "../Engines/constants";
 
 import { serialize } from "../Misc/decorators";
-import { RegisterClass } from "../Misc/typeStore";
 
 /**
  * The extract highlights post process sets all pixels to black except pixels above the specified luminance threshold. Used as the first step for a bloom effect.
@@ -69,5 +68,3 @@ export class ExtractHighlightsPostProcess extends PostProcess {
         super._gatherImports(useWebGPU, list);
     }
 }
-
-RegisterClass("BABYLON.ExtractHighlightsPostProcess", ExtractHighlightsPostProcess);

--- a/packages/dev/core/src/PostProcesses/filterPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/filterPostProcess.ts
@@ -6,7 +6,6 @@ import type { PostProcessOptions } from "./postProcess";
 import { PostProcess } from "./postProcess";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serializeAsMatrix } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -88,5 +87,3 @@ export class FilterPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.FilterPostProcess", FilterPostProcess);

--- a/packages/dev/core/src/PostProcesses/fxaaPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/fxaaPostProcess.ts
@@ -7,7 +7,6 @@ import { PostProcess } from "./postProcess";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { Constants } from "../Engines/constants";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
 import type { Scene } from "../scene";
@@ -90,5 +89,3 @@ export class FxaaPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.FxaaPostProcess", FxaaPostProcess);

--- a/packages/dev/core/src/PostProcesses/grainPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/grainPostProcess.ts
@@ -6,7 +6,6 @@ import { PostProcess } from "./postProcess";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { Constants } from "../Engines/constants";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -95,5 +94,3 @@ export class GrainPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.GrainPostProcess", GrainPostProcess);

--- a/packages/dev/core/src/PostProcesses/motionBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/motionBlurPostProcess.ts
@@ -15,7 +15,6 @@ import "../Animations/animatable";
 import "../Rendering/geometryBufferRendererSceneComponent";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { Scene } from "../scene";
@@ -364,5 +363,3 @@ export class MotionBlurPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.MotionBlurPostProcess", MotionBlurPostProcess);

--- a/packages/dev/core/src/PostProcesses/passPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/passPostProcess.ts
@@ -5,7 +5,6 @@ import type { PostProcessOptions } from "./postProcess";
 import { PostProcess } from "./postProcess";
 import { AbstractEngine } from "../Engines/abstractEngine";
 
-import { RegisterClass } from "../Misc/typeStore";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
 import type { Scene } from "../scene";
@@ -78,8 +77,6 @@ export class PassPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.PassPostProcess", PassPostProcess);
 
 /**
  * PassCubePostProcess which produces an output the same as it's input (which must be a cube texture)

--- a/packages/dev/core/src/PostProcesses/postProcess.ts
+++ b/packages/dev/core/src/PostProcesses/postProcess.ts
@@ -13,7 +13,7 @@ import type { Color4 } from "../Maths/math.color";
 import type { NodeMaterial } from "../Materials/Node/nodeMaterial";
 import { serialize, serializeAsColor4 } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
-import { GetClass, RegisterClass } from "../Misc/typeStore";
+import { GetClass } from "../Misc/typeStore";
 import { DrawWrapper } from "../Materials/drawWrapper";
 import type { RenderTargetWrapper } from "../Engines/renderTargetWrapper";
 import { ShaderLanguage } from "../Materials/shaderLanguage";
@@ -1340,5 +1340,3 @@ export class PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.PostProcess", PostProcess);

--- a/packages/dev/core/src/PostProcesses/refractionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/refractionPostProcess.ts
@@ -7,7 +7,6 @@ import { PostProcess } from "./postProcess";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 
 import "../Shaders/refraction.fragment";
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import type { Nullable } from "../types";
@@ -148,5 +147,3 @@ export class RefractionPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.RefractionPostProcess", RefractionPostProcess);

--- a/packages/dev/core/src/PostProcesses/screenSpaceCurvaturePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/screenSpaceCurvaturePostProcess.ts
@@ -10,7 +10,6 @@ import type { GeometryBufferRenderer } from "../Rendering/geometryBufferRenderer
 import "../Rendering/geometryBufferRendererSceneComponent";
 import "../Shaders/screenSpaceCurvature.fragment";
 import { EngineStore } from "../Engines/engineStore";
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -139,5 +138,3 @@ export class ScreenSpaceCurvaturePostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.ScreenSpaceCurvaturePostProcess", ScreenSpaceCurvaturePostProcess);

--- a/packages/dev/core/src/PostProcesses/screenSpaceReflectionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/screenSpaceReflectionPostProcess.ts
@@ -11,7 +11,6 @@ import type { PrePassRenderer } from "../Rendering/prePassRenderer";
 import { ScreenSpaceReflectionsConfiguration } from "../Rendering/screenSpaceReflectionsConfiguration";
 
 import "../Shaders/screenSpaceReflection.fragment";
-import { RegisterClass } from "../Misc/typeStore";
 
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { Scene } from "../scene";
@@ -305,5 +304,3 @@ export class ScreenSpaceReflectionPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.ScreenSpaceReflectionPostProcess", ScreenSpaceReflectionPostProcess);

--- a/packages/dev/core/src/PostProcesses/sharpenPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/sharpenPostProcess.ts
@@ -6,7 +6,6 @@ import { PostProcess } from "./postProcess";
 import { Constants } from "../Engines/constants";
 
 import "../Shaders/sharpen.fragment";
-import { RegisterClass } from "../Misc/typeStore";
 import { serialize } from "../Misc/decorators";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 
@@ -99,5 +98,3 @@ export class SharpenPostProcess extends PostProcess {
         );
     }
 }
-
-RegisterClass("BABYLON.SharpenPostProcess", SharpenPostProcess);

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -24,7 +24,6 @@ import "../Shaders/volumetricLightScatteringPass.vertex";
 import "../Shaders/volumetricLightScatteringPass.fragment";
 import { Color4, Color3 } from "../Maths/math.color";
 import { Viewport } from "../Maths/math.viewport";
-import { RegisterClass } from "../Misc/typeStore";
 import type { Nullable } from "../types";
 
 import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
@@ -646,5 +645,3 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
         return mesh;
     }
 }
-
-RegisterClass("BABYLON.VolumetricLightScatteringPostProcess", VolumetricLightScatteringPostProcess);

--- a/packages/dev/core/src/Rendering/GlobalIllumination/giRSMManager.ts
+++ b/packages/dev/core/src/Rendering/GlobalIllumination/giRSMManager.ts
@@ -28,7 +28,6 @@ import { BaseTexture } from "core/Materials/Textures/baseTexture";
 import type { WebGPURenderTargetWrapper } from "core/Engines/WebGPU/webgpuRenderTargetWrapper";
 import { expandToProperty, serialize } from "core/Misc/decorators";
 import { MaterialDefines } from "core/Materials/materialDefines";
-import { RegisterClass } from "core/Misc/typeStore";
 
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
@@ -1048,5 +1047,3 @@ export class GIRSMRenderPluginMaterial extends MaterialPluginBase {
         return shaderType === "vertex" ? null : frag;
     }
 }
-
-RegisterClass(`BABYLON.GIRSMRenderPluginMaterial`, GIRSMRenderPluginMaterial);

--- a/packages/dev/core/src/Rendering/reflectiveShadowMap.ts
+++ b/packages/dev/core/src/Rendering/reflectiveShadowMap.ts
@@ -18,7 +18,6 @@ import { MaterialDefines } from "core/Materials/materialDefines";
 import type { SpotLight } from "core/Lights/spotLight";
 import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
 import { expandToProperty, serialize } from "core/Misc/decorators";
-import { RegisterClass } from "core/Misc/typeStore";
 import { Light } from "core/Lights/light";
 import type { DirectionalLight } from "core/Lights/directionalLight";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -531,5 +530,3 @@ export class RSMCreatePluginMaterial extends MaterialPluginBase {
         };
     }
 }
-
-RegisterClass(`BABYLON.RSMCreatePluginMaterial`, RSMCreatePluginMaterial);

--- a/packages/dev/core/src/contextHelper.ts
+++ b/packages/dev/core/src/contextHelper.ts
@@ -1,0 +1,90 @@
+declare const require: any;
+
+const ConversionTable: { [key: string]: string } = {
+    vector2: "math.vector",
+    vector3: "math.vector",
+    vector4: "math.vector",
+    matrix: "math.vector",
+    color3: "math.color",
+    color4: "math.color",
+    valuecondition: "condition",
+    predicatecondition: "condition",
+    statecondition: "condition",
+    setparentaction: "directaction",
+    executecodeaction: "directaction",
+    donothingaction: "directaction",
+    stopanimationaction: "directaction",
+    playanimationaction: "directaction",
+    incrementvalueaction: "directaction",
+    setvalueaction: "directaction",
+    setstateaction: "directaction",
+    switchbooleanaction: "directaction",
+    combineaction: "directaction",
+    playsoundaction: "directaudioaction",
+    stopsoundaction: "directaudioaction",
+    followcamera: "followcamera",
+    arcfollowcamera: "followcamera",
+    oppositeblock: "oneminusblock",
+};
+
+const RenameTable: { [key: string]: string } = {
+    oppositeblock: "OneMinusBlock",
+};
+
+/** @internal */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+let _DiscoveredTypes: { [key: string]: any };
+
+function GetLastPartWithoutExtension(path: string) {
+    const parts = path.split("/");
+    const last = parts[parts.length - 1];
+
+    return last.replace(/\.[^/.]+$/, "");
+}
+
+/**
+ * Extract a class from the bundle context
+ * @param name name of the class to extract
+ * @returns the class or undefined if not found
+ */
+export function ExtractClass(name: string) {
+    if (!_DiscoveredTypes) {
+        _DiscoveredTypes = {};
+        // Use require.context to import all modules
+        const requireModule = require.context(
+            "./", // The relative path to your classes directory
+            true, // Whether to include subdirectories
+            /\.ts$/ // Regular expression to match JavaScript files
+        );
+
+        // Build the modules mapping
+        requireModule.keys().forEach((fileName: string) => {
+            if (fileName.indexOf("LibDeclarations") !== -1) {
+                return;
+            }
+
+            // Extract the class name from the file name
+            const className = GetLastPartWithoutExtension(fileName);
+
+            if (!className) {
+                return;
+            }
+            // Import the module and assign it to the modules object
+            _DiscoveredTypes[className.toLowerCase()] = requireModule(fileName);
+        });
+    }
+    let key = name.toLowerCase();
+    if (ConversionTable[key]) {
+        key = ConversionTable[key];
+    }
+
+    if (!_DiscoveredTypes[key]) {
+        return undefined;
+    }
+
+    let className = name;
+    if (RenameTable[key]) {
+        className = RenameTable[key];
+    }
+    return _DiscoveredTypes[key][className];
+}

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -89,7 +89,6 @@ import type { Texture } from "./Materials/Textures/texture";
 import { PointerPickingConfiguration } from "./Inputs/pointerPickingConfiguration";
 import { Logger } from "./Misc/logger";
 import type { AbstractEngine } from "./Engines/abstractEngine";
-import { RegisterClass } from "./Misc/typeStore";
 import type { IAssetContainer } from "./IAssetContainer";
 
 import type { EffectLayer } from "./Layers/effectLayer";
@@ -5914,6 +5913,3 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         return this.getLastSkeletonById(id);
     }
 }
-
-// Register Class Name
-RegisterClass("BABYLON.Scene", Scene);


### PR DESCRIPTION
Ok folks! another new monster :)

I removed the need for side-effects for a LOT OF classes by replacing RegisterClass with the use of require.context

@ryantrem: please make sure that it is not a problem for the Viewer
@RaananW: I did not do the change for the FlowGraph because for some reasons that I do not know you are using FGxxx in the key for RegisterClass

The main class:
https://github.com/BabylonJS/Babylon.js/pull/15671/files#diff-6a2ff5432bcbb1632f27a94f714a7a50f7b3c4cac5d35bd7b7f8570746752e12