### PR TITLE
Typo in the Particle Editor

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/particleSystems/particleSystemPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/particleSystems/particleSystemPropertyGridComponent.tsx
@@ -181,7 +181,7 @@ export class ParticleSystemPropertyGridComponent extends React.Component<IPartic
                         }}
                     />
                 )}
-                {system.isStopping() && <TextLineComponent label="System is stoppping..." ignoreValue={true} />}
+                {system.isStopping() && <TextLineComponent label="System is stopping..." ignoreValue={true} />}
             </>
         );
     }


### PR DESCRIPTION
Not the most urgent issue. :)

The typo appears in the [Particle Editor](https://playground.babylonjs.com/#M7MYT8#11) when you stop a particle system and it still takes time until it is stopped:

![image](https://github.com/user-attachments/assets/5b043076-13f8-4341-b2a9-7aa8dd11e53d)
