### PR TITLE
Viewer snapshot rendering mode

### DIFF
--- a/packages/public/@babylonjs/viewer-alpha/test/apps/web/published.html
+++ b/packages/public/@babylonjs/viewer-alpha/test/apps/web/published.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Babylon Viewer Demo</title>
+        <meta charset="UTF-8" />
+        <script type="module" src="https://unpkg.com/@babylonjs/viewer@preview/dist/babylon-viewer.esm.min.js"></script>
+        <style>
+            html,
+            body {
+                width: 100%;
+                height: 100%;
+                padding: 0;
+                margin: 0;
+                overflow: hidden;
+            }
+        </style>
+    </head>
+    <body ondragover="event.preventDefault()" ondrop="onDrop(event)">
+        <babylon-viewer engine="WebGPU" source="https://playground.babylonjs.com/scenes/BoomBox.glb"> </babylon-viewer>
+        <script>
+            const viewerElement = document.querySelector("babylon-viewer");
+            async function onDrop(event) {
+                const file = event.dataTransfer.files[0];
+                if (file) {
+                    event.preventDefault();
+                    await customElements.whenDefined("babylon-viewer");
+                    const reader = new FileReader();
+                    reader.onload = function (e) {
+                        const dataUri = e.target.result;
+                        viewerElement.source = dataUri;
+                    };
+                    reader.readAsDataURL(file);
+                }
+            }
+        </script>
+    </body>
+</html>

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -277,7 +277,7 @@ export class HTML3DElement extends LitElement {
                 return null;
             }
 
-            const array = value.split(" ");
+            const array = value.split(/\s+/);
             if (array.length % 8 !== 0) {
                 throw new Error(
                     `hotspots should be defined in sets of 8 elements: 'name meshIndex pointIndex1 pointIndex2 pointIndex3 barycentricCoord1 barycentricCoord2 barycentricCoord3', but a total of ${array.length} elements were found in '${value}'`

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -92,14 +92,13 @@
             viewerElement.addEventListener("viewerready", (event) => {
                 viewerDetails = viewerElement.viewerDetails;
 
-                //startHotSpotLinesRenderLoop();
                 console.log(`Viewer ready.`, viewerDetails);
             });
             viewerElement.addEventListener("modelchange", (event) => {
                 console.log(`Model changed.`, viewerDetails);
             });
             let isViewerConnected = true;
-            let hotspotVisible = true;
+            let hotspotVisible = false;
 
             (async () => {
                 // The module referenced in the script tag above is loaded asynchronously, so we need to wait for it to load and for the custom element to be defined.

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -65,7 +65,7 @@
 
     <body ondragover="event.preventDefault()" ondrop="onDrop(event)">
         <babylon-viewer
-            engine="WebGL"
+            engine="WebGPU"
             source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
             environment="../../../../../public/@babylonjs/viewer-alpha/assets/photoStudio.env"
             animation-speed="1.5"
@@ -92,7 +92,7 @@
             viewerElement.addEventListener("viewerready", (event) => {
                 viewerDetails = viewerElement.viewerDetails;
 
-                startHotSpotLinesRenderLoop();
+                //startHotSpotLinesRenderLoop();
                 console.log(`Viewer ready.`, viewerDetails);
             });
             viewerElement.addEventListener("modelchange", (event) => {


### PR DESCRIPTION
This change mostly is about using the new `SnapshotRenderingHelper` to enable WebGPUEngine snapshot rendering mode. Unfortunately there are some mysteries with the perf impact, most notably, when I was testing all this on my MacBook two weeks ago, I was seeing the frame rate on my test model (20x20x20 cubes) go from ~60fps to ~95fps (on my 120hz display). Now, I am seeing ~58fps -> 66fps, even if I checkout the same branch from two weeks ago (not just the version that is using `SnapshotRenderingHelper`). I have no explanation for this. The only thing I can think of is that I installed a MacOS update since then. Behavior is the same in Chrome and Edge. With an even heavier model (25x25x25 cubes), I am seeing these results:

### MacBook
- WebGL: 45fps
- WebGPU: 25fps
- WebGPU w/snapshot: 27fps

### Windows
- WebGL: 48fps
- WebGPU: 40fps
- WebGPU w/snapshot: 55fps

So snapshot rendering as is still improves perf for the viewer, but not as dramatically as when previously tested, and it's now worse than `Engine` (WebGL) on my MacBook, so it would be good to investigate more separately.

I included a couple other small changes in this PR as well:
- When ViewerElement parses the hotspots string, it splits on any amount of white space, not just a single white space (@CedricGuillemet).
- I changed the default engine for the Viewer test app to be WebGPU for now.
- Disabled the test hotspot in the Viewer test app by default since it kind of gets in the way when testing other models.
- Added a published.html test file to make it easy to test the published viewer package.
