### PR TITLE
Prevent multiple SpriteRenderers from repeatedly initializing the same shader

### DIFF
--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -254,7 +254,7 @@ export class SpriteRenderer {
     }
 
     private _createEffects() {
-        if (this._isDisposed) {
+        if (this._isDisposed || !this._shadersLoaded) {
             return;
         }
 


### PR DESCRIPTION
A race condition existed due to asynchronous loading of shader code as a side effect of the SpriteRenderer constructor.

https://forum.babylonjs.com/t/spriterenderer-tries-to-use-shader-before-its-loaded/54035