### PR TITLE
Fix local d.ts generation

### DIFF
--- a/packages/tools/accessibility/src/HtmlTwin/htmlTwinItemAdapter.tsx
+++ b/packages/tools/accessibility/src/HtmlTwin/htmlTwinItemAdapter.tsx
@@ -27,7 +27,7 @@ function getTwinItemFromNode(node: AccessibilityEntity, scene: Scene) {
  * @param props the props of the adapter
  * @returns
  */
-export function HTMLTwinItemAdapter(props: { node: AccessibilityEntity; scene: Scene; options: IHTMLTwinRendererOptions }) {
+export function HTMLTwinItemAdapter(props: { node: AccessibilityEntity; scene: Scene; options: IHTMLTwinRendererOptions }): JSX.Element | null {
     const { node, scene, options } = props;
     if (!node) {
         return null;

--- a/packages/tools/accessibility/src/HtmlTwin/htmlTwinSceneTree.tsx
+++ b/packages/tools/accessibility/src/HtmlTwin/htmlTwinSceneTree.tsx
@@ -29,7 +29,7 @@ function getFullscreenGuiTextures(scene: Scene) {
  * @param props
  * @returns
  */
-export function HTMLTwinSceneTree(props: { scene: Scene; options: IHTMLTwinRendererOptions }) {
+export function HTMLTwinSceneTree(props: { scene: Scene; options: IHTMLTwinRendererOptions }): JSX.Element {
     const { scene, options } = props;
 
     const [, setMeshIds] = useState(new Set<number>());


### PR DESCRIPTION
Under certain conditions we require return definitions, otherwise typescript uses `import("whatever").type`, which messes up with our UMD d.ts processing.

This fixes it for the associated functions.