### PR TITLE
WebGPU: Fix crash when using lightmaps

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -198,7 +198,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
     #ifdef RGBDLIGHTMAP
         lightmapColor = vec4f(fromRGBD(lightmapColor), lightmapColor.a);
     #endif
-	lightmapColor = vec4f(lightmapColor.rgb * vLightmapInfos.y, lightmapColor.a);
+	lightmapColor = vec4f(lightmapColor.rgb * uniforms.vLightmapInfos.y, lightmapColor.a);
 #endif
 
 #include<lightFragment>[0..maxSimultaneousLights]


### PR DESCRIPTION
See https://forum.babylonjs.com/t/lightmaptexture-issue-of-material-in-webgpu/54121