### PR TITLE
WebGPU: Fix requestAdapterInfo removed from the spec

### DIFF
--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -146,6 +146,11 @@ export interface GlslangOptions {
  */
 export interface WebGPUEngineOptions extends AbstractEngineOptions, GPURequestAdapterOptions {
     /**
+     * The featureLevel property of the GPURequestAdapterOptions interface
+     */
+    featureLevel?: string;
+
+    /**
      * Defines the category of adapter to use.
      * Is it the discrete or integrated device.
      */
@@ -639,10 +644,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
                     this._adapterSupportedExtensions = [];
                     this._adapter.features?.forEach((feature) => this._adapterSupportedExtensions.push(feature as WebGPUConstants.FeatureName));
                     this._adapterSupportedLimits = this._adapter.limits;
-
-                    this._adapter.requestAdapterInfo().then((adapterInfo) => {
-                        this._adapterInfo = adapterInfo;
-                    });
+                    this._adapterInfo = this._adapter.info;
 
                     const deviceDescriptor = this._options.deviceDescriptor ?? {};
                     const requiredFeatures = deviceDescriptor?.requiredFeatures ?? (this._options.enableAllFeatures ? this._adapterSupportedExtensions : undefined);

--- a/packages/dev/core/src/LibDeclarations/webgpu.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webgpu.d.ts
@@ -72,6 +72,7 @@ declare class GPU {
 }
 
 interface GPURequestAdapterOptions {
+    featureLevel?: string;
     powerPreference?: GPUPowerPreference;
     forceFallbackAdapter?: boolean /* default=false */;
 }
@@ -83,10 +84,10 @@ declare class GPUAdapter {
     readonly name: string;
     readonly features: GPUSupportedFeatures;
     readonly limits: GPUSupportedLimits;
+    readonly info: GPUAdapterInfo;
     readonly isFallbackAdapter: boolean;
 
     requestDevice(descriptor?: GPUDeviceDescriptor): Promise<GPUDevice>;
-    requestAdapterInfo(unmaskHints?: string[]): Promise<GPUAdapterInfo>;
 }
 
 interface GPUDeviceDescriptor extends GPUObjectDescriptorBase {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/https-playground-babylonjs-com-webgpu-yx6ib8-758-is-calling-requestadapterinfo/54116