### PR TITLE
GS Volume Culling

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -706,7 +706,6 @@ export class GaussianSplattingMesh extends Mesh {
         this._worker.onmessage = (e) => {
             this._depthMix = e.data.depthMix;
             const indexMix = new Uint32Array(e.data.depthMix.buffer);
-            //Logger.Log(`ahahahah ${this._vertexCount} - ${e.data.subsetSize}`);
             if (this._splatIndex) {
                 for (let j = 0; j < e.data.subsetSize; j++) {
                     this._splatIndex[j] = indexMix[2 * j];

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -13,7 +13,6 @@ import { Constants } from "core/Engines/constants";
 import { Tools } from "core/Misc/tools";
 import "core/Meshes/thinInstanceMesh";
 import type { ThinEngine } from "core/Engines/thinEngine";
-import { DeepCopier } from "core/Misc/deepCopier";
 import { Frustum } from "core/Maths/math.frustum";
 
 interface DelayedTextureUpdate {

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -1,7 +1,8 @@
 import type { ISceneLoaderPluginAsync, ISceneLoaderPluginFactory, ISceneLoaderAsyncResult, ISceneLoaderProgressEvent, SceneLoaderPluginOptions } from "core/Loading/sceneLoader";
 import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { SPLATFileLoaderMetadata } from "./splatFileLoader.metadata";
-import { GaussianSplattingMesh, type BoundingVolume } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
+import type { BoundingVolume } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
+import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
 import type { Nullable } from "core/types";


### PR DESCRIPTION
This is the 1st step for performance improvements with GS.
AABB Volumes used are coming from Compressed .PLY quantized chunks. It's far for being efficient. But goal here is to have everything in place to try different algorithms while not increasing complexity too much at once.

Batch of 256 splats are culled. visible ones are sorted and that subset is used for instance count.
It should decrease the pressure on GPU/CPU a little.

Next:
- Better partitioning (octree)
- wasm sorting
- radix sort?
- per splat culling
- per volume sorting of splats and volume sorting


EDIT: there should be 1 noticeable issue when camera moves fast with huge number of splats. Latency induced by sorting will make visible splat being not culled late and popping might be visible.