### PR TITLE
Improve handling of texture names in glTF loader

### DIFF
--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -905,8 +905,9 @@ export class Texture extends BaseTexture {
         serializationObject._creationFlags = this._creationFlags;
         serializationObject._useSRGBBuffer = this._useSRGBBuffer;
         if (Texture._SerializeInternalTextureUniqueId) {
-            serializationObject.internalTextureUniqueId = this._texture?.uniqueId ?? undefined;
+            serializationObject.internalTextureUniqueId = this._texture?.uniqueId;
         }
+        serializationObject.internalTextureLabel = this._texture?.label;
         serializationObject.noMipmap = this._noMipmap;
 
         this.name = savedName;
@@ -1003,8 +1004,12 @@ export class Texture extends BaseTexture {
                 }
             }
 
-            if (hasInternalTextureUniqueId && !internalTexture) {
-                texture?._texture?._setUniqueId(parsedTexture.internalTextureUniqueId);
+            if (texture && texture._texture) {
+                if (hasInternalTextureUniqueId && !internalTexture) {
+                    texture._texture._setUniqueId(parsedTexture.internalTextureUniqueId);
+                }
+
+                texture._texture.label = parsedTexture.internalTextureLabel;
             }
         };
 

--- a/packages/dev/core/src/Materials/Textures/textureSampler.ts
+++ b/packages/dev/core/src/Materials/Textures/textureSampler.ts
@@ -108,7 +108,7 @@ export class TextureSampler {
     public _comparisonFunction: number = 0;
 
     /**
-     * Used for debugging purpose only
+     * General label used for debugging or storing a name.
      */
     public label?: string;
 

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -2430,12 +2430,22 @@ export class GLTFLoader implements IGLTFLoader {
                 const name = image.uri || `${this._fileName}#image${image.index}`;
                 const dataUrl = `data:${this._uniqueRootUrl}${name}`;
                 babylonTexture.updateURL(dataUrl, data);
+
+                // Set the internal texture label.
+                const internalTexture = babylonTexture.getInternalTexture();
+                if (internalTexture) {
+                    internalTexture.label = image.name;
+                }
             })
         );
 
         babylonTexture.wrapU = samplerData.wrapU;
         babylonTexture.wrapV = samplerData.wrapV;
         assign(babylonTexture);
+
+        if (this._parent.useGltfTextureNames) {
+            babylonTexture.name = image.name || image.uri || `image${image.index}`;
+        }
 
         return Promise.all(promises).then(() => {
             return babylonTexture;

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -209,6 +209,7 @@ abstract class GLTFLoaderOptions {
             this.useSRGBBuffers = options.useSRGBBuffers ?? this.useSRGBBuffers;
             this.targetFps = options.targetFps ?? this.targetFps;
             this.alwaysComputeSkeletonRootNode = options.alwaysComputeSkeletonRootNode ?? this.alwaysComputeSkeletonRootNode;
+            this.useGltfTextureNames = options.useGltfTextureNames ?? this.useGltfTextureNames;
             this.preprocessUrlAsync = options.preprocessUrlAsync ?? this.preprocessUrlAsync;
             this.customRootNode = options.customRootNode;
             this.onMeshLoaded = options.onMeshLoaded;
@@ -328,6 +329,12 @@ abstract class GLTFLoaderOptions {
      * Set this to true if loading assets with invalid `skin.skeleton` values.
      */
     public alwaysComputeSkeletonRootNode = false;
+
+    /**
+     * If true, the loader will derive the name for Babylon textures from the glTF texture name, image name, or image url. Defaults to false.
+     * Note that it is possible for multiple Babylon textures to share the same name when the Babylon textures load from the same glTF texture or image.
+     */
+    public useGltfTextureNames = false;
 
     /**
      * Function called before loading a url referenced by the asset.


### PR DESCRIPTION
See https://forum.babylonjs.com/t/gltfloader-option-to-keep-or-prefer-original-texture-or-image-name-as-name-of-loaded-texture/37307

Tested with this PG: http://localhost:1338/#SJUH9H#3