### PR TITLE
WebGPU: Fix collisions in bind group cache

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheSampler.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheSampler.ts
@@ -65,7 +65,7 @@ export class WebGPUCacheSampler {
 
     public static GetSamplerHashCode(sampler: TextureSampler): number {
         // The WebGPU spec currently only allows values 1 and 4 for anisotropy
-        const anisotropy = sampler._cachedAnisotropicFilteringLevel && sampler._cachedAnisotropicFilteringLevel > 1 ? 4 : 1;
+        const anisotropy = sampler._cachedAnisotropicFilteringLevel ? sampler._cachedAnisotropicFilteringLevel : 1;
         const code =
             filterToBits[sampler.samplingMode] +
             comparisonFunctionToBits[(sampler._comparisonFunction || 0x0202) - 0x0200 + 1] +
@@ -243,8 +243,7 @@ export class WebGPUCacheSampler {
     }
 
     private static _GetSamplerDescriptor(sampler: TextureSampler, label?: string): GPUSamplerDescriptor {
-        // The WebGPU spec currently only allows values 1 and 4 for anisotropy
-        const anisotropy = sampler.useMipMaps && sampler._cachedAnisotropicFilteringLevel && sampler._cachedAnisotropicFilteringLevel > 1 ? 4 : 1;
+        const anisotropy = sampler.useMipMaps && sampler._cachedAnisotropicFilteringLevel ? sampler._cachedAnisotropicFilteringLevel : 1;
         const filterDescriptor = this._GetSamplerFilterDescriptor(sampler, anisotropy);
         return {
             label,


### PR DESCRIPTION
[This PG - localhost](http://localhost:1338/#8R5SSE#354) from #15634 generated bind group cache collisions. This is fixed by this PR.

I've also corrected the anisotropy value used to calculate the sampler hash code (I've mixed up the MSAA values - which are limited to 1 or 4 - with the anisotropy values, which are not!).