### PR TITLE
Make sure the _enginePromise variable is cleared when not needed.

### DIFF
--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -224,6 +224,7 @@ export function Dispose() {
             dumpToolsEngine.engine.dispose();
         });
     }
+    _enginePromise = null;
     _dumpToolsEngine = null;
 }
 


### PR DESCRIPTION
ee https://forum.babylonjs.com/t/engine-at-dumptools-is-not-being-disposed-properly/54259?u=raananw