### PR TITLE
Inspector: Fix crash when viewing texture in inspector with WebGL1

### DIFF
--- a/packages/dev/core/src/Shaders/lod.fragment.fx
+++ b/packages/dev/core/src/Shaders/lod.fragment.fx
@@ -11,7 +11,7 @@ uniform vec2 texSize;
 uniform int gamma;
 void main(void)
 {
-    gl_FragColor = textureLod(textureSampler,vUV,lod);
+    gl_FragColor = texture2DLodEXT(textureSampler,vUV,lod);
     if (gamma == 0) {
         gl_FragColor.rgb = pow(gl_FragColor.rgb, vec3(GammaEncodePowerApprox));
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/inspector-unable-to-preview-texture-in-webgl1-engine/54298