### PR TITLE
fix missing dirtying children for world transform freezing

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1249,6 +1249,8 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     public override markAsDirty(property?: string): AbstractMesh {
         this._currentRenderId = Number.MAX_VALUE;
+        // Make sure to call super.markAsDirty before setting the _isDirty flag, otherwise it might early out.
+        super.markAsDirty(property);
         this._isDirty = true;
         return this;
     }

--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -209,7 +209,7 @@ export class TransformNode extends Node {
 
     public set position(newPosition: Vector3) {
         this._position = newPosition;
-        this._isDirty = true;
+        this._markAsDirtyInternal();
     }
 
     /**
@@ -238,7 +238,7 @@ export class TransformNode extends Node {
     public set rotation(newRotation: Vector3) {
         this._rotation = newRotation;
         this._rotationQuaternion = null;
-        this._isDirty = true;
+        this._markAsDirtyInternal();
     }
 
     /**
@@ -250,7 +250,7 @@ export class TransformNode extends Node {
 
     public set scaling(newScaling: Vector3) {
         this._scaling = newScaling;
-        this._isDirty = true;
+        this._markAsDirtyInternal();
     }
 
     /**
@@ -267,7 +267,7 @@ export class TransformNode extends Node {
         if (quaternion) {
             this._rotation.setAll(0.0);
         }
-        this._isDirty = true;
+        this._markAsDirtyInternal();
     }
 
     /**
@@ -764,6 +764,19 @@ export class TransformNode extends Node {
             }
         }
         return super.markAsDirty(property);
+    }
+
+    private _markAsDirtyInternal(): void {
+        if (this._isDirty) return;
+        this._isDirty = true;
+        if (this._children) {
+            for (const child of this._children) {
+                if ((child as any)._isWorldMatrixFrozen && child instanceof TransformNode) {
+                    // Dirty the child if it is a transform node and has world matrix freezing (otherwise the dirtying is not necessary)
+                    child._markAsDirtyInternal();
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR aims to fix the bug reported here: 
https://forum.babylonjs.com/t/transform-setters-in-transformnode-do-not-dirty-children-different-behaviour-than-markasdirty/54260

However, it doesn't fix the exact case shown there, as the animation updates the properties of the position field, which doesn't dirty the transform node at all.
However, it does fix a similar case, shown in the playground example [#KHUCJ0#2] (https://playground.babylonjs.com/#KHUCJ0#2) (animating the position variable, instead of its fields)

This PR also fixes the case that any `AbstractMesh` does not dirty it's children in the markAsDirty function. I've found no specific issue caused by this, but it seemed like faulty behaviour.