### PR TITLE
Disable performancePriorty for Viewer

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -27,7 +27,7 @@ import { CreateBox } from "core/Meshes/Builders/boxBuilder";
 import { computeMaxExtents } from "core/Meshes/meshUtils";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Observable } from "core/Misc/observable";
-import { Scene, ScenePerformancePriority } from "core/scene";
+import { Scene } from "core/scene";
 import { registerBuiltInLoaders } from "loaders/dynamic";
 import { Viewport } from "core/Maths/math.viewport";
 import { GetHotSpotToRef } from "core/Meshes/abstractMesh.hotSpot";
@@ -204,7 +204,6 @@ export class Viewer implements IDisposable {
             scene: new Scene(this._engine),
             model: null,
         };
-        this._details.scene.performancePriority = ScenePerformancePriority.Aggressive;
         this._details.scene.clearColor = finalOptions.backgroundColor;
         this._snapshotHelper = new SnapshotRenderingHelper(this._details.scene, { morphTargetsNumMaxInfluences: 30 });
         this._camera = new ArcRotateCamera("camera1", 0, 0, 1, Vector3.Zero(), this._details.scene);


### PR DESCRIPTION
When I initially enabled this, I missed that it breaks rendering of some models. After a chat with @deltakosh, I tried deferring setting the performancePriority to Aggressive until after the scene is ready and at least one frame has rendered and that seemed to fix this issue for WebGL, but when using WebGPUEngine it's still broken. This PR will at least unbreak the Viewer while we continue investigating performancePriority + WebGPUEngine.