### PR TITLE
Skip frustum clipping in viewer

### DIFF
--- a/packages/public/@babylonjs/viewer-alpha/test/apps/web/published.html
+++ b/packages/public/@babylonjs/viewer-alpha/test/apps/web/published.html
@@ -3,7 +3,7 @@
     <head>
         <title>Babylon Viewer Demo</title>
         <meta charset="UTF-8" />
-        <script type="module" src="https://unpkg.com/@babylonjs/viewer@preview/dist/babylon-viewer.esm.min.js"></script>
+        <script type="module" src="https://cdn.jsdelivr.net/npm/@babylonjs/viewer@preview/dist/babylon-viewer.esm.min.js"></script>
         <style>
             html,
             body {

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -204,6 +204,8 @@ export class Viewer implements IDisposable {
             scene: new Scene(this._engine),
             model: null,
         };
+        this._details.scene.skipFrustumClipping = true;
+        this._details.scene.skipPointerMovePicking = true;
         this._details.scene.clearColor = finalOptions.backgroundColor;
         this._snapshotHelper = new SnapshotRenderingHelper(this._details.scene, { morphTargetsNumMaxInfluences: 30 });
         this._camera = new ArcRotateCamera("camera1", 0, 0, 1, Vector3.Zero(), this._details.scene);


### PR DESCRIPTION
I recently removed the code that was setting performancePriority to Aggressive because it broke some rendering scenarios (still investigating). However removing it also breaks other things. Specifically, we need to skip frustum culling (render all meshes) for WebGPU snapshot mode. So I'm adding this back explicitly (along with one other performancePriority related setting) for now. Also I updated the published.html test file to use jsdelivr instead of unpkg as it is faster and easier to use when testing.