### PR TITLE
Standard material: use the specular color of the material for reflectivity when there's no light

### DIFF
--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1743,9 +1743,7 @@ export class StandardMaterial extends PushMaterial {
                     ubo.updateFloat("pointSize", this.pointSize);
                 }
 
-                if (defines.SPECULARTERM) {
-                    ubo.updateColor4("vSpecularColor", this.specularColor, this.specularPower);
-                }
+                ubo.updateColor4("vSpecularColor", this.specularColor, this.specularPower);
 
                 ubo.updateColor3("vEmissiveColor", StandardMaterial.EmissiveTextureEnabled ? this.emissiveColor : Color3.BlackReadOnly);
                 ubo.updateColor4("vDiffuseColor", this.diffuseColor, this.alpha);

--- a/packages/dev/core/src/Shaders/ShadersInclude/defaultFragmentDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/defaultFragmentDeclaration.fx
@@ -1,9 +1,7 @@
 uniform vec4 vEyePosition;
 
 uniform vec4 vDiffuseColor;
-#ifdef SPECULARTERM
 uniform vec4 vSpecularColor;
-#endif
 uniform vec3 vEmissiveColor;
 uniform vec3 vAmbientColor;
 

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -495,6 +495,7 @@ color.rgb = max(color.rgb, 0.);
 				gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(toLinearSpace(specularColor), 1.0) * writeGeometryInfo;
 #endif
 #endif
+#endif
 
 #if !defined(PREPASS) || defined(WEBGL2)
 	gl_FragColor = color;

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -173,20 +173,17 @@ void main(void) {
 
 #define CUSTOM_FRAGMENT_BEFORE_LIGHTS
 
-	// Specular map
-#ifdef SPECULARTERM
 	float glossiness = vSpecularColor.a;
 	vec3 specularColor = vSpecularColor.rgb;
-
-#ifdef SPECULAR
-	vec4 specularMapColor = texture2D(specularSampler, vSpecularUV + uvOffset);
-	specularColor = specularMapColor.rgb;
-#ifdef GLOSSINESS
-	glossiness = glossiness * specularMapColor.a;
-#endif
-#endif
-#else
-	float glossiness = 0.;
+	// Specular map
+#ifdef SPECULARTERM
+	#ifdef SPECULAR
+		vec4 specularMapColor = texture2D(specularSampler, vSpecularUV + uvOffset);
+		specularColor = specularMapColor.rgb;
+		#ifdef GLOSSINESS
+			glossiness = glossiness * specularMapColor.a;
+		#endif
+	#endif
 #endif
 
 	// Lighting
@@ -492,15 +489,10 @@ color.rgb = max(color.rgb, 0.);
         gl_FragData[PREPASS_ALBEDO_SQRT_INDEX] = vec4(0.0, 0.0, 0.0, writeGeometryInfo); // We can't split albedo on std material
 #endif
 #ifdef PREPASS_REFLECTIVITY
-#if defined(SPECULARTERM)
 #if defined(SPECULAR)
 				gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(toLinearSpace(specularMapColor)) * writeGeometryInfo; // no specularity if no visibility
 #else
 				gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(toLinearSpace(specularColor), 1.0) * writeGeometryInfo;
-#endif
-#else
-			gl_FragData[PREPASS_REFLECTIVITY_INDEX] = vec4(0.0, 0.0, 0.0, 1.0) * writeGeometryInfo;
-#endif
 #endif
 #endif
 

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -167,20 +167,17 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 
 #define CUSTOM_FRAGMENT_BEFORE_LIGHTS
 
-	// Specular map
-#ifdef SPECULARTERM
 	var glossiness: f32 = uniforms.vSpecularColor.a;
 	var specularColor: vec3f = uniforms.vSpecularColor.rgb;
-
-#ifdef SPECULAR
-	var specularMapColor: vec4f = textureSample(specularSampler, specularSamplerSampler, fragmentInputs.vSpecularUV + uvOffset);
-	specularColor = specularMapColor.rgb;
-#ifdef GLOSSINESS
-	glossiness = glossiness * specularMapColor.a;
-#endif
-#endif
-#else
-	var glossiness: f32 = 0.;
+	// Specular map
+#ifdef SPECULARTERM
+	#ifdef SPECULAR
+		var specularMapColor: vec4f = textureSample(specularSampler, specularSamplerSampler, fragmentInputs.vSpecularUV + uvOffset);
+		specularColor = specularMapColor.rgb;
+		#ifdef GLOSSINESS
+			glossiness = glossiness * specularMapColor.a;
+		#endif
+	#endif
 #endif
 
 	// Lighting
@@ -490,7 +487,6 @@ color = vec4f(max(color.rgb, vec3f(0.)), color.a);
               writeGeometryInfo); // We can't split albedo on std material
 #endif
 #ifdef PREPASS_REFLECTIVITY
-#if defined(SPECULARTERM)
 #if defined(SPECULAR)
     fragData[PREPASS_REFLECTIVITY_INDEX] =
         vec4f(toLinearSpaceVec4(specularMapColor)) *
@@ -498,10 +494,6 @@ color = vec4f(max(color.rgb, vec3f(0.)), color.a);
 #else
     fragData[PREPASS_REFLECTIVITY_INDEX] =
         vec4f(toLinearSpaceVec3(specularColor), 1.0) * writeGeometryInfo;
-#endif
-#else
-    fragData[PREPASS_REFLECTIVITY_INDEX] =
-        vec4f(0.0, 0.0, 0.0, 1.0) * writeGeometryInfo;
 #endif
 #endif
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/prepass-renderer-giving-inconsistent-reflectivity-texture-based-on-lights-in-the-scene/54387

We align with what the geometry buffer renderer is doing in this case.