### PR TITLE
Viewer: add clear-color attribute

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -63,10 +63,6 @@ function updateSkybox(skybox: Nullable<Mesh>, camera: Camera): void {
     skybox?.scaling.setAll((camera.maxZ - camera.minZ) / 2);
 }
 
-const defaultViewerOptions = {
-    backgroundColor: new Color4(0.1, 0.1, 0.2, 1.0),
-} as const;
-
 export type ViewerDetails = {
     /**
      * Gets the Viewer instance.
@@ -85,13 +81,12 @@ export type ViewerDetails = {
 };
 
 export type ViewerOptions = Partial<
-    typeof defaultViewerOptions &
-        Readonly<{
-            /**
-             * Called once when the viewer is initialized and provides viewer details that can be used for advanced customization.
-             */
-            onInitialized: (details: Readonly<ViewerDetails>) => void;
-        }>
+    Readonly<{
+        /**
+         * Called once when the viewer is initialized and provides viewer details that can be used for advanced customization.
+         */
+        onInitialized: (details: Readonly<ViewerDetails>) => void;
+    }>
 >;
 
 export type ViewerHotSpotQuery = {
@@ -198,7 +193,6 @@ export class Viewer implements IDisposable {
         private readonly _engine: AbstractEngine,
         options?: ViewerOptions
     ) {
-        const finalOptions = { ...defaultViewerOptions, ...options };
         this._details = {
             viewer: this,
             scene: new Scene(this._engine),
@@ -206,7 +200,6 @@ export class Viewer implements IDisposable {
         };
         this._details.scene.skipFrustumClipping = true;
         this._details.scene.skipPointerMovePicking = true;
-        this._details.scene.clearColor = finalOptions.backgroundColor;
         this._snapshotHelper = new SnapshotRenderingHelper(this._details.scene, { morphTargetsNumMaxInfluences: 30 });
         this._camera = new ArcRotateCamera("camera1", 0, 0, 1, Vector3.Zero(), this._details.scene);
         this._camera.attachControl();

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -20,7 +20,6 @@ import { loadAssetContainerAsync } from "core/Loading/sceneLoader";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { CubeTexture } from "core/Materials/Textures/cubeTexture";
 import { Texture } from "core/Materials/Textures/texture";
-import { Color4 } from "core/Maths/math.color";
 import { Clamp } from "core/Maths/math.scalar.functions";
 import { TmpVectors, Vector3 } from "core/Maths/math.vector";
 import { CreateBox } from "core/Meshes/Builders/boxBuilder";


### PR DESCRIPTION
This change adds a `clear-color` attribute to the Viewer html element. Since it is in the html layer, it relies on WebAPI to convert an arbitrary color string to a Babylon Color4. It is transparent by default. I also made one other small change to have the root div (`:host` in css) inherit all from the outer babylon-viewer element. I think this should be safe, and it lets you do things like this in CSS:

```css
babylon-viewer {
  background-image: url("https://raw.githubusercontent.com/BabylonJS/Assets/master/textures/Checker_albedo.png");
}
```

Combining these two things together, with the default transparent `clear-color` you can get this:

![image](https://github.com/user-attachments/assets/5310c258-94fa-4271-9b5d-c53749089ca7)
