### PR TITLE
fix: raw camera texture type mismatch

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRRawCameraAccess.ts
+++ b/packages/dev/core/src/XR/features/WebXRRawCameraAccess.ts
@@ -168,7 +168,7 @@ export class WebXRRawCameraAccess extends WebXRAbstractFeature {
             internalTexture.invertY = false;
             internalTexture.format = Constants.TEXTUREFORMAT_RGBA;
             internalTexture.generateMipMaps = true;
-            internalTexture.type = Constants.TEXTURETYPE_FLOAT;
+            internalTexture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             internalTexture.samplingMode = Constants.TEXTURE_LINEAR_LINEAR_MIPLINEAR;
             internalTexture.width = view.camera.width;
             internalTexture.height = view.camera.height;


### PR DESCRIPTION
From the issue discussed in [forum](https://forum.babylonjs.com/t/read-pixels-from-raw-camera-texture/51358/19)

This PR aim to fix the issue where calling `texture.readPixels()` from texture obtained from `onTexturesUpdatedObservable` method result in an array of zeros
