### PR TITLE
Add cameraAutoOrbit, defaultAnimation, and animationAutoPlay to Viewer

### DIFF
--- a/packages/dev/core/src/Behaviors/Cameras/autoRotationBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Cameras/autoRotationBehavior.ts
@@ -168,6 +168,7 @@ export class AutoRotationBehavior implements Behavior<ArcRotateCamera> {
 
         this._attachedCamera.onAfterCheckInputsObservable.remove(this._onAfterCheckInputsObserver);
         this._attachedCamera = null;
+        this._lastFrameTime = null;
     }
 
     /**

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -5138,6 +5138,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         this.onKeyboardObservable.clear();
         this.onActiveCameraChanged.clear();
         this.onScenePerformancePriorityChangedObservable.clear();
+        this.onClearColorChangedObservable.clear();
         this._isDisposed = true;
     }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -219,10 +219,28 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
      * Gets or sets a boolean that indicates if the scene must clear the depth and stencil buffers before rendering a frame
      */
     public autoClearDepthAndStencil = true;
+
+    private _clearColor: Color4 = new Color4(0.2, 0.2, 0.3, 1.0);
+
+    /**
+     * Observable triggered when the performance priority is changed
+     */
+    public onClearColorChangedObservable = new Observable<Color4>();
+
     /**
      * Defines the color used to clear the render buffer (Default is (0.2, 0.2, 0.3, 1.0))
      */
-    public clearColor: Color4 = new Color4(0.2, 0.2, 0.3, 1.0);
+    public get clearColor(): Color4 {
+        return this._clearColor;
+    }
+
+    public set clearColor(value: Color4) {
+        if (value !== this._clearColor) {
+            this._clearColor = value;
+            this.onClearColorChangedObservable.notifyObservers(this._clearColor);
+        }
+    }
+
     /**
      * Defines the color used to simulate the ambient color (Default is (0, 0, 0))
      */
@@ -4348,7 +4366,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
                 rtt.onClearObservable.notifyObservers(this._engine);
             } else if (!rtt.skipInitialClear && !camera.isRightCamera) {
                 if (this.autoClear) {
-                    this._engine.clear(rtt.clearColor || this.clearColor, !rtt._cleared, true, true);
+                    this._engine.clear(rtt.clearColor || this._clearColor, !rtt._cleared, true, true);
                 }
                 rtt._cleared = true;
             }
@@ -4665,7 +4683,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
     private _clear(): void {
         if (this.autoClearDepthAndStencil || this.autoClear) {
-            this._engine.clear(this.clearColor, this.autoClear || this.forceWireframe || this.forcePointsCloud, this.autoClearDepthAndStencil, this.autoClearDepthAndStencil);
+            this._engine.clear(this._clearColor, this.autoClear || this.forceWireframe || this.forcePointsCloud, this.autoClearDepthAndStencil, this.autoClearDepthAndStencil);
         }
     }
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -148,6 +148,11 @@ export class Viewer implements IDisposable {
     public readonly onModelError = new Observable<unknown>();
 
     /**
+     * Fired when the camera auto orbit state changes.
+     */
+    public readonly onCameraAutoOrbitChanged = new Observable<void>();
+
+    /**
      * Fired when the selected animation changes.
      */
     public readonly onSelectedAnimationChanged = new Observable<void>();
@@ -239,6 +244,7 @@ export class Viewer implements IDisposable {
             } else {
                 this._camera.removeBehavior(this._autoRotationBehavior);
             }
+            this.onCameraAutoOrbitChanged.notifyObservers();
         }
     }
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -124,6 +124,7 @@ export type ViewerHotSpot = {
 };
 
 /**
+ * @experimental
  * Provides an experience for viewing a single 3D model.
  * @remarks
  * The Viewer is not tied to a specific UI framework and can be used with Babylon.js in a browser or with Babylon Native.

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -88,6 +88,15 @@ export type ViewerOptions = Partial<
     }>
 >;
 
+export type EnvironmentOptions = Partial<
+    Readonly<{
+        /**
+         * A value between 0 and 1 that specifies how much to blur the skybox.
+         */
+        blur: number;
+    }>
+>;
+
 export type ViewerHotSpotQuery = {
     /**
      * The index of the mesh within the loaded model.
@@ -410,7 +419,7 @@ export class Viewer implements IDisposable {
      * @param options The options to use when loading the environment.
      * @param abortSignal An optional signal that can be used to abort the loading process.
      */
-    public async loadEnvironment(url: string, options?: {}, abortSignal?: AbortSignal): Promise<void> {
+    public async loadEnvironment(url: string, options?: EnvironmentOptions, abortSignal?: AbortSignal): Promise<void> {
         await this._updateEnvironment(url, options, abortSignal);
     }
 
@@ -422,7 +431,7 @@ export class Viewer implements IDisposable {
         await this._updateEnvironment(undefined, undefined, abortSignal);
     }
 
-    private async _updateEnvironment(url: Nullable<string | undefined>, options?: {}, abortSignal?: AbortSignal): Promise<void> {
+    private async _updateEnvironment(url: Nullable<string | undefined>, options?: EnvironmentOptions, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
 
         this._loadEnvironmentAbortController?.abort("New environment is being loaded before previous environment finished loading.");
@@ -441,7 +450,7 @@ export class Viewer implements IDisposable {
                         const cubeTexture = CubeTexture.CreateFromPrefilteredData(url, this._details.scene);
                         this._details.scene.environmentTexture = cubeTexture;
 
-                        const skybox = createSkybox(this._details.scene, this._camera, cubeTexture, 0.3);
+                        const skybox = createSkybox(this._details.scene, this._camera, cubeTexture, options?.blur ?? 0.3);
                         this._snapshotHelper.fixMeshes([skybox]);
                         this._skybox = skybox;
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -226,6 +226,23 @@ export class Viewer implements IDisposable {
     }
 
     /**
+     * Enables or disables camera auto orbit.
+     */
+    public get cameraAutoOrbit(): boolean {
+        return this._camera.behaviors.includes(this._autoRotationBehavior);
+    }
+
+    public set cameraAutoOrbit(value: boolean) {
+        if (value !== this.cameraAutoOrbit) {
+            if (value) {
+                this._camera.addBehavior(this._autoRotationBehavior);
+            } else {
+                this._camera.removeBehavior(this._autoRotationBehavior);
+            }
+        }
+    }
+
+    /**
      * The list of animation names for the currently loaded model.
      */
     public get animations(): readonly string[] {

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -562,8 +562,10 @@ export class Viewer implements IDisposable {
 
         this.onEnvironmentChanged.clear();
         this.onEnvironmentError.clear();
+        this.onSkyboxBlurChanged.clear();
         this.onModelChanged.clear();
         this.onModelError.clear();
+        this.onCameraAutoOrbitChanged.clear();
         this.onSelectedAnimationChanged.clear();
         this.onAnimationSpeedChanged.clear();
         this.onIsAnimationPlayingChanged.clear();

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -379,6 +379,12 @@ export class HTML3DElement extends LitElement {
     public hotspots: Nullable<Record<string, ViewerHotSpotQuery>> = null;
 
     /**
+     * This default animation index to select when a model is loaded.
+     */
+    @property({ attribute: "default-animation", reflect: true })
+    public defaultAnimation: Nullable<number> = null;
+
+    /**
      * The list of animation names for the currently loaded model.
      */
     public get animations(): readonly string[] {
@@ -645,26 +651,33 @@ export class HTML3DElement extends LitElement {
     }
 
     private async _updateModel() {
-        try {
-            if (this.source) {
-                await this._viewerDetails?.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
-            } else {
-                await this._viewerDetails?.viewer.resetModel();
+        if (this._viewerDetails) {
+            try {
+                if (this.source) {
+                    await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
+                    if (this.defaultAnimation) {
+                        this._viewerDetails.viewer.selectedAnimation = this.defaultAnimation;
+                    }
+                } else {
+                    await this._viewerDetails.viewer.resetModel();
+                }
+            } catch (error) {
+                Logger.Log(error);
             }
-        } catch (error) {
-            Logger.Log(error);
         }
     }
 
     private async _updateEnv() {
-        try {
-            if (this.environment) {
-                await this._viewerDetails?.viewer.loadEnvironment(this.environment);
-            } else {
-                await this._viewerDetails?.viewer.resetEnvironment();
+        if (this._viewerDetails) {
+            try {
+                if (this.environment) {
+                    await this._viewerDetails.viewer.loadEnvironment(this.environment);
+                } else {
+                    await this._viewerDetails.viewer.resetEnvironment();
+                }
+            } catch (error) {
+                Logger.Log(error);
             }
-        } catch (error) {
-            Logger.Log(error);
         }
     }
 }

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -379,10 +379,16 @@ export class HTML3DElement extends LitElement {
     public hotspots: Nullable<Record<string, ViewerHotSpotQuery>> = null;
 
     /**
-     * This default animation index to select when a model is loaded.
+     * The default animation index to select when a model is loaded.
      */
     @property({ attribute: "default-animation", reflect: true })
     public defaultAnimation: Nullable<number> = null;
+
+    /**
+     * True if the default animation should play automatically when a model is loaded.
+     */
+    @property({ attribute: "animation-auto-play", reflect: true, type: Boolean })
+    public animationAutoPlay = false;
 
     /**
      * The list of animation names for the currently loaded model.
@@ -657,6 +663,9 @@ export class HTML3DElement extends LitElement {
                     await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
                     if (this.defaultAnimation) {
                         this._viewerDetails.viewer.selectedAnimation = this.defaultAnimation;
+                    }
+                    if (this.animationAutoPlay) {
+                        this._viewerDetails.viewer.playAnimation();
                     }
                 } else {
                     await this._viewerDetails.viewer.resetModel();

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -296,7 +296,6 @@ export class HTML3DElement extends LitElement {
     @property({
         attribute: "clear-color",
         reflect: true,
-        type: "string",
         converter: {
             fromAttribute: parseColor,
             toAttribute: (color: Nullable<Color4>) => (color ? color.toHexString() : null),
@@ -305,10 +304,15 @@ export class HTML3DElement extends LitElement {
     public clearColor: Nullable<Color4> = null;
 
     /**
+     * Disables camera auto-orbit.
+     */
+    @property({ attribute: "camera-auto-orbit-disabled", reflect: true, type: Boolean })
+    public cameraAutoOrbitDisabled = false;
+
+    /**
      * A string value that encodes one or more hotspots.
      */
     @property({
-        type: "string",
         converter: (value) => {
             if (!value) {
                 return null;
@@ -406,11 +410,15 @@ export class HTML3DElement extends LitElement {
             this._tearDownViewer();
             this._setupViewer();
         } else {
-            if (changedProperties.has("clearColor")) {
+            if (changedProperties.has("clearColor" satisfies keyof this)) {
                 this._updateClearColor();
             }
 
-            if (changedProperties.has("animationSpeed")) {
+            if (changedProperties.has("cameraAutoOrbitDisabled" satisfies keyof this)) {
+                this._updateCameraAutoOrbit();
+            }
+
+            if (changedProperties.has("animationSpeed" satisfies keyof this)) {
                 this._updateAnimationSpeed();
             }
 
@@ -579,6 +587,7 @@ export class HTML3DElement extends LitElement {
                         });
 
                         this._updateClearColor();
+                        this._updateCameraAutoOrbit();
                         this._updateSelectedAnimation();
                         this._updateAnimationSpeed();
                         this._updateModel();
@@ -610,6 +619,12 @@ export class HTML3DElement extends LitElement {
     private _updateClearColor() {
         if (this._viewerDetails) {
             this._viewerDetails.scene.clearColor = this.clearColor ?? new Color4(0, 0, 0, 0);
+        }
+    }
+
+    private _updateCameraAutoOrbit() {
+        if (this._viewerDetails) {
+            this._viewerDetails.viewer.cameraAutoOrbit = !this.cameraAutoOrbitDisabled;
         }
     }
 

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -323,6 +323,12 @@ export class HTML3DElement extends LitElement {
     public environment: Nullable<string> = null;
 
     /**
+     * A value between 0 and 1 that specifies how much to blur the skybox.
+     */
+    @property({ attribute: "skybox-blur", reflect: true })
+    public skyboxBlur: Nullable<number> = null;
+
+    /**
      * The clear color (e.g. background color) for the viewer.
      */
     @property({
@@ -680,7 +686,7 @@ export class HTML3DElement extends LitElement {
         if (this._viewerDetails) {
             try {
                 if (this.environment) {
-                    await this._viewerDetails.viewer.loadEnvironment(this.environment);
+                    await this._viewerDetails.viewer.loadEnvironment(this.environment, { blur: this.skyboxBlur ?? undefined });
                 } else {
                     await this._viewerDetails.viewer.resetEnvironment();
                 }

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -367,18 +367,42 @@ export class HTML3DElement extends LitElement {
             }
 
             return (camera: ArcRotateCamera) => {
-                let index = 0;
-                for (const property of ["alpha", "beta", "radius"] as const) {
+                for (const [index, property] of (["alpha", "beta", "radius"] as const).entries()) {
                     const value = array[index];
                     if (value !== "auto") {
                         camera[property] = Number(value);
                     }
-                    index++;
                 }
             };
         },
     })
     private _cameraOrbitCoercer: Nullable<(camera: ArcRotateCamera) => void> = null;
+
+    @property({
+        attribute: "camera-target",
+        converter: (value) => {
+            if (!value) {
+                return null;
+            }
+
+            const array = value.split(/\s+/);
+            if (array.length !== 3) {
+                throw new Error("cameraTarget should be defined as 'x y z'");
+            }
+
+            return (camera: ArcRotateCamera) => {
+                const target = camera.target;
+                for (const [index, property] of (["x", "y", "z"] as const).entries()) {
+                    const value = array[index];
+                    if (value !== "auto") {
+                        target[property] = Number(value);
+                    }
+                }
+                camera.target = target.clone();
+            };
+        },
+    })
+    private _cameraTargetCoercer: Nullable<(camera: ArcRotateCamera) => void> = null;
 
     /**
      * A string value that encodes one or more hotspots.
@@ -660,6 +684,7 @@ export class HTML3DElement extends LitElement {
                             this._propertyBindings.forEach((binding) => binding.syncToAttribute());
 
                             this._cameraOrbitCoercer?.(details.camera);
+                            this._cameraTargetCoercer?.(details.camera);
 
                             if (this.animationAutoPlay) {
                                 details.viewer.playAnimation();

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -61,10 +61,6 @@ type PrivateState = {
     [selectedAnimationKey]: number;
 };
 
-// function test(input: HTML3DElement & PrivateState) {
-//     input
-// }
-
 /**
  * Represents a custom element that displays a 3D model using the Babylon.js Viewer.
  */

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-internal-modules
-import type { Nullable, Observable } from "core/index";
+import type { ArcRotateCamera, Nullable, Observable } from "core/index";
 
 import type { PropertyValues } from "lit";
 import type { ViewerDetails, ViewerHotSpot, ViewerHotSpotQuery } from "./viewer";
@@ -366,19 +366,19 @@ export class HTML3DElement extends LitElement {
                 throw new Error("cameraOrbit should be defined as 'alpha beta radius'");
             }
 
-            return (details: ViewerDetails) => {
+            return (camera: ArcRotateCamera) => {
                 let index = 0;
                 for (const property of ["alpha", "beta", "radius"] as const) {
                     const value = array[index];
                     if (value !== "auto") {
-                        details.camera[property] = Number(value);
+                        camera[property] = Number(value);
                     }
                     index++;
                 }
             };
         },
     })
-    private _cameraOrbitCoercer: Nullable<(details: ViewerDetails) => void> = null;
+    private _cameraOrbitCoercer: Nullable<(camera: ArcRotateCamera) => void> = null;
 
     /**
      * A string value that encodes one or more hotspots.
@@ -659,7 +659,7 @@ export class HTML3DElement extends LitElement {
                             this._animations = [...details.viewer.animations];
                             this._propertyBindings.forEach((binding) => binding.syncToAttribute());
 
-                            this._cameraOrbitCoercer?.(details);
+                            this._cameraOrbitCoercer?.(details.camera);
 
                             if (this.animationAutoPlay) {
                                 details.viewer.playAnimation();

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -408,12 +408,6 @@ export class HTML3DElement extends LitElement {
     public hotspots: Nullable<Record<string, ViewerHotSpotQuery>> = null;
 
     /**
-     * The default animation index to select when a model is loaded.
-     */
-    @property({ attribute: "default-animation", reflect: true })
-    public defaultAnimation: Nullable<number> = null;
-
-    /**
      * True if the default animation should play automatically when a model is loaded.
      */
     @property({ attribute: "animation-auto-play", reflect: true, type: Boolean })
@@ -429,7 +423,7 @@ export class HTML3DElement extends LitElement {
     /**
      * The currently selected animation index.
      */
-    @property({ attribute: false, reflect: true })
+    @property({ attribute: "selected-animation" })
     public selectedAnimation = -1;
 
     /**
@@ -659,13 +653,10 @@ export class HTML3DElement extends LitElement {
 
                         details.viewer.onModelChanged.add(() => {
                             this._animations = [...details.viewer.animations];
-                            if (this.defaultAnimation) {
-                                details.viewer.selectedAnimation = this.defaultAnimation;
-                            }
+                            this._propertyBindings.forEach((binding) => binding.syncToAttribute());
                             if (this.animationAutoPlay) {
                                 details.viewer.playAnimation();
                             }
-                            this._propertyBindings.forEach((binding) => binding.syncToAttribute());
 
                             this._dispatchCustomEvent("modelchange", (type) => new Event(type));
                         });

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -71,6 +71,12 @@ export class HTML3DElement extends LitElement {
             (details) => (this.clearColor = details.scene.clearColor)
         ),
         this._createPropertyBinding(
+            "skyboxBlur",
+            (details) => details.viewer.onSkyboxBlurChanged,
+            (details) => (details.viewer.skyboxBlur = this.skyboxBlur ?? details.viewer.skyboxBlur),
+            (details) => (this.skyboxBlur = details.viewer.skyboxBlur)
+        ),
+        this._createPropertyBinding(
             "cameraAutoOrbit",
             (details) => details.viewer.onCameraAutoOrbitChanged,
             (details) => (details.viewer.cameraAutoOrbit = this.cameraAutoOrbit),
@@ -770,7 +776,7 @@ export class HTML3DElement extends LitElement {
         if (this._viewerDetails) {
             try {
                 if (this.environment) {
-                    await this._viewerDetails.viewer.loadEnvironment(this.environment, { blur: this.skyboxBlur ?? undefined });
+                    await this._viewerDetails.viewer.loadEnvironment(this.environment);
                 } else {
                     await this._viewerDetails.viewer.resetEnvironment();
                 }

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -336,7 +336,7 @@ export class HTML3DElement extends LitElement {
     public clearColor: Nullable<Color4> = null;
 
     /**
-     * Disables camera auto-orbit.
+     * Enables or disables camera auto-orbit.
      */
     @property({
         attribute: "camera-auto-orbit-disabled",

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -48,6 +48,8 @@
                 /* --ui-foreground-color: red; */
                 /* --ui-background-hue: 200;
                 --ui-background-saturation: 70%; */
+                /* background-color: aqua; */
+                background-image: url("https://raw.githubusercontent.com/BabylonJS/Assets/master/textures/Checker_albedo.png");
             }
 
             /* babylon-viewer::part(tool-bar) {
@@ -69,6 +71,10 @@
             source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
             environment="../../../../../public/@babylonjs/viewer-alpha/assets/photoStudio.env"
             animation-speed="1.5"
+            selected-animation="1"
+            camera-orbit="auto auto auto"
+            camera-target="auto auto auto"
+            camera-auto-orbit
             hotspots="testHotSpot1 1 228 113 111 0.217 0.341 0.442"
         >
             <!-- <div slot="tool-bar" style="position: absolute; top: 12px; left: 12px; width: 100px; height: 36px">
@@ -87,6 +93,16 @@
             const viewerElement = document.querySelector("babylon-viewer");
             const lines = document.querySelectorAll("line");
             const hotspotResult = { screenPosition: [0, 0], worldPosition: [0, 0, 0] };
+
+            setInterval(() => {
+                // viewerElement.cameraAutoOrbit = !viewerElement.cameraAutoOrbit;
+                // viewerElement.viewerDetails.viewer.cameraAutoOrbit = !viewerElement.viewerDetails.viewer.cameraAutoOrbit;
+                // const color = viewerElement.viewerDetails.scene.clearColor.clone();
+                // color.r = Math.random();
+                // viewerElement.viewerDetails.scene.clearColor = color;
+                // console.log(viewerElement.clearColor);
+                // viewerElement.selectedAnimation = 1;
+            }, 3000);
 
             let viewerDetails;
             viewerElement.addEventListener("viewerready", (event) => {

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -120,6 +120,13 @@
                 // The module referenced in the script tag above is loaded asynchronously, so we need to wait for it to load and for the custom element to be defined.
                 // Alternatively, we could just await import("/packages/tools/viewer-alpha/src/index.ts") here instead.
                 await customElements.whenDefined("babylon-viewer");
+
+                setInterval(() => {
+                    //console.log(viewerElement.skyboxBlur);
+                    //viewerElement.skyboxBlur = (Number(viewerElement.skyboxBlur) + 0.01) % 1;
+                    //console.log(viewerElement.skyboxBlur);
+                }, 16);
+
                 await new Promise((resolve) => setTimeout(resolve, 2000));
                 //viewerElement.source = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/BrainStem/glTF-Binary/BrainStem.glb";
                 //viewerElement.environment = "";


### PR DESCRIPTION
The main change here is to add a few more Viewer properties/attributes:

| Property | Attribute |
|--------|--------|
| `cameraAutoOrbit` | `camera-auto-orbit` |
| N/A | `camera-orbit` |
| N/A | `camera-target` |
| `selectedAnimation`| `selected-animation` |
| `animationAutoPlay` | `animation-auto-play` |
| `skyboxBlur` | `skybox-blur` |

I also added a `_createPropertyBinding` helper function that just simplifies creating a "two way binding" between a property on the lower level state (Viewer, Scene, etc.) and the higher level HTML3DElement. Not all properties fit this pattern, but for the ones that do it is simpler (and I expect there will be more).