### PR TITLE
fix(Gamepads): duplicate gamepad status check causing each frame to double up calls

### DIFF
--- a/packages/dev/core/src/Gamepads/gamepadSceneComponent.ts
+++ b/packages/dev/core/src/Gamepads/gamepadSceneComponent.ts
@@ -109,7 +109,7 @@ export class GamepadSystemSceneComponent implements ISceneComponent {
      * Registers the component in a given scene
      */
     public register(): void {
-        this.scene._beforeCameraUpdateStage.registerStep(SceneComponentConstants.STEP_BEFORECAMERAUPDATE_GAMEPAD, this, this._beforeCameraUpdate);
+        // Nothing to do for gamepads
     }
 
     /**
@@ -128,14 +128,6 @@ export class GamepadSystemSceneComponent implements ISceneComponent {
         if (gamepadManager) {
             gamepadManager.dispose();
             this.scene._gamepadManager = null;
-        }
-    }
-
-    private _beforeCameraUpdate(): void {
-        const gamepadManager = this.scene._gamepadManager;
-
-        if (gamepadManager && gamepadManager._isMonitoring) {
-            gamepadManager._checkGamepadsStatus();
         }
     }
 }

--- a/packages/dev/core/src/sceneComponent.ts
+++ b/packages/dev/core/src/sceneComponent.ts
@@ -67,7 +67,6 @@ export class SceneComponentConstants {
     public static readonly STEP_AFTERRENDERINGGROUPDRAW_BOUNDINGBOXRENDERER = 1;
 
     public static readonly STEP_BEFORECAMERAUPDATE_SIMPLIFICATIONQUEUE = 0;
-    public static readonly STEP_BEFORECAMERAUPDATE_GAMEPAD = 1;
 
     public static readonly STEP_BEFORECLEAR_PROCEDURALTEXTURE = 0;
     public static readonly STEP_BEFORECLEAR_PREPASS = 1;


### PR DESCRIPTION
Per [discussion on the forums](https://forum.babylonjs.com/t/scene-performance-using-universalcamera-quickly-deteriorates-and-eventually-crashes-when-gamepad-attached/54457/3):

### What Happens

When a simple scene is loaded with camera control attached, and a gamepad is attached, performance will quickly deteriorate and the FPS will start to go down within minutes. [(Repro)](https://playground.babylonjs.com/#SF2UOQ) _- make sure to have a gamepad attached_

### What Should Happen

Performance should not be impacted by a gamepad being connected.

### Proposed Solution

Remove the call to [`_checkGamepadStatus()` in `gamepadSceneComponent.ts`](https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Gamepads/gamepadSceneComponent.ts#L138). The call to [`_checkGamepadStatus()` in `gamepadManager._startMonitoringGamepads()`](https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Gamepads/gamepadManager.ts#L194) should be enough to kick off a recursive loop that ensures it is called just once per frame.

Rel: https://github.com/BabylonJS/Babylon.js/pull/13798 (might have unintentionally triggered this?)