### PR TITLE
Add toneMapping, contrast, and exposure to Viewer

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -175,6 +175,11 @@ export class Viewer implements IDisposable {
     public readonly onContrastChanged = new Observable<void>();
 
     /**
+     * Fired when the exposure changes.
+     */
+    public readonly onExposureChanged = new Observable<void>();
+
+    /**
      * Fired when a model is loaded into the viewer (or unloaded from the viewer).
      */
     public readonly onModelChanged = new Observable<void>();
@@ -220,6 +225,7 @@ export class Viewer implements IDisposable {
     private _toneMappingEnabled: boolean;
     private _toneMappingType: number;
     private _contrast: number;
+    private _exposure: number;
 
     private _isDisposed = false;
 
@@ -244,6 +250,7 @@ export class Viewer implements IDisposable {
             this._toneMappingEnabled = scene.imageProcessingConfiguration.toneMappingEnabled;
             this._toneMappingType = scene.imageProcessingConfiguration.toneMappingType;
             this._contrast = scene.imageProcessingConfiguration.contrast;
+            this._exposure = scene.imageProcessingConfiguration.exposure;
 
             this._imageProcessingConfigurationObserver = scene.imageProcessingConfiguration.onUpdateParameters.add(() => {
                 if (this._toneMappingEnabled !== scene.imageProcessingConfiguration.toneMappingEnabled) {
@@ -259,6 +266,11 @@ export class Viewer implements IDisposable {
                 if (this._contrast !== scene.imageProcessingConfiguration.contrast) {
                     this._contrast = scene.imageProcessingConfiguration.contrast;
                     this.onContrastChanged.notifyObservers();
+                }
+
+                if (this._exposure !== scene.imageProcessingConfiguration.exposure) {
+                    this._exposure = scene.imageProcessingConfiguration.exposure;
+                    this.onExposureChanged.notifyObservers();
                 }
             });
 
@@ -392,6 +404,19 @@ export class Viewer implements IDisposable {
     public set contrast(value: number) {
         this._snapshotHelper.disableSnapshotRendering();
         this._details.scene.imageProcessingConfiguration.contrast = value;
+        this._snapshotHelper.enableSnapshotRendering();
+    }
+
+    /**
+     * The exposure applied to the scene.
+     */
+    public get exposure(): number {
+        return this._exposure;
+    }
+
+    public set exposure(value: number) {
+        this._snapshotHelper.disableSnapshotRendering();
+        this._details.scene.imageProcessingConfiguration.exposure = value;
         this._snapshotHelper.enableSnapshotRendering();
     }
 
@@ -688,6 +713,7 @@ export class Viewer implements IDisposable {
         this.onSkyboxBlurChanged.clear();
         this.onToneMappingChanged.clear();
         this.onContrastChanged.clear();
+        this.onExposureChanged.clear();
         this.onModelChanged.clear();
         this.onModelError.clear();
         this.onCameraAutoOrbitChanged.clear();

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -231,16 +231,6 @@ export class Viewer implements IDisposable {
     ) {
         {
             const scene = new Scene(this._engine);
-            // let toneMappingType = 0;
-            // setInterval(() => {
-            //     console.log(`Setting tone mapping to ${toneMappingType}`);
-            //     this._snapshotHelper.disableSnapshotRendering();
-            //     //scene.imageProcessingConfiguration.isEnabled = true;
-            //     scene.imageProcessingConfiguration.toneMappingEnabled = true;
-            //     scene.imageProcessingConfiguration.toneMappingType = toneMappingType;
-            //     this._snapshotHelper.enableSnapshotRendering();
-            //     toneMappingType = (toneMappingType + 1) % 3;
-            // }, 2000);
             const camera = new ArcRotateCamera("Viewer Default Camera", 0, 0, 1, Vector3.Zero(), scene);
             this._details = {
                 viewer: this,

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -54,6 +54,7 @@ function throwIfAborted(...abortSignals: (Nullable<AbortSignal> | undefined)[]):
 function createSkybox(scene: Scene, camera: Camera, environmentTexture: CubeTexture, blur: number): Mesh {
     const hdrSkybox = CreateBox("hdrSkyBox", undefined, scene);
     const hdrSkyboxMaterial = new PBRMaterial("skyBox", scene);
+    // Use the default image processing configuration on the skybox (e.g. don't apply tone mapping, contrast, or exposure).
     hdrSkyboxMaterial.imageProcessingConfiguration = new ImageProcessingConfiguration();
     hdrSkyboxMaterial.backFaceCulling = false;
     hdrSkyboxMaterial.reflectionTexture = environmentTexture.clone();
@@ -247,6 +248,7 @@ export class Viewer implements IDisposable {
         {
             const scene = new Scene(this._engine);
 
+            // Deduce tone mapping, contrast, and exposure from the scene (so the viewer stays in sync if anything mutates these values directly on the scene).
             this._toneMappingEnabled = scene.imageProcessingConfiguration.toneMappingEnabled;
             this._toneMappingType = scene.imageProcessingConfiguration.toneMappingType;
             this._contrast = scene.imageProcessingConfiguration.contrast;
@@ -289,6 +291,7 @@ export class Viewer implements IDisposable {
         this._updateCamera(); // set default camera values
         this._autoRotationBehavior = this._details.camera.getBehaviorByName("AutoRotation") as AutoRotationBehavior;
 
+        // Default to KHR PBR Neutral tone mapping.
         this.toneMapping = "neutral";
 
         // Load a default light, but ignore errors as the user might be immediately loading their own environment.

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -342,7 +342,7 @@ export class Viewer implements IDisposable {
     /**
      * The tone mapping to use for rendering the scene.
      */
-    public get toneMapping(): ToneMapping {
+    public get toneMapping(): ToneMapping | "unknown" {
         if (!this._toneMappingEnabled) {
             return "none";
         }
@@ -354,6 +354,8 @@ export class Viewer implements IDisposable {
                 return "aces";
             case ImageProcessingConfiguration.TONEMAPPING_KHR_PBR_NEUTRAL:
                 return "neutral";
+            default:
+                return "unknown";
         }
     }
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -462,6 +462,21 @@ export class Viewer implements IDisposable {
     private async _updateModel(source: string | File | ArrayBufferView | undefined, options?: LoadAssetContainerOptions, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
 
+        // Enable transparency as coverage by default to be 3D Commerce compliant by default.
+        // https://doc.babylonjs.com/setup/support/3D_commerce_certif
+        if (!options?.pluginOptions?.gltf?.transparencyAsCoverage) {
+            options = {
+                ...options,
+                pluginOptions: {
+                    ...options?.pluginOptions,
+                    gltf: {
+                        ...options?.pluginOptions?.gltf,
+                        transparencyAsCoverage: true,
+                    },
+                },
+            };
+        }
+
         this._loadModelAbortController?.abort("New model is being loaded before previous model finished loading.");
         const abortController = (this._loadModelAbortController = new AbortController());
 

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -80,14 +80,30 @@ export class HTML3DElement extends LitElement {
         this._createPropertyBinding(
             "toneMapping",
             (details) => details.viewer.onToneMappingChanged,
-            (details) => (details.viewer.toneMapping = this.toneMapping ?? details.viewer.toneMapping),
-            (details) => (this.toneMapping = details.viewer.toneMapping)
+            (details) => {
+                if (this.toneMapping) {
+                    details.viewer.toneMapping = this.toneMapping;
+                }
+            },
+            (details) => {
+                if (details.viewer.toneMapping === "unknown") {
+                    this.toneMapping = null;
+                } else {
+                    this.toneMapping = details.viewer.toneMapping;
+                }
+            }
         ),
         this._createPropertyBinding(
             "contrast",
             (details) => details.viewer.onContrastChanged,
             (details) => (details.viewer.contrast = this.contrast ?? details.viewer.contrast),
             (details) => (this.contrast = details.viewer.contrast)
+        ),
+        this._createPropertyBinding(
+            "exposure",
+            (details) => details.viewer.onExposureChanged,
+            (details) => (details.viewer.exposure = this.exposure ?? details.viewer.exposure),
+            (details) => (this.exposure = details.viewer.exposure)
         ),
         this._createPropertyBinding(
             "cameraAutoOrbit",
@@ -373,6 +389,12 @@ export class HTML3DElement extends LitElement {
      */
     @property()
     public contrast: Nullable<number> = null;
+
+    /**
+     * The exposure applied to the scene.
+     */
+    @property()
+    public exposure: Nullable<number> = null;
 
     /**
      * The clear color (e.g. background color) for the viewer.

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -84,6 +84,12 @@ export class HTML3DElement extends LitElement {
             (details) => (this.toneMapping = details.viewer.toneMapping)
         ),
         this._createPropertyBinding(
+            "contrast",
+            (details) => details.viewer.onContrastChanged,
+            (details) => (details.viewer.contrast = this.contrast ?? details.viewer.contrast),
+            (details) => (this.contrast = details.viewer.contrast)
+        ),
+        this._createPropertyBinding(
             "cameraAutoOrbit",
             (details) => details.viewer.onCameraAutoOrbitChanged,
             (details) => (details.viewer.cameraAutoOrbit = this.cameraAutoOrbit),
@@ -345,7 +351,7 @@ export class HTML3DElement extends LitElement {
     /**
      * A value between 0 and 1 that specifies how much to blur the skybox.
      */
-    @property({ attribute: "skybox-blur", reflect: true })
+    @property({ attribute: "skybox-blur" })
     public skyboxBlur: Nullable<number> = null;
 
     /**
@@ -353,7 +359,6 @@ export class HTML3DElement extends LitElement {
      */
     @property({
         attribute: "tone-mapping",
-        reflect: true,
         converter: (value: string | null): ToneMapping => {
             if (!value || !isToneMapping(value)) {
                 return "neutral";
@@ -362,6 +367,12 @@ export class HTML3DElement extends LitElement {
         },
     })
     public toneMapping: Nullable<ToneMapping> = null;
+
+    /**
+     * The contrast applied to the scene.
+     */
+    @property()
+    public contrast: Nullable<number> = null;
 
     /**
      * The clear color (e.g. background color) for the viewer.

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -130,6 +130,10 @@ export class HTML3DElement extends LitElement {
             height: 100%;
         }
 
+        .canvas {
+            outline: none;
+        }
+
         .children-slot {
             position: absolute;
             top: 0;
@@ -679,7 +683,7 @@ export class HTML3DElement extends LitElement {
 
             if (this._canvasContainer && !this._viewerDetails) {
                 const canvas = document.createElement("canvas");
-                canvas.className = "full-size";
+                canvas.className = "full-size canvas";
                 canvas.setAttribute("touch-action", "none");
                 this._canvasContainer.appendChild(canvas);
 

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -2,7 +2,7 @@
 import type { ArcRotateCamera, Nullable, Observable } from "core/index";
 
 import type { PropertyValues } from "lit";
-import type { ViewerDetails, ViewerHotSpot, ViewerHotSpotQuery } from "./viewer";
+import type { ToneMapping, ViewerDetails, ViewerHotSpot, ViewerHotSpotQuery } from "./viewer";
 import type { CanvasViewerOptions } from "./viewerFactory";
 
 import { LitElement, css, defaultConverter, html } from "lit";
@@ -11,6 +11,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import { Color4 } from "core/Maths/math.color";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Logger } from "core/Misc/logger";
+import { isToneMapping } from "./viewer";
 import { createViewerForCanvas, getDefaultEngine } from "./viewerFactory";
 
 // Icon SVG is pulled from https://fluentuipr.z22.web.core.windows.net/heads/master/public-docsite-v9/storybook/iframe.html?id=icons-catalog--page&viewMode=story
@@ -75,6 +76,12 @@ export class HTML3DElement extends LitElement {
             (details) => details.viewer.onSkyboxBlurChanged,
             (details) => (details.viewer.skyboxBlur = this.skyboxBlur ?? details.viewer.skyboxBlur),
             (details) => (this.skyboxBlur = details.viewer.skyboxBlur)
+        ),
+        this._createPropertyBinding(
+            "toneMapping",
+            (details) => details.viewer.onToneMappingChanged,
+            (details) => (details.viewer.toneMapping = this.toneMapping ?? details.viewer.toneMapping),
+            (details) => (this.toneMapping = details.viewer.toneMapping)
         ),
         this._createPropertyBinding(
             "cameraAutoOrbit",
@@ -340,6 +347,21 @@ export class HTML3DElement extends LitElement {
      */
     @property({ attribute: "skybox-blur", reflect: true })
     public skyboxBlur: Nullable<number> = null;
+
+    /**
+     * The tone mapping to use for rendering the scene.
+     */
+    @property({
+        attribute: "tone-mapping",
+        reflect: true,
+        converter: (value: string | null): ToneMapping => {
+            if (!value || !isToneMapping(value)) {
+                return "neutral";
+            }
+            return value;
+        },
+    })
+    public toneMapping: Nullable<ToneMapping> = null;
 
     /**
      * The clear color (e.g. background color) for the viewer.


### PR DESCRIPTION
This change primarily adds three new properties (and corresponding attributes) to the viewer: `toneMapping`, `contrast`, and `exposure`. Notes on this:
- Tone mapping is set to KHR PBR Neutral by default.
- Tone mapping, contrast, and exposure are not applied to the skybox.
- When these attributes are explicitly set, they are re-applied when a new model is loaded. If they are not set, then the current property value is retained (similar behavior as some other attributes).

This change includes a few other small fixes as well:
- Enable transparency as coverage by default.
- Remove the outline from the canvas (otherwise it is clicked it shows a black outline).