### PR TITLE
IBL Shadows accumulation for different scene sizes

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
@@ -286,7 +286,7 @@ export class _IblShadowsAccumulationPass {
 
     private _setOutputTextureBindings() {
         const remenance = this._isMoving ? this.remenance : 0.99;
-        this._accumulationParams.set(remenance, this.reset ? 1.0 : 0.0, 0.0, 0.0);
+        this._accumulationParams.set(remenance, this.reset ? 1.0 : 0.0, this._renderPipeline.voxelGridSize, 0.0);
         this._outputTexture.setTexture("spatialBlurSampler", this._renderPipeline._getSpatialBlurTexture());
         this._outputTexture.setVector4("accumulationParameters", this._accumulationParams);
         this._outputTexture.setTexture("oldAccumulationSampler", this._oldAccumulationCopy ? this._oldAccumulationCopy : this._renderPipeline._dummyTexture2d);

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -34,67 +34,67 @@ interface IblShadowsSettings {
      * shadows but are more expensive to compute and require more memory.
      * The resolution is calculated as 2 to the power of this number.
      */
-    resolutionExp: number;
+    resolutionExp?: number;
 
     /**
      * The number of different directions to sample during the voxel tracing pass. Higher
      * values will result in better quality, more stable shadows but are more expensive to compute.
      */
-    sampleDirections: number;
+    sampleDirections?: number;
 
     /**
      * How dark the shadows are. 1.0 is full opacity, 0.0 is no shadows.
      */
-    shadowOpacity: number;
+    shadowOpacity?: number;
 
     /**
      * How long the shadows remain in the scene. 0.0 is no persistence, 1.0 is full persistence.
      */
-    shadowRemenance: number;
+    shadowRemenance?: number;
 
     /**
      * Render the voxel grid from 3 different axis. This will result in better quality shadows with fewer
      * bits of missing geometry.
      */
-    triPlanarVoxelization: boolean;
+    triPlanarVoxelization?: boolean;
 
     /**
      * A multiplier for the render size of the shadows. Used for rendering lower-resolution shadows
      * to increase performance. Should be a value between 0 and 1.
      */
-    shadowRenderSizeFactor: number;
+    shadowRenderSizeFactor?: number;
 
     /**
      * Separate control for the opacity of the voxel shadows.
      */
-    voxelShadowOpacity: number;
+    voxelShadowOpacity?: number;
 
     /**
      * Include screen-space shadows in the IBL shadow pipeline. This adds sharp shadows to small details
      * but only applies close to a shadow-casting object.
      */
-    ssShadowsEnabled: boolean;
+    ssShadowsEnabled?: boolean;
 
     /**
      * The number of samples used in the screen space shadow pass.
      */
-    ssShadowSampleCount: number;
+    ssShadowSampleCount?: number;
 
     /**
      * The stride of the screen-space shadow pass. This controls the distance between samples.
      */
-    ssShadowStride: number;
+    ssShadowStride?: number;
 
     /**
      * The maximum distance a shadow can be cast in screen space. This should usually be kept small
      * as screenspace shadows are mostly useful for small details.
      */
-    ssShadowDistanceScale: number;
+    ssShadowDistanceScale?: number;
 
     /**
      * Screen-space shadow thickness. This value controls the perceived thickness of the SS shadows.
      */
-    ssShadowThicknessScale: number;
+    ssShadowThicknessScale?: number;
 }
 
 /**

--- a/packages/dev/core/src/Shaders/iblShadowAccumulation.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblShadowAccumulation.fragment.fx
@@ -8,6 +8,7 @@ uniform vec4 accumulationParameters;
 
 #define remanence accumulationParameters.x
 #define resetb accumulationParameters.y
+#define sceneSize accumulationParameters.z
 
 uniform sampler2D motionSampler;
 uniform sampler2D positionSampler;
@@ -37,7 +38,7 @@ void main(void) {
 
   PrevShadows.z =
       !reset && all(lessThan(abs(prevCoord - vec2(0.5)), vec2(0.5))) &&
-              distance(LP.xyz, PrevLP) < 5e-2
+              distance(LP.xyz, PrevLP) < 5e-2 * sceneSize
           ? max(PrevShadows.z / (1.0 + PrevShadows.z), 1.0 - remanence)
           : 1.0;
   PrevShadows = max(vec3(0.0), PrevShadows);

--- a/packages/dev/core/src/ShadersWGSL/iblShadowAccumulation.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblShadowAccumulation.fragment.fx
@@ -4,6 +4,7 @@ uniform accumulationParameters: vec4f;
 
 #define remanence uniforms.accumulationParameters.x
 #define resetb uniforms.accumulationParameters.y
+#define sceneSize uniforms.accumulationParameters.z
 
 var motionSampler: texture_2d<f32>;
 var positionSampler: texture_2d<f32>;
@@ -41,7 +42,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   var newShadows : vec2f = textureLoad(spatialBlurSampler, shadowPixelCoord, 0).xy;
 
   PrevShadows.z = select(1.0, max(PrevShadows.z / (1.0 + PrevShadows.z), 1.0 - remanence), !reset && all(lessThan(abs(prevCoord -  vec2f(0.5)),  vec2f(0.5))) &&
-              distance(LP.xyz, PrevLP) < 5e-2);
+              distance(LP.xyz, PrevLP) < 5e-2 * sceneSize);
   PrevShadows = max( vec3f(0.0), PrevShadows);
 
   fragmentOutputs.color =  vec4f(mix(PrevShadows.x, newShadows.x, PrevShadows.z),


### PR DESCRIPTION
Accumulation is dependent upon distance between previous and current world positions and this scales with scene size.
The fix is to scale this comparison based on the size of the voxel grid.