### PR TITLE
Enable .env file for playwright tests

### DIFF
--- a/packages/tools/tests/playwright.config.ts
+++ b/packages/tools/tests/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 import { getCdpEndpoint } from "./browserstack.config";
 
+import { populateEnvironment } from "@dev/build-tools";
+populateEnvironment();
+
 const isCI = !!process.env.CI;
 const browserType = process.env.BROWSER || (isCI ? "Firefox" : "Chrome");
 const numberOfWorkers = process.env.CIWORKERS ? +process.env.CIWORKERS : process.env.CI ? 1 : browserType === "BrowserStack" ? 1 : undefined;


### PR DESCRIPTION
The .env file is not being read when running playwright tests. This change imports the `populateEnvironment` utility function and calls it so the .env file gets read.