### PR TITLE
Viewer loading progress bar

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -612,6 +612,9 @@ export class Viewer implements IDisposable {
             try {
                 if (source) {
                     this._loadingProgress.isLoading = true;
+                    if (this._loadingProgress.isLoading) {
+                        this._loadingProgress.progress = 0;
+                    }
                     this.onLoadingProgressChanged.notifyObservers();
                     this._details.model = await loadAssetContainerAsync(source, this._details.scene, options);
                     this._details.model.animationGroups.forEach((group) => {

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -200,7 +200,7 @@ export class HTML3DElement extends LitElement {
         .loading-progress-inner {
             width: 0;
             height: 100%;
-            border-radius: 2px;
+            border-radius: inherit;
             background-color: var(--ui-foreground-color);
             transition: width 0.3s linear;
         }
@@ -671,7 +671,7 @@ export class HTML3DElement extends LitElement {
                 <div id="canvasContainer" class="full-size"></div>
                 <slot class="full-size children-slot"></slot>
                 <slot name="progress-bar">
-                    <div part="loading-progress" class="bar loading-progress-outer ${showProgressBar ? "" : "loading-progress-outer-inactive"}" aria-label="Loading Progress">
+                    <div part="progress-bar" class="bar loading-progress-outer ${showProgressBar ? "" : "loading-progress-outer-inactive"}" aria-label="Loading Progress">
                         <div
                             class="loading-progress-inner ${isIndeterminate ? "loading-progress-inner-indeterminate" : ""}"
                             style="${isIndeterminate ? "" : `width: ${progressValue}%`}"

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -202,7 +202,7 @@ export class HTML3DElement extends LitElement {
             height: 100%;
             border-radius: 2px;
             background-color: var(--ui-foreground-color);
-            transition: width 0.3s ease;
+            transition: width 0.3s linear;
         }
 
         @keyframes indeterminate {

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -171,19 +171,22 @@ export class HTML3DElement extends LitElement {
             pointer-events: none;
         }
 
-        .loading-progress-outer {
+        .bar {
             position: absolute;
             width: calc(100% - 24px);
+            min-width: 150px;
+            max-width: 1280px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: var(--ui-background-color);
+        }
+
+        .loading-progress-outer {
             height: 4px;
             border-radius: 2px;
             border: none;
             outline: none;
-            min-width: 150px;
-            max-width: 1280px;
             top: 12px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: var(--ui-background-color);
             pointer-events: none;
             transition: opacity 0.5s ease;
         }
@@ -229,19 +232,12 @@ export class HTML3DElement extends LitElement {
         }
 
         .tool-bar {
-            position: absolute;
             display: flex;
             flex-direction: row;
             border-radius: 12px;
             border-color: var(--ui-foreground-color);
             height: 48px;
-            width: calc(100% - 24px);
-            min-width: 150px;
-            max-width: 1280px;
             bottom: 12px;
-            left: 50%;
-            transform: translateX(-50%);
-            background-color: var(--ui-background-color);
             color: var(--ui-foreground-color);
             -webkit-tap-highlight-color: transparent;
         }
@@ -677,7 +673,7 @@ export class HTML3DElement extends LitElement {
                 <slot name="progress-bar">
                     <div
                         part="loading-progress"
-                        class="loading-progress-outer ${showProgressBar ? "loading-progress-outer-active" : "loading-progress-outer-inactive"}"
+                        class="bar loading-progress-outer ${showProgressBar ? "loading-progress-outer-active" : "loading-progress-outer-inactive"}"
                         aria-label="Loading Progress"
                     >
                         <div
@@ -690,7 +686,7 @@ export class HTML3DElement extends LitElement {
                     ? ""
                     : html`
                           <slot name="tool-bar">
-                              <div part="tool-bar" class="tool-bar">
+                              <div part="tool-bar" class="bar tool-bar">
                                   <div class="animation-timeline">
                                       <button aria-label="${this.isAnimationPlaying ? "Pause" : "Play"}" @click="${this.toggleAnimation}">
                                           ${!this.isAnimationPlaying

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -201,7 +201,31 @@ export class HTML3DElement extends LitElement {
             height: 100%;
             border-radius: 4px;
             background-color: var(--ui-foreground-color);
-            //transition: width 0.2s ease;
+        }
+
+        @keyframes indeterminate {
+            0% {
+                left: 0%;
+                width: 0%;
+            }
+            20% {
+                left: 0%;
+                width: 30%;
+            }
+            80% {
+                left: 70%;
+                width: 30%;
+            }
+            100% {
+                left: 100%;
+                width: 0%;
+            }
+        }
+
+        .loading-progress-inner-indeterminate {
+            position: absolute;
+            animation: indeterminate 1.5s infinite;
+            animation-timing-function: linear;
         }
 
         .tool-bar {
@@ -642,7 +666,8 @@ export class HTML3DElement extends LitElement {
     // eslint-disable-next-line babylonjs/available
     override render() {
         const showProgressBar = this.loadingProgress !== false;
-        const progressValue = typeof this.loadingProgress === "boolean" ? (this.loadingProgress ? 0 : 100) : this.loadingProgress * 100;
+        const progressValue = typeof this.loadingProgress === "boolean" ? 100 : this.loadingProgress * 100;
+        const isIndeterminate = this.loadingProgress === true;
 
         // NOTE: The unnamed 'slot' element holds all child elements of the <babylon-viewer> that do not specify a 'slot' attribute.
         return html`
@@ -655,7 +680,10 @@ export class HTML3DElement extends LitElement {
                         class="loading-progress-outer ${showProgressBar ? "loading-progress-outer-active" : "loading-progress-outer-inactive"}"
                         aria-label="Loading Progress"
                     >
-                        <div class="loading-progress-inner" style="width: ${progressValue}%"></div>
+                        <div
+                            class="loading-progress-inner ${isIndeterminate ? "loading-progress-inner-indeterminate" : ""}"
+                            style="${isIndeterminate ? "" : `width: ${progressValue}%`}"
+                        ></div>
                     </div>
                 </slot>
                 ${this.animations.length === 0

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -205,16 +205,20 @@ export class HTML3DElement extends LitElement {
             transition: width 0.3s linear;
         }
 
+        /* The right side of the inner progress bar starts aligned with the left side of the outer progress bar (container).
+           So, if the width is 30%, then the left side of the inner progress bar moves a total of 130% of the width of the container.
+           This is why the first keyframe is at 23% ((100/130)*30).
+         */
         @keyframes indeterminate {
             0% {
                 left: 0%;
                 width: 0%;
             }
-            20% {
+            23% {
                 left: 0%;
                 width: 30%;
             }
-            80% {
+            77% {
                 left: 70%;
                 width: 30%;
             }

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -202,7 +202,7 @@ export class HTML3DElement extends LitElement {
             height: 100%;
             border-radius: 2px;
             background-color: var(--ui-foreground-color);
-            transition: width 0.25s ease;
+            transition: width 0.3s ease;
         }
 
         @keyframes indeterminate {

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -174,8 +174,8 @@ export class HTML3DElement extends LitElement {
         .loading-progress-outer {
             position: absolute;
             width: calc(100% - 24px);
-            height: 8px;
-            border-radius: 4px;
+            height: 4px;
+            border-radius: 2px;
             border: none;
             outline: none;
             min-width: 150px;
@@ -199,7 +199,7 @@ export class HTML3DElement extends LitElement {
         .loading-progress-inner {
             width: 0;
             height: 100%;
-            border-radius: 4px;
+            border-radius: 2px;
             background-color: var(--ui-foreground-color);
         }
 

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -191,12 +191,10 @@ export class HTML3DElement extends LitElement {
             transition: opacity 0.5s ease;
         }
 
-        .loading-progress-outer-active {
-            opacity: 1;
-        }
-
         .loading-progress-outer-inactive {
             opacity: 0;
+            /* Set the background color to the foreground color while in the inactive state so that the color seen is correct while fading out the opacity. */
+            background-color: var(--ui-foreground-color);
         }
 
         .loading-progress-inner {
@@ -204,6 +202,7 @@ export class HTML3DElement extends LitElement {
             height: 100%;
             border-radius: 2px;
             background-color: var(--ui-foreground-color);
+            transition: width 0.25s ease;
         }
 
         @keyframes indeterminate {
@@ -662,7 +661,8 @@ export class HTML3DElement extends LitElement {
     // eslint-disable-next-line babylonjs/available
     override render() {
         const showProgressBar = this.loadingProgress !== false;
-        const progressValue = typeof this.loadingProgress === "boolean" ? 100 : this.loadingProgress * 100;
+        // If loadingProgress is true, then the progress bar is indeterminate so the value doesn't matter.
+        const progressValue = typeof this.loadingProgress === "boolean" ? 0 : this.loadingProgress * 100;
         const isIndeterminate = this.loadingProgress === true;
 
         // NOTE: The unnamed 'slot' element holds all child elements of the <babylon-viewer> that do not specify a 'slot' attribute.
@@ -671,11 +671,7 @@ export class HTML3DElement extends LitElement {
                 <div id="canvasContainer" class="full-size"></div>
                 <slot class="full-size children-slot"></slot>
                 <slot name="progress-bar">
-                    <div
-                        part="loading-progress"
-                        class="bar loading-progress-outer ${showProgressBar ? "loading-progress-outer-active" : "loading-progress-outer-inactive"}"
-                        aria-label="Loading Progress"
-                    >
+                    <div part="loading-progress" class="bar loading-progress-outer ${showProgressBar ? "" : "loading-progress-outer-inactive"}" aria-label="Loading Progress">
                         <div
                             class="loading-progress-inner ${isIndeterminate ? "loading-progress-inner-indeterminate" : ""}"
                             style="${isIndeterminate ? "" : `width: ${progressValue}%`}"

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -171,7 +171,7 @@ export class HTML3DElement extends LitElement {
             pointer-events: none;
         }
 
-        .loading-progress {
+        .loading-progress-outer {
             position: absolute;
             width: calc(100% - 24px);
             height: 8px;
@@ -184,32 +184,24 @@ export class HTML3DElement extends LitElement {
             left: 50%;
             transform: translateX(-50%);
             background-color: var(--ui-background-color);
-            color: var(--ui-foreground-color);
             pointer-events: none;
             transition: opacity 0.5s ease;
         }
 
-        .loading-progress-active {
+        .loading-progress-outer-active {
             opacity: 1;
         }
 
-        .loading-progress-inactive {
+        .loading-progress-outer-inactive {
             opacity: 0;
         }
 
-        .loading-progress::-webkit-progress-bar {
-            background-color: var(--ui-background-color);
+        .loading-progress-inner {
+            width: 0;
+            height: 100%;
             border-radius: 4px;
-        }
-
-        .loading-progress::-webkit-progress-value {
             background-color: var(--ui-foreground-color);
-            border-radius: 4px;
-        }
-
-        .loading-progress::-moz-progress-bar {
-            background-color: var(--ui-foreground-color);
-            border-radius: 4px;
+            //transition: width 0.2s ease;
         }
 
         .tool-bar {
@@ -649,17 +641,22 @@ export class HTML3DElement extends LitElement {
 
     // eslint-disable-next-line babylonjs/available
     override render() {
+        const showProgressBar = this.loadingProgress !== false;
+        const progressValue = typeof this.loadingProgress === "boolean" ? (this.loadingProgress ? 0 : 100) : this.loadingProgress * 100;
+
         // NOTE: The unnamed 'slot' element holds all child elements of the <babylon-viewer> that do not specify a 'slot' attribute.
         return html`
             <div class="full-size">
                 <div id="canvasContainer" class="full-size"></div>
                 <slot class="full-size children-slot"></slot>
                 <slot name="progress-bar">
-                    <progress
-                        class="loading-progress ${this.loadingProgress === false ? "loading-progress-inactive" : "loading-progress-active"}"
-                        value="${this.loadingProgress === false ? 1 : this.loadingProgress}"
-                        max="1"
-                    ></progress>
+                    <div
+                        part="loading-progress"
+                        class="loading-progress-outer ${showProgressBar ? "loading-progress-outer-active" : "loading-progress-outer-inactive"}"
+                        aria-label="Loading Progress"
+                    >
+                        <div class="loading-progress-inner" style="width: ${progressValue}%"></div>
+                    </div>
                 </slot>
                 ${this.animations.length === 0
                     ? ""


### PR DESCRIPTION
This PR adds a default loading progress bar. The styling can be customized (via CSS variables for things like color or the progress-bar part for things like height, border radius, etc.) or completely replaced with custom UI (via the progress-bar slot). For cases where we don't know the size of the download, it is a simple indeterminate progress bar.

Currently this is only for model source download, it does not take into account environment texture download. I think we should probably bring this in as well, but it requires more changes to core. Open to thoughts though.

https://github.com/user-attachments/assets/daf9bd24-670e-4c00-99f4-69c1803b63e5

