### PR TITLE
Viewer hotspot activation

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -3,6 +3,7 @@ import { Observable } from "../Misc/observable";
 import type { Nullable } from "../types";
 import type { Scene } from "../scene";
 import { Matrix, Vector3, Vector2, TmpVectors, Quaternion } from "../Maths/math.vector";
+import { Clamp } from "../Maths/math.scalar.functions";
 import { Node } from "../node";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Mesh } from "../Meshes/mesh";
@@ -844,9 +845,9 @@ export class ArcRotateCamera extends TargetCamera {
         this.inertialPanningX = 0;
         this.inertialPanningY = 0;
 
-        alpha = Math.min(Math.max(alpha, this.lowerAlphaLimit ?? -Infinity), this.upperAlphaLimit ?? Infinity);
-        beta = Math.min(Math.max(beta, this.lowerBetaLimit ?? -Infinity), this.upperBetaLimit ?? Infinity);
-        radius = Math.min(Math.max(radius, this.lowerRadiusLimit ?? -Infinity), this.upperRadiusLimit ?? Infinity);
+        alpha = Clamp(alpha, this.lowerAlphaLimit ?? -Infinity, this.upperAlphaLimit ?? Infinity);
+        beta = Clamp(beta, this.lowerBetaLimit ?? -Infinity, this.upperBetaLimit ?? Infinity);
+        radius = Clamp(radius, this.lowerRadiusLimit ?? -Infinity, this.upperRadiusLimit ?? Infinity);
 
         this._goalAlpha = alpha;
         this._goalBeta = beta;

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -791,11 +791,11 @@ export class ArcRotateCamera extends TargetCamera {
      * @returns the camera itself
      */
     public override storeState(): Camera {
-        this._storedAlpha = this.alpha;
-        this._storedBeta = this.beta;
-        this._storedRadius = this.radius;
-        this._storedTarget = this._getTargetPosition().clone();
-        this._storedTargetScreenOffset = this.targetScreenOffset.clone();
+        this._storedAlpha = this._goalAlpha = this.alpha;
+        this._storedBeta = this._goalBeta = this.beta;
+        this._storedRadius = this._goalRadius = this.radius;
+        this._storedTarget = this._goalTarget = this._getTargetPosition().clone();
+        this._storedTargetScreenOffset = this._goalTargetScreenOffset = this.targetScreenOffset.clone();
 
         return super.storeState();
     }
@@ -843,6 +843,10 @@ export class ArcRotateCamera extends TargetCamera {
         this.inertialRadiusOffset = 0;
         this.inertialPanningX = 0;
         this.inertialPanningY = 0;
+
+        alpha = Math.min(Math.max(alpha, this.lowerAlphaLimit ?? -Infinity), this.upperAlphaLimit ?? Infinity);
+        beta = Math.min(Math.max(beta, this.lowerBetaLimit ?? -Infinity), this.upperBetaLimit ?? Infinity);
+        radius = Math.min(Math.max(radius, this.lowerRadiusLimit ?? -Infinity), this.upperRadiusLimit ?? Infinity);
 
         this._goalAlpha = alpha;
         this._goalBeta = beta;

--- a/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
@@ -102,4 +102,7 @@ export function GetHotSpotToRef(mesh: AbstractMesh, hotSpotQuery: HotSpotQuery, 
         TmpVectors.Vector3[0].scaleInPlace(hotSpotQuery.barycentric[i]);
         res.addInPlace(TmpVectors.Vector3[0]);
     }
+
+    // Convert the result to world space
+    Vector3.TransformCoordinatesToRef(res, mesh.getWorldMatrix(), res);
 }

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -507,9 +507,10 @@ export class Viewer implements IDisposable {
                         this.onAnimationProgressChanged.notifyObservers();
                     }),
                 ];
+
+                this._updateCamera(!this._isLoadingModel);
             }
 
-            this._updateCamera(true);
             this.onSelectedAnimationChanged.notifyObservers();
         }
     }

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -123,17 +123,20 @@ export type ViewerHotSpotQuery = {
     meshIndex: number;
 } & HotSpotQuery;
 
-export type ViewerHotSpotResult = {
+/**
+ * Provides the result of a hot spot query.
+ */
+export class ViewerHotSpotResult {
     /**
      * 2D canvas position in pixels
      */
-    screenPosition: [number, number];
+    public readonly screenPosition: [x: number, y: number] = [NaN, NaN];
 
     /**
      * 3D world coordinates
      */
-    worldPosition: [number, number, number];
-};
+    public readonly worldPosition: [x: number, y: number, z: number] = [NaN, NaN, NaN];
+}
 
 /**
  * @experimental
@@ -799,8 +802,11 @@ export class Viewer implements IDisposable {
         const scene = this._details.scene;
 
         Vector3.ProjectToRef(worldPos, mesh.getWorldMatrix(), scene.getTransformMatrix(), new Viewport(0, 0, viewportWidth, viewportHeight), screenPos);
-        result.screenPosition = [screenPos.x, screenPos.y];
-        result.worldPosition = [worldPos.x, worldPos.y, worldPos.z];
+        result.screenPosition[0] = screenPos.x;
+        result.screenPosition[1] = screenPos.y;
+        result.worldPosition[0] = worldPos.x;
+        result.worldPosition[1] = worldPos.y;
+        result.worldPosition[2] = worldPos.z;
         return true;
     }
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -118,14 +118,12 @@ export type ViewerHotSpotQuery = {
     meshIndex: number;
 } & HotSpotQuery;
 
-/**
- * Information computed from the hot spot surface data, canvas and mesh datas
- */
-export type ViewerHotSpot = {
+export type ViewerHotSpotResult = {
     /**
      * 2D canvas position in pixels
      */
     screenPosition: [number, number];
+
     /**
      * 3D world coordinates
      */
@@ -772,21 +770,21 @@ export class Viewer implements IDisposable {
 
     /**
      * retrun world and canvas coordinates of an hot spot
-     * @param hotSpotQuery mesh index and surface information to query the hot spot positions
-     * @param res Query a Hot Spot and does the conversion for Babylon Hot spot to a more generic HotSpotPositions, without Vector types
+     * @param query mesh index and surface information to query the hot spot positions
+     * @param result Query a Hot Spot and does the conversion for Babylon Hot spot to a more generic HotSpotPositions, without Vector types
      * @returns true if hotspot found
      */
-    public getHotSpotToRef(hotSpotQuery: Readonly<ViewerHotSpotQuery>, res: ViewerHotSpot): boolean {
+    public getHotSpotToRef(query: Readonly<ViewerHotSpotQuery>, result: ViewerHotSpotResult): boolean {
         if (!this._details.model) {
             return false;
         }
         const worldPos = TmpVectors.Vector3[1];
         const screenPos = TmpVectors.Vector3[0];
-        const mesh = this._details.model.meshes[hotSpotQuery.meshIndex];
+        const mesh = this._details.model.meshes[query.meshIndex];
         if (!mesh) {
             return false;
         }
-        GetHotSpotToRef(mesh, hotSpotQuery, worldPos);
+        GetHotSpotToRef(mesh, query, worldPos);
 
         const renderWidth = this._engine.getRenderWidth(); // Get the canvas width
         const renderHeight = this._engine.getRenderHeight(); // Get the canvas height
@@ -796,8 +794,8 @@ export class Viewer implements IDisposable {
         const scene = this._details.scene;
 
         Vector3.ProjectToRef(worldPos, mesh.getWorldMatrix(), scene.getTransformMatrix(), new Viewport(0, 0, viewportWidth, viewportHeight), screenPos);
-        res.screenPosition = [screenPos.x, screenPos.y];
-        res.worldPosition = [worldPos.x, worldPos.y, worldPos.z];
+        result.screenPosition = [screenPos.x, screenPos.y];
+        result.worldPosition = [worldPos.x, worldPos.y, worldPos.z];
         return true;
     }
 

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -113,6 +113,11 @@ export type EnvironmentOptions = Partial<Readonly<{}>>;
 
 export type ViewerHotSpotQuery = {
     /**
+     * The type of the hot spot.
+     */
+    type: "surface";
+
+    /**
      * The index of the mesh within the loaded model.
      */
     meshIndex: number;

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -23,7 +23,7 @@ import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { CubeTexture } from "core/Materials/Textures/cubeTexture";
 import { Texture } from "core/Materials/Textures/texture";
 import { Clamp } from "core/Maths/math.scalar.functions";
-import { TmpVectors, Vector3 } from "core/Maths/math.vector";
+import { Matrix, TmpVectors, Vector3 } from "core/Maths/math.vector";
 import { CreateBox } from "core/Meshes/Builders/boxBuilder";
 import { computeMaxExtents } from "core/Meshes/meshUtils";
 import { AsyncLock } from "core/Misc/asyncLock";
@@ -801,7 +801,7 @@ export class Viewer implements IDisposable {
         const viewportHeight = this._details.camera.viewport.height * renderHeight;
         const scene = this._details.scene;
 
-        Vector3.ProjectToRef(worldPos, mesh.getWorldMatrix(), scene.getTransformMatrix(), new Viewport(0, 0, viewportWidth, viewportHeight), screenPos);
+        Vector3.ProjectToRef(worldPos, Matrix.IdentityReadOnly, scene.getTransformMatrix(), new Viewport(0, 0, viewportWidth, viewportHeight), screenPos);
         result.screenPosition[0] = screenPos.x;
         result.screenPosition[1] = screenPos.y;
         result.worldPosition[0] = worldPos.x;

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -2,7 +2,7 @@
 import type { ArcRotateCamera, Nullable, Observable } from "core/index";
 
 import type { PropertyValues } from "lit";
-import type { ToneMapping, ViewerDetails, ViewerHotSpot, ViewerHotSpotQuery } from "./viewer";
+import type { ToneMapping, ViewerDetails, ViewerHotSpotResult, ViewerHotSpotQuery } from "./viewer";
 import type { CanvasViewerOptions } from "./viewerFactory";
 
 import { LitElement, css, defaultConverter, html } from "lit";
@@ -383,7 +383,7 @@ export class HTML3DElement extends LitElement {
      * @param result resulting world and screen positions
      * @returns world and screen space coordinates
      */
-    public queryHotSpot(name: string, result: ViewerHotSpot): boolean {
+    public queryHotSpot(name: string, result: ViewerHotSpotResult): boolean {
         // Retrieve all hotspots inside the viewer element
         let resultFound = false;
         // Iterate through each hotspot to get the 'data-surface' and 'data-name' attributes

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -9,6 +9,7 @@ import { LitElement, css, defaultConverter, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 
 import { Color4 } from "core/Maths/math.color";
+import { Vector3 } from "core/Maths/math.vector";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Logger } from "core/Misc/logger";
 import { isToneMapping, ViewerHotSpotResult } from "./viewer";
@@ -410,19 +411,14 @@ export class HTML3DElement extends LitElement {
         const result = new ViewerHotSpotResult();
         const query = this._queryHotSpot(name, result);
         if (query && this._viewerDetails) {
-            let cameraOrbit = query.cameraOrbit;
-            if (!cameraOrbit) {
-                // TODO: calculate
-                cameraOrbit = [0, 0, 0];
-            }
-
-            // TODO: Call a new function on ArcRotateCamera to do the animation (same logic it already has for restoring the original pose)
-            this._viewerDetails.camera.target.x = result.worldPosition[0];
-            this._viewerDetails.camera.target.y = result.worldPosition[1];
-            this._viewerDetails.camera.target.z = result.worldPosition[2];
-            this._viewerDetails.camera.alpha = cameraOrbit[0];
-            this._viewerDetails.camera.beta = cameraOrbit[1];
-            this._viewerDetails.camera.radius = cameraOrbit[2];
+            const cameraOrbit = query.cameraOrbit ?? [undefined, undefined, undefined];
+            this._viewerDetails.camera.interpolateTo(
+                cameraOrbit[0],
+                cameraOrbit[1],
+                cameraOrbit[2],
+                new Vector3(result.worldPosition[0], result.worldPosition[1], result.worldPosition[2])
+            );
+            return true;
         }
         return false;
     }

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -606,8 +606,8 @@ export class HTML3DElement extends LitElement {
     /**
      * The currently selected animation index.
      */
-    @property({ attribute: "selected-animation" })
-    public selectedAnimation = -1;
+    @property({ attribute: "selected-animation", type: Number })
+    public selectedAnimation: Nullable<number> = null;
 
     /**
      * True if an animation is currently playing.
@@ -924,7 +924,7 @@ export class HTML3DElement extends LitElement {
         if (this._viewerDetails) {
             try {
                 if (this.source) {
-                    await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
+                    await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined, defaultAnimation: this.selectedAnimation ?? 0 });
                 } else {
                     await this._viewerDetails.viewer.resetModel();
                 }

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -557,22 +557,7 @@ export class HTML3DElement extends LitElement {
                 return null;
             }
 
-            const array = value.split(/\s+/);
-            if (array.length % 8 !== 0) {
-                throw new Error(
-                    `hotspots should be defined in sets of 8 elements: 'name meshIndex pointIndex1 pointIndex2 pointIndex3 barycentricCoord1 barycentricCoord2 barycentricCoord3', but a total of ${array.length} elements were found in '${value}'`
-                );
-            }
-
-            const hotSpots: Record<string, ViewerHotSpotQuery> = {};
-            for (let offset = 0; offset < array.length; offset += 8) {
-                hotSpots[array[offset]] = {
-                    meshIndex: Number(array[offset + 1]),
-                    pointIndex: [Number(array[offset + 2]), Number(array[offset + 3]), Number(array[offset + 4])],
-                    barycentric: [Number(array[offset + 5]), Number(array[offset + 6]), Number(array[offset + 7])],
-                };
-            }
-            return hotSpots;
+            return JSON.parse(value);
         },
     })
     public hotSpots: Nullable<Record<string, ViewerHotSpotQuery>> = null;

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -779,8 +779,10 @@ export class HTML3DElement extends LitElement {
                                       ? html`<div class="select-container">
                                             <select id="hotspotsSelect" aria-label="Select HotSpot" @change="${this._onHotSpotsChanged}">
                                                 <option value="" hidden selected></option>
+                                                <!-- When the select is forced to be less wide than the options, padding on the right is lost. Pad with white space. -->
                                                 ${Object.keys(this.hotSpots).map((name) => html`<option value="${name}">${name}&nbsp;&nbsp;</option>`)}
                                             </select>
+                                            <!-- This button is not actually interactive, we want input to pass through to the select below. -->
                                             <button style="pointer-events: none">
                                                 <svg viewBox="0 0 20 20">
                                                     <path d="${targetFilledIcon}" fill="currentColor"></path>

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -388,9 +388,9 @@ export class HTML3DElement extends LitElement {
         let resultFound = false;
         // Iterate through each hotspot to get the 'data-surface' and 'data-name' attributes
         if (this._viewerDetails) {
-            const hotspot = this.hotspots?.[name];
-            if (hotspot) {
-                resultFound = this._viewerDetails.viewer.getHotSpotToRef(hotspot, result);
+            const hotSpot = this.hotSpots?.[name];
+            if (hotSpot) {
+                resultFound = this._viewerDetails.viewer.getHotSpotToRef(hotSpot, result);
             }
         }
         return resultFound;
@@ -551,6 +551,7 @@ export class HTML3DElement extends LitElement {
      * A string value that encodes one or more hotspots.
      */
     @property({
+        attribute: "hotspots",
         converter: (value) => {
             if (!value) {
                 return null;
@@ -563,18 +564,18 @@ export class HTML3DElement extends LitElement {
                 );
             }
 
-            const hotspots: Record<string, ViewerHotSpotQuery> = {};
+            const hotSpots: Record<string, ViewerHotSpotQuery> = {};
             for (let offset = 0; offset < array.length; offset += 8) {
-                hotspots[array[offset]] = {
+                hotSpots[array[offset]] = {
                     meshIndex: Number(array[offset + 1]),
                     pointIndex: [Number(array[offset + 2]), Number(array[offset + 3]), Number(array[offset + 4])],
                     barycentric: [Number(array[offset + 5]), Number(array[offset + 6]), Number(array[offset + 7])],
                 };
             }
-            return hotspots;
+            return hotSpots;
         },
     })
-    public hotspots: Nullable<Record<string, ViewerHotSpotQuery>> = null;
+    public hotSpots: Nullable<Record<string, ViewerHotSpotQuery>> = null;
 
     /**
      * True if the default animation should play automatically when a model is loaded.

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -129,8 +129,8 @@ export class HTML3DElement extends LitElement {
         this._createPropertyBinding(
             "selectedAnimation",
             (details) => details.viewer.onSelectedAnimationChanged,
-            (details) => (details.viewer.selectedAnimation = this.selectedAnimation),
-            (details) => (this.selectedAnimation = details.viewer.selectedAnimation ?? -1)
+            (details) => (details.viewer.selectedAnimation = this.selectedAnimation ?? details.viewer.selectedAnimation),
+            (details) => (this.selectedAnimation = details.viewer.selectedAnimation)
         ),
     ] as const;
 

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -173,7 +173,7 @@
             // use requestAnimationFrame to update with renderer
             const startHotSpotLinesRenderLoop = () => {
                 const hotspotBaseRect = document.querySelector("#anchor-button").getBoundingClientRect();
-                drawHotSpotLine(lines[0], "testHotSpot1", hotspotBaseRect);
+                drawHotSpotLine(lines[0], "hotspot 1", hotspotBaseRect);
                 if (hotspotVisible) {
                     requestAnimationFrame(startHotSpotLinesRenderLoop);
                 }
@@ -192,10 +192,6 @@
                 hotspotVisible = !hotspotVisible;
                 lines[0].style.visibility = hotspotVisible ? "visible" : "hidden";
                 startHotSpotLinesRenderLoop();
-
-                if (hotspotVisible) {
-                    viewerElement.focusHotSpot("testHotSpot1");
-                }
             }
         </script>
     </body>

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -76,12 +76,19 @@
             camera-target="auto auto auto"
             camera-auto-orbit
             hotspots='{
-                "testHotSpot1": {
+                "hotspot 1": {
                     "type": "surface",
                     "meshIndex": 1,
                     "pointIndex": [228, 113, 111],
                     "barycentric": [0.217, 0.341, 0.442],
                     "cameraOrbit": [1.085, 1.417, 0.518]
+                },
+                "hotspot 2": {
+                    "type": "surface",
+                    "meshIndex": 1,
+                    "pointIndex": [228, 113, 111],
+                    "barycentric": [0.217, 0.341, 0.442],
+                    "cameraOrbit": [2.085, 2.417, 2.518]
                 }
             }'
         >

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -89,6 +89,12 @@
                     "pointIndex": [228, 113, 111],
                     "barycentric": [0.217, 0.341, 0.442],
                     "cameraOrbit": [2.085, 2.417, 2.518]
+                },
+                "hotspot 3": {
+                    "type": "surface",
+                    "meshIndex": 1,
+                    "pointIndex": [228, 113, 111],
+                    "barycentric": [0.217, 0.341, 0.442]
                 }
             }'
         >

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -75,7 +75,14 @@
             camera-orbit="auto auto auto"
             camera-target="auto auto auto"
             camera-auto-orbit
-            hotspots="testHotSpot1 1 228 113 111 0.217 0.341 0.442"
+            hotspots='{
+                "testHotSpot1": {
+                    "type": "surface",
+                    "meshIndex": 1,
+                    "pointIndex": [228, 113, 111],
+                    "barycentric": [0.217, 0.341, 0.442]
+                }
+            }'
         >
             <!-- <div slot="tool-bar" style="position: absolute; top: 12px; left: 12px; width: 100px; height: 36px">
                 <button onclick="document.querySelector('babylon-viewer').toggleAnimation()">Toggle Animation</button>

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -80,7 +80,8 @@
                     "type": "surface",
                     "meshIndex": 1,
                     "pointIndex": [228, 113, 111],
-                    "barycentric": [0.217, 0.341, 0.442]
+                    "barycentric": [0.217, 0.341, 0.442],
+                    "cameraOrbit": [1.085, 1.417, 0.518]
                 }
             }'
         >
@@ -184,6 +185,10 @@
                 hotspotVisible = !hotspotVisible;
                 lines[0].style.visibility = hotspotVisible ? "visible" : "hidden";
                 startHotSpotLinesRenderLoop();
+
+                if (hotspotVisible) {
+                    viewerElement.focusHotSpot("testHotSpot1");
+                }
             }
         </script>
     </body>


### PR DESCRIPTION
This change makes it possible to programmatically "focus on" a hotspot. The camera target is determined by querying the hotspot. Additionally, each hotspot can optionally have additional explicit camera pose data (alpha/beta/radius) associated with it. When focusing on a hotspot, the calculated camera target is always used, and the alpha/beta/radius is used if it is provided.

Since hotspot data has become a bit more complex (with optional camera data), and since we expect other types of hotspots in the future (like static world space locations), I switched from a custom parsed format to it just being a JSON string. I think this is much more scalable, plus people will already be familiar with JSON, so no need to learn a bespoke way of encoding structured data in a string.

Hotspots are specified like this:
```html
<babylon-viewer
    source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
    hotspots='{
        "hotspot 1": {
            "type": "surface",
            "meshIndex": 1,
            "pointIndex": [228, 113, 111],
            "barycentric": [0.217, 0.341, 0.442],
            "cameraOrbit": [1.085, 1.417, 0.518]
        },
    }'
>
</babylon-viewer>
```

To focus on a hotspot, you can call `focusHotSpot` on the viewer element:
```js
document.querySelector('babylon-viewer').focusHotSpot('hotspot 1');
```

To make this a good experience, the camera pose is interpolated. To make this possible, I did a small refactor in `ArcRotateCamera` to add an `interpolateTo` function that does the same thing `ArcRotateCamera` already did when restoring the saved state, it's just now possible to interpolate to any goal state rather than only the stored state.

This PR also includes default UI to activate a defined hotspot (by activate, I mean invoke `focusOnHotspot`). Since the camera pose can be changed by user interactions, there is no concept of an "selected" hotspot, rather just the idea that you can one-off activate them. This is what the experience looks like:

https://github.com/user-attachments/assets/d9c4c1ef-31c4-4264-9da1-49d2b7f853a5

The new hotspot activation button is only displayed if there are hotspots defined in the `<babylon-viewer>`. If there are hotspots but no animations, then just the hotspot button is displayed in the center of the screen. We can iterate on UX design more later.

Other notes for this PR:
- Since it is now easy to interpolate the camera pose, it also interpolates when changing the selected animation (since the camera pose is updated based on the first frame of each animation).
- There was a bug in `GetHotSpotToRef` such that it returned the hotspot position in local space instead of world space (even though it was documented as returning the position in world space), so I fixed this. As such, when the viewer calculates the screen space position via `ProjectToRef`, it now just passes the identity matrix since the position is already in world space.
