### PR TITLE
Node editors: Fix editable properties for blocks with inheritance hierarchy

### DIFF
--- a/packages/dev/core/src/Decorators/nodeDecorator.ts
+++ b/packages/dev/core/src/Decorators/nodeDecorator.ts
@@ -78,6 +78,8 @@ export interface IPropertyDescriptionForEdition {
     groupName: string;
     /** options for the property */
     options: IEditablePropertyOption;
+    /** name of the class that contains the property */
+    className: string;
 }
 
 /**
@@ -106,6 +108,7 @@ export function editableInPropertyPage(
             type: propertyType,
             groupName: groupName,
             options: options ?? {},
+            className: target.constructor.name,
         });
     };
 }

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -707,8 +707,16 @@ export class GraphNode {
         if (propStore) {
             const source = this.content.data;
 
-            for (const { propertyName, displayName, type, options } of propStore) {
-                if (options && !options.embedded) {
+            const classes: string[] = [];
+
+            let proto = Object.getPrototypeOf(source);
+            while (proto) {
+                classes.push(proto.constructor.name);
+                proto = Object.getPrototypeOf(proto);
+            }
+
+            for (const { propertyName, displayName, type, options, className } of propStore) {
+                if (!options || !options.embedded || classes.indexOf(className) === -1) {
                     continue;
                 }
 

--- a/packages/tools/nodeEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -110,10 +110,18 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         const componentList: { [groupName: string]: JSX.Element[] } = {},
             groups: string[] = [];
 
-        for (const { propertyName, displayName, type, groupName, options } of propStore) {
+        const classes: string[] = [];
+
+        let proto = Object.getPrototypeOf(block);
+        while (proto) {
+            classes.push(proto.constructor.name);
+            proto = Object.getPrototypeOf(proto);
+        }
+
+        for (const { propertyName, displayName, type, groupName, options, className } of propStore) {
             let components = componentList[groupName];
 
-            if (options.embedded) {
+            if (options.embedded || classes.indexOf(className) === -1) {
                 continue;
             }
 

--- a/packages/tools/nodeGeometryEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -210,10 +210,18 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         const componentList: { [groupName: string]: JSX.Element[] } = {},
             groups: string[] = [];
 
-        for (const { propertyName, displayName, type, groupName, options } of propStore) {
+        const classes: string[] = [];
+
+        let proto = Object.getPrototypeOf(block);
+        while (proto) {
+            classes.push(proto.constructor.name);
+            proto = Object.getPrototypeOf(proto);
+        }
+
+        for (const { propertyName, displayName, type, groupName, options, className } of propStore) {
             let components = componentList[groupName];
 
-            if (options.embedded) {
+            if (options.embedded || classes.indexOf(className) === -1) {
                 continue;
             }
 

--- a/packages/tools/nodeRenderGraphEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeRenderGraphEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -138,10 +138,18 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         const componentList: { [groupName: string]: JSX.Element[] } = {},
             groups: string[] = [];
 
-        for (const { propertyName, displayName, type, groupName, options } of propStore) {
+        const classes: string[] = [];
+
+        let proto = Object.getPrototypeOf(block);
+        while (proto) {
+            classes.push(proto.constructor.name);
+            proto = Object.getPrototypeOf(proto);
+        }
+
+        for (const { propertyName, displayName, type, groupName, options, className } of propStore) {
             let components = componentList[groupName];
 
-            if (options.embedded) {
+            if (options.embedded || classes.indexOf(className) === -1) {
                 continue;
             }
 


### PR DESCRIPTION
I had this bug in NRGE:

![image](https://github.com/user-attachments/assets/6da14297-00ef-4ceb-8b45-54d74c04786a)

The properties of the `TAAObjectRenderer` are visible in the `ObjectRenderer` block, as both classes inherit from a base class, so all editable properties created by the `TAAObjectRenderer` and `ObjectRenderer` are added to the base class propstore.

To display only those properties that are appropriate for the selected block, the PR stores the class name together with the property data in the propstore, and checks at display time whether the property class is part of the class hierarchy of the block for which we want to display the properties.