### PR TITLE
Animations goToFrame: Fix breaking change introduced in #15126

### DIFF
--- a/packages/dev/core/src/Animations/animatable.core.ts
+++ b/packages/dev/core/src/Animations/animatable.core.ts
@@ -283,8 +283,9 @@ export class Animatable {
     /**
      * Jump directly to a given frame
      * @param frame defines the frame to jump to
+     * @param useWeight defines whether the animation weight should be applied to the image to be jumped to (false by default)
      */
-    public goToFrame(frame: number): void {
+    public goToFrame(frame: number, useWeight = false): void {
         const runtimeAnimations = this._runtimeAnimations;
 
         if (runtimeAnimations[0]) {
@@ -295,7 +296,7 @@ export class Animatable {
         }
 
         for (let index = 0; index < runtimeAnimations.length; index++) {
-            runtimeAnimations[index].goToFrame(frame, this._weight);
+            runtimeAnimations[index].goToFrame(frame, useWeight ? this._weight : -1);
         }
 
         this._goToFrame = frame;

--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -850,16 +850,17 @@ export class AnimationGroup implements IDisposable {
     /**
      * Goes to a specific frame in this animation group. Note that the animation group must be in playing or paused status
      * @param frame the frame number to go to
+     * @param useWeight defines whether the animation weight should be applied to the image to be jumped to (false by default)
      * @returns the animationGroup
      */
-    public goToFrame(frame: number): AnimationGroup {
+    public goToFrame(frame: number, useWeight = false): AnimationGroup {
         if (!this._isStarted) {
             return this;
         }
 
         for (let index = 0; index < this._animatables.length; index++) {
             const animatable = this._animatables[index];
-            animatable.goToFrame(frame);
+            animatable.goToFrame(frame, useWeight);
         }
 
         return this;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/animation-blending-and-key-interpolation-bug-in-new-cdn/54729/4.

My change in #15126 was a breaking change, because when the weight isn't -1, the animation is considered additive, and this can break if there isn't at least one animation that isn't additive.

I needed this change for Teams Avatar, so I made a change so that the old behavior is the default, but I added a flag so that I could use the animation weight on demand.