### PR TITLE
Extract ObjectRenderer from RenderTargetTexture

### DIFF
--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseObjectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseObjectRendererBlock.ts
@@ -1,9 +1,17 @@
-// eslint-disable-next-line import/no-internal-modules
-import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraph, FrameGraphTextureHandle, FrameGraphObjectList, Camera } from "core/index";
+import type {
+    NodeRenderGraphConnectionPoint,
+    Scene,
+    NodeRenderGraphBuildState,
+    FrameGraph,
+    FrameGraphTextureHandle,
+    FrameGraphObjectList,
+    Camera,
+    FrameGraphObjectRendererTask,
+    // eslint-disable-next-line import/no-internal-modules
+} from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
-import type { FrameGraphObjectRendererTask } from "../../../Tasks/Rendering/objectRendererTask";
 
 /**
  * @internal

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/geometryRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/geometryRendererBlock.ts
@@ -25,9 +25,12 @@ export class NodeRenderGraphGeometryRendererBlock extends NodeRenderGraphBlock {
      * @param name defines the block name
      * @param frameGraph defines the hosting frame graph
      * @param scene defines the hosting scene
+     * @param doNotChangeAspectRatio True (default) to not change the aspect ratio of the scene in the RTT
      */
-    public constructor(name: string, frameGraph: FrameGraph, scene: Scene) {
+    public constructor(name: string, frameGraph: FrameGraph, scene: Scene, doNotChangeAspectRatio = true) {
         super(name, frameGraph, scene);
+
+        this._additionalConstructionParameters = [doNotChangeAspectRatio];
 
         this.registerInput("depth", NodeRenderGraphBlockConnectionPointTypes.TextureBackBufferDepthStencilAttachment, true);
         this.registerInput("camera", NodeRenderGraphBlockConnectionPointTypes.Camera);
@@ -49,7 +52,7 @@ export class NodeRenderGraphGeometryRendererBlock extends NodeRenderGraphBlock {
 
         this.outputDepth._typeConnectionSource = this.depth;
 
-        this._frameGraphTask = new FrameGraphGeometryRendererTask(this.name, frameGraph, scene);
+        this._frameGraphTask = new FrameGraphGeometryRendererTask(this.name, frameGraph, scene, { doNotChangeAspectRatio });
     }
 
     /** Indicates if depth testing must be enabled or disabled */
@@ -72,6 +75,19 @@ export class NodeRenderGraphGeometryRendererBlock extends NodeRenderGraphBlock {
         this._frameGraphTask.depthWrite = value;
     }
 
+    /** True (default) to not change the aspect ratio of the scene in the RTT */
+    @editableInPropertyPage("Do not change aspect ratio", PropertyTypeForEdition.Boolean, "PROPERTIES")
+    public get doNotChangeAspectRatio() {
+        return this._frameGraphTask.objectRenderer.options.doNotChangeAspectRatio;
+    }
+
+    public set doNotChangeAspectRatio(value: boolean) {
+        this._frameGraphTask.dispose();
+        this._frameGraphTask = new FrameGraphGeometryRendererTask(this.name, this._frameGraph, this._scene, { doNotChangeAspectRatio: value });
+        this._additionalConstructionParameters = [value];
+    }
+
+    /** Width of the geometry texture */
     @editableInPropertyPage("Texture width", PropertyTypeForEdition.Int, "PROPERTIES")
     public get width() {
         return this._frameGraphTask.size.width;
@@ -81,6 +97,7 @@ export class NodeRenderGraphGeometryRendererBlock extends NodeRenderGraphBlock {
         this._frameGraphTask.size.width = value;
     }
 
+    /** Height of the geometry texture */
     @editableInPropertyPage("Texture height", PropertyTypeForEdition.Int, "PROPERTIES")
     public get height() {
         return this._frameGraphTask.size.height;
@@ -90,6 +107,7 @@ export class NodeRenderGraphGeometryRendererBlock extends NodeRenderGraphBlock {
         this._frameGraphTask.size.height = value;
     }
 
+    /** Indicates if the geometry texture width and height are percentages or absolute values */
     @editableInPropertyPage("Size is in percentage", PropertyTypeForEdition.Boolean, "PROPERTIES")
     public get sizeInPercentage() {
         return this._frameGraphTask.sizeIsPercentage;
@@ -99,6 +117,7 @@ export class NodeRenderGraphGeometryRendererBlock extends NodeRenderGraphBlock {
         this._frameGraphTask.sizeIsPercentage = value;
     }
 
+    /** Number of samples of the geometry texture */
     @editableInPropertyPage("Samples", PropertyTypeForEdition.Int, "PROPERTIES", { min: 1, max: 8 })
     public get samples() {
         return this._frameGraphTask.samples;

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/objectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/objectRendererBlock.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
+import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import { FrameGraphObjectRendererTask } from "../../../Tasks/Rendering/objectRendererTask";
 import { NodeRenderGraphBaseObjectRendererBlock } from "./baseObjectRendererBlock";
 
@@ -13,11 +14,26 @@ export class NodeRenderGraphObjectRendererBlock extends NodeRenderGraphBaseObjec
      * @param name defines the block name
      * @param frameGraph defines the hosting frame graph
      * @param scene defines the hosting scene
+     * @param doNotChangeAspectRatio True (default) to not change the aspect ratio of the scene in the RTT
      */
-    public constructor(name: string, frameGraph: FrameGraph, scene: Scene) {
+    public constructor(name: string, frameGraph: FrameGraph, scene: Scene, doNotChangeAspectRatio = true) {
         super(name, frameGraph, scene);
 
-        this._frameGraphTask = new FrameGraphObjectRendererTask(this.name, frameGraph, scene);
+        this._additionalConstructionParameters = [doNotChangeAspectRatio];
+
+        this._frameGraphTask = new FrameGraphObjectRendererTask(this.name, frameGraph, scene, { doNotChangeAspectRatio });
+    }
+
+    /** True (default) to not change the aspect ratio of the scene in the RTT */
+    @editableInPropertyPage("Do not change aspect ratio", PropertyTypeForEdition.Boolean, "PROPERTIES")
+    public get doNotChangeAspectRatio() {
+        return this._frameGraphTask.objectRenderer.options.doNotChangeAspectRatio;
+    }
+
+    public set doNotChangeAspectRatio(value: boolean) {
+        this._frameGraphTask.dispose();
+        this._frameGraphTask = new FrameGraphObjectRendererTask(this.name, this._frameGraph, this._scene, { doNotChangeAspectRatio: value });
+        this._additionalConstructionParameters = [value];
     }
 
     /**

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/taaObjectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/taaObjectRendererBlock.ts
@@ -23,11 +23,26 @@ export class NodeRenderGraphTAAObjectRendererBlock extends NodeRenderGraphBaseOb
      * @param name defines the block name
      * @param frameGraph defines the hosting frame graph
      * @param scene defines the hosting scene
+     * @param doNotChangeAspectRatio True (default) to not change the aspect ratio of the scene in the RTT
      */
-    public constructor(name: string, frameGraph: FrameGraph, scene: Scene) {
+    public constructor(name: string, frameGraph: FrameGraph, scene: Scene, doNotChangeAspectRatio = true) {
         super(name, frameGraph, scene);
 
-        this._frameGraphTask = new FrameGraphTAAObjectRendererTask(this.name, frameGraph, scene);
+        this._additionalConstructionParameters = [doNotChangeAspectRatio];
+
+        this._frameGraphTask = new FrameGraphTAAObjectRendererTask(this.name, frameGraph, scene, { doNotChangeAspectRatio });
+    }
+
+    /** True (default) to not change the aspect ratio of the scene in the RTT */
+    @editableInPropertyPage("Do not change aspect ratio", PropertyTypeForEdition.Boolean, "PROPERTIES")
+    public get doNotChangeAspectRatio() {
+        return this._frameGraphTask.objectRenderer.options.doNotChangeAspectRatio;
+    }
+
+    public set doNotChangeAspectRatio(value: boolean) {
+        this._frameGraphTask.dispose();
+        this._frameGraphTask = new FrameGraphTAAObjectRendererTask(this.name, this._frameGraph, this._scene, { doNotChangeAspectRatio: value });
+        this._additionalConstructionParameters = [value];
     }
 
     /** Number of accumulated samples */

--- a/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
@@ -1,5 +1,16 @@
-// eslint-disable-next-line import/no-internal-modules
-import type { Nullable, AbstractEngine, DrawWrapper, IColor4Like, Layer, FrameGraphTextureHandle, Effect, FrameGraphTextureManager, RenderTargetTexture } from "core/index";
+import type {
+    Nullable,
+    AbstractEngine,
+    DrawWrapper,
+    IColor4Like,
+    Layer,
+    FrameGraphTextureHandle,
+    Effect,
+    FrameGraphTextureManager,
+    ObjectRenderer,
+    Scene,
+    // eslint-disable-next-line import/no-internal-modules
+} from "core/index";
 import { Constants } from "../Engines/constants";
 import { EffectRenderer } from "../Materials/effectRenderer";
 import { CopyTextureToTexture } from "../Misc/copyTextureToTexture";
@@ -18,10 +29,15 @@ export class FrameGraphRenderContext extends FrameGraphContext {
     private _renderTargetIsBound = true;
     private readonly _copyTexture: CopyTextureToTexture;
 
+    private static _IsObjectRenderer(object: Layer | ObjectRenderer): object is ObjectRenderer {
+        return (object as ObjectRenderer).initRender !== undefined;
+    }
+
     /** @internal */
     constructor(
         private readonly _engine: AbstractEngine,
-        private readonly _textureManager: FrameGraphTextureManager
+        private readonly _textureManager: FrameGraphTextureManager,
+        private readonly _scene?: Scene
     ) {
         super();
         this._effectRenderer = new EffectRenderer(this._engine);
@@ -190,10 +206,27 @@ export class FrameGraphRenderContext extends FrameGraphContext {
     /**
      * Renders a RenderTargetTexture or a layer
      * @param object The RenderTargetTexture/Layer to render
+     * @param viewportWidth The width of the viewport (optional for Layer, but mandatory for ObjectRenderer)
+     * @param viewportHeight The height of the viewport (optional for Layer, but mandatory for ObjectRenderer)
      */
-    public render(object: Layer | RenderTargetTexture): void {
-        this._applyRenderTarget();
-        object.render();
+    public render(object: Layer | ObjectRenderer, viewportWidth?: number, viewportHeight?: number): void {
+        if (FrameGraphRenderContext._IsObjectRenderer(object)) {
+            if (object.shouldRender()) {
+                this._scene?.incrementRenderId();
+                this._scene?.resetCachedMaterial();
+
+                object.prepareRenderList();
+                object.initRender(viewportWidth!, viewportHeight!);
+
+                this._applyRenderTarget();
+                object.render();
+
+                object.finishRender();
+            }
+        } else {
+            this._applyRenderTarget();
+            object.render();
+        }
     }
 
     /**

--- a/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
@@ -29,8 +29,8 @@ export class FrameGraphRenderContext extends FrameGraphContext {
     private _renderTargetIsBound = true;
     private readonly _copyTexture: CopyTextureToTexture;
 
-    private static _IsObjectRenderer(object: Layer | ObjectRenderer): object is ObjectRenderer {
-        return (object as ObjectRenderer).initRender !== undefined;
+    private static _IsObjectRenderer(value: Layer | ObjectRenderer): value is ObjectRenderer {
+        return (value as ObjectRenderer).initRender !== undefined;
     }
 
     /** @internal */

--- a/packages/dev/core/src/Materials/Textures/multiRenderTarget.ts
+++ b/packages/dev/core/src/Materials/Textures/multiRenderTarget.ts
@@ -509,7 +509,7 @@ export class MultiRenderTarget extends RenderTargetTexture {
      * @param size Define the new size
      */
     public override resize(size: any) {
-        this._processSizeParameter(size, false);
+        this._processSizeParameter(size);
         this._rebuild(false, undefined, this._textureNames);
     }
 

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -1007,13 +1007,19 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             import("../../Misc/dumpTools").then((module) => (this._dumpTools = module));
         }
 
+        this._objectRenderer.prepareRenderList();
+
         this.onBeforeBindObservable.notifyObservers(this);
 
-        const result = this._objectRenderer.isReadyForRendering(this.getRenderWidth(), this.getRenderHeight());
+        this._objectRenderer.initRender(this.getRenderWidth(), this.getRenderHeight());
+
+        const isReady = this._objectRenderer._checkReadiness();
 
         this.onAfterUnbindObservable.notifyObservers(this);
 
-        return result;
+        this._objectRenderer.finishRender();
+
+        return isReady;
     }
 
     private _render(useCameraPostProcess: boolean = false, dumpForDebug: boolean = false): void {

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -611,7 +611,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             doNotChangeAspectRatio,
         });
 
-        this._objectRenderer.onBeforeRenderingManagerRenderObservable.addOnce(() => {
+        this._objectRenderer.onBeforeRenderingManagerRenderObservable.add(() => {
             // Before clear
             for (const step of this._scene!._beforeRenderTargetClearStage) {
                 step.action(this, this._currentFaceIndex, this._currentLayer);
@@ -634,7 +634,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             }
         });
 
-        this._objectRenderer.onAfterRenderingManagerRenderObservable.addOnce(() => {
+        this._objectRenderer.onAfterRenderingManagerRenderObservable.add(() => {
             // After Camera Draw
             for (const step of this._scene!._afterRenderTargetDrawStage) {
                 step.action(this, this._currentFaceIndex, this._currentLayer);

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -161,11 +161,15 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * The length of this list is passed through renderListLength: don't use renderList.length directly because the array can
      * hold dummy elements!
      */
-    public get getCustomRenderList(): (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>> {
+    public get getCustomRenderList(): Nullable<
+        (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>
+    > {
         return this._objectRenderer.getCustomRenderList;
     }
 
-    public set getCustomRenderList(value: (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>) {
+    public set getCustomRenderList(
+        value: Nullable<(layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>>
+    ) {
         this._objectRenderer.getCustomRenderList = value;
     }
 
@@ -302,10 +306,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         return this._objectRenderer.onBeforeRenderObservable;
     }
 
-    public set onBeforeRenderObservable(callback: Observable<number>) {
-        this._objectRenderer.onBeforeRenderObservable = callback;
-    }
-
     private _onBeforeRenderObserver: Nullable<Observer<number>>;
     /**
      * Set a before render callback in the texture.
@@ -323,10 +323,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      */
     public get onAfterRenderObservable() {
         return this._objectRenderer.onAfterRenderObservable;
-    }
-
-    public set onAfterRenderObservable(callback: Observable<number>) {
-        this._objectRenderer.onAfterRenderObservable = callback;
     }
 
     private _onAfterRenderObserver: Nullable<Observer<number>>;

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -13,11 +13,8 @@ import type { InternalTexture } from "../../Materials/Textures/internalTexture";
 import { Texture } from "../../Materials/Textures/texture";
 import { PostProcessManager } from "../../PostProcesses/postProcessManager";
 import type { PostProcess } from "../../PostProcesses/postProcess";
-import { RenderingManager } from "../../Rendering/renderingManager";
 import { Constants } from "../../Engines/constants";
 import type { IRenderTargetTexture, RenderTargetWrapper } from "../../Engines/renderTargetWrapper";
-
-import { _ObserveArray } from "../../Misc/arrayTools";
 
 import type { Material } from "../material";
 import { FloorPOT, NearestPOT } from "../../Misc/tools.functions";
@@ -25,6 +22,7 @@ import { Effect } from "../effect";
 import type { AbstractEngine } from "../../Engines/abstractEngine";
 import type { IParticleSystem } from "core/Particles/IParticleSystem";
 import { Logger } from "../../Misc/logger";
+import { ObjectRenderer } from "core/Rendering/objectRenderer";
 
 declare module "../effect" {
     export interface Effect {
@@ -108,63 +106,51 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
     /**
      * The texture will only be rendered once which can be useful to improve performance if everything in your render is static for instance.
      */
-    public static readonly REFRESHRATE_RENDER_ONCE: number = 0;
+    public static readonly REFRESHRATE_RENDER_ONCE: number = ObjectRenderer.REFRESHRATE_RENDER_ONCE;
     /**
-     * The texture will only be rendered rendered every frame and is recommended for dynamic contents.
+     * The texture will be rendered every frame and is recommended for dynamic contents.
      */
-    public static readonly REFRESHRATE_RENDER_ONEVERYFRAME: number = 1;
+    public static readonly REFRESHRATE_RENDER_ONEVERYFRAME: number = ObjectRenderer.REFRESHRATE_RENDER_ONEVERYFRAME;
     /**
      * The texture will be rendered every 2 frames which could be enough if your dynamic objects are not
      * the central point of your effect and can save a lot of performances.
      */
-    public static readonly REFRESHRATE_RENDER_ONEVERYTWOFRAMES: number = 2;
+    public static readonly REFRESHRATE_RENDER_ONEVERYTWOFRAMES: number = ObjectRenderer.REFRESHRATE_RENDER_ONEVERYTWOFRAMES;
 
     /**
      * Use this predicate to dynamically define the list of mesh you want to render.
      * If set, the renderList property will be overwritten.
      */
-    public renderListPredicate: (AbstractMesh: AbstractMesh) => boolean;
+    public get renderListPredicate(): (AbstractMesh: AbstractMesh) => boolean {
+        return this._objectRenderer.renderListPredicate;
+    }
 
-    private _renderList: Nullable<Array<AbstractMesh>>;
-    private _unObserveRenderList: Nullable<() => void> = null;
+    public set renderListPredicate(value: (AbstractMesh: AbstractMesh) => boolean) {
+        this._objectRenderer.renderListPredicate = value;
+    }
 
     /**
      * Use this list to define the list of mesh you want to render.
      */
     public get renderList(): Nullable<Array<AbstractMesh>> {
-        return this._renderList;
+        return this._objectRenderer.renderList;
     }
 
     public set renderList(value: Nullable<Array<AbstractMesh>>) {
-        if (this._renderList === value) {
-            return;
-        }
-        if (this._unObserveRenderList) {
-            this._unObserveRenderList();
-            this._unObserveRenderList = null;
-        }
-
-        if (value) {
-            this._unObserveRenderList = _ObserveArray(value, this._renderListHasChanged);
-        }
-
-        this._renderList = value;
+        this._objectRenderer.renderList = value;
     }
-
-    private _renderListHasChanged = (_functionName: String, previousLength: number) => {
-        const newLength = this._renderList ? this._renderList.length : 0;
-        if ((previousLength === 0 && newLength > 0) || newLength === 0) {
-            this.getScene()?.meshes.forEach((mesh) => {
-                mesh._markSubMeshesAsLightDirty();
-            });
-        }
-    };
 
     /**
      * Define the list of particle systems to render in the texture. If not provided, will render all the particle systems of the scene.
      * Note that the particle systems are rendered only if renderParticles is set to true.
      */
-    public particleSystemList: Nullable<Array<IParticleSystem>> = null;
+    public get particleSystemList(): Nullable<Array<IParticleSystem>> {
+        return this._objectRenderer.particleSystemList;
+    }
+
+    public set particleSystemList(value: Nullable<Array<IParticleSystem>>) {
+        this._objectRenderer.particleSystemList = value;
+    }
 
     /**
      * Use this function to overload the renderList array at rendering time.
@@ -175,40 +161,94 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * The length of this list is passed through renderListLength: don't use renderList.length directly because the array can
      * hold dummy elements!
      */
-    public getCustomRenderList: (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>;
+    public get getCustomRenderList(): (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>> {
+        return this._objectRenderer.getCustomRenderList;
+    }
+
+    public set getCustomRenderList(value: (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>) {
+        this._objectRenderer.getCustomRenderList = value;
+    }
 
     /**
-     * Define if particles should be rendered in your texture.
+     * Define if particles should be rendered in your texture (default: true).
      */
-    public renderParticles = true;
-    /**
-     * Define if sprites should be rendered in your texture.
-     */
-    public renderSprites = false;
+    public get renderParticles() {
+        return this._objectRenderer.renderParticles;
+    }
+
+    public set renderParticles(value: boolean) {
+        this._objectRenderer.renderParticles = value;
+    }
 
     /**
-     * Force checking the layerMask property even if a custom list of meshes is provided (ie. if renderList is not undefined)
+     * Define if sprites should be rendered in your texture (default: false).
      */
-    public forceLayerMaskCheck = false;
+    public get renderSprites() {
+        return this._objectRenderer.renderSprites;
+    }
+
+    public set renderSprites(value: boolean) {
+        this._objectRenderer.renderSprites = value;
+    }
+
+    /**
+     * Force checking the layerMask property even if a custom list of meshes is provided (ie. if renderList is not undefined) (default: false).
+     */
+    public get forceLayerMaskCheck() {
+        return this._objectRenderer.forceLayerMaskCheck;
+    }
+
+    public set forceLayerMaskCheck(value: boolean) {
+        this._objectRenderer.forceLayerMaskCheck = value;
+    }
 
     /**
      * Define the camera used to render the texture.
      */
-    public activeCamera: Nullable<Camera>;
+    public get activeCamera(): Nullable<Camera> {
+        return this._objectRenderer.activeCamera;
+    }
+
+    public set activeCamera(value: Nullable<Camera>) {
+        this._objectRenderer.activeCamera = value;
+    }
+
     /**
      * Override the mesh isReady function with your own one.
      */
-    public customIsReadyFunction: (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => boolean;
+    public get customIsReadyFunction(): (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => boolean {
+        return this._objectRenderer.customIsReadyFunction;
+    }
+
+    public set customIsReadyFunction(value: (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => boolean) {
+        this._objectRenderer.customIsReadyFunction = value;
+    }
+
     /**
      * Override the render function of the texture with your own one.
      */
-    public customRenderFunction: (
+    public get customRenderFunction(): (
         opaqueSubMeshes: SmartArray<SubMesh>,
         alphaTestSubMeshes: SmartArray<SubMesh>,
         transparentSubMeshes: SmartArray<SubMesh>,
         depthOnlySubMeshes: SmartArray<SubMesh>,
         beforeTransparents?: () => void
-    ) => void;
+    ) => void {
+        return this._objectRenderer.customRenderFunction;
+    }
+
+    public set customRenderFunction(
+        value: (
+            opaqueSubMeshes: SmartArray<SubMesh>,
+            alphaTestSubMeshes: SmartArray<SubMesh>,
+            transparentSubMeshes: SmartArray<SubMesh>,
+            depthOnlySubMeshes: SmartArray<SubMesh>,
+            beforeTransparents?: () => void
+        ) => void
+    ) {
+        this._objectRenderer.customRenderFunction = value;
+    }
+
     /**
      * Define if camera post processes should be use while rendering the texture.
      */
@@ -258,7 +298,13 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
     /**
      * An event triggered before rendering the texture
      */
-    public onBeforeRenderObservable = new Observable<number>();
+    public get onBeforeRenderObservable() {
+        return this._objectRenderer.onBeforeRenderObservable;
+    }
+
+    public set onBeforeRenderObservable(callback: Observable<number>) {
+        this._objectRenderer.onBeforeRenderObservable = callback;
+    }
 
     private _onBeforeRenderObserver: Nullable<Observer<number>>;
     /**
@@ -275,7 +321,13 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
     /**
      * An event triggered after rendering the texture
      */
-    public onAfterRenderObservable = new Observable<number>();
+    public get onAfterRenderObservable() {
+        return this._objectRenderer.onAfterRenderObservable;
+    }
+
+    public set onAfterRenderObservable(callback: Observable<number>) {
+        this._objectRenderer.onAfterRenderObservable = callback;
+    }
 
     private _onAfterRenderObserver: Nullable<Observer<number>>;
     /**
@@ -327,35 +379,48 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * Skip the initial clear of the rtt at the beginning of the frame render loop
      */
     public skipInitialClear = false;
-    protected _renderingManager: RenderingManager;
     /** @internal */
-    public _waitingRenderList?: string[];
+    public get _waitingRenderList() {
+        return this._objectRenderer._waitingRenderList;
+    }
+
+    /** @internal */
+    public set _waitingRenderList(value: string[] | undefined) {
+        this._objectRenderer._waitingRenderList = value;
+    }
+
+    protected _objectRenderer: ObjectRenderer;
     protected _doNotChangeAspectRatio: boolean;
-    protected _currentRefreshId = -1;
-    protected _refreshRate = 1;
     protected _textureMatrix: Matrix;
     protected _samples = 1;
     protected _renderTargetOptions: RenderTargetCreationOptions;
     private _canRescale = true;
     protected _renderTarget: Nullable<RenderTargetWrapper> = null;
+    private _currentFaceIndex: number;
+    private _currentLayer: number;
+    private _currentUseCameraPostProcess: boolean;
+    private _currentDumpForDebug: boolean;
+
     /**
      * Current render pass id of the render target texture. Note it can change over the rendering as there's a separate id for each face of a cube / each layer of an array layer!
      */
-    public renderPassId: number;
-    private _renderPassIds: number[];
+    public get renderPassId(): number {
+        return this._objectRenderer.renderPassId;
+    }
+
     /**
      * Gets the render pass ids used by the render target texture. For a single render target the array length will be 1, for a cube texture it will be 6 and for
      * a 2D texture array it will return an array of ids the size of the 2D texture array
      */
     public get renderPassIds(): readonly number[] {
-        return this._renderPassIds;
+        return this._objectRenderer.renderPassIds;
     }
 
     /**
      * Gets the current value of the refreshId counter
      */
     public get currentRefreshId() {
-        return this._currentRefreshId;
+        return this._objectRenderer.currentRefreshId;
     }
 
     /**
@@ -364,20 +429,8 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * @param material material or array of materials to use for this render pass. If undefined is passed, no specific material will be used but the regular material instead (mesh.material). It's possible to provide an array of materials to use a different material for each rendering in the case of a cube texture (6 rendering) and a 2D texture array (as many rendering as the length of the array)
      */
     public setMaterialForRendering(mesh: AbstractMesh | AbstractMesh[], material?: Material | Material[]): void {
-        let meshes;
-        if (!Array.isArray(mesh)) {
-            meshes = [mesh];
-        } else {
-            meshes = mesh;
-        }
-        for (let j = 0; j < meshes.length; ++j) {
-            for (let i = 0; i < this._renderPassIds.length; ++i) {
-                meshes[j].setMaterialForRenderPass(this._renderPassIds[i], material !== undefined ? (Array.isArray(material) ? material[i] : material) : undefined);
-            }
-        }
+        this._objectRenderer.setMaterialForRendering(mesh, material);
     }
-
-    private _isCubeData: boolean;
 
     /**
      * Define if the texture has multiple draw buffers or if false a single draw buffer.
@@ -547,25 +600,96 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         this._gammaSpace = gammaSpace;
         this._coordinatesMode = Texture.PROJECTION_MODE;
-        this.renderList = [] as AbstractMesh[];
         this.name = name;
         this.isRenderTarget = true;
         this._initialSizeParameter = size;
-        this._renderPassIds = [];
-        this._isCubeData = isCube;
 
         this._processSizeParameter(size);
 
-        this.renderPassId = this._renderPassIds[0];
+        this._objectRenderer = new ObjectRenderer(name, scene, {
+            numPasses: isCube ? 6 : this.getRenderLayers() || 1,
+            doNotChangeAspectRatio,
+        });
+
+        this._objectRenderer.onBeforeRenderingManagerRenderObservable.addOnce(() => {
+            // Before clear
+            for (const step of this._scene!._beforeRenderTargetClearStage) {
+                step.action(this, this._currentFaceIndex, this._currentLayer);
+            }
+
+            // Clear
+            if (this.onClearObservable.hasObservers()) {
+                this.onClearObservable.notifyObservers(engine);
+            } else if (!this.skipInitialClear) {
+                engine.clear(this.clearColor || this._scene!.clearColor, true, true, true);
+            }
+
+            if (!this._doNotChangeAspectRatio) {
+                this._scene!.updateTransformMatrix(true);
+            }
+
+            // Before Camera Draw
+            for (const step of this._scene!._beforeRenderTargetDrawStage) {
+                step.action(this, this._currentFaceIndex, this._currentLayer);
+            }
+        });
+
+        this._objectRenderer.onAfterRenderingManagerRenderObservable.addOnce(() => {
+            // After Camera Draw
+            for (const step of this._scene!._afterRenderTargetDrawStage) {
+                step.action(this, this._currentFaceIndex, this._currentLayer);
+            }
+
+            const saveGenerateMipMaps = this._texture?.generateMipMaps ?? false;
+
+            if (this._texture) {
+                this._texture.generateMipMaps = false; // if left true, the mipmaps will be generated (if this._texture.generateMipMaps = true) when the first post process binds its own RTT: by doing so it will unbind the current RTT,
+                // which will trigger a mipmap generation. We don't want this because it's a wasted work, we will do an unbind of the current RTT at the end of the process (see unbindFrameBuffer) which will
+                // trigger the generation of the final mipmaps
+            }
+
+            if (this._postProcessManager) {
+                this._postProcessManager._finalizeFrame(false, this._renderTarget ?? undefined, this._currentFaceIndex, this._postProcesses, this.ignoreCameraViewport);
+            } else if (this._currentUseCameraPostProcess) {
+                this._scene!.postProcessManager._finalizeFrame(false, this._renderTarget ?? undefined, this._currentFaceIndex);
+            }
+
+            for (const step of this._scene!._afterRenderTargetPostProcessStage) {
+                step.action(this, this._currentFaceIndex, this._currentLayer);
+            }
+
+            if (this._texture) {
+                this._texture.generateMipMaps = saveGenerateMipMaps;
+            }
+
+            if (!this._doNotChangeAspectRatio) {
+                this._scene!.updateTransformMatrix(true);
+            }
+
+            // Dump ?
+            if (this._currentDumpForDebug) {
+                if (!this._dumpTools) {
+                    Logger.Error("dumpTools module is still being loaded. To speed up the process import dump tools directly in your project");
+                } else {
+                    this._dumpTools.DumpFramebuffer(this.getRenderWidth(), this.getRenderHeight(), engine);
+                }
+            }
+        });
+
+        this._objectRenderer.onFastPathRenderObservable.add(() => {
+            if (this.onClearObservable.hasObservers()) {
+                this.onClearObservable.notifyObservers(engine);
+            } else {
+                if (!this.skipInitialClear) {
+                    engine.clear(this.clearColor || this._scene!.clearColor, true, true, true);
+                }
+            }
+        });
 
         this._resizeObserver = engine.onResizeObservable.add(() => {});
 
         this._generateMipMaps = generateMipMaps ? true : false;
         this._doNotChangeAspectRatio = doNotChangeAspectRatio;
-
-        // Rendering groups
-        this._renderingManager = new RenderingManager(scene);
-        this._renderingManager._useSceneAutoClearSetup = true;
 
         if (isMulti) {
             return;
@@ -627,28 +751,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         this._renderTarget?.createDepthStencilTexture(comparisonFunction, bilinearFiltering, generateStencil, samples, format, label);
     }
 
-    private _releaseRenderPassId(): void {
-        if (this._scene) {
-            const engine = this._scene.getEngine();
-            for (let i = 0; i < this._renderPassIds.length; ++i) {
-                engine.releaseRenderPassId(this._renderPassIds[i]);
-            }
-        }
-        this._renderPassIds = [];
-    }
-
-    private _createRenderPassId(): void {
-        this._releaseRenderPassId();
-
-        const engine = this._scene!.getEngine(); // scene can't be null in a RenderTargetTexture, see constructor
-        const numPasses = this._isCubeData ? 6 : this.getRenderLayers() || 1;
-
-        for (let i = 0; i < numPasses; ++i) {
-            this._renderPassIds[i] = engine.createRenderPassId(`RenderTargetTexture - ${this.name}#${i}`);
-        }
-    }
-
-    protected _processSizeParameter(size: TextureSize | { ratio: number }, createRenderPassIds = true): void {
+    protected _processSizeParameter(size: TextureSize | { ratio: number }): void {
         if ((<{ ratio: number }>size).ratio) {
             this._sizeRatio = (<{ ratio: number }>size).ratio;
             const engine = this._getEngine()!;
@@ -658,10 +761,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             };
         } else {
             this._size = <TextureSize>size;
-        }
-
-        if (createRenderPassIds) {
-            this._createRenderPassId();
         }
     }
 
@@ -677,26 +776,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         if (this._renderTarget) {
             this._samples = this._renderTarget.setSamples(value);
         }
-    }
-
-    /**
-     * Resets the refresh counter of the texture and start bak from scratch.
-     * Could be useful to regenerate the texture if it is setup to render only once.
-     */
-    public resetRefreshCounter(): void {
-        this._currentRefreshId = -1;
-    }
-
-    /**
-     * Define the refresh rate of the texture or the rendering frequency.
-     * Use 0 to render just once, 1 to render on every frame, 2 to render every two frames and so on...
-     */
-    public get refreshRate(): number {
-        return this._refreshRate;
-    }
-    public set refreshRate(value: number) {
-        this._refreshRate = value;
-        this.resetRefreshCounter();
     }
 
     /**
@@ -758,21 +837,28 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         }
     }
 
+    /**
+     * Resets the refresh counter of the texture and start bak from scratch.
+     * Could be useful to regenerate the texture if it is setup to render only once.
+     */
+    public resetRefreshCounter(): void {
+        this._objectRenderer.resetRefreshCounter();
+    }
+
+    /**
+     * Define the refresh rate of the texture or the rendering frequency.
+     * Use 0 to render just once, 1 to render on every frame, 2 to render every two frames and so on...
+     */
+    public get refreshRate(): number {
+        return this._objectRenderer.refreshRate;
+    }
+    public set refreshRate(value: number) {
+        this._objectRenderer.refreshRate = value;
+    }
+
     /** @internal */
     public _shouldRender(): boolean {
-        if (this._currentRefreshId === -1) {
-            // At least render once
-            this._currentRefreshId = 1;
-            return true;
-        }
-
-        if (this.refreshRate === this._currentRefreshId) {
-            this._currentRefreshId = 1;
-            return true;
-        }
-
-        this._currentRefreshId++;
-        return false;
+        return this._objectRenderer.shouldRender();
     }
 
     /**
@@ -880,7 +966,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             return;
         }
 
-        this._processSizeParameter(size, false);
+        this._processSizeParameter(size);
 
         if (wasCube) {
             this._renderTarget = scene.getEngine().createRenderTargetCubeTexture(this.getRenderSize(), this._renderTargetOptions);
@@ -897,8 +983,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             this.onResizeObservable.notifyObservers(this);
         }
     }
-
-    private _defaultRenderListPrepared: boolean;
 
     /**
      * Renders all the objects from the render list into the texture.
@@ -922,173 +1006,45 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             // avoid a static import to allow ignoring the import in some cases
             import("../../Misc/dumpTools").then((module) => (this._dumpTools = module));
         }
-        return this._render(false, false, true);
+        return this._objectRenderer.isReadyForRendering(this.getRenderWidth(), this.getRenderHeight());
     }
 
-    private _render(useCameraPostProcess: boolean = false, dumpForDebug: boolean = false, checkReadiness: boolean = false): boolean {
+    private _render(useCameraPostProcess: boolean = false, dumpForDebug: boolean = false): void {
         const scene = this.getScene();
 
         if (!scene) {
-            return checkReadiness;
+            return;
         }
-
-        const engine = scene.getEngine();
 
         if (this.useCameraPostProcesses !== undefined) {
             useCameraPostProcess = this.useCameraPostProcesses;
         }
 
-        if (this._waitingRenderList) {
-            if (!this.renderListPredicate) {
-                this.renderList = [];
-                for (let index = 0; index < this._waitingRenderList.length; index++) {
-                    const id = this._waitingRenderList[index];
-                    const mesh = scene.getMeshById(id);
-                    if (mesh) {
-                        this.renderList.push(mesh);
-                    }
-                }
-            }
-            this._waitingRenderList = undefined;
-        }
-
-        // Is predicate defined?
-        if (this.renderListPredicate) {
-            if (this.renderList) {
-                this.renderList.length = 0; // Clear previous renderList
-            } else {
-                this.renderList = [];
-            }
-
-            const scene = this.getScene();
-
-            if (!scene) {
-                return checkReadiness;
-            }
-
-            const sceneMeshes = scene.meshes;
-
-            for (let index = 0; index < sceneMeshes.length; index++) {
-                const mesh = sceneMeshes[index];
-                if (this.renderListPredicate(mesh)) {
-                    this.renderList.push(mesh);
-                }
-            }
-        }
-
-        const currentRenderPassId = engine.currentRenderPassId;
+        this._objectRenderer.prepareRenderList();
 
         this.onBeforeBindObservable.notifyObservers(this);
 
-        // Set custom projection.
-        // Needs to be before binding to prevent changing the aspect ratio.
-        const camera: Nullable<Camera> = this.activeCamera ?? scene.activeCamera;
-        const sceneCamera = scene.activeCamera;
+        this._objectRenderer.initRender(this.getRenderWidth(), this.getRenderHeight());
 
-        if (camera) {
-            if (camera !== scene.activeCamera) {
-                scene.setTransformMatrix(camera.getViewMatrix(), camera.getProjectionMatrix(true));
-                scene.activeCamera = camera;
+        if ((this.is2DArray || this.is3D) && !this.isMulti) {
+            for (let layer = 0; layer < this.getRenderLayers(); layer++) {
+                this._renderToTarget(0, useCameraPostProcess, dumpForDebug, layer);
+                scene.incrementRenderId();
+                scene.resetCachedMaterial();
             }
-            engine.setViewport(camera.rigParent ? camera.rigParent.viewport : camera.viewport, this.getRenderWidth(), this.getRenderHeight());
-        }
-
-        this._defaultRenderListPrepared = false;
-
-        let returnValue = checkReadiness;
-
-        if (!checkReadiness) {
-            if ((this.is2DArray || this.is3D) && !this.isMulti) {
-                for (let layer = 0; layer < this.getRenderLayers(); layer++) {
-                    this._renderToTarget(0, useCameraPostProcess, dumpForDebug, layer, camera);
-                    scene.incrementRenderId();
-                    scene.resetCachedMaterial();
-                }
-            } else if (this.isCube && !this.isMulti) {
-                for (let face = 0; face < 6; face++) {
-                    this._renderToTarget(face, useCameraPostProcess, dumpForDebug, undefined, camera);
-                    scene.incrementRenderId();
-                    scene.resetCachedMaterial();
-                }
-            } else {
-                this._renderToTarget(0, useCameraPostProcess, dumpForDebug, undefined, camera);
+        } else if (this.isCube && !this.isMulti) {
+            for (let face = 0; face < 6; face++) {
+                this._renderToTarget(face, useCameraPostProcess, dumpForDebug);
+                scene.incrementRenderId();
+                scene.resetCachedMaterial();
             }
         } else {
-            if (!scene.getViewMatrix()) {
-                // We probably didn't execute scene.render() yet, so make sure we have a view/projection matrix setup for the scene
-                scene.updateTransformMatrix();
-            }
-            const numLayers = this.is2DArray || this.is3D ? this.getRenderLayers() : this.isCube ? 6 : 1;
-            for (let layer = 0; layer < numLayers && returnValue; layer++) {
-                let currentRenderList: Nullable<Array<AbstractMesh>> = null;
-                const defaultRenderList = this.renderList ? this.renderList : scene.getActiveMeshes().data;
-                const defaultRenderListLength = this.renderList ? this.renderList.length : scene.getActiveMeshes().length;
-
-                engine.currentRenderPassId = this._renderPassIds[layer];
-
-                this.onBeforeRenderObservable.notifyObservers(layer);
-
-                if (this.getCustomRenderList) {
-                    currentRenderList = this.getCustomRenderList(layer, defaultRenderList, defaultRenderListLength);
-                }
-
-                if (!currentRenderList) {
-                    currentRenderList = defaultRenderList;
-                }
-
-                if (!this._doNotChangeAspectRatio) {
-                    scene.updateTransformMatrix(true);
-                }
-
-                for (let i = 0; i < currentRenderList.length && returnValue; ++i) {
-                    const mesh = currentRenderList[i];
-
-                    if (!mesh.isEnabled() || mesh.isBlocked || !mesh.isVisible || !mesh.subMeshes) {
-                        continue;
-                    }
-
-                    if (this.customIsReadyFunction) {
-                        if (!this.customIsReadyFunction(mesh, this.refreshRate, checkReadiness)) {
-                            returnValue = false;
-                            continue;
-                        }
-                    } else if (!mesh.isReady(true)) {
-                        returnValue = false;
-                        continue;
-                    }
-                }
-
-                this.onAfterRenderObservable.notifyObservers(layer);
-
-                if (this.is2DArray || this.is3D || this.isCube) {
-                    scene.incrementRenderId();
-                    scene.resetCachedMaterial();
-                }
-            }
-
-            const particleSystems = this.particleSystemList || scene.particleSystems;
-            for (const particleSystem of particleSystems) {
-                if (!particleSystem.isReady()) {
-                    returnValue = false;
-                }
-            }
+            this._renderToTarget(0, useCameraPostProcess, dumpForDebug);
         }
 
         this.onAfterUnbindObservable.notifyObservers(this);
 
-        engine.currentRenderPassId = currentRenderPassId;
-
-        scene.activeCamera = sceneCamera;
-        if (sceneCamera) {
-            if (this.activeCamera && this.activeCamera !== scene.activeCamera) {
-                scene.setTransformMatrix(sceneCamera.getViewMatrix(), sceneCamera.getProjectionMatrix(true));
-            }
-            engine.setViewport(sceneCamera.viewport);
-        }
-
-        scene.resetCachedMaterial();
-
-        return returnValue;
+        this._objectRenderer.finishRender();
     }
 
     private _bestReflectionRenderTargetDimension(renderDimension: number, scale: number): number {
@@ -1098,94 +1054,6 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         // Ensure we don't exceed the render dimension (while staying POT)
         return Math.min(FloorPOT(renderDimension), curved);
-    }
-
-    private _prepareRenderingManager(currentRenderList: Array<AbstractMesh>, currentRenderListLength: number, camera: Nullable<Camera>, checkLayerMask: boolean): void {
-        const scene = this.getScene();
-
-        if (!scene) {
-            return;
-        }
-
-        this._renderingManager.reset();
-
-        const sceneRenderId = scene.getRenderId();
-        for (let meshIndex = 0; meshIndex < currentRenderListLength; meshIndex++) {
-            const mesh = currentRenderList[meshIndex];
-
-            if (mesh && !mesh.isBlocked) {
-                if (this.customIsReadyFunction) {
-                    if (!this.customIsReadyFunction(mesh, this.refreshRate, false)) {
-                        this.resetRefreshCounter();
-                        continue;
-                    }
-                } else if (!mesh.isReady(this.refreshRate === 0)) {
-                    this.resetRefreshCounter();
-                    continue;
-                }
-
-                if (!mesh._internalAbstractMeshDataInfo._currentLODIsUpToDate && camera) {
-                    mesh._internalAbstractMeshDataInfo._currentLOD = scene.customLODSelector ? scene.customLODSelector(mesh, camera) : mesh.getLOD(camera);
-                    mesh._internalAbstractMeshDataInfo._currentLODIsUpToDate = true;
-                }
-                if (!mesh._internalAbstractMeshDataInfo._currentLOD) {
-                    continue;
-                }
-
-                let meshToRender = mesh._internalAbstractMeshDataInfo._currentLOD;
-
-                if (meshToRender !== mesh && meshToRender.billboardMode !== 0) {
-                    meshToRender.computeWorldMatrix(); // Compute world matrix if LOD is billboard
-                }
-
-                meshToRender._preActivateForIntermediateRendering(sceneRenderId);
-
-                let isMasked;
-                if (checkLayerMask && camera) {
-                    isMasked = (mesh.layerMask & camera.layerMask) === 0;
-                } else {
-                    isMasked = false;
-                }
-
-                if (mesh.isEnabled() && mesh.isVisible && mesh.subMeshes && !isMasked) {
-                    if (meshToRender !== mesh) {
-                        meshToRender._activate(sceneRenderId, true);
-                    }
-                    if (mesh._activate(sceneRenderId, true) && mesh.subMeshes.length) {
-                        if (!mesh.isAnInstance) {
-                            meshToRender._internalAbstractMeshDataInfo._onlyForInstancesIntermediate = false;
-                        } else {
-                            if (mesh._internalAbstractMeshDataInfo._actAsRegularMesh) {
-                                meshToRender = mesh;
-                            }
-                        }
-                        meshToRender._internalAbstractMeshDataInfo._isActiveIntermediate = true;
-
-                        scene._prepareSkeleton(meshToRender);
-
-                        for (let subIndex = 0; subIndex < meshToRender.subMeshes.length; subIndex++) {
-                            const subMesh = meshToRender.subMeshes[subIndex];
-                            this._renderingManager.dispatch(subMesh, meshToRender);
-                        }
-                    }
-
-                    mesh._postActivate();
-                }
-            }
-        }
-
-        const particleSystems = this.particleSystemList || scene.particleSystems;
-        for (let particleIndex = 0; particleIndex < particleSystems.length; particleIndex++) {
-            const particleSystem = particleSystems[particleIndex];
-
-            const emitter: any = particleSystem.emitter;
-
-            if (!particleSystem.isStarted() || !emitter || (emitter.position && !emitter.isEnabled())) {
-                continue;
-            }
-
-            this._renderingManager.dispatchParticles(particleSystem);
-        }
     }
 
     /**
@@ -1227,7 +1095,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         }
     }
 
-    private _renderToTarget(faceIndex: number, useCameraPostProcess: boolean, dumpForDebug: boolean, layer = 0, camera: Nullable<Camera> = null): void {
+    private _renderToTarget(faceIndex: number, useCameraPostProcess: boolean, dumpForDebug: boolean, layer = 0): void {
         const scene = this.getScene();
 
         if (!scene) {
@@ -1236,121 +1104,19 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         const engine = scene.getEngine();
 
-        // Bind
+        this._currentFaceIndex = faceIndex;
+        this._currentLayer = layer;
+        this._currentUseCameraPostProcess = useCameraPostProcess;
+        this._currentDumpForDebug = dumpForDebug;
+
         this._prepareFrame(scene, faceIndex, layer, useCameraPostProcess);
 
         engine._debugPushGroup?.(`render to face #${faceIndex} layer #${layer}`, 2);
 
-        if (this.is2DArray || this.is3D) {
-            engine.currentRenderPassId = this._renderPassIds[layer];
-            this.onBeforeRenderObservable.notifyObservers(layer);
-        } else {
-            engine.currentRenderPassId = this._renderPassIds[faceIndex];
-            this.onBeforeRenderObservable.notifyObservers(faceIndex);
-        }
-
-        const fastPath = engine.snapshotRendering && engine.snapshotRenderingMode === Constants.SNAPSHOTRENDERING_FAST;
-
-        if (!fastPath) {
-            // Get the list of meshes to render
-            let currentRenderList: Nullable<Array<AbstractMesh>> = null;
-            const defaultRenderList = this.renderList ? this.renderList : scene.getActiveMeshes().data;
-            const defaultRenderListLength = this.renderList ? this.renderList.length : scene.getActiveMeshes().length;
-
-            if (this.getCustomRenderList) {
-                currentRenderList = this.getCustomRenderList(this.is2DArray || this.is3D ? layer : faceIndex, defaultRenderList, defaultRenderListLength);
-            }
-
-            if (!currentRenderList) {
-                // No custom render list provided, we prepare the rendering for the default list, but check
-                // first if we did not already performed the preparation before so as to avoid re-doing it several times
-                if (!this._defaultRenderListPrepared) {
-                    this._prepareRenderingManager(defaultRenderList, defaultRenderListLength, camera, !this.renderList || this.forceLayerMaskCheck);
-                    this._defaultRenderListPrepared = true;
-                }
-                currentRenderList = defaultRenderList;
-            } else {
-                // Prepare the rendering for the custom render list provided
-                this._prepareRenderingManager(currentRenderList, currentRenderList.length, camera, this.forceLayerMaskCheck);
-            }
-
-            // Before clear
-            for (const step of scene._beforeRenderTargetClearStage) {
-                step.action(this, faceIndex, layer);
-            }
-
-            // Clear
-            if (this.onClearObservable.hasObservers()) {
-                this.onClearObservable.notifyObservers(engine);
-            } else if (!this.skipInitialClear) {
-                engine.clear(this.clearColor || scene.clearColor, true, true, true);
-            }
-
-            if (!this._doNotChangeAspectRatio) {
-                scene.updateTransformMatrix(true);
-            }
-
-            // Before Camera Draw
-            for (const step of scene._beforeRenderTargetDrawStage) {
-                step.action(this, faceIndex, layer);
-            }
-
-            // Render
-            this._renderingManager.render(this.customRenderFunction, currentRenderList, this.renderParticles, this.renderSprites);
-
-            // After Camera Draw
-            for (const step of scene._afterRenderTargetDrawStage) {
-                step.action(this, faceIndex, layer);
-            }
-
-            const saveGenerateMipMaps = this._texture?.generateMipMaps ?? false;
-
-            if (this._texture) {
-                this._texture.generateMipMaps = false; // if left true, the mipmaps will be generated (if this._texture.generateMipMaps = true) when the first post process binds its own RTT: by doing so it will unbind the current RTT,
-                // which will trigger a mipmap generation. We don't want this because it's a wasted work, we will do an unbind of the current RTT at the end of the process (see unbindFrameBuffer) which will
-                // trigger the generation of the final mipmaps
-            }
-
-            if (this._postProcessManager) {
-                this._postProcessManager._finalizeFrame(false, this._renderTarget ?? undefined, faceIndex, this._postProcesses, this.ignoreCameraViewport);
-            } else if (useCameraPostProcess) {
-                scene.postProcessManager._finalizeFrame(false, this._renderTarget ?? undefined, faceIndex);
-            }
-
-            for (const step of scene._afterRenderTargetPostProcessStage) {
-                step.action(this, faceIndex, layer);
-            }
-
-            if (this._texture) {
-                this._texture.generateMipMaps = saveGenerateMipMaps;
-            }
-
-            if (!this._doNotChangeAspectRatio) {
-                scene.updateTransformMatrix(true);
-            }
-
-            // Dump ?
-            if (dumpForDebug) {
-                if (!this._dumpTools) {
-                    Logger.Error("dumpTools module is still being loaded. To speed up the process import dump tools directly in your project");
-                } else {
-                    this._dumpTools.DumpFramebuffer(this.getRenderWidth(), this.getRenderHeight(), engine);
-                }
-            }
-        } else {
-            // Clear
-            if (this.onClearObservable.hasObservers()) {
-                this.onClearObservable.notifyObservers(engine);
-            } else {
-                if (!this.skipInitialClear) {
-                    engine.clear(this.clearColor || scene.clearColor, true, true, true);
-                }
-            }
-        }
+        this._objectRenderer.render(faceIndex + layer, true); // only faceIndex or layer (if any) will be different from 0 (we don't support array of cubes), so it's safe to add them to get the pass index
 
         engine._debugPopGroup?.(2);
 
-        // Unbind
         this._unbindFrameBuffer(engine, faceIndex);
 
         if (this._texture && this.isCube && faceIndex === 5) {
@@ -1373,7 +1139,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         alphaTestSortCompareFn: Nullable<(a: SubMesh, b: SubMesh) => number> = null,
         transparentSortCompareFn: Nullable<(a: SubMesh, b: SubMesh) => number> = null
     ): void {
-        this._renderingManager.setRenderingOrder(renderingGroupId, opaqueSortCompareFn, alphaTestSortCompareFn, transparentSortCompareFn);
+        this._objectRenderer.setRenderingOrder(renderingGroupId, opaqueSortCompareFn, alphaTestSortCompareFn, transparentSortCompareFn);
     }
 
     /**
@@ -1383,8 +1149,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * @param autoClearDepthStencil Automatically clears depth and stencil between groups if true.
      */
     public setRenderingAutoClearDepthStencil(renderingGroupId: number, autoClearDepthStencil: boolean): void {
-        this._renderingManager.setRenderingAutoClearDepthStencil(renderingGroupId, autoClearDepthStencil);
-        this._renderingManager._useSceneAutoClearSetup = false;
+        this._objectRenderer.setRenderingAutoClearDepthStencil(renderingGroupId, autoClearDepthStencil);
     }
 
     /**
@@ -1467,10 +1232,8 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
     public override dispose(): void {
         this.onResizeObservable.clear();
         this.onClearObservable.clear();
-        this.onAfterRenderObservable.clear();
         this.onAfterUnbindObservable.clear();
         this.onBeforeBindObservable.clear();
-        this.onBeforeRenderObservable.clear();
 
         if (this._postProcessManager) {
             this._postProcessManager.dispose();
@@ -1481,15 +1244,14 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             this._prePassRenderTarget.dispose();
         }
 
-        this._releaseRenderPassId();
+        this._objectRenderer.dispose();
+
         this.clearPostProcesses(true);
 
         if (this._resizeObserver) {
             this.getScene()!.getEngine().onResizeObservable.remove(this._resizeObserver);
             this._resizeObserver = null;
         }
-
-        this.renderList = null;
 
         // Remove from custom render targets
         const scene = this.getScene();
@@ -1521,9 +1283,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
     /** @internal */
     public override _rebuild(): void {
-        if (this.refreshRate === RenderTargetTexture.REFRESHRATE_RENDER_ONCE) {
-            this.refreshRate = RenderTargetTexture.REFRESHRATE_RENDER_ONCE;
-        }
+        this._objectRenderer._rebuild();
 
         if (this._postProcessManager) {
             this._postProcessManager._rebuild();
@@ -1534,9 +1294,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
      * Clear the info related to rendering groups preventing retention point in material dispose.
      */
     public freeRenderingGroups(): void {
-        if (this._renderingManager) {
-            this._renderingManager.freeRenderingGroups();
-        }
+        this._objectRenderer.freeRenderingGroups();
     }
 
     /**

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -1006,6 +1006,9 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
             // avoid a static import to allow ignoring the import in some cases
             import("../../Misc/dumpTools").then((module) => (this._dumpTools = module));
         }
+
+        this.onBeforeBindObservable.notifyObservers(this);
+
         return this._objectRenderer.isReadyForRendering(this.getRenderWidth(), this.getRenderHeight());
     }
 

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -1009,7 +1009,11 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
 
         this.onBeforeBindObservable.notifyObservers(this);
 
-        return this._objectRenderer.isReadyForRendering(this.getRenderWidth(), this.getRenderHeight());
+        const result = this._objectRenderer.isReadyForRendering(this.getRenderWidth(), this.getRenderHeight());
+
+        this.onAfterUnbindObservable.notifyObservers(this);
+
+        return result;
     }
 
     private _render(useCameraPostProcess: boolean = false, dumpForDebug: boolean = false): void {

--- a/packages/dev/core/src/Rendering/index.ts
+++ b/packages/dev/core/src/Rendering/index.ts
@@ -17,6 +17,7 @@ export * from "./renderingManager";
 export * from "./utilityLayerRenderer";
 export * from "./fluidRenderer/index";
 export * from "./reflectiveShadowMap";
+export * from "./objectRenderer";
 export * from "./GlobalIllumination/index";
 
 // Depth

--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -452,7 +452,8 @@ export class ObjectRenderer {
         engine.currentRenderPassId = currentRenderPassId;
     }
 
-    private _checkReadiness(): boolean {
+    /** @internal */
+    public _checkReadiness(): boolean {
         const scene = this._scene;
         const engine = scene.getEngine();
         const currentRenderPassId = engine.currentRenderPassId;

--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -465,7 +465,7 @@ export class ObjectRenderer {
         }
 
         const numPasses = this.options.numPasses;
-        for (let passIndex = 0; passIndex < numPasses; passIndex++) {
+        for (let passIndex = 0; passIndex < numPasses && returnValue; passIndex++) {
             let currentRenderList: Nullable<Array<AbstractMesh>> = null;
             const defaultRenderList = this.renderList ? this.renderList : scene.getActiveMeshes().data;
             const defaultRenderListLength = this.renderList ? this.renderList.length : scene.getActiveMeshes().length;

--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -91,7 +91,8 @@ export class ObjectRenderer {
      * The length of this list is passed through renderListLength: don't use renderList.length directly because the array can
      * hold dummy elements!
      */
-    public getCustomRenderList: (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>;
+    public getCustomRenderList: Nullable<(layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>> =
+        null;
 
     /**
      * Define if particles should be rendered.
@@ -132,27 +133,27 @@ export class ObjectRenderer {
     /**
      * An event triggered before rendering the objects
      */
-    public onBeforeRenderObservable = new Observable<number>();
+    public readonly onBeforeRenderObservable = new Observable<number>();
 
     /**
      * An event triggered after rendering the objects
      */
-    public onAfterRenderObservable = new Observable<number>();
+    public readonly onAfterRenderObservable = new Observable<number>();
 
     /**
      * An event triggered before the rendering group is processed
      */
-    public onBeforeRenderingManagerRenderObservable = new Observable<number>();
+    public readonly onBeforeRenderingManagerRenderObservable = new Observable<number>();
 
     /**
      * An event triggered after the rendering group is processed
      */
-    public onAfterRenderingManagerRenderObservable = new Observable<number>();
+    public readonly onAfterRenderingManagerRenderObservable = new Observable<number>();
 
     /**
      * An event triggered when fast path rendering is used
      */
-    public onFastPathRenderObservable = new Observable<number>();
+    public readonly onFastPathRenderObservable = new Observable<number>();
 
     protected _scene: Scene;
     protected _renderingManager: RenderingManager;

--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -1,0 +1,684 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { SmartArray, Nullable, Immutable, Camera, Scene, AbstractMesh, SubMesh, Material, IParticleSystem } from "core/index";
+import { Observable } from "../Misc/observable";
+import { RenderingManager } from "../Rendering/renderingManager";
+import { Constants } from "../Engines/constants";
+import { _ObserveArray } from "../Misc/arrayTools";
+
+/**
+ * Defines the options of the object renderer
+ */
+export interface ObjectRendererOptions {
+    /** The number of passes the renderer will support (1 by default) */
+    numPasses?: number;
+
+    /** True (default) to not change the aspect ratio of the scene in the RTT */
+    doNotChangeAspectRatio?: boolean;
+}
+
+/**
+ * A class that renders objects to the currently bound render target.
+ * This class only renders objects, and is not concerned with the output texture or post-processing.
+ */
+export class ObjectRenderer {
+    /**
+     * Objects will only be rendered once which can be useful to improve performance if everything in your render is static for instance.
+     */
+    public static readonly REFRESHRATE_RENDER_ONCE: number = 0;
+    /**
+     * Objects will be rendered every frame and is recommended for dynamic contents.
+     */
+    public static readonly REFRESHRATE_RENDER_ONEVERYFRAME: number = 1;
+    /**
+     * Objects will be rendered every 2 frames which could be enough if your dynamic objects are not
+     * the central point of your effect and can save a lot of performances.
+     */
+    public static readonly REFRESHRATE_RENDER_ONEVERYTWOFRAMES: number = 2;
+
+    /**
+     * Use this predicate to dynamically define the list of mesh you want to render.
+     * If set, the renderList property will be overwritten.
+     */
+    public renderListPredicate: (AbstractMesh: AbstractMesh) => boolean;
+
+    private _renderList: Nullable<Array<AbstractMesh>>;
+    private _unObserveRenderList: Nullable<() => void> = null;
+
+    /**
+     * Use this list to define the list of mesh you want to render.
+     */
+    public get renderList(): Nullable<Array<AbstractMesh>> {
+        return this._renderList;
+    }
+
+    public set renderList(value: Nullable<Array<AbstractMesh>>) {
+        if (this._renderList === value) {
+            return;
+        }
+        if (this._unObserveRenderList) {
+            this._unObserveRenderList();
+            this._unObserveRenderList = null;
+        }
+
+        if (value) {
+            this._unObserveRenderList = _ObserveArray(value, this._renderListHasChanged);
+        }
+
+        this._renderList = value;
+    }
+
+    private _renderListHasChanged = (_functionName: String, previousLength: number) => {
+        const newLength = this._renderList ? this._renderList.length : 0;
+        if ((previousLength === 0 && newLength > 0) || newLength === 0) {
+            this._scene.meshes.forEach((mesh) => {
+                mesh._markSubMeshesAsLightDirty();
+            });
+        }
+    };
+
+    /**
+     * Define the list of particle systems to render. If not provided, will render all the particle systems of the scene.
+     * Note that the particle systems are rendered only if renderParticles is set to true.
+     */
+    public particleSystemList: Nullable<Array<IParticleSystem>> = null;
+
+    /**
+     * Use this function to overload the renderList array at rendering time.
+     * Return null to render with the current renderList, else return the list of meshes to use for rendering.
+     * For 2DArray, layerOrFace is the index of the layer that is going to be rendered, else it is the faceIndex of
+     * the cube (if the RTT is a cube, else layerOrFace=0).
+     * The renderList passed to the function is the current render list (the one that will be used if the function returns null).
+     * The length of this list is passed through renderListLength: don't use renderList.length directly because the array can
+     * hold dummy elements!
+     */
+    public getCustomRenderList: (layerOrFace: number, renderList: Nullable<Immutable<Array<AbstractMesh>>>, renderListLength: number) => Nullable<Array<AbstractMesh>>;
+
+    /**
+     * Define if particles should be rendered.
+     */
+    public renderParticles = true;
+
+    /**
+     * Define if sprites should be rendered.
+     */
+    public renderSprites = false;
+
+    /**
+     * Force checking the layerMask property even if a custom list of meshes is provided (ie. if renderList is not undefined)
+     */
+    public forceLayerMaskCheck = false;
+
+    /**
+     * Define the camera used to render the objects.
+     */
+    public activeCamera: Nullable<Camera>;
+
+    /**
+     * Override the mesh isReady function with your own one.
+     */
+    public customIsReadyFunction: (mesh: AbstractMesh, refreshRate: number, preWarm?: boolean) => boolean;
+
+    /**
+     * Override the render function with your own one.
+     */
+    public customRenderFunction: (
+        opaqueSubMeshes: SmartArray<SubMesh>,
+        alphaTestSubMeshes: SmartArray<SubMesh>,
+        transparentSubMeshes: SmartArray<SubMesh>,
+        depthOnlySubMeshes: SmartArray<SubMesh>,
+        beforeTransparents?: () => void
+    ) => void;
+
+    /**
+     * An event triggered before rendering the objects
+     */
+    public onBeforeRenderObservable = new Observable<number>();
+
+    /**
+     * An event triggered after rendering the objects
+     */
+    public onAfterRenderObservable = new Observable<number>();
+
+    /**
+     * An event triggered before the rendering group is processed
+     */
+    public onBeforeRenderingManagerRenderObservable = new Observable<number>();
+
+    /**
+     * An event triggered after the rendering group is processed
+     */
+    public onAfterRenderingManagerRenderObservable = new Observable<number>();
+
+    /**
+     * An event triggered when fast path rendering is used
+     */
+    public onFastPathRenderObservable = new Observable<number>();
+
+    protected _scene: Scene;
+    protected _renderingManager: RenderingManager;
+    /** @internal */
+    public _waitingRenderList?: string[];
+    protected _currentRefreshId = -1;
+    protected _refreshRate = 1;
+    protected _doNotChangeAspectRatio: boolean;
+
+    /**
+     * The options used by the object renderer
+     */
+    public options: Required<ObjectRendererOptions>;
+
+    /**
+     * Friendly name of the object renderer
+     */
+    public name: string;
+
+    /**
+     * Current render pass id. Note it can change over the rendering as there's a separate id for each face of a cube / each layer of an array layer!
+     */
+    public renderPassId: number;
+    private _renderPassIds: number[];
+    /**
+     * Gets the render pass ids used by the object renderer.
+     */
+    public get renderPassIds(): readonly number[] {
+        return this._renderPassIds;
+    }
+
+    /**
+     * Gets the current value of the refreshId counter
+     */
+    public get currentRefreshId() {
+        return this._currentRefreshId;
+    }
+
+    /**
+     * Sets a specific material to be used to render a mesh/a list of meshes with this object renderer
+     * @param mesh mesh or array of meshes
+     * @param material material or array of materials to use for this render pass. If undefined is passed, no specific material will be used but the regular material instead (mesh.material). It's possible to provide an array of materials to use a different material for each rendering pass.
+     */
+    public setMaterialForRendering(mesh: AbstractMesh | AbstractMesh[], material?: Material | Material[]): void {
+        let meshes;
+        if (!Array.isArray(mesh)) {
+            meshes = [mesh];
+        } else {
+            meshes = mesh;
+        }
+        for (let j = 0; j < meshes.length; ++j) {
+            for (let i = 0; i < this.options.numPasses; ++i) {
+                meshes[j].setMaterialForRenderPass(this._renderPassIds[i], material !== undefined ? (Array.isArray(material) ? material[i] : material) : undefined);
+            }
+        }
+    }
+
+    /**
+     * Instantiates an object renderer.
+     * @param name The friendly name of the object renderer
+     * @param scene The scene the renderer belongs to
+     * @param options The options used to create the renderer (optional)
+     */
+    constructor(name: string, scene: Scene, options?: ObjectRendererOptions) {
+        this.name = name;
+        this._scene = scene;
+
+        this.renderList = [] as AbstractMesh[];
+        this._renderPassIds = [];
+
+        this.options = {
+            numPasses: 1,
+            doNotChangeAspectRatio: true,
+            ...options,
+        };
+
+        this._createRenderPassId();
+
+        this.renderPassId = this._renderPassIds[0];
+
+        // Rendering groups
+        this._renderingManager = new RenderingManager(scene);
+        this._renderingManager._useSceneAutoClearSetup = true;
+    }
+
+    private _releaseRenderPassId(): void {
+        const engine = this._scene.getEngine();
+        for (let i = 0; i < this.options.numPasses; ++i) {
+            engine.releaseRenderPassId(this._renderPassIds[i]);
+        }
+        this._renderPassIds.length = 0;
+    }
+
+    private _createRenderPassId(): void {
+        this._releaseRenderPassId();
+
+        const engine = this._scene.getEngine();
+
+        for (let i = 0; i < this.options.numPasses; ++i) {
+            this._renderPassIds[i] = engine.createRenderPassId(`ObjectRenderer - ${this.name}#${i}`);
+        }
+    }
+
+    /**
+     * Resets the refresh counter of the renderer and start back from scratch.
+     * Could be useful to re-render if it is setup to render only once.
+     */
+    public resetRefreshCounter(): void {
+        this._currentRefreshId = -1;
+    }
+
+    /**
+     * Defines the refresh rate of the rendering or the rendering frequency.
+     * Use 0 to render just once, 1 to render on every frame, 2 to render every two frames and so on...
+     */
+    public get refreshRate(): number {
+        return this._refreshRate;
+    }
+    public set refreshRate(value: number) {
+        this._refreshRate = value;
+        this.resetRefreshCounter();
+    }
+
+    /**
+     * Indicates if the renderer should render the current frame.
+     * The output is based on the specified refresh rate.
+     * @returns true if the renderer should render the current frame
+     */
+    public shouldRender(): boolean {
+        if (this._currentRefreshId === -1) {
+            // At least render once
+            this._currentRefreshId = 1;
+            return true;
+        }
+
+        if (this.refreshRate === this._currentRefreshId) {
+            this._currentRefreshId = 1;
+            return true;
+        }
+
+        this._currentRefreshId++;
+        return false;
+    }
+
+    /**
+     * This function will check if the renderer is ready to render (textures are loaded, shaders are compiled)
+     * @param viewportWidth defines the width of the viewport
+     * @param viewportHeight defines the height of the viewport
+     * @returns true if all required resources are ready
+     */
+    public isReadyForRendering(viewportWidth: number, viewportHeight: number): boolean {
+        this.prepareRenderList();
+        this.initRender(viewportWidth, viewportHeight);
+
+        const isReady = this._checkReadiness();
+
+        this.finishRender();
+
+        return isReady;
+    }
+
+    /**
+     * Makes sure the list of meshes is ready to be rendered
+     * You should call this function before "initRender", but if you know the render list is ok, you may call "initRender" directly
+     */
+    public prepareRenderList(): void {
+        const scene = this._scene;
+
+        if (this._waitingRenderList) {
+            if (!this.renderListPredicate) {
+                this.renderList = [];
+                for (let index = 0; index < this._waitingRenderList.length; index++) {
+                    const id = this._waitingRenderList[index];
+                    const mesh = scene.getMeshById(id);
+                    if (mesh) {
+                        this.renderList.push(mesh);
+                    }
+                }
+            }
+            this._waitingRenderList = undefined;
+        }
+
+        // Is predicate defined?
+        if (this.renderListPredicate) {
+            if (this.renderList) {
+                this.renderList.length = 0; // Clear previous renderList
+            } else {
+                this.renderList = [];
+            }
+
+            const sceneMeshes = this._scene.meshes;
+
+            for (let index = 0; index < sceneMeshes.length; index++) {
+                const mesh = sceneMeshes[index];
+                if (this.renderListPredicate(mesh)) {
+                    this.renderList.push(mesh);
+                }
+            }
+        }
+    }
+
+    private _defaultRenderListPrepared: boolean;
+    private _currentSceneCamera: Nullable<Camera> = null;
+
+    /**
+     * This method makes sure everything is setup before "render" can be called
+     * @param viewportWidth Width of the viewport to render to
+     * @param viewportHeight Height of the viewport to render to
+     */
+    public initRender(viewportWidth: number, viewportHeight: number): void {
+        const engine = this._scene.getEngine();
+        const camera: Nullable<Camera> = this.activeCamera ?? this._scene.activeCamera;
+
+        this._currentSceneCamera = this._scene.activeCamera;
+
+        if (camera) {
+            if (camera !== this._scene.activeCamera) {
+                this._scene.setTransformMatrix(camera.getViewMatrix(), camera.getProjectionMatrix(true));
+                this._scene.activeCamera = camera;
+            }
+            engine.setViewport(camera.rigParent ? camera.rigParent.viewport : camera.viewport, viewportWidth, viewportHeight);
+        }
+
+        this._defaultRenderListPrepared = false;
+    }
+
+    /**
+     * This method must be called after the "render" call(s), to complete the rendering process.
+     */
+    public finishRender() {
+        const scene = this._scene;
+
+        scene.activeCamera = this._currentSceneCamera;
+        if (this._currentSceneCamera) {
+            if (this.activeCamera && this.activeCamera !== scene.activeCamera) {
+                scene.setTransformMatrix(this._currentSceneCamera.getViewMatrix(), this._currentSceneCamera.getProjectionMatrix(true));
+            }
+            scene.getEngine().setViewport(this._currentSceneCamera.viewport);
+        }
+
+        scene.resetCachedMaterial();
+    }
+
+    /**
+     * Renders all the objects (meshes, particles systems, sprites) to the currently bound render target texture.
+     * @param passIndex defines the pass index to use (default: 0)
+     * @param skipOnAfterRenderObservable defines a flag to skip raising the onAfterRenderObservable
+     */
+    public render(passIndex = 0, skipOnAfterRenderObservable = false): void {
+        const scene = this._scene;
+        const engine = scene.getEngine();
+
+        const currentRenderPassId = engine.currentRenderPassId;
+
+        engine.currentRenderPassId = this._renderPassIds[passIndex];
+
+        this.onBeforeRenderObservable.notifyObservers(passIndex);
+
+        const fastPath = engine.snapshotRendering && engine.snapshotRenderingMode === Constants.SNAPSHOTRENDERING_FAST;
+
+        if (!fastPath) {
+            // Get the list of meshes to render
+            let currentRenderList: Nullable<Array<AbstractMesh>> = null;
+            const defaultRenderList = this.renderList ? this.renderList : scene.getActiveMeshes().data;
+            const defaultRenderListLength = this.renderList ? this.renderList.length : scene.getActiveMeshes().length;
+
+            if (this.getCustomRenderList) {
+                currentRenderList = this.getCustomRenderList(passIndex, defaultRenderList, defaultRenderListLength);
+            }
+
+            if (!currentRenderList) {
+                // No custom render list provided, we prepare the rendering for the default list, but check
+                // first if we did not already performed the preparation before so as to avoid re-doing it several times
+                if (!this._defaultRenderListPrepared) {
+                    this._prepareRenderingManager(defaultRenderList, defaultRenderListLength, !this.renderList || this.forceLayerMaskCheck);
+                    this._defaultRenderListPrepared = true;
+                }
+                currentRenderList = defaultRenderList;
+            } else {
+                // Prepare the rendering for the custom render list provided
+                this._prepareRenderingManager(currentRenderList, currentRenderList.length, this.forceLayerMaskCheck);
+            }
+
+            this.onBeforeRenderingManagerRenderObservable.notifyObservers(passIndex);
+
+            this._renderingManager.render(this.customRenderFunction, currentRenderList, this.renderParticles, this.renderSprites);
+
+            this.onAfterRenderingManagerRenderObservable.notifyObservers(passIndex);
+        } else {
+            this.onFastPathRenderObservable.notifyObservers(passIndex);
+        }
+
+        if (!skipOnAfterRenderObservable) {
+            this.onAfterRenderObservable.notifyObservers(passIndex);
+        }
+
+        engine.currentRenderPassId = currentRenderPassId;
+    }
+
+    private _checkReadiness(): boolean {
+        const scene = this._scene;
+        const engine = scene.getEngine();
+        const currentRenderPassId = engine.currentRenderPassId;
+
+        let returnValue = true;
+
+        if (!scene.getViewMatrix()) {
+            // We probably didn't execute scene.render() yet, so make sure we have a view/projection matrix setup for the scene
+            scene.updateTransformMatrix();
+        }
+
+        const numPasses = this.options.numPasses;
+        for (let passIndex = 0; passIndex < numPasses; passIndex++) {
+            let currentRenderList: Nullable<Array<AbstractMesh>> = null;
+            const defaultRenderList = this.renderList ? this.renderList : scene.getActiveMeshes().data;
+            const defaultRenderListLength = this.renderList ? this.renderList.length : scene.getActiveMeshes().length;
+
+            engine.currentRenderPassId = this._renderPassIds[passIndex];
+
+            this.onBeforeRenderObservable.notifyObservers(passIndex);
+
+            if (this.getCustomRenderList) {
+                currentRenderList = this.getCustomRenderList(passIndex, defaultRenderList, defaultRenderListLength);
+            }
+
+            if (!currentRenderList) {
+                currentRenderList = defaultRenderList;
+            }
+
+            if (!this._doNotChangeAspectRatio) {
+                scene.updateTransformMatrix(true);
+            }
+
+            for (let i = 0; i < currentRenderList.length && returnValue; ++i) {
+                const mesh = currentRenderList[i];
+
+                if (!mesh.isEnabled() || mesh.isBlocked || !mesh.isVisible || !mesh.subMeshes) {
+                    continue;
+                }
+
+                if (this.customIsReadyFunction) {
+                    if (!this.customIsReadyFunction(mesh, this.refreshRate, true)) {
+                        returnValue = false;
+                        continue;
+                    }
+                } else if (!mesh.isReady(true)) {
+                    returnValue = false;
+                    continue;
+                }
+            }
+
+            this.onAfterRenderObservable.notifyObservers(passIndex);
+
+            if (numPasses > 1) {
+                scene.incrementRenderId();
+                scene.resetCachedMaterial();
+            }
+        }
+
+        const particleSystems = this.particleSystemList || scene.particleSystems;
+        for (const particleSystem of particleSystems) {
+            if (!particleSystem.isReady()) {
+                returnValue = false;
+            }
+        }
+
+        engine.currentRenderPassId = currentRenderPassId;
+
+        return returnValue;
+    }
+
+    private _prepareRenderingManager(currentRenderList: Array<AbstractMesh>, currentRenderListLength: number, checkLayerMask: boolean): void {
+        const scene = this._scene;
+        const camera = scene.activeCamera;
+
+        this._renderingManager.reset();
+
+        const sceneRenderId = scene.getRenderId();
+        for (let meshIndex = 0; meshIndex < currentRenderListLength; meshIndex++) {
+            const mesh = currentRenderList[meshIndex];
+
+            if (mesh && !mesh.isBlocked) {
+                if (this.customIsReadyFunction) {
+                    if (!this.customIsReadyFunction(mesh, this.refreshRate, false)) {
+                        this.resetRefreshCounter();
+                        continue;
+                    }
+                } else if (!mesh.isReady(this.refreshRate === 0)) {
+                    this.resetRefreshCounter();
+                    continue;
+                }
+
+                if (!mesh._internalAbstractMeshDataInfo._currentLODIsUpToDate && camera) {
+                    mesh._internalAbstractMeshDataInfo._currentLOD = scene.customLODSelector ? scene.customLODSelector(mesh, camera) : mesh.getLOD(camera);
+                    mesh._internalAbstractMeshDataInfo._currentLODIsUpToDate = true;
+                }
+                if (!mesh._internalAbstractMeshDataInfo._currentLOD) {
+                    continue;
+                }
+
+                let meshToRender = mesh._internalAbstractMeshDataInfo._currentLOD;
+
+                if (meshToRender !== mesh && meshToRender.billboardMode !== 0) {
+                    meshToRender.computeWorldMatrix(); // Compute world matrix if LOD is billboard
+                }
+
+                meshToRender._preActivateForIntermediateRendering(sceneRenderId);
+
+                let isMasked;
+                if (checkLayerMask && camera) {
+                    isMasked = (mesh.layerMask & camera.layerMask) === 0;
+                } else {
+                    isMasked = false;
+                }
+
+                if (mesh.isEnabled() && mesh.isVisible && mesh.subMeshes && !isMasked) {
+                    if (meshToRender !== mesh) {
+                        meshToRender._activate(sceneRenderId, true);
+                    }
+                    if (mesh._activate(sceneRenderId, true) && mesh.subMeshes.length) {
+                        if (!mesh.isAnInstance) {
+                            meshToRender._internalAbstractMeshDataInfo._onlyForInstancesIntermediate = false;
+                        } else {
+                            if (mesh._internalAbstractMeshDataInfo._actAsRegularMesh) {
+                                meshToRender = mesh;
+                            }
+                        }
+                        meshToRender._internalAbstractMeshDataInfo._isActiveIntermediate = true;
+
+                        scene._prepareSkeleton(meshToRender);
+
+                        for (let subIndex = 0; subIndex < meshToRender.subMeshes.length; subIndex++) {
+                            const subMesh = meshToRender.subMeshes[subIndex];
+                            this._renderingManager.dispatch(subMesh, meshToRender);
+                        }
+                    }
+
+                    mesh._postActivate();
+                }
+            }
+        }
+
+        const particleSystems = this.particleSystemList || scene.particleSystems;
+        for (let particleIndex = 0; particleIndex < particleSystems.length; particleIndex++) {
+            const particleSystem = particleSystems[particleIndex];
+
+            const emitter: any = particleSystem.emitter;
+
+            if (!particleSystem.isStarted() || !emitter || (emitter.position && !emitter.isEnabled())) {
+                continue;
+            }
+
+            this._renderingManager.dispatchParticles(particleSystem);
+        }
+    }
+
+    /**
+     * Overrides the default sort function applied in the rendering group to prepare the meshes.
+     * This allowed control for front to back rendering or reversely depending of the special needs.
+     *
+     * @param renderingGroupId The rendering group id corresponding to its index
+     * @param opaqueSortCompareFn The opaque queue comparison function use to sort.
+     * @param alphaTestSortCompareFn The alpha test queue comparison function use to sort.
+     * @param transparentSortCompareFn The transparent queue comparison function use to sort.
+     */
+    public setRenderingOrder(
+        renderingGroupId: number,
+        opaqueSortCompareFn: Nullable<(a: SubMesh, b: SubMesh) => number> = null,
+        alphaTestSortCompareFn: Nullable<(a: SubMesh, b: SubMesh) => number> = null,
+        transparentSortCompareFn: Nullable<(a: SubMesh, b: SubMesh) => number> = null
+    ): void {
+        this._renderingManager.setRenderingOrder(renderingGroupId, opaqueSortCompareFn, alphaTestSortCompareFn, transparentSortCompareFn);
+    }
+
+    /**
+     * Specifies whether or not the stencil and depth buffer are cleared between two rendering groups.
+     *
+     * @param renderingGroupId The rendering group id corresponding to its index
+     * @param autoClearDepthStencil Automatically clears depth and stencil between groups if true.
+     */
+    public setRenderingAutoClearDepthStencil(renderingGroupId: number, autoClearDepthStencil: boolean): void {
+        this._renderingManager.setRenderingAutoClearDepthStencil(renderingGroupId, autoClearDepthStencil);
+        this._renderingManager._useSceneAutoClearSetup = false;
+    }
+
+    /**
+     * Clones the renderer.
+     * @returns the cloned renderer
+     */
+    public clone(): ObjectRenderer {
+        const newRenderer = new ObjectRenderer(this.name, this._scene, this.options);
+
+        if (this.renderList) {
+            newRenderer.renderList = this.renderList.slice(0);
+        }
+
+        return newRenderer;
+    }
+
+    /**
+     * Dispose the renderer and release its associated resources.
+     */
+    public dispose(): void {
+        this.onBeforeRenderObservable.clear();
+        this.onAfterRenderObservable.clear();
+        this.onBeforeRenderingManagerRenderObservable.clear();
+        this.onAfterRenderingManagerRenderObservable.clear();
+
+        this._releaseRenderPassId();
+
+        this.renderList = null;
+    }
+
+    /** @internal */
+    public _rebuild(): void {
+        if (this.refreshRate === ObjectRenderer.REFRESHRATE_RENDER_ONCE) {
+            this.refreshRate = ObjectRenderer.REFRESHRATE_RENDER_ONCE;
+        }
+    }
+
+    /**
+     * Clear the info related to rendering groups preventing retention point in material dispose.
+     */
+    public freeRenderingGroups(): void {
+        if (this._renderingManager) {
+            this._renderingManager.freeRenderingGroups();
+        }
+    }
+}

--- a/packages/tools/nodeRenderGraphEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeRenderGraphEditor/src/components/preview/previewManager.ts
@@ -64,22 +64,18 @@ export class PreviewManager {
 
         this._onUpdateRequiredObserver = globalState.stateManager.onUpdateRequiredObservable.add(() => {
             this._createNodeRenderGraph();
-            this._buildGraph();
         });
 
         this._onRebuildRequiredObserver = globalState.stateManager.onRebuildRequiredObservable.add(() => {
             this._createNodeRenderGraph();
-            this._buildGraph();
         });
 
         this._onImportFrameObserver = globalState.onImportFrameObservable.add(() => {
             this._createNodeRenderGraph();
-            this._buildGraph();
         });
 
         this._onResetRequiredObserver = globalState.onResetRequiredObservable.add(() => {
             this._createNodeRenderGraph();
-            this._buildGraph();
         });
 
         this._initAsync(targetCanvas);
@@ -149,11 +145,12 @@ export class PreviewManager {
 
         this._engine.runRenderLoop(() => {
             this._engine.resize();
-            this._scene.render();
+            if (this._scene.frameGraph) {
+                this._scene.render();
+            }
         });
 
         this._createNodeRenderGraph();
-        this._buildGraph();
     }
 
     private _reset() {
@@ -201,6 +198,8 @@ export class PreviewManager {
             return;
         }
 
+        this._scene.frameGraph = null;
+
         const serialized = this._globalState.nodeRenderGraph.serialize();
         this._nodeRenderGraph?.dispose();
         this._nodeRenderGraph = NodeRenderGraph.Parse(serialized, this._scene, {
@@ -208,6 +207,9 @@ export class PreviewManager {
             autoFillExternalInputs: false,
             debugTextures,
         });
+
+        this._buildGraph();
+
         (window as any).nrgPreview = this._nodeRenderGraph;
     }
 


### PR DESCRIPTION
The aim of this PR is to extract from `RenderTargetTexture` what is related to rendering only, and to leave specifically in `RenderTargetTexture` what is related to output texture management. This way, I can use `ObjectRenderer` in the frame graph, as the texture management part of `RenderTargetTexture` is of no use.

Firstly, `ObjectRenderer` can be changed to whatever name suits you :)

Secondly, the PR should be a non-breaking change (if it is, it's a bug!), which is why:
* I have two functions `prepareRenderList` and `initRender` that you have to call one after the other. I'd have preferred to call `prepareRenderList` inside `initRender` and have only the latter method public, but in the existing `RenderTargetTexture` function there's notification of the `onBeforeBindObservable` observable between these two blocks of code, and it doesn't make sense to have this observable in the `ObjectRenderer` class (because this class isn't concerned with texture management).
* There's a `skipOnAfterRenderObservable` parameter to the `ObjectRenderer.render` method, so as not to notify the `onAfterRenderObservable` at the end of `ObjectRenderer.render`. This is because in `RenderTargetTexture`, this observable is notified in the `Engine.unBindFramebuffer` callback: notifying it at the end of `ObjectRenderer.render` would have been a breaking change.

The expected usage is as follows (if you use the class directly - it's hidden from you if you use `RenderTargetTexture`):
* call `prepareRenderList()` (optional, you can avoid this call if you know that `renderList` is up to date)
* call `initRender(viewportWidth, viewportHeight)`.
* call `render(layerOrFaceIndex)` as many times as necessary (for a cube texture, you'll want to call it 6 times, each time linking the right face of the cube to the output texture)
* call `finishRender()`.

Once again, the names of these methods can be changed!