### PR TITLE
Fix Hotspot normal computation//add missing gizmo dispose

### DIFF
--- a/packages/dev/core/src/Gizmos/positionGizmo.ts
+++ b/packages/dev/core/src/Gizmos/positionGizmo.ts
@@ -389,6 +389,7 @@ export class PositionGizmo extends Gizmo implements IPositionGizmo {
         this.onDragStartObservable.clear();
         this.onDragObservable.clear();
         this.onDragEndObservable.clear();
+        super.dispose();
     }
 
     /**

--- a/packages/dev/core/src/Gizmos/rotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/rotationGizmo.ts
@@ -391,6 +391,7 @@ export class RotationGizmo extends Gizmo implements IRotationGizmo {
         this._observables.forEach((obs) => {
             this.gizmoLayer.utilityLayerScene.onPointerObservable.remove(obs);
         });
+        super.dispose();
     }
 
     /**

--- a/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
@@ -123,13 +123,13 @@ export function GetHotSpotToRef(mesh: AbstractMesh, hotSpotQuery: HotSpotQuery, 
         segmentB.normalize();
         Vector3.CrossToRef(segmentA, segmentB, resNormal);
 
-        // flip normal
-        const invertWinding =
+        // flip normal when face culling is changed
+        const flipNormal =
             mesh.material &&
             mesh.material.sideOrientation ===
                 (mesh.getScene().useRightHandedSystem ? Constants.MATERIAL_ClockWiseSideOrientation : Constants.MATERIAL_CounterClockWiseSideOrientation);
 
-        if (invertWinding) {
+        if (flipNormal) {
             resNormal.scaleInPlace(-1);
         }
 

--- a/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
@@ -121,12 +121,14 @@ export function GetHotSpotToRef(mesh: AbstractMesh, hotSpotQuery: HotSpotQuery, 
         segmentB.subtractInPlace(pointA);
         segmentA.normalize();
         segmentB.normalize();
-        Vector3.CrossToRef(segmentB, segmentA, resNormal);
+        Vector3.CrossToRef(segmentA, segmentB, resNormal);
 
         // flip normal
-        let invertWinding = mesh.material && mesh.material.sideOrientation === Constants.MATERIAL_CounterClockWiseSideOrientation;
-        invertWinding ||= mesh.getWorldMatrix().determinant() < 0;
-        invertWinding ||= mesh.getScene().useRightHandedSystem;
+        const invertWinding =
+            mesh.material &&
+            mesh.material.sideOrientation ===
+                (mesh.getScene().useRightHandedSystem ? Constants.MATERIAL_ClockWiseSideOrientation : Constants.MATERIAL_CounterClockWiseSideOrientation);
+
         if (invertWinding) {
             resNormal.scaleInPlace(-1);
         }


### PR DESCRIPTION
- Fix normal computation for hotspot.
- Add missing super.dispose for position and rotation gizmos ( https://forum.babylonjs.com/t/positiongizmo-dispose-not-complete/54770/2 )

Note:
Normal is local. world matrix is used when converting from local to world. So no need to use determinant. Only Clock orientation is important here.