### PR TITLE
Include Lit in viewer lib ES6 bundle

### DIFF
--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.dist.esm.mjs
@@ -26,6 +26,10 @@ const commonConfig = {
         nodeResolve({ mainFields: ["browser", "module", "main"] }),
         commonjs(),
     ],
+    onwarn(warning, warn) {
+        // Treat all warnings as errors.
+        throw new Error(warning.message);
+    },
 };
 
 const maxConfig = {

--- a/packages/public/@babylonjs/viewer-alpha/rollup.config.lib.mjs
+++ b/packages/public/@babylonjs/viewer-alpha/rollup.config.lib.mjs
@@ -1,5 +1,6 @@
 import typescript from "@rollup/plugin-typescript";
 import { dts } from "rollup-plugin-dts";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
 
 const commonConfig = {
     input: "../../../tools/viewer-alpha/src/index.ts",
@@ -14,7 +15,11 @@ const jsConfig = {
         format: "es",
         exports: "named",
     },
-    plugins: [typescript({ tsconfig: "tsconfig.build.lib.json" })],
+    plugins: [typescript({ tsconfig: "tsconfig.build.lib.json" }), nodeResolve({ mainFields: ["browser", "module", "main"] })],
+    onwarn(warning, warn) {
+        // Treat all warnings as errors.
+        throw new Error(warning.message);
+    },
 };
 
 const dtsConfig = {


### PR DESCRIPTION
Lit was added as a direct dependency of the Viewer, with the intention that it would be directly embedded as a private dependency of the Viewer to avoid any potential version conflicts (e.g. if a consuming app uses other custom elements that also use Lit). However, when it was added I missed adding the `nodeResolve` plugin, so it wasn't actually getting included in the bundle (it relied on the consuming app to bring in Lit). This PR fixes this, and also makes viewer package build warnings be errors so these types of issues don't slip through in the future.