### PR TITLE
Fix AnimationGroup isPlaying when mask is applied

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -915,7 +915,7 @@ export class AnimationGroup implements IDisposable {
         }
 
         // all animatables were removed? animation group ended!
-        if (this._animatables.length === 0) {
+        if (this._animatables.length === this._targetedAnimations.length - this._numActiveAnimatables) {
             this._isStarted = false;
             if (!skipOnAnimationEnd) {
                 this.onAnimationGroupEndObservable.notifyObservers(this);


### PR DESCRIPTION
Fixes the forum issue:
https://forum.babylonjs.com/t/animationgroup-isplaying-is-always-true-if-animationgroupmask-is-applied/54799/1