### PR TITLE
Some small Viewer bug fixes

### DIFF
--- a/packages/dev/core/src/Meshes/meshUtils.ts
+++ b/packages/dev/core/src/Meshes/meshUtils.ts
@@ -203,11 +203,13 @@ export function computeMaxExtents(
     };
 
     if (animationGroup && animationGroup.isStarted) {
+        const currentFrame = animationGroup.getCurrentFrame();
         const step = animationStep / animationGroup.getLength(0, 1);
         for (let frame = animationGroup.from; frame <= animationGroup.to; frame += step) {
             animationGroup.goToFrame(frame);
             updateMaxExtents();
         }
+        animationGroup.goToFrame(currentFrame);
     } else {
         updateMaxExtents();
     }

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -570,6 +570,7 @@ export class Viewer implements IDisposable {
             }
 
             this.onSelectedAnimationChanged.notifyObservers();
+            this.onAnimationProgressChanged.notifyObservers();
         }
     }
 

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -159,6 +159,7 @@ export class HTML3DElement extends LitElement {
                 calc(var(--ui-background-opacity) - 0.1)
             );
             all: inherit;
+            overflow: hidden;
         }
 
         .full-size {


### PR DESCRIPTION
This PR includes a few small bug fixes:
1. `computeMaxExtents` changes the current animation frame to do its calculations, but it doesn't restore the original value. This was causing the Viewer to start at the wrong animation frame when first starting an animation and when switching animations. I think it's best to fix this in the `computeMaxExtents` function so it leaves the animation in the state it found it in.
2. When switching animations, we reset to the first animation frame, and we need to fire one onAnimationProgressChanged event so the animation timeline properly syncs to the animation state.
3. The viewer HTML element should set overflow to hidden by default, otherwise if a child annotation is pulled out of view (e.g. through an animation or panning the camera) it will overflow and show scroll bars. Instead we just want the annotation to go out of view along with the model.