### PR TITLE
Fixes AnimationGroup isPlaying when mask is applied & played more than once

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -920,6 +920,7 @@ export class AnimationGroup implements IDisposable {
             if (!skipOnAnimationEnd) {
                 this.onAnimationGroupEndObservable.notifyObservers(this);
             }
+            this._animatables.length = 0;
         }
     }
 


### PR DESCRIPTION
A followup fix of #15836 and forum issue:
https://forum.babylonjs.com/t/animationgroup-isplaying-is-always-true-if-animationgroupmask-is-applied/54799

When `AnimationGroupMask` is applied, `isPlaying` will set to `false` on the first time, which works as expected.

However if the animation group is played more than once, `isPlaying` will still be `true` after the animation has ended (can be reproduced on the playground provided in the forum issue).

It is due to `AnimationGroup._animatables.length` being assumed to be 0 when the animation has ended.
So explicitly clear `AnimationGroup._animatables` should finally fix the issue.