### PR TITLE
CSG2: make FromMesh return CSG2

### DIFF
--- a/packages/dev/core/src/Meshes/csg2.ts
+++ b/packages/dev/core/src/Meshes/csg2.ts
@@ -395,7 +395,7 @@ export class CSG2 implements IDisposable {
      * @param ignoreWorldMatrix defines if the world matrix should be ignored
      * @returns a new CSG2 class
      */
-    public static FromMesh(mesh: Mesh, ignoreWorldMatrix = false): any {
+    public static FromMesh(mesh: Mesh, ignoreWorldMatrix = false): CSG2 {
         const sourceVertices = mesh.getVerticesData(VertexBuffer.PositionKind);
         const sourceIndices = mesh.getIndices();
         const worldMatrix = mesh.computeWorldMatrix(true);


### PR DESCRIPTION
## Background

Currently `CSG2.FromMesh` return `any` type, makes it harder to inference type of returned value, and make it harder for devs to get type hints compared to the old CSG.
After looking into the [doc](https://doc.babylonjs.com/typedoc/classes/BABYLON.CSG2), `FromVertexData` and other instance methods implicitly return `CSG2` type.

## Proposal

Make `CSG2.FromMesh` method return `CSG2` type instead of any.

## Risks

Since CSG2 is already released with any type, narrowing the type to CSG2 could be breaking for typescript users.

## References

Forum post: <https://forum.babylonjs.com/t/csg2-should-return-csg2-type-instead-of-any/54897>