### PR TITLE
facetParameters disableFacetData() doesn't block reuse of updateFacet…

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -2698,7 +2698,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
             facetData.facetPositions = [] as Vector3[];
             facetData.facetNormals = [] as Vector3[];
             facetData.facetPartitioning = new Array<number[]>();
-            facetData.facetParameters = null;
+            facetData.facetParameters = {};
             facetData.depthSortedIndices = new Uint32Array(0);
         }
         return this;


### PR DESCRIPTION
mesh.disableFacetData() sets the facetParameters to null, which doesn't allow updateFacetData() to be run again. This clears the object instead.  As the type  of facetParameters is already any, there is no change for the user other than being able to enable/ disable the feature.

https://playground.babylonjs.com/#8EWBO5