### PR TITLE
Parallel Compilation with no engine

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.functions.ts
+++ b/packages/dev/core/src/Engines/thinEngine.functions.ts
@@ -191,6 +191,9 @@ export function _createShaderProgram(
     return shaderProgram;
 }
 
+/**
+ * @internal
+ */
 export function _isRenderingStateCompiled(pipelineContext: IPipelineContext, gl: WebGLContext, validateShaderPrograms?: boolean): boolean {
     const webGLPipelineContext = pipelineContext as WebGLPipelineContext;
     if (webGLPipelineContext._isDisposed) {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -32,6 +32,7 @@ import {
     getStateObject,
     _createShaderProgram,
     deleteStateObject,
+    _isRenderingStateCompiled,
 } from "./thinEngine.functions";
 
 import type { AbstractEngineOptions, ISceneLike, PrepareTextureFunction, PrepareTextureProcessFunction } from "./abstractEngine";
@@ -2152,16 +2153,10 @@ export class ThinEngine extends AbstractEngine {
      * @internal
      */
     public _isRenderingStateCompiled(pipelineContext: IPipelineContext): boolean {
-        const webGLPipelineContext = pipelineContext as WebGLPipelineContext;
-        if (this._isDisposed || webGLPipelineContext._isDisposed) {
+        if (this._isDisposed) {
             return false;
         }
-        if (this._gl.getProgramParameter(webGLPipelineContext.program!, this._caps.parallelShaderCompile!.COMPLETION_STATUS_KHR)) {
-            this._finalizePipelineContext(webGLPipelineContext);
-            return true;
-        }
-
-        return false;
+        return _isRenderingStateCompiled(pipelineContext, this._gl, this.validateShaderPrograms);
     }
 
     /**

--- a/packages/dev/core/src/Materials/effect.functions.ts
+++ b/packages/dev/core/src/Materials/effect.functions.ts
@@ -57,6 +57,11 @@ export interface IPipelineGenerationOptions {
      * extend the pipeline generation options
      */
     extendedCreatePipelineOptions?: Partial<ICreateAndPreparePipelineContextOptions>;
+
+    /**
+     * If true, generating a new pipeline will return when the pipeline is ready to be used
+     */
+    waitForIsReady?: boolean;
 }
 
 /**

--- a/packages/dev/core/src/Materials/effect.functions.ts
+++ b/packages/dev/core/src/Materials/effect.functions.ts
@@ -321,3 +321,22 @@ export const createAndPreparePipelineContext = (
         throw e;
     }
 };
+
+export const _retryWithInterval = (condition: () => boolean, onSuccess: () => void, onError?: (e?: any) => void, step = 16, maxTimeout = 1000) => {
+    const int = setInterval(() => {
+        try {
+            if (condition()) {
+                clearInterval(int);
+                onSuccess();
+            }
+        } catch (e) {
+            clearInterval(int);
+            onError?.(e);
+        }
+        maxTimeout -= step;
+        if (maxTimeout < 0) {
+            clearInterval(int);
+            onError?.();
+        }
+    }, step);
+};

--- a/packages/dev/core/src/Materials/effect.ts
+++ b/packages/dev/core/src/Materials/effect.ts
@@ -15,7 +15,7 @@ import { ShaderLanguage } from "./shaderLanguage";
 import type { InternalTexture } from "../Materials/Textures/internalTexture";
 import type { ThinTexture } from "../Materials/Textures/thinTexture";
 import type { IPipelineGenerationOptions } from "./effect.functions";
-import { _processShaderCode, getCachedPipeline, createAndPreparePipelineContext, resetCachedPipeline } from "./effect.functions";
+import { _processShaderCode, getCachedPipeline, createAndPreparePipelineContext, resetCachedPipeline, _retryWithInterval } from "./effect.functions";
 
 /**
  * Defines the route to the shader code. The priority is as follows:
@@ -587,29 +587,22 @@ export class Effect implements IDisposable {
         });
 
         if (!this._pipelineContext || this._pipelineContext.isAsync) {
-            setTimeout(() => {
-                this._checkIsReady(null);
-            }, 16);
+            this._checkIsReady(null);
         }
     }
 
     private _checkIsReady(previousPipelineContext: Nullable<IPipelineContext>) {
-        try {
-            if (this._isReadyInternal()) {
-                return;
+        _retryWithInterval(
+            () => {
+                return this._isReadyInternal() || this._isDisposed;
+            },
+            () => {
+                // no-op - done in the _isReadyInternal call
+            },
+            (e) => {
+                this._processCompilationErrors(e, previousPipelineContext);
             }
-        } catch (e) {
-            this._processCompilationErrors(e, previousPipelineContext);
-            return;
-        }
-
-        if (this._isDisposed) {
-            return;
-        }
-
-        setTimeout(() => {
-            this._checkIsReady(previousPipelineContext);
-        }, 16);
+        );
     }
 
     /**

--- a/packages/dev/core/src/Materials/effect.webgl.functions.ts
+++ b/packages/dev/core/src/Materials/effect.webgl.functions.ts
@@ -96,6 +96,7 @@ export async function generatePipelineContext(
                             // max a second for the pipeline to be ready
                             let maxTimeout = 1000;
                             // not using the render loop as it is not guaranteed that this is done with an engine present
+                            // Using setInterval to keep the package as small as possible.
                             const int = setInterval(() => {
                                 if (_isRenderingStateCompiled(pipeline, context)) {
                                     clearInterval(int);

--- a/packages/dev/core/src/Materials/effect.webgl.functions.ts
+++ b/packages/dev/core/src/Materials/effect.webgl.functions.ts
@@ -89,8 +89,8 @@ export async function generatePipelineContext(
                             _preparePipelineContext,
                             _executeWhenRenderingStateIsCompiled
                         );
-                        // the default behavior so far.
-                        if (!options.waitForIsReady) {
+                        // the default behavior so far. If not async or no request to wait for isReady, resolve immediately
+                        if (!options.waitForIsReady || !pipeline.isAsync) {
                             resolve(pipeline);
                         } else {
                             // max a second for the pipeline to be ready


### PR DESCRIPTION
In certain cases dev wish to precompile shaders on a different canvas, outside of the context of a babylon engine.
This can accelerate future shader compilations as the browser itself caches shaders (tested on both chrome and safari).

So a pipeline can be created where:
1. Pipeline is generated first, without any Babylon engine
2. babylon engine is created
3. Pipeline is (re)created with the same shader, resulting in a much faster shader compilation.

If step 1 can be done in parallel to step 2, this can speed up the loading process (for example if the package using in step 2 is large enough to be slow to download).

However, so far there was no support for parallel precompilation as this information comes from the engine. as there is no engine, there is no flag set.

This PR makes the following changes:

1. If parallel compilation can be enabled, it is enabled, while maintaining the current behavior in thinEngine
2. WebGL preprocessor is not included per default and not async loaded, as it is the default one and is probably the one mostly used. This saves one async import
3. A new flag was added when generating the pipeline - if `waitForIsReady` is set to true, the promise will resolve when the pipeline is ready,a s opposed to right after the shader was compiled.

Reasoning behind using setInterval - this code is only used for shader precompilation by external packages (and not by babylon internals). to avoid addding unneeded code to this package, I decided to use a standard browser feature.

Though this PG will only work locally (due to non-exported internal function) this si the PG i have used to test the functionality - #8Z0MKW#104 . this is for future reference, mainly for me.