### PR TITLE
TEXTURETYPE_UNSIGNED_INT confusion

### DIFF
--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -115,7 +115,7 @@ export class GPUPicker {
             scene,
             false,
             undefined,
-            Constants.TEXTURETYPE_UNSIGNED_INT,
+            Constants.TEXTURETYPE_UNSIGNED_BYTE,
             false,
             Constants.TEXTURE_NEAREST_NEAREST
         );

--- a/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.multiRender.ts
@@ -149,7 +149,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: TextureSize, o
     let textureCount = 1;
     let samples = 1;
 
-    const defaultType = Constants.TEXTURETYPE_UNSIGNED_INT;
+    const defaultType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
     const defaultSamplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
     const defaultUseSRGBBuffer = false;
     const defaultFormat = Constants.TEXTUREFORMAT_RGBA;
@@ -245,7 +245,7 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: TextureSize, o
 
         const filters = this._getSamplingParameters(samplingMode, generateMipMaps);
         if (type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
-            type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             Logger.Warn("Float textures are not supported. Render target forced to TEXTURETYPE_UNSIGNED_BYTE type");
         }
 
@@ -335,13 +335,13 @@ ThinEngine.prototype.createMultipleRenderTarget = function (size: TextureSize, o
                 glDepthTextureType = gl.FLOAT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT32F;
             } else if (depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH32FLOAT_STENCIL8) {
-                depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+                depthTextureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
                 glDepthTextureType = gl.FLOAT_32_UNSIGNED_INT_24_8_REV;
                 glDepthTextureInternalFormat = gl.DEPTH32F_STENCIL8;
                 glDepthTextureFormat = gl.DEPTH_STENCIL;
                 glDepthTextureAttachment = gl.DEPTH_STENCIL_ATTACHMENT;
             } else if (depthTextureFormat === Constants.TEXTUREFORMAT_DEPTH24) {
-                depthTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+                depthTextureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
                 glDepthTextureType = gl.UNSIGNED_INT;
                 glDepthTextureInternalFormat = gl.DEPTH_COMPONENT24;
                 glDepthTextureAttachment = gl.DEPTH_ATTACHMENT;

--- a/packages/dev/core/src/Engines/Extensions/engine.rawTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.rawTexture.ts
@@ -25,7 +25,7 @@ declare module "../abstractEngine" {
          * @param format defines the format of the data
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the compression used (null by default)
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param useSRGBBuffer defines if the texture must be loaded in a sRGB GPU buffer (if supported by the GPU).
          */
         updateRawTexture(
@@ -42,7 +42,7 @@ declare module "../abstractEngine" {
          * @param texture defines the texture to update
          * @param data defines the data to store
          * @param format defines the data format
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param invertY defines if data must be stored with Y axis inverted
          */
         updateRawCubeTexture(texture: InternalTexture, data: ArrayBufferView[], format: number, type: number, invertY: boolean): void;
@@ -52,7 +52,7 @@ declare module "../abstractEngine" {
          * @param texture defines the texture to update
          * @param data defines the data to store
          * @param format defines the data format
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the compression used (null by default)
          */
@@ -63,7 +63,7 @@ declare module "../abstractEngine" {
          * @param texture defines the texture to update
          * @param data defines the data to store
          * @param format defines the data format
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the compression used (null by default)
          * @param level defines which level of the texture to update
@@ -76,7 +76,7 @@ declare module "../abstractEngine" {
          * @param scene defines the current scene
          * @param size defines the size of the textures
          * @param format defines the format of the data
-         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
          * @param noMipmap defines if the engine should avoid generating the mip levels
          * @param callback defines a callback used to extract texture data from loaded data
          * @param mipmapGenerator defines to provide an optional tool to generate mip levels
@@ -103,7 +103,7 @@ declare module "../abstractEngine" {
          * @param scene defines the current scene
          * @param size defines the size of the textures
          * @param format defines the format of the data
-         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
          * @param noMipmap defines if the engine should avoid generating the mip levels
          * @param callback defines a callback used to extract texture data from loaded data
          * @param mipmapGenerator defines to provide an optional tool to generate mip levels
@@ -144,7 +144,7 @@ declare module "../abstractEngine" {
          * @param format defines the data format
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the used compression (can be null)
-         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT...)
+         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT...)
          */
         updateRawTexture3D(texture: InternalTexture, data: Nullable<ArrayBufferView>, format: number, invertY: boolean, compression: Nullable<string>, textureType: number): void;
 
@@ -164,7 +164,7 @@ declare module "../abstractEngine" {
          * @param format defines the data format
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the used compression (can be null)
-         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT...)
+         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT...)
          */
         updateRawTexture2DArray(
             texture: InternalTexture,
@@ -183,7 +183,7 @@ ThinEngine.prototype.updateRawTexture = function (
     format: number,
     invertY: boolean,
     compression: Nullable<string> = null,
-    type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
     useSRGBBuffer: boolean = false
 ): void {
     if (!texture) {
@@ -233,7 +233,7 @@ ThinEngine.prototype.createRawTexture = function (
     invertY: boolean,
     samplingMode: number,
     compression: Nullable<string> = null,
-    type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     creationFlags = 0,
     useSRGBBuffer = false
@@ -597,7 +597,7 @@ function _makeCreateRawTextureFunction(is3D: boolean) {
         invertY: boolean,
         samplingMode: number,
         compression: Nullable<string> = null,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ): InternalTexture {
         const target = is3D ? this._gl.TEXTURE_3D : this._gl.TEXTURE_2D_ARRAY;
         const source = is3D ? InternalTextureSource.Raw3D : InternalTextureSource.Raw2DArray;
@@ -664,7 +664,7 @@ function _makeUpdateRawTextureFunction(is3D: boolean) {
         format: number,
         invertY: boolean,
         compression: Nullable<string> = null,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ): void {
         const target = is3D ? this._gl.TEXTURE_3D : this._gl.TEXTURE_2D_ARRAY;
         const internalType = this._getWebGLTextureType(textureType);

--- a/packages/dev/core/src/Engines/Extensions/engine.renderTarget.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.renderTarget.ts
@@ -311,7 +311,7 @@ ThinEngine.prototype._setupDepthStencilTexture = function (
     internalTexture.samples = samples;
     internalTexture.generateMipMaps = false;
     internalTexture.samplingMode = bilinearFiltering ? Constants.TEXTURE_BILINEAR_SAMPLINGMODE : Constants.TEXTURE_NEAREST_SAMPLINGMODE;
-    internalTexture.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+    internalTexture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
     internalTexture._comparisonFunction = comparisonFunction;
 
     const gl = this._gl;

--- a/packages/dev/core/src/Engines/Extensions/engine.renderTargetCube.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.renderTargetCube.ts
@@ -25,7 +25,7 @@ ThinEngine.prototype.createRenderTargetCubeTexture = function (size: number, opt
         generateMipMaps: true,
         generateDepthBuffer: true,
         generateStencilBuffer: false,
-        type: Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
         samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
         format: Constants.TEXTUREFORMAT_RGBA,
         ...options,
@@ -47,7 +47,7 @@ ThinEngine.prototype.createRenderTargetCubeTexture = function (size: number, opt
     const filters = this._getSamplingParameters(fullOptions.samplingMode, fullOptions.generateMipMaps);
 
     if (fullOptions.type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
-        fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+        fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         Logger.Warn("Float textures are not supported. Cube render target forced to TEXTURETYPE_UNESIGNED_BYTE type");
     }
 

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.multiRender.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.multiRender.ts
@@ -202,7 +202,7 @@ WebGPUEngine.prototype.createMultipleRenderTarget = function (size: TextureSize,
         }
 
         if (type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
-            type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             Logger.Warn("Float textures are not supported. Render target forced to TEXTURETYPE_UNSIGNED_BYTE type");
         }
 

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.rawTexture.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.rawTexture.ts
@@ -26,7 +26,7 @@ declare module "../../abstractEngine" {
          * @param format defines the format of the data
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the compression used (null by default)
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param useSRGBBuffer defines if the texture must be loaded in a sRGB GPU buffer (if supported by the GPU).
          */
         updateRawTexture(
@@ -44,7 +44,7 @@ declare module "../../abstractEngine" {
          * @param data defines the array of data to use to create each face
          * @param size defines the size of the textures
          * @param format defines the format of the data
-         * @param type defines the type of the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+         * @param type defines the type of the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
          * @param generateMipMaps  defines if the engine should generate the mip levels
          * @param invertY defines if data must be stored with Y axis inverted
          * @param samplingMode defines the required sampling mode (like Texture.NEAREST_SAMPLINGMODE)
@@ -67,7 +67,7 @@ declare module "../../abstractEngine" {
          * @param texture defines the texture to update
          * @param data defines the data to store
          * @param format defines the data format
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param invertY defines if data must be stored with Y axis inverted
          */
         updateRawCubeTexture(texture: InternalTexture, data: ArrayBufferView[], format: number, type: number, invertY: boolean): void;
@@ -77,7 +77,7 @@ declare module "../../abstractEngine" {
          * @param texture defines the texture to update
          * @param data defines the data to store
          * @param format defines the data format
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the compression used (null by default)
          */
@@ -88,7 +88,7 @@ declare module "../../abstractEngine" {
          * @param texture defines the texture to update
          * @param data defines the data to store
          * @param format defines the data format
-         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+         * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the compression used (null by default)
          * @param level defines which level of the texture to update
@@ -101,7 +101,7 @@ declare module "../../abstractEngine" {
          * @param scene defines the current scene
          * @param size defines the size of the textures
          * @param format defines the format of the data
-         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
          * @param noMipmap defines if the engine should avoid generating the mip levels
          * @param callback defines a callback used to extract texture data from loaded data
          * @param mipmapGenerator defines to provide an optional tool to generate mip levels
@@ -128,7 +128,7 @@ declare module "../../abstractEngine" {
          * @param scene defines the current scene
          * @param size defines the size of the textures
          * @param format defines the format of the data
-         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+         * @param type defines the type fo the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
          * @param noMipmap defines if the engine should avoid generating the mip levels
          * @param callback defines a callback used to extract texture data from loaded data
          * @param mipmapGenerator defines to provide an optional tool to generate mip levels
@@ -169,7 +169,7 @@ declare module "../../abstractEngine" {
          * @param format defines the data format
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the used compression (can be null)
-         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT...)
+         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT...)
          */
         updateRawTexture3D(texture: InternalTexture, data: Nullable<ArrayBufferView>, format: number, invertY: boolean, compression: Nullable<string>, textureType: number): void;
 
@@ -189,7 +189,7 @@ declare module "../../abstractEngine" {
          * @param format defines the data format
          * @param invertY defines if data must be stored with Y axis inverted
          * @param compression defines the used compression (can be null)
-         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT...)
+         * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT...)
          */
         updateRawTexture2DArray(
             texture: InternalTexture,
@@ -211,7 +211,7 @@ ThinWebGPUEngine.prototype.createRawTexture = function (
     invertY: boolean,
     samplingMode: number,
     compression: Nullable<string> = null,
-    type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
     creationFlags: number = 0,
     useSRGBBuffer: boolean = false
 ): InternalTexture {
@@ -248,7 +248,7 @@ ThinWebGPUEngine.prototype.updateRawTexture = function (
     format: number,
     invertY: boolean,
     compression: Nullable<string> = null,
-    type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
     useSRGBBuffer: boolean = false
 ): void {
     if (!texture) {
@@ -464,7 +464,7 @@ ThinWebGPUEngine.prototype.createRawTexture3D = function (
     invertY: boolean,
     samplingMode: number,
     compression: Nullable<string> = null,
-    textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
     creationFlags: number = 0
 ): InternalTexture {
     const source = InternalTextureSource.Raw3D;
@@ -502,7 +502,7 @@ ThinWebGPUEngine.prototype.updateRawTexture3D = function (
     format: number,
     invertY: boolean,
     compression: Nullable<string> = null,
-    textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+    textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
 ): void {
     if (!this._doNotHandleContextLost) {
         texture._bufferView = bufferView;
@@ -540,7 +540,7 @@ ThinWebGPUEngine.prototype.createRawTexture2DArray = function (
     invertY: boolean,
     samplingMode: number,
     compression: Nullable<string> = null,
-    textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+    textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
     creationFlags: number = 0
 ): InternalTexture {
     const source = InternalTextureSource.Raw2DArray;
@@ -578,7 +578,7 @@ ThinWebGPUEngine.prototype.updateRawTexture2DArray = function (
     format: number,
     invertY: boolean,
     compression: Nullable<string> = null,
-    textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+    textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
 ): void {
     if (!this._doNotHandleContextLost) {
         texture._bufferView = bufferView;

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTargetCube.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.renderTargetCube.ts
@@ -23,7 +23,7 @@ ThinWebGPUEngine.prototype.createRenderTargetCubeTexture = function (size: numbe
         generateMipMaps: true,
         generateDepthBuffer: true,
         generateStencilBuffer: false,
-        type: Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
         samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
         format: Constants.TEXTUREFORMAT_RGBA,
         samples: 1,

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -794,7 +794,7 @@ export abstract class AbstractEngine {
                 cubeData,
                 1,
                 Constants.TEXTUREFORMAT_RGBA,
-                Constants.TEXTURETYPE_UNSIGNED_INT,
+                Constants.TEXTURETYPE_UNSIGNED_BYTE,
                 false,
                 false,
                 Constants.TEXTURE_NEAREST_SAMPLINGMODE
@@ -2166,7 +2166,7 @@ export abstract class AbstractEngine {
      * @param invertY defines if data must be stored with Y axis inverted
      * @param samplingMode defines the required sampling mode (Texture.NEAREST_SAMPLINGMODE by default)
      * @param compression defines the compression used (null by default)
-     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
      * @param useSRGBBuffer defines if the texture must be loaded in a sRGB GPU buffer (if supported by the GPU).
      * @returns the raw texture inside an InternalTexture
@@ -2193,7 +2193,7 @@ export abstract class AbstractEngine {
      * @param data defines the array of data to use to create each face
      * @param size defines the size of the textures
      * @param format defines the format of the data
-     * @param type defines the type of the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+     * @param type defines the type of the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
      * @param generateMipMaps  defines if the engine should generate the mip levels
      * @param invertY defines if data must be stored with Y axis inverted
      * @param samplingMode defines the required sampling mode (like Texture.NEAREST_SAMPLINGMODE)

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -230,7 +230,7 @@ export class Constants {
 
     /** UNSIGNED_BYTE */
     public static readonly TEXTURETYPE_UNSIGNED_BYTE = 0;
-    /** UNSIGNED_BYTE (2nd reference) */
+    /** @deprecated use more explicit TEXTURETYPE_UNSIGNED_BYTE instead. Use TEXTURETYPE_UNSIGNED_INTEGER for 32bits values.*/
     public static readonly TEXTURETYPE_UNSIGNED_INT = 0;
     /** FLOAT */
     public static readonly TEXTURETYPE_FLOAT = 1;

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -164,7 +164,7 @@ export class Engine extends ThinEngine {
 
     /** UNSIGNED_BYTE */
     public static readonly TEXTURETYPE_UNSIGNED_BYTE = Constants.TEXTURETYPE_UNSIGNED_BYTE;
-    /** UNSIGNED_BYTE (2nd reference) */
+    /** @deprecated use more explicit TEXTURETYPE_UNSIGNED_BYTE instead. Use TEXTURETYPE_UNSIGNED_INTEGER for 32bits values.*/
     public static readonly TEXTURETYPE_UNSIGNED_INT = Constants.TEXTURETYPE_UNSIGNED_INT;
     /** FLOAT */
     public static readonly TEXTURETYPE_FLOAT = Constants.TEXTURETYPE_FLOAT;

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -1656,7 +1656,7 @@ export class NativeEngine extends Engine {
         invertY: boolean,
         samplingMode: number,
         compression: Nullable<string> = null,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags: number = 0,
         useSRGBBuffer: boolean = false
     ): InternalTexture {
@@ -1696,7 +1696,7 @@ export class NativeEngine extends Engine {
         invertY: boolean,
         samplingMode: number,
         compression: Nullable<string> = null,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ): InternalTexture {
         const texture = new InternalTexture(this, InternalTextureSource.Raw2DArray);
 
@@ -1732,7 +1732,7 @@ export class NativeEngine extends Engine {
         format: number,
         invertY: boolean,
         compression: Nullable<string> = null,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         useSRGBBuffer: boolean = false
     ): void {
         if (!texture) {
@@ -2129,7 +2129,7 @@ export class NativeEngine extends Engine {
                 const imageData = CreateImageDataArrayBufferViews(data, info);
 
                 texture.format = Constants.TEXTUREFORMAT_RGBA;
-                texture.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+                texture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
                 texture.generateMipMaps = true;
                 texture.getEngine().updateTextureSamplingMode(Texture.TRILINEAR_SAMPLINGMODE, texture);
                 texture._isRGBD = true;
@@ -2227,7 +2227,7 @@ export class NativeEngine extends Engine {
         source = InternalTextureSource.Unknown
     ): InternalTexture {
         let generateMipMaps = false;
-        let type = Constants.TEXTURETYPE_UNSIGNED_INT;
+        let type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         let samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
         let format = Constants.TEXTUREFORMAT_RGBA;
         let useSRGBBuffer = false;
@@ -2235,7 +2235,7 @@ export class NativeEngine extends Engine {
         let label: string | undefined;
         if (options !== undefined && typeof options === "object") {
             generateMipMaps = !!options.generateMipMaps;
-            type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_INT : options.type;
+            type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_BYTE : options.type;
             samplingMode = options.samplingMode === undefined ? Constants.TEXTURE_TRILINEAR_SAMPLINGMODE : options.samplingMode;
             format = options.format === undefined ? Constants.TEXTUREFORMAT_RGBA : options.format;
             useSRGBBuffer = options.useSRGBBuffer === undefined ? false : options.useSRGBBuffer;
@@ -2255,7 +2255,7 @@ export class NativeEngine extends Engine {
             samplingMode = Constants.TEXTURE_NEAREST_SAMPLINGMODE;
         }
         if (type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
-            type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             Logger.Warn("Float textures are not supported. Type forced to TEXTURETYPE_UNSIGNED_BYTE");
         }
 

--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -753,13 +753,13 @@ export class NullEngine extends Engine {
             fullOptions.generateMipMaps = options.generateMipMaps;
             fullOptions.generateDepthBuffer = options.generateDepthBuffer === undefined ? true : options.generateDepthBuffer;
             fullOptions.generateStencilBuffer = fullOptions.generateDepthBuffer && options.generateStencilBuffer;
-            fullOptions.type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_INT : options.type;
+            fullOptions.type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_BYTE : options.type;
             fullOptions.samplingMode = options.samplingMode === undefined ? Constants.TEXTURE_TRILINEAR_SAMPLINGMODE : options.samplingMode;
         } else {
             fullOptions.generateMipMaps = <boolean>options;
             fullOptions.generateDepthBuffer = true;
             fullOptions.generateStencilBuffer = false;
-            fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             fullOptions.samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
         }
         const texture = new InternalTexture(this, InternalTextureSource.RenderTarget);
@@ -798,7 +798,7 @@ export class NullEngine extends Engine {
             generateMipMaps: true,
             generateDepthBuffer: true,
             generateStencilBuffer: false,
-            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
             format: Constants.TEXTUREFORMAT_RGBA,
             ...options,
@@ -852,7 +852,7 @@ export class NullEngine extends Engine {
      * @param invertY defines if data must be stored with Y axis inverted
      * @param samplingMode defines the required sampling mode (Texture.NEAREST_SAMPLINGMODE by default)
      * @param compression defines the compression used (null by default)
-     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
      * @param useSRGBBuffer defines if the texture must be loaded in a sRGB GPU buffer (if supported by the GPU).
      * @returns the raw texture inside an InternalTexture
@@ -866,7 +866,7 @@ export class NullEngine extends Engine {
         invertY: boolean,
         samplingMode: number,
         compression: Nullable<string> = null,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags = 0,
         useSRGBBuffer = false
     ): InternalTexture {
@@ -897,7 +897,7 @@ export class NullEngine extends Engine {
      * @param format defines the format of the data
      * @param invertY defines if data must be stored with Y axis inverted
      * @param compression defines the compression used (null by default)
-     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
      * @param useSRGBBuffer defines if the texture must be loaded in a sRGB GPU buffer (if supported by the GPU).
      */
     public override updateRawTexture(
@@ -906,7 +906,7 @@ export class NullEngine extends Engine {
         format: number,
         invertY: boolean,
         compression: Nullable<string> = null,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         useSRGBBuffer: boolean = false
     ): void {
         if (texture) {

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -2875,7 +2875,7 @@ export class ThinEngine extends AbstractEngine {
     ): InternalTexture {
         let generateMipMaps = false;
         let createMipMaps = false;
-        let type = Constants.TEXTURETYPE_UNSIGNED_INT;
+        let type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         let samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
         let format = Constants.TEXTUREFORMAT_RGBA;
         let useSRGBBuffer = false;
@@ -2886,7 +2886,7 @@ export class ThinEngine extends AbstractEngine {
         if (options !== undefined && typeof options === "object") {
             generateMipMaps = !!options.generateMipMaps;
             createMipMaps = !!options.createMipMaps;
-            type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_INT : options.type;
+            type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_BYTE : options.type;
             samplingMode = options.samplingMode === undefined ? Constants.TEXTURE_TRILINEAR_SAMPLINGMODE : options.samplingMode;
             format = options.format === undefined ? Constants.TEXTUREFORMAT_RGBA : options.format;
             useSRGBBuffer = options.useSRGBBuffer === undefined ? false : options.useSRGBBuffer;
@@ -2908,7 +2908,7 @@ export class ThinEngine extends AbstractEngine {
             samplingMode = Constants.TEXTURE_NEAREST_SAMPLINGMODE;
         }
         if (type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
-            type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             Logger.Warn("Float textures are not supported. Type forced to TEXTURETYPE_UNSIGNED_BYTE");
         }
 

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -2270,7 +2270,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         if (options !== undefined && typeof options === "object") {
             fullOptions.generateMipMaps = options.generateMipMaps;
             fullOptions.createMipMaps = options.createMipMaps;
-            fullOptions.type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_INT : options.type;
+            fullOptions.type = options.type === undefined ? Constants.TEXTURETYPE_UNSIGNED_BYTE : options.type;
             fullOptions.samplingMode = options.samplingMode === undefined ? Constants.TEXTURE_TRILINEAR_SAMPLINGMODE : options.samplingMode;
             fullOptions.format = options.format === undefined ? Constants.TEXTUREFORMAT_RGBA : options.format;
             fullOptions.samples = options.samples ?? 1;
@@ -2279,7 +2279,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             fullOptions.label = options.label;
         } else {
             fullOptions.generateMipMaps = <boolean>options;
-            fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             fullOptions.samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
             fullOptions.format = Constants.TEXTUREFORMAT_RGBA;
             fullOptions.samples = 1;
@@ -2293,7 +2293,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             fullOptions.samplingMode = Constants.TEXTURE_NEAREST_SAMPLINGMODE;
         }
         if (fullOptions.type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
-            fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+            fullOptions.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             Logger.Warn("Float textures are not supported. Type forced to TEXTURETYPE_UNSIGNED_BYTE");
         }
 

--- a/packages/dev/core/src/Helpers/environmentHelper.ts
+++ b/packages/dev/core/src/Helpers/environmentHelper.ts
@@ -226,7 +226,7 @@ export class EnvironmentHelper {
             groundMirrorAmount: 1,
             groundMirrorFresnelWeight: 1,
             groundMirrorFallOffDistance: 0,
-            groundMirrorTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            groundMirrorTextureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
 
             groundYBias: 0.00001,
 

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -62,7 +62,7 @@ export interface IEffectLayerOptions {
     renderingGroupId: number;
 
     /**
-     * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
+     * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_BYTE
      */
     mainTextureType: number;
 
@@ -362,7 +362,7 @@ export abstract class EffectLayer {
             alphaBlendingMode: Constants.ALPHA_COMBINE,
             camera: null,
             renderingGroupId: -1,
-            mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            mainTextureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             generateStencilBuffer: false,
             ...options,
         };

--- a/packages/dev/core/src/Layers/glowLayer.ts
+++ b/packages/dev/core/src/Layers/glowLayer.ts
@@ -93,7 +93,7 @@ export interface IGlowLayerOptions {
     alphaBlendingMode?: number;
 
     /**
-     * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
+     * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_BYTE
      */
     mainTextureType: number;
 
@@ -212,7 +212,7 @@ export class GlowLayer extends EffectLayer {
             renderingGroupId: -1,
             ldrMerge: false,
             alphaBlendingMode: Constants.ALPHA_ADD,
-            mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            mainTextureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             generateStencilBuffer: false,
             ...options,
         };
@@ -296,7 +296,7 @@ export class GlowLayer extends EffectLayer {
         if (this._engine.getCaps().textureHalfFloatRender) {
             textureType = Constants.TEXTURETYPE_HALF_FLOAT;
         } else {
-            textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+            textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
 
         this._blurTexture1 = new RenderTargetTexture(

--- a/packages/dev/core/src/Layers/highlightLayer.ts
+++ b/packages/dev/core/src/Layers/highlightLayer.ts
@@ -143,7 +143,7 @@ export interface IHighlightLayerOptions {
     renderingGroupId: number;
 
     /**
-     * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_INT
+     * The type of the main texture. Default: TEXTURETYPE_UNSIGNED_BYTE
      */
     mainTextureType: number;
 
@@ -327,7 +327,7 @@ export class HighlightLayer extends EffectLayer {
             alphaBlendingMode: Constants.ALPHA_COMBINE,
             camera: null,
             renderingGroupId: -1,
-            mainTextureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            mainTextureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             forceGLSL: false,
             ...options,
         };
@@ -412,7 +412,7 @@ export class HighlightLayer extends EffectLayer {
         if (this._engine.getCaps().textureHalfFloatRender) {
             textureType = Constants.TEXTURETYPE_HALF_FLOAT;
         } else {
-            textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+            textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
 
         this._blurTexture = new RenderTargetTexture(

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -914,7 +914,7 @@ export class ShadowGenerator implements IShadowGenerator {
             } else if (caps.textureFloatRender && caps.textureFloatLinearFiltering) {
                 this._textureType = Constants.TEXTURETYPE_FLOAT;
             } else {
-                this._textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+                this._textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             }
         } else {
             if (caps.textureFloatRender && caps.textureFloatLinearFiltering) {
@@ -922,7 +922,7 @@ export class ShadowGenerator implements IShadowGenerator {
             } else if (caps.textureHalfFloatRender && caps.textureHalfFloatLinearFiltering) {
                 this._textureType = Constants.TEXTURETYPE_HALF_FLOAT;
             } else {
-                this._textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+                this._textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             }
         }
 
@@ -1144,7 +1144,7 @@ export class ShadowGenerator implements IShadowGenerator {
             this._kernelBlurXPostprocess.autoClear = false;
             this._kernelBlurYPostprocess.autoClear = false;
 
-            if (this._textureType === Constants.TEXTURETYPE_UNSIGNED_INT) {
+            if (this._textureType === Constants.TEXTURETYPE_UNSIGNED_BYTE) {
                 (<BlurPostProcess>this._kernelBlurXPostprocess).packedFloat = true;
                 (<BlurPostProcess>this._kernelBlurYPostprocess).packedFloat = true;
             }
@@ -1492,7 +1492,7 @@ export class ShadowGenerator implements IShadowGenerator {
     private _prepareShadowDefines(subMesh: SubMesh, useInstances: boolean, defines: string[], isTransparent: boolean): string[] {
         defines.push("#define SM_LIGHTTYPE_" + this._light.getClassName().toUpperCase());
 
-        defines.push("#define SM_FLOAT " + (this._textureType !== Constants.TEXTURETYPE_UNSIGNED_INT ? "1" : "0"));
+        defines.push("#define SM_FLOAT " + (this._textureType !== Constants.TEXTURETYPE_UNSIGNED_BYTE ? "1" : "0"));
 
         defines.push("#define SM_ESM " + (this.useExponentialShadowMap || this.useBlurExponentialShadowMap ? "1" : "0"));
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1166,7 +1166,7 @@ export class NodeMaterial extends PushMaterial {
         samplingMode: number = Constants.TEXTURE_NEAREST_SAMPLINGMODE,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         textureFormat = Constants.TEXTUREFORMAT_RGBA
     ): Nullable<PostProcess> {
         if (this.mode !== NodeMaterialModes.PostProcess) {
@@ -1191,7 +1191,7 @@ export class NodeMaterial extends PushMaterial {
         samplingMode: number = Constants.TEXTURE_NEAREST_SAMPLINGMODE,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         textureFormat = Constants.TEXTUREFORMAT_RGBA
     ): PostProcess {
         let tempName = this.name + this._buildId;

--- a/packages/dev/core/src/Materials/Textures/MultiviewRenderTarget.ts
+++ b/packages/dev/core/src/Materials/Textures/MultiviewRenderTarget.ts
@@ -24,7 +24,7 @@ export class MultiviewRenderTarget extends RenderTargetTexture {
      * @param size the size of the render target (used for each view)
      */
     constructor(scene?: Scene, size: number | { width: number; height: number } | { ratio: number } = 512) {
-        super("multiview rtt", size, scene, false, true, Constants.TEXTURETYPE_UNSIGNED_INT, false, undefined, false, false, true, undefined, true);
+        super("multiview rtt", size, scene, false, true, Constants.TEXTURETYPE_UNSIGNED_BYTE, false, undefined, false, false, true, undefined, true);
         this._renderTarget = (this.getScene()!.getEngine() as Engine).createMultiviewRenderTargetTexture(this.getRenderWidth(), this.getRenderHeight());
         this._texture = this._renderTarget.texture!;
         this._texture.isMultiview = true;

--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
@@ -166,7 +166,7 @@ export class ProceduralTexture extends Texture {
         fallbackTexture: Nullable<Texture> | IProceduralTextureCreationOptions = null,
         generateMipMaps = true,
         isCube = false,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ) {
         super(null, scene, !generateMipMaps);
 

--- a/packages/dev/core/src/Materials/Textures/baseTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/baseTexture.ts
@@ -676,10 +676,10 @@ export class BaseTexture extends ThinTexture implements IAnimatable {
      */
     public get textureType(): number {
         if (!this._texture) {
-            return Constants.TEXTURETYPE_UNSIGNED_INT;
+            return Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
 
-        return this._texture.type !== undefined ? this._texture.type : Constants.TEXTURETYPE_UNSIGNED_INT;
+        return this._texture.type !== undefined ? this._texture.type : Constants.TEXTURETYPE_UNSIGNED_BYTE;
     }
 
     /**

--- a/packages/dev/core/src/Materials/Textures/colorGradingTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/colorGradingTexture.ts
@@ -100,7 +100,7 @@ export class ColorGradingTexture extends BaseTexture {
                 false,
                 Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
                 null,
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
         } else {
             texture = engine.createRawTexture3D(
@@ -113,7 +113,7 @@ export class ColorGradingTexture extends BaseTexture {
                 false,
                 Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
                 null,
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
         }
 

--- a/packages/dev/core/src/Materials/Textures/mirrorTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/mirrorTexture.ts
@@ -159,7 +159,7 @@ export class MirrorTexture extends RenderTargetTexture {
         size: number | { width: number; height: number } | { ratio: number },
         scene?: Scene,
         generateMipMaps?: boolean,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         samplingMode = Texture.BILINEAR_SAMPLINGMODE,
         generateDepthBuffer = true
     ) {

--- a/packages/dev/core/src/Materials/Textures/multiRenderTarget.ts
+++ b/packages/dev/core/src/Materials/Textures/multiRenderTarget.ts
@@ -263,7 +263,7 @@ export class MultiRenderTarget extends RenderTargetTexture {
             if (options && options.types && options.types[i] !== undefined) {
                 types.push(options.types[i]);
             } else {
-                types.push(options && options.defaultType ? options.defaultType : Constants.TEXTURETYPE_UNSIGNED_INT);
+                types.push(options && options.defaultType ? options.defaultType : Constants.TEXTURETYPE_UNSIGNED_BYTE);
             }
 
             if (options && options.samplingModes && options.samplingModes[i] !== undefined) {

--- a/packages/dev/core/src/Materials/Textures/rawCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/rawCubeTexture.ts
@@ -17,7 +17,7 @@ export class RawCubeTexture extends CubeTexture {
      * @param data defines the array of data to use to create each face
      * @param size defines the size of the textures
      * @param format defines the format of the data
-     * @param type defines the type of the data (like Engine.TEXTURETYPE_UNSIGNED_INT)
+     * @param type defines the type of the data (like Engine.TEXTURETYPE_UNSIGNED_BYTE)
      * @param generateMipMaps  defines if the engine should generate the mip levels
      * @param invertY defines if data must be stored with Y axis inverted
      * @param samplingMode defines the required sampling mode (like Texture.NEAREST_SAMPLINGMODE)
@@ -28,7 +28,7 @@ export class RawCubeTexture extends CubeTexture {
         data: Nullable<ArrayBufferView[]>,
         size: number,
         format: number = Constants.TEXTUREFORMAT_RGBA,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         generateMipMaps: boolean = false,
         invertY: boolean = false,
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
@@ -43,7 +43,7 @@ export class RawCubeTexture extends CubeTexture {
      * Updates the raw cube texture.
      * @param data defines the data to store
      * @param format defines the data format
-     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_INT by default)
+     * @param type defines the type fo the data (Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
      * @param invertY defines if data must be stored with Y axis inverted
      * @param compression defines the compression used (null by default)
      */

--- a/packages/dev/core/src/Materials/Textures/rawTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/rawTexture.ts
@@ -40,7 +40,7 @@ export class RawTexture extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags?: number,
         useSRGBBuffer?: boolean
     ) {
@@ -191,7 +191,7 @@ export class RawTexture extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags: number = 0,
         useSRGBBuffer: boolean = false
     ): RawTexture {
@@ -220,7 +220,7 @@ export class RawTexture extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags: number = 0,
         useSRGBBuffer: boolean = false
     ): RawTexture {
@@ -248,7 +248,7 @@ export class RawTexture extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         useSRGBBuffer: boolean = false
     ): RawTexture {
         return new RawTexture(

--- a/packages/dev/core/src/Materials/Textures/rawTexture2DArray.ts
+++ b/packages/dev/core/src/Materials/Textures/rawTexture2DArray.ts
@@ -28,7 +28,7 @@ export class RawTexture2DArray extends Texture {
      * @param generateMipMaps defines a boolean indicating if mip levels should be generated (true by default)
      * @param invertY defines if texture must be stored with Y axis inverted
      * @param samplingMode defines the sampling mode to use (Texture.TRILINEAR_SAMPLINGMODE by default)
-     * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT...)
+     * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT...)
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
      */
     constructor(
@@ -42,7 +42,7 @@ export class RawTexture2DArray extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags?: number
     ) {
         super(null, scene, !generateMipMaps, invertY);
@@ -86,7 +86,7 @@ export class RawTexture2DArray extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ): RawTexture2DArray {
         return new RawTexture2DArray(data, width, height, depth, Constants.TEXTUREFORMAT_RGBA, scene, generateMipMaps, invertY, samplingMode, type);
     }

--- a/packages/dev/core/src/Materials/Textures/rawTexture3D.ts
+++ b/packages/dev/core/src/Materials/Textures/rawTexture3D.ts
@@ -38,7 +38,7 @@ export class RawTexture3D extends Texture {
      * @param generateMipMaps defines a boolean indicating if mip levels should be generated (true by default)
      * @param invertY defines if texture must be stored with Y axis inverted
      * @param samplingMode defines the sampling mode to use (Texture.TRILINEAR_SAMPLINGMODE by default)
-     * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT...)
+     * @param textureType defines the texture Type (Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT...)
      * @param creationFlags specific flags to use when creating the texture (Constants.TEXTURE_CREATIONFLAG_STORAGE for storage textures, for eg)
      */
     constructor(
@@ -52,7 +52,7 @@ export class RawTexture3D extends Texture {
         generateMipMaps: boolean = true,
         invertY: boolean = false,
         samplingMode: number = Texture.TRILINEAR_SAMPLINGMODE,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         creationFlags?: number
     ) {
         super(null, scene, !generateMipMaps, invertY);

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -550,7 +550,7 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
         scene?: Nullable<Scene>,
         generateMipMaps: boolean | RenderTargetTextureOptions = false,
         doNotChangeAspectRatio: boolean = true,
-        type: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        type: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         isCube = false,
         samplingMode = Texture.TRILINEAR_SAMPLINGMODE,
         generateDepthBuffer = true,

--- a/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
@@ -76,7 +76,7 @@ export class CubeMapToSphericalPolynomialTools {
         const gammaSpace = texture.gammaSpace;
         // Always read as RGBA.
         const format = Constants.TEXTUREFORMAT_RGBA;
-        let type = Constants.TEXTURETYPE_UNSIGNED_INT;
+        let type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         if (texture.textureType == Constants.TEXTURETYPE_FLOAT || texture.textureType == Constants.TEXTURETYPE_HALF_FLOAT) {
             type = Constants.TEXTURETYPE_FLOAT;
         }
@@ -171,7 +171,7 @@ export class CubeMapToSphericalPolynomialTools {
                     }
 
                     // Handle Integer types.
-                    if (cubeInfo.type === Constants.TEXTURETYPE_UNSIGNED_INT) {
+                    if (cubeInfo.type === Constants.TEXTURETYPE_UNSIGNED_BYTE) {
                         r /= 255;
                         g /= 255;
                         b /= 255;

--- a/packages/dev/core/src/Misc/dds.ts
+++ b/packages/dev/core/src/Misc/dds.ts
@@ -135,7 +135,7 @@ export interface DDSInfo {
      */
     dxgiFormat: number;
     /**
-     * Texture type eg. Engine.TEXTURETYPE_UNSIGNED_INT, Engine.TEXTURETYPE_FLOAT
+     * Texture type eg. Engine.TEXTURETYPE_UNSIGNED_BYTE, Engine.TEXTURETYPE_FLOAT
      */
     textureType: number;
     /**
@@ -169,7 +169,7 @@ export class DDSTools {
 
         const fourCC = header[off_pfFourCC];
         const dxgiFormat = fourCC === FOURCC_DX10 ? extendedHeader[off_dxgiFormat] : 0;
-        let textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+        let textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
 
         switch (fourCC) {
             case FOURCC_D3DFMT_R16G16B16A16F:
@@ -570,7 +570,7 @@ export class DDSTools {
                                 }
                             }
 
-                            texture.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+                            texture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
                         } else {
                             const floatAvailable = caps.textureFloat && ((destTypeMustBeFilterable && caps.textureFloatLinearFiltering) || !destTypeMustBeFilterable);
                             const halfFloatAvailable = caps.textureHalfFloat && ((destTypeMustBeFilterable && caps.textureHalfFloatLinearFiltering) || !destTypeMustBeFilterable);
@@ -640,7 +640,7 @@ export class DDSTools {
                             engine._uploadDataToTextureDirectly(texture, floatArray, face, i);
                         }
                     } else if (info.isRGB) {
-                        texture.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+                        texture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
                         if (bpp === 24) {
                             texture.format = Constants.TEXTUREFORMAT_RGB;
                             dataLength = width * height * 3;
@@ -661,14 +661,14 @@ export class DDSTools {
 
                         byteArray = DDSTools._GetLuminanceArrayBuffer(width, height, data.byteOffset + dataOffset, dataLength, data.buffer);
                         texture.format = Constants.TEXTUREFORMAT_LUMINANCE;
-                        texture.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+                        texture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
 
                         engine._uploadDataToTextureDirectly(texture, byteArray, face, i);
                     } else {
                         dataLength = (((Math.max(4, width) / 4) * Math.max(4, height)) / 4) * blockBytes;
                         byteArray = new Uint8Array(data.buffer, data.byteOffset + dataOffset, dataLength);
 
-                        texture.type = Constants.TEXTURETYPE_UNSIGNED_INT;
+                        texture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
                         engine._uploadCompressedDataToTextureDirectly(texture, internalCompressedFormat, width, height, byteArray, face, i);
                     }
                 }

--- a/packages/dev/core/src/Misc/environmentTextureTools.ts
+++ b/packages/dev/core/src/Misc/environmentTextureTools.ts
@@ -231,7 +231,7 @@ export async function CreateEnvTextureAsync(texture: BaseTexture, options: Creat
         texture.textureType !== Constants.TEXTURETYPE_HALF_FLOAT &&
         texture.textureType !== Constants.TEXTURETYPE_FLOAT &&
         texture.textureType !== Constants.TEXTURETYPE_UNSIGNED_BYTE &&
-        texture.textureType !== Constants.TEXTURETYPE_UNSIGNED_INT &&
+        texture.textureType !== Constants.TEXTURETYPE_UNSIGNED_BYTE &&
         texture.textureType !== Constants.TEXTURETYPE_UNSIGNED_INTEGER &&
         texture.textureType !== -1
     ) {

--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -240,7 +240,7 @@ export function CreateScreenshotUsingRenderTarget(
         scene,
         false,
         false,
-        Constants.TEXTURETYPE_UNSIGNED_INT,
+        Constants.TEXTURETYPE_UNSIGNED_BYTE,
         false,
         Texture.BILINEAR_SAMPLINGMODE,
         undefined,

--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -58,7 +58,7 @@ export function CreateResizedCopy(texture: Texture, width: number, height: numbe
         useBilinearMode ? Texture.BILINEAR_SAMPLINGMODE : Texture.NEAREST_SAMPLINGMODE,
         engine,
         false,
-        Constants.TEXTURETYPE_UNSIGNED_INT
+        Constants.TEXTURETYPE_UNSIGNED_BYTE
     );
     passPostProcess.externalTextureSamplerBinding = true;
     passPostProcess.onEffectCreatedObservable.addOnce((e) => {

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline.ts
@@ -449,7 +449,7 @@ export class DefaultRenderingPipeline extends PostProcessRenderPipeline implemen
                 this._defaultPipelineTextureType = Constants.TEXTURETYPE_FLOAT;
             }
         } else {
-            this._defaultPipelineTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+            this._defaultPipelineTextureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
 
         // Attach

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -271,9 +271,9 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
      * @param ratio The size of the postprocesses. Can be a number shared between passes or an object for more precision: { ssaoRatio: 0.5, blurRatio: 1.0 }
      * @param cameras The array of cameras that the rendering pipeline will be attached to
      * @param forceGeometryBuffer Set to true if you want to use the legacy geometry buffer renderer
-     * @param textureType The texture type used by the different post processes created by SSAO (default: Constants.TEXTURETYPE_UNSIGNED_INT)
+     * @param textureType The texture type used by the different post processes created by SSAO (default: Constants.TEXTURETYPE_UNSIGNED_BYTE)
      */
-    constructor(name: string, scene: Scene, ratio: any, cameras?: Camera[], forceGeometryBuffer = false, textureType = Constants.TEXTURETYPE_UNSIGNED_INT) {
+    constructor(name: string, scene: Scene, ratio: any, cameras?: Camera[], forceGeometryBuffer = false, textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE) {
         super(scene.getEngine(), name);
 
         this._scene = scene;

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssaoRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssaoRenderingPipeline.ts
@@ -247,7 +247,7 @@ export class SSAORenderingPipeline extends PostProcessRenderPipeline {
             Texture.BILINEAR_SAMPLINGMODE,
             this._scene.getEngine(),
             false,
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
         this._blurVPostProcess = new BlurPostProcess(
             "BlurV",
@@ -258,7 +258,7 @@ export class SSAORenderingPipeline extends PostProcessRenderPipeline {
             Texture.BILINEAR_SAMPLINGMODE,
             this._scene.getEngine(),
             false,
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
 
         this._blurHPostProcess.onActivateObservable.add(() => {

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/standardRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/standardRenderingPipeline.ts
@@ -681,7 +681,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
                 scene.getEngine(),
                 false,
                 "#define PASS_POST_PROCESS",
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
             this.addEffect(
                 new PostProcessRenderEffect(
@@ -711,7 +711,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
                 scene.getEngine(),
                 false,
                 "#define PASS_POST_PROCESS",
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
             this.addEffect(
                 new PostProcessRenderEffect(
@@ -741,7 +741,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
                 scene.getEngine(),
                 false,
                 "#define PASS_POST_PROCESS",
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
             this.addEffect(
                 new PostProcessRenderEffect(
@@ -774,7 +774,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
                 scene.getEngine(),
                 false,
                 "#define PASS_POST_PROCESS",
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
             this.addEffect(
                 new PostProcessRenderEffect(
@@ -803,7 +803,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
 
         if (this._fxaaEnabled) {
             // Create fxaa post-process
-            this.fxaaPostProcess = new FxaaPostProcess("fxaa", 1.0, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            this.fxaaPostProcess = new FxaaPostProcess("fxaa", 1.0, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
             this.addEffect(
                 new PostProcessRenderEffect(
                     scene.getEngine(),
@@ -1250,7 +1250,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
             scene.getEngine(),
             false,
             defines.join("\n"),
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
 
         let outputLiminance = 1;
@@ -1313,7 +1313,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
             scene.getEngine(),
             false,
             "#define LENS_FLARE",
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
         this.addEffect(
             new PostProcessRenderEffect(
@@ -1339,7 +1339,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
             scene.getEngine(),
             false,
             "#define LENS_FLARE_COMPOSE",
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
         this.addEffect(
             new PostProcessRenderEffect(
@@ -1431,7 +1431,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
             scene.getEngine(),
             false,
             "#define DEPTH_OF_FIELD",
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
         this.depthOfFieldPostProcess.onApply = (effect: Effect) => {
             effect.setTextureFromPostProcess("otherSampler", this._currentDepthOfFieldSource);
@@ -1456,7 +1456,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
     // Create motion blur post-process
     private _createMotionBlurPostProcess(scene: Scene, ratio: number): void {
         if (this._isObjectBasedMotionBlur) {
-            const mb = new MotionBlurPostProcess("HDRMotionBlur", scene, ratio, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            const mb = new MotionBlurPostProcess("HDRMotionBlur", scene, ratio, null, Texture.BILINEAR_SAMPLINGMODE, scene.getEngine(), false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
             mb.motionStrength = this.motionStrength;
             mb.motionBlurSamples = this.motionBlurSamples;
             this.motionBlurPostProcess = mb;
@@ -1472,7 +1472,7 @@ export class StandardRenderingPipeline extends PostProcessRenderPipeline impleme
                 scene.getEngine(),
                 false,
                 "#define MOTION_BLUR\n#define MAX_MOTION_SAMPLES " + this.motionBlurSamples.toFixed(1),
-                Constants.TEXTURETYPE_UNSIGNED_INT
+                Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
 
             let motionScale: number = 0;

--- a/packages/dev/core/src/PostProcesses/bloomMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/bloomMergePostProcess.ts
@@ -58,7 +58,7 @@ export class BloomMergePostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         const blockCompilationFinal = typeof options === "number" ? blockCompilation : !!options.blockCompilation;

--- a/packages/dev/core/src/PostProcesses/blurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/blurPostProcess.ts
@@ -93,7 +93,7 @@ export class BlurPostProcess extends PostProcess {
         samplingMode: number = Texture.BILINEAR_SAMPLINGMODE,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         defines = "",
         blockCompilation = false,
         textureFormat = Constants.TEXTUREFORMAT_RGBA

--- a/packages/dev/core/src/PostProcesses/chromaticAberrationPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/chromaticAberrationPostProcess.ts
@@ -79,7 +79,7 @@ export class ChromaticAberrationPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         super(

--- a/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/circleOfConfusionPostProcess.ts
@@ -98,7 +98,7 @@ export class CircleOfConfusionPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         const localOptions = {

--- a/packages/dev/core/src/PostProcesses/convolutionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/convolutionPostProcess.ts
@@ -49,7 +49,7 @@ export class ConvolutionPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ) {
         super(name, "convolution", ["kernel", "screenSize"], null, options, camera, samplingMode, engine, reusable, null, textureType);
         this.kernel = kernel;

--- a/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldBlurPostProcess.ts
@@ -54,7 +54,7 @@ export class DepthOfFieldBlurPostProcess extends BlurPostProcess {
         samplingMode = Texture.BILINEAR_SAMPLINGMODE,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false,
         textureFormat = Constants.TEXTUREFORMAT_RGBA
     ) {

--- a/packages/dev/core/src/PostProcesses/depthOfFieldMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/depthOfFieldMergePostProcess.ts
@@ -44,7 +44,7 @@ export class DepthOfFieldMergePostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         const blockCompilationFinal = typeof options === "number" ? blockCompilation : !!options.blockCompilation;

--- a/packages/dev/core/src/PostProcesses/extractHighlightsPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/extractHighlightsPostProcess.ts
@@ -59,7 +59,7 @@ export class ExtractHighlightsPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         const localOptions = {

--- a/packages/dev/core/src/PostProcesses/fxaaPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/fxaaPostProcess.ts
@@ -31,7 +31,7 @@ export class FxaaPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ) {
         super(name, "fxaa", ["texelSize"], null, options, camera, samplingMode || Texture.BILINEAR_SAMPLINGMODE, engine, reusable, null, textureType, "fxaa", undefined, true);
 

--- a/packages/dev/core/src/PostProcesses/grainPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/grainPostProcess.ts
@@ -53,7 +53,7 @@ export class GrainPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         super(name, "grain", ["intensity", "animatedSeed"], [], options, camera, samplingMode, engine, reusable, null, textureType, undefined, null, blockCompilation);

--- a/packages/dev/core/src/PostProcesses/highlightsPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/highlightsPostProcess.ts
@@ -27,7 +27,7 @@ export class HighlightsPostProcess extends PostProcess {
      * @param samplingMode The sampling mode to be used when computing the pass. (default: 0)
      * @param engine The engine which the post process will be applied. (default: current engine)
      * @param reusable If the post process can be reused on the same frame. (default: false)
-     * @param textureType Type of texture for the post process (default: Engine.TEXTURETYPE_UNSIGNED_INT)
+     * @param textureType Type of texture for the post process (default: Engine.TEXTURETYPE_UNSIGNED_BYTE)
      */
     constructor(
         name: string,
@@ -36,7 +36,7 @@ export class HighlightsPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ) {
         super(name, "highlights", null, null, options, camera, samplingMode, engine, reusable, null, textureType);
     }

--- a/packages/dev/core/src/PostProcesses/imageProcessingPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/imageProcessingPostProcess.ts
@@ -418,7 +418,7 @@ export class ImageProcessingPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         imageProcessingConfiguration?: ImageProcessingConfiguration
     ) {
         super(name, "imageProcessing", [], [], options, camera, samplingMode, engine, reusable, null, textureType, "postprocess", null, true);

--- a/packages/dev/core/src/PostProcesses/motionBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/motionBlurPostProcess.ts
@@ -128,7 +128,7 @@ export class MotionBlurPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false,
         forceGeometryBuffer = false
     ) {

--- a/packages/dev/core/src/PostProcesses/passPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/passPostProcess.ts
@@ -40,7 +40,7 @@ export class PassPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         super(name, "pass", null, null, options, camera, samplingMode, engine, reusable, undefined, textureType, undefined, null, blockCompilation);
@@ -154,7 +154,7 @@ export class PassCubePostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         super(name, "passCube", null, null, options, camera, samplingMode, engine, reusable, "#define POSITIVEX", textureType, undefined, null, blockCompilation);
@@ -194,5 +194,5 @@ export class PassCubePostProcess extends PostProcess {
 }
 
 AbstractEngine._RescalePostProcessFactory = (engine: AbstractEngine) => {
-    return new PassPostProcess("rescale", 1, null, Constants.TEXTURE_BILINEAR_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+    return new PassPostProcess("rescale", 1, null, Constants.TEXTURE_BILINEAR_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
 };

--- a/packages/dev/core/src/PostProcesses/postProcess.ts
+++ b/packages/dev/core/src/PostProcesses/postProcess.ts
@@ -143,7 +143,7 @@ export type PostProcessOptions = EffectWrapperCreationOptions & {
      */
     reusable?: boolean;
     /**
-     * Type of the texture created for this post process (default: Constants.TEXTURETYPE_UNSIGNED_INT)
+     * Type of the texture created for this post process (default: Constants.TEXTURETYPE_UNSIGNED_BYTE)
      */
     textureType?: number;
     /**
@@ -602,7 +602,7 @@ export class PostProcess {
         engine?: AbstractEngine,
         reusable?: boolean,
         defines: Nullable<string> = null,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         vertexUrl: string = "postprocess",
         indexParameters?: any,
         blockCompilation = false,
@@ -623,7 +623,7 @@ export class PostProcess {
             engine = options.engine;
             reusable = options.reusable;
             defines = Array.isArray(options.defines) ? options.defines.join("\n") : (options.defines ?? null);
-            textureType = options.textureType ?? Constants.TEXTURETYPE_UNSIGNED_INT;
+            textureType = options.textureType ?? Constants.TEXTURETYPE_UNSIGNED_BYTE;
             vertexUrl = options.vertexUrl ?? "postprocess";
             indexParameters = options.indexParameters;
             blockCompilation = options.blockCompilation ?? false;

--- a/packages/dev/core/src/PostProcesses/screenSpaceCurvaturePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/screenSpaceCurvaturePostProcess.ts
@@ -63,7 +63,7 @@ export class ScreenSpaceCurvaturePostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         super(

--- a/packages/dev/core/src/PostProcesses/screenSpaceReflectionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/screenSpaceReflectionPostProcess.ts
@@ -100,7 +100,7 @@ export class ScreenSpaceReflectionPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false,
         forceGeometryBuffer = false
     ) {

--- a/packages/dev/core/src/PostProcesses/sharpenPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/sharpenPostProcess.ts
@@ -55,7 +55,7 @@ export class SharpenPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         blockCompilation = false
     ) {
         super(name, "sharpen", ["sharpnessAmounts", "screenSize"], null, options, camera, samplingMode, engine, reusable, null, textureType, undefined, null, blockCompilation);

--- a/packages/dev/core/src/PostProcesses/subSurfaceScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/subSurfaceScatteringPostProcess.ts
@@ -33,7 +33,7 @@ export class SubSurfaceScatteringPostProcess extends PostProcess {
         samplingMode?: number,
         engine?: AbstractEngine,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ) {
         super(
             name,

--- a/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/tonemapPostProcess.ts
@@ -39,7 +39,7 @@ export class TonemapPostProcess extends PostProcess {
      * @param camera defines the camera to use (can be null)
      * @param samplingMode defines the required sampling mode (BABYLON.Texture.BILINEAR_SAMPLINGMODE by default)
      * @param engine defines the hosting engine (can be ignore if camera is set)
-     * @param textureFormat defines the texture format to use (BABYLON.Engine.TEXTURETYPE_UNSIGNED_INT by default)
+     * @param textureFormat defines the texture format to use (BABYLON.Engine.TEXTURETYPE_UNSIGNED_BYTE by default)
      * @param reusable If the post process can be reused on the same frame. (default: false)
      */
     constructor(
@@ -50,7 +50,7 @@ export class TonemapPostProcess extends PostProcess {
         camera: Nullable<Camera>,
         samplingMode: number = Constants.TEXTURE_BILINEAR_SAMPLINGMODE,
         engine?: AbstractEngine,
-        textureFormat = Constants.TEXTURETYPE_UNSIGNED_INT,
+        textureFormat = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         reusable?: boolean
     ) {
         super(name, "tonemap", ["_ExposureAdjustment"], null, 1.0, camera, samplingMode, engine, reusable, null, textureFormat);

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -389,7 +389,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
             scene,
             false,
             true,
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
         this._volumetricLightScatteringRTT.wrapU = Texture.CLAMP_ADDRESSMODE;
         this._volumetricLightScatteringRTT.wrapV = Texture.CLAMP_ADDRESSMODE;

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsImportanceSamplingRenderer.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsImportanceSamplingRenderer.ts
@@ -238,7 +238,7 @@ export class _IblShadowsImportanceSamplingRenderer {
             height: this._scene.getEngine().getRenderHeight(),
             samplingMode: Texture.BILINEAR_SAMPLINGMODE,
             engine: this._engine,
-            textureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            textureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             uniforms: ["sizeParams"],
             samplers: ["cdfy", "icdfy", "cdfx", "icdfx", "iblSource"],
             defines: this._iblSource?.isCube ? "#define IBL_USE_CUBE_MAP\n" : "",

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -853,7 +853,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             height: this.scene.getEngine().getRenderHeight(),
             samplingMode: Constants.TEXTURE_NEAREST_SAMPLINGMODE,
             engine: this.scene.getEngine(),
-            textureType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            textureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             textureFormat: Constants.TEXTUREFORMAT_RGBA,
             uniforms: ["sizeParams"],
             samplers: textureNames,

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
@@ -153,7 +153,7 @@ export class _IblShadowsSpatialBlurPass {
             textureOptions,
             false,
             false,
-            Constants.TEXTURETYPE_UNSIGNED_INT
+            Constants.TEXTURETYPE_UNSIGNED_BYTE
         );
         this._outputTexture.refreshRate = -1;
         this._outputTexture.autoClear = false;

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -136,13 +136,13 @@ export class PrePassRenderer {
         },
         {
             purpose: Constants.PREPASS_VELOCITY_TEXTURE_TYPE,
-            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             format: Constants.TEXTUREFORMAT_RGBA,
             name: "prePass_Velocity",
         },
         {
             purpose: Constants.PREPASS_REFLECTIVITY_TEXTURE_TYPE,
-            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             format: Constants.TEXTUREFORMAT_RGBA,
             name: "prePass_Reflectivity",
         },
@@ -166,13 +166,13 @@ export class PrePassRenderer {
         },
         {
             purpose: Constants.PREPASS_ALBEDO_SQRT_TEXTURE_TYPE,
-            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             format: Constants.TEXTUREFORMAT_RGBA,
             name: "prePass_Albedo",
         },
         {
             purpose: Constants.PREPASS_WORLD_NORMAL_TEXTURE_TYPE,
-            type: Constants.TEXTURETYPE_UNSIGNED_INT,
+            type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             format: Constants.TEXTUREFORMAT_RGBA,
             name: "prePass_WorldNormal",
         },
@@ -342,7 +342,7 @@ export class PrePassRenderer {
         const rt = new PrePassRenderTarget(name, renderTargetTexture, { width: this._engine.getRenderWidth(), height: this._engine.getRenderHeight() }, 0, this._scene, {
             generateMipMaps: false,
             generateStencilBuffer: this._engine.isStencilEnable,
-            defaultType: Constants.TEXTURETYPE_UNSIGNED_INT,
+            defaultType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
             types: [],
             drawOnlyOnFirstAttachmentByDefault: true,
         });

--- a/packages/dev/postProcesses/src/edgeDetection/edgeDetectionPostProcess.ts
+++ b/packages/dev/postProcesses/src/edgeDetection/edgeDetectionPostProcess.ts
@@ -78,7 +78,7 @@ export class EdgeDetectionPostProcess extends PostProcess {
         camera: Nullable<Camera>,
         samplingMode?: number,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSTEXTURETYPE_UNSIGNED_BYTEIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE
     ) {
         super(
             name,

--- a/packages/dev/postProcesses/src/edgeDetection/edgeDetectionPostProcess.ts
+++ b/packages/dev/postProcesses/src/edgeDetection/edgeDetectionPostProcess.ts
@@ -78,7 +78,7 @@ export class EdgeDetectionPostProcess extends PostProcess {
         camera: Nullable<Camera>,
         samplingMode?: number,
         reusable?: boolean,
-        textureType: number = Constants.TEXTURETYPE_UNSIGNED_INT
+        textureType: number = Constants.TEXTURETYPE_UNSTEXTURETYPE_UNSIGNED_BYTEIGNED_INT
     ) {
         super(
             name,

--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -430,7 +430,7 @@ export class _GLTFMaterialExporter {
      * @returns base64 image string
      */
     private async _getImageDataAsync(buffer: Uint8Array | Float32Array, width: number, height: number, mimeType: ImageMimeType): Promise<ArrayBuffer> {
-        const textureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+        const textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
 
         const hostingScene = this._exporter._babylonScene;
         const engine = hostingScene.getEngine();
@@ -1057,7 +1057,7 @@ export class _GLTFMaterialExporter {
 
     private _getPixelsFromTexture(babylonTexture: BaseTexture): Promise<Nullable<Uint8Array | Float32Array>> {
         const pixels =
-            babylonTexture.textureType === Constants.TEXTURETYPE_UNSIGNED_INT
+            babylonTexture.textureType === Constants.TEXTURETYPE_UNSIGNED_BYTE
                 ? (babylonTexture.readPixels() as Promise<Uint8Array>)
                 : (babylonTexture.readPixels() as Promise<Float32Array>);
         return pixels;

--- a/packages/tools/nodeEditor/src/sharedComponents/textureLineComponent.tsx
+++ b/packages/tools/nodeEditor/src/sharedComponents/textureLineComponent.tsx
@@ -78,9 +78,9 @@ export class TextureLineComponent extends React.Component<ITextureLineComponentP
         let passPostProcess: PostProcess;
 
         if (!texture.isCube) {
-            passPostProcess = new PassPostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            passPostProcess = new PassPostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
         } else {
-            const passCubePostProcess = new PassCubePostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            const passCubePostProcess = new PassCubePostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
             passCubePostProcess.face = options.face;
 
             passPostProcess = passCubePostProcess;

--- a/packages/tools/nodeGeometryEditor/src/sharedComponents/textureLineComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/sharedComponents/textureLineComponent.tsx
@@ -78,9 +78,9 @@ export class TextureLineComponent extends React.Component<ITextureLineComponentP
         let passPostProcess: PostProcess;
 
         if (!texture.isCube) {
-            passPostProcess = new PassPostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            passPostProcess = new PassPostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
         } else {
-            const passCubePostProcess = new PassCubePostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            const passCubePostProcess = new PassCubePostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
             passCubePostProcess.face = options.face;
 
             passPostProcess = passCubePostProcess;

--- a/packages/tools/nodeRenderGraphEditor/src/sharedComponents/textureLineComponent.tsx
+++ b/packages/tools/nodeRenderGraphEditor/src/sharedComponents/textureLineComponent.tsx
@@ -78,9 +78,9 @@ export class TextureLineComponent extends React.Component<ITextureLineComponentP
         let passPostProcess: PostProcess;
 
         if (!texture.isCube) {
-            passPostProcess = new PassPostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            passPostProcess = new PassPostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
         } else {
-            const passCubePostProcess = new PassCubePostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_INT);
+            const passCubePostProcess = new PassCubePostProcess("pass", 1, null, Texture.NEAREST_SAMPLINGMODE, engine, false, Constants.TEXTURETYPE_UNSIGNED_BYTE);
             passCubePostProcess.face = options.face;
 
             passPostProcess = passCubePostProcess;

--- a/packages/tools/viewer/src/managers/sceneManager.ts
+++ b/packages/tools/viewer/src/managers/sceneManager.ts
@@ -1470,11 +1470,11 @@ export class SceneManager {
             this._defaultHighpTextureType = Constants.TEXTURETYPE_FLOAT;
             this._shadowGeneratorBias = 0.001;
         } else {
-            this._defaultHighpTextureType = Constants.TEXTURETYPE_UNSIGNED_INT;
+            this._defaultHighpTextureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
             this._shadowGeneratorBias = 0.001;
         }
 
-        this._defaultPipelineTextureType = this._hdrSupport ? this._defaultHighpTextureType : Constants.TEXTURETYPE_UNSIGNED_INT;
+        this._defaultPipelineTextureType = this._hdrSupport ? this._defaultHighpTextureType : Constants.TEXTURETYPE_UNSIGNED_BYTE;
     }
 
     /**


### PR DESCRIPTION
TEXTURETYPE_UNSIGNED_INT is 8bits/component
TEXTURETYPE_UNSIGNED_INTEGER is 32bits/component
TEXTURETYPE_INT is 32bits/component
To avoid confusion, this PR use more explicit TEXTURETYPE_UNSIGNED_BYTE instead of TEXTURETYPE_UNSIGNED_INT and deprecates its definition.
