### PR TITLE
Instanced BoundingBoxRenderer

### DIFF
--- a/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
+++ b/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
@@ -1,13 +1,13 @@
 import { Scene } from "../scene";
-import { VertexBuffer } from "../Buffers/buffer";
+import { Buffer, VertexBuffer } from "../Buffers/buffer";
 import type { SubMesh } from "../Meshes/subMesh";
 import { AbstractMesh } from "../Meshes/abstractMesh";
-import { Matrix } from "../Maths/math.vector";
+import { Matrix, Vector3 } from "../Maths/math.vector";
 import { SmartArray } from "../Misc/smartArray";
 import type { Nullable, FloatArray, IndicesArray } from "../types";
 import type { ISceneComponent } from "../sceneComponent";
 import { SceneComponentConstants } from "../sceneComponent";
-import type { BoundingBox } from "../Culling/boundingBox";
+import { BoundingBox } from "../Culling/boundingBox";
 import type { Effect } from "../Materials/effect";
 import { Material } from "../Materials/material";
 import { ShaderMaterial } from "../Materials/shaderMaterial";
@@ -18,6 +18,7 @@ import { DrawWrapper } from "../Materials/drawWrapper";
 import { UniformBuffer } from "../Materials/uniformBuffer";
 import { CreateBoxVertexData } from "../Meshes/Builders/boxBuilder";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
+import { Constants } from "../Engines/constants";
 
 declare module "../scene" {
     export interface Scene {
@@ -90,6 +91,13 @@ Object.defineProperty(AbstractMesh.prototype, "showBoundingBox", {
     configurable: true,
 });
 
+const mat1 = Matrix.Identity();
+const vec = new Vector3(),
+    vec2 = new Vector3();
+
+// BoundingBox copies from it, so it's safe to reuse vectors here
+const dummyBoundingBox = new BoundingBox(vec, vec);
+
 /**
  * Component responsible of rendering the bounding box of the meshes in a scene.
  * This is usually used through the mesh.showBoundingBox or the scene.forceShowBoundingBoxes properties
@@ -120,11 +128,19 @@ export class BoundingBoxRenderer implements ISceneComponent {
 
     /**
      * Observable raised before rendering a bounding box
+     * When {@link BoundingBoxRenderer.useInstances} enabled,
+     * this would only be triggered once for one rendering, instead of once every bounding box.
+     * Events would be triggered with a dummy box to keep backwards compatibility,
+     * the passed bounding box has no meaning and should be ignored.
      */
     public onBeforeBoxRenderingObservable = new Observable<BoundingBox>();
 
     /**
      * Observable raised after rendering a bounding box
+     * When {@link BoundingBoxRenderer.useInstances} enabled,
+     * this would only be triggered once for one rendering, instead of once every bounding box.
+     * Events would be triggered with a dummy box to keep backwards compatibility,
+     * the passed bounding box has no meaning and should be ignored.
      */
     public onAfterBoxRenderingObservable = new Observable<BoundingBox>();
 
@@ -162,6 +178,29 @@ export class BoundingBoxRenderer implements ISceneComponent {
     private _uniformBufferFront: UniformBuffer;
     private _uniformBufferBack: UniformBuffer;
     private _renderPassIdForOcclusionQuery: number;
+    /**
+     * Internal buffer for instanced rendering
+     * @internal
+     */
+    private _matrixBuffer: Nullable<Buffer> = null;
+    private _matrices: Nullable<Float32Array> = null;
+
+    /**
+     * Internal state of whether instanced rendering enabled
+     * @internal
+     */
+    protected _useInstances = false;
+    /**
+     * Choose whether dynamic vertex buffer should be used for instanced rendering.
+     * If true, the buffer would be updated instead of recreated when rendering a frame,
+     * this could reduce memory pressure.
+     */
+    public updatable = true;
+
+    /** @internal */
+    public _drawWrapperFront: Nullable<DrawWrapper> = null;
+    /** @internal */
+    public _drawWrapperBack: Nullable<DrawWrapper> = null;
 
     /**
      * Instantiates a new bounding box renderer in a scene.
@@ -231,7 +270,8 @@ export class BoundingBoxRenderer implements ISceneComponent {
             this.scene,
             "boundingBoxRenderer",
             {
-                attributes: [VertexBuffer.PositionKind],
+                attributes: [VertexBuffer.PositionKind, "world0", "world1", "world2", "world3"],
+
                 uniforms: ["world", "viewProjection", "viewProjectionR", "color"],
                 uniformBuffers: ["BoundingBoxRenderer"],
                 shaderLanguage: this._shaderLanguage,
@@ -299,6 +339,10 @@ export class BoundingBoxRenderer implements ISceneComponent {
             vb._rebuild();
         }
         this._createIndexBuffer();
+
+        if (this._matrixBuffer) {
+            this._matrixBuffer._rebuild();
+        }
     }
 
     /**
@@ -314,6 +358,11 @@ export class BoundingBoxRenderer implements ISceneComponent {
      */
     public render(renderingGroupId: number): void {
         if (this.renderList.length === 0 || !this.enabled) {
+            return;
+        }
+
+        if (this._useInstances) {
+            this._renderInstanced(renderingGroupId);
             return;
         }
 
@@ -399,7 +448,7 @@ export class BoundingBoxRenderer implements ISceneComponent {
         engine.setDepthWrite(true);
     }
 
-    private _createWrappersForBoundingBox(boundingBox: BoundingBox): void {
+    private _createWrappersForBoundingBox(boundingBox: BoundingBox | BoundingBoxRenderer): void {
         if (!boundingBox._drawWrapperFront) {
             const engine = this.scene.getEngine();
 
@@ -484,6 +533,229 @@ export class BoundingBoxRenderer implements ISceneComponent {
     }
 
     /**
+     * Sets whether to use instanced rendering.
+     * When not enabled, BoundingBoxRenderer renders in a loop,
+     * calling engine.drawElementsType for each bounding box in renderList,
+     * making every bounding box 1 or 2 draw call.
+     * When enabled, it collects bounding boxes to render,
+     * and render all boxes in 1 or 2 draw call.
+     * This could make the rendering with many bounding boxes much faster than not enabled,
+     * but could result in a difference in rendering result if
+     * {@link BoundingBoxRenderer.showBackLines} enabled,
+     * because drawing the black/white part of each box one after the other
+     * can be different from drawing the black part of all boxes and then the white part.
+     * Also, when enabled, events of {@link BoundingBoxRenderer.onBeforeBoxRenderingObservable}
+     * and {@link BoundingBoxRenderer.onAfterBoxRenderingObservable} would only be triggered once
+     * for one rendering, instead of once every bounding box.
+     * Events would be triggered with a dummy box to keep backwards compatibility,
+     * the passed bounding box has no meaning and should be ignored.
+     * @param val whether to use instanced rendering
+     */
+    set useInstances(val: boolean) {
+        this._useInstances = val;
+        if (this._colorShader) {
+            this._colorShader.setDefine("INSTANCES", val);
+        }
+        if (!val) {
+            this._cleanupInstances();
+        }
+    }
+
+    get useInstances(): boolean {
+        return this._useInstances;
+    }
+
+    /**
+     * Instanced render the bounding boxes of a specific rendering group
+     * @internal
+     * @param renderingGroupId defines the rendering group to render
+     */
+    public _renderInstanced(renderingGroupId: number): void {
+        if (this.renderList.length === 0 || !this.enabled) {
+            return;
+        }
+        this._prepareResources();
+
+        if (!this._colorShader.isReady()) {
+            return;
+        }
+
+        const colorShader = this._colorShader;
+        let matrices = this._matrices;
+        const expectedLength = this.renderList.length * 16;
+        if (!matrices || matrices.length < expectedLength || matrices.length > expectedLength * 2) {
+            matrices = new Float32Array(expectedLength);
+            this._matrices = matrices;
+        }
+
+        this.onBeforeBoxRenderingObservable.notifyObservers(dummyBoundingBox);
+
+        let instancesCount = 0;
+
+        for (let boundingBoxIndex = 0; boundingBoxIndex < this.renderList.length; boundingBoxIndex++) {
+            // p = performance.now()
+            const boundingBox = this.renderList.data[boundingBoxIndex];
+            if (boundingBox._tag !== renderingGroupId) {
+                continue;
+            }
+
+            const min = boundingBox.minimum;
+            const max = boundingBox.maximum;
+
+            const diff = max.subtractToRef(min, vec2);
+            const median = min.addToRef(diff.scaleToRef(0.5, vec), vec);
+
+            const m = (mat1 as any)._m;
+
+            // Directly update the matrix values in column-major order
+            m[0] = diff._x; // Scale X
+            m[3] = median._x; // Translate X
+
+            m[5] = diff._y; // Scale Y
+            m[7] = median._y; // Translate Y
+
+            m[10] = diff._z; // Scale Z
+            m[11] = median._z; // Translate Z
+            mat1.multiplyToArray(boundingBox.getWorldMatrix(), matrices, instancesCount * 16);
+
+            instancesCount++;
+        }
+
+        const engine = this.scene.getEngine();
+        // keeps the original depth function and depth write
+        const depthFunction = engine.getDepthFunction() ?? Constants.LEQUAL;
+        const depthWrite = engine.getDepthWrite();
+        engine.setDepthWrite(false);
+        const matrixBuffer = this._matrixBuffer;
+        if (this.updatable && matrixBuffer?.isUpdatable() && matrixBuffer.getData() === matrices) {
+            matrixBuffer.update(matrices);
+        } else {
+            this._createInstanceBuffer(matrices, !this.updatable);
+        }
+
+        this._createWrappersForBoundingBox(this);
+
+        const useReverseDepthBuffer = engine.useReverseDepthBuffer;
+        const transformMatrix = this.scene.getTransformMatrix();
+
+        if (this.showBackLines) {
+            const drawWrapperBack = this._drawWrapperBack ?? colorShader._getDrawWrapper();
+
+            colorShader._preBind(drawWrapperBack);
+
+            engine.bindBuffers(this._vertexBuffers, this._indexBuffer, colorShader.getEffect());
+
+            // Back
+            if (useReverseDepthBuffer) {
+                engine.setDepthFunctionToLessOrEqual();
+            } else {
+                engine.setDepthFunctionToGreaterOrEqual();
+            }
+            const _uniformBufferBack: UniformBuffer = this._uniformBufferBack;
+
+            _uniformBufferBack.bindToEffect(drawWrapperBack.effect!, "BoundingBoxRenderer");
+            _uniformBufferBack.updateColor4("color", this.backColor, 1);
+            _uniformBufferBack.updateMatrix("viewProjection", transformMatrix);
+            _uniformBufferBack.update();
+
+            // Draw order
+            engine.drawElementsType(Material.LineListDrawMode, 0, 24, instancesCount);
+        }
+
+        const drawWrapperFront = colorShader._getDrawWrapper();
+
+        colorShader._preBind(drawWrapperFront);
+
+        engine.bindBuffers(this._vertexBuffers, this._indexBuffer, colorShader.getEffect());
+
+        // Front
+        if (useReverseDepthBuffer) {
+            engine.setDepthFunctionToGreater();
+        } else {
+            engine.setDepthFunctionToLess();
+        }
+        const _uniformBufferFront: UniformBuffer = this._uniformBufferFront;
+        _uniformBufferFront.bindToEffect(drawWrapperFront.effect!, "BoundingBoxRenderer");
+        _uniformBufferFront.updateColor4("color", this.frontColor, 1);
+        _uniformBufferFront.updateMatrix("viewProjection", transformMatrix);
+        _uniformBufferFront.update();
+
+        // Draw order
+        engine.drawElementsType(Material.LineListDrawMode, 0, 24, instancesCount);
+
+        this.onAfterBoxRenderingObservable.notifyObservers(dummyBoundingBox);
+
+        colorShader.unbind();
+        engine.setDepthFunction(depthFunction);
+        engine.setDepthWrite(depthWrite);
+    }
+
+    /**
+     * Creates buffer for instanced rendering
+     * @internal
+     * @param buffer buffer to set
+     * @param staticBuffer indicates that the buffer is static, so that you won't change it after it is set
+     */
+    _createInstanceBuffer(buffer: Float32Array, staticBuffer: boolean): void {
+        const vertexBuffers = this._vertexBuffers;
+        this._cleanupInstanceBuffer();
+        // this.instancesCount = buffer.length / stride;
+        const matrixBuffer = new Buffer(this.scene.getEngine(), buffer, !staticBuffer, 16, false, true);
+
+        vertexBuffers.world0 = matrixBuffer.createVertexBuffer("world0", 0, 4);
+        vertexBuffers.world1 = matrixBuffer.createVertexBuffer("world1", 4, 4);
+        vertexBuffers.world2 = matrixBuffer.createVertexBuffer("world2", 8, 4);
+        vertexBuffers.world3 = matrixBuffer.createVertexBuffer("world3", 12, 4);
+
+        this._matrixBuffer = matrixBuffer;
+    }
+
+    /**
+     * Clean up buffers for instanced rendering
+     * @internal
+     */
+    _cleanupInstanceBuffer(): void {
+        const vertexBuffers = this._vertexBuffers;
+        if (vertexBuffers.world0) {
+            vertexBuffers.world0.dispose();
+            delete vertexBuffers.world0;
+        }
+        if (vertexBuffers.world1) {
+            vertexBuffers.world1.dispose();
+            delete vertexBuffers.world1;
+        }
+        if (vertexBuffers.world2) {
+            vertexBuffers.world2.dispose();
+            delete vertexBuffers.world2;
+        }
+        if (vertexBuffers.world3) {
+            vertexBuffers.world3.dispose();
+            delete vertexBuffers.world3;
+        }
+        this._matrices = null;
+        if (this._matrixBuffer) {
+            this._matrixBuffer.dispose();
+            this._matrixBuffer = null;
+        }
+    }
+
+    /**
+     * Clean up resources for instanced rendering
+     * @internal
+     */
+    _cleanupInstances(): void {
+        this._cleanupInstanceBuffer();
+        if (this._drawWrapperFront) {
+            this._drawWrapperFront.dispose();
+            this._drawWrapperFront = null;
+        }
+        if (this._drawWrapperBack) {
+            this._drawWrapperBack.dispose();
+            this._drawWrapperBack = null;
+        }
+    }
+
+    /**
      * Dispose and release the resources attached to this renderer.
      */
     public dispose(): void {
@@ -519,5 +791,6 @@ export class BoundingBoxRenderer implements ISceneComponent {
             this.scene.getEngine()._releaseBuffer(this._fillIndexBuffer);
             this._fillIndexBuffer = null;
         }
+        this._cleanupInstances();
     }
 }

--- a/packages/dev/core/src/Shaders/boundingBoxRenderer.vertex.fx
+++ b/packages/dev/core/src/Shaders/boundingBoxRenderer.vertex.fx
@@ -1,17 +1,26 @@
-﻿// Attributes
+// Attributes
 attribute vec3 position;
 
 #include<__decl__boundingBoxRendererVertex>
 
+#ifdef INSTANCES
+attribute vec4 world0;
+attribute vec4 world1;
+attribute vec4 world2;
+attribute vec4 world3;
+#endif
 
 #define CUSTOM_VERTEX_DEFINITIONS
 
 void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
-
+#ifdef INSTANCES
+    mat4 finalWorld = mat4(world0, world1, world2, world3);
+    vec4 worldPos = finalWorld * vec4(position, 1.0);
+#else
     vec4 worldPos = world * vec4(position, 1.0);
-
+#endif
 #ifdef MULTIVIEW
 	if (gl_ViewID_OVR == 0u) {
 		gl_Position = viewProjection * worldPos;

--- a/packages/dev/core/src/ShadersWGSL/boundingBoxRenderer.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/boundingBoxRenderer.vertex.fx
@@ -4,14 +4,25 @@ attribute position: vec3f;
 uniform world: mat4x4f;
 uniform viewProjection: mat4x4f;
 
+#ifdef INSTANCES
+attribute world0 : vec4<f32>;
+attribute world1 : vec4<f32>;
+attribute world2 : vec4<f32>;
+attribute world3 : vec4<f32>;
+#endif
+
 #define CUSTOM_VERTEX_DEFINITIONS
 
 @vertex
 fn main(input : VertexInputs) -> FragmentInputs {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
-
+#ifdef INSTANCES
+	var finalWorld = mat4x4<f32>(vertexInputs.world0, vertexInputs.world1, vertexInputs.world2, vertexInputs.world3);
+    var worldPos: vec4f = finalWorld *  vec4f(input.position, 1.0);
+#else
     var worldPos: vec4f = uniforms.world *  vec4f(input.position, 1.0);
+#endif
 	vertexOutputs.position = uniforms.viewProjection * worldPos;
 
 #define CUSTOM_VERTEX_MAIN_END


### PR DESCRIPTION
## Background

Currently in BoundingBoxRenderer, it renders in a loop, calling `engine.drawElementsType` for each bounding box in `renderList`, making every bounding box 1 or 2 [draw call](https://doc.babylonjs.com/features/featuresDeepDive/scene/optimize_your_scene/#reducing-draw-calls).
Since it renders on web, it would suffer the same performance issue like meshes when draw calls increases.

## Proposal

Since only the `worldMatrix` changes for different bounding boxes, it should benefit from instancing, like [thin instances](https://doc.babylonjs.com/features/featuresDeepDive/mesh/copies/thinInstances) for meshes.

1. Allocate buffers for instancing.
2. Loop renderList and fill buffers.
3. Copy buffers to gpu.
4. Render instanced.

With instancing the draw call needed for each BoundingBoxRenderer could be reduced to 1 or 2 (in case `this.showBackLines` enabled)

Example:
<https://playground.babylonjs.com/#37HN68#14>

## Alternatives

Since there are very few[1] vertex needed, and there is already [`vectorsWorld`](https://github.com/BabylonJS/Babylon.js/blob/73ab4d666c0506a5fe551ce852a23e0e8ec0d15a/packages/dev/core/src/Culling/boundingBox.ts#L43) in `BoundingBox`, which [updates](https://github.com/BabylonJS/Babylon.js/blob/73ab4d666c0506a5fe551ce852a23e0e8ec0d15a/packages/dev/core/src/Culling/boundingBox.ts#L166) every time world matrix updates, the computation of matrices can be skipped, and reuse computation result of `vectorsWorld` to rebuild vertex buffer every time it renders. In this case `_indexBuffer` needs to be reconstructed is count of bounding box mismatches.

[1]: 24 points in case of `CreateBoxVertexData`, or 8 points if constructed manually, since uvs and normals are not needed for rendering as lines

## Compatibility

1. It's disabled by default for backwards compatibility.
2. It could result in a difference in rendering result if
`showBackLines` enabled, because drawing the black/white part of each box one after the other can be different from drawing the black part of all boxes and then the white part.
3. Events of `onBeforeBoxRenderingObservable` and `onAfterBoxRenderingObservable` would only be triggered once
for one rendering, instead of once every bounding box. Events would be triggered with a dummy box to keep backwards compatibility.

## References

Forum post: <https://forum.babylonjs.com/t/batched-or-instanced-boundingboxrenderer/54977>