### PR TITLE
improve performance of glTFLoader._applyExtensions

### DIFF
--- a/packages/dev/core/src/types.ts
+++ b/packages/dev/core/src/types.ts
@@ -196,3 +196,10 @@ export type Constructor<C extends new (...args: any[]) => any, I extends Instanc
  * Alias type for image sources
  */
 export type ImageSource = ImageBitmap | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | OffscreenCanvas;
+
+/**
+ * Type modifier to make an optional property required
+ */
+export type WithRequiredProperty<Type, Key extends keyof Type> = Type & {
+    [Property in Key]-?: Type[Property];
+};

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoaderExtension.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoaderExtension.ts
@@ -1,4 +1,4 @@
-﻿import type { Nullable } from "core/types";
+﻿import type { Nullable, WithRequiredProperty } from "core/types";
 import type { Animation } from "core/Animations/animation";
 import type { AnimationGroup } from "core/Animations/animationGroup";
 import type { Material } from "core/Materials/material";
@@ -214,3 +214,7 @@ export interface IGLTFLoaderExtension extends IGLTFBaseLoaderExtension, IDisposa
      */
     loadBufferAsync?(context: string, buffer: IBuffer, byteOffset: number, byteLength: number): Nullable<Promise<ArrayBufferView>>;
 }
+
+export type IGLTFLoaderExtensionFunctionName = keyof IGLTFLoaderExtension;
+
+export type IGLTFLoaderExtensionWithRequireFunction<F extends IGLTFLoaderExtensionFunctionName> = WithRequiredProperty<IGLTFLoaderExtension, F>;


### PR DESCRIPTION
### Cache extensions by `_getActiveExtensionsHasOwnFunction`

for a specific function name, cache extensions which are enabled and have the specific function， avoid repeated traversals

### ILoaderProperty._activeLoaderExtensionFunctions

use `Map` to replace `{}` for ILoaderProperty._activeLoaderExtensionFunctions, to imporve has/set/delete operation


### for specific p and fName, Just ensure avoid recursive call of `applyExtension(p, fName, ...)`

Let's say there is an enabled extension which name is `extensionA` and has function `loadSomeAsyc`.

For a specific property `p`,

First, `applyExtension(p, fName, ...) ` should not be called recursively.
In other words, the following trace should not occur:

```
applyExtension(p, 'loadSomeAsyc') 

             -> ... 

                   -> applyExtension(p, 'loadSomeAsyc') 

                            -> ... 

```

Second, `extensionA.loadSomeAsyc(p, ...)` should not be called recursively.
In other words, the following trace should not occur:

```
applyExtension(p, 'loadSomeAsyc') 

       -> extensionA.loadSomeAsyc(p) 

             -> ... 

                   -> applyExtension(p, 'loadSomeAsyc') 

                         -> extensionA.loadSomeAsyc(p)

                                 -> ... 
```

so, just ensue no recursive call of `applyExtension(p, 'loadSomeAsyc')`,  two goals can be achieved at the same time.

