### PR TITLE
Fix audio engine init issue

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -364,6 +364,10 @@ export class Engine extends ThinEngine {
             const canvas = <HTMLCanvasElement>canvasOrContext;
 
             this._sharedInit(canvas);
+        } else if ((<any>canvasOrContext).canvas) {
+            const context = <WebGLRenderingContext | WebGL2RenderingContext>canvasOrContext;
+
+            this._sharedInit(context.canvas as HTMLCanvasElement);
         }
     }
 


### PR DESCRIPTION
When the `Engine` constructor is called with a `WebGLRenderingContext` or `WebGL2RenderingContext`, the audio engine does not get initialized. This change fixes the issue by calling `Engine._sharedInit` with the WebGL rendering context's canvas.

Note that the WebGL rendering context's canvas may be an `OffscreenCanvas` and its type is cast to `HTMLCanvasElement` for the call to `Engine._sharedInit` because it would be a large change to make `AbstractEngine.__renderingCanvas` support both types. This is done the same way in the `WebGPUEngine` constructor, with the only consequence for the audio engine being that the mute button stays at the top-left of the document instead of automatically repositioning to the top-left of the canvas.

- Reported on forum https://forum.babylonjs.com/t/can-not-start-audio-if-webglcontext/55113
- Reproduced with playground https://playground.babylonjs.com#D73ZT5#7.