### PR TITLE
Viewer panning sensitivity

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
@@ -1,5 +1,6 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { AbstractMesh, Nullable, PickingInfo } from "core/index";
 import { Vector3, TmpVectors, Matrix } from "../Maths/math.vector";
-import type { AbstractMesh } from "./abstractMesh";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Constants } from "core/Engines/constants";
 
@@ -16,6 +17,25 @@ export type HotSpotQuery = {
      */
     barycentric: [number, number, number];
 };
+
+/**
+ * Create a HotSpotQuery from a picking info
+ * @remarks If there is no pickedMesh or the pickedMesh has no indices, null will be returned
+ * @param pickingInfo picking info to use
+ * @returns HotSpotQuery or null if it was not possible to create one
+ */
+export function CreateHotSpotQueryForPickingInfo(pickingInfo: PickingInfo): Nullable<HotSpotQuery> {
+    const indices = pickingInfo.pickedMesh?.getIndices();
+    if (indices) {
+        const base = pickingInfo.faceId * 3;
+        return {
+            pointIndex: [indices[base], indices[base + 1], indices[base + 2]],
+            barycentric: [pickingInfo.bu, pickingInfo.bv, 1 - pickingInfo.bu - pickingInfo.bv],
+        };
+    }
+
+    return null;
+}
 
 /**
  * Return a transformed local position from a mesh and vertex index

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -1068,6 +1068,7 @@ export class Viewer implements IDisposable {
     private _pick(screenX: number, screenY: number): Nullable<PickingInfo> {
         if (this._details.model) {
             const model = this._details.model;
+            // Refresh bounding info to ensure morph target and skeletal animations are taken into account.
             model.meshes.forEach((mesh) => mesh.refreshBoundingInfo(true, true));
             const pickingInfo = this._details.scene.pick(screenX, screenY, (mesh) => model.meshes.includes(mesh));
             if (pickingInfo.hit) {

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -379,6 +379,11 @@ export class Viewer implements IDisposable {
                 if (pointerInfo.type === PointerEventTypes.POINTERDOUBLETAP) {
                     const pickingInfo = this._pick(pointerInfo.event.offsetX, pointerInfo.event.offsetY);
                     if (pickingInfo?.pickedPoint) {
+                        const distance = pickingInfo.pickedPoint.subtract(camera.position).dot(camera.getForwardRay().direction);
+                        // Immediately reset the target and the radius based on the distance to the picked point.
+                        // This eliminates unnecessary camera movement on the local z-axis when interpolating.
+                        camera.target = camera.position.add(camera.getForwardRay().direction.scale(distance));
+                        camera.radius = distance;
                         camera.interpolateTo(undefined, undefined, undefined, pickingInfo.pickedPoint);
                     } else {
                         camera.restoreState();
@@ -949,7 +954,7 @@ export class Viewer implements IDisposable {
                 this._details.scene.render();
 
                 // Update the camera panning sensitivity related properties based on the camera's distance from the target.
-                this._details.camera.panningSensibility = 10000 / this._details.camera.radius;
+                this._details.camera.panningSensibility = 5000 / this._details.camera.radius;
                 this._details.camera.speed = this._details.camera.radius * 0.2;
 
                 if (this.isAnimationPlaying) {
@@ -1023,7 +1028,7 @@ export class Viewer implements IDisposable {
         this._details.camera.minZ = goalRadius * 0.001;
         this._details.camera.maxZ = goalRadius * 1000;
         this._details.camera.wheelDeltaPercentage = 0.01;
-        this._details.camera.pinchDeltaPercentage = 0.01;
+        this._details.camera.useNaturalPinchZoom = true;
         this._details.camera.restoreStateInterpolationFactor = 0.1;
         this._details.camera.storeState();
 


### PR DESCRIPTION
Prior to this change, it was difficult (in some scenarios nearly impossible) to pan the camera when the camera is close to a part of the mesh. This PR has a couple of related changes to help with this situation:

1. The panning sensitivity and speed are now relative to the camera's distance from its target (e.g. the ArcRotateCamera's radius). This is done directly in the Viewer, rather than trying to make this an optional behavior of the ArcRotateCamera itself.
2. The viewer now directly handles double click/tap and does a pick operation. If it hits a model mesh, then it updates the camera target. If not, it resets the camera pose (previously the behavior of double click/tap always).

This means you can zoom in on part of the mesh, double click/tap to make it the new target, and then easily rotate or pan the camera around that part of the mesh.

The Viewer's new `pick` function is exposed through the viewer details, and this change also includes a new `CreateHotSpotQueryForPickingInfo` function. These will be used in conjunction by tooling to create hotspots in the future.