### PR TITLE
Edge Renderer: Fix edges not displayed the second time we enable the edge renderer for a mesh

### DIFF
--- a/packages/dev/core/src/Rendering/edgesRenderer.ts
+++ b/packages/dev/core/src/Rendering/edgesRenderer.ts
@@ -271,6 +271,11 @@ export class EdgesRenderer implements IEdgesRenderer {
             shader.checkReadyOnEveryCall = scene.getEngine().isWebGPU;
 
             scene._edgeRenderLineShader = shader;
+
+            scene.onDisposeObservable.add(() => {
+                scene._edgeRenderLineShader!.dispose();
+                scene._edgeRenderLineShader = null;
+            });
         }
 
         return scene._edgeRenderLineShader;
@@ -371,7 +376,6 @@ export class EdgesRenderer implements IEdgesRenderer {
         if (this._ib) {
             this._source.getScene().getEngine()._releaseBuffer(this._ib);
         }
-        this._lineShader.dispose();
 
         this._drawWrapper?.dispose();
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/edges-rendering-stop-working/55156