### PR TITLE
Various small Viewer fixes

### DIFF
--- a/packages/dev/core/src/Misc/deepMerger.ts
+++ b/packages/dev/core/src/Misc/deepMerger.ts
@@ -1,0 +1,26 @@
+// https://stackoverflow.com/a/48218209
+/**
+ * Merges a series of objects into a single object, deeply.
+ * @param objects The objects to merge (objects later in the list take precedence).
+ * @returns The merged object.
+ */
+export function deepMerge<T extends Object>(...objects: T[]): T {
+    const isRecord = (obj: unknown): obj is Record<string, unknown> => !!obj && typeof obj === "object";
+
+    return objects.reduce<Record<string, unknown>>((prev, obj) => {
+        Object.keys(obj).forEach((key) => {
+            const pVal = prev[key];
+            const oVal = (obj as Record<string, unknown>)[key];
+
+            if (Array.isArray(pVal) && Array.isArray(oVal)) {
+                prev[key] = pVal.concat(...oVal);
+            } else if (isRecord(pVal) && isRecord(oVal)) {
+                prev[key] = deepMerge(pVal, oVal);
+            } else {
+                prev[key] = oVal;
+            }
+        });
+
+        return prev;
+    }, {}) as T;
+}

--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -33,6 +33,7 @@ export * from "./logger";
 export * from "./typeStore";
 export * from "./filesInputStore";
 export * from "./deepCopier";
+export * from "./deepMerger";
 export * from "./pivotTools";
 export * from "./precisionDate";
 export * from "./screenshotTools";

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
@@ -10,14 +10,28 @@ import type { INode, IMeshPrimitive, IMesh } from "../glTFLoaderInterfaces";
 import type { IKHRMaterialVariants_Mapping, IKHRMaterialVariants_Variant, IKHRMaterialVariants_Variants } from "babylonjs-gltf2interface";
 import type { TransformNode } from "core/Meshes/transformNode";
 import { registerGLTFExtension, unregisterGLTFExtension } from "../glTFLoaderExtensionRegistry";
-import type { GLTFLoaderExtensionOptions } from "../../glTFFileLoader";
+import type { MaterialVariantsController } from "../../glTFFileLoader";
 
 const NAME = "KHR_materials_variants";
 
-// NOTE: This "backward" type definition is needed due to the way namespaces are handled in the UMD bundle.
-export type MaterialVariantsController = Parameters<Required<GLTFLoaderExtensionOptions[typeof NAME]>["onLoaded"]>[0];
+export { MaterialVariantsController };
 
 declare module "../../glTFFileLoader" {
+    // Define options related types here so they can be referenced in the options,
+    // but export the types at the module level. This ensures the types are in the
+    // correct namespace for UMD.
+    type MaterialVariantsController = {
+        /**
+         * The list of available variant names for this asset.
+         */
+        readonly variants: readonly string[];
+
+        /**
+         * Gets or sets the selected variant.
+         */
+        selectedVariant: string;
+    };
+
     // eslint-disable-next-line jsdoc/require-jsdoc
     export interface GLTFLoaderExtensionOptions {
         /**
@@ -29,17 +43,7 @@ declare module "../../glTFFileLoader" {
              * Defines a callback that will be called if material variants are loaded.
              * @experimental
              */
-            onLoaded: (controller: {
-                /**
-                 * The list of available variant names for this asset.
-                 */
-                readonly variants: readonly string[];
-
-                /**
-                 * Gets or sets the selected variant.
-                 */
-                selectedVariant: string;
-            }) => void;
+            onLoaded: (controller: MaterialVariantsController) => void;
         }>;
     }
 }

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -78,6 +78,7 @@ import { nodeAnimationData } from "./glTFLoaderAnimation";
 import type { IObjectInfo } from "core/ObjectModel/objectModelInterfaces";
 import { registeredGLTFExtensions, registerGLTFExtension, unregisterGLTFExtension } from "./glTFLoaderExtensionRegistry";
 import type { GLTFExtensionFactory } from "./glTFLoaderExtensionRegistry";
+import { deepMerge } from "core/Misc/deepMerger";
 export { GLTFFileLoader };
 
 interface TypedArrayLike extends ArrayBufferView {
@@ -99,28 +100,6 @@ interface ILoaderProperty extends IProperty {
 interface IWithMetadata {
     metadata: any;
     _internalMetadata: any;
-}
-
-// https://stackoverflow.com/a/48218209
-function mergeDeep(...objects: any[]): any {
-    const isObject = (obj: any) => obj && typeof obj === "object";
-
-    return objects.reduce((prev, obj) => {
-        Object.keys(obj).forEach((key) => {
-            const pVal = prev[key];
-            const oVal = obj[key];
-
-            if (Array.isArray(pVal) && Array.isArray(oVal)) {
-                prev[key] = pVal.concat(...oVal);
-            } else if (isObject(pVal) && isObject(oVal)) {
-                prev[key] = mergeDeep(pVal, oVal);
-            } else {
-                prev[key] = oVal;
-            }
-        });
-
-        return prev;
-    }, {});
 }
 
 /**
@@ -907,7 +886,7 @@ export class GLTFLoader implements IGLTFLoader {
                         const babylonTransformNodeForSkin = node._babylonTransformNodeForSkin!;
 
                         // Merge the metadata from the skin node to the skinned mesh in case a loader extension added metadata.
-                        babylonTransformNode.metadata = mergeDeep(babylonTransformNodeForSkin.metadata, babylonTransformNode.metadata || {});
+                        babylonTransformNode.metadata = deepMerge(babylonTransformNodeForSkin.metadata, babylonTransformNode.metadata || {});
 
                         const skin = ArrayItem.Get(`${context}/skin`, this._gltf.skins, node.skin);
                         promises.push(

--- a/packages/tools/viewer-alpha/test/apps/web/index.html
+++ b/packages/tools/viewer-alpha/test/apps/web/index.html
@@ -144,8 +144,6 @@
         </div>
         <script type="module" src="/packages/tools/viewer-alpha/src/index.ts"></script>
         <script type="module">
-            import { Inspector } from "inspector/inspector";
-
             const viewerElement = document.querySelector("babylon-viewer");
             const lines = document.querySelectorAll("line");
             const hotspotResult = { screenPosition: [0, 0], worldPosition: [0, 0, 0] };
@@ -237,7 +235,8 @@
             };
 
             let isInspectorVisible = false;
-            globalThis.onToggleInspector = () => {
+            globalThis.onToggleInspector = async () => {
+                const { Inspector } = await import("inspector/inspector");
                 console.log("toggle inspector");
                 if (isInspectorVisible) {
                     Inspector.Hide();


### PR DESCRIPTION
1. I noticed we had a deepMerge implementation in the glTF loader, so I moved this to core and use it in the Viewer to merge default options with user options.
2. Reworked how the MaterialVariantsController type is defined to remove some nasty type complexities.
3. Import the ray module since we need it for picking now.
4. Sort imports in Viewer.ts.