### PR TITLE
Add tone mapping parameter to sandbox

### DIFF
--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -24,6 +24,7 @@ import type { ITextureCreationOptions } from "core/Materials/Textures/texture";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
 import { setOpenGLOrientationForUV, useOpenGLOrientationForUV } from "core/Compat/compatibilityOptions";
+import { ImageProcessingConfiguration } from "core/Materials/imageProcessingConfiguration";
 
 function getFileExtension(str: string): string {
     return str.split(".").pop() || "";
@@ -49,6 +50,7 @@ interface IRenderingZoneProps {
     assetUrl?: string;
     autoRotate?: boolean;
     cameraPosition?: Vector3;
+    toneMapping?: number;
     expanded: boolean;
     onEngineCreated?: (engine: AbstractEngine) => void;
 }
@@ -282,6 +284,14 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
 
     onSceneLoaded(filename: string) {
         this._scene.skipFrustumClipping = true;
+
+        if (this.props.toneMapping !== undefined) {
+            this._scene.imageProcessingConfiguration.toneMappingEnabled = true;
+            this._scene.imageProcessingConfiguration.toneMappingType = this.props.toneMapping;
+        } else if (this.props.globalState.commerceMode) {
+            this._scene.imageProcessingConfiguration.toneMappingEnabled = true;
+            this._scene.imageProcessingConfiguration.toneMappingType = ImageProcessingConfiguration.TONEMAPPING_KHR_PBR_NEUTRAL;
+        }
 
         this.props.globalState.onSceneLoaded.notifyObservers({ scene: this._scene, filename: filename });
 

--- a/packages/tools/sandbox/src/sandbox.tsx
+++ b/packages/tools/sandbox/src/sandbox.tsx
@@ -15,6 +15,7 @@ import { Color3, Color4 } from "core/Maths/math";
 import "./scss/main.scss";
 import fullScreenLogo from "./img/logo-fullscreen.svg";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
+import { ImageProcessingConfiguration } from "core/Materials/imageProcessingConfiguration";
 
 interface ISandboxProps {}
 
@@ -38,6 +39,7 @@ export class Sandbox extends React.Component<
     private _assetUrl?: string;
     private _autoRotate?: boolean;
     private _cameraPosition?: Vector3;
+    private _toneMapping?: number;
     private _logoRef: React.RefObject<HTMLImageElement>;
     private _dropTextRef: React.RefObject<HTMLDivElement>;
     private _clickInterceptorRef: React.RefObject<HTMLDivElement>;
@@ -168,16 +170,16 @@ export class Sandbox extends React.Component<
                 const split = param.split("=", 2);
                 const name = split[0];
                 const value = split[1];
-                switch (name) {
-                    case "assetUrl": {
+                switch (name.toLowerCase()) {
+                    case "asseturl": {
                         this._assetUrl = value;
                         break;
                     }
-                    case "autoRotate": {
+                    case "autorotate": {
                         this._autoRotate = value === "true" ? true : false;
                         break;
                     }
-                    case "cameraPosition": {
+                    case "cameraposition": {
                         this._cameraPosition = Vector3.FromArray(
                             value.split(",").map(function (component) {
                                 return +component;
@@ -217,13 +219,26 @@ export class Sandbox extends React.Component<
                         this._globalState.skybox = value === "true" ? true : false;
                         break;
                     }
-                    case "clearColor": {
+                    case "clearcolor": {
                         this._clearColor = value;
                         break;
                     }
                     case "camera": {
                         this._camera = +value;
                         break;
+                    }
+                    case "tonemapping": {
+                        switch (value.toLowerCase()) {
+                            case "standard":
+                                this._toneMapping = ImageProcessingConfiguration.TONEMAPPING_STANDARD;
+                                break;
+                            case "aces":
+                                this._toneMapping = ImageProcessingConfiguration.TONEMAPPING_ACES;
+                                break;
+                            case "khr_pbr_neutral":
+                                this._toneMapping = ImageProcessingConfiguration.TONEMAPPING_KHR_PBR_NEUTRAL;
+                                break;
+                        }
                     }
                 }
             }
@@ -250,6 +265,7 @@ export class Sandbox extends React.Component<
                             assetUrl={this._assetUrl}
                             autoRotate={this._autoRotate}
                             cameraPosition={this._cameraPosition}
+                            toneMapping={this._toneMapping}
                             expanded={!this.state.isFooterVisible}
                             onEngineCreated={this.onEngineCreated}
                         />


### PR DESCRIPTION
See https://forum.babylonjs.com/t/url-syntax-for-sandbox/55129.

This change also makes the 3dcommerce mode use Khronos PBR Neutral tone mapper by default.