### PR TITLE
Fix slight pixel color changes in the CI during sandbox tests

### DIFF
--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -1,6 +1,13 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, defineConfig } from "@playwright/test";
 import { readFileSync } from "fs";
 import { getGlobalConfig } from "@tools/test-tools";
+import * as path from "path";
+
+export default defineConfig({
+    expect: {
+        toHaveScreenshot: { maxDiffPixels: 800, stylePath: path.join(__dirname, "screenshot.css") },
+    },
+});
 
 const url = process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339");
 
@@ -15,8 +22,7 @@ test("Sandbox is loaded (Desktop)", async ({ page }) => {
     // check visibility of both canvas AND the editor
     await expect(page.locator("#canvasZone")).toBeVisible();
     // check snapshot of the page
-    const snapshot = await page.screenshot();
-    expect(snapshot).toMatchSnapshot();
+    await expect(page).toHaveScreenshot();
 });
 
 test("dropping an image to the sandbox", async ({ page }) => {
@@ -45,8 +51,7 @@ test("dropping an image to the sandbox", async ({ page }) => {
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "hidden" });
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "detached" });
     // check snapshot of the page
-    const snapshot = await page.screenshot();
-    expect(snapshot).toMatchSnapshot();
+    await expect(page).toHaveScreenshot();
 });
 
 test("loading a model using query parameters", async ({ page }) => {
@@ -61,8 +66,7 @@ test("loading a model using query parameters", async ({ page }) => {
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "hidden" });
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "detached" });
     // check snapshot of the page
-    const snapshot = await page.screenshot();
-    expect(snapshot).toMatchSnapshot();
+    await expect(page).toHaveScreenshot();
 });
 
 test("inspector is opened when clicking on the button", async ({ page }) => {
@@ -83,6 +87,5 @@ test("inspector is opened when clicking on the button", async ({ page }) => {
     await expect(page.locator("#inspector-host")).toBeVisible();
     await expect(page.locator("#scene-explorer-host")).toBeVisible();
     // check snapshot of the page
-    const snapshot = await page.screenshot();
-    expect(snapshot).toMatchSnapshot();
+    await expect(page).toHaveScreenshot();
 });

--- a/packages/tools/sandbox/test/screenshot.css
+++ b/packages/tools/sandbox/test/screenshot.css
@@ -1,0 +1,4 @@
+/* force white text */
+* {
+    color: #fff !important;
+}


### PR DESCRIPTION
Sandbox tests should be consistent locally and on the CI. This PR makes sure that the tests work on both CI and locally, forcing css color of the text.

This should also trigger the sandbox test(s)