### PR TITLE
Do not pick during a multi-touch gesture

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -658,6 +658,9 @@ export class InputManager {
 
             let needToIgnoreNext = false;
 
+            // Never pick if this is a multi-touch gesture (e.g. pinch)
+            checkPicking = checkPicking && !this._isMultiTouchGesture;
+
             if (checkPicking) {
                 const btn = evt.button;
                 clickInfo.hasSwiped = this._isPointerSwiping();


### PR DESCRIPTION
An issue was [reported in the forum](https://forum.babylonjs.com/t/pinch-zoom-triggers-onpicktrigger/39362) where pinch gestures were causing meshes to be picked. This addresses that bug by adding the condition that we only pick a mesh when not in a multi-touch gesture.