### PR TITLE
Update launch to match the repo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -284,56 +284,28 @@
             "url": "http://localhost:1344",
             "preLaunchTask": "Node Render Graph Editor Serve for core (Dev)"
         },
-        {
-            "type": "msedge",
-            "request": "launch",
-            "name": "VSM development (Edge)",
-            "url": "http://localhost:1342",
-            "preLaunchTask": "VSM Serve (Dev)"
-        },
-        {
-            "type": "chrome",
-            "request": "launch",
-            "name": "VSM development (Chrome)",
-            "url": "http://localhost:1342",
-            "preLaunchTask": "VSM Serve (Dev)"
-        },
-        {
-            "type": "msedge",
-            "request": "launch",
-            "name": "Launch VSM (Edge)",
-            "url": "http://localhost:1342",
-            "preLaunchTask": "VSM Serve for core (Dev)"
-        },
-        {
-            "type": "chrome",
-            "request": "launch",
-            "name": "Launch VSM (Chrome)",
-            "url": "http://localhost:1342",
-            "preLaunchTask": "VSM Serve for core (Dev)"
-        },
-        {
-            /*
-            Launch the playground to be use to test changes in dev packages
-            */
-            "type": "msedge",
-            "request": "launch",
-            "name": "Run and Watch Dev host (ES6-Dev)",
-            "url": "http://localhost:1338",
-            "outFiles": ["!**/node_modules/**"],
-            "preLaunchTask": "Run and Watch Dev host (Dev)"
-        },
-        {
-            /*
-            Launch the playground to be use to test changes in dev packages
-            */
-            "type": "msedge",
-            "request": "launch",
-            "name": "Run and Watch Dev host - SSL (ES6-Dev)",
-            "url": "https://localhost:1338",
-            "outFiles": ["!**/node_modules/**"],
-            "preLaunchTask": "Run and Watch Dev host (Dev)"
-        },
+        // {
+        //     /*
+        //     Launch the playground to be use to test changes in dev packages
+        //     */
+        //     "type": "msedge",
+        //     "request": "launch",
+        //     "name": "Run and Watch Dev host (ES6-Dev)",
+        //     "url": "http://localhost:1338",
+        //     "outFiles": ["!**/node_modules/**"],
+        //     "preLaunchTask": "Run and Watch Dev host (Dev)"
+        // },
+        // {
+        //     /*
+        //     Launch the playground to be use to test changes in dev packages
+        //     */
+        //     "type": "msedge",
+        //     "request": "launch",
+        //     "name": "Run and Watch Dev host - SSL (ES6-Dev)",
+        //     "url": "https://localhost:1338",
+        //     "outFiles": ["!**/node_modules/**"],
+        //     "preLaunchTask": "Run and Watch Dev host (Dev)"
+        // },
         {
             /*
             Launch tests
@@ -377,12 +349,13 @@
         {
             /*
             Launch tests
-            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            Note - the recommended way would be to use the extension in the test tab of vscode.
             */
             "type": "node",
             "request": "launch",
             "name": "Run validation tests - WebGL2 (Dev)",
-            "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "--selectProjects", "visualization", "-i", "webgl2"],
+            "runtimeExecutable": "npx",
+            "runtimeArgs": ["playwright", "test", "-c", "${workspaceRoot}/playwright.config.ts", "--project", "webgl2"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,
@@ -392,23 +365,14 @@
         },
         {
             /*
-            Launch tests
-            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            Launch test
+            Note that the recommended way would be to use the extension in the test tab of vscode.
             */
             "type": "node",
             "request": "launch",
             "name": "Run single validation test - WebGL2 (Dev)",
-            "runtimeArgs": [
-                "--inspect-brk",
-                "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                "--runInBand",
-                "--selectProjects",
-                "visualization",
-                "-i",
-                "webgl2",
-                "-t",
-                "${input:testName}"
-            ],
+            "runtimeExecutable": "npx",
+            "runtimeArgs": ["playwright", "test", "-c", "${workspaceRoot}/playwright.config.ts", "--project", "webgl2", "-g", "${input:testName}"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,
@@ -418,24 +382,14 @@
         },
         {
             /*
-            Launch tests
-            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            Update test snapshots
+            Note that the recommended way would be to use the extension in the test tab of vscode.
             */
             "type": "node",
             "request": "launch",
+            "runtimeExecutable": "npx",
             "name": "Update single validation test - WebGL2 (Dev)",
-            "runtimeArgs": [
-                "--inspect-brk",
-                "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                "--runInBand",
-                "--selectProjects",
-                "visualization",
-                "-i",
-                "webgl2",
-                "-t",
-                "${input:testName}",
-                "-u"
-            ],
+            "runtimeArgs": ["playwright", "test", "-c", "${workspaceRoot}/playwright.config.ts", "-project", "webgl2", "-g", "${input:testName}", "--update-snapshots"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,
@@ -488,12 +442,13 @@
         {
             /*
             Launch tests
-            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            Recommended way would be to use the extension in the test tab of vscode.
             */
             "type": "node",
             "request": "launch",
             "name": "Run validation tests - WebGPU (Dev)",
-            "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "--selectProjects", "visualization", "-i", "webgpu"],
+            "runtimeExecutable": "npx",
+            "runtimeArgs": ["playwright", "test", "-c", "${workspaceRoot}/playwright.config.ts", "--project", "webgpu"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,
@@ -507,22 +462,13 @@
         {
             /*
             Launch tests
-            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            Recommended way would be to use the extension in the test tab of vscode.
             */
             "type": "node",
             "request": "launch",
             "name": "Run single validation test - WebGPU (Dev)",
-            "runtimeArgs": [
-                "--inspect-brk",
-                "${workspaceRoot}/node_modules/jest/bin/jest.js",
-                "--runInBand",
-                "--selectProjects",
-                "visualization",
-                "-i",
-                "webgpu",
-                "-t",
-                "${input:testName}"
-            ],
+            "runtimeExecutable": "npx",
+            "runtimeArgs": ["playwright", "test", "-c", "${workspaceRoot}/playwright.config.ts", "--project", "webgpu", "-g", "${input:testName}"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,
@@ -533,12 +479,13 @@
         {
             /*
             Launch tests
-            https://jestjs.io/docs/troubleshooting#debugging-in-vs-code
+            Recommended way would be to use the extension in the test tab of vscode.
             */
             "type": "node",
             "request": "launch",
             "name": "Run interactions tests (Dev)",
-            "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/jest/bin/jest.js", "--runInBand", "--selectProjects", "interactions"],
+            "runtimeExecutable": "npx",
+            "runtimeArgs": ["playwright", "test", "-c", "${workspaceRoot}/playwright.config.ts", "--project", "webgpu", "-g", "${input:testName}", "--update-snapshots"],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -284,28 +284,6 @@
             "url": "http://localhost:1344",
             "preLaunchTask": "Node Render Graph Editor Serve for core (Dev)"
         },
-        // {
-        //     /*
-        //     Launch the playground to be use to test changes in dev packages
-        //     */
-        //     "type": "msedge",
-        //     "request": "launch",
-        //     "name": "Run and Watch Dev host (ES6-Dev)",
-        //     "url": "http://localhost:1338",
-        //     "outFiles": ["!**/node_modules/**"],
-        //     "preLaunchTask": "Run and Watch Dev host (Dev)"
-        // },
-        // {
-        //     /*
-        //     Launch the playground to be use to test changes in dev packages
-        //     */
-        //     "type": "msedge",
-        //     "request": "launch",
-        //     "name": "Run and Watch Dev host - SSL (ES6-Dev)",
-        //     "url": "https://localhost:1338",
-        //     "outFiles": ["!**/node_modules/**"],
-        //     "preLaunchTask": "Run and Watch Dev host (Dev)"
-        // },
         {
             /*
             Launch tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,5 +33,6 @@
     "[css]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "jest.runMode": "on-demand"
 }


### PR DESCRIPTION
This PR updates launch.json to match the current tools we are using.

WebGL2 and WebGPU tests have moved to playwright. Both all and single test are supported. Note that I am still stronglyr ecommend to use the playwright vscode extension instead of running tests like that, as it is simpler to evaluate, easier to use, and faster.