### PR TITLE
doc fix: links in readme of loader package

### DIFF
--- a/packages/public/@babylonjs/loaders/readme.md
+++ b/packages/public/@babylonjs/loaders/readme.md
@@ -1,6 +1,6 @@
 # Babylon.js Loaders module
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "loaders".
+For usage documentation please visit https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes/.
 
 # Installation instructions
 
@@ -20,4 +20,4 @@ import "@babylonjs/loaders/glTF";
 
 This will extend Babylon's loader plugins to allow the load of gltf and glb files.
 
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support).
+For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).


### PR DESCRIPTION
Although old links can redirect to new one, the document page for loader usage is better for "Loading Any File Type", I think (and I fixed a link for ES6 usage page while at it).