### PR TITLE
Factor out DracoCompression

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -94,7 +94,7 @@ export abstract class DracoCodec implements IDisposable {
      * @param configuration The configuration for the DracoCodec instance.
      */
     constructor(configuration: IDracoCodecConfiguration) {
-        // check if the decoder binary and worker pool was injected
+        // check if the codec binary and worker pool was injected
         // Note - it is expected that the developer checked if WebWorker, WebAssembly and the URL object are available
         if (configuration.workerPool) {
             // Set the promise accordingly
@@ -148,7 +148,7 @@ export abstract class DracoCodec implements IDisposable {
     }
 
     /**
-     * Returns a promise that resolves when ready. Call this manually to ensure draco compression is ready before use.
+     * Returns a promise that resolves when ready. Call this manually to ensure the draco codec is ready before use.
      * @returns a promise that resolves when ready
      */
     public async whenReadyAsync(): Promise<void> {

--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -1,6 +1,7 @@
 import type { Nullable } from "core/types";
 import { Tools } from "../../Misc/tools";
 import { AutoReleaseWorkerPool } from "../../Misc/workerPool";
+import type { WorkerPool } from "../../Misc/workerPool";
 import type { IDisposable } from "../../scene";
 import { initializeWebWorker } from "./dracoCompressionWorker";
 
@@ -33,7 +34,7 @@ export interface IDracoCodecConfiguration {
      * If provided, numWorkers will be ignored and the worker pool will be used instead.
      * If provided the draco script will not be loaded from the DracoConfiguration.
      */
-    workerPool?: AutoReleaseWorkerPool;
+    workerPool?: WorkerPool;
 
     /**
      * Optional ArrayBuffer of the WebAssembly binary.
@@ -64,7 +65,7 @@ export function _GetDefaultNumWorkers(): number {
  * @internal
  */
 export abstract class DracoCodec implements IDisposable {
-    protected _workerPoolPromise?: Promise<AutoReleaseWorkerPool>;
+    protected _workerPoolPromise?: Promise<WorkerPool>;
     protected _modulePromise?: Promise<{ module: any /** DecoderModule | EncoderModule */ }>;
 
     /**

--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -50,7 +50,7 @@ export interface IDracoCodecConfiguration {
 /**
  * @internal
  */
-export function GetDefaultNumWorkers(): number {
+export function _GetDefaultNumWorkers(): number {
     if (typeof navigator !== "object" || !navigator.hardwareConcurrency) {
         return 1;
     }
@@ -82,7 +82,8 @@ export abstract class DracoCodec<M> implements IDisposable {
 
     /**
      * The default draco compression object
-     * Subclasses should override this value with a valid instance.
+     * Subclasses should override this value using the narrowed type of the subclass,
+     * and define a public `get Default()` that returns the narrowed instance.
      */
     protected static _Default: Nullable<DracoCodec<unknown>>;
 
@@ -121,7 +122,7 @@ export abstract class DracoCodec<M> implements IDisposable {
      * @param _config The configuration for the DracoCodec instance.
      */
     constructor(_config: IDracoCodecConfiguration) {
-        const config = { numWorkers: GetDefaultNumWorkers(), ..._config };
+        const config = { numWorkers: _GetDefaultNumWorkers(), ..._config };
         // check if the decoder binary and worker pool was injected
         // Note - it is expected that the developer checked if WebWorker, WebAssembly and the URL object are available
         if (config.workerPool) {
@@ -168,7 +169,7 @@ export abstract class DracoCodec<M> implements IDisposable {
                         await Tools.LoadBabylonScriptAsync(codecInfo.url);
                     }
                 }
-                return /*await*/ this._createModuleAsync(wasmBinary as ArrayBuffer, config.jsModule);
+                return this._createModuleAsync(wasmBinary as ArrayBuffer, config.jsModule);
             });
         }
     }

--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -71,21 +71,22 @@ export abstract class DracoCodec implements IDisposable {
      * The configuration for the Draco codec.
      * Subclasses should override this value with a valid configuration.
      */
-    public static Config: IDracoCodecConfiguration;
+    public static DefaultConfiguration: IDracoCodecConfiguration;
 
     /**
-     * Returns true if the codec's `Configuration` is available.
-     */
-    public static get Available(): boolean {
-        return !!((this.Config.wasmUrl && this.Config.wasmBinaryUrl && typeof WebAssembly === "object") || this.Config.fallbackUrl);
-    }
-
-    /**
-     * The default draco compression object
+     * The default draco codec object
      * Subclasses should override this value using the narrowed type of the subclass,
      * and define a public `get Default()` that returns the narrowed instance.
      */
     protected static _Default: Nullable<DracoCodec>;
+
+    /**
+     * Returns true if the Default's codec's `Configuration` is available.
+     */
+    public static get DefaultAvailable(): boolean {
+        // `this` will point to subclass
+        return !!((this.DefaultConfiguration.wasmUrl && this.DefaultConfiguration.wasmBinaryUrl && typeof WebAssembly === "object") || this.DefaultConfiguration.fallbackUrl);
+    }
 
     /**
      * Reset the default draco compression object to null and disposing the removed default instance.
@@ -94,6 +95,7 @@ export abstract class DracoCodec implements IDisposable {
      * @param skipDispose set to true to not dispose the removed default instance
      */
     public static ResetDefault(skipDispose?: boolean): void {
+        // `this` will point to subclass
         if (this._Default) {
             if (!skipDispose) {
                 this._Default.dispose();
@@ -119,10 +121,10 @@ export abstract class DracoCodec implements IDisposable {
 
     /**
      * Constructor
-     * @param _config The configuration for the DracoCodec instance.
+     * @param configuration The configuration for the DracoCodec instance.
      */
-    constructor(_config: IDracoCodecConfiguration) {
-        const config = { numWorkers: _GetDefaultNumWorkers(), ..._config };
+    constructor(configuration: IDracoCodecConfiguration) {
+        const config = { numWorkers: _GetDefaultNumWorkers(), ...configuration };
         // check if the decoder binary and worker pool was injected
         // Note - it is expected that the developer checked if WebWorker, WebAssembly and the URL object are available
         if (config.workerPool) {

--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -63,9 +63,9 @@ export function _GetDefaultNumWorkers(): number {
  * Base class for a Draco codec.
  * @internal
  */
-export abstract class DracoCodec<M> implements IDisposable {
+export abstract class DracoCodec implements IDisposable {
     protected _workerPoolPromise?: Promise<AutoReleaseWorkerPool>;
-    protected _modulePromise?: Promise<{ module: M }>;
+    protected _modulePromise?: Promise<{ module: any /** DecoderModule | EncoderModule */ }>;
 
     /**
      * The configuration for the Draco codec.
@@ -85,7 +85,7 @@ export abstract class DracoCodec<M> implements IDisposable {
      * Subclasses should override this value using the narrowed type of the subclass,
      * and define a public `get Default()` that returns the narrowed instance.
      */
-    protected static _Default: Nullable<DracoCodec<unknown>>;
+    protected static _Default: Nullable<DracoCodec>;
 
     /**
      * Reset the default draco compression object to null and disposing the removed default instance.
@@ -110,7 +110,7 @@ export abstract class DracoCodec<M> implements IDisposable {
     /**
      * Creates the JS Module for the corresponding wasm.
      */
-    protected abstract _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: M }>;
+    protected abstract _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: any /** DecoderModule | EncoderModule */ }>;
 
     /**
      * Returns the worker content.

--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -1,0 +1,205 @@
+import type { Nullable } from "core/types";
+import { Tools } from "../../Misc/tools";
+import { AutoReleaseWorkerPool } from "../../Misc/workerPool";
+import type { IDisposable } from "../../scene";
+import { initializeWebWorker } from "./dracoCompressionWorker";
+
+/**
+ * Configuration for using a Draco codec.
+ */
+export interface IDracoCodecConfiguration {
+    /**
+     * The url to the WebAssembly module.
+     */
+    wasmUrl?: string;
+
+    /**
+     * The url to the WebAssembly binary.
+     */
+    wasmBinaryUrl?: string;
+
+    /**
+     * The url to the fallback JavaScript module.
+     */
+    fallbackUrl?: string;
+
+    /**
+     * The number of workers for async operations. Specify `0` to disable web workers and run synchronously in the current context.
+     */
+    numWorkers?: number;
+
+    /**
+     * Optional worker pool to use for async encoding/decoding.
+     * If provided, numWorkers will be ignored and the worker pool will be used instead.
+     * If provided the draco script will not be loaded from the DracoConfiguration.
+     */
+    workerPool?: AutoReleaseWorkerPool;
+
+    /**
+     * Optional ArrayBuffer of the WebAssembly binary.
+     * If provided it will be used instead of loading the binary from wasmBinaryUrl.
+     */
+    wasmBinary?: ArrayBuffer;
+
+    /**
+     * The codec module if already available.
+     */
+    jsModule?: any /* DracoDecoderModule | DracoEncoderModule */;
+}
+
+/**
+ * @internal
+ */
+export function GetDefaultNumWorkers(): number {
+    if (typeof navigator !== "object" || !navigator.hardwareConcurrency) {
+        return 1;
+    }
+
+    // Use 50% of the available logical processors but capped at 4.
+    return Math.min(Math.floor(navigator.hardwareConcurrency * 0.5), 4);
+}
+
+/**
+ * Base class for a Draco codec.
+ * @internal
+ */
+export abstract class DracoCodec<M> implements IDisposable {
+    protected _workerPoolPromise?: Promise<AutoReleaseWorkerPool>;
+    protected _modulePromise?: Promise<{ module: M }>;
+
+    /**
+     * The configuration for the Draco codec.
+     * Subclasses should override this value with a valid configuration.
+     */
+    public static Config: IDracoCodecConfiguration;
+
+    /**
+     * Returns true if the codec's `Configuration` is available.
+     */
+    public static get Available(): boolean {
+        return !!((this.Config.wasmUrl && this.Config.wasmBinaryUrl && typeof WebAssembly === "object") || this.Config.fallbackUrl);
+    }
+
+    /**
+     * The default draco compression object
+     * Subclasses should override this value with a valid instance.
+     */
+    protected static _Default: Nullable<DracoCodec<unknown>>;
+
+    /**
+     * Reset the default draco compression object to null and disposing the removed default instance.
+     * Note that if the workerPool is a member of the static Configuration object it is recommended not to run dispose,
+     * unless the static worker pool is no longer needed.
+     * @param skipDispose set to true to not dispose the removed default instance
+     */
+    public static ResetDefault(skipDispose?: boolean): void {
+        if (this._Default) {
+            if (!skipDispose) {
+                this._Default.dispose();
+            }
+            this._Default = null;
+        }
+    }
+
+    /**
+     * Checks if the default codec JS module is in scope.
+     */
+    protected abstract _isModuleAvailable(): boolean;
+
+    /**
+     * Creates the JS Module for the corresponding wasm.
+     */
+    protected abstract _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: M }>;
+
+    /**
+     * Returns the worker content.
+     */
+    protected abstract _getWorkerContent(): string;
+
+    /**
+     * Constructor
+     * @param _config The configuration for the DracoCodec instance.
+     */
+    constructor(_config: IDracoCodecConfiguration) {
+        const config = { numWorkers: GetDefaultNumWorkers(), ..._config };
+        // check if the decoder binary and worker pool was injected
+        // Note - it is expected that the developer checked if WebWorker, WebAssembly and the URL object are available
+        if (config.workerPool) {
+            // Set the promise accordingly
+            this._workerPoolPromise = Promise.resolve(config.workerPool);
+            return;
+        }
+
+        // to avoid making big changes to the code here, if wasmBinary is provided use it in the wasmBinaryPromise
+        const wasmBinaryProvided = config.wasmBinary;
+        const numberOfWorkers = config.numWorkers;
+        const useWorkers = numberOfWorkers && typeof Worker === "function" && typeof URL === "function";
+        const urlNeeded = useWorkers || (!useWorkers && !config.jsModule);
+        // code maintained here for back-compat with no changes
+
+        const codecInfo: { url: string | undefined; wasmBinaryPromise: Promise<ArrayBuffer | undefined> } =
+            config.wasmUrl && config.wasmBinaryUrl && typeof WebAssembly === "object"
+                ? {
+                      url: urlNeeded ? Tools.GetBabylonScriptURL(config.wasmUrl, true) : "",
+                      wasmBinaryPromise: wasmBinaryProvided ? Promise.resolve(wasmBinaryProvided) : Tools.LoadFileAsync(Tools.GetBabylonScriptURL(config.wasmBinaryUrl, true)),
+                  }
+                : {
+                      url: urlNeeded ? Tools.GetBabylonScriptURL(config.fallbackUrl!) : "",
+                      wasmBinaryPromise: Promise.resolve(undefined),
+                  };
+        // If using workers, initialize a worker pool with either the wasm or url?
+        if (useWorkers) {
+            this._workerPoolPromise = codecInfo.wasmBinaryPromise.then((wasmBinary) => {
+                const workerContent = this._getWorkerContent();
+                const workerBlobUrl = URL.createObjectURL(new Blob([workerContent], { type: "application/javascript" }));
+
+                return new AutoReleaseWorkerPool(numberOfWorkers as number, () => {
+                    const worker = new Worker(workerBlobUrl);
+                    return initializeWebWorker(worker, wasmBinary, codecInfo.url);
+                });
+            });
+        } else {
+            this._modulePromise = codecInfo.wasmBinaryPromise.then(async (wasmBinary) => {
+                if (this._isModuleAvailable()) {
+                    if (!config.jsModule) {
+                        if (!codecInfo.url) {
+                            throw new Error("Draco codec module is not available");
+                        }
+                        await Tools.LoadBabylonScriptAsync(codecInfo.url);
+                    }
+                }
+                return /*await*/ this._createModuleAsync(wasmBinary as ArrayBuffer, config.jsModule);
+            });
+        }
+    }
+
+    /**
+     * Returns a promise that resolves when ready. Call this manually to ensure draco compression is ready before use.
+     * @returns a promise that resolves when ready
+     */
+    public async whenReadyAsync(): Promise<void> {
+        if (this._workerPoolPromise) {
+            await this._workerPoolPromise;
+            return;
+        }
+
+        if (this._modulePromise) {
+            await this._modulePromise;
+            return;
+        }
+    }
+
+    /**
+     * Stop all async operations and release resources.
+     */
+    public dispose(): void {
+        if (this._workerPoolPromise) {
+            this._workerPoolPromise.then((workerPool) => {
+                workerPool.dispose();
+            });
+        }
+
+        delete this._workerPoolPromise;
+        delete this._modulePromise;
+    }
+}

--- a/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCodec.ts
@@ -161,7 +161,7 @@ export abstract class DracoCodec implements IDisposable {
             });
         } else {
             this._modulePromise = codecInfo.wasmBinaryPromise.then(async (wasmBinary) => {
-                if (this._isModuleAvailable()) {
+                if (!this._isModuleAvailable()) {
                     if (!config.jsModule) {
                         if (!codecInfo.url) {
                             throw new Error("Draco codec module is not available");

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -5,7 +5,7 @@ import type { MeshData } from "./dracoDecoder";
 import { VertexBuffer } from "../buffer";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "core/types";
-import { Geometry } from "../geometry";
+import type { Geometry } from "../geometry";
 import type { BoundingInfo } from "../../Culling/boundingInfo";
 import type { Scene } from "../../scene";
 

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -1,9 +1,13 @@
-import { _GetDefaultNumWorkers } from "./dracoCodec";
+import { _GetDefaultNumWorkers, _IsConfigurationAvailable } from "./dracoCodec";
 import type { IDracoCodecConfiguration } from "./dracoCodec";
 import { DracoDecoder } from "./dracoDecoder";
+import type { MeshData } from "./dracoDecoder";
 import { VertexBuffer } from "../buffer";
 import { VertexData } from "../mesh.vertexData";
 import type { Nullable } from "core/types";
+import { Geometry } from "../geometry";
+import type { BoundingInfo } from "../../Culling/boundingInfo";
+import type { Scene } from "../../scene";
 
 /**
  * Configuration for Draco compression
@@ -35,16 +39,18 @@ export interface IDracoCompressionOptions extends Pick<IDracoCodecConfiguration,
  *
  * To update the configuration, use the following code:
  * ```javascript
- *     DracoCompression.DefaultConfiguration = {
- *        wasmUrl: "<url to the WebAssembly library>",
- *        wasmBinaryUrl: "<url to the WebAssembly binary>",
- *        fallbackUrl: "<url to the fallback JavaScript library>",
+ *     DracoCompression.Configuration = {
+ *         decoder: {
+ *             wasmUrl: "<url to the WebAssembly library>",
+ *             wasmBinaryUrl: "<url to the WebAssembly binary>",
+ *             fallbackUrl: "<url to the fallback JavaScript library>",
+ *         }
  *     };
  * ```
  *
  * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support WebAssembly or only support the JavaScript version.
  * Decoding will automatically fallback to the JavaScript version if WebAssembly version is not configured or if WebAssembly is not supported by the browser.
- * Use `DracoCompression.DefaultAvailable` to determine if the decoder configuration is available for the current context.
+ * Use `DracoCompression.DecoderAvailable` to determine if the decoder configuration is available for the current context.
  *
  * To decode Draco compressed data, get the default DracoCompression object and call decodeMeshToGeometryAsync:
  * ```javascript
@@ -53,40 +59,22 @@ export interface IDracoCompressionOptions extends Pick<IDracoCodecConfiguration,
  *
  * @see https://playground.babylonjs.com/#DMZIBD#0
  */
-export class DracoCompression extends DracoDecoder {
-    /**
-     * Default configuration for the DracoCompression. Defaults to the following:
-     * - numWorkers: 50% of the available logical processors, capped to 4. If no logical processors are available, defaults to 1.
-     * - wasmUrl: `"https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"`
-     * - wasmBinaryUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.wasm"`
-     * - fallbackUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.js"`
-     */
-    public static override DefaultConfiguration: IDracoCodecConfiguration = { ...DracoDecoder.DefaultConfiguration }; // Use copy
+export class DracoCompression {
+    private _decoder: DracoDecoder;
 
     /**
-     * @deprecated See {@link DracoCompression.DefaultConfiguration}
+     * The configuration. Defaults to the following urls:
+     * - wasmUrl: "https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"
+     * - wasmBinaryUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.wasm"
+     * - fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js"
      */
-    public static get Configuration(): IDracoCompressionConfiguration {
-        return { decoder: DracoCompression.DefaultConfiguration };
-    }
-    public static set Configuration(config: IDracoCompressionConfiguration) {
-        DracoCompression.DefaultConfiguration = config.decoder;
-    }
+    public static Configuration: IDracoCompressionConfiguration = { decoder: { ...DracoDecoder.DefaultConfiguration } }; // Use copy
 
     /**
-     * @deprecated See {@link DracoCompression.DefaultAvailable}
+     * Returns true if the decoder configuration is available.
      */
     public static get DecoderAvailable(): boolean {
-        return DracoCompression.DefaultAvailable;
-    }
-
-    protected static override _Default: Nullable<DracoCompression> = null;
-    /**
-     * Default instance for the DracoCompression.
-     */
-    public static override get Default(): DracoCompression {
-        DracoCompression._Default ??= new DracoCompression();
-        return DracoCompression._Default;
+        return _IsConfigurationAvailable(DracoCompression.Configuration.decoder);
     }
 
     /**
@@ -94,18 +82,96 @@ export class DracoCompression extends DracoDecoder {
      */
     public static DefaultNumWorkers = _GetDefaultNumWorkers();
 
+    protected static _Default: Nullable<DracoCompression> = null;
+    /**
+     * Default instance for the DracoCompression.
+     */
+    public static get Default(): DracoCompression {
+        DracoCompression._Default ??= new DracoCompression();
+        return DracoCompression._Default;
+    }
+
+    /**
+     * Reset the default draco compression object to null and disposing the removed default instance.
+     * Note that if the workerPool is a member of the static Configuration object it is recommended not to run dispose,
+     * unless the static worker pool is no longer needed.
+     * @param skipDispose set to true to not dispose the removed default instance
+     */
+    public static ResetDefault(skipDispose?: boolean): void {
+        if (DracoCompression._Default) {
+            if (!skipDispose) {
+                DracoCompression._Default.dispose();
+            }
+            DracoCompression._Default = null;
+        }
+    }
+
     /**
      * Creates a new DracoCompression object.
-     * @param numWorkersOrOptions Overrides for the DefaultConfiguration. Either:
+     * @param numWorkersOrOptions Overrides for the Configuration. Either:
      * - The number of workers for async operations or a config object. Specify `0` to disable web workers and run synchronously in the current context.
      * - An options object
      */
     constructor(numWorkersOrOptions: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
         const configuration =
             typeof numWorkersOrOptions === "number"
-                ? { ...DracoCompression.DefaultConfiguration, numWorkers: numWorkersOrOptions }
-                : { ...DracoCompression.DefaultConfiguration, ...numWorkersOrOptions };
-        super(configuration);
+                ? { ...DracoCompression.Configuration, numWorkers: numWorkersOrOptions }
+                : { ...DracoCompression.Configuration, ...numWorkersOrOptions };
+        this._decoder = new DracoDecoder(configuration);
+    }
+
+    /**
+     * Stop all async operations and release resources.
+     */
+    public dispose(): void {
+        this._decoder.dispose();
+    }
+
+    /**
+     * Returns a promise that resolves when ready. Call this manually to ensure draco compression is ready before use.
+     * @returns a promise that resolves when ready
+     */
+    public async whenReadyAsync(): Promise<void> {
+        return this._decoder.whenReadyAsync();
+    }
+
+    /**
+     * Decode Draco compressed mesh data to mesh data.
+     * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
+     * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
+     * @param gltfNormalizedOverride A map of attributes from vertex buffer kinds to normalized flags to override the Draco normalization
+     * @returns A promise that resolves with the decoded mesh data
+     */
+    public decodeMeshToMeshDataAsync(
+        data: ArrayBuffer | ArrayBufferView,
+        attributes?: { [kind: string]: number },
+        gltfNormalizedOverride?: { [kind: string]: boolean }
+    ): Promise<MeshData> {
+        return this._decoder.decodeMeshToMeshDataAsync(data, attributes, gltfNormalizedOverride);
+    }
+
+    /**
+     * Decode Draco compressed mesh data to Babylon geometry.
+     * @param name The name to use when creating the geometry
+     * @param scene The scene to use when creating the geometry
+     * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
+     * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
+     * @returns A promise that resolves with the decoded geometry
+     */
+    public async decodeMeshToGeometryAsync(name: string, scene: Scene, data: ArrayBuffer | ArrayBufferView, attributes?: { [kind: string]: number }): Promise<Geometry> {
+        return this._decoder.decodeMeshToGeometryAsync(name, scene, data, attributes);
+    }
+
+    /** @internal */
+    public async _decodeMeshToGeometryForGltfAsync(
+        name: string,
+        scene: Scene,
+        data: ArrayBuffer | ArrayBufferView,
+        attributes: { [kind: string]: number },
+        gltfNormalizedOverride: { [kind: string]: boolean },
+        boundingInfo: Nullable<BoundingInfo>
+    ): Promise<Geometry> {
+        return this._decoder._decodeMeshToGeometryForGltfAsync(name, scene, data, attributes, gltfNormalizedOverride, boundingInfo);
     }
 
     /**
@@ -116,7 +182,7 @@ export class DracoCompression extends DracoDecoder {
      * @deprecated Use {@link decodeMeshToGeometryAsync} for better performance in some cases
      */
     public async decodeMeshAsync(data: ArrayBuffer | ArrayBufferView, attributes?: { [kind: string]: number }): Promise<VertexData> {
-        const meshData = await this.decodeMeshToMeshDataAsync(data, attributes);
+        const meshData = await this._decoder.decodeMeshToMeshDataAsync(data, attributes);
         const vertexData = new VertexData();
         if (meshData.indices) {
             vertexData.indices = meshData.indices;

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -1,33 +1,7 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-import type { BoundingInfo } from "../../Culling/boundingInfo";
-import { Tools } from "../../Misc/tools";
-import { AutoReleaseWorkerPool } from "../../Misc/workerPool";
-import type { Nullable } from "../../types";
-import type { IDisposable, Scene } from "../../scene";
-import { Geometry } from "../geometry";
+import { GetDefaultNumWorkers, type IDracoCodecConfiguration } from "./dracoCodec";
+import { DracoDecoder } from "./dracoDecoder";
 import { VertexBuffer } from "../buffer";
 import { VertexData } from "../mesh.vertexData";
-import type { DecoderModule } from "draco3dgltf";
-import { Logger } from "../../Misc/logger";
-import { decodeMesh, type AttributeData, type Message, workerFunction, initializeWebWorker } from "./dracoCompressionWorker";
-import { DracoDecoderModule } from "draco3dgltf";
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare let DracoDecoderModule: DracoDecoderModule;
-
-interface MeshData {
-    indices?: Uint16Array | Uint32Array;
-    attributes: Array<AttributeData>;
-    totalVertices: number;
-}
-
-function createDecoderAsync(wasmBinary?: ArrayBuffer, jsModule?: DracoDecoderModule): Promise<{ module: DecoderModule }> {
-    return new Promise((resolve) => {
-        (jsModule || DracoDecoderModule)({ wasmBinary }).then((module) => {
-            resolve({ module });
-        });
-    });
-}
 
 /**
  * Configuration for Draco compression
@@ -36,431 +10,46 @@ export interface IDracoCompressionConfiguration {
     /**
      * Configuration for the decoder.
      */
-    decoder: {
-        /**
-         * The url to the WebAssembly module.
-         */
-        wasmUrl?: string;
-
-        /**
-         * The url to the WebAssembly binary.
-         */
-        wasmBinaryUrl?: string;
-
-        /**
-         * The url to the fallback JavaScript module.
-         */
-        fallbackUrl?: string;
-        /**
-         * Optional worker pool to use for async decoding instead of creating a new worker pool.
-         */
-        workerPool?: AutoReleaseWorkerPool;
-        /**
-         * Optional ArrayBuffer of the WebAssembly binary
-         */
-        wasmBinary?: ArrayBuffer;
-
-        /**
-         * The decoder module if already available.
-         */
-        jsModule?: any /* DecoderModule */;
-    };
+    decoder: IDracoCodecConfiguration;
 }
 
 /**
  * Options for Draco compression
  */
-export interface IDracoCompressionOptions {
-    /**
-     * The number of workers for async operations. Specify `0` to disable web workers and run synchronously in the current context.
-     */
-    numWorkers?: number;
-    /**
-     * Optional ArrayBuffer of the WebAssembly binary.
-     * If provided it will be used instead of loading the binary from wasmBinaryUrl.
-     */
-    wasmBinary?: ArrayBuffer;
-    /**
-     * Optional worker pool to use for async decoding.
-     * If provided, numWorkers will be ignored and the worker pool will be used instead.
-     * If provided the draco script will not be loaded from the DracoConfiguration.
-     */
-    workerPool?: AutoReleaseWorkerPool;
-}
+export interface IDracoCompressionOptions extends Pick<IDracoCodecConfiguration, "numWorkers" | "wasmBinary" | "workerPool"> {}
 
 /**
- * Draco compression (https://google.github.io/draco/)
- *
- * This class wraps the Draco module.
- *
- * **Encoder**
- *
- * The encoder is not currently implemented.
- *
- * **Decoder**
- *
- * By default, the configuration points to a copy of the Draco decoder files for glTF from the babylon.js preview cdn https://preview.babylonjs.com/draco_wasm_wrapper_gltf.js.
- *
- * To update the configuration, use the following code:
- * ```javascript
- *     DracoCompression.Configuration = {
- *         decoder: {
- *             wasmUrl: "<url to the WebAssembly library>",
- *             wasmBinaryUrl: "<url to the WebAssembly binary>",
- *             fallbackUrl: "<url to the fallback JavaScript library>",
- *         }
- *     };
- * ```
- *
- * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support WebAssembly or only support the JavaScript version.
- * Decoding will automatically fallback to the JavaScript version if WebAssembly version is not configured or if WebAssembly is not supported by the browser.
- * Use `DracoCompression.DecoderAvailable` to determine if the decoder configuration is available for the current context.
- *
- * To decode Draco compressed data, get the default DracoCompression object and call decodeMeshToGeometryAsync:
- * ```javascript
- *     var geometry = await DracoCompression.Default.decodeMeshToGeometryAsync(data);
- * ```
- *
- * @see https://playground.babylonjs.com/#DMZIBD#0
+ * @deprecated Use {@link DracoDecoder} instead.
  */
-export class DracoCompression implements IDisposable {
-    private _workerPoolPromise?: Promise<AutoReleaseWorkerPool>;
-    private _decoderModulePromise?: Promise<{ module: DecoderModule }>;
-
+export class DracoCompression extends DracoDecoder {
     /**
-     * The configuration. Defaults to the following urls:
-     * - wasmUrl: "https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"
-     * - wasmBinaryUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.wasm"
-     * - fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js"
+     * The configuration for the Draco compression.
+     * WARNING: This is a reference to `DracoDecoder.Config`.
      */
     public static Configuration: IDracoCompressionConfiguration = {
-        decoder: {
-            wasmUrl: `${Tools._DefaultCdnUrl}/draco_wasm_wrapper_gltf.js`,
-            wasmBinaryUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.wasm`,
-            fallbackUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.js`,
-        },
+        decoder: DracoDecoder.Config,
     };
 
     /**
      * Returns true if the decoder configuration is available.
+     * WARNING: This is a reference to `DracoDecoder.Available`.
      */
     public static get DecoderAvailable(): boolean {
-        const decoder = DracoCompression.Configuration.decoder;
-        return !!((decoder.wasmUrl && decoder.wasmBinaryUrl && typeof WebAssembly === "object") || decoder.fallbackUrl);
+        return DracoDecoder.Available;
     }
 
     /**
      * Default number of workers to create when creating the draco compression object.
      */
-    public static DefaultNumWorkers = DracoCompression.GetDefaultNumWorkers();
-
-    private static GetDefaultNumWorkers(): number {
-        if (typeof navigator !== "object" || !navigator.hardwareConcurrency) {
-            return 1;
-        }
-
-        // Use 50% of the available logical processors but capped at 4.
-        return Math.min(Math.floor(navigator.hardwareConcurrency * 0.5), 4);
-    }
-
-    private static _Default: Nullable<DracoCompression> = null;
-
-    /**
-     * Default instance for the draco compression object.
-     */
-    public static get Default(): DracoCompression {
-        if (!DracoCompression._Default) {
-            DracoCompression._Default = new DracoCompression();
-        }
-
-        return DracoCompression._Default;
-    }
-
-    /**
-     * Reset the default draco compression object to null and disposing the removed default instance.
-     * Note that if the workerPool is a member of the static Configuration object it is recommended not to run dispose,
-     * unless the static worker pool is no longer needed.
-     * @param skipDispose set to true to not dispose the removed default instance
-     */
-    public static ResetDefault(skipDispose?: boolean): void {
-        if (DracoCompression._Default) {
-            if (!skipDispose) {
-                DracoCompression._Default.dispose();
-            }
-            DracoCompression._Default = null;
-        }
-    }
+    public static DefaultNumWorkers = GetDefaultNumWorkers();
 
     /**
      * Constructor
-     * @param numWorkers The number of workers for async operations Or an options object. Specify `0` to disable web workers and run synchronously in the current context.
+     * @param numWorkersOrConfig The number of workers for async operations or a config object. Specify `0` to disable web workers and run synchronously in the current context.
      */
-    constructor(numWorkers: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
-        const decoder = DracoCompression.Configuration.decoder;
-        // check if the decoder binary and worker pool was injected
-        // Note - it is expected that the developer checked if WebWorker, WebAssembly and the URL object are available
-        if (decoder.workerPool || (typeof numWorkers === "object" && numWorkers.workerPool)) {
-            // set the promise accordingly
-            this._workerPoolPromise = Promise.resolve(decoder.workerPool || (numWorkers as IDracoCompressionOptions).workerPool!);
-        } else {
-            // to avoid making big changes to the decider, if wasmBinary is provided use it in the wasmBinaryPromise
-            const wasmBinaryProvided = decoder.wasmBinary || (typeof numWorkers === "object" && numWorkers.wasmBinary);
-            const numberOfWorkers = typeof numWorkers === "number" ? numWorkers : numWorkers.numWorkers;
-            const useWorkers = numberOfWorkers && typeof Worker === "function" && typeof URL === "function";
-            const urlNeeded = useWorkers || (!useWorkers && !decoder.jsModule);
-            // code maintained here for back-compat with no changes
-
-            const decoderInfo: { url: string | undefined; wasmBinaryPromise: Promise<ArrayBuffer | undefined> } =
-                decoder.wasmUrl && decoder.wasmBinaryUrl && typeof WebAssembly === "object"
-                    ? {
-                          url: urlNeeded ? Tools.GetBabylonScriptURL(decoder.wasmUrl, true) : "",
-                          wasmBinaryPromise: wasmBinaryProvided ? Promise.resolve(wasmBinaryProvided) : Tools.LoadFileAsync(Tools.GetBabylonScriptURL(decoder.wasmBinaryUrl, true)),
-                      }
-                    : {
-                          url: urlNeeded ? Tools.GetBabylonScriptURL(decoder.fallbackUrl!) : "",
-                          wasmBinaryPromise: Promise.resolve(undefined),
-                      };
-            if (useWorkers) {
-                this._workerPoolPromise = decoderInfo.wasmBinaryPromise.then((decoderWasmBinary) => {
-                    const workerContent = `${decodeMesh}(${workerFunction})()`;
-                    const workerBlobUrl = URL.createObjectURL(new Blob([workerContent], { type: "application/javascript" }));
-
-                    return new AutoReleaseWorkerPool(numberOfWorkers as number, () => {
-                        const worker = new Worker(workerBlobUrl);
-                        return initializeWebWorker(worker, decoderWasmBinary, decoderInfo.url);
-                    });
-                });
-            } else {
-                this._decoderModulePromise = decoderInfo.wasmBinaryPromise.then(async (decoderWasmBinary) => {
-                    if (typeof DracoDecoderModule === "undefined") {
-                        if (!decoder.jsModule) {
-                            if (!decoderInfo.url) {
-                                throw new Error("Draco decoder module is not available");
-                            }
-                            await Tools.LoadBabylonScriptAsync(decoderInfo.url);
-                        }
-                    }
-                    return await createDecoderAsync(decoderWasmBinary as ArrayBuffer, decoder.jsModule);
-                });
-            }
-        }
-    }
-
-    /**
-     * Stop all async operations and release resources.
-     */
-    public dispose(): void {
-        if (this._workerPoolPromise) {
-            this._workerPoolPromise.then((workerPool) => {
-                workerPool.dispose();
-            });
-        }
-
-        delete this._workerPoolPromise;
-        delete this._decoderModulePromise;
-    }
-
-    /**
-     * Returns a promise that resolves when ready. Call this manually to ensure draco compression is ready before use.
-     * @returns a promise that resolves when ready
-     */
-    public async whenReadyAsync(): Promise<void> {
-        if (this._workerPoolPromise) {
-            await this._workerPoolPromise;
-            return;
-        }
-
-        if (this._decoderModulePromise) {
-            await this._decoderModulePromise;
-            return;
-        }
-    }
-
-    /**
-     * Decode Draco compressed mesh data to mesh data.
-     * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
-     * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
-     * @param gltfNormalizedOverride A map of attributes from vertex buffer kinds to normalized flags to override the Draco normalization
-     * @returns A promise that resolves with the decoded mesh data
-     */
-    public decodeMeshToMeshDataAsync(
-        data: ArrayBuffer | ArrayBufferView,
-        attributes?: { [kind: string]: number },
-        gltfNormalizedOverride?: { [kind: string]: boolean }
-    ): Promise<MeshData> {
-        const dataView = data instanceof ArrayBuffer ? new Int8Array(data) : new Int8Array(data.buffer, data.byteOffset, data.byteLength);
-
-        const applyGltfNormalizedOverride = (kind: string, normalized: boolean): boolean => {
-            if (gltfNormalizedOverride && gltfNormalizedOverride[kind] !== undefined) {
-                if (normalized !== gltfNormalizedOverride[kind]) {
-                    Logger.Warn(
-                        `Normalized flag from Draco data (${normalized}) does not match normalized flag from glTF accessor (${gltfNormalizedOverride[kind]}). Using flag from glTF accessor.`
-                    );
-                }
-
-                return gltfNormalizedOverride[kind];
-            } else {
-                return normalized;
-            }
-        };
-
-        if (this._workerPoolPromise) {
-            return this._workerPoolPromise.then((workerPool) => {
-                return new Promise<MeshData>((resolve, reject) => {
-                    workerPool.push((worker, onComplete) => {
-                        let resultIndices: Nullable<Uint16Array | Uint32Array> = null;
-                        const resultAttributes: Array<AttributeData> = [];
-
-                        const onError = (error: ErrorEvent) => {
-                            worker.removeEventListener("error", onError);
-                            worker.removeEventListener("message", onMessage);
-                            reject(error);
-                            onComplete();
-                        };
-
-                        const onMessage = (event: MessageEvent<Message>) => {
-                            const message = event.data;
-                            switch (message.id) {
-                                case "decodeMeshDone": {
-                                    worker.removeEventListener("error", onError);
-                                    worker.removeEventListener("message", onMessage);
-                                    resolve({ indices: resultIndices!, attributes: resultAttributes, totalVertices: message.totalVertices });
-                                    onComplete();
-                                    break;
-                                }
-                                case "indices": {
-                                    resultIndices = message.data;
-                                    break;
-                                }
-                                case "attribute": {
-                                    resultAttributes.push({
-                                        kind: message.kind,
-                                        data: message.data,
-                                        size: message.size,
-                                        byteOffset: message.byteOffset,
-                                        byteStride: message.byteStride,
-                                        normalized: applyGltfNormalizedOverride(message.kind, message.normalized),
-                                    });
-                                    break;
-                                }
-                            }
-                        };
-
-                        worker.addEventListener("error", onError);
-                        worker.addEventListener("message", onMessage);
-
-                        const dataViewCopy = dataView.slice();
-                        worker.postMessage({ id: "decodeMesh", dataView: dataViewCopy, attributes: attributes }, [dataViewCopy.buffer]);
-                    });
-                });
-            });
-        }
-
-        if (this._decoderModulePromise) {
-            return this._decoderModulePromise.then((decoder) => {
-                let resultIndices: Nullable<Uint16Array | Uint32Array> = null;
-                const resultAttributes: Array<AttributeData> = [];
-
-                const numPoints = decodeMesh(
-                    decoder.module,
-                    dataView,
-                    attributes,
-                    (indices) => {
-                        resultIndices = indices;
-                    },
-                    (kind, data, size, byteOffset, byteStride, normalized) => {
-                        resultAttributes.push({
-                            kind,
-                            data,
-                            size,
-                            byteOffset,
-                            byteStride,
-                            normalized,
-                        });
-                    }
-                );
-
-                return { indices: resultIndices!, attributes: resultAttributes, totalVertices: numPoints };
-            });
-        }
-
-        throw new Error("Draco decoder module is not available");
-    }
-
-    /**
-     * Decode Draco compressed mesh data to Babylon geometry.
-     * @param name The name to use when creating the geometry
-     * @param scene The scene to use when creating the geometry
-     * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
-     * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
-     * @returns A promise that resolves with the decoded geometry
-     */
-    public async decodeMeshToGeometryAsync(name: string, scene: Scene, data: ArrayBuffer | ArrayBufferView, attributes?: { [kind: string]: number }): Promise<Geometry> {
-        const meshData = await this.decodeMeshToMeshDataAsync(data, attributes);
-        const geometry = new Geometry(name, scene);
-        if (meshData.indices) {
-            geometry.setIndices(meshData.indices);
-        }
-        for (const attribute of meshData.attributes) {
-            geometry.setVerticesBuffer(
-                new VertexBuffer(
-                    scene.getEngine(),
-                    attribute.data,
-                    attribute.kind,
-                    false,
-                    undefined,
-                    attribute.byteStride,
-                    undefined,
-                    attribute.byteOffset,
-                    attribute.size,
-                    undefined,
-                    attribute.normalized,
-                    true
-                ),
-                meshData.totalVertices
-            );
-        }
-        return geometry;
-    }
-
-    /** @internal */
-    public async _decodeMeshToGeometryForGltfAsync(
-        name: string,
-        scene: Scene,
-        data: ArrayBuffer | ArrayBufferView,
-        attributes: { [kind: string]: number },
-        gltfNormalizedOverride: { [kind: string]: boolean },
-        boundingInfo: Nullable<BoundingInfo>
-    ): Promise<Geometry> {
-        const meshData = await this.decodeMeshToMeshDataAsync(data, attributes, gltfNormalizedOverride);
-        const geometry = new Geometry(name, scene);
-        if (boundingInfo) {
-            geometry._boundingInfo = boundingInfo;
-            geometry.useBoundingInfoFromGeometry = true;
-        }
-        if (meshData.indices) {
-            geometry.setIndices(meshData.indices);
-        }
-        for (const attribute of meshData.attributes) {
-            geometry.setVerticesBuffer(
-                new VertexBuffer(
-                    scene.getEngine(),
-                    attribute.data,
-                    attribute.kind,
-                    false,
-                    undefined,
-                    attribute.byteStride,
-                    undefined,
-                    attribute.byteOffset,
-                    attribute.size,
-                    undefined,
-                    attribute.normalized,
-                    true
-                ),
-                meshData.totalVertices
-            );
-        }
-        return geometry;
+    constructor(numWorkersOrConfig: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
+        const config = typeof numWorkersOrConfig === "number" ? { ...DracoDecoder.Config, numWorkers: numWorkersOrConfig } : { ...DracoDecoder.Config, ...numWorkersOrConfig };
+        super(config);
     }
 
     /**

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -1,4 +1,4 @@
-import { GetDefaultNumWorkers, type IDracoCodecConfiguration } from "./dracoCodec";
+import { _GetDefaultNumWorkers, type IDracoCodecConfiguration } from "./dracoCodec";
 import { DracoDecoder } from "./dracoDecoder";
 import { VertexBuffer } from "../buffer";
 import { VertexData } from "../mesh.vertexData";
@@ -74,7 +74,7 @@ export class DracoCompression extends DracoDecoder {
     /**
      * Default number of workers to create when creating the draco compression object.
      */
-    public static DefaultNumWorkers = GetDefaultNumWorkers();
+    public static DefaultNumWorkers = _GetDefaultNumWorkers();
 
     /**
      * Constructor

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -115,8 +115,8 @@ export class DracoCompression {
     constructor(numWorkersOrOptions: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
         const configuration =
             typeof numWorkersOrOptions === "number"
-                ? { ...DracoCompression.Configuration, numWorkers: numWorkersOrOptions }
-                : { ...DracoCompression.Configuration, ...numWorkersOrOptions };
+                ? { ...DracoCompression.Configuration.decoder, numWorkers: numWorkersOrOptions }
+                : { ...DracoCompression.Configuration.decoder, ...numWorkersOrOptions };
         this._decoder = new DracoDecoder(configuration);
     }
 

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -1,4 +1,5 @@
-import { _GetDefaultNumWorkers, type IDracoCodecConfiguration } from "./dracoCodec";
+import { _GetDefaultNumWorkers } from "./dracoCodec";
+import type { IDracoCodecConfiguration } from "./dracoCodec";
 import { DracoDecoder } from "./dracoDecoder";
 import { VertexBuffer } from "../buffer";
 import { VertexData } from "../mesh.vertexData";

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -62,14 +62,15 @@ export class DracoCompression extends DracoDecoder {
      * - fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js"
      */
     public static Configuration: IDracoCompressionConfiguration = {
-        decoder: DracoDecoder.Config, // TODO: Remove this reference or update the JSDoc with warning.
+        decoder: DracoDecoder.Config,
     };
 
     /**
      * Returns true if the decoder configuration is available.
      */
     public static get DecoderAvailable(): boolean {
-        return DracoDecoder.Available; // TODO: Remove this reference or update the JSDoc with warning.
+        const decoder = DracoCompression.Configuration.decoder;
+        return !!((decoder.wasmUrl && decoder.wasmBinaryUrl && typeof WebAssembly === "object") || decoder.fallbackUrl);
     }
 
     /**
@@ -82,7 +83,10 @@ export class DracoCompression extends DracoDecoder {
      * @param numWorkersOrConfig The number of workers for async operations or a config object. Specify `0` to disable web workers and run synchronously in the current context.
      */
     constructor(numWorkersOrConfig: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
-        const config = typeof numWorkersOrConfig === "number" ? { ...DracoDecoder.Config, numWorkers: numWorkersOrConfig } : { ...DracoDecoder.Config, ...numWorkersOrConfig };
+        const config =
+            typeof numWorkersOrConfig === "number"
+                ? { ...DracoCompression.Configuration.decoder, numWorkers: numWorkersOrConfig }
+                : { ...DracoCompression.Configuration.decoder, ...numWorkersOrConfig };
         super(config);
     }
 

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -19,23 +19,56 @@ export interface IDracoCompressionConfiguration {
 export interface IDracoCompressionOptions extends Pick<IDracoCodecConfiguration, "numWorkers" | "wasmBinary" | "workerPool"> {}
 
 /**
- * @deprecated Use {@link DracoDecoder} instead.
+ * Draco compression (https://google.github.io/draco/)
+ *
+ * This class wraps the Draco module.
+ *
+ * **Encoder**
+ *
+ * The encoder is not currently implemented.
+ *
+ * **Decoder**
+ *
+ * By default, the configuration points to a copy of the Draco decoder files for glTF from the babylon.js preview cdn https://preview.babylonjs.com/draco_wasm_wrapper_gltf.js.
+ *
+ * To update the configuration, use the following code:
+ * ```javascript
+ *     DracoCompression.Configuration = {
+ *         decoder: {
+ *             wasmUrl: "<url to the WebAssembly library>",
+ *             wasmBinaryUrl: "<url to the WebAssembly binary>",
+ *             fallbackUrl: "<url to the fallback JavaScript library>",
+ *         }
+ *     };
+ * ```
+ *
+ * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support WebAssembly or only support the JavaScript version.
+ * Decoding will automatically fallback to the JavaScript version if WebAssembly version is not configured or if WebAssembly is not supported by the browser.
+ * Use `DracoCompression.DecoderAvailable` to determine if the decoder configuration is available for the current context.
+ *
+ * To decode Draco compressed data, get the default DracoCompression object and call decodeMeshToGeometryAsync:
+ * ```javascript
+ *     var geometry = await DracoCompression.Default.decodeMeshToGeometryAsync(data);
+ * ```
+ *
+ * @see https://playground.babylonjs.com/#DMZIBD#0
  */
 export class DracoCompression extends DracoDecoder {
     /**
-     * The configuration for the Draco compression.
-     * WARNING: This is a reference to `DracoDecoder.Config`.
+     * The configuration. Defaults to the following urls:
+     * - wasmUrl: "https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"
+     * - wasmBinaryUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.wasm"
+     * - fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js"
      */
     public static Configuration: IDracoCompressionConfiguration = {
-        decoder: DracoDecoder.Config,
+        decoder: DracoDecoder.Config, // TODO: Remove this reference or update the JSDoc with warning.
     };
 
     /**
      * Returns true if the decoder configuration is available.
-     * WARNING: This is a reference to `DracoDecoder.Available`.
      */
     public static get DecoderAvailable(): boolean {
-        return DracoDecoder.Available;
+        return DracoDecoder.Available; // TODO: Remove this reference or update the JSDoc with warning.
     }
 
     /**

--- a/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
@@ -1,4 +1,5 @@
-import { type DecoderModule, DracoDecoderModule } from "draco3dgltf";
+import { DracoDecoderModule } from "draco3dgltf";
+import type { DecoderModule } from "draco3dgltf";
 import { DracoCodec, type IDracoCodecConfiguration } from "./dracoCodec";
 import { Tools } from "../../Misc/tools";
 import { Geometry } from "../geometry";
@@ -7,7 +8,8 @@ import { Logger } from "../../Misc/logger";
 import type { BoundingInfo } from "../../Culling/boundingInfo";
 import type { Scene } from "../../scene";
 import type { Nullable } from "../../types";
-import { decodeMesh, type AttributeData, type Message, workerFunction } from "./dracoCompressionWorker";
+import { decodeMesh, workerFunction } from "./dracoCompressionWorker";
+import type { AttributeData, Message } from "./dracoCompressionWorker";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare let DracoDecoderModule: DracoDecoderModule;

--- a/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
@@ -1,0 +1,282 @@
+import { type DecoderModule, DracoDecoderModule } from "draco3dgltf";
+import { DracoCodec, type IDracoCodecConfiguration } from "./dracoCodec";
+import { Tools } from "../../Misc/tools";
+import { Geometry } from "../geometry";
+import { VertexBuffer } from "../buffer";
+import { Logger } from "../../Misc/logger";
+import type { BoundingInfo } from "../../Culling/boundingInfo";
+import type { Scene } from "../../scene";
+import type { Nullable } from "../../types";
+import { decodeMesh, type AttributeData, type Message, workerFunction } from "./dracoCompressionWorker";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+declare let DracoDecoderModule: DracoDecoderModule;
+
+interface MeshData {
+    indices?: Uint16Array | Uint32Array;
+    attributes: Array<AttributeData>;
+    totalVertices: number;
+}
+
+/**
+ * Draco compression (https://google.github.io/draco/)
+ *
+ * This class wraps the Draco decoder module.
+ *
+ * By default, the configuration points to a copy of the Draco decoder files for glTF from the Babylon.js preview cdn https://preview.babylonjs.com/draco_wasm_wrapper_gltf.js.
+ *
+ * To update the configuration, use the following code:
+ * ```javascript
+ *     DracoDecoder.Config = {
+ *          wasmUrl: "<url to the WebAssembly library>",
+ *          wasmBinaryUrl: "<url to the WebAssembly binary>",
+ *          fallbackUrl: "<url to the fallback JavaScript library>",
+ *     };
+ * ```
+ *
+ * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support WebAssembly or only support the JavaScript version.
+ * Decoding will automatically fallback to the JavaScript version if WebAssembly version is not configured or if WebAssembly is not supported by the browser.
+ * Use `DracoDecoder.Available` to determine if the decoder configuration is available for the current context.
+ *
+ * To decode Draco compressed data, get the default DracoDecoder object and call decodeMeshToGeometryAsync:
+ * ```javascript
+ *     var geometry = await DracoDecoder.Default.decodeMeshToGeometryAsync(data);
+ * ```
+ */
+export class DracoDecoder extends DracoCodec<DecoderModule> {
+    protected static override _Default: Nullable<DracoDecoder> = null;
+    /**
+     * Default instance for the DracoDecoder.
+     */
+    public static get Default(): DracoDecoder {
+        if (!DracoDecoder._Default) {
+            DracoDecoder._Default = new DracoDecoder();
+        }
+        return DracoDecoder._Default;
+    }
+
+    /**
+     * Configuration for the DracoDecoder. Defaults to the following:
+     * - numWorkers: 50% of the available logical processors, capped to 4. If no logical processors are available, defaults to 1.
+     * - wasmUrl: `"https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"`
+     * - wasmBinaryUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.wasm"`
+     * - fallbackUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.js"`
+     */
+    public static override Config: IDracoCodecConfiguration = {
+        wasmUrl: `${Tools._DefaultCdnUrl}/draco_wasm_wrapper_gltf.js`,
+        wasmBinaryUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.wasm`,
+        fallbackUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.js`,
+    };
+
+    protected override _isModuleAvailable(): boolean {
+        return typeof DracoDecoderModule !== "undefined";
+    }
+
+    protected override _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: DecoderModule }> {
+        return new Promise((resolve) => {
+            ((jsModule as DracoDecoderModule) || DracoDecoderModule)({ wasmBinary }).then((module) => {
+                resolve({ module });
+            });
+        });
+    }
+
+    protected override _getWorkerContent(): string {
+        return `${decodeMesh}(${workerFunction})()`;
+    }
+
+    /**
+     * Creates a new Draco decoder.
+     * @param config Optional override of the configuration for the DracoDecoder. If not provided, defaults to `DracoDecoder.Config`.
+     */
+    constructor(config?: IDracoCodecConfiguration) {
+        // Order of final config will be config > DracoDecoder.Config.
+        super({ ...DracoDecoder.Config, ...(config ?? {}) });
+    }
+
+    /**
+     * Decode Draco compressed mesh data to mesh data.
+     * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
+     * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
+     * @param gltfNormalizedOverride A map of attributes from vertex buffer kinds to normalized flags to override the Draco normalization
+     * @returns A promise that resolves with the decoded mesh data
+     */
+    public decodeMeshToMeshDataAsync(
+        data: ArrayBuffer | ArrayBufferView,
+        attributes?: { [kind: string]: number },
+        gltfNormalizedOverride?: { [kind: string]: boolean }
+    ): Promise<MeshData> {
+        const dataView = data instanceof ArrayBuffer ? new Int8Array(data) : new Int8Array(data.buffer, data.byteOffset, data.byteLength);
+
+        const applyGltfNormalizedOverride = (kind: string, normalized: boolean): boolean => {
+            if (gltfNormalizedOverride && gltfNormalizedOverride[kind] !== undefined) {
+                if (normalized !== gltfNormalizedOverride[kind]) {
+                    Logger.Warn(
+                        `Normalized flag from Draco data (${normalized}) does not match normalized flag from glTF accessor (${gltfNormalizedOverride[kind]}). Using flag from glTF accessor.`
+                    );
+                }
+
+                return gltfNormalizedOverride[kind];
+            } else {
+                return normalized;
+            }
+        };
+
+        if (this._workerPoolPromise) {
+            return this._workerPoolPromise.then((workerPool) => {
+                return new Promise<MeshData>((resolve, reject) => {
+                    workerPool.push((worker, onComplete) => {
+                        let resultIndices: Nullable<Uint16Array | Uint32Array> = null;
+                        const resultAttributes: Array<AttributeData> = [];
+
+                        const onError = (error: ErrorEvent) => {
+                            worker.removeEventListener("error", onError);
+                            worker.removeEventListener("message", onMessage);
+                            reject(error);
+                            onComplete();
+                        };
+
+                        const onMessage = (event: MessageEvent<Message>) => {
+                            const message = event.data;
+                            switch (message.id) {
+                                case "indices": {
+                                    resultIndices = message.data;
+                                    break;
+                                }
+                                case "attribute": {
+                                    resultAttributes.push({
+                                        kind: message.kind,
+                                        data: message.data,
+                                        size: message.size,
+                                        byteOffset: message.byteOffset,
+                                        byteStride: message.byteStride,
+                                        normalized: applyGltfNormalizedOverride(message.kind, message.normalized),
+                                    });
+                                    break;
+                                }
+                                case "decodeMeshDone": {
+                                    worker.removeEventListener("error", onError);
+                                    worker.removeEventListener("message", onMessage);
+                                    resolve({ indices: resultIndices!, attributes: resultAttributes, totalVertices: message.totalVertices });
+                                    onComplete();
+                                    break;
+                                }
+                            }
+                        };
+
+                        worker.addEventListener("error", onError);
+                        worker.addEventListener("message", onMessage);
+
+                        const dataViewCopy = dataView.slice();
+                        worker.postMessage({ id: "decodeMesh", dataView: dataViewCopy, attributes: attributes }, [dataViewCopy.buffer]);
+                    });
+                });
+            });
+        }
+
+        if (this._modulePromise) {
+            return this._modulePromise.then((decoder) => {
+                let resultIndices: Nullable<Uint16Array | Uint32Array> = null;
+                const resultAttributes: Array<AttributeData> = [];
+
+                const numPoints = decodeMesh(
+                    decoder.module,
+                    dataView,
+                    attributes,
+                    (indices) => {
+                        resultIndices = indices;
+                    },
+                    (kind, data, size, byteOffset, byteStride, normalized) => {
+                        resultAttributes.push({
+                            kind,
+                            data,
+                            size,
+                            byteOffset,
+                            byteStride,
+                            normalized,
+                        });
+                    }
+                );
+
+                return { indices: resultIndices!, attributes: resultAttributes, totalVertices: numPoints };
+            });
+        }
+
+        throw new Error("Draco decoder module is not available");
+    }
+
+    /**
+     * Decode Draco compressed mesh data to Babylon geometry.
+     * @param name The name to use when creating the geometry
+     * @param scene The scene to use when creating the geometry
+     * @param data The ArrayBuffer or ArrayBufferView for the Draco compression data
+     * @param attributes A map of attributes from vertex buffer kinds to Draco unique ids
+     * @returns A promise that resolves with the decoded geometry
+     */
+    public async decodeMeshToGeometryAsync(name: string, scene: Scene, data: ArrayBuffer | ArrayBufferView, attributes?: { [kind: string]: number }): Promise<Geometry> {
+        const meshData = await this.decodeMeshToMeshDataAsync(data, attributes);
+        const geometry = new Geometry(name, scene);
+        if (meshData.indices) {
+            geometry.setIndices(meshData.indices);
+        }
+        for (const attribute of meshData.attributes) {
+            geometry.setVerticesBuffer(
+                new VertexBuffer(
+                    scene.getEngine(),
+                    attribute.data,
+                    attribute.kind,
+                    false,
+                    undefined,
+                    attribute.byteStride,
+                    undefined,
+                    attribute.byteOffset,
+                    attribute.size,
+                    undefined,
+                    attribute.normalized,
+                    true
+                ),
+                meshData.totalVertices
+            );
+        }
+        return geometry;
+    }
+
+    /** @internal */
+    public async _decodeMeshToGeometryForGltfAsync(
+        name: string,
+        scene: Scene,
+        data: ArrayBuffer | ArrayBufferView,
+        attributes: { [kind: string]: number },
+        gltfNormalizedOverride: { [kind: string]: boolean },
+        boundingInfo: Nullable<BoundingInfo>
+    ): Promise<Geometry> {
+        const meshData = await this.decodeMeshToMeshDataAsync(data, attributes, gltfNormalizedOverride);
+        const geometry = new Geometry(name, scene);
+        if (boundingInfo) {
+            geometry._boundingInfo = boundingInfo;
+            geometry.useBoundingInfoFromGeometry = true;
+        }
+        if (meshData.indices) {
+            geometry.setIndices(meshData.indices);
+        }
+        for (const attribute of meshData.attributes) {
+            geometry.setVerticesBuffer(
+                new VertexBuffer(
+                    scene.getEngine(),
+                    attribute.data,
+                    attribute.kind,
+                    false,
+                    undefined,
+                    attribute.byteStride,
+                    undefined,
+                    attribute.byteOffset,
+                    attribute.size,
+                    undefined,
+                    attribute.normalized,
+                    true
+                ),
+                meshData.totalVertices
+            );
+        }
+        return geometry;
+    }
+}

--- a/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
@@ -19,6 +19,8 @@ interface MeshData {
 }
 
 /**
+ * @experimental This class is an experimental version of `DracoCompression` and is subject to change.
+ *
  * Draco compression (https://google.github.io/draco/)
  *
  * This class wraps the Draco decoder module.

--- a/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
@@ -1,5 +1,4 @@
 import { DracoDecoderModule } from "draco3dgltf";
-import type { DecoderModule } from "draco3dgltf";
 import { DracoCodec, type IDracoCodecConfiguration } from "./dracoCodec";
 import { Tools } from "../../Misc/tools";
 import { Geometry } from "../geometry";
@@ -47,7 +46,7 @@ interface MeshData {
  *     var geometry = await DracoDecoder.Default.decodeMeshToGeometryAsync(data);
  * ```
  */
-export class DracoDecoder extends DracoCodec<DecoderModule> {
+export class DracoDecoder extends DracoCodec {
     protected static override _Default: Nullable<DracoDecoder> = null;
     /**
      * Default instance for the DracoDecoder.
@@ -74,7 +73,7 @@ export class DracoDecoder extends DracoCodec<DecoderModule> {
         return typeof DracoDecoderModule !== "undefined";
     }
 
-    protected override async _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: DecoderModule }> {
+    protected override async _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: any /** DecoderModule */ }> {
         const module = await ((jsModule as DracoDecoderModule) || DracoDecoderModule)({ wasmBinary });
         return { module };
     }

--- a/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
@@ -51,9 +51,7 @@ export class DracoDecoder extends DracoCodec<DecoderModule> {
      * Default instance for the DracoDecoder.
      */
     public static get Default(): DracoDecoder {
-        if (!DracoDecoder._Default) {
-            DracoDecoder._Default = new DracoDecoder();
-        }
+        DracoDecoder._Default ??= new DracoDecoder();
         return DracoDecoder._Default;
     }
 
@@ -74,12 +72,9 @@ export class DracoDecoder extends DracoCodec<DecoderModule> {
         return typeof DracoDecoderModule !== "undefined";
     }
 
-    protected override _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: DecoderModule }> {
-        return new Promise((resolve) => {
-            ((jsModule as DracoDecoderModule) || DracoDecoderModule)({ wasmBinary }).then((module) => {
-                resolve({ module });
-            });
-        });
+    protected override async _createModuleAsync(wasmBinary?: ArrayBuffer, jsModule?: any): Promise<{ module: DecoderModule }> {
+        const module = await ((jsModule as DracoDecoderModule) || DracoDecoderModule)({ wasmBinary });
+        return { module };
     }
 
     protected override _getWorkerContent(): string {

--- a/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoDecoder.ts
@@ -30,7 +30,7 @@ interface MeshData {
  *
  * To update the configuration, use the following code:
  * ```javascript
- *     DracoDecoder.Config = {
+ *     DracoDecoder.DefaultConfiguration = {
  *          wasmUrl: "<url to the WebAssembly library>",
  *          wasmBinaryUrl: "<url to the WebAssembly binary>",
  *          fallbackUrl: "<url to the fallback JavaScript library>",
@@ -39,7 +39,7 @@ interface MeshData {
  *
  * Draco has two versions, one for WebAssembly and one for JavaScript. The decoder configuration can be set to only support WebAssembly or only support the JavaScript version.
  * Decoding will automatically fallback to the JavaScript version if WebAssembly version is not configured or if WebAssembly is not supported by the browser.
- * Use `DracoDecoder.Available` to determine if the decoder configuration is available for the current context.
+ * Use `DracoDecoder.DefaultAvailable` to determine if the decoder configuration is available for the current context.
  *
  * To decode Draco compressed data, get the default DracoDecoder object and call decodeMeshToGeometryAsync:
  * ```javascript
@@ -47,6 +47,19 @@ interface MeshData {
  * ```
  */
 export class DracoDecoder extends DracoCodec {
+    /**
+     * Default configuration for the DracoDecoder. Defaults to the following:
+     * - numWorkers: 50% of the available logical processors, capped to 4. If no logical processors are available, defaults to 1.
+     * - wasmUrl: `"https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"`
+     * - wasmBinaryUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.wasm"`
+     * - fallbackUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.js"`
+     */
+    public static override DefaultConfiguration: IDracoCodecConfiguration = {
+        wasmUrl: `${Tools._DefaultCdnUrl}/draco_wasm_wrapper_gltf.js`,
+        wasmBinaryUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.wasm`,
+        fallbackUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.js`,
+    };
+
     protected static override _Default: Nullable<DracoDecoder> = null;
     /**
      * Default instance for the DracoDecoder.
@@ -55,19 +68,6 @@ export class DracoDecoder extends DracoCodec {
         DracoDecoder._Default ??= new DracoDecoder();
         return DracoDecoder._Default;
     }
-
-    /**
-     * Configuration for the DracoDecoder. Defaults to the following:
-     * - numWorkers: 50% of the available logical processors, capped to 4. If no logical processors are available, defaults to 1.
-     * - wasmUrl: `"https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js"`
-     * - wasmBinaryUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.wasm"`
-     * - fallbackUrl: `"https://cdn.babylonjs.com/draco_decoder_gltf.js"`
-     */
-    public static override Config: IDracoCodecConfiguration = {
-        wasmUrl: `${Tools._DefaultCdnUrl}/draco_wasm_wrapper_gltf.js`,
-        wasmBinaryUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.wasm`,
-        fallbackUrl: `${Tools._DefaultCdnUrl}/draco_decoder_gltf.js`,
-    };
 
     protected override _isModuleAvailable(): boolean {
         return typeof DracoDecoderModule !== "undefined";
@@ -84,11 +84,10 @@ export class DracoDecoder extends DracoCodec {
 
     /**
      * Creates a new Draco decoder.
-     * @param config Optional override of the configuration for the DracoDecoder. If not provided, defaults to `DracoDecoder.Config`.
+     * @param configuration Optional override of the configuration for the DracoDecoder. If not provided, defaults to {@link DracoDecoder.DefaultConfiguration}.
      */
-    constructor(config?: IDracoCodecConfiguration) {
-        // Order of final config will be config > DracoDecoder.Config.
-        super({ ...DracoDecoder.Config, ...(config ?? {}) });
+    constructor(configuration: IDracoCodecConfiguration = DracoDecoder.DefaultConfiguration) {
+        super(configuration);
     }
 
     /**

--- a/packages/dev/core/src/Meshes/Compression/index.ts
+++ b/packages/dev/core/src/Meshes/Compression/index.ts
@@ -1,2 +1,3 @@
 export * from "./dracoCompression";
 export * from "./meshoptCompression";
+export * from "./dracoDecoder";

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -1,4 +1,4 @@
-import { DracoCompression } from "core/Meshes/Compression/dracoCompression";
+import { DracoDecoder } from "core/Meshes/Compression/dracoDecoder";
 import type { Nullable } from "core/types";
 import { VertexBuffer } from "core/Buffers/buffer";
 import type { Geometry } from "core/Meshes/geometry";
@@ -39,9 +39,9 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
     public readonly name = NAME;
 
     /**
-     * The draco compression used to decode vertex data or DracoCompression.Default if not defined
+     * The draco decoder used to decode vertex data or DracoDecoder.Default if not defined
      */
-    public dracoCompression?: DracoCompression;
+    public dracoDecoder?: DracoDecoder;
 
     /**
      * Defines whether this extension is enabled.
@@ -60,12 +60,12 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
      */
     constructor(loader: GLTFLoader) {
         this._loader = loader;
-        this.enabled = DracoCompression.DecoderAvailable && this._loader.isExtensionUsed(NAME);
+        this.enabled = DracoDecoder.DefaultAvailable && this._loader.isExtensionUsed(NAME);
     }
 
     /** @internal */
     public dispose(): void {
-        delete this.dracoCompression;
+        delete this.dracoDecoder;
         (this._loader as any) = null;
     }
 
@@ -119,11 +119,11 @@ export class KHR_draco_mesh_compression implements IGLTFLoaderExtension {
             const bufferView = ArrayItem.Get(extensionContext, this._loader.gltf.bufferViews, extension.bufferView) as IBufferViewDraco;
             if (!bufferView._dracoBabylonGeometry) {
                 bufferView._dracoBabylonGeometry = this._loader.loadBufferViewAsync(`/bufferViews/${bufferView.index}`, bufferView).then((data) => {
-                    const dracoCompression = this.dracoCompression || DracoCompression.Default;
+                    const dracoDecoder = this.dracoDecoder || DracoDecoder.Default;
                     const positionAccessor = ArrayItem.TryGet(this._loader.gltf.accessors, primitive.attributes["POSITION"]);
                     const babylonBoundingInfo =
                         !this._loader.parent.alwaysComputeBoundingBox && !babylonMesh.skeleton && positionAccessor ? LoadBoundingInfoFromPositionAccessor(positionAccessor) : null;
-                    return dracoCompression
+                    return dracoDecoder
                         ._decodeMeshToGeometryForGltfAsync(babylonMesh.name, this._loader.babylonScene, data, attributes, normalized, babylonBoundingInfo)
                         .catch((error) => {
                             throw new Error(`${context}: ${error.message}`);

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -663,7 +663,7 @@
         },
         {
             "title": "Draco Decoder",
-            "playgroundId": "#22MFU2#81",
+            "playgroundId": "#22MFU2#82",
             "referenceImage": "draco.png"
         },
         {

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -662,6 +662,11 @@
             "referenceImage": "draco.png"
         },
         {
+            "title": "Draco Decoder",
+            "playgroundId": "#22MFU2#81",
+            "referenceImage": "draco.png"
+        },
+        {
             "title": "GLTF Normals",
             "playgroundId": "#SMEAEB#0",
             "referenceImage": "gltfnormals.png"


### PR DESCRIPTION
Rather than implement the Draco encoding in DracoCompression, we think it'd be best to separate encoding from decoding functionality by creating separate classes for each. This PR factors out common methods and fields of DracoCompression in preparation to be reused for Draco encoding.

- DracoDecoder: new class to supersede DracoCompression. Manages own `Default` instance and static `DefaultConfiguration`. 
- DracoCodec: new base class for Draco. Contains common methods and fields related to Draco module consumption, workers setup, and managing `Default` and `DefaultConfiguration`.
- DracoCompression: deprecated in favor of DracoDecoder. Backwards compat is maintained. While it inherits from DracoDecoder, it maintains its own separate `Default` and `DefaultConfiguration`.
