### PR TITLE
MaterialPluginBase: add doNotSerialize

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.ts
@@ -106,12 +106,24 @@ export class PBRMetallicRoughnessMaterial extends PBRBaseSimpleMaterial {
         const serializationObject = SerializationHelper.Serialize(this);
         serializationObject.customType = "BABYLON.PBRMetallicRoughnessMaterial";
 
-        serializationObject.clearCoat = this.clearCoat.serialize();
-        serializationObject.anisotropy = this.anisotropy.serialize();
-        serializationObject.brdf = this.brdf.serialize();
-        serializationObject.sheen = this.sheen.serialize();
-        serializationObject.subSurface = this.subSurface.serialize();
-        serializationObject.iridescence = this.iridescence.serialize();
+        if (!this.clearCoat.doNotSerialize) {
+            serializationObject.clearCoat = this.clearCoat.serialize();
+        }
+        if (!this.anisotropy.doNotSerialize) {
+            serializationObject.anisotropy = this.anisotropy.serialize();
+        }
+        if (!this.brdf.doNotSerialize) {
+            serializationObject.brdf = this.brdf.serialize();
+        }
+        if (!this.sheen.doNotSerialize) {
+            serializationObject.sheen = this.sheen.serialize();
+        }
+        if (!this.subSurface.doNotSerialize) {
+            serializationObject.subSurface = this.subSurface.serialize();
+        }
+        if (!this.iridescence.doNotSerialize) {
+            serializationObject.iridescence = this.iridescence.serialize();
+        }
 
         return serializationObject;
     }

--- a/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.ts
@@ -103,12 +103,24 @@ export class PBRSpecularGlossinessMaterial extends PBRBaseSimpleMaterial {
         const serializationObject = SerializationHelper.Serialize(this);
         serializationObject.customType = "BABYLON.PBRSpecularGlossinessMaterial";
 
-        serializationObject.clearCoat = this.clearCoat.serialize();
-        serializationObject.anisotropy = this.anisotropy.serialize();
-        serializationObject.brdf = this.brdf.serialize();
-        serializationObject.sheen = this.sheen.serialize();
-        serializationObject.subSurface = this.subSurface.serialize();
-        serializationObject.iridescence = this.iridescence.serialize();
+        if (!this.clearCoat.doNotSerialize) {
+            serializationObject.clearCoat = this.clearCoat.serialize();
+        }
+        if (!this.anisotropy.doNotSerialize) {
+            serializationObject.anisotropy = this.anisotropy.serialize();
+        }
+        if (!this.brdf.doNotSerialize) {
+            serializationObject.brdf = this.brdf.serialize();
+        }
+        if (!this.sheen.doNotSerialize) {
+            serializationObject.sheen = this.sheen.serialize();
+        }
+        if (!this.subSurface.doNotSerialize) {
+            serializationObject.subSurface = this.subSurface.serialize();
+        }
+        if (!this.iridescence.doNotSerialize) {
+            serializationObject.iridescence = this.iridescence.serialize();
+        }
 
         return serializationObject;
     }

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1931,7 +1931,9 @@ export class Material implements IAnimatable, IClipPlanesHolder {
 
         if (this.pluginManager) {
             for (const plugin of this.pluginManager._plugins) {
-                serializationObject.plugins[plugin.getClassName()] = plugin.serialize();
+                if (!plugin.doNotSerialize) {
+                    serializationObject.plugins[plugin.getClassName()] = plugin.serialize();
+                }
             }
         }
     }

--- a/packages/dev/core/src/Materials/materialPluginBase.ts
+++ b/packages/dev/core/src/Materials/materialPluginBase.ts
@@ -48,6 +48,11 @@ export class MaterialPluginBase {
     @serialize()
     public registerForExtraEvents: boolean = false;
 
+    /**
+     * Specifies if the material plugin should be serialized, `true` to skip serialization
+     */
+    public doNotSerialize = false;
+
     protected _material: Material;
     protected _pluginManager: MaterialPluginManager;
     protected _pluginDefineNames?: { [name: string]: any };


### PR DESCRIPTION
This commit adds a new public property `doNotSerialize` to `MaterialPluginBase`, so that a material plugin can be configured to skip serialization like meshes and materials.

## Compatibility

Existing material plugins would implicitly have this field as they extend MaterialPluginBase. Material plugins that does not extend MaterialPluginBase will not have a doNotSerialize after this, but when using if to check, it would have the same result as false, which should be the default value, so backward compatibility for js projects would not be broken after this.
 In typescript projects, type checking ensures that plugins extending MaterialPluginBase.

 ## References

 Forum post: <https://forum.babylonjs.com/t/donotserialize-for-material-plugins/55228>