### PR TITLE
Fix issue when using core with exactOptionalPropertyTypes: true

### DIFF
--- a/packages/dev/core/src/Meshes/lattice.material.ts
+++ b/packages/dev/core/src/Meshes/lattice.material.ts
@@ -108,7 +108,11 @@ export class LatticePluginMaterial extends MaterialPluginBase {
      * @param shaderLanguage The shader language to use.
      * @returns the description of the uniforms
      */
-    public override getUniforms(shaderLanguage: ShaderLanguage = ShaderLanguage.GLSL) {
+    public override getUniforms(shaderLanguage: ShaderLanguage = ShaderLanguage.GLSL): {
+        ubo: { name: string; size: number; type: string; arraySize?: number }[];
+        vertex?: string;
+        fragment?: string;
+    } {
         if (shaderLanguage === ShaderLanguage.WGSL) {
             // For webgpu we only define the UBO with the correct type and size.
             return {

--- a/packages/tools/tests/tsconfig.build.json
+++ b/packages/tools/tests/tsconfig.build.json
@@ -3,7 +3,8 @@
 
     "compilerOptions": {
         "outDir": "./dist",
-        "rootDir": "./src",
+        "exactOptionalPropertyTypes": true,
+        "rootDir": "./src"
     },
 
     "references": [


### PR DESCRIPTION
On first glance this looks completely unneeded. However, when compiled without the return type, the signature of this function is:

```javascript
getUniforms(shaderLanguage?: ShaderLanguage): {
        ubo: {
            name: string;
            size: number;
            type: string;
        }[];
        vertex?: undefined;
    } | {
        ubo: {
            name: string;
            size: number;
            type: string;
        }[];
        vertex: string;
    };
```

When a project is using the flag `exactOptionalPropertyTypes` in their tsconfig, it expect that this will not happen. Forcing the return type fixes the issue with the signature.

To fully test that I have added the signature to our es6 test compile step.