### PR TITLE
Fix broken nightly Native 

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -50,7 +50,7 @@ float getAttenuation(float cosAngle, float exponent) {
 
 float getIESAttenuation(float cosAngle, sampler2D iesLightSampler) {
 	float angle = acos(cosAngle) / PI;
-	return texture2D(iesLightSampler, vec2(angle, 0.), 0.).r;
+	return texture2D(iesLightSampler, vec2(angle, 0.)).r;
 }
 
 lightingInfo basicSpotLighting(vec3 viewDirectionW, vec3 lightVectorW, vec3 vNormal, float attenuation, vec3 diffuseColor, vec3 specularColor, float glossiness) {


### PR DESCRIPTION
fix native issue introduced with https://github.com/BabylonJS/Babylon.js/pull/15952
No support for bias parameter with glsl `texture` function and bias value is 0 -> removed.
