### PR TITLE
Fix an issue where SPZ splat is flipped

### DIFF
--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -258,8 +258,8 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
             const ny = y / 127.5 - 1;
             const nz = z / 127.5 - 1;
             rot[i * 32 + 28 + 1] = x;
-            rot[i * 32 + 28 + 2] = y;
-            rot[i * 32 + 28 + 3] = z;
+            rot[i * 32 + 28 + 2] = -ny * 127.5 + 127.5;
+            rot[i * 32 + 28 + 3] = -nz * 127.5 + 127.5;
             rot[i * 32 + 28 + 0] = (1 - Math.sqrt(nx * nx + ny * ny + nz * nz)) * 127.5 + 127.5;
             byteOffset += 3;
         }

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -228,7 +228,7 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
         for (let i = 0; i < splatCount; i++) {
             position[i * 8 + 0] = read24bComponent(ubuf, byteOffset + 0);
             position[i * 8 + 1] = -read24bComponent(ubuf, byteOffset + 3);
-            position[i * 8 + 2] = read24bComponent(ubuf, byteOffset + 6);
+            position[i * 8 + 2] = -read24bComponent(ubuf, byteOffset + 6);
             byteOffset += 9;
         }
 


### PR DESCRIPTION
Fixed an issue where loading 3D Gaussian Splatting in .spz format caused the left and right sides to be flipped.

Display on the Scaniverse page (https://scaniverse.com/news/spz-gaussian-splat-open-source-file-format)
![image](https://github.com/user-attachments/assets/315b08d4-0108-48c8-ad4c-a2a1adb5cecd)

Display in Babylon.js (before the fix)
![image](https://github.com/user-attachments/assets/20c702ee-0174-4c15-8d78-d72560ad9662)

Display in Babylon.js (after the fix)
![image](https://github.com/user-attachments/assets/8ac96c56-c213-49e3-9d5d-9afdd459095a)
