### PR TITLE
Grl webgl ubo fix

### DIFF
--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterial.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterial.ts
@@ -291,7 +291,7 @@ export class GreasedLinePluginMaterial extends MaterialPluginBase implements IGr
     override bindForSubMesh(uniformBuffer: UniformBuffer) {
         if (this._cameraFacing) {
             uniformBuffer.updateMatrix("grl_projection", this._scene.getProjectionMatrix());
-            uniformBuffer.updateMatrix("viewProjection", this._scene.getTransformMatrix());
+            !this._isGLSL(this._material.shaderLanguage) && uniformBuffer.updateMatrix("viewProjection", this._scene.getTransformMatrix());
 
             const resolutionLineWidth = TmpVectors.Vector4[0];
             resolutionLineWidth.x = this._aspect;


### PR DESCRIPTION
Fixing this issue: https://forum.babylonjs.com/t/after-upgrade-to-7-39-1-cannot-add-an-uniform-after-ubo-has-been-created/55296