### PR TITLE
Adding KHR_node_hoverability

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -1136,7 +1136,7 @@ export class InputManager {
     }
 
     /**
-     * Force the value of meshUnderPointer
+     * Set the value of meshUnderPointer for a given pointerId
      * @param mesh - defines the mesh to use
      * @param pointerId - optional pointer id when using more than one pointer. Defaults to 0
      * @param pickResult - optional pickingInfo data used to find mesh
@@ -1168,6 +1168,13 @@ export class InputManager {
         } else {
             delete this._meshUnderPointerId[pointerId];
             this._pointerOverMesh = null;
+        }
+        // if we reached this point, meshUnderPointerId has been updated. We need to notify observers that are registered.
+        if (this._scene.onMeshUnderPointerUpdatedObservable.hasObservers()) {
+            this._scene.onMeshUnderPointerUpdatedObservable.notifyObservers({
+                mesh,
+                pointerId,
+            });
         }
     }
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -926,6 +926,11 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     public onEnvironmentTextureChangedObservable = new Observable<Nullable<BaseTexture>>();
 
     /**
+     * An event triggered when the state of mesh under pointer, for a specific pointerId, changes.
+     */
+    public onMeshUnderPointerUpdatedObservable = new Observable<{ mesh: Nullable<AbstractMesh>; pointerId: number }>();
+
+    /**
      * Gets or sets a user defined funtion to select LOD from a mesh and a camera.
      * By default this function is undefined and Babylon.js will select LOD based on distance to camera
      */
@@ -5266,6 +5271,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         this.onScenePerformancePriorityChangedObservable.clear();
         this.onClearColorChangedObservable.clear();
         this.onEnvironmentTextureChangedObservable.clear();
+        this.onMeshUnderPointerUpdatedObservable.clear();
         this._isDisposed = true;
     }
 

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_node_hoverability.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_node_hoverability.ts
@@ -1,0 +1,60 @@
+import type { GLTFLoader } from "../glTFLoader";
+import type { IGLTFLoaderExtension } from "../glTFLoaderExtension";
+import { registerGLTFExtension, unregisterGLTFExtension } from "../glTFLoaderExtensionRegistry";
+
+const NAME = "KHR_node_hoverability";
+
+declare module "../../glTFFileLoader" {
+    // eslint-disable-next-line jsdoc/require-jsdoc
+    export interface GLTFLoaderExtensionOptions {
+        /**
+         * Defines options for the KHR_node_hoverability extension.
+         */
+        // NOTE: Don't use NAME here as it will break the UMD type declarations.
+        ["KHR_node_hoverability"]: {};
+    }
+}
+
+/**
+ * Loader extension for KHR_node_hoverability
+ * @see https://github.com/KhronosGroup/glTF/pull/2426
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class KHR_node_hoverability implements IGLTFLoaderExtension {
+    /**
+     * The name of this extension.
+     */
+    public readonly name = NAME;
+    /**
+     * Defines whether this extension is enabled.
+     */
+    public enabled: boolean;
+
+    private _loader: GLTFLoader;
+
+    /**
+     * @internal
+     */
+    constructor(loader: GLTFLoader) {
+        this._loader = loader;
+        this.enabled = loader.isExtensionUsed(NAME);
+    }
+
+    public async onReady(): Promise<void> {
+        this._loader.gltf.nodes?.forEach((node) => {
+            // default is true, so only apply if false
+            if (node.extensions?.KHR_node_hoverability && node.extensions?.KHR_node_hoverability.hoverable === false) {
+                node._babylonTransformNode?.getChildMeshes().forEach((mesh) => {
+                    mesh.pointerOverDisableMeshTesting = true;
+                });
+            }
+        });
+    }
+
+    public dispose() {
+        (this._loader as any) = null;
+    }
+}
+
+unregisterGLTFExtension(NAME);
+registerGLTFExtension(NAME, true, (loader) => new KHR_node_hoverability(loader));


### PR DESCRIPTION
Using existing flag (`_pointerOverDisableMeshTesting`) to disable "hovering" when the flag in glTF is set to false. As the flag in glTF is inherited to all children, I am setting it on all child meshes of a specific node's transform node and not only to the direct descendants.

On top of that I have added. new observable to scene, onMeshUnderPointerUpdatedObservable, which wil be triggered if it has observers and the mesh under pointer was updated (also if the mesh is null, of course).

Interactivity events will be added after this is merged.