### PR TITLE
Match Babylon's RHS

### DIFF
--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -256,6 +256,8 @@ export class WebXRCamera extends FreeCamera {
                 this._referencedPosition.z *= -1;
                 this._referenceQuaternion.z *= -1;
                 this._referenceQuaternion.w *= -1;
+            } else {
+                this._referenceQuaternion.multiplyInPlace(this._rotate180);
             }
 
             if (this._firstFrame) {


### PR DESCRIPTION
This line was missing for RHS scenes when using WebXR. it is already done on the rig cameras, so this is a cosmetic change - this camera is not used for actually rendering the scene, but it should hold the right transformation/view matrix/projection matrix 