### PR TITLE
use _retryWithInterval where possible

### DIFF
--- a/packages/dev/core/src/Materials/effect.functions.ts
+++ b/packages/dev/core/src/Materials/effect.functions.ts
@@ -322,6 +322,9 @@ export const createAndPreparePipelineContext = (
     }
 };
 
+/**
+ * @internal
+ */
 export const _retryWithInterval = (condition: () => boolean, onSuccess: () => void, onError?: (e?: any) => void, step = 16, maxTimeout = 1000) => {
     const int = setInterval(() => {
         try {

--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -12,6 +12,7 @@ import type { Nullable } from "../types";
 import { ApplyPostProcess } from "./textureTools";
 
 import type { AbstractEngine } from "../Engines/abstractEngine";
+import { _retryWithInterval } from "../Materials/effect.functions";
 
 let screenshotCanvas: Nullable<HTMLCanvasElement> = null;
 
@@ -258,33 +259,37 @@ export function CreateScreenshotUsingRenderTarget(
     customizeTexture?.(texture);
 
     const renderWhenReady = () => {
-        if (texture.isReadyForRendering() && camera.isReady(true)) {
-            engine.onEndFrameObservable.addOnce(() => {
-                if (finalWidth === width && finalHeight === height) {
-                    texture.readPixels(undefined, undefined, undefined, false)!.then((data) => {
-                        DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
-                        texture.dispose();
-                    });
-                } else {
-                    const importPromise = engine.isWebGPU ? import("../ShadersWGSL/pass.fragment") : import("../Shaders/pass.fragment");
-                    importPromise.then(() =>
-                        ApplyPostProcess("pass", texture.getInternalTexture()!, scene, undefined, undefined, undefined, finalWidth, finalHeight).then((texture) => {
-                            engine._readTexturePixels(texture, finalWidth, finalHeight, -1, 0, null, true, false, 0, 0).then((data) => {
-                                DumpData(finalWidth, finalHeight, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
-                                texture.dispose();
-                            });
-                        })
-                    );
-                }
-            });
-            scene.incrementRenderId();
-            scene.resetCachedMaterial();
-            texture.render(true);
-            engine.setSize(originalSize.width, originalSize.height);
-            camera.getProjectionMatrix(true); // Force cache refresh;
-        } else {
-            setTimeout(renderWhenReady, 16);
-        }
+        _retryWithInterval(
+            () => texture.isReadyForRendering() && camera.isReady(true),
+            () => {
+                engine.onEndFrameObservable.addOnce(() => {
+                    if (finalWidth === width && finalHeight === height) {
+                        texture.readPixels(undefined, undefined, undefined, false)!.then((data) => {
+                            DumpData(width, height, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
+                            texture.dispose();
+                        });
+                    } else {
+                        const importPromise = engine.isWebGPU ? import("../ShadersWGSL/pass.fragment") : import("../Shaders/pass.fragment");
+                        importPromise.then(() =>
+                            ApplyPostProcess("pass", texture.getInternalTexture()!, scene, undefined, undefined, undefined, finalWidth, finalHeight).then((texture) => {
+                                engine._readTexturePixels(texture, finalWidth, finalHeight, -1, 0, null, true, false, 0, 0).then((data) => {
+                                    DumpData(finalWidth, finalHeight, data, successCallback as (data: string | ArrayBuffer) => void, mimeType, fileName, true, undefined, quality);
+                                    texture.dispose();
+                                });
+                            })
+                        );
+                    }
+                });
+                scene.incrementRenderId();
+                scene.resetCachedMaterial();
+                texture.render(true);
+                engine.setSize(originalSize.width, originalSize.height);
+                camera.getProjectionMatrix(true); // Force cache refresh;
+            },
+            () => {},
+            16,
+            2000 /* 2 seconds */
+        );
     };
 
     const renderToTexture = () => {
@@ -380,10 +385,10 @@ export function CreateScreenshotUsingRenderTargetAsync(
 
 /**
  * Gets height and width for screenshot size
- * @param engine
- * @param camera
- * @param size
- * @private
+ * @param engine The engine to use for rendering
+ * @param camera The camera to use for rendering
+ * @param size This size of the screenshot. can be a number or an object implementing IScreenshotSize
+ * @returns height and width for screenshot size
  */
 function _GetScreenshotSize(engine: AbstractEngine, camera: Camera, size: IScreenshotSize | number): { height: number; width: number; finalWidth: number; finalHeight: number } {
     let height = 0;


### PR DESCRIPTION
This is an example of how _retryWithInterval can be used instead of setTimout of the calling function.

There are a few other places in the framework that could benefit from that, but looking for feedback whether or not it makes sense to do the work.