### PR TITLE
Small Viewer fixes

### DIFF
--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -409,6 +409,8 @@ export class Viewer implements IDisposable {
             };
         }
         this._details.scene.skipFrustumClipping = true;
+        this._details.scene.skipPointerDownPicking = true;
+        this._details.scene.skipPointerUpPicking = true;
         this._details.scene.skipPointerMovePicking = true;
         this._snapshotHelper = new SnapshotRenderingHelper(this._details.scene, { morphTargetsNumMaxInfluences: 30 });
         this._details.camera.attachControl();

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -730,6 +730,9 @@ export class HTML3DElement extends LitElement {
     @query("#canvasContainer")
     private _canvasContainer: HTMLDivElement | undefined;
 
+    @query("#materialSelect")
+    private _materialSelect: HTMLSelectElement | undefined;
+
     /**
      * Toggles the play/pause animation state if there is a selected animation.
      */
@@ -752,6 +755,10 @@ export class HTML3DElement extends LitElement {
     // eslint-disable-next-line babylonjs/available
     override update(changedProperties: PropertyValues<this>): void {
         super.update(changedProperties);
+
+        if (this._materialSelect) {
+            this._materialSelect.value = "";
+        }
 
         if (changedProperties.get("engine")) {
             this._tearDownViewer();
@@ -841,8 +848,7 @@ export class HTML3DElement extends LitElement {
             if (this._hasHotSpots) {
                 toolbarControls.push(html`
                     <div class="select-container">
-                        <select aria-label="Select HotSpot" @change="${this._onHotSpotsChanged}">
-                            <option value="" hidden selected></option>
+                        <select id="materialSelect" aria-label="Select HotSpot" @change="${this._onHotSpotsChanged}">
                             <!-- When the select is forced to be less wide than the options, padding on the right is lost. Pad with white space. -->
                             ${Object.keys(this.hotSpots).map((name) => html`<option value="${name}">${name}&nbsp;&nbsp;</option>`)}
                         </select>


### PR DESCRIPTION
1. Disable pick on pointer down/up (not just move). Picking handled explicitly.
2. Hotspots default UI tries to use a <select> element like a menu (no "selected" item). To do this, I was adding a hidden option that is selected. I found though that this doesn't work in some browsers, in that it just shows the hidden option. I tried a new approach here that just programmatically clears the selected value after it changes, which works on all browsers except chromium (Chrome/Edge) on Mac, where the only thing that doesn't work correctly is that it shows a check mark by the first item when there is no selected value. I will probably need to replace the use of <select> with a custom dropdown, but that will come later. For now, this is still an improvement.