### PR TITLE
Viewer: Allow environment texture and skybox to be set separately (and a couple other small changes)

### DIFF
--- a/packages/tools/viewer-alpha/src/index.ts
+++ b/packages/tools/viewer-alpha/src/index.ts
@@ -1,4 +1,4 @@
-export type { CameraAutoOrbit, LoadEnvironmentOptions, LoadModelOptions, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
+export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
 export type { CanvasViewerOptions } from "./viewerFactory";
 
 export { Viewer, ViewerHotSpotResult } from "./viewer";

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -897,6 +897,13 @@ export class Viewer implements IDisposable {
     }
 
     /**
+     * Resets the camera to its initial pose.
+     */
+    public resetCamera() {
+        this._details.camera.restoreState();
+    }
+
+    /**
      * Disposes of the resources held by the Viewer.
      */
     public dispose(): void {

--- a/packages/tools/viewer-alpha/src/viewerAnnotationElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerAnnotationElement.ts
@@ -13,8 +13,9 @@ import { ViewerHotSpotResult } from "./viewer";
  */
 @customElement("babylon-viewer-annotation")
 export class HTML3DAnnotationElement extends LitElement {
-    // eslint-disable-next-line @typescript-eslint/naming-convention, jsdoc/require-jsdoc
-    static override styles = css`
+    /** @internal */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public static override styles = css`
         :host {
             display: inline-block;
             position: absolute;
@@ -40,8 +41,8 @@ export class HTML3DAnnotationElement extends LitElement {
     @property({ attribute: "hotspot" })
     public hotSpot: string = "";
 
-    // eslint-disable-next-line babylonjs/available
-    override connectedCallback(): void {
+    /** @internal */
+    public override connectedCallback(): void {
         super.connectedCallback();
         this._internals.states?.add("invalid");
 
@@ -79,8 +80,8 @@ export class HTML3DAnnotationElement extends LitElement {
         };
     }
 
-    // eslint-disable-next-line babylonjs/available
-    override disconnectedCallback(): void {
+    /** @internal */
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
 
         this._viewerAttachment?.dispose();
@@ -89,6 +90,7 @@ export class HTML3DAnnotationElement extends LitElement {
         this._internals.states?.add("invalid");
     }
 
+    /** @internal */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     protected override render() {
         return html` <slot></slot> `;

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -154,8 +154,9 @@ export class HTML3DElement extends LitElement {
         ),
     ] as const;
 
-    // eslint-disable-next-line @typescript-eslint/naming-convention, jsdoc/require-jsdoc
-    static override styles = css`
+    /** @internal */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public static override styles = css`
         :host {
             --ui-foreground-color: white;
             --ui-background-hue: 233;
@@ -786,7 +787,8 @@ export class HTML3DElement extends LitElement {
     }
 
     /** @internal */
-    public override update(changedProperties: PropertyValues<this>): void {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    protected override update(changedProperties: PropertyValues<this>): void {
         super.update(changedProperties);
 
         if (this._materialSelect) {
@@ -813,7 +815,8 @@ export class HTML3DElement extends LitElement {
     }
 
     /** @internal */
-    public override render() {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    protected override render() {
         const showProgressBar = this.loadingProgress !== false;
         // If loadingProgress is true, then the progress bar is indeterminate so the value doesn't matter.
         const progressValue = typeof this.loadingProgress === "boolean" ? 0 : this.loadingProgress * 100;

--- a/packages/tools/viewer-alpha/src/viewerElement.ts
+++ b/packages/tools/viewer-alpha/src/viewerElement.ts
@@ -15,11 +15,15 @@ import { Logger } from "core/Misc/logger";
 import { isToneMapping, ViewerHotSpotResult } from "./viewer";
 import { createViewerForCanvas, getDefaultEngine } from "./viewerFactory";
 
-// Icon SVG is pulled from https://react.fluentui.dev/?path=/docs/icons-catalog--docs
-const playFilledIcon = "M17.22 8.68a1.5 1.5 0 0 1 0 2.63l-10 5.5A1.5 1.5 0 0 1 5 15.5v-11A1.5 1.5 0 0 1 7.22 3.2l10 5.5Z";
-const pauseFilledIcon = "M5 2a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h2a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H5Zm8 0a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h2a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2h-2Z";
+// Icon SVG is pulled from https://iconcloud.design
+const playFilledIcon =
+    "M5 5.27368C5 3.56682 6.82609 2.48151 8.32538 3.2973L20.687 10.0235C22.2531 10.8756 22.2531 13.124 20.687 13.9762L8.32538 20.7024C6.82609 21.5181 5 20.4328 5 18.726V5.27368Z";
+const pauseFilledIcon =
+    "M5.74609 3C4.7796 3 3.99609 3.7835 3.99609 4.75V19.25C3.99609 20.2165 4.7796 21 5.74609 21H9.24609C10.2126 21 10.9961 20.2165 10.9961 19.25V4.75C10.9961 3.7835 10.2126 3 9.24609 3H5.74609ZM14.7461 3C13.7796 3 12.9961 3.7835 12.9961 4.75V19.25C12.9961 20.2165 13.7796 21 14.7461 21H18.2461C19.2126 21 19.9961 20.2165 19.9961 19.25V4.75C19.9961 3.7835 19.2126 3 18.2461 3H14.7461Z";
+const arrowResetFilledIcon =
+    "M7.20711 2.54289C7.59763 2.93342 7.59763 3.56658 7.20711 3.95711L5.41421 5.75H13.25C17.6683 5.75 21.25 9.33172 21.25 13.75C21.25 18.1683 17.6683 21.75 13.25 21.75C8.83172 21.75 5.25 18.1683 5.25 13.75C5.25 13.1977 5.69772 12.75 6.25 12.75C6.80228 12.75 7.25 13.1977 7.25 13.75C7.25 17.0637 9.93629 19.75 13.25 19.75C16.5637 19.75 19.25 17.0637 19.25 13.75C19.25 10.4363 16.5637 7.75 13.25 7.75H5.41421L7.20711 9.54289C7.59763 9.93342 7.59763 10.5666 7.20711 10.9571C6.81658 11.3476 6.18342 11.3476 5.79289 10.9571L2.29289 7.45711C1.90237 7.06658 1.90237 6.43342 2.29289 6.04289L5.79289 2.54289C6.18342 2.15237 6.81658 2.15237 7.20711 2.54289Z";
 const targetFilledIcon =
-    "M10 11.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM5 10a5 5 0 1 1 10 0 5 5 0 0 1-10 0Zm5-3.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7ZM2 10a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Z";
+    "M12 14C13.1046 14 14 13.1046 14 12C14 10.8954 13.1046 10 12 10C10.8954 10 10 10.8954 10 12C10 13.1046 10.8954 14 12 14ZM6 12C6 8.68629 8.68629 6 12 6C15.3137 6 18 8.68629 18 12C18 15.3137 15.3137 18 12 18C8.68629 18 6 15.3137 6 12ZM12 8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8ZM2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4Z";
 
 const allowedAnimationSpeeds = [0.5, 1, 1.5, 2] as const;
 
@@ -740,6 +744,13 @@ export class HTML3DElement extends LitElement {
         this._viewerDetails?.viewer.toggleAnimation();
     }
 
+    /**
+     * Resets the camera to its initial pose.
+     */
+    public resetCamera() {
+        this._viewerDetails?.viewer.resetCamera();
+    }
+
     // eslint-disable-next-line babylonjs/available
     override connectedCallback(): void {
         super.connectedCallback();
@@ -802,12 +813,12 @@ export class HTML3DElement extends LitElement {
                         <button aria-label="${this.isAnimationPlaying ? "Pause" : "Play"}" @click="${this.toggleAnimation}">
                             ${!this.isAnimationPlaying
                                 ? html`
-                                      <svg viewBox="0 0 20 20">
+                                      <svg viewBox="0 0 24 24">
                                           <path d="${playFilledIcon}" fill="currentColor"></path>
                                       </svg>
                                   `
                                 : html`
-                                      <svg viewBox="-3 -2 24 24">
+                                      <svg viewBox="0 0 24 24">
                                           <path d="${pauseFilledIcon}" fill="currentColor"></path>
                                       </svg>
                                   `}
@@ -844,6 +855,15 @@ export class HTML3DElement extends LitElement {
                 `);
             }
 
+            // Always include a button to reset the camera pose.
+            toolbarControls.push(html`
+                <button aria-label="Reset Camera Pose" @click="${this.resetCamera}">
+                    <svg viewBox="0 0 24 24">
+                        <path d="${arrowResetFilledIcon}" fill="currentColor"></path>
+                    </svg>
+                </button>
+            `);
+
             // If hotspots have been defined, add hotspot controls.
             if (this._hasHotSpots) {
                 toolbarControls.push(html`
@@ -854,7 +874,7 @@ export class HTML3DElement extends LitElement {
                         </select>
                         <!-- This button is not actually interactive, we want input to pass through to the select below. -->
                         <button style="pointer-events: none">
-                            <svg viewBox="0 0 20 20">
+                            <svg viewBox="0 0 24 24">
                                 <path d="${targetFilledIcon}" fill="currentColor"></path>
                             </svg>
                         </button>

--- a/packages/tools/viewer-alpha/src/viewerFactory.ts
+++ b/packages/tools/viewer-alpha/src/viewerFactory.ts
@@ -72,7 +72,7 @@ export async function createViewerForCanvas(canvas: HTMLCanvasElement, options?:
 
         // If the canvas is not visible, suspend rendering.
         let offscreenRenderingSuspension: Nullable<IDisposable> = null;
-        const interactionObserver = new IntersectionObserver((entries) => {
+        const intersectionObserver = new IntersectionObserver((entries) => {
             if (entries.length > 0) {
                 if (entries[entries.length - 1].isIntersecting) {
                     offscreenRenderingSuspension?.dispose();
@@ -82,8 +82,8 @@ export async function createViewerForCanvas(canvas: HTMLCanvasElement, options?:
                 }
             }
         });
-        interactionObserver.observe(canvas);
-        disposeActions.push(() => interactionObserver.disconnect());
+        intersectionObserver.observe(canvas);
+        disposeActions.push(() => intersectionObserver.disconnect());
 
         // Call the original onInitialized callback, if one was provided.
         onInitialized?.(details);


### PR DESCRIPTION
The main change in this PR is to allow the environment texture and the skybox to be configured separately (this has come up multiple times, including in the [forum](https://forum.babylonjs.com/t/babylon-viewer-v2/54317/37). To try to keep this simple, `Viewer.loadEnvironment` now has an options object where you can specify whether the "environment" should be used for lighting or skybox or both. On the html element level, the `environment` attribute behaves the same as before (sets both the env texture and the skybox), but there are also now `environment-lighting` and `environment-skybox` attributes if you want to set them separately. This makes `environment` essentially a shorthand, somewhat like `padding` relative to `padding-top`, `padding-bottom`, etc.

The other changes included in this PR are:
- Adding a reset camera button (so that discovering double click/tap is not required). This change was based on feedback from @PatrickRyanMS.
- If animation is playing, pause it when activating a hotspot (e.g. moving the camera to a pose associated with the hotspot). Without this, a `surface` type hotspot will almost certainly have moved by the time the camera finishes its interpolation. This change was based on feedback from @PatrickRyanMS.
- Update the icons to use svg from https://iconcloud.design. This change was based on feedback from @PatrickRyanMS.
- Mark various internal members as `@internal` so they don't show up in the API docs.