### PR TITLE
Inspector: Don't display empty morph targets

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/meshes/meshPropertyGridComponent.tsx
@@ -367,7 +367,10 @@ export class MeshPropertyGridComponent extends React.Component<
 
         if (mesh.morphTargetManager) {
             for (let index = 0; index < mesh.morphTargetManager.numTargets; index++) {
-                morphTargets.push(mesh.morphTargetManager.getTarget(index));
+                const target = mesh.morphTargetManager.getTarget(index);
+                if (target.hasPositions) {
+                    morphTargets.push(target);
+                }
             }
         }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/uv-morphing-results-in-two-textures-of-different-types-use-the-same-sampler-location/55346/3