### PR TITLE
Allow CustomRequestModifiers to modify URL

### DIFF
--- a/packages/dev/core/src/Misc/webRequest.ts
+++ b/packages/dev/core/src/Misc/webRequest.ts
@@ -195,10 +195,7 @@ export class WebRequest implements IWebRequest {
             if (this._shouldSkipRequestModifications(url)) {
                 return;
             }
-            const newUrl = update(this._xhr, url);
-            if (newUrl !== undefined) {
-                url = newUrl;
-            }
+            url = update(this._xhr, url) || url;
         }
 
         // Clean url

--- a/packages/dev/core/src/Misc/webRequest.ts
+++ b/packages/dev/core/src/Misc/webRequest.ts
@@ -31,7 +31,7 @@ export class WebRequest implements IWebRequest {
     /**
      * Add callback functions in this array to update all the requests before they get sent to the network
      */
-    public static CustomRequestModifiers = new Array<(request: XMLHttpRequest, url: string) => void>();
+    public static CustomRequestModifiers = new Array<(request: XMLHttpRequest, url: string) => string | void>();
 
     /**
      * If set to true, requests to Babylon.js CDN requests will not be modified
@@ -195,7 +195,10 @@ export class WebRequest implements IWebRequest {
             if (this._shouldSkipRequestModifications(url)) {
                 return;
             }
-            update(this._xhr, url);
+            const newUrl = update(this._xhr, url);
+            if (newUrl !== undefined) {
+                url = newUrl;
+            }
         }
 
         // Clean url


### PR DESCRIPTION
This can be useful, for example, when the assets are hosted on private S3 buckets and the user signs the URLs that Babylon requests on the fly.