### PR TITLE
Support loading color grading texture from blob url

### DIFF
--- a/packages/dev/core/src/Materials/Textures/colorGradingTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/colorGradingTexture.ts
@@ -240,8 +240,11 @@ export class ColorGradingTexture extends BaseTexture {
      * Starts the loading process of the texture.
      */
     private _loadTexture() {
-        if (this.url && this.url.toLocaleLowerCase().indexOf(".3dl") == this.url.length - 4) {
-            this._load3dlTexture();
+        if (this.url) {
+            const url = this.url.toLocaleLowerCase();
+            if (url.endsWith(".3dl") || url.startsWith("blob:")) {
+                this._load3dlTexture();
+            }
         }
     }
 


### PR DESCRIPTION
The old check expects the URL to end with `.3dl`, which won't work for blob URLs.