### PR TITLE
Add BitArray and use it in OptimizeIndices

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.vertexData.functions.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.functions.ts
@@ -1,4 +1,5 @@
 import type { IndicesArray } from "core/types";
+import { BitArray } from "core/Misc/bitArray";
 
 /**
  * Sort (in place) the index array so that faces with common indices are close
@@ -26,7 +27,7 @@ export function OptimizeIndices(indices: IndicesArray) {
     });
 
     // Step 3: Traverse faces using DFS to ensure connected faces are close
-    const visited = new Array(faceCount).fill(false);
+    const visited = new BitArray(faceCount);
     const sortedFaces: Array<number[]> = [];
 
     // Using a stack and not a recursive version to avoid call stack overflow
@@ -36,10 +37,10 @@ export function OptimizeIndices(indices: IndicesArray) {
         while (stack.length > 0) {
             const currentFaceIndex = stack.pop()!;
 
-            if (visited[currentFaceIndex]) {
+            if (visited.get(currentFaceIndex)) {
                 continue;
             }
-            visited[currentFaceIndex] = true;
+            visited.set(currentFaceIndex, true);
             sortedFaces.push(faces[currentFaceIndex]);
 
             // Push unvisited neighbors (faces sharing a vertex) onto the stack
@@ -51,7 +52,7 @@ export function OptimizeIndices(indices: IndicesArray) {
                 }
 
                 neighbors.forEach((neighborFaceIndex) => {
-                    if (!visited[neighborFaceIndex]) {
+                    if (!visited.get(neighborFaceIndex)) {
                         stack.push(neighborFaceIndex);
                     }
                 });
@@ -61,7 +62,7 @@ export function OptimizeIndices(indices: IndicesArray) {
 
     // Start DFS from the first face
     for (let i = 0; i < faceCount; i++) {
-        if (!visited[i]) {
+        if (!visited.get(i)) {
             deepFirstSearchStack(i);
         }
     }

--- a/packages/dev/core/src/Misc/bitArray.ts
+++ b/packages/dev/core/src/Misc/bitArray.ts
@@ -7,15 +7,19 @@ function getBitMask(bitIndex: number): number {
 }
 
 /**
- * An array that effectively stores boolean values where each value is a single bit of backing data.
+ * An fixed size array that effectively stores boolean values where each value is a single bit of backing data.
  * @remarks
  * All bits are initialized to false.
  */
 export class BitArray {
     private readonly _byteArray: Uint8Array;
 
-    public constructor(private readonly _size: number) {
-        this._byteArray = new Uint8Array(Math.ceil(this._size / 8));
+    /**
+     * Creates a new bit array with a fixed size.
+     * @param size The number of bits to store.
+     */
+    public constructor(public readonly size: number) {
+        this._byteArray = new Uint8Array(Math.ceil(this.size / 8));
     }
 
     /**
@@ -24,7 +28,7 @@ export class BitArray {
      * @returns The value at the specified index.
      */
     public get(bitIndex: number): boolean {
-        if (bitIndex >= this._size) {
+        if (bitIndex >= this.size) {
             throw new RangeError("Bit index out of range");
         }
         const byteIndex = getByteIndex(bitIndex);
@@ -38,7 +42,7 @@ export class BitArray {
      * @param value The value to set.
      */
     public set(bitIndex: number, value: boolean): void {
-        if (bitIndex >= this._size) {
+        if (bitIndex >= this.size) {
             throw new RangeError("Bit index out of range");
         }
         const byteIndex = getByteIndex(bitIndex);

--- a/packages/dev/core/src/Misc/bitArray.ts
+++ b/packages/dev/core/src/Misc/bitArray.ts
@@ -1,0 +1,52 @@
+function getByteIndex(bitIndex: number): number {
+    return Math.floor(bitIndex / 8);
+}
+
+function getBitMask(bitIndex: number): number {
+    return 1 << bitIndex % 8;
+}
+
+/**
+ * An array that effectively stores boolean values where each value is a single bit of backing data.
+ * @remarks
+ * All bits are initialized to false.
+ */
+export class BitArray {
+    private readonly _byteArray: Uint8Array;
+
+    public constructor(private readonly _size: number) {
+        this._byteArray = new Uint8Array(Math.ceil(this._size / 8));
+    }
+
+    /**
+     * Gets the current value at the specified index.
+     * @param bitIndex The index to get the value from.
+     * @returns The value at the specified index.
+     */
+    public get(bitIndex: number): boolean {
+        if (bitIndex >= this._size) {
+            throw new RangeError("Bit index out of range");
+        }
+        const byteIndex = getByteIndex(bitIndex);
+        const bitMask = getBitMask(bitIndex);
+        return (this._byteArray[byteIndex] & bitMask) !== 0;
+    }
+
+    /**
+     * Sets the value at the specified index.
+     * @param bitIndex The index to set the value at.
+     * @param value The value to set.
+     */
+    public set(bitIndex: number, value: boolean): void {
+        if (bitIndex >= this._size) {
+            throw new RangeError("Bit index out of range");
+        }
+        const byteIndex = getByteIndex(bitIndex);
+        const bitMask = getBitMask(bitIndex);
+        if (value) {
+            this._byteArray[byteIndex] |= bitMask;
+        } else {
+            this._byteArray[byteIndex] &= ~bitMask;
+        }
+    }
+}

--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -76,6 +76,7 @@ export * from "./greasedLineTools";
 export * from "./equirectangularCapture";
 export * from "./decorators.serialization";
 export * from "./asyncLock";
+export * from "./bitArray";
 
 // RGBDTextureTools
 export * from "../Shaders/rgbdDecode.fragment";


### PR DESCRIPTION
Booleans can be up to 4 bytes (depending on the JS engine and the scenario). A `BitArray` always uses just 1 bit per boolean, which means up to 32x less memory. Some light reading indicated that some JS engines will optimize Arrays that only contain booleans to use 1 bit per boolean, but this isn't what I saw happening when taking a few heap snapshots in Chrome (rather, I saw a ~5mb Array for a model with ~1.3M indices). Perf is pretty much identical between this `BitArray` and a normal `Array` of `boolean`s, until you have 100,000,000+ entries, in which case the `BitArray` is orders of magnitude faster. Not sure we'll ever have a use case this big, so maybe irrelevant, but good to know its now slower.