### PR TITLE
Add useFill parameter to CreateScreenshot

### DIFF
--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -99,9 +99,10 @@ export function CreateScreenshot(
         const destWidth = screenshotCanvas.width;
         const destHeight = screenshotCanvas.height;
 
-        // Calculate scale factors for width and height. Use the larger of the two to fill the screenshot.
+        // Calculate scale factors for width and height.
         const scaleX = destWidth / srcWidth;
         const scaleY = destHeight / srcHeight;
+        // Use the larger of the two scales to fill the screenshot dimensions, else use the smaller to fit.
         const scale = useFill ? Math.max(scaleX, scaleY) : Math.min(scaleX, scaleY);
         const newWidth = srcWidth * scale;
         const newHeight = srcHeight * scale;


### PR DESCRIPTION
CreateScreenshot currently letterboxes the rendering canvas in the screenshot. The `useFill` property, if true, will fill the given `size` dimension of the screenshot with the rendering canvas. If the rendering canvas' aspect ratio does not match the aspect ratio of the dimensions, then it will be clipped to fit. 

Other:
- Early return if using `CreateScreenshotUsingRenderTarget`
- Update comments