### PR TITLE
Morph target manager: Refactor of code + ability to disable position morphing

### DIFF
--- a/packages/dev/core/src/Culling/Helper/computeShaderBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/computeShaderBoundingHelper.ts
@@ -168,6 +168,7 @@ export class ComputeShaderBoundingHelper implements IBoundingInfoHelperPlatform 
             if (manager) {
                 defines = defines.slice();
                 defines.push("#define MORPHTARGETS");
+                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + maxNumInfluencers);
 
                 const computeShaderWithMorph = this._getComputeShader(defines, hasBones, true);

--- a/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
@@ -107,6 +107,7 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
                 numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
                 if (numInfluencers > 0) {
                     defines.push("#define MORPHTARGETS");
+                    defines.push("#define MORPHTARGETS_POSITION");
                 }
                 if (manager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -696,6 +696,7 @@ export abstract class EffectLayer {
             morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
             if (morphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);
                 if (manager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1625,6 +1625,7 @@ export class ShadowGenerator implements IShadowGenerator {
                 morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
                 if (morphInfluencers > 0) {
                     defines.push("#define MORPHTARGETS");
+                    defines.push("#define MORPHTARGETS_POSITION");
                     defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);
                     if (manager.isUsingTextureForTargets) {
                         defines.push("#define MORPHTARGETS_TEXTURE");

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -148,6 +148,8 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
 
     /** MORPH TARGETS */
     public MORPHTARGETS = false;
+    /** Morph target position */
+    public MORPHTARGETS_POSITION = false;
     /** Morph target normal */
     public MORPHTARGETS_NORMAL = false;
     /** Morph target tangent */

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -234,6 +234,7 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public NONUNIFORMSCALING = false;
 
     public MORPHTARGETS = false;
+    public MORPHTARGETS_POSITION = false;
     public MORPHTARGETS_NORMAL = false;
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -85,11 +85,15 @@ export function PrepareAttributesForMorphTargets(attribs: string[], mesh: Abstra
         if (manager?.isUsingTextureForTargets) {
             return;
         }
+        const position = manager && manager.supportsPositions;
         const normal = manager && manager.supportsNormals && defines["NORMAL"];
         const tangent = manager && manager.supportsTangents && defines["TANGENT"];
         const uv = manager && manager.supportsUVs && defines["UV1"];
+        const uv2 = manager && manager.supportsUV2s && defines["UV2"];
         for (let index = 0; index < influencers; index++) {
-            attribs.push(Constants.PositionKind + index);
+            if (position) {
+                attribs.push(Constants.PositionKind + index);
+            }
 
             if (normal) {
                 attribs.push(Constants.NormalKind + index);
@@ -101,6 +105,10 @@ export function PrepareAttributesForMorphTargets(attribs: string[], mesh: Abstra
 
             if (uv) {
                 attribs.push(Constants.UVKind + "_" + index);
+            }
+
+            if (uv2) {
+                attribs.push(Constants.UV2Kind + "_" + index);
             }
 
             if (attribs.length > maxAttributesCount) {
@@ -682,6 +690,7 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_UV2"] = manager.supportsUV2s && defines["UV2"];
         defines["MORPHTARGETS_TANGENT"] = manager.supportsTangents && defines["TANGENT"];
         defines["MORPHTARGETS_NORMAL"] = manager.supportsNormals && defines["NORMAL"];
+        defines["MORPHTARGETS_POSITION"] = manager.supportsPositions;
         defines["NUM_MORPH_INFLUENCERS"] = manager.numMaxInfluencers || manager.numInfluencers;
         defines["MORPHTARGETS"] = defines["NUM_MORPH_INFLUENCERS"] > 0;
 
@@ -691,6 +700,7 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_UV2"] = false;
         defines["MORPHTARGETS_TANGENT"] = false;
         defines["MORPHTARGETS_NORMAL"] = false;
+        defines["MORPHTARGETS_POSITION"] = false;
         defines["MORPHTARGETS"] = false;
         defines["NUM_MORPH_INFLUENCERS"] = 0;
     }

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -773,6 +773,7 @@ export class ShaderMaterial extends PushMaterial {
             const uv2 = manager.supportsUV2s && defines.indexOf("#define UV2") !== -1;
             const tangent = manager.supportsTangents && defines.indexOf("#define TANGENT") !== -1;
             const normal = manager.supportsNormals && defines.indexOf("#define NORMAL") !== -1;
+            const position = manager.supportsPositions;
             numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
             if (uv) {
                 defines.push("#define MORPHTARGETS_UV");
@@ -785,6 +786,9 @@ export class ShaderMaterial extends PushMaterial {
             }
             if (normal) {
                 defines.push("#define MORPHTARGETS_NORMAL");
+            }
+            if (position) {
+                defines.push("#define MORPHTARGETS_POSITION");
             }
             if (numInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
@@ -939,7 +943,7 @@ export class ShaderMaterial extends PushMaterial {
 
         drawWrapper!._wasPreviouslyUsingInstances = !!useInstances;
 
-        if (!effect?.isReady() ?? true) {
+        if (!effect?.isReady()) {
             return false;
         }
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -156,6 +156,7 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public TWOSIDEDLIGHTING = false;
     public SHADOWFLOAT = false;
     public MORPHTARGETS = false;
+    public MORPHTARGETS_POSITION = false;
     public MORPHTARGETS_NORMAL = false;
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;

--- a/packages/dev/core/src/Morph/morphTarget.ts
+++ b/packages/dev/core/src/Morph/morphTarget.ts
@@ -145,6 +145,23 @@ export class MorphTarget implements IAnimatable {
     }
 
     /**
+     * Gets the number of vertices stored in this target
+     */
+    public get vertexCount(): number {
+        return this._positions
+            ? this._positions.length / 3
+            : this._normals
+              ? this._normals.length / 3
+              : this._tangents
+                ? this._tangents.length / 3
+                : this._uvs
+                  ? this._uvs.length / 2
+                  : this._uv2s
+                    ? this._uv2s.length / 2
+                    : 0;
+    }
+
+    /**
      * Affects position data to this target
      * @param data defines the position data to use
      */

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -62,85 +62,30 @@ export class MorphTargetManager implements IDisposable {
      */
     public optimizeInfluencers = true;
 
-    private _enablePositionMorphing = true;
     /**
      * Gets or sets a boolean indicating if positions must be morphed
      */
-    public get enablePositionMorphing() {
-        return this._enablePositionMorphing;
-    }
+    public enablePositionMorphing = true;
 
-    public set enablePositionMorphing(value: boolean) {
-        if (this._enablePositionMorphing === value) {
-            return;
-        }
-        this._enablePositionMorphing = value;
-        this._mustSynchronize = true;
-    }
-
-    private _enableNormalMorphing = true;
     /**
      * Gets or sets a boolean indicating if normals must be morphed
      */
-    public get enableNormalMorphing() {
-        return this._enableNormalMorphing;
-    }
+    public enableNormalMorphing = true;
 
-    public set enableNormalMorphing(value: boolean) {
-        if (this._enableNormalMorphing === value) {
-            return;
-        }
-        this._enableNormalMorphing = value;
-        this._mustSynchronize = true;
-    }
-
-    private _enableTangentMorphing = true;
     /**
      * Gets or sets a boolean indicating if tangents must be morphed
      */
-    public get enableTangentMorphing() {
-        return this._enableTangentMorphing;
-    }
+    public enableTangentMorphing = true;
 
-    public set enableTangentMorphing(value: boolean) {
-        if (this._enableTangentMorphing === value) {
-            return;
-        }
-        this._enableTangentMorphing = value;
-        this._mustSynchronize = true;
-    }
-
-    private _enableUVMorphing = true;
     /**
      * Gets or sets a boolean indicating if UV must be morphed
      */
-    public get enableUVMorphing() {
-        return this._enableUVMorphing;
-    }
+    public enableUVMorphing = true;
 
-    public set enableUVMorphing(value: boolean) {
-        if (this._enableUVMorphing === value) {
-            return;
-        }
-        this._enableUVMorphing = value;
-        this._mustSynchronize = true;
-    }
-
-    private _enableUV2Morphing = true;
     /**
      * Gets or sets a boolean indicating if UV2 must be morphed
      */
-    public get enableUV2Morphing() {
-        return this._enableUV2Morphing;
-    }
-
-    public set enableUV2Morphing(value: boolean) {
-        if (this._enableUV2Morphing === value) {
-            return;
-        }
-        this._enableUV2Morphing = value;
-        this._mustSynchronize = true;
-    }
+    public enableUV2Morphing = true;
 
     /**
      * Sets a boolean indicating that adding new target or updating an existing target will not update the underlying data buffers
@@ -154,6 +99,7 @@ export class MorphTargetManager implements IDisposable {
                 this._blockCounter = 0;
 
                 this._mustSynchronize = true;
+                this._syncActiveTargets();
             }
         }
     }
@@ -205,6 +151,7 @@ export class MorphTargetManager implements IDisposable {
 
         this._numMaxInfluencers = value;
         this._mustSynchronize = true;
+        this._syncActiveTargets();
     }
 
     /**
@@ -353,9 +300,11 @@ export class MorphTargetManager implements IDisposable {
         this._targetDataLayoutChangedObservers.push(
             target._onDataLayoutChanged.add(() => {
                 this._mustSynchronize = true;
+                this._syncActiveTargets();
             })
         );
         this._mustSynchronize = true;
+        this._syncActiveTargets();
     }
 
     /**
@@ -381,11 +330,6 @@ export class MorphTargetManager implements IDisposable {
      * @internal
      */
     public _bind(effect: Effect) {
-        if (this._mustSynchronize) {
-            this._mustSynchronize = false;
-            this.synchronize();
-            this._syncActiveTargets(false);
-        }
         effect.setFloat3("morphTargetTextureInfo", this._textureVertexStride, this._textureWidth, this._textureHeight);
         effect.setFloatArray("morphTargetTextureIndices", this._morphTargetTextureIndices);
         effect.setTexture("morphTargets", this._targetStoreTexture);
@@ -428,7 +372,7 @@ export class MorphTargetManager implements IDisposable {
         return serializationObject;
     }
 
-    private _syncActiveTargets(needUpdate: boolean): void {
+    private _syncActiveTargets(needUpdate = false): void {
         if (this.areUpdatesFrozen) {
             return;
         }

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -239,6 +239,7 @@ export class MorphTargetManager implements IDisposable {
         }
         this._useTextureToStoreTargets = value;
         this._mustSynchronize = true;
+        this._syncActiveTargets();
     }
 
     /**
@@ -319,6 +320,7 @@ export class MorphTargetManager implements IDisposable {
             target.onInfluenceChanged.remove(this._targetInfluenceChangedObservers.splice(index, 1)[0]);
             target._onDataLayoutChanged.remove(this._targetDataLayoutChangedObservers.splice(index, 1)[0]);
             this._mustSynchronize = true;
+            this._syncActiveTargets();
         }
 
         if (this._scene) {

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -27,13 +27,7 @@ import { Viewport } from "../Maths/math.viewport";
 import { RegisterClass } from "../Misc/typeStore";
 import type { Nullable } from "../types";
 
-import {
-    BindBonesParameters,
-    BindMorphTargetParameters,
-    PrepareAttributesForMorphTargetsInfluencers,
-    PrepareDefinesForMorphTargets,
-    PushAttributesForInstances,
-} from "../Materials/materialHelper.functions";
+import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -27,7 +27,13 @@ import { Viewport } from "../Maths/math.viewport";
 import { RegisterClass } from "../Misc/typeStore";
 import type { Nullable } from "../types";
 
-import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import {
+    BindBonesParameters,
+    BindMorphTargetParameters,
+    PrepareAttributesForMorphTargetsInfluencers,
+    PrepareDefinesForMorphTargets,
+    PushAttributesForInstances,
+} from "../Materials/materialHelper.functions";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 
@@ -257,6 +263,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
 
                 if (morphTargetManager.isUsingTextureForTargets) {

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -447,6 +447,7 @@ export class DepthRenderer {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
 
                 if (morphTargetManager.isUsingTextureForTargets) {

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -783,6 +783,7 @@ export class GeometryBufferRenderer {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
                 if (morphTargetManager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -337,6 +337,7 @@ export class OutlineRenderer implements ISceneComponent {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
 
                 if (morphTargetManager.isUsingTextureForTargets) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -5,8 +5,11 @@
 			if (i >= morphTargetCount) break;
 
 			vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;
-			positionUpdated += (readVector3FromRawSampler(i, vertexID) - position) * morphTargetInfluences[i];
-			vertexID += 1.0;
+
+			#ifdef MORPHTARGETS_POSITION
+				positionUpdated += (readVector3FromRawSampler(i, vertexID) - position) * morphTargetInfluences[i];
+				vertexID += 1.0;
+			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated += (readVector3FromRawSampler(i, vertexID)  - normal) * morphTargetInfluences[i];
@@ -29,7 +32,9 @@
 		}
 		#endif
 	#else
+		#ifdef MORPHTARGETS_POSITION
 		positionUpdated += (position{X} - position) * morphTargetInfluences[{X}];
+		#endif
 		
 		#ifdef MORPHTARGETS_NORMAL
 		normalUpdated += (normal{X} - normal) * morphTargetInfluences[{X}];

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -1,6 +1,8 @@
 ﻿#ifdef MORPHTARGETS
 	#ifndef MORPHTARGETS_TEXTURE
+		#ifdef MORPHTARGETS_POSITION
 		attribute vec3 position{X};
+		#endif
 
 		#ifdef MORPHTARGETS_NORMAL
 		attribute vec3 normal{X};

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -7,8 +7,11 @@
 			}
 
 			vertexID = f32(vertexInputs.vertexIndex) * uniforms.morphTargetTextureInfo.x;
-			positionUpdated = positionUpdated + (readVector3FromRawSampler(i, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[i];
-			vertexID = vertexID + 1.0;
+
+			#ifdef MORPHTARGETS_POSITION
+				positionUpdated = positionUpdated + (readVector3FromRawSampler(i, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[i];
+				vertexID = vertexID + 1.0;
+			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated = normalUpdated + (readVector3FromRawSampler(i, vertexID)  - vertexInputs.normal) * uniforms.morphTargetInfluences[i];
@@ -31,7 +34,9 @@
 		}
 		#endif
 	#else
-		positionUpdated = positionUpdated + (vertexInputs.position{X} - vertexInputs.position) * uniforms.morphTargetInfluences[{X}];
+		#ifdef MORPHTARGETS_POSITION
+			positionUpdated = positionUpdated + (vertexInputs.position{X} - vertexInputs.position) * uniforms.morphTargetInfluences[{X}];
+		#endif
 		
 		#ifdef MORPHTARGETS_NORMAL
 		    normalUpdated += (vertexInputs.normal{X} - vertexInputs.normal) * uniforms.morphTargetInfluences[{X}];

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -1,6 +1,8 @@
 ﻿#ifdef MORPHTARGETS
 	#ifndef MORPHTARGETS_TEXTURE
+		#ifdef MORPHTARGETS_POSITION
 		attribute position{X} : vec3<f32>;
+		#endif
 
 		#ifdef MORPHTARGETS_NORMAL
 		attribute normal{X} : vec3<f32>;


### PR DESCRIPTION
The morph texture was created too often, which led to problems with the fast snapshot rendering mode in WebGPU.

So, I reworked the code and also added the option of not morphing positions.

[EDIT] Supporting "positions" optionally is a breaking change, as I had to add the "MORPHTARGETS_POSITION" define in a few places in the code. Let me know if I should remove this feature.
