### PR TITLE
Limit cases where KHR_texture_transform offset is adjusted for non-origin rotation

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_texture_transform.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_texture_transform.ts
@@ -1,7 +1,6 @@
 import type { ITextureInfo, IKHRTextureTransform } from "babylonjs-gltf2interface";
 import { Tools } from "core/Misc/tools";
 import type { Texture } from "core/Materials/Textures/texture";
-import type { Nullable } from "core/types";
 import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
 import { GLTFExporter } from "../glTFExporter";
 
@@ -48,78 +47,61 @@ export class KHR_texture_transform implements IGLTFExporterExtensionV2 {
     }
 
     public postExportTexture?(context: string, textureInfo: ITextureInfo, babylonTexture: Texture): void {
-        const canUseExtension =
-            babylonTexture &&
-            babylonTexture.uAng === 0 &&
-            babylonTexture.vAng === 0 &&
-            (babylonTexture.wAng === 0 ||
-                (babylonTexture.uRotationCenter === 0 && babylonTexture.vRotationCenter === 0) ||
-                (babylonTexture.uScale === 1 && babylonTexture.vScale === 1));
-        if (canUseExtension) {
-            const textureTransform: IKHRTextureTransform = {};
-            let transformIsRequired = false;
-
-            if (babylonTexture.uOffset !== 0 || babylonTexture.vOffset !== 0) {
-                textureTransform.offset = [babylonTexture.uOffset, babylonTexture.vOffset];
-                transformIsRequired = true;
-            }
-
-            if (babylonTexture.uScale !== 1 || babylonTexture.vScale !== 1) {
-                textureTransform.scale = [babylonTexture.uScale, babylonTexture.vScale];
-                transformIsRequired = true;
-            }
-
-            if (babylonTexture.wAng !== 0) {
-                textureTransform.rotation = -babylonTexture.wAng;
-                transformIsRequired = true;
-
-                if (babylonTexture.uRotationCenter !== 0 || babylonTexture.vRotationCenter !== 0) {
-                    textureTransform.offset = AdjustOffsetForRotationCenter(babylonTexture);
-                }
-            }
-
-            if (babylonTexture.coordinatesIndex !== 0) {
-                textureTransform.texCoord = babylonTexture.coordinatesIndex;
-                transformIsRequired = true;
-            }
-
-            if (!transformIsRequired) {
-                return;
-            }
-
-            this._wasUsed = true;
-            if (!textureInfo.extensions) {
-                textureInfo.extensions = {};
-            }
-            textureInfo.extensions[NAME] = textureTransform;
+        const scene = babylonTexture.getScene();
+        if (!scene) {
+            Tools.Warn(`${context}: "scene" is not defined for Babylon texture ${babylonTexture.name}! Not exporting with ${NAME}.`);
+            return;
         }
-    }
 
-    public preExportTextureAsync(context: string, babylonTexture: Texture): Promise<Nullable<Texture>> {
-        return new Promise((resolve, reject) => {
-            const scene = babylonTexture.getScene();
-            if (!scene) {
-                reject(`${context}: "scene" is not defined for Babylon texture ${babylonTexture.name}!`);
-                return;
-            }
+        /*
+         * The KHR_texture_transform schema only supports w rotation around the origin.
+         * See https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform#gltf-schema-updates.
+         */
+        if (babylonTexture.uAng !== 0 || babylonTexture.vAng !== 0) {
+            Tools.Warn(`${context}: Texture ${babylonTexture.name} with rotation in the u or v axis is not supported in glTF.`);
+            return;
+        }
 
-            /*
-             * The KHR_texture_transform schema only supports w rotation around the origin.
-             * See https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_texture_transform#gltf-schema-updates.
-             */
-            if (babylonTexture.uAng !== 0 || babylonTexture.vAng !== 0) {
-                Tools.Warn(`${context}: Texture ${babylonTexture.name} with rotation in the u or v axis is not supported in glTF.`);
-                resolve(null);
-            }
-            if (babylonTexture.wAng !== 0 && (babylonTexture.uRotationCenter !== 0 || babylonTexture.vRotationCenter !== 0)) {
+        const textureTransform: IKHRTextureTransform = {};
+        let transformIsRequired = false;
+
+        if (babylonTexture.uOffset !== 0 || babylonTexture.vOffset !== 0) {
+            textureTransform.offset = [babylonTexture.uOffset, babylonTexture.vOffset];
+            transformIsRequired = true;
+        }
+
+        if (babylonTexture.uScale !== 1 || babylonTexture.vScale !== 1) {
+            textureTransform.scale = [babylonTexture.uScale, babylonTexture.vScale];
+            transformIsRequired = true;
+        }
+
+        if (babylonTexture.wAng !== 0) {
+            if (babylonTexture.uRotationCenter !== 0 || babylonTexture.vRotationCenter !== 0) {
                 if (babylonTexture.uScale !== 1 || babylonTexture.vScale !== 1) {
                     Tools.Warn(`${context}: Texture ${babylonTexture.name} with scaling and a rotation not centered at the origin cannot be exported with ${NAME}`);
-                    resolve(null);
+                    return;
                 }
-                Tools.Warn(`${context}: Texture ${babylonTexture.name} with rotation not centered at the origin will be exported with an adjusted texture offset.`);
+                Tools.Warn(`${context}: Texture ${babylonTexture.name} with rotation not centered at the origin will be exported with an adjusted texture offset for ${NAME}.`);
+                textureTransform.offset = AdjustOffsetForRotationCenter(babylonTexture);
             }
-            resolve(babylonTexture);
-        });
+            textureTransform.rotation = -babylonTexture.wAng;
+            transformIsRequired = true;
+        }
+
+        if (babylonTexture.coordinatesIndex !== 0) {
+            textureTransform.texCoord = babylonTexture.coordinatesIndex;
+            transformIsRequired = true;
+        }
+
+        if (!transformIsRequired) {
+            return;
+        }
+
+        this._wasUsed = true;
+        if (!textureInfo.extensions) {
+            textureInfo.extensions = {};
+        }
+        textureInfo.extensions[NAME] = textureTransform;
     }
 }
 


### PR DESCRIPTION
I overlooked how scaling affects the calculations here https://github.com/BabylonJS/Babylon.js/pull/16015. For now, just go back to the original behavior (don't export KHR_texture_transform) if we can't adjust this offset. 

While here, I also merged preExportTexture into postExportTexture so we don't have to check conditions twice.