### PR TITLE
Make position morph binding as optional in renderers + enable other attrib type morph

### DIFF
--- a/packages/dev/core/src/Culling/Helper/computeShaderBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/computeShaderBoundingHelper.ts
@@ -145,7 +145,7 @@ export class ComputeShaderBoundingHelper implements IBoundingInfoHelperPlatform 
             this._processedMeshes.push(mesh);
 
             const manager = (<Mesh>mesh).morphTargetManager;
-            if (manager) {
+            if (manager && manager.supportsPositions) {
                 maxNumInfluencers = Math.max(maxNumInfluencers, manager.numTargets);
             }
         }
@@ -165,10 +165,9 @@ export class ComputeShaderBoundingHelper implements IBoundingInfoHelperPlatform 
             this._uniqueComputeShaders.add(computeShaderWithoutMorph);
 
             const manager = (<Mesh>mesh).morphTargetManager;
-            if (manager) {
+            if (manager && manager.supportsPositions) {
                 defines = defines.slice();
                 defines.push("#define MORPHTARGETS");
-                defines.push("#define MORPHTARGETS_POSITION");
                 defines.push("#define NUM_MORPH_INFLUENCERS " + maxNumInfluencers);
 
                 const computeShaderWithMorph = this._getComputeShader(defines, hasBones, true);
@@ -233,7 +232,7 @@ export class ComputeShaderBoundingHelper implements IBoundingInfoHelperPlatform 
             const [computeShaderWithoutMorph, computeShaderWithMorph] = this._computeShaders[i];
 
             const manager = (<Mesh>mesh).morphTargetManager;
-            const hasMorphs = manager && manager.numInfluencers > 0;
+            const hasMorphs = manager && manager.numInfluencers > 0 && manager.supportsPositions;
             const computeShader = hasMorphs ? computeShaderWithMorph : computeShaderWithoutMorph;
 
             this._extractDataAndLink(computeShader, mesh as Mesh, VertexBuffer.PositionKind, 3, "positionBuffer", this._positionBuffers);

--- a/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
@@ -5,7 +5,12 @@ import type { Engine } from "core/Engines/engine";
 import { Constants } from "core/Engines/constants";
 import type { Nullable } from "core/types";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
-import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForBakedVertexAnimation } from "core/Materials/materialHelper.functions";
+import {
+    BindBonesParameters,
+    BindMorphTargetParameters,
+    PrepareAttributesForBakedVertexAnimation,
+    PrepareAttributesForMorphTargetsInfluencers,
+} from "core/Materials/materialHelper.functions";
 import type { Mesh } from "core/Meshes/mesh";
 import type { IBoundingInfoHelperPlatform } from "./IBoundingInfoHelperPlatform";
 import { extractMinAndMax } from "core/Maths/math.functions";
@@ -63,9 +68,7 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
             let computeEffect: Effect;
             let numInfluencers = 0;
             const defines: string[] = [];
-            let uniforms: string[] = [];
             const attribs = [VertexBuffer.PositionKind];
-            const samplers: string[] = [];
 
             // Bones
             if (mesh && mesh.useBones && mesh.computeBonesUsingShaders && mesh.skeleton) {
@@ -75,28 +78,9 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
                     attribs.push(VertexBuffer.MatricesIndicesExtraKind);
                     attribs.push(VertexBuffer.MatricesWeightsExtraKind);
                 }
-
-                const skeleton = mesh.skeleton;
-
                 defines.push("#define NUM_BONE_INFLUENCERS " + mesh.numBoneInfluencers);
-
-                if (skeleton.isUsingTextureForMatrices) {
-                    defines.push("#define BONETEXTURE");
-
-                    if (uniforms.indexOf("boneTextureWidth") === -1) {
-                        uniforms.push("boneTextureWidth");
-                    }
-
-                    if (samplers.indexOf("boneSampler") === -1) {
-                        samplers.push("boneSampler");
-                    }
-                } else {
-                    defines.push("#define BonesPerMesh " + (skeleton.bones.length + 1));
-
-                    if (uniforms.indexOf("mBones") === -1) {
-                        uniforms.push("mBones");
-                    }
-                }
+                defines.push("#define BONETEXTURE " + mesh.skeleton.isUsingTextureForMatrices);
+                defines.push("#define BonesPerMesh " + (mesh.skeleton.bones.length + 1));
             } else {
                 defines.push("#define NUM_BONE_INFLUENCERS 0");
             }
@@ -107,55 +91,49 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
                 numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
                 if (numInfluencers > 0) {
                     defines.push("#define MORPHTARGETS");
-                    defines.push("#define MORPHTARGETS_POSITION");
-                }
-                if (manager.isUsingTextureForTargets) {
-                    defines.push("#define MORPHTARGETS_TEXTURE");
-
-                    if (uniforms.indexOf("morphTargetTextureIndices") === -1) {
-                        uniforms.push("morphTargetTextureIndices");
+                    if (manager.supportsPositions) {
+                        defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
+                        defines.push("#define MORPHTARGETS_POSITION");
                     }
-
-                    if (samplers.indexOf("morphTargets") === -1) {
-                        samplers.push("morphTargets");
+                    defines.push("#define NUM_MORPH_INFLUENCERS " + numInfluencers);
+                    if (manager.isUsingTextureForTargets) {
+                        defines.push("#define MORPHTARGETS_TEXTURE");
                     }
-                }
-                defines.push("#define NUM_MORPH_INFLUENCERS " + numInfluencers);
-                for (let index = 0; index < numInfluencers; index++) {
-                    attribs.push(VertexBuffer.PositionKind + index);
-                }
-                if (numInfluencers > 0) {
-                    uniforms = uniforms.slice();
-                    uniforms.push("morphTargetInfluences");
-                    uniforms.push("morphTargetCount");
-                    uniforms.push("morphTargetTextureInfo");
-                    uniforms.push("morphTargetTextureIndices");
+                    PrepareAttributesForMorphTargetsInfluencers(
+                        attribs,
+                        mesh,
+                        numInfluencers,
+                        true, // usePositionMorph
+                        false, // useNormalMorph
+                        false, // useTangentMorph
+                        false, // useUVMorph
+                        false // useUV2Morph
+                    );
                 }
             }
 
             // Baked Vertex Animation
             const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;
-
             if (bvaManager && bvaManager.isEnabled) {
                 defines.push("#define BAKED_VERTEX_ANIMATION_TEXTURE");
-                if (uniforms.indexOf("bakedVertexAnimationSettings") === -1) {
-                    uniforms.push("bakedVertexAnimationSettings");
-                }
-                if (uniforms.indexOf("bakedVertexAnimationTextureSizeInverted") === -1) {
-                    uniforms.push("bakedVertexAnimationTextureSizeInverted");
-                }
-                if (uniforms.indexOf("bakedVertexAnimationTime") === -1) {
-                    uniforms.push("bakedVertexAnimationTime");
-                }
-
-                if (samplers.indexOf("bakedVertexAnimationTexture") === -1) {
-                    samplers.push("bakedVertexAnimationTexture");
-                }
                 PrepareAttributesForBakedVertexAnimation(attribs, mesh, defines);
             }
 
             const join = defines.join("\n");
             if (!this._effects[join]) {
+                const uniforms = [
+                    "boneTextureWidth",
+                    "mBones",
+                    "morphTargetInfluences",
+                    "morphTargetCount",
+                    "morphTargetTextureInfo",
+                    "morphTargetTextureIndices",
+                    "bakedVertexAnimationSettings",
+                    "bakedVertexAnimationTextureSizeInverted",
+                    "bakedVertexAnimationTime",
+                ];
+                const samplers = ["boneSampler", "morphTargets", "bakedVertexAnimationTexture"];
+
                 const computeEffectOptions = {
                     attributes: attribs,
                     uniformsNames: uniforms,

--- a/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
@@ -91,8 +91,8 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
                 numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
                 if (numInfluencers > 0) {
                     defines.push("#define MORPHTARGETS");
+                    if (manager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
                     if (manager.supportsPositions) {
-                        defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                         defines.push("#define MORPHTARGETS_POSITION");
                     }
                     defines.push("#define NUM_MORPH_INFLUENCERS " + numInfluencers);

--- a/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
@@ -204,9 +204,9 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
         BindBonesParameters(mesh, effect);
 
         // Morph targets
-        const manager = (<Mesh>mesh).morphTargetManager;
-        if (manager && manager.numInfluencers > 0) {
-            BindMorphTargetParameters(<Mesh>mesh, effect);
+        BindMorphTargetParameters(mesh, effect);
+        if (mesh.morphTargetManager && mesh.morphTargetManager.isUsingTextureForTargets) {
+            mesh.morphTargetManager._bind(effect);
         }
 
         // BVA

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -696,18 +696,18 @@ export abstract class EffectLayer {
             morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
             if (morphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                if (manager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
+                if (manager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+                if (manager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+                if (manager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+                if (manager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
                 if (manager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                     defines.push("#define MORPHTARGETS_POSITION");
                 }
-                if (manager.supportsNormals) defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
-                if (manager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTANGENTS");
                 if (manager.supportsUVs) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
                     if (uv1) defines.push("#define MORPHTARGETS_UV");
                 }
                 if (manager.supportsUV2s) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                     if (uv2) defines.push("#define MORPHTARGETS_UV2");
                 }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -696,12 +696,34 @@ export abstract class EffectLayer {
             morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
             if (morphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
-                defines.push("#define MORPHTARGETS_POSITION");
+                if (manager.supportsPositions) {
+                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
+                    defines.push("#define MORPHTARGETS_POSITION");
+                }
+                if (manager.supportsNormals) defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
+                if (manager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTANGENTS");
+                if (manager.supportsUVs) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
+                    if (uv1) defines.push("#define MORPHTARGETS_UV");
+                }
+                if (manager.supportsUV2s) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
+                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
+                }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);
                 if (manager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");
                 }
-                PrepareAttributesForMorphTargetsInfluencers(attribs, mesh, morphInfluencers);
+                PrepareAttributesForMorphTargetsInfluencers(
+                    attribs,
+                    mesh,
+                    morphInfluencers,
+                    true, // usePositionMorph
+                    false, // useNormalMorph
+                    false, // useTangentMorph
+                    uv1, // useUVMorph
+                    uv2 // useUV2Morph
+                );
             }
         }
 

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1631,21 +1631,21 @@ export class ShadowGenerator implements IShadowGenerator {
                 morphInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
                 if (morphInfluencers > 0) {
                     defines.push("#define MORPHTARGETS");
+                    if (manager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
+                    if (manager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+                    if (manager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+                    if (manager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+                    if (manager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
                     if (manager.supportsPositions) {
-                        defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                         defines.push("#define MORPHTARGETS_POSITION");
                     }
                     if (manager.supportsNormals) {
-                        defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
                         if (useNormal) defines.push("#define MORPHTARGETS_NORMAL");
                     }
-                    if (manager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
                     if (manager.supportsUVs) {
-                        defines.push("#define MORPHTARGETS_SUPPORTUVS");
                         if (uv1) defines.push("#define MORPHTARGETS_UV");
                     }
                     if (manager.supportsUV2s) {
-                        defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                         if (uv2) defines.push("#define MORPHTARGETS_UV2");
                     }
                     defines.push("#define NUM_MORPH_INFLUENCERS " + morphInfluencers);

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1329,7 +1329,6 @@ export class ShadowGenerator implements IShadowGenerator {
 
                 // Morph targets
                 BindMorphTargetParameters(renderingMesh, effect);
-
                 if (renderingMesh.morphTargetManager && renderingMesh.morphTargetManager.isUsingTextureForTargets) {
                     renderingMesh.morphTargetManager._bind(effect);
                 }

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -268,7 +268,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 injectionCode += `${positionOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${position.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
             }
-            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASPOSITIONS) || defined(MORPHTARGETS_POSITION)\n`;
+            injectionCode += `#ifdef MORPHTARGETTEXTURE_HASPOSITIONS\n`;
             injectionCode += `vertexID += 1.0;\n`;
             injectionCode += `#endif\n`;
 
@@ -277,7 +277,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 injectionCode += `${normalOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${normal.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
             }
-            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASNORMALS) || defined(MORPHTARGETS_NORMAL)\n`;
+            injectionCode += `#ifdef MORPHTARGETTEXTURE_HASNORMALS\n`;
             injectionCode += `vertexID += 1.0;\n`;
             injectionCode += `#endif\n`;
 
@@ -286,7 +286,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 injectionCode += `${uvOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
             }
-            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASUVS) || defined(MORPHTARGETS_UV)\n`;
+            injectionCode += `#ifdef MORPHTARGETTEXTURE_HASUVS\n`;
             injectionCode += `vertexID += 1.0;\n`;
             injectionCode += `#endif\n`;
 
@@ -301,7 +301,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 }
                 injectionCode += `#endif\n`;
             }
-            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASTANGENTS) || defined(MORPHTARGETS_TANGENT)\n`;
+            injectionCode += `#ifdef MORPHTARGETTEXTURE_HASTANGENTS\n`;
             injectionCode += `vertexID += 1.0;\n`;
             injectionCode += `#endif\n`;
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -267,56 +267,48 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 injectionCode += `#ifdef MORPHTARGETS_POSITION\n`;
                 injectionCode += `${positionOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${position.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
-                injectionCode += `#if defined(MORPHTARGETS_SUPPORTPOSITIONS) || defined(MORPHTARGETS_POSITION)\n`;
-                injectionCode += `vertexID += 1.0;\n`;
-                injectionCode += `#endif\n`;
             }
+            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASPOSITIONS) || defined(MORPHTARGETS_POSITION)\n`;
+            injectionCode += `vertexID += 1.0;\n`;
+            injectionCode += `#endif\n`;
 
             if (supportNormals) {
-                if (defines["NORMAL"]) {
-                    injectionCode += `#ifdef MORPHTARGETS_NORMAL\n`;
-                    injectionCode += `${normalOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${normal.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
-                    injectionCode += `#endif\n`;
-                }
-                injectionCode += `#if defined(MORPHTARGETS_SUPPORTNORMALS) || defined(MORPHTARGETS_NORMAL)\n`;
-                injectionCode += `vertexID += 1.0;\n`;
+                injectionCode += `#ifdef MORPHTARGETS_NORMAL\n`;
+                injectionCode += `${normalOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID) - ${normal.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
             }
+            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASNORMALS) || defined(MORPHTARGETS_NORMAL)\n`;
+            injectionCode += `vertexID += 1.0;\n`;
+            injectionCode += `#endif\n`;
 
             if (supportUVs) {
-                if (defines["UV1"]) {
-                    injectionCode += `#ifdef MORPHTARGETS_UV\n`;
-                    injectionCode += `${uvOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
-                    injectionCode += `#endif\n`;
-                }
-                injectionCode += `#if defined(MORPHTARGETS_SUPPORTUVS) || defined(MORPHTARGETS_UV)\n`;
-                injectionCode += `vertexID += 1.0;\n`;
+                injectionCode += `#ifdef MORPHTARGETS_UV\n`;
+                injectionCode += `${uvOutput.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
             }
+            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASUVS) || defined(MORPHTARGETS_UV)\n`;
+            injectionCode += `vertexID += 1.0;\n`;
+            injectionCode += `#endif\n`;
 
             if (supportTangents) {
-                if (defines["TANGENT"]) {
-                    injectionCode += `#ifdef MORPHTARGETS_TANGENT\n`;
-                    injectionCode += `${tangentOutput.associatedVariableName}.xyz += (readVector3FromRawSampler(i, vertexID) - ${tangent.associatedVariableName}.xyz) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
+                injectionCode += `#ifdef MORPHTARGETS_TANGENT\n`;
+                injectionCode += `${tangentOutput.associatedVariableName}.xyz += (readVector3FromRawSampler(i, vertexID) - ${tangent.associatedVariableName}.xyz) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
 
-                    if (tangent.type === NodeMaterialBlockConnectionPointTypes.Vector4) {
-                        injectionCode += `${tangentOutput.associatedVariableName}.w = ${tangent.associatedVariableName}.w;\n`;
-                    } else {
-                        injectionCode += `${tangentOutput.associatedVariableName}.w = 1.;\n`;
-                    }
-                    injectionCode += `#endif\n`;
+                if (tangent.type === NodeMaterialBlockConnectionPointTypes.Vector4) {
+                    injectionCode += `${tangentOutput.associatedVariableName}.w = ${tangent.associatedVariableName}.w;\n`;
+                } else {
+                    injectionCode += `${tangentOutput.associatedVariableName}.w = 1.;\n`;
                 }
-                injectionCode += `#if defined(MORPHTARGETS_SUPPORTTANGENTS) || defined(MORPHTARGETS_TANGENT)\n`;
-                injectionCode += `vertexID += 1.0;\n`;
                 injectionCode += `#endif\n`;
             }
+            injectionCode += `#if defined(MORPHTARGETTEXTURE_HASTANGENTS) || defined(MORPHTARGETS_TANGENT)\n`;
+            injectionCode += `vertexID += 1.0;\n`;
+            injectionCode += `#endif\n`;
 
             if (supportUV2s) {
-                if (defines["UV2"]) {
-                    injectionCode += `#ifdef MORPHTARGETS_UV2\n`;
-                    injectionCode += `${uv2Output.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv2.associatedVariableName}) * morphTargetInfluences[i];\n`;
-                    injectionCode += `#endif\n`;
-                }
+                injectionCode += `#ifdef MORPHTARGETS_UV2\n`;
+                injectionCode += `${uv2Output.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv2.associatedVariableName}) * morphTargetInfluences[i];\n`;
+                injectionCode += `#endif\n`;
             }
 
             injectionCode += "}\n";

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -158,6 +158,16 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public MORPHTARGETS_UV = false;
     /** Morph target uv2 */
     public MORPHTARGETS_UV2 = false;
+    /** Morph target support positions */
+    public MORPHTARGETS_SUPPORTPOSITIONS = false;
+    /** Morph target support normals */
+    public MORPHTARGETS_SUPPORTNORMALS = false;
+    /** Morph target support tangents */
+    public MORPHTARGETS_SUPPORTTANGENTS = false;
+    /** Morph target support uvs */
+    public MORPHTARGETS_SUPPORTUVS = false;
+    /** Morph target support uv2s */
+    public MORPHTARGETS_SUPPORTUV2S = false;
     /** Number of morph influencers */
     public NUM_MORPH_INFLUENCERS = 0;
     /** Using a texture to store morph target data */

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -159,15 +159,15 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     /** Morph target uv2 */
     public MORPHTARGETS_UV2 = false;
     /** Morph target support positions */
-    public MORPHTARGETS_SUPPORTPOSITIONS = false;
+    public MORPHTARGETTEXTURE_HASPOSITIONS = false;
     /** Morph target support normals */
-    public MORPHTARGETS_SUPPORTNORMALS = false;
+    public MORPHTARGETTEXTURE_HASNORMALS = false;
     /** Morph target support tangents */
-    public MORPHTARGETS_SUPPORTTANGENTS = false;
+    public MORPHTARGETTEXTURE_HASTANGENTS = false;
     /** Morph target support uvs */
-    public MORPHTARGETS_SUPPORTUVS = false;
+    public MORPHTARGETTEXTURE_HASUVS = false;
     /** Morph target support uv2s */
-    public MORPHTARGETS_SUPPORTUV2S = false;
+    public MORPHTARGETTEXTURE_HASUV2S = false;
     /** Number of morph influencers */
     public NUM_MORPH_INFLUENCERS = 0;
     /** Using a texture to store morph target data */

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -239,11 +239,11 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;
     public MORPHTARGETS_UV2 = false;
-    public MORPHTARGETS_SUPPORTPOSITIONS = false;
-    public MORPHTARGETS_SUPPORTNORMALS = false;
-    public MORPHTARGETS_SUPPORTTANGENTS = false;
-    public MORPHTARGETS_SUPPORTUVS = false;
-    public MORPHTARGETS_SUPPORTUV2S = false;
+    public MORPHTARGETTEXTURE_HASPOSITIONS = false;
+    public MORPHTARGETTEXTURE_HASNORMALS = false;
+    public MORPHTARGETTEXTURE_HASTANGENTS = false;
+    public MORPHTARGETTEXTURE_HASUVS = false;
+    public MORPHTARGETTEXTURE_HASUV2S = false;
     public NUM_MORPH_INFLUENCERS = 0;
     public MORPHTARGETS_TEXTURE = false;
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -239,6 +239,11 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;
     public MORPHTARGETS_UV2 = false;
+    public MORPHTARGETS_SUPPORTPOSITIONS = false;
+    public MORPHTARGETS_SUPPORTNORMALS = false;
+    public MORPHTARGETS_SUPPORTTANGENTS = false;
+    public MORPHTARGETS_SUPPORTUVS = false;
+    public MORPHTARGETS_SUPPORTUV2S = false;
     public NUM_MORPH_INFLUENCERS = 0;
     public MORPHTARGETS_TEXTURE = false;
 

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -717,11 +717,11 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_NORMAL"] = manager.supportsNormals && defines["NORMAL"];
         defines["MORPHTARGETS_POSITION"] = manager.supportsPositions;
 
-        defines["MORPHTARGETS_SUPPORTUVS"] = manager.supportsUVs;
-        defines["MORPHTARGETS_SUPPORTUV2S"] = manager.supportsUV2s;
-        defines["MORPHTARGETS_SUPPORTTANGENTS"] = manager.supportsTangents;
-        defines["MORPHTARGETS_SUPPORTNORMALS"] = manager.supportsNormals;
-        defines["MORPHTARGETS_SUPPORTPOSITIONS"] = manager.supportsPositions;
+        defines["MORPHTARGETTEXTURE_HASUVS"] = manager.hasUVs;
+        defines["MORPHTARGETTEXTURE_HASUV2S"] = manager.hasUV2s;
+        defines["MORPHTARGETTEXTURE_HASTANGENTS"] = manager.hasTangents;
+        defines["MORPHTARGETTEXTURE_HASNORMALS"] = manager.hasNormals;
+        defines["MORPHTARGETTEXTURE_HASPOSITIONS"] = manager.hasPositions;
 
         defines["NUM_MORPH_INFLUENCERS"] = manager.numMaxInfluencers || manager.numInfluencers;
         defines["MORPHTARGETS"] = defines["NUM_MORPH_INFLUENCERS"] > 0;
@@ -734,11 +734,11 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_NORMAL"] = false;
         defines["MORPHTARGETS_POSITION"] = false;
 
-        defines["MORPHTARGETS_SUPPORTUVS"] = false;
-        defines["MORPHTARGETS_SUPPORTUV2S"] = false;
-        defines["MORPHTARGETS_SUPPORTTANGENTS"] = false;
-        defines["MORPHTARGETS_SUPPORTNORMALS"] = false;
-        defines["MORPHTARGETS_SUPPORTPOSITIONS"] = false;
+        defines["MORPHTARGETTEXTURE_HASUVS"] = false;
+        defines["MORPHTARGETTEXTURE_HASUV2S"] = false;
+        defines["MORPHTARGETTEXTURE_HASTANGENTS"] = false;
+        defines["MORPHTARGETTEXTURE_HASNORMALS"] = false;
+        defines["MORPHTARGETTEXTURE_HASPOSITIONS"] = false;
 
         defines["MORPHTARGETS"] = false;
         defines["NUM_MORPH_INFLUENCERS"] = 0;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -21,7 +21,13 @@ import { prepareDefinesForClipPlanes } from "./clipPlaneMaterialHelper";
 
 // Temps
 const _TempFogColor = Color3.Black();
-const _TmpMorphInfluencers = { NUM_MORPH_INFLUENCERS: 0 };
+const _TmpMorphInfluencers = {
+    NUM_MORPH_INFLUENCERS: 0,
+    NORMAL: false,
+    TANGENT: false,
+    UV: false,
+    UV2: false,
+};
 
 /**
  * Binds the logarithmic depth information from the scene to the effect for the given defines.
@@ -64,10 +70,28 @@ export function BindFogParameters(scene: Scene, mesh?: AbstractMesh, effect?: Ef
  * @param attribs The current list of supported attribs
  * @param mesh The mesh to prepare the morph targets attributes for
  * @param influencers The number of influencers
+ * @param usePositionMorph Whether the position morph target is used
+ * @param useNormalMorph Whether the normal morph target is used
+ * @param useTangentMorph Whether the tangent morph target is used
+ * @param useUVMorph Whether the UV morph target is used
+ * @param useUV2Morph Whether the UV2 morph target is used
  */
-export function PrepareAttributesForMorphTargetsInfluencers(attribs: string[], mesh: AbstractMesh, influencers: number): void {
+export function PrepareAttributesForMorphTargetsInfluencers(
+    attribs: string[],
+    mesh: AbstractMesh,
+    influencers: number,
+    usePositionMorph = true,
+    useNormalMorph = false,
+    useTangentMorph = false,
+    useUVMorph = false,
+    useUV2Morph = false
+): void {
     _TmpMorphInfluencers.NUM_MORPH_INFLUENCERS = influencers;
-    PrepareAttributesForMorphTargets(attribs, mesh, _TmpMorphInfluencers);
+    _TmpMorphInfluencers.NORMAL = useNormalMorph;
+    _TmpMorphInfluencers.TANGENT = useTangentMorph;
+    _TmpMorphInfluencers.UV = useUVMorph;
+    _TmpMorphInfluencers.UV2 = useUV2Morph;
+    PrepareAttributesForMorphTargets(attribs, mesh, _TmpMorphInfluencers, usePositionMorph);
 }
 
 /**
@@ -75,8 +99,9 @@ export function PrepareAttributesForMorphTargetsInfluencers(attribs: string[], m
  * @param attribs The current list of supported attribs
  * @param mesh The mesh to prepare the morph targets attributes for
  * @param defines The current Defines of the effect
+ * @param usePositionMorph Whether the position morph target is used
  */
-export function PrepareAttributesForMorphTargets(attribs: string[], mesh: AbstractMesh, defines: any): void {
+export function PrepareAttributesForMorphTargets(attribs: string[], mesh: AbstractMesh, defines: any, usePositionMorph = true): void {
     const influencers = defines["NUM_MORPH_INFLUENCERS"];
 
     if (influencers > 0 && EngineStore.LastCreatedEngine) {
@@ -85,7 +110,7 @@ export function PrepareAttributesForMorphTargets(attribs: string[], mesh: Abstra
         if (manager?.isUsingTextureForTargets) {
             return;
         }
-        const position = manager && manager.supportsPositions;
+        const position = manager && manager.supportsPositions && usePositionMorph;
         const normal = manager && manager.supportsNormals && defines["NORMAL"];
         const tangent = manager && manager.supportsTangents && defines["TANGENT"];
         const uv = manager && manager.supportsUVs && defines["UV1"];
@@ -691,6 +716,13 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_TANGENT"] = manager.supportsTangents && defines["TANGENT"];
         defines["MORPHTARGETS_NORMAL"] = manager.supportsNormals && defines["NORMAL"];
         defines["MORPHTARGETS_POSITION"] = manager.supportsPositions;
+
+        defines["MORPHTARGETS_SUPPORTUVS"] = manager.supportsUVs;
+        defines["MORPHTARGETS_SUPPORTUV2S"] = manager.supportsUV2s;
+        defines["MORPHTARGETS_SUPPORTTANGENTS"] = manager.supportsTangents;
+        defines["MORPHTARGETS_SUPPORTNORMALS"] = manager.supportsNormals;
+        defines["MORPHTARGETS_SUPPORTPOSITIONS"] = manager.supportsPositions;
+
         defines["NUM_MORPH_INFLUENCERS"] = manager.numMaxInfluencers || manager.numInfluencers;
         defines["MORPHTARGETS"] = defines["NUM_MORPH_INFLUENCERS"] > 0;
 
@@ -701,6 +733,13 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_TANGENT"] = false;
         defines["MORPHTARGETS_NORMAL"] = false;
         defines["MORPHTARGETS_POSITION"] = false;
+
+        defines["MORPHTARGETS_SUPPORTUVS"] = false;
+        defines["MORPHTARGETS_SUPPORTUV2S"] = false;
+        defines["MORPHTARGETS_SUPPORTTANGENTS"] = false;
+        defines["MORPHTARGETS_SUPPORTNORMALS"] = false;
+        defines["MORPHTARGETS_SUPPORTPOSITIONS"] = false;
+
         defines["MORPHTARGETS"] = false;
         defines["NUM_MORPH_INFLUENCERS"] = 0;
     }

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -18,7 +18,7 @@ import type { AbstractEngine } from "../Engines/abstractEngine";
 import type { Material } from "./material";
 import type { Nullable } from "../types";
 import { prepareDefinesForClipPlanes } from "./clipPlaneMaterialHelper";
-import { MorphTargetManager } from "core/Morph/morphTargetManager";
+import type { MorphTargetManager } from "core/Morph/morphTargetManager";
 
 // Temps
 const _TempFogColor = Color3.Black();

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -31,7 +31,6 @@ import {
     BindMorphTargetParameters,
     BindSceneUniformBuffer,
     PrepareAttributesForBakedVertexAnimation,
-    PrepareAttributesForMorphTargetsInfluencers,
     PrepareDefinesAndAttributesForMorphTargets,
     PushAttributesForInstances,
 } from "./materialHelper.functions";

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -775,24 +775,24 @@ export class ShaderMaterial extends PushMaterial {
             const tangent = defines.indexOf("#define TANGENT") !== -1;
             const normal = defines.indexOf("#define NORMAL") !== -1;
             numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
+            if (manager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+            if (manager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
+            if (manager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+            if (manager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+            if (manager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
             if (manager.supportsUVs) {
-                defines.push("#define MORPHTARGETS_SUPPORTUVS");
                 if (uv) defines.push("#define MORPHTARGETS_UV");
             }
             if (manager.supportsUV2s) {
-                defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                 if (uv2) defines.push("#define MORPHTARGETS_UV2");
             }
             if (manager.supportsTangents) {
-                defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
                 if (tangent) defines.push("#define MORPHTARGETS_TANGENT");
             }
             if (manager.supportsNormals) {
-                defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
                 if (normal) defines.push("#define MORPHTARGETS_NORMAL");
             }
             if (manager.supportsPositions) {
-                defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                 defines.push("#define MORPHTARGETS_POSITION");
             }
             if (numInfluencers > 0) {

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -1231,9 +1231,9 @@ export class ShaderMaterial extends PushMaterial {
 
         if (effect && mesh && (mustRebind || !this.isFrozen)) {
             // Morph targets
-            const manager = (<Mesh>mesh).morphTargetManager;
-            if (manager && manager.numInfluencers > 0) {
-                BindMorphTargetParameters(<Mesh>mesh, effect);
+            BindMorphTargetParameters(mesh, effect);
+            if (mesh.morphTargetManager && mesh.morphTargetManager.isUsingTextureForTargets) {
+                mesh.morphTargetManager._bind(effect);
             }
 
             const bvaManager = (<Mesh>mesh).bakedVertexAnimationManager;

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -32,6 +32,7 @@ import {
     BindSceneUniformBuffer,
     PrepareAttributesForBakedVertexAnimation,
     PrepareAttributesForMorphTargetsInfluencers,
+    PrepareDefinesAndAttributesForMorphTargets,
     PushAttributesForInstances,
 } from "./materialHelper.functions";
 
@@ -774,33 +775,18 @@ export class ShaderMaterial extends PushMaterial {
             const uv2 = defines.indexOf("#define UV2") !== -1;
             const tangent = defines.indexOf("#define TANGENT") !== -1;
             const normal = defines.indexOf("#define NORMAL") !== -1;
-            numInfluencers = manager.numMaxInfluencers || manager.numInfluencers;
-            if (manager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
-            if (manager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
-            if (manager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
-            if (manager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
-            if (manager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
-            if (manager.supportsUVs) {
-                if (uv) defines.push("#define MORPHTARGETS_UV");
-            }
-            if (manager.supportsUV2s) {
-                if (uv2) defines.push("#define MORPHTARGETS_UV2");
-            }
-            if (manager.supportsTangents) {
-                if (tangent) defines.push("#define MORPHTARGETS_TANGENT");
-            }
-            if (manager.supportsNormals) {
-                if (normal) defines.push("#define MORPHTARGETS_NORMAL");
-            }
-            if (manager.supportsPositions) {
-                defines.push("#define MORPHTARGETS_POSITION");
-            }
-            if (numInfluencers > 0) {
-                defines.push("#define MORPHTARGETS");
-            }
+            numInfluencers = PrepareDefinesAndAttributesForMorphTargets(
+                manager,
+                defines,
+                attribs,
+                mesh!,
+                true, // usePositionMorph
+                normal, // useNormalMorph
+                tangent, // useTangentMorph
+                uv, // useUVMorph
+                uv2 // useUV2Morph
+            );
             if (manager.isUsingTextureForTargets) {
-                defines.push("#define MORPHTARGETS_TEXTURE");
-
                 if (uniforms.indexOf("morphTargetTextureIndices") === -1) {
                     uniforms.push("morphTargetTextureIndices");
                 }
@@ -809,17 +795,6 @@ export class ShaderMaterial extends PushMaterial {
                     this._options.samplers.push("morphTargets");
                 }
             }
-            defines.push("#define NUM_MORPH_INFLUENCERS " + numInfluencers);
-            PrepareAttributesForMorphTargetsInfluencers(
-                attribs,
-                mesh!,
-                numInfluencers,
-                true, // usePositionMorph
-                normal, // useNormalMorph
-                tangent, // useTangentMorph
-                uv, // useUVMorph
-                uv2 // useUV2Morph
-            );
             if (numInfluencers > 0) {
                 uniforms = uniforms.slice();
                 uniforms.push("morphTargetInfluences");

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -161,11 +161,11 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;
     public MORPHTARGETS_UV2 = false;
-    public MORPHTARGETS_SUPPORTPOSITIONS = false;
-    public MORPHTARGETS_SUPPORTNORMALS = false;
-    public MORPHTARGETS_SUPPORTTANGENTS = false;
-    public MORPHTARGETS_SUPPORTUVS = false;
-    public MORPHTARGETS_SUPPORTUV2S = false;
+    public MORPHTARGETTEXTURE_HASPOSITIONS = false;
+    public MORPHTARGETTEXTURE_HASNORMALS = false;
+    public MORPHTARGETTEXTURE_HASTANGENTS = false;
+    public MORPHTARGETTEXTURE_HASUVS = false;
+    public MORPHTARGETTEXTURE_HASUV2S = false;
     public NUM_MORPH_INFLUENCERS = 0;
     public MORPHTARGETS_TEXTURE = false;
     public NONUNIFORMSCALING = false; // https://playground.babylonjs.com#V6DWIH

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -161,6 +161,11 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;
     public MORPHTARGETS_UV2 = false;
+    public MORPHTARGETS_SUPPORTPOSITIONS = false;
+    public MORPHTARGETS_SUPPORTNORMALS = false;
+    public MORPHTARGETS_SUPPORTTANGENTS = false;
+    public MORPHTARGETS_SUPPORTUVS = false;
+    public MORPHTARGETS_SUPPORTUV2S = false;
     public NUM_MORPH_INFLUENCERS = 0;
     public MORPHTARGETS_TEXTURE = false;
     public NONUNIFORMSCALING = false; // https://playground.babylonjs.com#V6DWIH

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -204,6 +204,41 @@ export class MorphTargetManager implements IDisposable {
     }
 
     /**
+     * Gets a boolean indicating if this manager has data for morphing positions
+     */
+    public get hasPositions(): boolean {
+        return this._supportsPositions;
+    }
+
+    /**
+     * Gets a boolean indicating if this manager has data for morphing normals
+     */
+    public get hasNormals(): boolean {
+        return this._supportsNormals;
+    }
+
+    /**
+     * Gets a boolean indicating if this manager has data for morphing tangents
+     */
+    public get hasTangents(): boolean {
+        return this._supportsTangents;
+    }
+
+    /**
+     * Gets a boolean indicating if this manager has data for morphing texture coordinates
+     */
+    public get hasUVs(): boolean {
+        return this._supportsUVs;
+    }
+
+    /**
+     * Gets a boolean indicating if this manager has data for morphing texture coordinates 2
+     */
+    public get hasUV2s(): boolean {
+        return this._supportsUV2s;
+    }
+
+    /**
      * Gets the number of targets stored in this manager
      */
     public get numTargets(): number {
@@ -349,6 +384,7 @@ export class MorphTargetManager implements IDisposable {
             copy.addTarget(target.clone());
         }
 
+        copy.enablePositionMorphing = this.enablePositionMorphing;
         copy.enableNormalMorphing = this.enableNormalMorphing;
         copy.enableTangentMorphing = this.enableTangentMorphing;
         copy.enableUVMorphing = this.enableUVMorphing;

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -27,7 +27,7 @@ import { Viewport } from "../Maths/math.viewport";
 import { RegisterClass } from "../Misc/typeStore";
 import type { Nullable } from "../types";
 
-import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import { BindBonesParameters, BindMorphTargetParameters, PrepareDefinesAndAttributesForMorphTargets, PushAttributesForInstances } from "../Materials/materialHelper.functions";
 import type { AbstractEngine } from "../Engines/abstractEngine";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 
@@ -257,42 +257,19 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
         }
 
         // Morph targets
-        const morphTargetManager = (mesh as Mesh).morphTargetManager;
-        let numMorphInfluencers = 0;
-        if (morphTargetManager) {
-            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
-            if (numMorphInfluencers > 0) {
-                defines.push("#define MORPHTARGETS");
-                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
-                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
-                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
-                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
-                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
-                if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_POSITION");
-                }
-                if (morphTargetManager.supportsUVs) {
-                    if (uv1) defines.push("#define MORPHTARGETS_UV");
-                }
-                if (morphTargetManager.supportsUV2s) {
-                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
-                }
-                defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
-                if (morphTargetManager.isUsingTextureForTargets) {
-                    defines.push("#define MORPHTARGETS_TEXTURE");
-                }
-                PrepareAttributesForMorphTargetsInfluencers(
-                    attribs,
-                    mesh,
-                    numMorphInfluencers,
-                    true, // usePositionMorph
-                    false, // useNormalMorph
-                    false, // useTangentMorph
-                    uv1, // useUVMorph
-                    uv2 // useUV2Morph
-                );
-            }
-        }
+        const numMorphInfluencers = mesh.morphTargetManager
+            ? PrepareDefinesAndAttributesForMorphTargets(
+                  mesh.morphTargetManager,
+                  defines,
+                  attribs,
+                  mesh,
+                  true, // usePositionMorph
+                  false, // useNormalMorph
+                  false, // useTangentMorph
+                  uv1, // useUVMorph
+                  uv2 // useUV2Morph
+              )
+            : 0;
 
         // Instances
         if (useInstances) {

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -263,18 +263,18 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
+                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
                 if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                     defines.push("#define MORPHTARGETS_POSITION");
                 }
-                if (morphTargetManager.supportsNormals) defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
-                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTANGENTS");
                 if (morphTargetManager.supportsUVs) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
                     if (uv1) defines.push("#define MORPHTARGETS_UV");
                 }
                 if (morphTargetManager.supportsUV2s) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                     if (uv2) defines.push("#define MORPHTARGETS_UV2");
                 }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -215,19 +215,20 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
 
         // Alpha test
         if (material) {
-            if (material.needAlphaTesting()) {
+            const needAlphaTesting = material.needAlphaTesting();
+            if (needAlphaTesting) {
                 defines.push("#define ALPHATEST");
             }
 
             if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                 attribs.push(VertexBuffer.UVKind);
                 defines.push("#define UV1");
-                uv1 = true;
+                uv1 = needAlphaTesting;
             }
             if (mesh.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
                 attribs.push(VertexBuffer.UV2Kind);
                 defines.push("#define UV2");
-                uv2 = true;
+                uv2 = needAlphaTesting;
             }
         }
 

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -452,18 +452,18 @@ export class DepthRenderer {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
+                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
                 if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                     defines.push("#define MORPHTARGETS_POSITION");
                 }
-                if (morphTargetManager.supportsNormals) defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
-                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
                 if (morphTargetManager.supportsUVs) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
                     if (uv1) defines.push("#define MORPHTARGETS_UV");
                 }
                 if (morphTargetManager.supportsUV2s) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                     if (uv2) defines.push("#define MORPHTARGETS_UV2");
                 }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -17,7 +17,7 @@ import { addClipPlaneUniforms, bindClipPlane, prepareStringDefinesForClipPlanes 
 
 import type { Material } from "../Materials/material";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
-import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import { BindBonesParameters, BindMorphTargetParameters, PrepareDefinesAndAttributesForMorphTargets, PushAttributesForInstances } from "../Materials/materialHelper.functions";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import type { IEffectCreationOptions } from "core/Materials";
@@ -446,42 +446,19 @@ export class DepthRenderer {
         }
 
         // Morph targets
-        const morphTargetManager = (mesh as Mesh).morphTargetManager;
-        let numMorphInfluencers = 0;
-        if (morphTargetManager) {
-            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
-            if (numMorphInfluencers > 0) {
-                defines.push("#define MORPHTARGETS");
-                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
-                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
-                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
-                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
-                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
-                if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_POSITION");
-                }
-                if (morphTargetManager.supportsUVs) {
-                    if (uv1) defines.push("#define MORPHTARGETS_UV");
-                }
-                if (morphTargetManager.supportsUV2s) {
-                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
-                }
-                defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
-                if (morphTargetManager.isUsingTextureForTargets) {
-                    defines.push("#define MORPHTARGETS_TEXTURE");
-                }
-                PrepareAttributesForMorphTargetsInfluencers(
-                    attribs,
-                    mesh,
-                    numMorphInfluencers,
-                    true, // usePositionMorph
-                    false, // useNormalMorph
-                    false, // useTangentMorph
-                    uv1, // useUVMorph
-                    uv2 // useUV2Morph
-                );
-            }
-        }
+        const numMorphInfluencers = mesh.morphTargetManager
+            ? PrepareDefinesAndAttributesForMorphTargets(
+                  mesh.morphTargetManager,
+                  defines,
+                  attribs,
+                  mesh,
+                  true, // usePositionMorph
+                  false, // useNormalMorph
+                  false, // useTangentMorph
+                  uv1, // useUVMorph
+                  uv2 // useUV2Morph
+              )
+            : 0;
 
         // Points cloud rendering
         if (material.pointsCloud) {

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -403,16 +403,21 @@ export class DepthRenderer {
 
         const attribs = [VertexBuffer.PositionKind];
 
+        let uv1 = false;
+        let uv2 = false;
+
         // Alpha test
         if (material.needAlphaTesting() && material.getAlphaTestTexture()) {
             defines.push("#define ALPHATEST");
             if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                 attribs.push(VertexBuffer.UVKind);
                 defines.push("#define UV1");
+                uv1 = true;
             }
             if (mesh.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
                 attribs.push(VertexBuffer.UV2Kind);
                 defines.push("#define UV2");
+                uv2 = true;
             }
         }
 
@@ -447,14 +452,34 @@ export class DepthRenderer {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
-                defines.push("#define MORPHTARGETS_POSITION");
+                if (morphTargetManager.supportsPositions) {
+                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
+                    defines.push("#define MORPHTARGETS_POSITION");
+                }
+                if (morphTargetManager.supportsNormals) defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
+                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
+                if (morphTargetManager.supportsUVs) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
+                    if (uv1) defines.push("#define MORPHTARGETS_UV");
+                }
+                if (morphTargetManager.supportsUV2s) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
+                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
+                }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
-
                 if (morphTargetManager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");
                 }
-
-                PrepareAttributesForMorphTargetsInfluencers(attribs, mesh, numMorphInfluencers);
+                PrepareAttributesForMorphTargetsInfluencers(
+                    attribs,
+                    mesh,
+                    numMorphInfluencers,
+                    true, // usePositionMorph
+                    false, // useNormalMorph
+                    false, // useTangentMorph
+                    uv1, // useUVMorph
+                    uv2 // useUV2Morph
+                );
             }
         }
 

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -21,7 +21,7 @@ import "../Shaders/geometry.fragment";
 import "../Shaders/geometry.vertex";
 import { MaterialFlags } from "../Materials/materialFlags";
 import { addClipPlaneUniforms, bindClipPlane, prepareStringDefinesForClipPlanes } from "../Materials/clipPlaneMaterialHelper";
-import { BindMorphTargetParameters, BindSceneUniformBuffer, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import { BindMorphTargetParameters, BindSceneUniformBuffer, PrepareDefinesAndAttributesForMorphTargets, PushAttributesForInstances } from "../Materials/materialHelper.functions";
 
 import "../Engines/Extensions/engine.multiRender";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -782,45 +782,19 @@ export class GeometryBufferRenderer {
         }
 
         // Morph targets
-        const morphTargetManager = (mesh as Mesh).morphTargetManager;
-        let numMorphInfluencers = 0;
-        if (morphTargetManager) {
-            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
-            if (numMorphInfluencers > 0) {
-                defines.push("#define MORPHTARGETS");
-                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
-                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
-                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
-                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
-                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
-                if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_POSITION");
-                }
-                if (morphTargetManager.supportsNormals) {
-                    defines.push("#define MORPHTARGETS_NORMAL");
-                }
-                if (morphTargetManager.supportsUVs) {
-                    if (uv1) defines.push("#define MORPHTARGETS_UV");
-                }
-                if (morphTargetManager.supportsUV2s) {
-                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
-                }
-                defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
-                if (morphTargetManager.isUsingTextureForTargets) {
-                    defines.push("#define MORPHTARGETS_TEXTURE");
-                }
-                PrepareAttributesForMorphTargetsInfluencers(
-                    attribs,
-                    mesh,
-                    numMorphInfluencers,
-                    true, // usePositionMorph
-                    true, // useNormalMorph
-                    false, // useTangentMorph
-                    uv1, // useUVMorph
-                    uv2 // useUV2Morph
-                );
-            }
-        }
+        const numMorphInfluencers = mesh.morphTargetManager
+            ? PrepareDefinesAndAttributesForMorphTargets(
+                  mesh.morphTargetManager,
+                  defines,
+                  attribs,
+                  mesh,
+                  true, // usePositionMorph
+                  true, // useNormalMorph
+                  false, // useTangentMorph
+                  uv1, // useUVMorph
+                  uv2 // useUV2Morph
+              )
+            : 0;
 
         // Instances
         if (useInstances) {

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -788,21 +788,21 @@ export class GeometryBufferRenderer {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
+                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
                 if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                     defines.push("#define MORPHTARGETS_POSITION");
                 }
                 if (morphTargetManager.supportsNormals) {
-                    defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
                     defines.push("#define MORPHTARGETS_NORMAL");
                 }
-                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
                 if (morphTargetManager.supportsUVs) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
                     if (uv1) defines.push("#define MORPHTARGETS_UV");
                 }
                 if (morphTargetManager.supportsUV2s) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                     if (uv2) defines.push("#define MORPHTARGETS_UV2");
                 }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -554,6 +554,9 @@ export class GeometryBufferRenderer {
         const attribs = [VertexBuffer.PositionKind, VertexBuffer.NormalKind];
         const mesh = subMesh.getMesh();
 
+        let uv1 = false;
+        let uv2 = false;
+
         if (material) {
             let needUv = false;
             // Alpha test
@@ -699,10 +702,12 @@ export class GeometryBufferRenderer {
                 if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                     attribs.push(VertexBuffer.UVKind);
                     defines.push("#define UV1");
+                    uv1 = true;
                 }
                 if (mesh.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
                     attribs.push(VertexBuffer.UV2Kind);
                     defines.push("#define UV2");
+                    uv2 = true;
                 }
             }
         }
@@ -783,12 +788,37 @@ export class GeometryBufferRenderer {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
-                defines.push("#define MORPHTARGETS_POSITION");
+                if (morphTargetManager.supportsPositions) {
+                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
+                    defines.push("#define MORPHTARGETS_POSITION");
+                }
+                if (morphTargetManager.supportsNormals) {
+                    defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
+                    defines.push("#define MORPHTARGETS_NORMAL");
+                }
+                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
+                if (morphTargetManager.supportsUVs) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
+                    if (uv1) defines.push("#define MORPHTARGETS_UV");
+                }
+                if (morphTargetManager.supportsUV2s) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
+                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
+                }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
                 if (morphTargetManager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");
                 }
-                PrepareAttributesForMorphTargetsInfluencers(attribs, mesh, numMorphInfluencers);
+                PrepareAttributesForMorphTargetsInfluencers(
+                    attribs,
+                    mesh,
+                    numMorphInfluencers,
+                    true, // usePositionMorph
+                    true, // useNormalMorph
+                    false, // useTangentMorph
+                    uv1, // useUVMorph
+                    uv2 // useUV2Morph
+                );
             }
         }
 

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -287,16 +287,21 @@ export class OutlineRenderer implements ISceneComponent {
 
         const scene = mesh.getScene();
 
+        let uv1 = false;
+        let uv2 = false;
+
         // Alpha test
         if (material.needAlphaTesting()) {
             defines.push("#define ALPHATEST");
             if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                 attribs.push(VertexBuffer.UVKind);
                 defines.push("#define UV1");
+                uv1 = true;
             }
             if (mesh.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
                 attribs.push(VertexBuffer.UV2Kind);
                 defines.push("#define UV2");
+                uv2 = true;
             }
         }
         //Logarithmic depth
@@ -337,14 +342,37 @@ export class OutlineRenderer implements ISceneComponent {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
-                defines.push("#define MORPHTARGETS_POSITION");
+                if (morphTargetManager.supportsPositions) {
+                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
+                    defines.push("#define MORPHTARGETS_POSITION");
+                }
+                if (morphTargetManager.supportsNormals) {
+                    defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
+                    defines.push("#define MORPHTARGETS_NORMAL");
+                }
+                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
+                if (morphTargetManager.supportsUVs) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
+                    if (uv1) defines.push("#define MORPHTARGETS_UV");
+                }
+                if (morphTargetManager.supportsUV2s) {
+                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
+                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
+                }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
-
                 if (morphTargetManager.isUsingTextureForTargets) {
                     defines.push("#define MORPHTARGETS_TEXTURE");
                 }
-
-                PrepareAttributesForMorphTargetsInfluencers(attribs, mesh, numMorphInfluencers);
+                PrepareAttributesForMorphTargetsInfluencers(
+                    attribs,
+                    mesh,
+                    numMorphInfluencers,
+                    true, // usePositionMorph
+                    true, // useNormalMorph
+                    false, // useTangentMorph
+                    uv1, // useUVMorph
+                    uv2 // useUV2Morph
+                );
             }
         }
 

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -342,21 +342,21 @@ export class OutlineRenderer implements ISceneComponent {
             numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
             if (numMorphInfluencers > 0) {
                 defines.push("#define MORPHTARGETS");
+                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
+                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
+                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
+                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
+                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
                 if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_SUPPORTPOSITIONS");
                     defines.push("#define MORPHTARGETS_POSITION");
                 }
                 if (morphTargetManager.supportsNormals) {
-                    defines.push("#define MORPHTARGETS_SUPPORTNORMALS");
                     defines.push("#define MORPHTARGETS_NORMAL");
                 }
-                if (morphTargetManager.supportsTangents) defines.push("#define MORPHTARGETS_SUPPORTTANGENTS");
                 if (morphTargetManager.supportsUVs) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUVS");
                     if (uv1) defines.push("#define MORPHTARGETS_UV");
                 }
                 if (morphTargetManager.supportsUV2s) {
-                    defines.push("#define MORPHTARGETS_SUPPORTUV2S");
                     if (uv2) defines.push("#define MORPHTARGETS_UV2");
                 }
                 defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -10,7 +10,7 @@ import { SceneComponentConstants } from "../sceneComponent";
 import { DrawWrapper } from "../Materials/drawWrapper";
 
 import { addClipPlaneUniforms, bindClipPlane, prepareStringDefinesForClipPlanes } from "core/Materials/clipPlaneMaterialHelper";
-import { BindBonesParameters, BindMorphTargetParameters, PrepareAttributesForMorphTargetsInfluencers, PushAttributesForInstances } from "../Materials/materialHelper.functions";
+import { BindBonesParameters, BindMorphTargetParameters, PrepareDefinesAndAttributesForMorphTargets, PushAttributesForInstances } from "../Materials/materialHelper.functions";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import type { IEffectCreationOptions } from "core/Materials/effect";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -336,45 +336,19 @@ export class OutlineRenderer implements ISceneComponent {
         }
 
         // Morph targets
-        const morphTargetManager = (mesh as Mesh).morphTargetManager;
-        let numMorphInfluencers = 0;
-        if (morphTargetManager) {
-            numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
-            if (numMorphInfluencers > 0) {
-                defines.push("#define MORPHTARGETS");
-                if (morphTargetManager.hasPositions) defines.push("#define MORPHTARGETTEXTURE_HASPOSITIONS");
-                if (morphTargetManager.hasNormals) defines.push("#define MORPHTARGETTEXTURE_HASNORMALS");
-                if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
-                if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
-                if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
-                if (morphTargetManager.supportsPositions) {
-                    defines.push("#define MORPHTARGETS_POSITION");
-                }
-                if (morphTargetManager.supportsNormals) {
-                    defines.push("#define MORPHTARGETS_NORMAL");
-                }
-                if (morphTargetManager.supportsUVs) {
-                    if (uv1) defines.push("#define MORPHTARGETS_UV");
-                }
-                if (morphTargetManager.supportsUV2s) {
-                    if (uv2) defines.push("#define MORPHTARGETS_UV2");
-                }
-                defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
-                if (morphTargetManager.isUsingTextureForTargets) {
-                    defines.push("#define MORPHTARGETS_TEXTURE");
-                }
-                PrepareAttributesForMorphTargetsInfluencers(
-                    attribs,
-                    mesh,
-                    numMorphInfluencers,
-                    true, // usePositionMorph
-                    true, // useNormalMorph
-                    false, // useTangentMorph
-                    uv1, // useUVMorph
-                    uv2 // useUV2Morph
-                );
-            }
-        }
+        const numMorphInfluencers = mesh.morphTargetManager
+            ? PrepareDefinesAndAttributesForMorphTargets(
+                  mesh.morphTargetManager,
+                  defines,
+                  attribs,
+                  mesh,
+                  true, // usePositionMorph
+                  true, // useNormalMorph
+                  false, // useTangentMorph
+                  uv1, // useUVMorph
+                  uv2 // useUV2Morph
+              )
+            : 0;
 
         // Instances
         if (useInstances) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -9,28 +9,28 @@
 			#ifdef MORPHTARGETS_POSITION
 				positionUpdated += (readVector3FromRawSampler(i, vertexID) - position) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTPOSITIONS) || defined(MORPHTARGETS_POSITION)
+			#if defined(MORPHTARGETTEXTURE_HASPOSITIONS) || defined(MORPHTARGETS_POSITION)
 				vertexID += 1.0;
 			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated += (readVector3FromRawSampler(i, vertexID)  - normal) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTNORMALS) || defined(MORPHTARGETS_NORMAL)
+			#if defined(MORPHTARGETTEXTURE_HASNORMALS) || defined(MORPHTARGETS_NORMAL)
 				vertexID += 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_UV
 				uvUpdated += (readVector3FromRawSampler(i, vertexID).xy - uv) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTUVS) || defined(MORPHTARGETS_UV)
+			#if defined(MORPHTARGETTEXTURE_HASUVS) || defined(MORPHTARGETS_UV)
 				vertexID += 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_TANGENT
 				tangentUpdated.xyz += (readVector3FromRawSampler(i, vertexID)  - tangent.xyz) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTTANGENTS) || defined(MORPHTARGETS_TANGENT)
+			#if defined(MORPHTARGETTEXTURE_HASTANGENTS) || defined(MORPHTARGETS_TANGENT)
 				vertexID += 1.0;
 			#endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -9,28 +9,28 @@
 			#ifdef MORPHTARGETS_POSITION
 				positionUpdated += (readVector3FromRawSampler(i, vertexID) - position) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETTEXTURE_HASPOSITIONS) || defined(MORPHTARGETS_POSITION)
+			#ifdef MORPHTARGETTEXTURE_HASPOSITIONS
 				vertexID += 1.0;
 			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated += (readVector3FromRawSampler(i, vertexID)  - normal) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETTEXTURE_HASNORMALS) || defined(MORPHTARGETS_NORMAL)
+			#ifdef MORPHTARGETTEXTURE_HASNORMALS
 				vertexID += 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_UV
 				uvUpdated += (readVector3FromRawSampler(i, vertexID).xy - uv) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETTEXTURE_HASUVS) || defined(MORPHTARGETS_UV)
+			#ifdef MORPHTARGETTEXTURE_HASUVS
 				vertexID += 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_TANGENT
 				tangentUpdated.xyz += (readVector3FromRawSampler(i, vertexID)  - tangent.xyz) * morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETTEXTURE_HASTANGENTS) || defined(MORPHTARGETS_TANGENT)
+			#ifdef MORPHTARGETTEXTURE_HASTANGENTS
 				vertexID += 1.0;
 			#endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -8,21 +8,29 @@
 
 			#ifdef MORPHTARGETS_POSITION
 				positionUpdated += (readVector3FromRawSampler(i, vertexID) - position) * morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTPOSITIONS) || defined(MORPHTARGETS_POSITION)
 				vertexID += 1.0;
 			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated += (readVector3FromRawSampler(i, vertexID)  - normal) * morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTNORMALS) || defined(MORPHTARGETS_NORMAL)
 				vertexID += 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_UV
 				uvUpdated += (readVector3FromRawSampler(i, vertexID).xy - uv) * morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTUVS) || defined(MORPHTARGETS_UV)
 				vertexID += 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_TANGENT
 				tangentUpdated.xyz += (readVector3FromRawSampler(i, vertexID)  - tangent.xyz) * morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTTANGENTS) || defined(MORPHTARGETS_TANGENT)
 				vertexID += 1.0;
 			#endif
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -11,28 +11,28 @@
 			#ifdef MORPHTARGETS_POSITION
 				positionUpdated = positionUpdated + (readVector3FromRawSampler(i, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETTEXTURE_HASPOSITIONS) || defined(MORPHTARGETS_POSITION)
+			#ifdef MORPHTARGETTEXTURE_HASPOSITIONS
 				vertexID = vertexID + 1.0;
 			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated = normalUpdated + (readVector3FromRawSampler(i, vertexID)  - vertexInputs.normal) * uniforms.morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETTEXTURE_HASNORMALS) || defined(MORPHTARGETS_NORMAL)
+			#ifdef MORPHTARGETTEXTURE_HASNORMALS
 				vertexID = vertexID + 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_UV
 				uvUpdated = uvUpdated + (readVector3FromRawSampler(i, vertexID).xy - vertexInputs.uv) * uniforms.morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTUVS) || defined(MORPHTARGETS_UV)
+			#ifdef MORPHTARGETTEXTURE_HASUVS
 				vertexID = vertexID + 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_TANGENT
 				tangentUpdated = vec4f(tangentUpdated.xyz + (readVector3FromRawSampler(i, vertexID)  - vertexInputs.tangent.xyz) * uniforms.morphTargetInfluences[i], tangentUpdated.a);
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTTANGENTS) || defined(MORPHTARGETS_TANGENT)
+			#ifdef MORPHTARGETTEXTURE_HASTANGENTS
 				vertexID = vertexID + 1.0;
 			#endif
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -11,14 +11,14 @@
 			#ifdef MORPHTARGETS_POSITION
 				positionUpdated = positionUpdated + (readVector3FromRawSampler(i, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTPOSITIONS) || defined(MORPHTARGETS_POSITION)
+			#if defined(MORPHTARGETTEXTURE_HASPOSITIONS) || defined(MORPHTARGETS_POSITION)
 				vertexID = vertexID + 1.0;
 			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated = normalUpdated + (readVector3FromRawSampler(i, vertexID)  - vertexInputs.normal) * uniforms.morphTargetInfluences[i];
 			#endif
-			#if defined(MORPHTARGETS_SUPPORTNORMALS) || defined(MORPHTARGETS_NORMAL)
+			#if defined(MORPHTARGETTEXTURE_HASNORMALS) || defined(MORPHTARGETS_NORMAL)
 				vertexID = vertexID + 1.0;
 			#endif
 
@@ -47,7 +47,7 @@
 		#endif
 		
 		#ifdef MORPHTARGETS_NORMAL
-		    normalUpdated += (vertexInputs.normal{X} - vertexInputs.normal) * uniforms.morphTargetInfluences[{X}];
+		    normalUpdated = normalUpdated + (vertexInputs.normal{X} - vertexInputs.normal) * uniforms.morphTargetInfluences[{X}];
 		#endif
 
 		#ifdef MORPHTARGETS_TANGENT

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -10,21 +10,29 @@
 
 			#ifdef MORPHTARGETS_POSITION
 				positionUpdated = positionUpdated + (readVector3FromRawSampler(i, vertexID) - vertexInputs.position) * uniforms.morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTPOSITIONS) || defined(MORPHTARGETS_POSITION)
 				vertexID = vertexID + 1.0;
 			#endif
 		
 			#ifdef MORPHTARGETS_NORMAL
 				normalUpdated = normalUpdated + (readVector3FromRawSampler(i, vertexID)  - vertexInputs.normal) * uniforms.morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTNORMALS) || defined(MORPHTARGETS_NORMAL)
 				vertexID = vertexID + 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_UV
 				uvUpdated = uvUpdated + (readVector3FromRawSampler(i, vertexID).xy - vertexInputs.uv) * uniforms.morphTargetInfluences[i];
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTUVS) || defined(MORPHTARGETS_UV)
 				vertexID = vertexID + 1.0;
 			#endif
 
 			#ifdef MORPHTARGETS_TANGENT
 				tangentUpdated = vec4f(tangentUpdated.xyz + (readVector3FromRawSampler(i, vertexID)  - vertexInputs.tangent.xyz) * uniforms.morphTargetInfluences[i], tangentUpdated.a);
+			#endif
+			#if defined(MORPHTARGETS_SUPPORTTANGENTS) || defined(MORPHTARGETS_TANGENT)
 				vertexID = vertexID + 1.0;
 			#endif
 


### PR DESCRIPTION
In #16014 it is now possible to disable position morphs, but since we changed all renderers that use morph targets to unconditionally add the `MORPHTARGETS_POSITION` define, I tried to use those renderers with meshes that don't have position morphs and found that it caused problems.

This PR fixes the issue mentioned above and enables normal, tangent, uv, and uv2 morphing, which were present in the renderers' shader code but not working in practice. (This is an additional issue I discovered while editing the code)

This is a list of fixed renderers Each of the morph types supported by these renderers existed in the shader but were not actually working because the isReady function did not add the appropriate attributes and define:

- DepthRenderer - uv, uv2
- EffectLayer - uv, uv2
- GeometryBufferRenderer - normal, uv, uv2
- OutlineRenderer - normal, uv, uv2
- ShadowGenerator - normal, uv, uv2
- VolumetricLightScatteringPostProcess - uv, uv2

This is a list of fixed renderers that had code that did not account for the case where the Morph Target Manager does not support Position Morph:

- ComputeShaderBoundingHelper
- TransformFeedbackBoundingHelper
- MorphTargetsBlock

The following defines have been added to handle cases where the list of morph data types that the MorphTargetManager has on the texture does not match the list of morph data types required by the shader.

```
MORPHTARGETS_SUPPORTPOSITIONS
MORPHTARGETS_SUPPORTNORMALS
MORPHTARGETS_SUPPORTTANGENTS
MORPHTARGETS_SUPPORTUVS
MORPHTARGETS_SUPPORTUV2S
```

See morphTargetsVertex.fx for more details
