### PR TITLE
If HTTP connection closed prematurely, consider retry

### DIFF
--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -680,8 +680,7 @@ export const RequestFile = (
                                 if (onSuccess) {
                                     onSuccess(data, request);
                                 }
-                            }
-                            catch (e) {
+                            } catch (e) {
                                 handleError(e);
                             }
                             return;


### PR DESCRIPTION
xhr2 (used for HTTP under node) will return response=null if the server returns a response but the connection is closed before the full response has been downloaded. Previously this would lead to a null reference in some handlers, e.g. glTFFileLoader would throw "Cannot read properties of null (reading 'byteLength')". With this change onSuccess is not called if the response is null; instead the retry logic can choose to retry or error.