### PR TITLE
WebGPU: Fix conflicting variable type in GreasedLine shader

### DIFF
--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
@@ -95,7 +95,7 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                         grlNormal.x *= grlFinalPosition.w;
                         grlNormal.y *= grlFinalPosition.w;
 
-                        let pr: f32 = vec4f(uniforms.grl_aspect_resolution_lineWidth.yz, 0.0, 1.0) * uniforms.grl_projection;
+                        let pr = vec4f(uniforms.grl_aspect_resolution_lineWidth.yz, 0.0, 1.0) * uniforms.grl_projection;
                         grlNormal.x /= pr.x;
                         grlNormal.y /= pr.y;
                     #endif


### PR DESCRIPTION
Fixes a type mismatch causing an error in this Lazy GreasedLine updates pg: [https://playground.babylonjs.com/#H1LRZ3#39](https://playground.babylonjs.com/#H1LRZ3#39) from the [docs](https://doc.babylonjs.com/features/featuresDeepDive/mesh/creation/param/greased_line/#example-pg--H1LRZ3-39) when using the WebGPU engine and latest BabylonJS.