### PR TITLE
SubMesh: pre-allocate buffers for _getLinesIndexBuffer

### DIFF
--- a/packages/dev/core/src/Meshes/subMesh.ts
+++ b/packages/dev/core/src/Meshes/subMesh.ts
@@ -434,7 +434,7 @@ export class SubMesh implements ICullable {
      */
     public _getLinesIndexBuffer(indices: IndicesArray, engine: AbstractEngine): DataBuffer {
         if (!this._linesIndexBuffer) {
-            const adjustedIndexCount = Math.floor(this.indexCount / 3) * 3;
+            const adjustedIndexCount = Math.floor(this.indexCount / 3) * 6;
             const shouldUseUint32 = this.verticesStart + this.verticesCount > 65535;
             const linesIndices = shouldUseUint32 ? new Uint32Array(adjustedIndexCount) : new Uint16Array(adjustedIndexCount);
 

--- a/packages/dev/core/src/Meshes/subMesh.ts
+++ b/packages/dev/core/src/Meshes/subMesh.ts
@@ -434,16 +434,29 @@ export class SubMesh implements ICullable {
      */
     public _getLinesIndexBuffer(indices: IndicesArray, engine: AbstractEngine): DataBuffer {
         if (!this._linesIndexBuffer) {
-            const linesIndices = [];
+            const adjustedIndexCount = Math.floor(this.indexCount / 3) * 3;
+            const shouldUseUint32 = this.verticesStart + this.verticesCount > 65535;
+            const linesIndices = shouldUseUint32 ? new Uint32Array(adjustedIndexCount) : new Uint16Array(adjustedIndexCount);
 
+            let offset = 0;
             if (indices.length === 0) {
                 // Unindexed mesh
                 for (let index = this.indexStart; index < this.indexStart + this.indexCount; index += 3) {
-                    linesIndices.push(index, index + 1, index + 1, index + 2, index + 2, index);
+                    linesIndices[offset++] = index;
+                    linesIndices[offset++] = index + 1;
+                    linesIndices[offset++] = index + 1;
+                    linesIndices[offset++] = index + 2;
+                    linesIndices[offset++] = index + 2;
+                    linesIndices[offset++] = index;
                 }
             } else {
                 for (let index = this.indexStart; index < this.indexStart + this.indexCount; index += 3) {
-                    linesIndices.push(indices[index], indices[index + 1], indices[index + 1], indices[index + 2], indices[index + 2], indices[index]);
+                    linesIndices[offset++] = indices[index];
+                    linesIndices[offset++] = indices[index + 1];
+                    linesIndices[offset++] = indices[index + 1];
+                    linesIndices[offset++] = indices[index + 2];
+                    linesIndices[offset++] = indices[index + 2];
+                    linesIndices[offset++] = indices[index];
                 }
             }
 


### PR DESCRIPTION
## Background

Currently in _getLinesIndexBuffer a linesIndices buffer is initialized as array, which size grows dynamically in the loop after it, which could lead to memory reallocations and more gc pressures. Also, uses array to store numbers would result in at least a 8-bytes double pre spec, and likely 24-bytes “heap number” in some chrome v8.

## Proposal

Pre-allocate buffers as TypedArray, from the loop below we can know that the size of linesIndices should be exactly 2x the size of this.indexCount (aligned down to 3 elements). This can also eliminate the overhead of scanning the buffer in engine._normalizeIndexData.

## References

Forum post: <https://forum.babylonjs.com/t/submesh-pre-allocate-buffers-for-getlinesindexbuffer/55585>