### PR TITLE
GreasedLine OIT support

### DIFF
--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts
@@ -106,11 +106,17 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
     if (shaderType === "fragment") {
         return {
             CUSTOM_FRAGMENT_DEFINITIONS: `
+                    #ifdef PBR
+                         #define grlFinalColor finalColor
+                    #else
+                         #define grlFinalColor color
+                    #endif
+
                     varying float grlCounters;
                     varying float grlColorPointer;
                     uniform sampler2D grl_colors;
                 `,
-            CUSTOM_FRAGMENT_MAIN_END: `
+            CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: `
                     float grlColorMode = grl_colorMode_visibility_colorsWidth_useColors.x;
                     float grlVisibility = grl_colorMode_visibility_colorsWidth_useColors.y;
                     float grlColorsWidth = grl_colorMode_visibility_colorsWidth_useColors.z;
@@ -121,21 +127,21 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                     float grlDashOffset = grl_dashOptions.z;
                     float grlDashRatio = grl_dashOptions.w;
 
-                    gl_FragColor.a *= step(grlCounters, grlVisibility);
-                    if(gl_FragColor.a == 0.) discard;
+                    grlFinalColor.a *= step(grlCounters, grlVisibility);
+                    if(grlFinalColor.a == 0.) discard;
 
                     if(grlUseDash == 1.){
-                        gl_FragColor.a *= ceil(mod(grlCounters + grlDashOffset, grlDashArray) - (grlDashArray * grlDashRatio));
-                        if (gl_FragColor.a == 0.) discard;
+                        grlFinalColor.a *= ceil(mod(grlCounters + grlDashOffset, grlDashArray) - (grlDashArray * grlDashRatio));
+                        if (grlFinalColor.a == 0.) discard;
                     }
 
                     #ifdef GREASED_LINE_HAS_COLOR
                         if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_SET}.) {
-                            gl_FragColor.rgb = grl_singleColor;
+                            grlFinalColor.rgb = grl_singleColor;
                         } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_ADD}.) {
-                            gl_FragColor.rgb += grl_singleColor;
+                            grlFinalColor.rgb += grl_singleColor;
                         } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_MULTIPLY}.) {
-                            gl_FragColor.rgb *= grl_singleColor;
+                            grlFinalColor.rgb *= grl_singleColor;
                         }
                     #else
                         if (grlUseColors == 1.) {
@@ -146,11 +152,11 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                                 vec4 grlColor = texture2D(grl_colors, lookup, 0.0);
                             #endif
                             if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_SET}.) {
-                                gl_FragColor = grlColor;
+                                grlFinalColor = grlColor;
                             } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_ADD}.) {
-                                gl_FragColor += grlColor;
+                                grlFinalColor += grlColor;
                             } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_MULTIPLY}.) {
-                                gl_FragColor *= grlColor;
+                                grlFinalColor *= grlColor;
                             }
                         }
                     #endif

--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
@@ -116,13 +116,19 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
     if (shaderType === "fragment") {
         return {
             CUSTOM_FRAGMENT_DEFINITIONS: `
+                    #ifdef PBR
+                         #define grlFinalColor finalColor
+                    #else
+                         #define grlFinalColor color
+                    #endif
+
                     varying grlCounters: f32;
                     varying grlColorPointer: 32;
 
                     var grl_colors: texture_2d<f32>;
                     var grl_colorsSampler: sampler;
                 `,
-            CUSTOM_FRAGMENT_MAIN_END: `
+            CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: `
                     let grlColorMode: f32 = uniforms.grl_colorMode_visibility_colorsWidth_useColors.x;
                     let grlVisibility: f32 = uniforms.grl_colorMode_visibility_colorsWidth_useColors.y;
                     let grlColorsWidth: f32 = uniforms.grl_colorMode_visibility_colorsWidth_useColors.z;
@@ -133,27 +139,27 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                     let grlDashOffset: f32 = uniforms.grl_dashOptions.z;
                     let grlDashRatio: f32 = uniforms.grl_dashOptions.w;
 
-                    fragmentOutputs.color.a *= step(fragmentInputs.grlCounters, grlVisibility);
-                    if (fragmentOutputs.color.a == 0.0) {
+                    finalColor.a *= step(fragmentInputs.grlCounters, grlVisibility);
+                    if (finalColor.a == 0.0) {
                         discard;
                     }
 
                     if (grlUseDash == 1.0) {
                         let dashPosition = (fragmentInputs.grlCounters + grlDashOffset) % grlDashArray;
-                        fragmentOutputs.color.a *= ceil(dashPosition - (grlDashArray * grlDashRatio));
+                        finalColor.a *= ceil(dashPosition - (grlDashArray * grlDashRatio));
 
-                        if (fragmentOutputs.color.a == 0.0) {
+                        if (finalColor.a == 0.0) {
                             discard;
                         }
                     }
 
                     #ifdef GREASED_LINE_HAS_COLOR
                         if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_SET}.) {
-                            fragmentOutputs.color = vec4f(uniforms.grl_singleColor, fragmentOutputs.color.a);
+                            finalColor = vec4f(uniforms.grl_singleColor, finalColor.a);
                         } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_ADD}.) {
-                            fragmentOutputs.color += vec4f(uniforms.grl_singleColor, fragmentOutputs.color.a);
+                            finalColor += vec4f(uniforms.grl_singleColor, finalColor.a);
                         } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_MULTIPLY}.) {
-                            fragmentOutputs.color *= vec4f(uniforms.grl_singleColor, fragmentOutputs.color.a);
+                            finalColor *= vec4f(uniforms.grl_singleColor, finalColor.a);
                         }
                     #else
                         if (grlUseColors == 1.) {
@@ -164,11 +170,11 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                                 let grlColor: vec4f = textureSample(grl_colors, grl_colorsSampler, lookup);
                             #endif
                             if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_SET}.) {
-                                fragmentOutputs.color = grlColor;
+                                finalColor = grlColor;
                             } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_ADD}.) {
-                                fragmentOutputs.color += grlColor;
+                                finalColor += grlColor;
                             } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_MULTIPLY}.) {
-                                fragmentOutputs.color *= grlColor;
+                                finalColor *= grlColor;
                             }
                         }
                     #endif

--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
@@ -139,27 +139,27 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                     let grlDashOffset: f32 = uniforms.grl_dashOptions.z;
                     let grlDashRatio: f32 = uniforms.grl_dashOptions.w;
 
-                    finalColor.a *= step(fragmentInputs.grlCounters, grlVisibility);
-                    if (finalColor.a == 0.0) {
+                    grlFinalColor.a *= step(fragmentInputs.grlCounters, grlVisibility);
+                    if (grlFinalColor.a == 0.0) {
                         discard;
                     }
 
                     if (grlUseDash == 1.0) {
                         let dashPosition = (fragmentInputs.grlCounters + grlDashOffset) % grlDashArray;
-                        finalColor.a *= ceil(dashPosition - (grlDashArray * grlDashRatio));
+                        grlFinalColor.a *= ceil(dashPosition - (grlDashArray * grlDashRatio));
 
-                        if (finalColor.a == 0.0) {
+                        if (grlFinalColor.a == 0.0) {
                             discard;
                         }
                     }
 
                     #ifdef GREASED_LINE_HAS_COLOR
                         if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_SET}.) {
-                            finalColor = vec4f(uniforms.grl_singleColor, finalColor.a);
+                            grlFinalColor = vec4f(uniforms.grl_singleColor, grlFinalColor.a);
                         } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_ADD}.) {
-                            finalColor += vec4f(uniforms.grl_singleColor, finalColor.a);
+                            grlFinalColor += vec4f(uniforms.grl_singleColor, grlFinalColor.a);
                         } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_MULTIPLY}.) {
-                            finalColor *= vec4f(uniforms.grl_singleColor, finalColor.a);
+                            grlFinalColor *= vec4f(uniforms.grl_singleColor, grlFinalColor.a);
                         }
                     #else
                         if (grlUseColors == 1.) {
@@ -170,11 +170,11 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                                 let grlColor: vec4f = textureSample(grl_colors, grl_colorsSampler, lookup);
                             #endif
                             if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_SET}.) {
-                                finalColor = grlColor;
+                                grlFinalColor = grlColor;
                             } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_ADD}.) {
-                                finalColor += grlColor;
+                                grlFinalColor += grlColor;
                             } else if (grlColorMode == ${GreasedLineMeshColorMode.COLOR_MODE_MULTIPLY}.) {
-                                finalColor *= grlColor;
+                                grlFinalColor *= grlColor;
                             }
                         }
                     #endif


### PR DESCRIPTION
Added OIT support to `GreasedLinePluginMaterial`, both GLSL and WGSL.
`GreasedLineSimpleMaterial` doesn't support `alpha` so it was not changed.