### PR TITLE
Morph target manager: Don't recreate texture if not needed when updates are re-enabled

### DIFF
--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -98,7 +98,6 @@ export class MorphTargetManager implements IDisposable {
             if (this._blockCounter <= 0) {
                 this._blockCounter = 0;
 
-                this._mustSynchronize = true;
                 this._syncActiveTargets();
             }
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/morphtargetmanager-performence-issue/55661