### PR TITLE
Small Viewer fixes

### DIFF
--- a/packages/tools/viewer-alpha/src/index.ts
+++ b/packages/tools/viewer-alpha/src/index.ts
@@ -1,5 +1,6 @@
 export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
 export type { CanvasViewerOptions } from "./viewerFactory";
+export type { HotSpot } from "./viewerElement";
 
 export { Viewer, ViewerHotSpotResult } from "./viewer";
 export { HTML3DElement } from "./viewerElement";

--- a/packages/tools/viewer-alpha/src/viewer.ts
+++ b/packages/tools/viewer-alpha/src/viewer.ts
@@ -274,8 +274,10 @@ export class Viewer implements IDisposable {
 
     /**
      * Fired when a model is loaded into the viewer (or unloaded from the viewer).
+     * @remarks
+     * The event argument is the source that was loaded, or null if no model is loaded.
      */
-    public readonly onModelChanged = new Observable<void>();
+    public readonly onModelChanged = new Observable<Nullable<string | File | ArrayBufferView>>();
 
     /**
      * Fired when an error occurs while loading a model.
@@ -785,7 +787,7 @@ export class Viewer implements IDisposable {
                 this._updateCamera();
                 this._updateLight();
                 this._applyAnimationSpeed();
-                this.onModelChanged.notifyObservers();
+                this.onModelChanged.notifyObservers(source ?? null);
             } catch (e) {
                 this.onModelError.notifyObservers(e);
                 throw e;


### PR DESCRIPTION
- In a recent change I introduced the ability to have separate env lighting and skybox textures, but I made a mistake that resulted in loading errors not propagating. This is fixed in this PR.
- Export the `HotSpot` type (makes it much easier to use in consuming code).
- Add the *source* to the `onModelChange` observable. This is transient data (e.g. we don't want to store a `File` or `ArrayBuffer` indefinitely), so it is included in the observable event data. The actual loaded model (not the source) can be accessed through the existing `model` property, which is an `AssetContainer`.