### PR TITLE
Add generic Assert function

### DIFF
--- a/packages/dev/core/src/Meshes/meshUtils.ts
+++ b/packages/dev/core/src/Meshes/meshUtils.ts
@@ -3,6 +3,7 @@ import { VertexBuffer } from "../Buffers/buffer";
 import { TmpVectors, Vector3 } from "../Maths/math.vector";
 import type { FloatArray, Nullable } from "../types";
 import type { AbstractMesh } from "./abstractMesh";
+import { Assert } from "../Misc/assert";
 
 function getExtentCorners(extent: { minimum: Vector3; maximum: Vector3 }): Array<Vector3> {
     const minX = extent.minimum.x;
@@ -181,7 +182,8 @@ export function computeMaxExtents(
                 skeleton.prepare(true);
 
                 const bones = skeleton.bones;
-                const perBoneCorners = skinnedMeshCorners.get(mesh.uniqueId)!;
+                const perBoneCorners = skinnedMeshCorners.get(mesh.uniqueId);
+                Assert(perBoneCorners);
                 perBoneCorners.forEach((corners, boneIndex) => {
                     // Transform the per-bone corners into world space and update the max extent for each corner.
                     for (const corner of corners) {
@@ -193,7 +195,9 @@ export function computeMaxExtents(
                 });
             } else {
                 // Transform the corners into world space and update the max extent for each corner.
-                for (const corner of meshCorners.get(mesh.uniqueId)!) {
+                const corners = meshCorners.get(mesh.uniqueId);
+                Assert(corners);
+                for (const corner of corners) {
                     Vector3.TransformCoordinatesToRef(corner, worldMatrix, position);
                     maxExtents[i].minimum.minimizeInPlace(position);
                     maxExtents[i].maximum.maximizeInPlace(position);

--- a/packages/dev/core/src/Misc/assert.ts
+++ b/packages/dev/core/src/Misc/assert.ts
@@ -1,0 +1,9 @@
+/**
+ * Asserts that the given value is truthy.
+ * @param value The value to check.
+ */
+export function assert(value: unknown): asserts value {
+    if (!value) {
+        throw new Error("assertion failed");
+    }
+}

--- a/packages/dev/core/src/Misc/assert.ts
+++ b/packages/dev/core/src/Misc/assert.ts
@@ -2,7 +2,7 @@
  * Asserts that the given value is truthy.
  * @param value The value to check.
  */
-export function assert(value: unknown): asserts value {
+export function Assert(value: unknown): asserts value {
     if (!value) {
         throw new Error("assertion failed");
     }


### PR DESCRIPTION
This adds a generic `Assert` function using the `asserts` keyword introduced in TS 3.7 (we don't have any other uses of `asserts` in the codebase currently). This generic `Assert` function just asserts a truthy value. If the assertion fails, it throws a generic error. Since it uses the `asserts` keyword it can affect control flow.

Some example use cases:
- Inserting a value into a map, and then later in the code retrieving it. Instead of using a non-null assertion, you could call `Assert`, which can make debugging easier since the exception is thrown at the time of retrieval rather than when the value is actually used (e.g. it could be passed through a bunch of functions and eventually causes an exception trying to operate on an undefined value).
```ts
map.set("foo", foo);
// a bunch of other code, where you could possibly have made a programming error
const foo = map.get("foo");
Assert(foo);
// Foo is now guaranteed to be defined
foo.doSomething();
```
- Other truthy cases
```ts
const value = null! as A | B;
Assert(value instanceof A);
// value is now guaranteed to be an A
value.doAnAThing();
```

I did not add a `message` param to this `Assert` function because those strings would end up in the final bundle and increase its size. Since assertions are supposed to be for programming errors (not usage errors), they are really intended to contributors, not consumers, and I don't think consumers should pay the extra cost.