### PR TITLE
force chrome on WebGPU tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,7 +68,7 @@ export default defineConfig({
         {
             name: "webgpu",
             testMatch: "**/*webgpu.test.ts",
-            use: getUseDefinition("WebGPU"),
+            use: getUseDefinition("WebGPU", "Chrome", false, true),
         },
         {
             name: "interaction",
@@ -100,7 +100,7 @@ export default defineConfig({
     snapshotPathTemplate: "packages/tools/tests/test/visualization/ReferenceImages/{arg}{ext}",
 });
 
-function getUseDefinition(title: string, browser = browserType, noBrowserStack = false) {
+function getUseDefinition(title: string, browser = browserType, noBrowserStack = false, forceChromeInsteadOfChromium = forceChrome) {
     const args = browser === "Chrome" ? ["--use-angle=default", "--js-flags=--expose-gc"] : browser === "Firefox" ? ["-wait-for-browser"] : [];
     args.push(...customFlags);
     if (noBrowserStack) {
@@ -112,7 +112,7 @@ function getUseDefinition(title: string, browser = browserType, noBrowserStack =
             },
         };
     }
-    return forceChrome
+    return forceChromeInsteadOfChromium && browserType !== "BrowserStack"
         ? {
               // use real chrome (not chromium) for webgpu tests
               channel: "chrome",


### PR DESCRIPTION
This will prevent running webgpu tests on the internal chromium version, which doesn't support WebGPU.

Note that the local chrome version will be used, so if no chrome is installed WebGPU tests will fail.