### PR TITLE
Check if TransformNode is parent in removeChild

### DIFF
--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -862,6 +862,7 @@ export class TransformNode extends Node {
      * @returns the current mesh
      */
     public removeChild(mesh: TransformNode, preserveScalingSign: boolean = false): this {
+        if (mesh.parent !== this) return this;
         mesh.setParent(null, preserveScalingSign);
         return this;
     }


### PR DESCRIPTION
The function's description is misleading. "Removes the passed mesh from the current mesh children list" does not mean removing the parent from the passed mesh.

This change updates the function to remove the parent from the passed mesh only if it is the parent of the passed mesh. Otherwise, the parent of the passed mesh is left alone.