### PR TITLE
WebGPU: fix crashes in Firefox and Safari

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -13,6 +13,7 @@ import type { WebGPUPipelineContext } from "./webgpuPipelineContext";
 import { WebGPUTextureHelper } from "./webgpuTextureHelper";
 import { renderableTextureFormatToIndex } from "./webgpuTextureManager";
 import { checkNonFloatVertexBuffers } from "core/Buffers/buffer.nonFloatVertexBuffers";
+import { Logger } from "core/Misc/logger";
 
 enum StatePosition {
     StencilReadMask = 0,
@@ -63,6 +64,8 @@ const stencilOpToIndex: { [name: number]: number } = {
 
 /** @internal */
 export abstract class WebGPUCacheRenderPipeline {
+    public static LogErrorIfNoVertexBuffer = false;
+
     public static NumCacheHitWithoutHash = 0;
     public static NumCacheHitWithHash = 0;
     public static NumCacheMiss = 0;
@@ -791,6 +794,11 @@ export abstract class WebGPUCacheRenderPipeline {
                 // In WebGL it's valid to not bind a vertex buffer to an attribute, but it's not valid in WebGPU
                 // So we must bind a dummy buffer when we are not given one for a specific attribute
                 vertexBuffer = this._emptyVertexBuffer;
+                if (WebGPUCacheRenderPipeline.LogErrorIfNoVertexBuffer) {
+                    Logger.Error(
+                        `No vertex buffer is provided for the "${attributes[index]}" attribute. A default empty vertex buffer will be used, but this may generate errors in some browsers.`
+                    );
+                }
             }
 
             const buffer = vertexBuffer.effectiveBuffer?.underlyingResource;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -420,15 +420,18 @@ export class WebGPUTextureManager {
                 (processorOptions.processor as WebGPUShaderProcessorWGSL).pureMode = false;
 
                 const vertexModule = this._device.createShaderModule({
+                    label: `BabylonWebGPUDevice${this._engine.uniqueId}_InternalVertexShader_${index}`,
                     code: final.vertexCode,
                 });
                 const fragmentModule = this._device.createShaderModule({
+                    label: `BabylonWebGPUDevice${this._engine.uniqueId}_InternalFragmentShader_${index}`,
                     code: final.fragmentCode,
                 });
                 modules = this._compiledShaders[index] = [vertexModule, fragmentModule];
             }
 
             const pipeline = this._device.createRenderPipeline({
+                label: `BabylonWebGPUDevice${this._engine.uniqueId}_InternalPipeline_${format}_${index}`,
                 layout: WebGPUConstants.AutoLayoutMode.Auto,
                 vertex: {
                     module: modules[0],
@@ -468,15 +471,17 @@ export class WebGPUTextureManager {
             if (!modules) {
                 const vertexModule = this._device.createShaderModule({
                     code: copyVideoToTextureVertexSource,
+                    label: `BabylonWebGPUDevice${this._engine.uniqueId}_CopyVideoToTexture_VertexShader`,
                 });
                 const fragmentModule = this._device.createShaderModule({
                     code: index === 0 ? copyVideoToTextureFragmentSource : copyVideoToTextureInvertYFragmentSource,
+                    label: `BabylonWebGPUDevice${this._engine.uniqueId}_CopyVideoToTexture_FragmentShader_${index === 0 ? "DontInvertY" : "InvertY"}`,
                 });
                 modules = this._videoCompiledShaders[index] = [vertexModule, fragmentModule];
             }
 
             const pipeline = this._device.createRenderPipeline({
-                label: `BabylonWebGPUDevice${this._engine.uniqueId}_CopyVideoToTexture_${format}_${index === 0 ? "DontInvertY" : "InvertY"}`,
+                label: `BabylonWebGPUDevice${this._engine.uniqueId}_InternalVideoPipeline_${format}_${index === 0 ? "DontInvertY" : "InvertY"}`,
                 layout: WebGPUConstants.AutoLayoutMode.Auto,
                 vertex: {
                     module: modules[0],

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -37,6 +37,19 @@ const attributeAsUniform: { [name: string]: boolean } = {
     particle_texturemask: true,
 };
 
+const attributeDefine: { [name: string]: string } = {
+    normal: "NORMAL",
+    tangent: "TANGENT",
+    uv: "UV1",
+    uv2: "UV2",
+    uv3: "UV3",
+    uv4: "UV4",
+    uv5: "UV5",
+    uv6: "UV6",
+    uv7: "UV7",
+    uv8: "UV8",
+};
+
 /**
  * Block used to expose an input value
  */
@@ -602,12 +615,30 @@ export class InputBlock extends NodeMaterialBlock {
                 }
                 if (state.shaderLanguage === ShaderLanguage.WGSL) {
                     if (!alreadyDeclared) {
-                        state._attributeDeclaration += `attribute ${this.declarationVariableName}: ${state._getShaderType(this.type)};\n`;
+                        const defineName = attributeDefine[this.name];
+                        if (defineName) {
+                            state._attributeDeclaration += `#ifdef ${defineName}\n`;
+                            state._attributeDeclaration += `attribute ${this.declarationVariableName}: ${state._getShaderType(this.type)};\n`;
+                            state._attributeDeclaration += `#else\n`;
+                            state._attributeDeclaration += `let ${this.declarationVariableName}: ${state._getShaderType(this.type)} = ${state._getShaderType(this.type)}(0.);\n`;
+                            state._attributeDeclaration += `#endif\n`;
+                        } else {
+                            state._attributeDeclaration += `attribute ${this.declarationVariableName}: ${state._getShaderType(this.type)};\n`;
+                        }
                     }
                     this._prefix = `vertexInputs.`;
                 } else {
                     if (!alreadyDeclared) {
-                        state._attributeDeclaration += `attribute ${state._getShaderType(this.type)} ${this.declarationVariableName};\n`;
+                        const defineName = attributeDefine[this.name];
+                        if (defineName) {
+                            state._attributeDeclaration += `#ifdef ${defineName}\n`;
+                            state._attributeDeclaration += `attribute ${state._getShaderType(this.type)} ${this.declarationVariableName};\n`;
+                            state._attributeDeclaration += `#else\n`;
+                            state._attributeDeclaration += `${state._getShaderType(this.type)} ${this.declarationVariableName} = ${state._getShaderType(this.type)}(0.);\n`;
+                            state._attributeDeclaration += `#endif\n`;
+                        } else {
+                            state._attributeDeclaration += `attribute ${state._getShaderType(this.type)} ${this.declarationVariableName};\n`;
+                        }
                     }
                 }
                 if (define && !alreadyDeclared) {

--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineBaseMesh.ts
@@ -221,6 +221,7 @@ export abstract class GreasedLineBaseMesh extends Mesh {
             this._updateColorPointers();
         }
         this._createVertexBuffers(this._options.ribbonOptions?.smoothShading);
+        this._createOffsetsBuffer(this._offsets || []);
         !this.doNotSyncBoundingInfo && this.refreshBoundingInfo();
 
         this.greasedLineMaterial?.updateLazy();


### PR DESCRIPTION
[This PG](https://playground.babylonjs.com/?webgpu#H1LRZ3#39) crashes in Firefox / Safari because an empty vertex buffer is bound to the pipeline. The fix is simply to call `this._createOffsetsBuffer()` earlier so that the correct vertex buffer is created (cc @RolandCsibrei, to make sure it's the right fix / in the right place).

[This PG](https://playground.babylonjs.com/?webgpu#LPTLZM#298) crashes for the same reason, but the fix is a bit more complex as we shouldn't use an attribute in a node material if the mesh using that material doesn't support the attribute. So I've added some code to declare a regular (dummy) variable with the same name as the attribute when the latter is not supported.

Note that I also added some debug code (mostly labels) to ease debugging in WebGPU.