### PR TITLE
Allow for creating a zero size plane

### DIFF
--- a/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
@@ -23,8 +23,8 @@ export function CreatePlaneVertexData(options: { size?: number; width?: number; 
     const normals = [];
     const uvs = [];
 
-    const width: number = options.width || options.size || 1;
-    const height: number = options.height || options.size || 1;
+    const width: number = typeof options.width !== "undefined" ? options.width : typeof options.size !== "undefined" ? options.size : 1;
+    const height: number = typeof options.height !== "undefined" ? options.height : typeof options.size !== "undefined" ? options.size : 1;
     const sideOrientation = options.sideOrientation === 0 ? 0 : options.sideOrientation || VertexData.DEFAULTSIDE;
 
     // Vertices

--- a/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/planeBuilder.ts
@@ -23,8 +23,8 @@ export function CreatePlaneVertexData(options: { size?: number; width?: number; 
     const normals = [];
     const uvs = [];
 
-    const width: number = typeof options.width !== "undefined" ? options.width : typeof options.size !== "undefined" ? options.size : 1;
-    const height: number = typeof options.height !== "undefined" ? options.height : typeof options.size !== "undefined" ? options.size : 1;
+    const width: number = options.width !== undefined ? options.width : options.size !== undefined ? options.size : 1;
+    const height: number = options.height !== undefined ? options.height : options.size !== undefined ? options.size : 1;
     const sideOrientation = options.sideOrientation === 0 ? 0 : options.sideOrientation || VertexData.DEFAULTSIDE;
 
     // Vertices


### PR DESCRIPTION
I have a use case for creating a plane with zero width/height and then updating it live. The current method of checking whether a size/width/height is passed does not allow this. These changes check if the value is defined instead of is truthy.