### PR TITLE
Use same configuration between DracoCompression and DracoDecoder

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -35,7 +35,8 @@ export interface IDracoCompressionOptions extends Pick<IDracoCodecConfiguration,
  *
  * **Decoder**
  *
- * By default, the configuration points to a copy of the Draco decoder files for glTF from the babylon.js preview cdn https://preview.babylonjs.com/draco_wasm_wrapper_gltf.js.
+ * By default, the configuration points to a copy of the Draco decoder files for glTF from the babylon.js cdn https://cdn.babylonjs.com/draco_wasm_wrapper_gltf.js.
+ * The configuration is shared with the DracoDecoder class.
  *
  * To update the configuration, use the following code:
  * ```javascript

--- a/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoCompression.ts
@@ -68,13 +68,25 @@ export class DracoCompression {
      * - wasmBinaryUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.wasm"
      * - fallbackUrl: "https://cdn.babylonjs.com/draco_decoder_gltf.js"
      */
-    public static Configuration: IDracoCompressionConfiguration = { decoder: { ...DracoDecoder.DefaultConfiguration } }; // Use copy
+    public static get Configuration(): IDracoCompressionConfiguration {
+        return {
+            get decoder() {
+                return DracoDecoder.DefaultConfiguration;
+            },
+            set decoder(value: IDracoCodecConfiguration) {
+                DracoDecoder.DefaultConfiguration = value;
+            },
+        };
+    }
+    public static set Configuration(value: IDracoCompressionConfiguration) {
+        DracoDecoder.DefaultConfiguration = value.decoder;
+    }
 
     /**
      * Returns true if the decoder configuration is available.
      */
     public static get DecoderAvailable(): boolean {
-        return _IsConfigurationAvailable(DracoCompression.Configuration.decoder);
+        return _IsConfigurationAvailable(DracoDecoder.DefaultConfiguration);
     }
 
     /**
@@ -115,8 +127,8 @@ export class DracoCompression {
     constructor(numWorkersOrOptions: number | IDracoCompressionOptions = DracoCompression.DefaultNumWorkers) {
         const configuration =
             typeof numWorkersOrOptions === "number"
-                ? { ...DracoCompression.Configuration.decoder, numWorkers: numWorkersOrOptions }
-                : { ...DracoCompression.Configuration.decoder, ...numWorkersOrOptions };
+                ? { ...DracoDecoder.DefaultConfiguration, numWorkers: numWorkersOrOptions }
+                : { ...DracoDecoder.DefaultConfiguration, ...numWorkersOrOptions };
         this._decoder = new DracoDecoder(configuration);
     }
 

--- a/packages/dev/core/src/Meshes/Compression/test/integration/draco.test.ts
+++ b/packages/dev/core/src/Meshes/Compression/test/integration/draco.test.ts
@@ -1,0 +1,35 @@
+import { DracoDecoder } from "../../dracoDecoder";
+import type { IDracoCodecConfiguration } from "../../dracoCodec";
+import { DracoCompression } from "../../dracoCompression";
+
+describe("Draco Mesh Compression tests", () => {
+    describe("DracoDecoder's configuration is affected by updates to DracoCompression's", () => {
+        const originalConfig: IDracoCodecConfiguration = { ...DracoDecoder.DefaultConfiguration };
+        const testUrl = "testUrl";
+
+        afterEach(() => {
+            expect(DracoDecoder.DefaultConfiguration.fallbackUrl).toBe(testUrl);
+            expect(DracoDecoder.DefaultConfiguration.fallbackUrl).toBe(DracoCompression.Configuration.decoder.fallbackUrl);
+            expect(DracoDecoder.DefaultConfiguration).toBe(DracoCompression.Configuration.decoder);
+            DracoDecoder.DefaultConfiguration = originalConfig;
+        });
+
+        it("updates via DracoCompression.Configuration.decoder.fallbackUrl", () => {
+            DracoCompression.Configuration.decoder.fallbackUrl = testUrl;
+        });
+
+        it("updates via DracoCompression.Configuration.decoder", () => {
+            DracoCompression.Configuration.decoder = {
+                fallbackUrl: testUrl,
+            };
+        });
+
+        it("updates via DracoCompression.Configuration", () => {
+            DracoCompression.Configuration = {
+                decoder: {
+                    fallbackUrl: testUrl,
+                },
+            };
+        });
+    });
+});

--- a/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
+++ b/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
@@ -160,7 +160,7 @@ export const evaluateInitEngineForVisualization = async ({
     BABYLON.SceneLoader.ShowLoadingScreen = false;
     BABYLON.SceneLoader.ForceFullSceneLoadingForIncremental = true;
 
-    BABYLON.DracoCompression.Configuration.decoder = {
+    BABYLON.DracoDecoder.DefaultConfiguration = {
         wasmUrl: baseUrl + "/draco_wasm_wrapper_gltf.js",
         wasmBinaryUrl: baseUrl + "/draco_decoder_gltf.wasm",
         fallbackUrl: baseUrl + "/draco_decoder_gltf.js",


### PR DESCRIPTION
Rather than maintain a separate copy of a configuration for DracoCompression, reference DracoEncoder's instead.
See https://forum.babylonjs.com/t/babylon-draco-url-config-not-working/55741/9

Example test: #2WHRHL#1