### PR TITLE
standardMaterial: remove _worldViewProjectionMatrix

### DIFF
--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -6,7 +6,7 @@ import type { IAnimatable } from "../Animations/animatable.interface";
 
 import type { Nullable } from "../types";
 import { Scene } from "../scene";
-import { Matrix } from "../Maths/math.vector";
+import type { Matrix } from "../Maths/math.vector";
 import { Color3 } from "../Maths/math.color";
 import { VertexBuffer } from "../Buffers/buffer";
 import type { SubMesh } from "../Meshes/subMesh";

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -809,7 +809,6 @@ export class StandardMaterial extends PushMaterial {
     public readonly detailMap: DetailMapConfiguration;
 
     protected _renderTargets = new SmartArray<RenderTargetTexture>(16);
-    protected _worldViewProjectionMatrix = Matrix.Zero();
     protected _globalAmbientColor = new Color3(0, 0, 0);
     protected _cacheHasRenderTargetTextures = false;
 


### PR DESCRIPTION
It's not found elsewhere in this repo, removing it to save some memory.

Forum link: <https://forum.babylonjs.com/t/standardmaterial-is-worldviewprojectionmatrix-still-in-use/55971>

If I understand correctly, changelog should be auto generated from this PR, right?