### PR TITLE
Improve docs of addChild() and setParent()

### DIFF
--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -785,6 +785,7 @@ export class TransformNode extends Node {
     /**
      * Defines the passed node as the parent of the current node.
      * The node will remain exactly where it is and its position / rotation will be updated accordingly.
+     * If you don't want to preserve the current rotation / position, assign the parent through parent accessor.
      * Note that if the mesh has a pivot matrix / point defined it will be applied after the parent was updated.
      * In that case the node will not remain in the same space as it is, as the pivot will be applied.
      * To avoid this, you can set updatePivot to true and the pivot will be updated to identity
@@ -845,7 +846,9 @@ export class TransformNode extends Node {
     }
 
     /**
-     * Adds the passed mesh as a child to the current mesh
+     * Adds the passed mesh as a child to the current mesh.
+     * The node will remain exactly where it is and its position / rotation will be updated accordingly.
+     * This method is equivalent to calling setParent().
      * @param mesh defines the child mesh
      * @param preserveScalingSign if true, keep scaling sign of child. Otherwise, scaling sign might change.
      * @returns the current mesh


### PR DESCRIPTION
I struggled a lot with using `addChild()`. It seemed to mess up the position of the child mesh. I had no idea why, because the documentation only said:

> Adds the passed mesh as a child to the current mesh

It also wasn't clear to me what's the relationship between just assigning to `.parent` or calling `setParent()`.

After struggling with these problems for many weeks, I finally read the source and figured out that `addChild()` simply calls `setParent()`, the documentation of which does say what it does with child coordinates.

I'd hope this little improvement to the docs will help others to better understand the relationship between these three ways of setting the parent.