### PR TITLE
Allow the users to control the max fps of the engine

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -914,7 +914,7 @@ export abstract class AbstractEngine {
             return;
         }
 
-        if (value === 0) {
+        if (value <= 0) {
             this._minFrameTime = Number.MAX_VALUE;
             return;
         }

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -922,7 +922,11 @@ export abstract class AbstractEngine {
         this._minFrameTime = 1000 / (value + 1); // We need to provide a bit of leeway to ensure we don't go under because of vbl sync
     }
 
-    protected _isOverFrameTime(timestamp: number): boolean {
+    protected _isOverFrameTime(timestamp?: number): boolean {
+        if (!timestamp) {
+            return false;
+        }
+
         const elapsedTime = timestamp - this._lastFrameTime;
         if (this._maxFPS === undefined || elapsedTime >= this._minFrameTime) {
             this._lastFrameTime = timestamp;
@@ -932,7 +936,7 @@ export abstract class AbstractEngine {
         return true;
     }
 
-    protected _processFrame(timestamp: number) {
+    protected _processFrame(timestamp?: number) {
         this._frameHandler = 0;
 
         if (!this._contextWasLost && !this._isOverFrameTime(timestamp)) {
@@ -958,7 +962,7 @@ export abstract class AbstractEngine {
     }
 
     /** @internal */
-    public _renderLoop(timestamp: number): void {
+    public _renderLoop(timestamp: number | undefined): void {
         this._processFrame(timestamp);
 
         // The first condition prevents queuing another frame if we no longer have active render loops (e.g., if

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -902,7 +902,7 @@ export abstract class AbstractEngine {
      */
     public skipFrameRender = false;
 
-    /** Gets or sets max frame per second allowed */
+    /** Gets or sets max frame per second allowed. Will return undefined if not capped */
     public get maxFPS(): number | undefined {
         return this._maxFPS;
     }

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -889,16 +889,55 @@ export abstract class AbstractEngine {
     public abstract get performanceMonitor(): PerformanceMonitor;
 
     /** @internal */
-    public _boundRenderFunction: any = () => this._renderLoop();
+    public _boundRenderFunction: any = (timestamp: number) => this._renderLoop(timestamp);
 
-    /** @internal */
-    public _renderLoop(): void {
-        // Reset the frame handler before rendering a frame to determine if a new frame has been queued.
+    protected _maxFPS: number | undefined;
+    protected _minFrameTime: number;
+    protected _lastFrameTime: number = 0;
+
+    /**
+     * Skip frame rendering but keep the frame heartbeat (begin/end frame).
+     * This is useful if you need all the plumbing but not the rendering work.
+     * (for instance when capturing a screenshot where you do not want to mix rendering to the screen and to the screenshot)
+     */
+    public skipFrameRender = false;
+
+    /** Gets or sets max frame per second allowed */
+    public get maxFPS(): number | undefined {
+        return this._maxFPS;
+    }
+
+    public set maxFPS(value: number | undefined) {
+        this._maxFPS = value;
+
+        if (value === undefined) {
+            return;
+        }
+
+        if (value === 0) {
+            this._minFrameTime = Number.MAX_VALUE;
+            return;
+        }
+
+        this._minFrameTime = 1000 / (value + 1); // We need to provide a bit of leeway to ensure we don't go under because of vbl sync
+    }
+
+    protected _isOverFrameTime(timestamp: number): boolean {
+        const elapsedTime = timestamp - this._lastFrameTime;
+        if (this._maxFPS === undefined || elapsedTime >= this._minFrameTime) {
+            this._lastFrameTime = timestamp;
+            return false;
+        }
+
+        return true;
+    }
+
+    protected _processFrame(timestamp: number) {
         this._frameHandler = 0;
 
-        if (!this._contextWasLost) {
+        if (!this._contextWasLost && !this._isOverFrameTime(timestamp)) {
             let shouldRender = true;
-            if (this._isDisposed || (!this.renderEvenInBackground && this._windowIsBackground)) {
+            if (this.isDisposed || (!this.renderEvenInBackground && this._windowIsBackground)) {
                 shouldRender = false;
             }
 
@@ -907,7 +946,7 @@ export abstract class AbstractEngine {
                 this.beginFrame();
 
                 // Child canvases
-                if (!this._renderViews()) {
+                if (!this.skipFrameRender && !this._renderViews()) {
                     // Main frame
                     this._renderFrame();
                 }
@@ -916,6 +955,11 @@ export abstract class AbstractEngine {
                 this.endFrame();
             }
         }
+    }
+
+    /** @internal */
+    public _renderLoop(timestamp: number): void {
+        this._processFrame(timestamp);
 
         // The first condition prevents queuing another frame if we no longer have active render loops (e.g., if
         // `stopRenderLoop` is called mid frame). The second condition prevents queuing another frame if one has

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -636,30 +636,8 @@ export class Engine extends ThinEngine {
         }
     }
 
-    public override _renderLoop(): void {
-        // Reset the frame handler before rendering a frame to determine if a new frame has been queued.
-        this._frameHandler = 0;
-
-        if (!this._contextWasLost) {
-            let shouldRender = true;
-            if (this.isDisposed || (!this.renderEvenInBackground && this._windowIsBackground)) {
-                shouldRender = false;
-            }
-
-            if (shouldRender) {
-                // Start new frame
-                this.beginFrame();
-
-                // Child canvases
-                if (!this._renderViews()) {
-                    // Main frame
-                    this._renderFrame();
-                }
-
-                // Present
-                this.endFrame();
-            }
-        }
+    public override _renderLoop(timestamp: number): void {
+        this._processFrame(timestamp);
 
         // The first condition prevents queuing another frame if we no longer have active render loops (e.g., if
         // `stopRenderLoop` is called mid frame). The second condition prevents queuing another frame if one has

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -636,7 +636,7 @@ export class Engine extends ThinEngine {
         }
     }
 
-    public override _renderLoop(timestamp: number): void {
+    public override _renderLoop(timestamp?: number): void {
         this._processFrame(timestamp);
 
         // The first condition prevents queuing another frame if we no longer have active render loops (e.g., if

--- a/packages/dev/core/src/Misc/screenshotTools.ts
+++ b/packages/dev/core/src/Misc/screenshotTools.ts
@@ -256,6 +256,9 @@ export function CreateScreenshotUsingRenderTarget(
         return;
     }
 
+    // Prevent engine to render on screen while we do the screenshot
+    engine.skipFrameRender = true;
+
     const originalSize = { width: engine.getRenderWidth(), height: engine.getRenderHeight() };
     engine.setSize(width, height); // we need this call to trigger onResizeObservable with the screenshot width/height on all the subsystems that are observing this event and that needs to (re)create some resources with the right dimensions
 
@@ -312,6 +315,12 @@ export function CreateScreenshotUsingRenderTarget(
                 texture.render(true);
                 engine.setSize(originalSize.width, originalSize.height);
                 camera.getProjectionMatrix(true); // Force cache refresh;
+
+                engine.skipFrameRender = false;
+            },
+            () => {
+                // Restore engine frame rendering on error
+                engine.skipFrameRender = false;
             }
         );
     };


### PR DESCRIPTION
Users now can set `engine.maxFPS` to set an upper limit to the rendering speed

You can even set it to < 1 values (like 0.5 to render every 2 seconds).

I also introduced a boolean to keep the engine pumping messages while not rendering (and I used it for the screenshot system)