### PR TITLE
Use local resources when developing

### DIFF
--- a/packages/tools/babylonServer/public/index.html
+++ b/packages/tools/babylonServer/public/index.html
@@ -54,6 +54,10 @@
         <script src="recast.js"></script>
         <script src="https://rawcdn.githack.com/BabylonJS/Extensions/f43ab677b4bca0a6ab77132d3f785be300382760/ClonerSystem/src/babylonx.cloner.js"></script>
         <script src="https://rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js"></script>
+        <script>
+            // make sure the script base url is correct - should be the same as this page's origin
+            BABYLON.Tools.ScriptBaseUrl = window.location.origin;
+        </script>
         <script src="sceneJs.js"></script>
     </body>
 </html>

--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -203,6 +203,18 @@ let checkBabylonVersionAsync = function () {
 
     return new Promise((resolve) => {
         loadInSequence(frameworkScripts, 0, resolve);
+    }).then(() => {
+        // if local, set the default base URL
+        if (snapshot) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/" + snapshot;
+        } else if (version) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
+        } else if (activeVersion === "local") {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+        }
     });
 };
 


### PR DESCRIPTION
When using the local server or a snapshot/version on the playground the async-loaded resources are still downloaded from the cdn instead of the local directory.

For example, opening this:

https://playground.babylonjs.com/?version=6.0.0#4RN0VF

Will load the 6.0.0 CDN resources, but the basis loader will still be downloaded from the main CDN. Same thing goes to local development.

This PR changes that - when developing locally you will get the locally-hosted resources. Same thing for snapshots and versioned URLs.