### PR TITLE
reset ideal width and height on serialization

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2637,10 +2637,12 @@ export class Control implements IAnimatable, IFocusableControl {
         let idealHeight = 0;
         // the host's ideal width and height are influencing the serialization, as they are used in getValue() of ValueAndUnit.
         // for a proper serialization, we need to temporarily set them to 0 and re-set them back afterwards.
-        idealHeight = this.host.idealHeight;
-        idealWidth = this.host.idealWidth;
-        this.host.idealWidth = 0;
-        this.host.idealHeight = 0;
+        if (this.host) {
+            idealHeight = this.host.idealHeight;
+            idealWidth = this.host.idealWidth;
+            this.host.idealWidth = 0;
+            this.host.idealHeight = 0;
+        }
         SerializationHelper.Serialize(this, serializationObject);
         serializationObject.name = this.name;
         serializationObject.className = this.getClassName();
@@ -2670,8 +2672,10 @@ export class Control implements IAnimatable, IFocusableControl {
         // Animations
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
         // re-set the ideal width and height
-        this.host.idealWidth = idealWidth;
-        this.host.idealHeight = idealHeight;
+        if (this.host) {
+            this.host.idealWidth = idealWidth;
+            this.host.idealHeight = idealHeight;
+        }
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2598,7 +2598,6 @@ export class Control implements IAnimatable, IFocusableControl {
     public clone(host?: AdvancedDynamicTexture): Control {
         const serialization: any = {};
         this.serialize(serialization, true);
-
         const controlType = Tools.Instantiate("BABYLON.GUI." + serialization.className);
         const cloned = new controlType();
         cloned.parse(serialization, host);
@@ -2634,6 +2633,14 @@ export class Control implements IAnimatable, IFocusableControl {
         if (!this.isSerializable && !force) {
             return;
         }
+        let idealWidth = 0;
+        let idealHeight = 0;
+        // the host's ideal width and height are influencing the serialization, as they are used in getValue() of ValueAndUnit.
+        // for a proper serialization, we need to temporarily set them to 0 and re-set them back afterwards.
+        idealHeight = this.host.idealHeight;
+        idealWidth = this.host.idealWidth;
+        this.host.idealWidth = 0;
+        this.host.idealHeight = 0;
         SerializationHelper.Serialize(this, serializationObject);
         serializationObject.name = this.name;
         serializationObject.className = this.getClassName();
@@ -2662,6 +2669,9 @@ export class Control implements IAnimatable, IFocusableControl {
 
         // Animations
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
+        // re-set the ideal width and height
+        this.host.idealWidth = idealWidth;
+        this.host.idealHeight = idealHeight;
     }
 
     /**


### PR DESCRIPTION
When closning an element in an ADT (i.e. a GUI element), the ideal width andd ideal height of its host influence the data serialized.
I consider this a bug on our end - serialized data should not be influenced by the object's parent.

This PR resets the ideal width and height of the ADT host when cloning an element.

There is an interesting "breaking change" here, but it is far fetched and probably not really used:
When cloning from one ADT to another, it is possible that the element will not have different size, if both ADTs have a different idealWidth or idealHeight.
However, as this can be considered a bug fix, the new behavior is the right one, so I don't see that as a problem nor as a breaking change.

PG to test: #KKA6L4#20

Forum post that triggered it:


https://forum.babylonjs.com/t/gui-control-clone-doesnt-respect-ideal-width/55494?u=raananw