### PR TITLE
Allow overriding assets loading URLs in core

### DIFF
--- a/packages/dev/core/src/Helpers/environmentHelper.ts
+++ b/packages/dev/core/src/Helpers/environmentHelper.ts
@@ -16,6 +16,7 @@ import { Constants } from "../Engines/constants";
 import { CreatePlane } from "../Meshes/Builders/planeBuilder";
 import { CreateBox } from "../Meshes/Builders/boxBuilder";
 import { Plane } from "../Maths/math.plane";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Represents the different options available during the creation of
@@ -193,17 +194,17 @@ export class EnvironmentHelper {
     /**
      * Default ground texture URL.
      */
-    private static _GroundTextureCDNUrl = "https://assets.babylonjs.com/environments/backgroundGround.png";
+    private static _GroundTextureCDNUrl = "https://assets.babylonjs.com/core/environments/backgroundGround.png";
 
     /**
      * Default skybox texture URL.
      */
-    private static _SkyboxTextureCDNUrl = "https://assets.babylonjs.com/environments/backgroundSkybox.dds";
+    private static _SkyboxTextureCDNUrl = "https://assets.babylonjs.com/core/environments/backgroundSkybox.dds";
 
     /**
      * Default environment texture URL.
      */
-    private static _EnvironmentTextureCDNUrl = "https://assets.babylonjs.com/environments/environmentSpecular.env";
+    private static _EnvironmentTextureCDNUrl = "https://assets.babylonjs.com/core/environments/environmentSpecular.env";
 
     /**
      * Creates the default options for the helper.
@@ -214,7 +215,7 @@ export class EnvironmentHelper {
         return {
             createGround: true,
             groundSize: 15,
-            groundTexture: this._GroundTextureCDNUrl,
+            groundTexture: Tools.GetAssetUrl(this._GroundTextureCDNUrl),
             groundColor: new Color3(0.2, 0.2, 0.3).toLinearSpace(scene.getEngine().useExactSrgbConversions).scale(3),
             groundOpacity: 0.9,
             enableGroundShadow: true,
@@ -232,7 +233,7 @@ export class EnvironmentHelper {
 
             createSkybox: true,
             skyboxSize: 20,
-            skyboxTexture: this._SkyboxTextureCDNUrl,
+            skyboxTexture: Tools.GetAssetUrl(this._SkyboxTextureCDNUrl),
             skyboxColor: new Color3(0.2, 0.2, 0.3).toLinearSpace(scene.getEngine().useExactSrgbConversions).scale(3),
 
             backgroundYRotation: 0,
@@ -240,7 +241,7 @@ export class EnvironmentHelper {
             rootPosition: Vector3.Zero(),
 
             setupImageProcessing: true,
-            environmentTexture: this._EnvironmentTextureCDNUrl,
+            environmentTexture: Tools.GetAssetUrl(this._EnvironmentTextureCDNUrl),
             cameraExposure: 0.8,
             cameraContrast: 1.2,
             toneMappingEnabled: true,

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2081,8 +2081,8 @@ export class NodeMaterial extends PushMaterial {
 
         const currentScreen = new CurrentScreenBlock("CurrentScreen");
         uv.connectTo(currentScreen);
-
-        currentScreen.texture = new Texture("https://assets.babylonjs.com/nme/currentScreenPostProcess.png", this.getScene());
+        const textureUrl = Tools.GetAssetUrl("https://assets.babylonjs.com/core/nme/currentScreenPostProcess.png");
+        currentScreen.texture = new Texture(textureUrl, this.getScene());
 
         const fragmentOutput = new FragmentOutputBlock("FragmentOutput");
         currentScreen.connectTo(fragmentOutput, { output: "rgba" });

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -116,6 +116,11 @@ export class Tools {
     }
 
     /**
+     * The base URL to use to load assets. If empty the default base url is used.
+     */
+    public static AssetBaseUrl = "";
+
+    /**
      * Sets a preprocessing function to run on a source URL before importing it
      * Note that this function will execute AFTER the base URL is appended to the URL
      */
@@ -472,7 +477,32 @@ export class Tools {
     /**
      * @internal
      */
-    public static _DefaultCdnUrl = "https://cdn.babylonjs.com";
+    public static readonly _DefaultCdnUrl = "https://cdn.babylonjs.com";
+
+    /**
+     * @internal
+     */
+    public static readonly _DefaultAssetsUrl = "https://assets.babylonjs.com/core";
+
+    /**
+     * This function will convert asset URLs if the AssetBaseUrl parameter is set.
+     * Any URL with `assets.babylonjs.com/core` will be replaced with the value of AssetBaseUrl.
+     * @param url the URL to convert
+     * @returns a new URL
+     */
+    public static GetAssetUrl(url: string): string {
+        if (!url) {
+            return "";
+        }
+
+        if (Tools.AssetBaseUrl && url.startsWith(Tools._DefaultAssetsUrl)) {
+            // normalize the baseUrl
+            const baseUrl = Tools.AssetBaseUrl[Tools.AssetBaseUrl.length - 1] === "/" ? Tools.AssetBaseUrl.substring(0, Tools.AssetBaseUrl.length - 1) : Tools.AssetBaseUrl;
+            return url.replace(Tools._DefaultAssetsUrl, baseUrl);
+        }
+
+        return url;
+    }
 
     /**
      * Get a script URL including preprocessing

--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -121,6 +121,15 @@ export class Tools {
     public static AssetBaseUrl = "";
 
     /**
+     * Sets both the script base URL and the assets base URL to the same value.
+     * Setter only!
+     */
+    public static set CDNBaseUrl(value: string) {
+        Tools.ScriptBaseUrl = value;
+        Tools.AssetBaseUrl = value;
+    }
+
+    /**
      * Sets a preprocessing function to run on a source URL before importing it
      * Note that this function will execute AFTER the base URL is appended to the URL
      */

--- a/packages/dev/core/src/Particles/particleHelper.ts
+++ b/packages/dev/core/src/Particles/particleHelper.ts
@@ -42,7 +42,8 @@ export class ParticleHelper {
         }
 
         system.emitter = emitter;
-        system.particleTexture = new Texture("https://assets.babylonjs.com/textures/flare.png", system.getScene());
+        const textureUrl = Tools.GetAssetUrl("https://assets.babylonjs.com/core/textures/flare.png");
+        system.particleTexture = new Texture(textureUrl, system.getScene());
         system.createConeEmitter(0.1, Math.PI / 4);
 
         // Particle color

--- a/packages/dev/core/src/Particles/particleSystemSet.ts
+++ b/packages/dev/core/src/Particles/particleSystemSet.ts
@@ -23,6 +23,7 @@ class ParticleSystemSetEmitterCreationOptions {
 export class ParticleSystemSet implements IDisposable {
     /**
      * Gets or sets base Assets URL
+     * Only used when parsing particle systems from JSON, not part of the core assets
      */
     public static BaseAssetsUrl = "https://assets.babylonjs.com/particles";
 

--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -25,6 +25,7 @@ import { Axis } from "../../Maths/math.axis";
 import { EngineStore } from "../../Engines/engineStore";
 import { Constants } from "../../Engines/constants";
 import type { WebXRCompositionLayerWrapper } from "./Layers/WebXRCompositionLayer";
+import { Tools } from "core/Misc/tools";
 
 declare const XRHand: XRHand;
 
@@ -529,13 +530,13 @@ export class WebXRHandTracking extends WebXRAbstractFeature {
     public static readonly Version = 1;
 
     /** The base URL for the default hand model. */
-    public static DEFAULT_HAND_MODEL_BASE_URL = "https://assets.babylonjs.com/meshes/HandMeshes/";
+    public static DEFAULT_HAND_MODEL_BASE_URL = "https://assets.babylonjs.com/core/meshes/HandMeshes/";
     /** The filename to use for the default right hand model. */
     public static DEFAULT_HAND_MODEL_RIGHT_FILENAME = "r_hand_rhs.glb";
     /** The filename to use for the default left hand model. */
     public static DEFAULT_HAND_MODEL_LEFT_FILENAME = "l_hand_rhs.glb";
     /** The URL pointing to the default hand model NodeMaterial shader. */
-    public static DEFAULT_HAND_MODEL_SHADER_URL = "https://assets.babylonjs.com/meshes/HandMeshes/handsShader.json";
+    public static DEFAULT_HAND_MODEL_SHADER_URL = "https://assets.babylonjs.com/core/meshes/HandMeshes/handsShader.json";
 
     // We want to use lightweight models, diameter will initially be 1 but scaled to the values returned from WebXR.
     private static readonly _ICOSPHERE_PARAMS = { radius: 0.5, flat: false, subdivisions: 2 };
@@ -598,16 +599,15 @@ export class WebXRHandTracking extends WebXRAbstractFeature {
 
             const handsDefined = !!(WebXRHandTracking._RightHandGLB && WebXRHandTracking._LeftHandGLB);
             // load them in parallel
+            const defaulrHandGLBUrl = Tools.GetAssetUrl(WebXRHandTracking.DEFAULT_HAND_MODEL_BASE_URL);
             const handGLBs = await Promise.all([
-                WebXRHandTracking._RightHandGLB ||
-                    SceneLoader.ImportMeshAsync("", WebXRHandTracking.DEFAULT_HAND_MODEL_BASE_URL, WebXRHandTracking.DEFAULT_HAND_MODEL_RIGHT_FILENAME, scene),
-                WebXRHandTracking._LeftHandGLB ||
-                    SceneLoader.ImportMeshAsync("", WebXRHandTracking.DEFAULT_HAND_MODEL_BASE_URL, WebXRHandTracking.DEFAULT_HAND_MODEL_LEFT_FILENAME, scene),
+                WebXRHandTracking._RightHandGLB || SceneLoader.ImportMeshAsync("", defaulrHandGLBUrl, WebXRHandTracking.DEFAULT_HAND_MODEL_RIGHT_FILENAME, scene),
+                WebXRHandTracking._LeftHandGLB || SceneLoader.ImportMeshAsync("", defaulrHandGLBUrl, WebXRHandTracking.DEFAULT_HAND_MODEL_LEFT_FILENAME, scene),
             ]);
             WebXRHandTracking._RightHandGLB = handGLBs[0];
             WebXRHandTracking._LeftHandGLB = handGLBs[1];
-
-            const handShader = await NodeMaterial.ParseFromFileAsync("handShader", WebXRHandTracking.DEFAULT_HAND_MODEL_SHADER_URL, scene, undefined, true);
+            const shaderUrl = Tools.GetAssetUrl(WebXRHandTracking.DEFAULT_HAND_MODEL_SHADER_URL);
+            const handShader = await NodeMaterial.ParseFromFileAsync("handShader", shaderUrl, scene, undefined, true);
 
             // depth prepass and alpha mode
             handShader.needDepthPrePass = true;

--- a/packages/dev/gui/src/3D/controls/MRTK3/touchHolographicButton.ts
+++ b/packages/dev/gui/src/3D/controls/MRTK3/touchHolographicButton.ts
@@ -29,6 +29,7 @@ import { TextBlock } from "../../../2D/controls/textBlock";
 import { TouchButton3D } from "../touchButton3D";
 import { TransformNode } from "core/Meshes/transformNode";
 import { Vector3 } from "core/Maths/math.vector";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Class used to create the mrtkv3 button
@@ -37,7 +38,7 @@ export class TouchHolographicButton extends TouchButton3D {
     /**
      * Base Url for the frontplate model.
      */
-    public static MRTK_ASSET_BASE_URL = "https://assets.babylonjs.com/meshes/MRTK/";
+    public static MRTK_ASSET_BASE_URL = "https://assets.babylonjs.com/core/MRTK/";
 
     /**
      * File name for the frontplate model.
@@ -614,8 +615,8 @@ export class TouchHolographicButton extends TouchButton3D {
         backPlateMesh.isPickable = false;
         backPlateMesh.visibility = 0;
         backPlateMesh.scaling.z = 0.2;
-
-        SceneLoader.ImportMeshAsync(undefined, TouchHolographicButton.MRTK_ASSET_BASE_URL, TouchHolographicButton.BACKPLATE_MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(TouchHolographicButton.MRTK_ASSET_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, TouchHolographicButton.BACKPLATE_MODEL_FILENAME, scene).then((result) => {
             const backPlateModel = result.meshes[1];
             backPlateModel.visibility = 0;
 
@@ -652,8 +653,8 @@ export class TouchHolographicButton extends TouchButton3D {
         collisionMesh.isNearPickable = true;
         collisionMesh.visibility = 0;
         collisionMesh.position = Vector3.Forward(scene.useRightHandedSystem).scale((this.backPlateDepth - this.frontPlateDepth) / 2);
-
-        SceneLoader.ImportMeshAsync(undefined, TouchHolographicButton.MRTK_ASSET_BASE_URL, TouchHolographicButton.FRONTPLATE_MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(TouchHolographicButton.MRTK_ASSET_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, TouchHolographicButton.FRONTPLATE_MODEL_FILENAME, scene).then((result) => {
             const collisionPlate = CreateBox(
                 `${this.name}_collisionPlate`,
                 {
@@ -699,7 +700,8 @@ export class TouchHolographicButton extends TouchButton3D {
         innerQuadMesh.scaling.z = this.flatPlaneDepth;
         innerQuadMesh.position.z += this.backPlateDepth / 2 - this.flatPlaneDepth;
 
-        SceneLoader.ImportMeshAsync(undefined, TouchHolographicButton.MRTK_ASSET_BASE_URL, TouchHolographicButton.INNERQUAD_MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(TouchHolographicButton.MRTK_ASSET_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, TouchHolographicButton.INNERQUAD_MODEL_FILENAME, scene).then((result) => {
             const innerQuadModel = result.meshes[1];
             innerQuadModel.name = `${this.name}_innerQuad`;
             innerQuadModel.isPickable = false;
@@ -728,7 +730,8 @@ export class TouchHolographicButton extends TouchButton3D {
         backGlowMesh.scaling.z = this.flatPlaneDepth;
         backGlowMesh.position.z += this.backPlateDepth / 2 - this.flatPlaneDepth * 2;
 
-        SceneLoader.ImportMeshAsync(undefined, TouchHolographicButton.MRTK_ASSET_BASE_URL, TouchHolographicButton.BACKGLOW_MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(TouchHolographicButton.MRTK_ASSET_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, TouchHolographicButton.BACKGLOW_MODEL_FILENAME, scene).then((result) => {
             const backGlowModel = result.meshes[1];
             backGlowModel.name = `${this.name}_backGlow`;
             backGlowModel.isPickable = false;

--- a/packages/dev/gui/src/3D/controls/holographicBackplate.ts
+++ b/packages/dev/gui/src/3D/controls/holographicBackplate.ts
@@ -6,6 +6,7 @@ import { FluentBackplateMaterial } from "../materials/fluentBackplate/fluentBack
 import { Control3D } from "./control3D";
 import { SceneLoader } from "core/Loading/sceneLoader";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Class used to create a holographic backplate in 3D
@@ -15,7 +16,7 @@ export class HolographicBackplate extends Control3D {
     /**
      * Base Url for the button model.
      */
-    public static MODEL_BASE_URL: string = "https://assets.babylonjs.com/meshes/MRTK/";
+    public static MODEL_BASE_URL: string = "https://assets.babylonjs.com/core/MRTK/";
     /**
      * File name for the button model.
      */
@@ -77,8 +78,8 @@ export class HolographicBackplate extends Control3D {
         );
         collisionMesh.isPickable = true;
         collisionMesh.visibility = 0;
-
-        SceneLoader.ImportMeshAsync(undefined, HolographicBackplate.MODEL_BASE_URL, HolographicBackplate.MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(HolographicBackplate.MODEL_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, HolographicBackplate.MODEL_FILENAME, scene).then((result) => {
             const importedModel = result.meshes[1];
             importedModel.name = `${this.name}_frontPlate`;
             importedModel.isPickable = false;

--- a/packages/dev/gui/src/3D/controls/holographicSlate.ts
+++ b/packages/dev/gui/src/3D/controls/holographicSlate.ts
@@ -25,6 +25,7 @@ import { VertexData } from "core/Meshes/mesh.vertexData";
 import type { Observer } from "core/Misc/observable";
 import type { Scene } from "core/scene";
 import type { Nullable } from "core/types";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Class used to create a holographic slate
@@ -34,7 +35,7 @@ export class HolographicSlate extends ContentDisplay3D {
     /**
      * Base Url for the assets.
      */
-    public static ASSETS_BASE_URL: string = "https://assets.babylonjs.com/meshes/MRTK/";
+    public static ASSETS_BASE_URL: string = "https://assets.babylonjs.com/core/MRTK/";
     /**
      * File name for the close icon.
      */
@@ -342,9 +343,9 @@ export class HolographicSlate extends ContentDisplay3D {
         closeButton.node!.parent = node;
 
         this._positionElements();
-
-        this._followButton.imageUrl = HolographicSlate.ASSETS_BASE_URL + HolographicSlate.FOLLOW_ICON_FILENAME;
-        this._closeButton.imageUrl = HolographicSlate.ASSETS_BASE_URL + HolographicSlate.CLOSE_ICON_FILENAME;
+        const baseUrl = Tools.GetAssetUrl(HolographicSlate.ASSETS_BASE_URL);
+        this._followButton.imageUrl = baseUrl + HolographicSlate.FOLLOW_ICON_FILENAME;
+        this._closeButton.imageUrl = baseUrl + HolographicSlate.CLOSE_ICON_FILENAME;
 
         this._followButton.isBackplateVisible = false;
         this._closeButton.isBackplateVisible = false;

--- a/packages/dev/gui/src/3D/controls/nearMenu.ts
+++ b/packages/dev/gui/src/3D/controls/nearMenu.ts
@@ -8,6 +8,7 @@ import { TouchHolographicMenu } from "./touchHolographicMenu";
 import type { Observer } from "core/Misc/observable";
 import type { Vector3 } from "core/Maths/math.vector";
 import type { PickingInfo } from "core/Collisions/pickingInfo";
+import { Tools } from "core/Misc/tools";
 
 /**
  * NearMenu that displays buttons and follows the camera
@@ -17,7 +18,7 @@ export class NearMenu extends TouchHolographicMenu {
     /**
      * Base Url for the assets.
      */
-    private static _ASSETS_BASE_URL: string = "https://assets.babylonjs.com/meshes/MRTK/";
+    private static _ASSETS_BASE_URL: string = "https://assets.babylonjs.com/core/MRTK/";
     /**
      * File name for the close icon.
      */
@@ -66,7 +67,8 @@ export class NearMenu extends TouchHolographicMenu {
 
     private _createPinButton(parent: TransformNode) {
         const control = new TouchHolographicButton("pin" + this.name, false);
-        control.imageUrl = NearMenu._ASSETS_BASE_URL + NearMenu._PIN_ICON_FILENAME;
+        const baseUrl = Tools.GetAssetUrl(NearMenu._ASSETS_BASE_URL);
+        control.imageUrl = baseUrl + NearMenu._PIN_ICON_FILENAME;
         control.parent = this;
         control._host = this._host;
         control.isToggleButton = true;

--- a/packages/dev/gui/src/3D/controls/slider3D.ts
+++ b/packages/dev/gui/src/3D/controls/slider3D.ts
@@ -12,6 +12,7 @@ import { SceneLoader } from "core/Loading/sceneLoader";
 import { MRDLSliderBarMaterial } from "../materials/mrdl/mrdlSliderBarMaterial";
 import { MRDLSliderThumbMaterial } from "../materials/mrdl/mrdlSliderThumbMaterial";
 import { MRDLBackplateMaterial } from "../materials/mrdl/mrdlBackplateMaterial";
+import { Tools } from "core/Misc/tools";
 
 const SLIDER_MIN: number = 0;
 const SLIDER_MAX: number = 100;
@@ -27,7 +28,7 @@ export class Slider3D extends Control3D {
     /**
      * Base Url for the models.
      */
-    public static MODEL_BASE_URL: string = "https://assets.babylonjs.com/meshes/MRTK/";
+    public static MODEL_BASE_URL: string = "https://assets.babylonjs.com/core/MRTK/";
 
     /**
      * File name for the 8x4 model.
@@ -219,8 +220,8 @@ export class Slider3D extends Control3D {
         sliderBackplate.isPickable = false;
         sliderBackplate.visibility = 0;
         sliderBackplate.scaling = new Vector3(1, 0.5, 0.8);
-
-        SceneLoader.ImportMeshAsync(undefined, Slider3D.MODEL_BASE_URL, Slider3D.MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(Slider3D.MODEL_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, Slider3D.MODEL_FILENAME, scene).then((result) => {
             // make all meshes not pickable. Required meshes' pickable state will be set later.
             result.meshes.forEach((m) => {
                 m.isPickable = false;

--- a/packages/dev/gui/src/3D/controls/touchHolographicButton.ts
+++ b/packages/dev/gui/src/3D/controls/touchHolographicButton.ts
@@ -21,6 +21,7 @@ import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import { SceneLoader } from "core/Loading/sceneLoader";
 import { IsDocumentAvailable } from "core/Misc/domManagement";
 import { Scalar } from "core/Maths/math.scalar";
+import { Tools } from "core/Misc/tools";
 
 /**
  * Class used to create a holographic button in 3D
@@ -30,7 +31,7 @@ export class TouchHolographicButton extends TouchButton3D {
     /**
      * Base Url for the button model.
      */
-    public static MODEL_BASE_URL: string = "https://assets.babylonjs.com/meshes/MRTK/";
+    public static MODEL_BASE_URL: string = "https://assets.babylonjs.com/core/MRTK/";
     /**
      * File name for the button model.
      */
@@ -337,8 +338,8 @@ export class TouchHolographicButton extends TouchButton3D {
         collisionMesh.isNearPickable = true;
         collisionMesh.visibility = 0;
         collisionMesh.position = Vector3.Forward(scene.useRightHandedSystem).scale(-this._frontPlateDepth / 2);
-
-        SceneLoader.ImportMeshAsync(undefined, TouchHolographicButton.MODEL_BASE_URL, TouchHolographicButton.MODEL_FILENAME, scene).then((result) => {
+        const baseUrl = Tools.GetAssetUrl(TouchHolographicButton.MODEL_BASE_URL);
+        SceneLoader.ImportMeshAsync(undefined, baseUrl, TouchHolographicButton.MODEL_FILENAME, scene).then((result) => {
             const alphaMesh = CreateBox(
                 "${this.name}_alphaMesh",
                 {

--- a/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentBackplate/fluentBackplateMaterial.ts
@@ -23,6 +23,7 @@ import { Constants } from "core/Engines/constants";
 import "./shaders/fluentBackplate.fragment";
 import "./shaders/fluentBackplate.vertex";
 import { HandleFallbacksForShadows, PrepareAttributesForInstances, PrepareDefinesForAttributes, PrepareUniformsAndSamplersList } from "core/Materials/materialHelper.functions";
+import { Tools } from "core/Misc/tools";
 
 /** @internal */
 class FluentBackplateMaterialDefines extends MaterialDefines {
@@ -45,12 +46,12 @@ export class FluentBackplateMaterial extends PushMaterial {
     /**
      * URL pointing to the texture used to define the coloring for the fluent blob effect.
      */
-    public static BLOB_TEXTURE_URL = "https://assets.babylonjs.com/meshes/MRTK/mrtk-fluent-backplate-blob.png";
+    public static BLOB_TEXTURE_URL = "https://assets.babylonjs.com/core/MRTK/mrtk-fluent-backplate-blob.png";
 
     /**
      * URL pointing to the texture used to define iridescent map.
      */
-    public static IM_TEXTURE_URL = "https://assets.babylonjs.com/meshes/MRTK/mrtk-fluent-backplate-iridescence.png";
+    public static IM_TEXTURE_URL = "https://assets.babylonjs.com/core/MRTK/mrtk-fluent-backplate-iridescence.png";
 
     private _blobTexture: Texture;
     private _iridescentMap: Texture;
@@ -224,9 +225,10 @@ export class FluentBackplateMaterial extends PushMaterial {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
-
-        this._blobTexture = new Texture(FluentBackplateMaterial.BLOB_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
-        this._iridescentMap = new Texture(FluentBackplateMaterial.IM_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
+        const blobTextureUrl = Tools.GetAssetUrl(FluentBackplateMaterial.BLOB_TEXTURE_URL);
+        const iridescentMapUrl = Tools.GetAssetUrl(FluentBackplateMaterial.IM_TEXTURE_URL);
+        this._blobTexture = new Texture(blobTextureUrl, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
+        this._iridescentMap = new Texture(iridescentMapUrl, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public override needAlphaBlending(): boolean {

--- a/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/fluentButton/fluentButtonMaterial.ts
@@ -23,6 +23,7 @@ import { Constants } from "core/Engines/constants";
 import "./shaders/fluentButton.fragment";
 import "./shaders/fluentButton.vertex";
 import { HandleFallbacksForShadows, PrepareAttributesForInstances, PrepareDefinesForAttributes, PrepareUniformsAndSamplersList } from "core/Materials/materialHelper.functions";
+import { Tools } from "core/Misc/tools";
 
 /** @internal */
 class FluentButtonMaterialDefines extends MaterialDefines {
@@ -45,7 +46,7 @@ export class FluentButtonMaterial extends PushMaterial {
     /**
      * URL pointing to the texture used to define the coloring for the fluent blob effect.
      */
-    public static BLOB_TEXTURE_URL = "https://assets.babylonjs.com/meshes/MRTK/mrtk-fluent-button-blob.png";
+    public static BLOB_TEXTURE_URL = "https://assets.babylonjs.com/core/MRTK/mrtk-fluent-button-blob.png";
 
     /**
      * Gets or sets the width of the glowing edge, relative to the scale of the button.
@@ -276,8 +277,8 @@ export class FluentButtonMaterial extends PushMaterial {
         this.alphaMode = Constants.ALPHA_ADD;
         this.disableDepthWrite = true;
         this.backFaceCulling = false;
-
-        this._blobTexture = new Texture(FluentButtonMaterial.BLOB_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
+        const blobTextureUrl = Tools.GetAssetUrl(FluentButtonMaterial.BLOB_TEXTURE_URL);
+        this._blobTexture = new Texture(blobTextureUrl, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public override needAlphaBlending(): boolean {

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlBackplateMaterial.ts
@@ -23,6 +23,7 @@ import { Constants } from "core/Engines/constants";
 import "./shaders/mrdlBackplate.fragment";
 import "./shaders/mrdlBackplate.vertex";
 import { HandleFallbacksForShadows, PrepareAttributesForInstances, PrepareDefinesForAttributes, PrepareUniformsAndSamplersList } from "core/Materials/materialHelper.functions";
+import { Tools } from "core/Misc/tools";
 
 /** @internal */
 class MRDLBackplateMaterialDefines extends MaterialDefines {
@@ -46,7 +47,7 @@ export class MRDLBackplateMaterial extends PushMaterial {
     /**
      * URL pointing to the texture used to define the coloring for the Iridescent Map effect.
      */
-    public static IRIDESCENT_MAP_TEXTURE_URL = "https://assets.babylonjs.com/meshes/MRTK/MRDL/mrtk-mrdl-backplate-iridescence.png";
+    public static IRIDESCENT_MAP_TEXTURE_URL = "https://assets.babylonjs.com/core/MRTK/MRDL/mrtk-mrdl-backplate-iridescence.png";
     private _iridescentMapTexture: Texture;
 
     /**
@@ -216,8 +217,8 @@ export class MRDLBackplateMaterial extends PushMaterial {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
-
-        this._iridescentMapTexture = new Texture(MRDLBackplateMaterial.IRIDESCENT_MAP_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
+        const textureUrl = Tools.GetAssetUrl(MRDLBackplateMaterial.IRIDESCENT_MAP_TEXTURE_URL);
+        this._iridescentMapTexture = new Texture(textureUrl, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
     }
 
     public override needAlphaBlending(): boolean {

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderBarMaterial.ts
@@ -23,6 +23,7 @@ import { Constants } from "core/Engines/constants";
 import "./shaders/mrdlSliderBar.fragment";
 import "./shaders/mrdlSliderBar.vertex";
 import { HandleFallbacksForShadows, PrepareAttributesForInstances, PrepareDefinesForAttributes, PrepareUniformsAndSamplersList } from "core/Materials/materialHelper.functions";
+import { Tools } from "core/Misc/tools";
 
 /** @internal */
 class MRDLSliderBarMaterialDefines extends MaterialDefines {
@@ -48,7 +49,7 @@ export class MRDLSliderBarMaterial extends PushMaterial {
     /**
      * URL pointing to the texture used to define the coloring for the Iridescent Map effect.
      */
-    public static BLUE_GRADIENT_TEXTURE_URL = "https://assets.babylonjs.com/meshes/MRTK/MRDL/mrtk-mrdl-blue-gradient.png";
+    public static BLUE_GRADIENT_TEXTURE_URL = "https://assets.babylonjs.com/core/MRTK/MRDL/mrtk-mrdl-blue-gradient.png";
     private _blueGradientTexture: Texture;
     private _decalTexture: Texture;
     private _reflectionMapTexture: Texture;
@@ -487,7 +488,8 @@ export class MRDLSliderBarMaterial extends PushMaterial {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
-        this._blueGradientTexture = new Texture(MRDLSliderBarMaterial.BLUE_GRADIENT_TEXTURE_URL, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
+        const textureUrl = Tools.GetAssetUrl(MRDLSliderBarMaterial.BLUE_GRADIENT_TEXTURE_URL);
+        this._blueGradientTexture = new Texture(textureUrl, this.getScene(), true, false, Texture.NEAREST_SAMPLINGMODE);
         this._decalTexture = new Texture("", this.getScene());
         this._reflectionMapTexture = new Texture("", this.getScene());
         this._indirectEnvTexture = new Texture("", this.getScene());

--- a/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
+++ b/packages/dev/gui/src/3D/materials/mrdl/mrdlSliderThumbMaterial.ts
@@ -23,6 +23,7 @@ import { Constants } from "core/Engines/constants";
 import "./shaders/mrdlSliderThumb.fragment";
 import "./shaders/mrdlSliderThumb.vertex";
 import { HandleFallbacksForShadows, PrepareAttributesForInstances, PrepareDefinesForAttributes, PrepareUniformsAndSamplersList } from "core/Materials/materialHelper.functions";
+import { Tools } from "core/Misc/tools";
 
 /** @internal */
 class MRDLSliderThumbMaterialDefines extends MaterialDefines {
@@ -48,7 +49,7 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
     /**
      * URL pointing to the texture used to define the coloring for the Iridescent Map effect.
      */
-    public static BLUE_GRADIENT_TEXTURE_URL = "https://assets.babylonjs.com/meshes/MRTK/MRDL/mrtk-mrdl-blue-gradient.png";
+    public static BLUE_GRADIENT_TEXTURE_URL = "https://assets.babylonjs.com/core/MRTK/MRDL/mrtk-mrdl-blue-gradient.png";
     private _blueGradientTexture: Texture;
     private _decalTexture: Texture;
     private _reflectionMapTexture: Texture;
@@ -488,7 +489,8 @@ export class MRDLSliderThumbMaterial extends PushMaterial {
         super(name, scene);
         this.alphaMode = Constants.ALPHA_DISABLE;
         this.backFaceCulling = false;
-        this._blueGradientTexture = new Texture(MRDLSliderThumbMaterial.BLUE_GRADIENT_TEXTURE_URL, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
+        const textureUrl = Tools.GetAssetUrl(MRDLSliderThumbMaterial.BLUE_GRADIENT_TEXTURE_URL);
+        this._blueGradientTexture = new Texture(textureUrl, scene, true, false, Texture.NEAREST_SAMPLINGMODE);
         this._decalTexture = new Texture("", this.getScene());
         this._reflectionMapTexture = new Texture("", this.getScene());
         this._indirectEnvTexture = new Texture("", this.getScene());

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/renderGridPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/renderGridPropertyGridComponent.tsx
@@ -11,6 +11,7 @@ import { GridMaterial } from "materials/grid/gridMaterial";
 import { CheckBoxLineComponent } from "shared-ui-components/lines/checkBoxLineComponent";
 import type { GlobalState } from "../../../globalState";
 import { CreateGround } from "core/Meshes/Builders/groundBuilder";
+import { Tools } from "core/Misc/tools";
 
 interface IRenderGridPropertyGridComponentProps {
     globalState: GlobalState;
@@ -63,7 +64,8 @@ export class RenderGridPropertyGridComponent extends React.Component<IRenderGrid
             groundMaterial.lineColor = new Color3(1.0, 1.0, 1.0);
             groundMaterial.opacity = 0.8;
             groundMaterial.zOffset = 1.0;
-            groundMaterial.opacityTexture = new Texture("https://assets.babylonjs.com/environments/backgroundGround.png", scene);
+            const textureUrl = Tools.GetAssetUrl("https://assets.babylonjs.com/core/environments/backgroundGround.png");
+            groundMaterial.opacityTexture = new Texture(textureUrl, scene);
 
             this._gridMesh.material = groundMaterial;
 


### PR DESCRIPTION
Directly related to this:

https://github.com/BabylonJS/Assets/pull/89

This allows a developer to avoid using our assets library and define their own URL for loading assets.
All assets referenced will be in the `/core` directory in the Assets repository.