### PR TITLE
fix race condition with meshopt compression

### DIFF
--- a/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
@@ -5,6 +5,11 @@ import type { Nullable } from "../../types";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare let MeshoptDecoder: any;
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+let NumberOfWorkers = 0;
+// eslint-disable-next-line @typescript-eslint/naming-convention
+let WorkerTimeout: Nullable<ReturnType<typeof setTimeout>> = null;
+
 /**
  * Configuration for meshoptimizer compression
  */
@@ -103,9 +108,20 @@ export class MeshoptCompression implements IDisposable {
      */
     public decodeGltfBufferAsync(source: Uint8Array, count: number, stride: number, mode: "ATTRIBUTES" | "TRIANGLES" | "INDICES", filter?: string): Promise<Uint8Array> {
         return this._decoderModulePromise!.then(async () => {
-            MeshoptDecoder.useWorkers(1);
+            if (NumberOfWorkers === 0) {
+                MeshoptDecoder.useWorkers(1);
+                NumberOfWorkers = 1;
+            }
             const result = await MeshoptDecoder.decodeGltfBufferAsync(count, stride, source, mode, filter);
-            MeshoptDecoder.useWorkers(0);
+            // a simple debounce to avoid switching back and forth between workers and no workers while decoding
+            if (WorkerTimeout !== null) {
+                clearTimeout(WorkerTimeout);
+                WorkerTimeout = setTimeout(() => {
+                    MeshoptDecoder.useWorkers(0);
+                    NumberOfWorkers = 0;
+                    WorkerTimeout = null;
+                }, 500);
+            }
             return result;
         });
     }

--- a/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
+++ b/packages/dev/core/src/Meshes/Compression/meshoptCompression.ts
@@ -116,12 +116,12 @@ export class MeshoptCompression implements IDisposable {
             // a simple debounce to avoid switching back and forth between workers and no workers while decoding
             if (WorkerTimeout !== null) {
                 clearTimeout(WorkerTimeout);
-                WorkerTimeout = setTimeout(() => {
-                    MeshoptDecoder.useWorkers(0);
-                    NumberOfWorkers = 0;
-                    WorkerTimeout = null;
-                }, 500);
             }
+            WorkerTimeout = setTimeout(() => {
+                MeshoptDecoder.useWorkers(0);
+                NumberOfWorkers = 0;
+                WorkerTimeout = null;
+            }, 1000);
             return result;
         });
     }


### PR DESCRIPTION
In certain (rare, one must say) cases, the calll to useWorkers(0) makes the meshopt not work correctly and not return the mesh even after the work is done.

This adds a kind of debounce to setting the workers number back to 0.