### PR TITLE
DepthRenderer: fix effect cache

### DIFF
--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -544,7 +544,8 @@ export class DepthRenderer {
                         shaderLanguage: this._shaderLanguage,
                     },
                     engine
-                )
+                ),
+                join
             );
         }
 


### PR DESCRIPTION
This commit fixed the `defines` prop in `drawWrapper` so that the effect cache would work as expected.

Forum link: <https://forum.babylonjs.com/t/depthrenderer-effect-not-cached/56092>