### PR TITLE
SH view space

### DIFF
--- a/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
+++ b/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
@@ -48,7 +48,7 @@ void main () {
     vPosition = position;
 
 #if SH_DEGREE > 0
-    vec3 dir = normalize(worldPos.xyz - vEyePosition.xyz);
+    vec3 dir = normalize(splat.center.xyz + world[3].xyz - vEyePosition.xyz);
     dir.y *= -1.; // Up is inverted. This corresponds to change in _makeSplat method
     vColor.xyz = computeSH(splat, splat.color.xyz, dir);
 #endif

--- a/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
+++ b/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
@@ -8,6 +8,8 @@
 #include<fogVertexDeclaration>
 #include<logDepthDeclaration>
 
+#include<helperFunctions>
+
 // Attributes
 attribute float splatIndex;
 
@@ -48,7 +50,10 @@ void main () {
     vPosition = position;
 
 #if SH_DEGREE > 0
-    vec3 dir = normalize(splat.center.xyz + world[3].xyz - vEyePosition.xyz);
+    mat3 worldRot = mat3(world);
+    mat3 normWorldRot = inverseMat3(worldRot);
+
+    vec3 dir = normalize(normWorldRot * (worldPos.xyz - vEyePosition.xyz));
     dir.y *= -1.; // Up is inverted. This corresponds to change in _makeSplat method
     vColor.xyz = computeSH(splat, splat.color.xyz, dir);
 #endif


### PR DESCRIPTION
Fix viewdirection to make SH computation happen in GS local coordinates.

Tested with https://playground.babylonjs.com/#CID4NN#278

set `ofs` to true to add a rotation and translation offset. Rendering should be the same with of without this offset.

NOTE : I'll wait for partners feedback before merging it.