### PR TITLE
Add AbortError and use in Viewer

### DIFF
--- a/packages/dev/core/src/Misc/error.ts
+++ b/packages/dev/core/src/Misc/error.ts
@@ -82,3 +82,14 @@ export class RuntimeError extends BaseError {
         BaseError._setPrototypeOf(this, RuntimeError.prototype);
     }
 }
+
+/**
+ * Used for flow control when an operation is aborted, such as with AbortController.
+ */
+export class AbortError extends BaseError {
+    public constructor(message = "Operation aborted") {
+        super(message);
+        this.name = "AbortError";
+        BaseError._setPrototypeOf(this, AbortError.prototype);
+    }
+}

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -37,6 +37,7 @@ import { computeMaxExtents } from "core/Meshes/meshUtils";
 import { BuildTuple } from "core/Misc/arrayTools";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { deepMerge } from "core/Misc/deepMerger";
+import { AbortError } from "core/Misc/error";
 import { Observable } from "core/Misc/observable";
 import { SnapshotRenderingHelper } from "core/Misc/snapshotRenderingHelper";
 import { Scene } from "core/scene";
@@ -957,7 +958,7 @@ export class Viewer implements IDisposable {
     private async _updateModel(source: string | File | ArrayBufferView | undefined, options?: LoadModelOptions, abortSignal?: AbortSignal): Promise<void> {
         this._throwIfDisposedOrAborted(abortSignal);
 
-        this._loadModelAbortController?.abort("New model is being loaded before previous model finished loading.");
+        this._loadModelAbortController?.abort(new AbortError("New model is being loaded before previous model finished loading."));
         const abortController = (this._loadModelAbortController = new AbortController());
 
         await this._loadModelLock.lockAsync(async () => {
@@ -1004,11 +1005,11 @@ export class Viewer implements IDisposable {
 
         const locks: AsyncLock[] = [];
         if (options.lighting) {
-            this._loadEnvironmentAbortController?.abort("New environment lighting is being loaded before previous environment lighting finished loading.");
+            this._loadEnvironmentAbortController?.abort(new AbortError("New environment lighting is being loaded before previous environment lighting finished loading."));
             locks.push(this._loadEnvironmentLock);
         }
         if (options.skybox) {
-            this._loadSkyboxAbortController?.abort("New environment skybox is being loaded before previous environment skybox finished loading.");
+            this._loadSkyboxAbortController?.abort(new AbortError("New environment skybox is being loaded before previous environment skybox finished loading."));
             locks.push(this._loadSkyboxLock);
         }
 
@@ -1123,8 +1124,8 @@ export class Viewer implements IDisposable {
         this.selectedAnimation = -1;
         this.animationProgress = 0;
 
-        this._loadEnvironmentAbortController?.abort("Thew viewer is being disposed.");
-        this._loadModelAbortController?.abort("Thew viewer is being disposed.");
+        this._loadEnvironmentAbortController?.abort(new AbortError("Thew viewer is being disposed."));
+        this._loadModelAbortController?.abort(new AbortError("Thew viewer is being disposed."));
 
         this._renderLoopController?.dispose();
         this._scene.dispose();

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -12,6 +12,7 @@ import { Color4 } from "core/Maths/math.color";
 import { Vector3 } from "core/Maths/math.vector";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Deferred } from "core/Misc/deferred";
+import { AbortError } from "core/Misc/error";
 import { Logger } from "core/Misc/logger";
 import { isToneMapping, Viewer, ViewerHotSpotResult } from "./viewer";
 import { createViewerForCanvas, getDefaultEngine } from "./viewerFactory";
@@ -1209,7 +1210,10 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
                     await this._viewerDetails.viewer.resetModel();
                 }
             } catch (error) {
-                Logger.Log(error);
+                // If loadModel was aborted (e.g. because a new model load was requested before this one finished), we can just ignore the error.
+                if (!(error instanceof AbortError)) {
+                    Logger.Error(error);
+                }
             }
         }
     }
@@ -1240,7 +1244,10 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
 
                 await Promise.all(promises);
             } catch (error) {
-                Logger.Log(error);
+                // If loadEnvironment was aborted (e.g. because a new environment load was requested before this one finished), we can just ignore the error.
+                if (!(error instanceof AbortError)) {
+                    Logger.Error(error);
+                }
             }
         }
     }


### PR DESCRIPTION
There was some feedback from users that it was confusing to see abort/cancellation errors in the log, since it seemed to indicate something bad was happening when in reality it wasn't. It was simply that a new model or environment was being loaded before the previous one finished loading. This change introduces an `AbortError` (there isn't a standard as part of WebAPI), uses it in the `AbortController.abort` calls, and checks for it in the `ViewerElement` so we can ignore abort/cancellation errors (but still log "real" errors).

@alexandremottet, @cournoll