### PR TITLE
Fix animation auto play

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -45,7 +45,17 @@ import { registerBuiltInLoaders } from "loaders/dynamic";
 const toneMappingOptions = ["none", "standard", "aces", "neutral"] as const;
 export type ToneMapping = (typeof toneMappingOptions)[number];
 
-export type LoadModelOptions = LoadAssetContainerOptions;
+export type LoadModelOptions = LoadAssetContainerOptions & {
+    /**
+     * The default animation index.
+     */
+    defaultAnimation?: number;
+
+    /**
+     * Whether to play the default animation immediately after loading.
+     */
+    animationAutoPlay?: boolean;
+};
 
 export type CameraAutoOrbit = {
     /**
@@ -963,6 +973,10 @@ export class Viewer implements IDisposable {
 
             if (source) {
                 this._setModel(await this._loadModel(source, options, abortController.signal), source);
+                this._selectAnimation(options?.defaultAnimation ?? 0, false);
+                if (options?.animationAutoPlay) {
+                    this.playAnimation();
+                }
             }
         });
     }

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -45,12 +45,7 @@ import { registerBuiltInLoaders } from "loaders/dynamic";
 const toneMappingOptions = ["none", "standard", "aces", "neutral"] as const;
 export type ToneMapping = (typeof toneMappingOptions)[number];
 
-export type LoadModelOptions = LoadAssetContainerOptions & {
-    /**
-     * The default animation index.
-     */
-    defaultAnimation?: number;
-};
+export type LoadModelOptions = LoadAssetContainerOptions;
 
 export type CameraAutoOrbit = {
     /**
@@ -968,7 +963,6 @@ export class Viewer implements IDisposable {
 
             if (source) {
                 this._setModel(await this._loadModel(source, options, abortController.signal), source);
-                this._selectAnimation(options?.defaultAnimation ?? 0, false);
             }
         });
     }

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1204,7 +1204,11 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
         if (this._viewerDetails) {
             try {
                 if (this.source) {
-                    await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined, defaultAnimation: this.selectedAnimation ?? 0 });
+                    await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
+                    this._viewerDetails.viewer.selectedAnimation = this.selectedAnimation ?? 0;
+                    if (this.animationAutoPlay) {
+                        this._viewerDetails.viewer.playAnimation();
+                    }
                 } else {
                     await this._viewerDetails.viewer.resetModel();
                 }

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1138,11 +1138,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
                     this._cameraOrbitCoercer?.(details.camera);
                     this._cameraTargetCoercer?.(details.camera);
 
-                    // If animation auto play was set, then start the default animation (if possible).
-                    if (this.animationAutoPlay) {
-                        details.viewer.playAnimation();
-                    }
-
                     this._dispatchCustomEvent("modelchange", (type) => new CustomEvent(type, { detail: source }));
                 });
 

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1204,11 +1204,11 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
         if (this._viewerDetails) {
             try {
                 if (this.source) {
-                    await this._viewerDetails.viewer.loadModel(this.source, { pluginExtension: this.extension ?? undefined });
-                    this._viewerDetails.viewer.selectedAnimation = this.selectedAnimation ?? 0;
-                    if (this.animationAutoPlay) {
-                        this._viewerDetails.viewer.playAnimation();
-                    }
+                    await this._viewerDetails.viewer.loadModel(this.source, {
+                        pluginExtension: this.extension ?? undefined,
+                        defaultAnimation: this.selectedAnimation ?? 0,
+                        animationAutoPlay: this.animationAutoPlay,
+                    });
                 } else {
                     await this._viewerDetails.viewer.resetModel();
                 }


### PR DESCRIPTION
With some recent refactoring I broke `animation-auto-play`. Previously it was doing some juggling with responsibilities split across the `Viewer` and the `ViewerElement`. With this change, I moved all the responsibility to the `Viewer`, dependent on load options. This makes it much simpler to ensure the logic is correct. An alternative would be to make the `ViewerElement` entirely responsible, and have it sequentially load the model, then set the selectedAnimation, then play the animation. The only reason I don't want to do it this way is because changing the selectedAnimation animates the camera pose (based on computed bounds), and when the model is first being loaded, we don't want this animation. So it's either add load options for the Viewer, or expose the `selectAnimation` function so the `ViewerElement` can select an animation without animating the camera pose. But since other view framework layers would want the same behavior, I think it's better to do it in the `Viewer`.