### PR TITLE
Add missing environment change event

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -87,7 +87,7 @@ export type EnvironmentParams = {
     blur: number;
 
     /**
-     * The rotation of the environment lighting in degrees.
+     * The rotation of the environment lighting in radians.
      */
     rotation: number;
 

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -63,6 +63,7 @@ export interface ViewerElementEventMap extends HTMLElementEventMap {
     viewerready: Event;
     viewerrender: Event;
     environmentchange: Event;
+    environmentconfigurationchange: Event;
     environmenterror: ErrorEvent;
     modelchange: CustomEvent<Nullable<string | File | ArrayBufferView>>;
     modelerror: ErrorEvent;
@@ -1122,6 +1123,10 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
 
                 details.viewer.onEnvironmentChanged.add(() => {
                     this._dispatchCustomEvent("environmentchange", (type) => new Event(type));
+                });
+
+                details.viewer.onEnvironmentConfigurationChanged.add(() => {
+                    this._dispatchCustomEvent("environmentconfigurationchange", (type) => new Event(type));
                 });
 
                 details.viewer.onEnvironmentError.add((error) => {

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -566,7 +566,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     public environmentIntensity: Nullable<number> = null;
 
     /**
-     * A value in degrees that specifies the rotation of the environment.
+     * A value in radians that specifies the rotation of the environment.
      */
     @property({
         type: Number,


### PR DESCRIPTION
Writting down to documentation for the new environment properties, I realise that :
- no event was triggerred by the `ViewerElement` when the environment configuration change
- some comments still mentionning degrees for the enviornment rotation