### PR TITLE
Add missing argument when exporting glTF animation

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -863,7 +863,8 @@ export class GLTFExporter {
                 this._bufferViews,
                 this._accessors,
                 this._animationSampleRate,
-                stateLH.getNodesSet()
+                stateLH.getNodesSet(),
+                this._options.shouldExportAnimation
             );
         }
     }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/the-function-call-is-missing-parameter-shouldexportanimation/55466