### PR TITLE
ShadowGenerator: add doNotSerialize

### DIFF
--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -267,6 +267,12 @@ export class ShadowGenerator implements IShadowGenerator {
      */
     public onAfterShadowMapRenderMeshObservable = new Observable<Mesh>();
 
+    /**
+     * Specifies if the `ShadowGenerator` should be serialized, `true` to skip serialization.
+     * Note a `ShadowGenerator` will not be serialized if its light has `doNotSerialize=true`
+     */
+    public doNotSerialize = false;
+
     protected _bias = 0.00005;
     /**
      * Gets the bias: offset applied on the depth preventing acnea (in light direction).

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -72,6 +72,13 @@ export interface ICustomShaderOptions {
 export interface IShadowGenerator {
     /** Gets or set the id of the shadow generator. It will be the one from the light if not defined */
     id: string;
+
+    /**
+     * Specifies if the `ShadowGenerator` should be serialized, `true` to skip serialization.
+     * Note a `ShadowGenerator` will not be serialized if its light has `doNotSerialize=true`
+     */
+    doNotSerialize?: boolean;
+
     /**
      * Gets the main RTT containing the shadow map (usually storing depth from the light point of view).
      * @returns The render target texture if present otherwise, null

--- a/packages/dev/core/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGeneratorSceneComponent.ts
@@ -71,11 +71,17 @@ export class ShadowGeneratorSceneComponent implements ISceneSerializableComponen
         serializationObject.shadowGenerators = [];
         const lights = this.scene.lights;
         for (const light of lights) {
+            if (light.doNotSerialize) {
+                continue;
+            }
             const shadowGenerators = light.getShadowGenerators();
             if (shadowGenerators) {
                 const iterator = shadowGenerators.values();
                 for (let key = iterator.next(); key.done !== true; key = iterator.next()) {
                     const shadowGenerator = key.value;
+                    if (shadowGenerator.doNotSerialize) {
+                        continue;
+                    }
                     serializationObject.shadowGenerators.push(shadowGenerator.serialize());
                 }
             }


### PR DESCRIPTION
This PR adds doNotSerialize to `ShadowGenerator` and `IShadowGenerator` (optional field for `IShadowGenerator` to avoid being breaking).
Also, in `ShadowGeneratorSceneComponent` serialization of a `ShadowGenerator` would be skipped if it has `doNotSerialize=true`, or its light has `doNotSerialize=true`.
This should fix <https://forum.babylonjs.com/t/shadowgenerators-serialized-without-light/56134>.