### PR TITLE
Sprites: Fixed crash when deleting/creating two sprite managers in succession

### DIFF
--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -297,6 +297,7 @@ export class SpriteRenderer {
         );
 
         this._drawWrapperDepth.effect = this._drawWrapperBase.effect;
+        this._drawWrapperBase.effect._refCount++;
         this._drawWrapperDepth.materialContext = this._drawWrapperBase.materialContext;
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/bug-sprite-not-appearing-after-multiple-clicks-when-recreating-spritemanager/56169