### PR TITLE
Add snapshot URL to tools snapshots and tests

### DIFF
--- a/packages/tools/playground/test/interactions.playground.test.ts
+++ b/packages/tools/playground/test/interactions.playground.test.ts
@@ -3,7 +3,7 @@ import { getGlobalConfig } from "@tools/test-tools";
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
-const url = process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.PLAYGROUND_PORT || ":1338") + snapshot;
+const url = (process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.PLAYGROUND_PORT || ":1338")) + snapshot;
 
 console.log("Running tests on: ", url);
 

--- a/packages/tools/playground/test/interactions.playground.test.ts
+++ b/packages/tools/playground/test/interactions.playground.test.ts
@@ -5,6 +5,8 @@ import { getGlobalConfig } from "@tools/test-tools";
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
 const url = process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.PLAYGROUND_PORT || ":1338") + snapshot;
 
+console.log("Running tests on: ", url);
+
 test("Playground is loaded (Desktop)", async ({ page }) => {
     await page.goto(url, {
         waitUntil: "networkidle",

--- a/packages/tools/playground/test/interactions.playground.test.ts
+++ b/packages/tools/playground/test/interactions.playground.test.ts
@@ -1,7 +1,9 @@
 import { test, expect } from "@playwright/test";
 import { getGlobalConfig } from "@tools/test-tools";
 
-const url = process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.PLAYGROUND_PORT || ":1338");
+// if running in the CI we need to use the babylon snapshot when loading the tools
+const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
+const url = process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.PLAYGROUND_PORT || ":1338") + snapshot;
 
 test("Playground is loaded (Desktop)", async ({ page }) => {
     await page.goto(url, {

--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -7,7 +7,9 @@ test.beforeAll(async () => {
     test.setTimeout(30000);
 });
 
-const url = process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339");
+// if running in the CI we need to use the babylon snapshot when loading the tools
+const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
+const url = process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339") + snapshot;
 
 test("Sandbox is loaded (Desktop)", async ({ page }) => {
     await page.goto(url, {

--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -11,6 +11,8 @@ test.beforeAll(async () => {
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
 const url = process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339") + snapshot;
 
+console.log("Running tests on: ", url);
+
 test("Sandbox is loaded (Desktop)", async ({ page }) => {
     await page.goto(url, {
         waitUntil: "networkidle",

--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -9,7 +9,7 @@ test.beforeAll(async () => {
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
-const url = process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339") + snapshot;
+const url = (process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339")) + snapshot;
 
 console.log("Running tests on: ", url);
 

--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -57,7 +57,7 @@ test("dropping an image to the sandbox", async ({ page }) => {
 });
 
 test("loading a model using query parameters", async ({ page }) => {
-    await page.goto(url + "?assetUrl=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Box/glTF-Binary/Box.glb", {
+    await page.goto(url + snapshot ? "&" : "?" + "assetUrl=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Box/glTF-Binary/Box.glb", {
         waitUntil: "networkidle",
     });
     await page.setViewportSize({
@@ -72,7 +72,7 @@ test("loading a model using query parameters", async ({ page }) => {
 });
 
 test("inspector is opened when clicking on the button", async ({ page }) => {
-    await page.goto(url + "?assetUrl=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Box/glTF-Binary/Box.glb", {
+    await page.goto(url + snapshot ? "&" : "?" + "assetUrl=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/main/2.0/Box/glTF-Binary/Box.glb", {
         waitUntil: "networkidle",
     });
     await page.setViewportSize({

--- a/packages/tools/tests/test/playwright/interaction.tools.test.ts
+++ b/packages/tools/tests/test/playwright/interaction.tools.test.ts
@@ -1,10 +1,12 @@
 import { getGlobalConfig } from "@tools/test-tools";
 import { test, expect } from "@playwright/test";
 
-const nmeUrl = process.env.NME_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NME_PORT || ":1340");
-const ngeUrl = process.env.NGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NGE_PORT || ":1343");
-const guiUrl = process.env.GUIEDITOR_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.GUIEDITOR_PORT || ":1341");
-const nrgeUrl = process.env.NRGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NRGE_PORT || ":1344");
+// if running in the CI we need to use the babylon snapshot when loading the tools
+const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
+const nmeUrl = process.env.NME_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NME_PORT || ":1340") + snapshot;
+const ngeUrl = process.env.NGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NGE_PORT || ":1343") + snapshot;
+const guiUrl = process.env.GUIEDITOR_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.GUIEDITOR_PORT || ":1341") + snapshot;
+const nrgeUrl = process.env.NRGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NRGE_PORT || ":1344") + snapshot;
 
 test.beforeAll(async () => {
     // Set timeout for this hook.

--- a/packages/tools/tests/test/playwright/interaction.tools.test.ts
+++ b/packages/tools/tests/test/playwright/interaction.tools.test.ts
@@ -3,10 +3,10 @@ import { test, expect } from "@playwright/test";
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
-const nmeUrl = process.env.NME_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NME_PORT || ":1340") + snapshot;
-const ngeUrl = process.env.NGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NGE_PORT || ":1343") + snapshot;
-const guiUrl = process.env.GUIEDITOR_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.GUIEDITOR_PORT || ":1341") + snapshot;
-const nrgeUrl = process.env.NRGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NRGE_PORT || ":1344") + snapshot;
+const nmeUrl = (process.env.NME_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NME_PORT || ":1340")) + snapshot;
+const ngeUrl = (process.env.NGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NGE_PORT || ":1343")) + snapshot;
+const guiUrl = (process.env.GUIEDITOR_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.GUIEDITOR_PORT || ":1341")) + snapshot;
+const nrgeUrl = (process.env.NRGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NRGE_PORT || ":1344")) + snapshot;
 
 test.beforeAll(async () => {
     // Set timeout for this hook.


### PR DESCRIPTION
The tests were configured to test changes to the tools, but didn't take into account that it is possible that the core library would change as well. So they were testing using the CDN version of Babylon, instead of the snapshot version.

This changes that.