### PR TITLE
Coloured IBL shadows

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -138,6 +138,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
     private _dummyTexture3d: RawTexture3D;
     private _shadowOpacity: number = 0.8;
     private _enabled: boolean = true;
+    private _coloredShadows: boolean = false;
     private _materialsWithRenderPlugin: Material[] = [];
 
     /**
@@ -172,6 +173,21 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
 
     public set shadowOpacity(value: number) {
         this._shadowOpacity = value;
+        this._setPluginParameters();
+    }
+
+    /**
+     * Render the shadows in color rather than black and white.
+     * This is slightly more expensive than black and white shadows but can be much
+     * more accurate when the strongest lights in the IBL are non-white.
+     */
+    public get coloredShadows(): boolean {
+        return this._coloredShadows;
+    }
+
+    public set coloredShadows(value: boolean) {
+        this._coloredShadows = value;
+        this._voxelTracingPass.coloredShadows = value;
         this._setPluginParameters();
     }
 
@@ -1038,6 +1054,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
         }
 
         plugin.isEnabled = this._enabled;
+        plugin.isColored = this._coloredShadows;
 
         this._materialsWithRenderPlugin.push(material);
     }
@@ -1052,6 +1069,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
                 const plugin = mat.pluginManager.getPlugin<IBLShadowsPluginMaterial>(IBLShadowsPluginMaterial.Name)!;
                 plugin.iblShadowsTexture = this._getAccumulatedTexture().getInternalTexture()!;
                 plugin.shadowOpacity = this.shadowOpacity;
+                plugin.isColored = this._coloredShadows;
             }
         });
     }

--- a/packages/dev/core/src/Shaders/iblShadowAccumulation.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblShadowAccumulation.fragment.fx
@@ -33,17 +33,18 @@ void main(void) {
   vec2 velocityColor = texelFetch(motionSampler, gbufferPixelCoord, 0).xy;
   vec2 prevCoord = vUV + velocityColor;
   vec3 PrevLP = texture(prevPositionSampler, prevCoord).xyz;
-  vec3 PrevShadows = texture(oldAccumulationSampler, prevCoord).xyz;
-  vec2 newShadows = texelFetch(spatialBlurSampler, shadowPixelCoord, 0).xy;
+  vec4 PrevShadows = texture(oldAccumulationSampler, prevCoord);
+  vec3 newShadows = texelFetch(spatialBlurSampler, shadowPixelCoord, 0).xyz;
 
-  PrevShadows.z =
+  PrevShadows.a =
       !reset && all(lessThan(abs(prevCoord - vec2(0.5)), vec2(0.5))) &&
               distance(LP.xyz, PrevLP) < 5e-2 * sceneSize
-          ? max(PrevShadows.z / (1.0 + PrevShadows.z), 1.0 - remanence)
+          ? max(PrevShadows.a / (1.0 + PrevShadows.a), 1.0 - remanence)
           : 1.0;
-  PrevShadows = max(vec3(0.0), PrevShadows);
+  PrevShadows = max(vec4(0.0), PrevShadows);
 
   gl_FragColor =
-      vec4(mix(PrevShadows.x, newShadows.x, PrevShadows.z),
-           mix(PrevShadows.y, newShadows.y, PrevShadows.z), PrevShadows.z, 1.0);
+      vec4(mix(PrevShadows.x, newShadows.x, PrevShadows.a),
+           mix(PrevShadows.y, newShadows.y, PrevShadows.a), 
+           mix(PrevShadows.z, newShadows.z, PrevShadows.a), PrevShadows.a);
 }

--- a/packages/dev/core/src/Shaders/iblShadowSpatialBlur.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblShadowSpatialBlur.fragment.fx
@@ -32,12 +32,12 @@ void main(void)
 
     float depth = -texelFetch(depthSampler, gbufferPixelCoord, 0).x;
 
-    vec3 X = vec3(0.0);
+    vec4 X = vec4(0.0);
     for(int y = 0; y < nbWeights; ++y) {
         for(int x = 0; x < nbWeights; ++x) {
           ivec2 gBufferCoords = gbufferPixelCoord + int(stridef) * ivec2(x - (nbWeights >> 1), y - (nbWeights >> 1));
           ivec2 shadowCoords = shadowPixelCoord + int(stridef) * ivec2(x - (nbWeights >> 1), y - (nbWeights >> 1));
-          vec2 T = texelFetch(voxelTracingSampler, shadowCoords, 0).xy;
+          vec4 T = texelFetch(voxelTracingSampler, shadowCoords, 0);
           float ddepth = -texelFetch(depthSampler, gBufferCoords, 0).x - depth;
           vec3 dN = texelFetch(worldNormalSampler, gBufferCoords, 0).xyz - N;
           float w = weights[x] * weights[y] *
@@ -45,9 +45,9 @@ void main(void)
                              (ddepth * ddepth) -
                          1e1 * dot(dN, dN));
 
-          X += vec3(w * T.x, w * T.y, w);
+          X += vec4(w * T.x, w * T.y, w * T.z, w);
         }
     }
 
-    gl_FragColor = vec4(X.x / X.z, X.y / X.z, 1.0, 1.0);
+    gl_FragColor = vec4(X.x / X.w, X.y / X.w, X.z / X.w, 1.0);
 }

--- a/packages/dev/core/src/Shaders/iblShadowVoxelTracing.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblShadowVoxelTracing.fragment.fx
@@ -407,7 +407,7 @@ void main(void) {
   float specShadowAccum = 0.001;
   float sampleWeight = 0.001;
   #ifdef COLOR_SHADOWS
-    vec3 totalLight = vec3(0.0);
+    vec3 totalLight = vec3(0.001);
     vec3 shadowedLight = vec3(0.0);
   #endif
   for (uint i = 0u; i < nbDirs; i++) {

--- a/packages/dev/core/src/ShadersWGSL/iblShadowAccumulation.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblShadowAccumulation.fragment.fx
@@ -38,13 +38,14 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   var velocityColor: vec2f = textureLoad(motionSampler, gbufferPixelCoord, 0).xy;
   var prevCoord: vec2f = input.vUV + velocityColor;
   var PrevLP: vec3f = textureSampleLevel(prevPositionSampler, prevPositionSamplerSampler, prevCoord, 0.0).xyz;
-  var PrevShadows: vec3f = textureSampleLevel(oldAccumulationSampler, oldAccumulationSamplerSampler, prevCoord, 0.0).xyz;
-  var newShadows : vec2f = textureLoad(spatialBlurSampler, shadowPixelCoord, 0).xy;
+  var PrevShadows: vec4f = textureSampleLevel(oldAccumulationSampler, oldAccumulationSamplerSampler, prevCoord, 0.0);
+  var newShadows : vec3f = textureLoad(spatialBlurSampler, shadowPixelCoord, 0).xyz;
 
-  PrevShadows.z = select(1.0, max(PrevShadows.z / (1.0 + PrevShadows.z), 1.0 - remanence), !reset && all(lessThan(abs(prevCoord -  vec2f(0.5)),  vec2f(0.5))) &&
+  PrevShadows.a = select(1.0, max(PrevShadows.a / (1.0 + PrevShadows.a), 1.0 - remanence), !reset && all(lessThan(abs(prevCoord -  vec2f(0.5)),  vec2f(0.5))) &&
               distance(LP.xyz, PrevLP) < 5e-2 * sceneSize);
-  PrevShadows = max( vec3f(0.0), PrevShadows);
+  PrevShadows = max( vec4f(0.0), PrevShadows);
 
-  fragmentOutputs.color =  vec4f(mix(PrevShadows.x, newShadows.x, PrevShadows.z),
-                                mix(PrevShadows.y, newShadows.y, PrevShadows.z), PrevShadows.z, 1.0);
+  fragmentOutputs.color =  vec4f(mix(PrevShadows.x, newShadows.x, PrevShadows.a),
+                                mix(PrevShadows.y, newShadows.y, PrevShadows.a),
+                                mix(PrevShadows.z, newShadows.z, PrevShadows.a), PrevShadows.a);
 }

--- a/packages/dev/core/src/ShadersWGSL/iblShadowSpatialBlur.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblShadowSpatialBlur.fragment.fx
@@ -32,13 +32,13 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 
     var depth: f32 = -textureLoad(depthSampler, gbufferPixelCoord, 0).x;
 
-    var X: vec3f =  vec3f(0.0);
+    var X: vec4f =  vec4f(0.0);
     for(var y: i32 = 0; y < nbWeights; y++) {
         for(var x: i32 = 0; x < nbWeights; x++) {
             var gBufferCoords: vec2i = gbufferPixelCoord + i32(stridef) * vec2i(x - (nbWeights >> 1), y - (nbWeights >> 1));
             var shadowCoords: vec2i = shadowPixelCoord + i32(stridef) * vec2i(x - (nbWeights >> 1), y - (nbWeights >> 1));
 
-            var T : vec2f = textureLoad(voxelTracingSampler, shadowCoords, 0).xy;
+            var T : vec3f = textureLoad(voxelTracingSampler, shadowCoords, 0).xyz;
             var ddepth: f32 = -textureLoad(depthSampler, gBufferCoords, 0).x - depth;
             var dN: vec3f = textureLoad(worldNormalSampler, gBufferCoords, 0).xyz - N;
             var w: f32 = weights[x] * weights[y] *
@@ -46,9 +46,9 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
                                (ddepth * ddepth) -
                            1e1 * dot(dN, dN));
 
-            X +=  vec3f(w * T.x, w * T.y, w);
+            X +=  vec4f(w * T.x, w * T.y, w * T.z, w);
         }
     }
 
-    fragmentOutputs.color =  vec4f(X.x / X.z, X.y / X.z, 0.0, 1.0);
+    fragmentOutputs.color =  vec4f(X.x / X.w, X.y / X.w, X.z / X.w, 1.0);
 }

--- a/packages/dev/core/src/ShadersWGSL/iblShadowVoxelTracing.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblShadowVoxelTracing.fragment.fx
@@ -434,7 +434,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   var specShadowAccum: f32 = 0.001;
   var sampleWeight : f32 = 0.001;
   #ifdef COLOR_SHADOWS
-  var totalLight: vec3f = vec3f(0.0);
+  var totalLight: vec3f = vec3f(0.001);
   var shadowedLight: vec3f = vec3f(0.0);
   #endif
   for (var i: u32 = 0; i < nbDirs; i++) {

--- a/packages/dev/core/src/ShadersWGSL/iblShadowVoxelTracing.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblShadowVoxelTracing.fragment.fx
@@ -11,6 +11,10 @@ var icdfSamplerSampler: sampler;
 var icdfSampler: texture_2d<f32>;
 var voxelGridSamplerSampler: sampler;
 var voxelGridSampler: texture_3d<f32>;
+#ifdef COLOR_SHADOWS
+var iblSamplerSampler: sampler;
+var iblSampler: texture_cube<f32>;
+#endif
 
 // shadow parameters: var nbDirs: i32, var frameId: i32, unused, var envRot: f32
 uniform shadowParameters: vec4f;
@@ -418,9 +422,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   VP /= VP.w;
 
   N = normalize(N);
-  var noise
-      : vec3f =
-            textureLoad(blueNoiseSampler, currentPixel & vec2i(0xFF), 0).xyz;
+  var noise : vec3f = textureLoad(blueNoiseSampler, currentPixel & vec2i(0xFF), 0).xyz;
   noise.z = fract(noise.z + goldenSequence(frameId * nbDirs));
 
 #ifdef VOXEL_MARCH_DIAGNOSTIC_INFO_OPTION
@@ -431,21 +433,29 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   var shadowAccum: f32 = 0.001;
   var specShadowAccum: f32 = 0.001;
   var sampleWeight : f32 = 0.001;
+  #ifdef COLOR_SHADOWS
+  var totalLight: vec3f = vec3f(0.0);
+  var shadowedLight: vec3f = vec3f(0.0);
+  #endif
   for (var i: u32 = 0; i < nbDirs; i++) {
     var dirId: u32 = nbDirs * GlobalIndex + i;
     var L: vec4f;
+    var T: vec2f;
     {
       var r: vec2f = plasticSequence(frameId * nbDirs + i);
       r = fract(r +  vec2f(2.0) * abs(noise.xy -  vec2f(0.5)));
-      var T: vec2f;
       T.x = textureSampleLevel(icdfSampler, icdfSamplerSampler, vec2f(r.x, 0.0), 0.0).x;
       T.y = textureSampleLevel(icdfSampler, icdfSamplerSampler, vec2f(T.x, r.y), 0.0).y;
-      T.x -= normalizedRotation;
-      L =  vec4f(uv_to_normal(T), 0);
+      L =  vec4f(uv_to_normal(vec2f(T.x - normalizedRotation, T.y)), 0);
 #ifndef RIGHT_HANDED
       L.z *= -1.0;
 #endif
     }
+    #ifdef COLOR_SHADOWS
+      var lightDir: vec3f = uv_to_normal(vec2f(1.0 - fract(T.x + 0.25), T.y));
+      var ibl: vec3f = textureSampleLevel(iblSampler, iblSamplerSampler, lightDir, 0.0).xyz;
+      var pdf: f32 = textureSampleLevel(icdfSampler, icdfSamplerSampler, T, 0.0).z;
+    #endif
     var cosNL: f32 = dot(N, L.xyz);
     var opacity: f32 = 0.0;
 
@@ -456,8 +466,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
       // rte world-space normalization
       var unormWP : vec4f = uniforms.invViewMtx * VP2;
       var WP: vec3f = (uniforms.wsNormalizationMtx * unormWP).xyz;
-      var vxNoise: vec2f =
-           vec2f(uint2float(hash(dirId * 2)), uint2float(hash(dirId * 2 + 1)));
+      var vxNoise: vec2f = vec2f(uint2float(hash(dirId * 2)), uint2float(hash(dirId * 2 + 1)));
 #ifdef VOXEL_MARCH_DIAGNOSTIC_INFO_OPTION
       VoxelMarchDiagnosticInfo voxel_march_diagnostic_info;
       opacity = max(opacity,
@@ -483,19 +492,33 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
                        screenSpaceShadow(VP2.xyz, VL, Resolution, nearPlaneZ, farPlaneZ,
                                          abs(2.0 * noise.z - 1.0));
       opacity = max(opacity, ssShadow);
-      var rcos: f32 = 1.0 - cosNL;
-      shadowAccum += (1.0 - opacity * (1.0 - pow(rcos, 8.0)));
-      sampleWeight += 1.0;
-      // spec shadow
-      var VR : vec3f = abs((uniforms.viewMtx * vec4f(reflect(-L.xyz, N), 0.0)).xyz);
-      specShadowAccum += max(1.0 - (opacity * pow(VR.z, 8.0)), 0.0);
+      #ifdef COLOR_SHADOWS
+        // total IBL shadowed light from samples
+        var light: vec3f = select(vec3f(0.0), vec3f(cosNL) / vec3f(pdf) * ibl, pdf > 1e-6);
+        shadowedLight += light*opacity;
+        totalLight += light;
+      #else
+        var rcos: f32 = 1.0 - cosNL;
+        shadowAccum += (1.0 - opacity * (1.0 - pow(rcos, 8.0)));
+        sampleWeight += 1.0;
+        // spec shadow
+        var VR : vec3f = abs((uniforms.viewMtx * vec4f(reflect(-L.xyz, N), 0.0)).xyz);
+        specShadowAccum += max(1.0 - (opacity * pow(VR.z, 8.0)), 0.0);
+      #endif
     }
     noise.z = fract(noise.z + GOLD);
   }
-#ifdef VOXEL_MARCH_DIAGNOSTIC_INFO_OPTION
-  fragmentOutputs.color =
-      vec4f(shadowAccum / sampleWeight, specShadowAccum / sampleWeight, heat / sampleWeight, 1.0);
-#else
-  fragmentOutputs.color = vec4f(shadowAccum / sampleWeight, specShadowAccum / sampleWeight, 0.0, 1.0);
+  #ifdef COLOR_SHADOWS
+    // total IBL colour from samples
+    var shadow: vec3f = (totalLight - shadowedLight) / totalLight;
+    var maxShadow: f32 = max(max(shadow.x, max(shadow.y, shadow.z)), 1.0);
+    fragmentOutputs.color = vec4f(shadow/maxShadow, 1.0);
+  #else
+    #ifdef VOXEL_MARCH_DIAGNOSTIC_INFO_OPTION
+      fragmentOutputs.color =
+          vec4f(shadowAccum / sampleWeight, specShadowAccum / sampleWeight, heat / sampleWeight, 1.0);
+    #else
+      fragmentOutputs.color = vec4f(shadowAccum / sampleWeight, specShadowAccum / sampleWeight, 0.0, 1.0);
+    #endif
 #endif
 }


### PR DESCRIPTION
This PR adds a toggle to the IBL Render Pipeline to enable coloured shadow rendering. It requires more texture samples during voxel tracing but produces more accurate results. Defaults to off.
![1](https://github.com/user-attachments/assets/425b3f1f-6282-402a-bd24-f40cf778229c)
![B W2](https://github.com/user-attachments/assets/68d9349a-04ce-4fcb-9842-e0567af72378)

https://playground.babylonjs.com/#8R5SSE#497