### PR TITLE
Node Editors: Fix wrong properties displayed in node editors

### DIFF
--- a/packages/dev/core/src/Decorators/nodeDecorator.ts
+++ b/packages/dev/core/src/Decorators/nodeDecorator.ts
@@ -108,7 +108,7 @@ export function editableInPropertyPage(
             type: propertyType,
             groupName: groupName,
             options: options ?? {},
-            className: target.constructor.name,
+            className: target.getClassName(),
         });
     };
 }

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/basePostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/basePostProcessBlock.ts
@@ -53,6 +53,14 @@ export class NodeRenderGraphBasePostProcessBlock extends NodeRenderGraphBlock {
     }
 
     /**
+     * Gets the current class name
+     * @returns the class name
+     */
+    public override getClassName() {
+        return "NodeRenderGraphBasePostProcessBlock";
+    }
+
+    /**
      * Gets the source input component
      */
     public get source(): NodeRenderGraphConnectionPoint {

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseObjectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseObjectRendererBlock.ts
@@ -87,6 +87,16 @@ export class NodeRenderGraphBaseObjectRendererBlock extends NodeRenderGraphBlock
         this._frameGraphTask.depthWrite = value;
     }
 
+    /** Indicates if shadows must be enabled or disabled */
+    @editableInPropertyPage("Disable shadows", PropertyTypeForEdition.Boolean, "PROPERTIES")
+    public get disableShadows() {
+        return this._frameGraphTask.disableShadows;
+    }
+
+    public set disableShadows(value: boolean) {
+        this._frameGraphTask.disableShadows = value;
+    }
+
     /**
      * Gets the current class name
      * @returns the class name
@@ -191,6 +201,7 @@ export class NodeRenderGraphBaseObjectRendererBlock extends NodeRenderGraphBlock
         const codes: string[] = [];
         codes.push(`${this._codeVariableName}.depthTest = ${this.depthTest};`);
         codes.push(`${this._codeVariableName}.depthWrite = ${this.depthWrite};`);
+        codes.push(`${this._codeVariableName}.disableShadows = ${this.disableShadows};`);
         return super._dumpPropertiesCode() + codes.join("\n");
     }
 
@@ -198,6 +209,7 @@ export class NodeRenderGraphBaseObjectRendererBlock extends NodeRenderGraphBlock
         const serializationObject = super.serialize();
         serializationObject.depthTest = this.depthTest;
         serializationObject.depthWrite = this.depthWrite;
+        serializationObject.disableShadows = this.disableShadows;
         return serializationObject;
     }
 
@@ -205,5 +217,6 @@ export class NodeRenderGraphBaseObjectRendererBlock extends NodeRenderGraphBlock
         super._deserialize(serializationObject);
         this.depthTest = serializationObject.depthTest;
         this.depthWrite = serializationObject.depthWrite;
+        this.disableShadows = serializationObject.disableShadows;
     }
 }

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/objectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/objectRendererBlock.ts
@@ -36,16 +36,6 @@ export class NodeRenderGraphObjectRendererBlock extends NodeRenderGraphBaseObjec
         this._additionalConstructionParameters = [value];
     }
 
-    /** Indicates if shadows must be enabled or disabled */
-    @editableInPropertyPage("Disable shadows", PropertyTypeForEdition.Boolean, "PROPERTIES")
-    public get disableShadows() {
-        return this._frameGraphTask.disableShadows;
-    }
-
-    public set disableShadows(value: boolean) {
-        this._frameGraphTask.disableShadows = value;
-    }
-
     /**
      * Gets the current class name
      * @returns the class name
@@ -57,21 +47,18 @@ export class NodeRenderGraphObjectRendererBlock extends NodeRenderGraphBaseObjec
     protected override _dumpPropertiesCode() {
         const codes: string[] = [];
         codes.push(`${this._codeVariableName}.doNotChangeAspectRatio = ${this.doNotChangeAspectRatio};`);
-        codes.push(`${this._codeVariableName}.disableShadows = ${this.disableShadows};`);
         return super._dumpPropertiesCode() + codes.join("\n");
     }
 
     public override serialize(): any {
         const serializationObject = super.serialize();
         serializationObject.doNotChangeAspectRatio = this.doNotChangeAspectRatio;
-        serializationObject.disableShadows = this.disableShadows;
         return serializationObject;
     }
 
     public override _deserialize(serializationObject: any) {
         super._deserialize(serializationObject);
         this.doNotChangeAspectRatio = serializationObject.doNotChangeAspectRatio;
-        this.disableShadows = serializationObject.disableShadows;
     }
 }
 

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/taaObjectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/taaObjectRendererBlock.ts
@@ -95,6 +95,7 @@ export class NodeRenderGraphTAAObjectRendererBlock extends NodeRenderGraphBaseOb
 
     protected override _dumpPropertiesCode() {
         const codes: string[] = [];
+        codes.push(`${this._codeVariableName}.doNotChangeAspectRatio = ${this.doNotChangeAspectRatio};`);
         codes.push(`${this._codeVariableName}.samples = ${this.samples};`);
         codes.push(`${this._codeVariableName}.factor = ${this.factor};`);
         codes.push(`${this._codeVariableName}.disableOnCameraMove = ${this.disableOnCameraMove};`);
@@ -104,6 +105,7 @@ export class NodeRenderGraphTAAObjectRendererBlock extends NodeRenderGraphBaseOb
 
     public override serialize(): any {
         const serializationObject = super.serialize();
+        serializationObject.doNotChangeAspectRatio = this.doNotChangeAspectRatio;
         serializationObject.samples = this.samples;
         serializationObject.factor = this.factor;
         serializationObject.disableOnCameraMove = this.disableOnCameraMove;
@@ -113,6 +115,7 @@ export class NodeRenderGraphTAAObjectRendererBlock extends NodeRenderGraphBaseOb
 
     public override _deserialize(serializationObject: any) {
         super._deserialize(serializationObject);
+        this.doNotChangeAspectRatio = serializationObject.doNotChangeAspectRatio;
         this.samples = serializationObject.samples;
         this.factor = serializationObject.factor;
         this.disableOnCameraMove = serializationObject.disableOnCameraMove;

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -712,8 +712,8 @@ export class GraphNode {
             const classes: string[] = [];
 
             let proto = Object.getPrototypeOf(source);
-            while (proto) {
-                classes.push(proto.constructor.name);
+            while (proto && proto.getClassName) {
+                classes.push(proto.getClassName());
                 proto = Object.getPrototypeOf(proto);
             }
 

--- a/packages/tools/nodeEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -113,8 +113,8 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         const classes: string[] = [];
 
         let proto = Object.getPrototypeOf(block);
-        while (proto) {
-            classes.push(proto.constructor.name);
+        while (proto && proto.getClassName) {
+            classes.push(proto.getClassName());
             proto = Object.getPrototypeOf(proto);
         }
 

--- a/packages/tools/nodeGeometryEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeGeometryEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -158,8 +158,8 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         const classes: string[] = [];
 
         let proto = Object.getPrototypeOf(block);
-        while (proto) {
-            classes.push(proto.constructor.name);
+        while (proto && proto.getClassName) {
+            classes.push(proto.getClassName());
             proto = Object.getPrototypeOf(proto);
         }
 

--- a/packages/tools/nodeRenderGraphEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeRenderGraphEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -141,8 +141,8 @@ export class GenericPropertyTabComponent extends React.Component<IPropertyCompon
         const classes: string[] = [];
 
         let proto = Object.getPrototypeOf(block);
-        while (proto) {
-            classes.push(proto.constructor.name);
+        while (proto && proto.getClassName) {
+            classes.push(proto.getClassName());
             proto = Object.getPrototypeOf(proto);
         }
 


### PR DESCRIPTION
`instance.constructor.name` doesn't work with minified packages, so I used `instance.constructor.getClassName()` instead, as all the classes involved implement a `getClassName` method.