### PR TITLE
GS Creation options

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -31,6 +31,7 @@ interface DelayedTextureUpdate {
 interface CreationOptions {
     useWebWorker: boolean;
 }
+
 // @internal
 const unpackUnorm = (value: number, bits: number) => {
     const t = (1 << bits) - 1;
@@ -393,6 +394,7 @@ export class GaussianSplattingMesh extends Mesh {
      * @param url defines the url to load from (optional)
      * @param scene defines the hosting scene (optional)
      * @param keepInRam keep datas in ram for editing purpose
+     * @param options creation options
      */
     constructor(name: string, url: Nullable<string> = null, scene: Nullable<Scene> = null, keepInRam: boolean = false, options: CreationOptions = { useWebWorker: true }) {
         super(name, scene);
@@ -1240,8 +1242,10 @@ export class GaussianSplattingMesh extends Mesh {
         this._colorsTexture = null;
         this._shTextures = null;
 
-        this._worker?.terminate();
-        this._worker = null;
+        if (this._worker) {
+            this._worker.terminate();
+            this._worker = null;
+        }
 
         super.dispose(doNotRecurse, true);
     }

--- a/packages/dev/core/src/Shaders/ShadersInclude/gaussianSplatting.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/gaussianSplatting.fx
@@ -209,7 +209,7 @@ vec4 gaussianSplatting(vec2 meshPos, vec3 worldPos, vec2 scale, vec3 covA, vec3 
 
     float mid = (cov2d[0][0] + cov2d[1][1]) / 2.0;
     float radius = length(vec2((cov2d[0][0] - cov2d[1][1]) / 2.0, cov2d[0][1]));
-    float lambda1 = mid + radius, lambda2 = mid - radius;
+    float lambda1 = mid + radius + 0.001, lambda2 = mid - radius + 0.001;
 
     if (lambda2 < 0.0)
     {


### PR DESCRIPTION
Creation options to bypass webworker usage and favor direct sorting instead.
This is mostly used for runtime creation/update of dynamic GS. Not usefull for classic static GS.