### PR TITLE
Now the Model type is usable by class that extends Viewer

### DIFF
--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -2,7 +2,7 @@ export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, PostProcess
 export type { CanvasViewerOptions } from "./viewerFactory";
 export type { HotSpot } from "./viewerElement";
 
-export { Viewer, ViewerHotSpotResult } from "./viewer";
+export { Viewer, ViewerHotSpotResult, Model } from "./viewer";
 export { HTML3DElement, ViewerElement } from "./viewerElement";
 export { createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";


### PR DESCRIPTION
**Before**
If you extend `Viewer` and call `_loadModel` you cannot use the type `Model` anywhere in the extended class. 

**Now**
You can use the type `Model`