### PR TITLE
Added Area Light support for more materials and NME

### DIFF
--- a/packages/dev/core/src/Lights/rectAreaLight.ts
+++ b/packages/dev/core/src/Lights/rectAreaLight.ts
@@ -133,7 +133,11 @@ export class RectAreaLight extends AreaLight {
     }
 
     public transferToNodeMaterialEffect(effect: Effect, lightDataUniformName: string) {
-        // TO DO: Implement this to add support for NME.
+        if (this._computeTransformedInformation()) {
+            effect.setFloat3(lightDataUniformName, this._pointTransformedPosition.x, this._pointTransformedPosition.y, this._pointTransformedPosition.z);
+        } else {
+            effect.setFloat3(lightDataUniformName, this.position.x, this.position.y, this.position.z);
+        }
         return this;
     }
 }

--- a/packages/dev/core/src/Lights/rectAreaLight.ts
+++ b/packages/dev/core/src/Lights/rectAreaLight.ts
@@ -114,7 +114,14 @@ export class RectAreaLight extends AreaLight {
      */
     public transferToEffect(effect: Effect, lightIndex: string): RectAreaLight {
         if (this._computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4("vLightData", this._pointTransformedPosition.x, this._pointTransformedPosition.y, this._pointTransformedPosition.z, 0, lightIndex);
+            this._uniformBuffer.updateFloat4(
+                "vLightData",
+                this._pointTransformedPosition.x,
+                this._pointTransformedPosition.y,
+                this._pointTransformedPosition.z,
+                this.intensity,
+                lightIndex
+            );
             this._uniformBuffer.updateFloat4("vLightWidth", this._pointTransformedWidth.x / 2, this._pointTransformedWidth.y / 2, this._pointTransformedWidth.z / 2, 0, lightIndex);
             this._uniformBuffer.updateFloat4(
                 "vLightHeight",
@@ -125,7 +132,7 @@ export class RectAreaLight extends AreaLight {
                 lightIndex
             );
         } else {
-            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, 0.0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.intensity, lightIndex);
             this._uniformBuffer.updateFloat4("vLightWidth", this._width.x / 2, this._width.y / 2, this._width.z / 2, 0.0, lightIndex);
             this._uniformBuffer.updateFloat4("vLightHeight", this._height.x / 2, this._height.y / 2, this._height.z / 2, 0.0, lightIndex);
         }

--- a/packages/dev/core/src/Lights/rectAreaLight.ts
+++ b/packages/dev/core/src/Lights/rectAreaLight.ts
@@ -114,14 +114,7 @@ export class RectAreaLight extends AreaLight {
      */
     public transferToEffect(effect: Effect, lightIndex: string): RectAreaLight {
         if (this._computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4(
-                "vLightData",
-                this._pointTransformedPosition.x,
-                this._pointTransformedPosition.y,
-                this._pointTransformedPosition.z,
-                this.intensity,
-                lightIndex
-            );
+            this._uniformBuffer.updateFloat4("vLightData", this._pointTransformedPosition.x, this._pointTransformedPosition.y, this._pointTransformedPosition.z, 0, lightIndex);
             this._uniformBuffer.updateFloat4("vLightWidth", this._pointTransformedWidth.x / 2, this._pointTransformedWidth.y / 2, this._pointTransformedWidth.z / 2, 0, lightIndex);
             this._uniformBuffer.updateFloat4(
                 "vLightHeight",
@@ -132,7 +125,7 @@ export class RectAreaLight extends AreaLight {
                 lightIndex
             );
         } else {
-            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.intensity, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, 0, lightIndex);
             this._uniformBuffer.updateFloat4("vLightWidth", this._width.x / 2, this._width.y / 2, this._width.z / 2, 0.0, lightIndex);
             this._uniformBuffer.updateFloat4("vLightHeight", this._height.x / 2, this._height.y / 2, this._height.z / 2, 0.0, lightIndex);
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -237,6 +237,8 @@ export class LightBlock extends NodeMaterialBlock {
     }
 
     public override updateUniformsAndSamples(state: NodeMaterialBuildState, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines, uniformBuffers: string[]) {
+        state.samplers.push("areaLightsLTC1Sampler");
+        state.samplers.push("areaLightsLTC2Sampler");
         for (let lightIndex = 0; lightIndex < nodeMaterial.maxSimultaneousLights; lightIndex++) {
             if (!defines["LIGHT" + lightIndex]) {
                 break;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -212,6 +212,10 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     /** Camera is perspective */
     public CAMERA_PERSPECTIVE = false;
 
+    public AREALIGHTSUPPORTED = true;
+
+    public AREALIGHTNOROUGHTNESS = true;
+
     /**
      * Creates a new NodeMaterialDefines
      */
@@ -1757,6 +1761,15 @@ export class NodeMaterial extends PushMaterial {
                 } else {
                     scene.resetCachedMaterial();
                     subMesh.setEffect(effect, defines, this._materialContext);
+                }
+            }
+        }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
                 }
             }
         }

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -163,7 +163,7 @@
             #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
                 info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
-                    1.0
+                    0.5
                 #else
                     vReflectionInfos.y
                 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -163,7 +163,7 @@
             #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
                 info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
-                    0.5
+                    1.0
                 #else
                     vReflectionInfos.y
                 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -161,11 +161,13 @@
             #elif defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
             #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+                info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0, light{X}.vLightData.a);
+                    0.5
                 #else
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, vReflectionInfos.y, light{X}.vLightData.a);
+                    vReflectionInfos.y
                 #endif
+                );
             #endif
         #endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -161,7 +161,11 @@
             #elif defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
             #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
-                info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, vReflectionInfos.y);
+                #ifdef AREALIGHTNOROUGHTNESS
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0);
+                #else
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, vReflectionInfos.y);
+                #endif
             #endif
         #endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -162,9 +162,9 @@
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
             #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
                 #ifdef AREALIGHTNOROUGHTNESS
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0);
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0, light{X}.vLightData.a);
                 #else
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, vReflectionInfos.y);
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, vReflectionInfos.y, light{X}.vLightData.a);
                 #endif
             #endif
         #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -162,6 +162,7 @@ vec3 computeProjectionTextureDiffuseLighting(sampler2D projectionLightSampler, m
 uniform sampler2D areaLightsLTC1Sampler;
 uniform sampler2D areaLightsLTC2Sampler;
 
+#define inline
 lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirectionW, vec3 vNormal, vec3 vPosition, vec3 lightPosition, vec3 halfWidth, vec3 halfHeight, vec3 diffuseColor, vec3 specularColor, float roughness) 
 {
 	lightingInfo result;

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -162,7 +162,7 @@ vec3 computeProjectionTextureDiffuseLighting(sampler2D projectionLightSampler, m
 uniform sampler2D areaLightsLTC1Sampler;
 uniform sampler2D areaLightsLTC2Sampler;
 
-lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirectionW, vec3 vNormal, vec3 vPosition, vec3 lightPosition, vec3 halfWidth, vec3 halfHeight, vec3 diffuseColor, vec3 specularColor, float roughness, float intensity) 
+lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirectionW, vec3 vNormal, vec3 vPosition, vec3 lightPosition, vec3 halfWidth, vec3 halfHeight, vec3 diffuseColor, vec3 specularColor, float roughness) 
 {
 	lightingInfo result;
 	areaLightData data = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc2, viewDirectionW, vNormal, vPosition, lightPosition, halfWidth, halfHeight, roughness);
@@ -172,7 +172,7 @@ lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirect
 	result.specular += specularColor * fresnel * data.Specular;
 #endif
 	
-	result.diffuse += diffuseColor * data.Diffuse * intensity;
+	result.diffuse += diffuseColor * data.Diffuse;
 	return result;
 }
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -162,17 +162,17 @@ vec3 computeProjectionTextureDiffuseLighting(sampler2D projectionLightSampler, m
 uniform sampler2D areaLightsLTC1Sampler;
 uniform sampler2D areaLightsLTC2Sampler;
 
-lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirectionW, vec3 vNormal, vec3 vPosition, vec4 lightData, vec3 halfWidth, vec3 halfHeight, vec3 diffuseColor, vec3 specularColor, float roughness ) 
+lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirectionW, vec3 vNormal, vec3 vPosition, vec3 lightPosition, vec3 halfWidth, vec3 halfHeight, vec3 diffuseColor, vec3 specularColor, float roughness, float intensity) 
 {
 	lightingInfo result;
-	areaLightData data = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc2, viewDirectionW, vNormal, vPosition, lightData.xyz, halfWidth, halfHeight, roughness);
+	areaLightData data = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc2, viewDirectionW, vNormal, vPosition, lightPosition, halfWidth, halfHeight, roughness);
 
 #ifdef SPECULARTERM
 	vec3 fresnel = ( specularColor * data.Fresnel.x + ( vec3( 1.0 ) - specularColor ) * data.Fresnel.y );
 	result.specular += specularColor * fresnel * data.Specular;
 #endif
 	
-	result.diffuse += diffuseColor * data.Diffuse;
+	result.diffuse += diffuseColor * data.Diffuse * intensity;
 	return result;
 }
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/ltcHelperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/ltcHelperFunctions.fx
@@ -111,6 +111,7 @@ areaLightData computeAreaLightSpecularDiffuseFresnel(const in sampler2D ltc1, co
 	rectCoords[ 2 ] = lightPos - halfWidth + halfHeight;
 	rectCoords[ 3 ] = lightPos + halfWidth + halfHeight;
 
+#ifdef SPECULARTERM
 	vec2 uv = LTCUv( normal, viewDir, roughness );
 
 	vec4 t1 = texture2D( ltc1, uv );
@@ -125,7 +126,6 @@ areaLightData computeAreaLightSpecularDiffuseFresnel(const in sampler2D ltc1, co
 		vec3( t1.z, 0, t1.w )
 	);
 
-#ifdef SPECULARTERM
 	result.Specular = LTCEvaluate( normal, viewDir, position, mInv, rectCoords );
 	result.Fresnel = t2;
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/ltcHelperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/ltcHelperFunctions.fx
@@ -102,6 +102,7 @@ struct areaLightData
 	vec4 Fresnel;
 };
 
+#define inline
 areaLightData computeAreaLightSpecularDiffuseFresnel(const in sampler2D ltc1, const in sampler2D ltc2, const in vec3 viewDir, const in vec3 normal, const in vec3 position, const in vec3 lightPos, const in vec3 halfWidth, const in vec3 halfHeight, const in float roughness) 
 {
 	areaLightData result;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -161,11 +161,13 @@
             #elif defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
             #elif define(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0, light{X}.vLightData.a);
+                    0.5
                 #else
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, uniforms.vReflectionInfos.y, light{X}.vLightData.a);
+                    uniforms.vReflectionInfos.y
                 #endif
+                    );
             #endif
         #endif
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -163,7 +163,7 @@
             #elif define(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
                     info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
-                    0.5
+                    1.0
                 #else
                     uniforms.vReflectionInfos.y
                 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -162,9 +162,9 @@
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
             #elif define(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
                 #ifdef AREALIGHTNOROUGHTNESS
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0);
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0, light{X}.vLightData.a);
                 #else
-                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, uniforms.vReflectionInfos.y);
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, uniforms.vReflectionInfos.y, light{X}.vLightData.a);
                 #endif
             #endif
         #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -163,7 +163,7 @@
             #elif define(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
                     info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
-                    1.0
+                    0.5
                 #else
                     uniforms.vReflectionInfos.y
                 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -161,7 +161,11 @@
             #elif defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
             #elif define(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
-                info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, uniforms.vReflectionInfos.y);
+                #ifdef AREALIGHTNOROUGHTNESS
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0);
+                #else
+                    info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, uniforms.vReflectionInfos.y);
+                #endif
             #endif
         #endif
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
@@ -165,15 +165,15 @@ var areaLightsLTC1Sampler: texture_2d<f32>;
 var areaLightsLTC2SamplerSampler: sampler;
 var areaLightsLTC2Sampler: texture_2d<f32>;
 
-fn computeAreaLighting(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_2d<f32>, ltc2Sampler:sampler, viewDirectionW: vec3f, vNormal:vec3f, vPosition:vec3f, lightData:vec4f, halfWidth:vec3f,  halfHeight:vec3f, diffuseColor:vec3f, specularColor:vec3f, roughness:f32 ) -> lightingInfo
+fn computeAreaLighting(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_2d<f32>, ltc2Sampler:sampler, viewDirectionW: vec3f, vNormal:vec3f, vPosition:vec3f, lightPosition:vec3f, halfWidth:vec3f,  halfHeight:vec3f, diffuseColor:vec3f, specularColor:vec3f, roughness:f32, intensity:f32 ) -> lightingInfo
 {
 	var result: lightingInfo;
-	var data: areaLightData = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc1Sampler, ltc2, ltc2Sampler, viewDirectionW, vNormal, vPosition, lightData.xyz, halfWidth, halfHeight, roughness);
+	var data: areaLightData = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc1Sampler, ltc2, ltc2Sampler, viewDirectionW, vNormal, vPosition, lightData, halfWidth, halfHeight, roughness);
 #ifdef SPECULARTERM
 	var fresnel:vec3f = ( specularColor * data.Fresnel.x + ( vec3f( 1.0 ) - specularColor ) * data.Fresnel.y );
 	result.specular += specularColor * fresnel * data.Specular;
 #endif
-	result.diffuse += diffuseColor * data.Diffuse;
+	result.diffuse += diffuseColor * data.Diffuse * intensity;
 	return result;
 }
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
@@ -165,7 +165,7 @@ var areaLightsLTC1Sampler: texture_2d<f32>;
 var areaLightsLTC2SamplerSampler: sampler;
 var areaLightsLTC2Sampler: texture_2d<f32>;
 
-fn computeAreaLighting(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_2d<f32>, ltc2Sampler:sampler, viewDirectionW: vec3f, vNormal:vec3f, vPosition:vec3f, lightPosition:vec3f, halfWidth:vec3f,  halfHeight:vec3f, diffuseColor:vec3f, specularColor:vec3f, roughness:f32, intensity:f32 ) -> lightingInfo
+fn computeAreaLighting(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_2d<f32>, ltc2Sampler:sampler, viewDirectionW: vec3f, vNormal:vec3f, vPosition:vec3f, lightPosition:vec3f, halfWidth:vec3f,  halfHeight:vec3f, diffuseColor:vec3f, specularColor:vec3f, roughness:f32 ) -> lightingInfo
 {
 	var result: lightingInfo;
 	var data: areaLightData = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc1Sampler, ltc2, ltc2Sampler, viewDirectionW, vNormal, vPosition, lightData, halfWidth, halfHeight, roughness);
@@ -173,7 +173,7 @@ fn computeAreaLighting(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_
 	var fresnel:vec3f = ( specularColor * data.Fresnel.x + ( vec3f( 1.0 ) - specularColor ) * data.Fresnel.y );
 	result.specular += specularColor * fresnel * data.Specular;
 #endif
-	result.diffuse += diffuseColor * data.Diffuse * intensity;
+	result.diffuse += diffuseColor * data.Diffuse;
 	return result;
 }
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
@@ -168,7 +168,7 @@ var areaLightsLTC2Sampler: texture_2d<f32>;
 fn computeAreaLighting(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_2d<f32>, ltc2Sampler:sampler, viewDirectionW: vec3f, vNormal:vec3f, vPosition:vec3f, lightPosition:vec3f, halfWidth:vec3f,  halfHeight:vec3f, diffuseColor:vec3f, specularColor:vec3f, roughness:f32 ) -> lightingInfo
 {
 	var result: lightingInfo;
-	var data: areaLightData = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc1Sampler, ltc2, ltc2Sampler, viewDirectionW, vNormal, vPosition, lightData, halfWidth, halfHeight, roughness);
+	var data: areaLightData = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc1Sampler, ltc2, ltc2Sampler, viewDirectionW, vNormal, vPosition, lightPosition, halfWidth, halfHeight, roughness);
 #ifdef SPECULARTERM
 	var fresnel:vec3f = ( specularColor * data.Fresnel.x + ( vec3f( 1.0 ) - specularColor ) * data.Fresnel.y );
 	result.specular += specularColor * fresnel * data.Specular;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/ltcHelperFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/ltcHelperFunctions.fx
@@ -109,7 +109,8 @@ fn computeAreaLightSpecularDiffuseFresnel(ltc1: texture_2d<f32>, ltc1Sampler:sam
 	var rectCoords1:vec3f = lightPos - halfWidth - halfHeight;
 	var rectCoords2:vec3f = lightPos - halfWidth + halfHeight;
 	var rectCoords3:vec3f = lightPos + halfWidth + halfHeight;
-
+	
+#ifdef SPECULARTERM
 	var uv:vec2f = LTCUv( normal, viewDir, roughness );
 
 	var t1:vec4f = textureSample( ltc1, ltc1Sampler, uv );
@@ -121,7 +122,6 @@ fn computeAreaLightSpecularDiffuseFresnel(ltc1: texture_2d<f32>, ltc1Sampler:sam
 		vec3f( t1.z, 0, t1.w )
 	);
 
-#ifdef SPECULARTERM
 	// LTC Fresnel Approximation by Stephen Hill
 	// http://blog.selfshadow.com/publications/s2016-advances/s2016_ltc_fresnel.pdf
 	result.Fresnel = t2;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/lights/rectAreaLightPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/lights/rectAreaLightPropertyGridComponent.tsx
@@ -70,6 +70,13 @@ export class RectAreaLightPropertyGridComponent extends React.Component<IRectAre
                         propertyName="height"
                         onPropertyChangedObservable={this.props.onPropertyChangedObservable}
                     />
+                    <FloatLineComponent
+                        lockObject={this.props.lockObject}
+                        label="Intensity"
+                        target={light}
+                        propertyName="intensity"
+                        onPropertyChangedObservable={this.props.onPropertyChangedObservable}
+                    />
                 </LineContainerComponent>
                 <CommonLightPropertyGridComponent
                     globalState={this.props.globalState}

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -254,9 +254,6 @@ export class CellMaterial extends PushMaterial {
                 this._materialContext
             );
         }
-        if (!subMesh.effect || !subMesh.effect.isReady()) {
-            return false;
-        }
 
         // Check if Area Lights have LTC texture.
         if (defines["AREALIGHTUSED"]) {
@@ -265,6 +262,10 @@ export class CellMaterial extends PushMaterial {
                     return false;
                 }
             }
+        }
+
+        if (!subMesh.effect || !subMesh.effect.isReady()) {
+            return false;
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -63,6 +63,8 @@ class CellMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -221,7 +223,7 @@ export class CellMaterial extends PushMaterial {
                 "diffuseMatrix",
                 "logarithmicDepthConstant",
             ];
-            const samplers = ["diffuseSampler"];
+            const samplers = ["diffuseSampler", "areaLightsLTC1Sampler", "areaLightsLTC2Sampler"];
             const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
@@ -254,6 +256,15 @@ export class CellMaterial extends PushMaterial {
         }
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
+        }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -343,9 +343,6 @@ export class FurMaterial extends PushMaterial {
                 this._materialContext
             );
         }
-        if (!subMesh.effect || !subMesh.effect.isReady()) {
-            return false;
-        }
 
         // Check if Area Lights have LTC texture.
         if (defines["AREALIGHTUSED"]) {
@@ -354,6 +351,10 @@ export class FurMaterial extends PushMaterial {
                     return false;
                 }
             }
+        }
+
+        if (!subMesh.effect || !subMesh.effect.isReady()) {
+            return false;
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -66,6 +66,8 @@ class FurMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -309,7 +311,7 @@ export class FurMaterial extends PushMaterial {
                 "furOcclusion",
             ];
             addClipPlaneUniforms(uniforms);
-            const samplers = ["diffuseSampler", "heightTexture", "furTexture"];
+            const samplers = ["diffuseSampler", "heightTexture", "furTexture", "areaLightsLTC1Sampler", "areaLightsLTC2Sampler"];
 
             const uniformBuffers: string[] = [];
 
@@ -343,6 +345,15 @@ export class FurMaterial extends PushMaterial {
         }
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
+        }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -59,6 +59,8 @@ class GradientMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -215,7 +217,7 @@ export class GradientMaterial extends PushMaterial {
                 "scale",
             ];
             addClipPlaneUniforms(uniforms);
-            const samplers: string[] = [];
+            const samplers: string[] = ["areaLightsLTC1Sampler", "areaLightsLTC2Sampler"];
             const uniformBuffers: string[] = [];
 
             PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
@@ -248,6 +250,15 @@ export class GradientMaterial extends PushMaterial {
         }
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
+        }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -248,9 +248,6 @@ export class GradientMaterial extends PushMaterial {
                 this._materialContext
             );
         }
-        if (!subMesh.effect || !subMesh.effect.isReady()) {
-            return false;
-        }
 
         // Check if Area Lights have LTC texture.
         if (defines["AREALIGHTUSED"]) {
@@ -259,6 +256,10 @@ export class GradientMaterial extends PushMaterial {
                     return false;
                 }
             }
+        }
+
+        if (!subMesh.effect || !subMesh.effect.isReady()) {
+            return false;
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -102,6 +102,8 @@ class LavaMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -291,7 +293,7 @@ export class LavaMaterial extends PushMaterial {
             ];
             addClipPlaneUniforms(uniforms);
 
-            const samplers = ["diffuseSampler", "noiseTexture"];
+            const samplers = ["diffuseSampler", "noiseTexture", "areaLightsLTC1Sampler", "areaLightsLTC2Sampler"];
             const uniformBuffers: string[] = [];
 
             PrepareUniformsAndSamplersList(<IEffectCreationOptions>{
@@ -324,6 +326,15 @@ export class LavaMaterial extends PushMaterial {
         }
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
+        }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -324,9 +324,6 @@ export class LavaMaterial extends PushMaterial {
                 this._materialContext
             );
         }
-        if (!subMesh.effect || !subMesh.effect.isReady()) {
-            return false;
-        }
 
         // Check if Area Lights have LTC texture.
         if (defines["AREALIGHTUSED"]) {
@@ -335,6 +332,10 @@ export class LavaMaterial extends PushMaterial {
                     return false;
                 }
             }
+        }
+
+        if (!subMesh.effect || !subMesh.effect.isReady()) {
+            return false;
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -100,6 +100,8 @@ class NormalMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -255,7 +257,7 @@ export class NormalMaterial extends PushMaterial {
                 "diffuseMatrix",
                 "logarithmicDepthConstant",
             ];
-            const samplers = ["diffuseSampler"];
+            const samplers = ["diffuseSampler", "areaLightsLTC1Sampler", "areaLightsLTC2Sampler"];
             const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
@@ -289,6 +291,15 @@ export class NormalMaterial extends PushMaterial {
         }
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
+        }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -289,9 +289,6 @@ export class NormalMaterial extends PushMaterial {
                 this._materialContext
             );
         }
-        if (!subMesh.effect || !subMesh.effect.isReady()) {
-            return false;
-        }
 
         // Check if Area Lights have LTC texture.
         if (defines["AREALIGHTUSED"]) {
@@ -300,6 +297,10 @@ export class NormalMaterial extends PushMaterial {
                     return false;
                 }
             }
+        }
+
+        if (!subMesh.effect || !subMesh.effect.isReady()) {
+            return false;
         }
 
         defines._renderId = scene.getRenderId();

--- a/packages/dev/materials/src/simple/simpleMaterial.ts
+++ b/packages/dev/materials/src/simple/simpleMaterial.ts
@@ -60,6 +60,8 @@ class SimpleMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -210,7 +212,7 @@ export class SimpleMaterial extends PushMaterial {
                 "diffuseMatrix",
                 "logarithmicDepthConstant",
             ];
-            const samplers = ["diffuseSampler"];
+            const samplers = ["diffuseSampler", "areaLightsLTC1Sampler", "areaLightsLTC2Sampler"];
             const uniformBuffers: string[] = [];
 
             addClipPlaneUniforms(uniforms);
@@ -241,6 +243,16 @@ export class SimpleMaterial extends PushMaterial {
                 this._materialContext
             );
         }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
+        }
+
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
         }

--- a/packages/dev/materials/src/terrain/terrainMaterial.ts
+++ b/packages/dev/materials/src/terrain/terrainMaterial.ts
@@ -63,6 +63,8 @@ class TerrainMaterialDefines extends MaterialDefines {
     public IMAGEPROCESSINGPOSTPROCESS = false;
     public SKIPFINALCOLORCLAMP = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -285,6 +287,8 @@ export class TerrainMaterial extends PushMaterial {
                 "bump2Sampler",
                 "bump3Sampler",
                 "logarithmicDepthConstant",
+                "areaLightsLTC1Sampler",
+                "areaLightsLTC2Sampler",
             ];
 
             const uniformBuffers: string[] = [];
@@ -319,6 +323,16 @@ export class TerrainMaterial extends PushMaterial {
                 this._materialContext
             );
         }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
+        }
+
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
         }

--- a/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
+++ b/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
@@ -68,6 +68,8 @@ class TriPlanarMaterialDefines extends MaterialDefines {
     public SKIPFINALCOLORCLAMP = false;
     public NONUNIFORMSCALING = false;
     public LOGARITHMICDEPTH = false;
+    public AREALIGHTSUPPORTED = true;
+    public AREALIGHTNOROUGHTNESS = true;
 
     constructor() {
         super();
@@ -266,7 +268,17 @@ export class TriPlanarMaterial extends PushMaterial {
                 "mBones",
                 "tileSize",
             ];
-            const samplers = ["diffuseSamplerX", "diffuseSamplerY", "diffuseSamplerZ", "normalSamplerX", "normalSamplerY", "normalSamplerZ", "logarithmicDepthConstant"];
+            const samplers = [
+                "diffuseSamplerX",
+                "diffuseSamplerY",
+                "diffuseSamplerZ",
+                "normalSamplerX",
+                "normalSamplerY",
+                "normalSamplerZ",
+                "logarithmicDepthConstant",
+                "areaLightsLTC1Sampler",
+                "areaLightsLTC2Sampler",
+            ];
 
             const uniformBuffers: string[] = [];
 
@@ -300,6 +312,16 @@ export class TriPlanarMaterial extends PushMaterial {
                 this._materialContext
             );
         }
+
+        // Check if Area Lights have LTC texture.
+        if (defines["AREALIGHTUSED"]) {
+            for (let index = 0; index < mesh.lightSources.length; index++) {
+                if (!mesh.lightSources[index]._isReady()) {
+                    return false;
+                }
+            }
+        }
+
         if (!subMesh.effect || !subMesh.effect.isReady()) {
             return false;
         }


### PR DESCRIPTION
Continued the work to add Area light support to the following materials as well as NME: 

- cellMaterial
- furMaterial
- gradientMaterial
- lavaMaterial
- normalMaterial
- simpleMaterial
- terrainMaterial
- triPlanarMaterial
