### PR TITLE
Fix loading screen when the scrollbar is present

### DIFF
--- a/packages/dev/core/src/Loading/loadingScreen.ts
+++ b/packages/dev/core/src/Loading/loadingScreen.ts
@@ -328,8 +328,8 @@ export class DefaultLoadingScreen implements ILoadingScreen {
                 const canvasPositioning = window.getComputedStyle(canvas).position;
 
                 loadingDiv.style.position = canvasPositioning === "fixed" ? "fixed" : "absolute";
-                loadingDiv.style.left = currentCanvasRect.left + "px";
-                loadingDiv.style.top = currentCanvasRect.top + "px";
+                loadingDiv.style.left = currentCanvasRect.left + window.scrollX + "px";
+                loadingDiv.style.top = currentCanvasRect.top + window.scrollY + "px";
                 loadingDiv.style.width = currentCanvasRect.width + "px";
                 loadingDiv.style.height = currentCanvasRect.height + "px";
 


### PR DESCRIPTION
The following PR fixes the loading screen when the scrollbar is present and already scrolled.

Forum link: https://forum.babylonjs.com/t/loading-screen-misplaced-on-multiple-canvases/56234/4.