### PR TITLE
Only export Model type

### DIFF
--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -1,8 +1,8 @@
-export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
+export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, Model, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
 export type { CanvasViewerOptions } from "./viewerFactory";
 export type { HotSpot } from "./viewerElement";
 
-export { Viewer, ViewerHotSpotResult, Model } from "./viewer";
+export { Viewer, ViewerHotSpotResult } from "./viewer";
 export { HTML3DElement, ViewerElement } from "./viewerElement";
 export { createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";


### PR DESCRIPTION
`Model` is only a type, and has to be exported as a type only for the Viewer test app (there are otherwise errors).