### PR TITLE
Expose specularPower to roughness conversion

### DIFF
--- a/packages/dev/core/src/Helpers/index.ts
+++ b/packages/dev/core/src/Helpers/index.ts
@@ -2,3 +2,4 @@ export * from "./environmentHelper";
 export * from "./photoDome";
 export * from "./sceneHelpers";
 export * from "./videoDome";
+export * from "./materialConversionHelper";

--- a/packages/dev/core/src/Helpers/materialConversionHelper.ts
+++ b/packages/dev/core/src/Helpers/materialConversionHelper.ts
@@ -1,0 +1,38 @@
+import { Vector2 } from "core/Maths/math.vector";
+
+/**
+ * Given the control points, solve for x based on a given t for a cubic bezier curve
+ * @param t a value between 0 and 1
+ * @param p0 first control point
+ * @param p1 second control point
+ * @param p2 third control point
+ * @param p3 fourth control point
+ * @returns number result of cubic bezier curve at the specified t
+ */
+function cubicBezierCurve(t: number, p0: number, p1: number, p2: number, p3: number): number {
+    return (1 - t) * (1 - t) * (1 - t) * p0 + 3 * (1 - t) * (1 - t) * t * p1 + 3 * (1 - t) * t * t * p2 + t * t * t * p3;
+}
+
+/**
+ * Helper class with material parameter convertion utilities.
+ */
+export class MaterialConversionHelper {
+    /**
+     * Evaluates a specified specular power value to determine the appropriate roughness value,
+     * based on a pre-defined cubic bezier curve with specular on the abscissa axis (x-axis)
+     * and roughness on the ordinant axis (y-axis)
+     * @param specularPower specular power of standard material
+     * @param p0 first control point
+     * @param p1 second control point
+     * @param p2 third control point
+     * @param p3 fourth control point
+     * @returns Number representing the roughness value
+     */
+    static SpecularPowerToRoughness(specularPower: number, p0 = new Vector2(0, 1), p1 = new Vector2(0, 0.1), p2 = new Vector2(0, 0.1), p3 = new Vector2(1300, 0.1)): number {
+        // Given P0.x = 0, P1.x = 0, P2.x = 0
+        //   x = t * t * t * P3.x
+        //   t = (x / P3.x)^(1/3)
+        const t = Math.pow(specularPower / p3.x, 0.333333);
+        return cubicBezierCurve(t, p0.y, p1.y, p2.y, p3.y);
+    }
+}

--- a/packages/dev/core/src/Helpers/materialConversionHelper.ts
+++ b/packages/dev/core/src/Helpers/materialConversionHelper.ts
@@ -14,25 +14,20 @@ function cubicBezierCurve(t: number, p0: number, p1: number, p2: number, p3: num
 }
 
 /**
- * Helper class with material parameter convertion utilities.
+ * Evaluates a specified specular power value to determine the appropriate roughness value,
+ * based on a pre-defined cubic bezier curve with specular on the abscissa axis (x-axis)
+ * and roughness on the ordinant axis (y-axis)
+ * @param specularPower specular power of standard material
+ * @param p0 first control point
+ * @param p1 second control point
+ * @param p2 third control point
+ * @param p3 fourth control point
+ * @returns Number representing the roughness value
  */
-export class MaterialConversionHelper {
-    /**
-     * Evaluates a specified specular power value to determine the appropriate roughness value,
-     * based on a pre-defined cubic bezier curve with specular on the abscissa axis (x-axis)
-     * and roughness on the ordinant axis (y-axis)
-     * @param specularPower specular power of standard material
-     * @param p0 first control point
-     * @param p1 second control point
-     * @param p2 third control point
-     * @param p3 fourth control point
-     * @returns Number representing the roughness value
-     */
-    static SpecularPowerToRoughness(specularPower: number, p0 = new Vector2(0, 1), p1 = new Vector2(0, 0.1), p2 = new Vector2(0, 0.1), p3 = new Vector2(1300, 0.1)): number {
-        // Given P0.x = 0, P1.x = 0, P2.x = 0
-        //   x = t * t * t * P3.x
-        //   t = (x / P3.x)^(1/3)
-        const t = Math.pow(specularPower / p3.x, 0.333333);
-        return cubicBezierCurve(t, p0.y, p1.y, p2.y, p3.y);
-    }
+export function SpecularPowerToRoughness(specularPower: number, p0 = new Vector2(0, 1), p1 = new Vector2(0, 0.1), p2 = new Vector2(0, 0.1), p3 = new Vector2(1300, 0.1)): number {
+    // Given P0.x = 0, P1.x = 0, P2.x = 0
+    //   x = t * t * t * P3.x
+    //   t = (x / P3.x)^(1/3)
+    const t = Math.pow(specularPower / p3.x, 0.333333);
+    return cubicBezierCurve(t, p0.y, p1.y, p2.y, p3.y);
 }

--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -21,7 +21,7 @@ import { DumpTools } from "core/Misc/dumpTools";
 import type { Material } from "core/Materials/material";
 import type { StandardMaterial } from "core/Materials/standardMaterial";
 import type { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
-import { MaterialConversionHelper } from "core/Helpers/materialConversionHelper";
+import { SpecularPowerToRoughness } from "core/Helpers/materialConversionHelper";
 
 const epsilon = 1e-6;
 const dielectricSpecular = new Color3(0.04, 0.04, 0.04);
@@ -93,7 +93,7 @@ export function _ConvertToGLTFPBRMetallicRoughness(babylonStandardMaterial: Stan
     const opacity = babylonStandardMaterial.alpha;
     const specularPower = Scalar.Clamp(babylonStandardMaterial.specularPower, 0, maxSpecularPower);
 
-    const roughness = MaterialConversionHelper.SpecularPowerToRoughness(specularPower);
+    const roughness = SpecularPowerToRoughness(specularPower);
 
     const glTFPbrMetallicRoughness: IMaterialPbrMetallicRoughness = {
         baseColorFactor: [diffuse.r, diffuse.g, diffuse.b, opacity],

--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -4,7 +4,6 @@ import type { ITextureInfo, IMaterial, IMaterialPbrMetallicRoughness, IMaterialO
 import { ImageMimeType, MaterialAlphaMode, TextureMagFilter, TextureMinFilter, TextureWrapMode } from "babylonjs-gltf2interface";
 
 import type { Nullable } from "core/types";
-import { Vector2 } from "core/Maths/math.vector";
 import { Color3 } from "core/Maths/math.color";
 import { Scalar } from "core/Maths/math.scalar";
 import { Tools } from "core/Misc/tools";
@@ -22,6 +21,7 @@ import { DumpTools } from "core/Misc/dumpTools";
 import type { Material } from "core/Materials/material";
 import type { StandardMaterial } from "core/Materials/standardMaterial";
 import type { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
+import { MaterialConversionHelper } from "core/Helpers/materialConversionHelper";
 
 const epsilon = 1e-6;
 const dielectricSpecular = new Color3(0.04, 0.04, 0.04);
@@ -89,45 +89,11 @@ export function _SolveMetallic(diffuse: number, specular: number, oneMinusSpecul
  * @internal
  */
 export function _ConvertToGLTFPBRMetallicRoughness(babylonStandardMaterial: StandardMaterial): IMaterialPbrMetallicRoughness {
-    // Defines a cubic bezier curve where x is specular power and y is roughness
-    const P0 = new Vector2(0, 1);
-    const P1 = new Vector2(0, 0.1);
-    const P2 = new Vector2(0, 0.1);
-    const P3 = new Vector2(1300, 0.1);
-
-    /**
-     * Given the control points, solve for x based on a given t for a cubic bezier curve
-     * @param t a value between 0 and 1
-     * @param p0 first control point
-     * @param p1 second control point
-     * @param p2 third control point
-     * @param p3 fourth control point
-     * @returns number result of cubic bezier curve at the specified t
-     */
-    function cubicBezierCurve(t: number, p0: number, p1: number, p2: number, p3: number): number {
-        return (1 - t) * (1 - t) * (1 - t) * p0 + 3 * (1 - t) * (1 - t) * t * p1 + 3 * (1 - t) * t * t * p2 + t * t * t * p3;
-    }
-
-    /**
-     * Evaluates a specified specular power value to determine the appropriate roughness value,
-     * based on a pre-defined cubic bezier curve with specular on the abscissa axis (x-axis)
-     * and roughness on the ordinant axis (y-axis)
-     * @param specularPower specular power of standard material
-     * @returns Number representing the roughness value
-     */
-    function solveForRoughness(specularPower: number): number {
-        // Given P0.x = 0, P1.x = 0, P2.x = 0
-        //   x = t * t * t * P3.x
-        //   t = (x / P3.x)^(1/3)
-        const t = Math.pow(specularPower / P3.x, 0.333333);
-        return cubicBezierCurve(t, P0.y, P1.y, P2.y, P3.y);
-    }
-
     const diffuse = babylonStandardMaterial.diffuseColor.toLinearSpace(babylonStandardMaterial.getScene().getEngine().useExactSrgbConversions).scale(0.5);
     const opacity = babylonStandardMaterial.alpha;
     const specularPower = Scalar.Clamp(babylonStandardMaterial.specularPower, 0, maxSpecularPower);
 
-    const roughness = solveForRoughness(specularPower);
+    const roughness = MaterialConversionHelper.SpecularPowerToRoughness(specularPower);
 
     const glTFPbrMetallicRoughness: IMaterialPbrMetallicRoughness = {
         baseColorFactor: [diffuse.r, diffuse.g, diffuse.b, opacity],


### PR DESCRIPTION
When using RectAreaLight with StandardMaterial, the value used to calculate specular will come from "roughness". However, all other lights calculate specular based on "specularPower". If a user has a scene with multiple lights sources (RectAreaLight + PointLight for example), and uses StandardMaterial for its meshes, it needs to set the roughness to the bast value possible so that the specular behaves similarly for all lights. 

We already perform a specularPower to roughness conversion when exporting StandardMaterial to GLTF. This PR makes that logic available so users can also consume it using the new "MaterialConversionHelper" class.