### PR TITLE
Fix flipped camera on export

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -213,11 +213,9 @@ export function ConvertCameraRotationToGLTF(rotation: Quaternion): Quaternion {
 }
 
 export function RotateNode180Y(node: INode) {
-    if (node.rotation) {
-        const rotation = Quaternion.FromArrayToRef(node.rotation || [0, 0, 0, 1], 0, TmpVectors.Quaternion[1]);
-        rotation180Y.multiplyToRef(rotation, rotation);
-        node.rotation = rotation.asArray();
-    }
+    const rotation = Quaternion.FromArrayToRef(node.rotation || [0, 0, 0, 1], 0, TmpVectors.Quaternion[1]);
+    rotation180Y.multiplyToRef(rotation, rotation);
+    node.rotation = rotation.asArray();
 }
 
 /**


### PR DESCRIPTION
See the OP from here: https://forum.babylonjs.com/t/gltfexport-flipped-camera/45986/21
Remove check for undefined node rotation; we should set it regardless.