### PR TITLE
Rendering Engine: Fix alpha support

### DIFF
--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -547,7 +547,7 @@ export class ThinEffectLayer {
 
         // Diffuse
         if (material) {
-            const needAlphaTest = material.needAlphaTesting();
+            const needAlphaTest = material.needAlphaTestingForMesh(mesh);
 
             const diffuseTexture = material.getAlphaTestTexture();
             const needAlphaBlendFromDiffuse =
@@ -941,7 +941,7 @@ export class ThinEffectLayer {
             }
 
             if (!renderingMaterial) {
-                const needAlphaTest = material.needAlphaTesting();
+                const needAlphaTest = material.needAlphaTestingForMesh(effectiveMesh);
 
                 const diffuseTexture = material.getAlphaTestTexture();
                 const needAlphaBlendFromDiffuse =

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1608,9 +1608,9 @@ export class ShadowGenerator implements IShadowGenerator {
             }
 
             // Alpha test
-            const needAlphaTesting = material.needAlphaTesting();
+            const needAlphaTesting = material.needAlphaTestingForMesh(mesh);
 
-            if (needAlphaTesting || material.needAlphaBlending()) {
+            if (needAlphaTesting || material.needAlphaBlendingForMesh(mesh)) {
                 if (this.useOpacityTextureForTransparentShadow) {
                     this._opacityTexture = (material as any).opacityTexture;
                 } else {

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -889,7 +889,7 @@ export class BackgroundMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Values that need to be evaluated on every frame
         PrepareDefinesForFrameBoundValues(scene, engine, this, defines, useInstances, null, subMesh.getRenderingMesh().hasThinInstances);

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1040,6 +1040,10 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      * @returns whether or not this material should be rendered in alpha blend mode.
      */
     public override needAlphaBlending(): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsBlend;
+        }
+
         if (this._disableAlphaBlending) {
             return false;
         }
@@ -1051,6 +1055,10 @@ export abstract class PBRBaseMaterial extends PushMaterial {
      * @returns whether or not this material should be rendered in alpha test mode.
      */
     public override needAlphaTesting(): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsTest;
+        }
+
         if (this._forceAlphaTest) {
             return true;
         }
@@ -1951,7 +1959,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 this._useLogarithmicDepth,
                 this.pointsCloud,
                 this.fogEnabled,
-                this._shouldTurnAlphaTestOn(mesh) || this._forceAlphaTest,
+                this.needAlphaTestingForMesh(mesh) || this.needAlphaTesting(),
                 defines,
                 this._applyDecalMapAfterDetailMap
             );

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -750,12 +750,6 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     public _alphaCutOff = 0.4;
 
     /**
-     * Enforces alpha test in opaque or blend mode in order to improve the performances of some situations.
-     * @internal
-     */
-    public override _forceAlphaTest = false;
-
-    /**
      * A fresnel is applied to the alpha of the model to ensure grazing angles edges are not alpha tested.
      * And/Or occlude the blended part. (alpha is converted to gamma to compute the fresnel)
      * @internal
@@ -1057,10 +1051,6 @@ export abstract class PBRBaseMaterial extends PushMaterial {
     public override needAlphaTesting(): boolean {
         if (this._hasTransparencyMode) {
             return this._transparencyModeIsTest;
-        }
-
-        if (this._forceAlphaTest) {
-            return true;
         }
 
         if (this.subSurface?.disableAlphaBlending) {
@@ -1959,7 +1949,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 this._useLogarithmicDepth,
                 this.pointsCloud,
                 this.fogEnabled,
-                this.needAlphaTestingForMesh(mesh) || this.needAlphaTesting(),
+                this.needAlphaTestingForMesh(mesh),
                 defines,
                 this._applyDecalMapAfterDetailMap
             );

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1147,6 +1147,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     /**
      * Specifies whether or not this material should be rendered in alpha blend mode.
      * @returns a boolean specifying if alpha blending is needed
+     * @deprecated Please use needAlphaBlendingForMesh instead
      */
     public needAlphaBlending(): boolean {
         if (this._hasTransparencyMode) {
@@ -1184,6 +1185,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     /**
      * Specifies whether or not this material should be rendered in alpha test mode.
      * @returns a boolean specifying if an alpha test is needed.
+     * @deprecated Please use needAlphaTestingForMesh instead
      */
     public needAlphaTesting(): boolean {
         if (this._hasTransparencyMode) {

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1092,11 +1092,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     }
 
     /**
-     * Enforces alpha test in opaque or blend mode in order to improve the performances of some situations.
-     */
-    protected _forceAlphaTest = false;
-
-    /**
      * The transparency mode of the material.
      */
     protected _transparencyMode: Nullable<number> = null;
@@ -1126,8 +1121,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         }
 
         this._transparencyMode = value;
-
-        this._forceAlphaTest = value === Material.MATERIAL_ALPHATESTANDBLEND;
 
         this._markAllSubMeshesAsTexturesAndMiscDirty();
     }
@@ -1195,10 +1188,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     public needAlphaTesting(): boolean {
         if (this._hasTransparencyMode) {
             return this._transparencyModeIsTest;
-        }
-
-        if (this._forceAlphaTest) {
-            return true;
         }
 
         return false;

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1132,6 +1132,18 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         this._markAllSubMeshesAsTexturesAndMiscDirty();
     }
 
+    protected get _hasTransparencyMode(): boolean {
+        return this._transparencyMode != null;
+    }
+
+    protected get _transparencyModeIsBlend(): boolean {
+        return this._transparencyMode === Material.MATERIAL_ALPHABLEND || this._transparencyMode === Material.MATERIAL_ALPHATESTANDBLEND;
+    }
+
+    protected get _transparencyModeIsTest(): boolean {
+        return this._transparencyMode === Material.MATERIAL_ALPHATEST || this._transparencyMode === Material.MATERIAL_ALPHATESTANDBLEND;
+    }
+
     /**
      * Returns true if alpha blending should be disabled.
      */
@@ -1144,6 +1156,10 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * @returns a boolean specifying if alpha blending is needed
      */
     public needAlphaBlending(): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsBlend;
+        }
+
         if (this._disableAlphaBlending) {
             return false;
         }
@@ -1157,6 +1173,10 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * @returns a boolean specifying if alpha blending is needed for the mesh
      */
     public needAlphaBlendingForMesh(mesh: AbstractMesh): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsBlend;
+        }
+
         if (mesh.visibility < 1.0) {
             return true;
         }
@@ -1173,6 +1193,10 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * @returns a boolean specifying if an alpha test is needed.
      */
     public needAlphaTesting(): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsTest;
+        }
+
         if (this._forceAlphaTest) {
             return true;
         }
@@ -1185,7 +1209,11 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * @param mesh defines the mesh to check
      * @returns a boolean specifying if alpha testing should be turned on for the mesh
      */
-    protected _shouldTurnAlphaTestOn(mesh: AbstractMesh): boolean {
+    public needAlphaTestingForMesh(mesh: AbstractMesh): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsTest;
+        }
+
         return !this.needAlphaBlendingForMesh(mesh) && this.needAlphaTesting();
     }
 

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -839,7 +839,7 @@ export class ShaderMaterial extends PushMaterial {
         }
 
         // Alpha test
-        if (mesh && this._shouldTurnAlphaTestOn(mesh)) {
+        if (mesh && this.needAlphaTestingForMesh(mesh)) {
             defines.push("#define ALPHATEST");
         }
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -878,6 +878,10 @@ export class StandardMaterial extends PushMaterial {
      * @returns a boolean specifying if alpha blending is needed
      */
     public override needAlphaBlending(): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsBlend;
+        }
+
         if (this._disableAlphaBlending) {
             return false;
         }
@@ -895,6 +899,10 @@ export class StandardMaterial extends PushMaterial {
      * @returns a boolean specifying if an alpha test is needed.
      */
     public override needAlphaTesting(): boolean {
+        if (this._hasTransparencyMode) {
+            return this._transparencyModeIsTest;
+        }
+
         if (this._forceAlphaTest) {
             return true;
         }
@@ -1237,7 +1245,7 @@ export class StandardMaterial extends PushMaterial {
             this._useLogarithmicDepth,
             this.pointsCloud,
             this.fogEnabled,
-            this._shouldTurnAlphaTestOn(mesh) || this._forceAlphaTest,
+            this.needAlphaTestingForMesh(mesh) || this.needAlphaTesting(),
             defines,
             this._applyDecalMapAfterDetailMap
         );

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -903,10 +903,6 @@ export class StandardMaterial extends PushMaterial {
             return this._transparencyModeIsTest;
         }
 
-        if (this._forceAlphaTest) {
-            return true;
-        }
-
         return this._hasAlphaChannel() && (this._transparencyMode == null || this._transparencyMode === Material.MATERIAL_ALPHATEST);
     }
 
@@ -1245,7 +1241,7 @@ export class StandardMaterial extends PushMaterial {
             this._useLogarithmicDepth,
             this.pointsCloud,
             this.fogEnabled,
-            this.needAlphaTestingForMesh(mesh) || this.needAlphaTesting(),
+            this.needAlphaTestingForMesh(mesh),
             defines,
             this._applyDecalMapAfterDetailMap
         );

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -215,7 +215,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
 
         // Alpha test
         if (material) {
-            const needAlphaTesting = material.needAlphaTesting();
+            const needAlphaTesting = material.needAlphaTestingForMesh(mesh);
             if (needAlphaTesting) {
                 defines.push("#define ALPHATEST");
             }
@@ -466,7 +466,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
                     effect.setMatrix("viewProjection", scene.getTransformMatrix());
 
                     // Alpha test
-                    if (material.needAlphaTesting()) {
+                    if (material.needAlphaTestingForMesh(effectiveMesh)) {
                         const alphaTexture = material.getAlphaTestTexture();
 
                         if (alphaTexture) {

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -284,7 +284,7 @@ export class DepthRenderer {
 
                 if (!renderingMaterial) {
                     // Alpha test
-                    if (material.needAlphaTesting()) {
+                    if (material.needAlphaTestingForMesh(effectiveMesh)) {
                         const alphaTexture = material.getAlphaTestTexture();
 
                         if (alphaTexture) {
@@ -407,7 +407,7 @@ export class DepthRenderer {
         let uv2 = false;
 
         // Alpha test
-        if (material.needAlphaTesting() && material.getAlphaTestTexture()) {
+        if (material.needAlphaTestingForMesh(mesh) && material.getAlphaTestTexture()) {
             defines.push("#define ALPHATEST");
             if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                 attribs.push(VertexBuffer.UVKind);

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -560,7 +560,7 @@ export class GeometryBufferRenderer {
         if (material) {
             let needUv = false;
             // Alpha test
-            if (material.needAlphaTesting() && material.getAlphaTestTexture()) {
+            if (material.needAlphaTestingForMesh(mesh) && material.getAlphaTestTexture()) {
                 defines.push("#define ALPHATEST");
                 defines.push(`#define ALPHATEST_UV${material.getAlphaTestTexture().coordinatesIndex + 1}`);
                 needUv = true;
@@ -1099,7 +1099,7 @@ export class GeometryBufferRenderer {
                 material._preBind(drawWrapper, sideOrientation);
 
                 // Alpha test
-                if (material.needAlphaTesting()) {
+                if (material.needAlphaTestingForMesh(effectiveMesh)) {
                     const alphaTexture = material.getAlphaTestTexture();
                     if (alphaTexture) {
                         effect.setTexture("diffuseSampler", alphaTexture);

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -242,7 +242,7 @@ export class OutlineRenderer implements ISceneComponent {
         }
 
         // Alpha test
-        if (material && material.needAlphaTesting()) {
+        if (material && material.needAlphaTestingForMesh(effectiveMesh)) {
             const alphaTexture = material.getAlphaTestTexture();
             if (alphaTexture) {
                 effect.setTexture("diffuseSampler", alphaTexture);
@@ -291,7 +291,7 @@ export class OutlineRenderer implements ISceneComponent {
         let uv2 = false;
 
         // Alpha test
-        if (material.needAlphaTesting()) {
+        if (material.needAlphaTestingForMesh(mesh)) {
             defines.push("#define ALPHATEST");
             if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
                 attribs.push(VertexBuffer.UVKind);

--- a/packages/dev/core/src/Rendering/renderingGroup.ts
+++ b/packages/dev/core/src/Rendering/renderingGroup.ts
@@ -411,7 +411,7 @@ export class RenderingGroup {
         if (material.needAlphaBlendingForMesh(mesh)) {
             // Transparent
             this._transparentSubMeshes.push(subMesh);
-        } else if (material.needAlphaTesting()) {
+        } else if (material.needAlphaTestingForMesh(mesh)) {
             // Alpha test
             if (material.needDepthPrePass) {
                 this._depthOnlySubMeshes.push(subMesh);

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -154,7 +154,7 @@ export class CellMaterial extends PushMaterial {
         defines.CELLBASIC = !this.computeHighLevel;
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -230,7 +230,7 @@ export class FurMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -144,7 +144,7 @@ export class GradientMaterial extends PushMaterial {
 
         PrepareDefinesForFrameBoundValues(scene, engine, this, defines, useInstances ? true : false);
 
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);
 

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -212,7 +212,7 @@ export class LavaMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = true;

--- a/packages/dev/materials/src/mix/mixMaterial.ts
+++ b/packages/dev/materials/src/mix/mixMaterial.ts
@@ -240,7 +240,7 @@ export class MixMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -187,7 +187,7 @@ export class NormalMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = true;

--- a/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
@@ -141,7 +141,7 @@ export class ShadowOnlyMaterial extends PushMaterial {
 
         PrepareDefinesForFrameBoundValues(scene, engine, this, defines, useInstances ? true : false);
 
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, 1);
 

--- a/packages/dev/materials/src/simple/simpleMaterial.ts
+++ b/packages/dev/materials/src/simple/simpleMaterial.ts
@@ -143,7 +143,7 @@ export class SimpleMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);

--- a/packages/dev/materials/src/terrain/terrainMaterial.ts
+++ b/packages/dev/materials/src/terrain/terrainMaterial.ts
@@ -205,7 +205,7 @@ export class TerrainMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);

--- a/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
+++ b/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
@@ -207,7 +207,7 @@ export class TriPlanarMaterial extends PushMaterial {
         }
 
         // Misc.
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights, this._disableLighting);

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -394,7 +394,7 @@ export class WaterMaterial extends PushMaterial {
 
         PrepareDefinesForFrameBoundValues(scene, engine, this, defines, useInstances ? true : false);
 
-        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this._shouldTurnAlphaTestOn(mesh), defines);
+        PrepareDefinesForMisc(mesh, scene, this._useLogarithmicDepth, this.pointsCloud, this.fogEnabled, this.needAlphaTestingForMesh(mesh), defines);
 
         if (defines._areMiscDirty) {
             defines.FRESNELSEPARATE = this._fresnelSeparate;

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -52,7 +52,7 @@
         },
         {
             "title": "NME Loop Block",
-            "playgroundId": "#D8AK3Z#109",
+            "playgroundId": "#D8AK3Z#115",
             "referenceImage": "nme-loop.png",
             "excludedEngines": ["webgl1"]
         },
@@ -1302,7 +1302,7 @@
         },
         {
             "title": "Visibility",
-            "playgroundId": "#PXC9CF#2",
+            "playgroundId": "#PXC9CF#6",
             "referenceImage": "visibility.png"
         },
         {
@@ -1606,7 +1606,7 @@
         {
             "title": "Prepass SSAO + visibility",
             "renderCount": 30,
-            "playgroundId": "#PXC9CF#4",
+            "playgroundId": "#PXC9CF#7",
             "excludedEngines": ["webgl1"],
             "referenceImage": "prepass-ssao-visibility.png"
         },


### PR DESCRIPTION
I took Gary's WIP PR (#15573) as a base, but decided to go another way: keep all the existing code and simply honor the `transparencyMode` value when it's set.

This is because the existing code is quite complicated and has a lot of interconnections. I felt that trying to simplify it was too complicated and error-prone, so I made changes to simply use the `transparencyMode` parameter when set and keep the existing code-path otherwise.

At some point, we could deprecate the existing code and keep only the code related to `transparencyMode`. In addition, I think it's easier to document the breaking change:
* if you give a non-null value to `transparencyMode`, it will always be honored, whatever values you give to other properties (like mesh visibility, material alpha, etc)
* If `transparencyMode` is null, no change is made to the existing behavior, which is fully compatible with the past.

Other changes (from Gary's PR):
* `_shouldTurnAlphaTestOn` has been renamed to `needAlphaTestingForMesh`. This is not a breaking change, since `_shouldTurnAlphaTestOn` was **protected**, and more in line with the existing `needAlphaBlendingForMesh` method.
* All occurrences of `needAlphaTesting` have been replaced by `needAlphaTestingForMesh`: the behavior might change because of this, but it's not a breaking change but a bug fix.

Regarding failed visualization tests (3):
* "NME loop block". It didn't fail because of the changes but because of timing issues (a node material was loaded in parallel to the test - I now wait for the material to load before returning from the `createScene` function).
* "Visibility" and "Prepass SSAO + visibility" are in fact the same test. They are expected to fail, as they set `transparencyMode=OPAQUE` and define certain properties that allow blending in the current code path, whereas with the PR, the material is no longer transparent. To correct the tests, I set `transparencyMode=ALPHABLEND` and `useAlphaFromAlbedoTexture=false`. Indeed, when `useAlphaFromAlbedoTexture=true` (as was the case in the test), the alpha of the albedo texture is taken into account when `transparencyMode=ALPHABLEND` (as expected), but not in the actual code path when `transparencyMode=OPAQUE`. So the images were different if I didn't set `useAlphaFromAlbedoTexture` to `false`.

cc @sebavan and @bghgary 