### PR TITLE
Add more cases of calling error callbacks

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -953,7 +953,7 @@ function importMeshAsyncCore(
                 pluginExtension,
                 name,
                 pluginOptions
-            ).catch((error) => reject(error));
+            ).catch(reject);
         } catch (error) {
             reject(error);
         }
@@ -1163,7 +1163,7 @@ function appendSceneAsyncCore(
                 pluginExtension,
                 name,
                 pluginOptions
-            ).catch((error) => reject(error));
+            ).catch(reject);
         } catch (error) {
             reject(error);
         }
@@ -1309,7 +1309,7 @@ function internalLoadAssetContainerAsync(
                 pluginExtension,
                 name,
                 pluginOptions
-            ).catch((error) => reject(error));
+            ).catch(reject);
         } catch (error) {
             reject(error);
         }
@@ -1437,7 +1437,7 @@ function importAnimationsAsyncCore(
                 pluginExtension,
                 name,
                 pluginOptions
-            ).catch((error) => reject(error));
+            ).catch(reject);
         } catch (error) {
             reject(error);
         }

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -960,7 +960,8 @@ function importMeshAsyncCore(
     });
 }
 
-async function loadScene(
+// This is the core implementation of load scene
+async function loadSceneImplAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     engine: Nullable<AbstractEngine> = EngineStore.LastCreatedEngine,
@@ -976,7 +977,7 @@ async function loadScene(
         return;
     }
 
-    await appendAsync(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
+    await appendSceneImplAsync(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -989,10 +990,11 @@ async function loadScene(
  */
 export function loadSceneAsync(source: SceneSource, engine: AbstractEngine, options?: LoadOptions): Promise<Scene> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return loadSceneAsyncCore(rootUrl, source, engine, onProgress, pluginExtension, name, pluginOptions);
+    return loadSceneSharedAsync(rootUrl, source, engine, onProgress, pluginExtension, name, pluginOptions);
 }
 
-function loadSceneAsyncCore(
+// This function is shared between the new module level loadSceneAsync and the legacy SceneLoader.LoadAsync
+function loadSceneSharedAsync(
     rootUrl: string,
     sceneFilename?: SceneSource,
     engine?: Nullable<AbstractEngine>,
@@ -1002,7 +1004,7 @@ function loadSceneAsyncCore(
     pluginOptions?: PluginOptions
 ): Promise<Scene> {
     return new Promise((resolve, reject) => {
-        loadScene(
+        loadSceneImplAsync(
             rootUrl,
             sceneFilename,
             engine,
@@ -1020,7 +1022,8 @@ function loadSceneAsyncCore(
     });
 }
 
-async function appendAsync(
+// This is the core implementation of append scene
+async function appendSceneImplAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
@@ -1135,10 +1138,11 @@ async function appendAsync(
  */
 export async function appendSceneAsync(source: SceneSource, scene: Scene, options?: AppendOptions): Promise<void> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    await appendSceneAsyncCore(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+    await appendSceneSharedAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
 }
 
-function appendSceneAsyncCore(
+// This function is shared between the new module level appendSceneAsync and the legacy SceneLoader.AppendAsync
+function appendSceneSharedAsync(
     rootUrl: string,
     sceneFilename?: SceneSource,
     scene?: Nullable<Scene>,
@@ -1149,7 +1153,7 @@ function appendSceneAsyncCore(
 ): Promise<Scene> {
     return new Promise((resolve, reject) => {
         try {
-            appendAsync(
+            appendSceneImplAsync(
                 rootUrl,
                 sceneFilename,
                 scene,
@@ -1170,7 +1174,8 @@ function appendSceneAsyncCore(
     });
 }
 
-async function loadAssetContainerCoreAsync(
+// This is the core implementation of load asset container
+async function loadAssetContainerImplAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
@@ -1281,10 +1286,11 @@ async function loadAssetContainerCoreAsync(
  */
 export function loadAssetContainerAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<AssetContainer> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return internalLoadAssetContainerAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+    return loadAssetContainerSharedAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
 }
 
-function internalLoadAssetContainerAsync(
+// This function is shared between the new module level loadAssetContainerAsync and the legacy SceneLoader.LoadAssetContainerAsync
+function loadAssetContainerSharedAsync(
     rootUrl: string,
     sceneFilename?: SceneSource,
     scene?: Nullable<Scene>,
@@ -1295,7 +1301,7 @@ function internalLoadAssetContainerAsync(
 ): Promise<AssetContainer> {
     return new Promise((resolve, reject) => {
         try {
-            loadAssetContainerCoreAsync(
+            loadAssetContainerImplAsync(
                 rootUrl,
                 sceneFilename,
                 scene,
@@ -1316,7 +1322,8 @@ function internalLoadAssetContainerAsync(
     });
 }
 
-async function importAnimations(
+// This is the core implementation of import animations
+async function importAnimationsImplAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
@@ -1391,7 +1398,7 @@ async function importAnimations(
         }
     };
 
-    await loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
+    await loadAssetContainerImplAsync(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1403,10 +1410,11 @@ async function importAnimations(
  */
 export async function importAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<void> {
     const { rootUrl = "", overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    await importAnimationsAsyncCore(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
+    await importAnimationsSharedAsync(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
 }
 
-function importAnimationsAsyncCore(
+// This function is shared between the new module level importAnimationsAsync and the legacy SceneLoader.ImportAnimationsAsync
+function importAnimationsSharedAsync(
     rootUrl: string,
     sceneFilename?: SceneSource,
     scene?: Nullable<Scene>,
@@ -1420,7 +1428,7 @@ function importAnimationsAsyncCore(
 ): Promise<Scene> {
     return new Promise((resolve, reject) => {
         try {
-            importAnimations(
+            importAnimationsImplAsync(
                 rootUrl,
                 sceneFilename,
                 scene,
@@ -1633,7 +1641,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        loadScene(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+        loadSceneImplAsync(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
             onError?.(EngineStore.LastCreatedScene!, error?.message, error)
         );
     }
@@ -1656,7 +1664,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<Scene> {
-        return loadSceneAsyncCore(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
+        return loadSceneSharedAsync(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1681,7 +1689,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        appendAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+        appendSceneImplAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
             onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error)
         );
     }
@@ -1704,7 +1712,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<Scene> {
-        return appendSceneAsyncCore(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+        return appendSceneSharedAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1729,7 +1737,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+        loadAssetContainerImplAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
             onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error)
         );
     }
@@ -1752,7 +1760,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<AssetContainer> {
-        return internalLoadAssetContainerAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+        return loadAssetContainerSharedAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1783,7 +1791,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): void {
-        importAnimations(
+        importAnimationsImplAsync(
             rootUrl,
             sceneFilename,
             scene,
@@ -1828,6 +1836,6 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<Scene> {
-        return importAnimationsAsyncCore(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
+        return importAnimationsSharedAsync(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
     }
 }

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -928,35 +928,39 @@ function importMeshAsyncCore(
     pluginOptions?: PluginOptions
 ): Promise<ISceneLoaderAsyncResult> {
     return new Promise((resolve, reject) => {
-        importMeshAsync(
-            meshNames,
-            rootUrl,
-            sceneFilename,
-            scene,
-            (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
-                resolve({
-                    meshes: meshes,
-                    particleSystems: particleSystems,
-                    skeletons: skeletons,
-                    animationGroups: animationGroups,
-                    transformNodes: transformNodes,
-                    geometries: geometries,
-                    lights: lights,
-                    spriteManagers: spriteManagers,
-                });
-            },
-            onProgress,
-            (scene, message, exception) => {
-                reject(exception || new Error(message));
-            },
-            pluginExtension,
-            name,
-            pluginOptions
-        );
+        try {
+            importMeshAsync(
+                meshNames,
+                rootUrl,
+                sceneFilename,
+                scene,
+                (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
+                    resolve({
+                        meshes: meshes,
+                        particleSystems: particleSystems,
+                        skeletons: skeletons,
+                        animationGroups: animationGroups,
+                        transformNodes: transformNodes,
+                        geometries: geometries,
+                        lights: lights,
+                        spriteManagers: spriteManagers,
+                    });
+                },
+                onProgress,
+                (scene, message, exception) => {
+                    reject(exception || new Error(message));
+                },
+                pluginExtension,
+                name,
+                pluginOptions
+            ).catch((error) => reject(error));
+        } catch (error) {
+            reject(error);
+        }
     });
 }
 
-function loadScene(
+async function loadScene(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     engine: Nullable<AbstractEngine> = EngineStore.LastCreatedEngine,
@@ -966,13 +970,13 @@ function loadScene(
     pluginExtension: Nullable<string> = null,
     name = "",
     pluginOptions: PluginOptions = {}
-): void {
+): Promise<void> {
     if (!engine) {
         Tools.Error("No engine available");
         return;
     }
 
-    appendAsync(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
+    await appendAsync(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1144,21 +1148,25 @@ function appendSceneAsyncCore(
     pluginOptions?: PluginOptions
 ): Promise<Scene> {
     return new Promise((resolve, reject) => {
-        appendAsync(
-            rootUrl,
-            sceneFilename,
-            scene,
-            (scene) => {
-                resolve(scene);
-            },
-            onProgress,
-            (scene, message, exception) => {
-                reject(exception || new Error(message));
-            },
-            pluginExtension,
-            name,
-            pluginOptions
-        );
+        try {
+            appendAsync(
+                rootUrl,
+                sceneFilename,
+                scene,
+                (scene) => {
+                    resolve(scene);
+                },
+                onProgress,
+                (scene, message, exception) => {
+                    reject(exception || new Error(message));
+                },
+                pluginExtension,
+                name,
+                pluginOptions
+            ).catch((error) => reject(error));
+        } catch (error) {
+            reject(error);
+        }
     });
 }
 
@@ -1286,25 +1294,29 @@ function internalLoadAssetContainerAsync(
     pluginOptions?: PluginOptions
 ): Promise<AssetContainer> {
     return new Promise((resolve, reject) => {
-        loadAssetContainerCoreAsync(
-            rootUrl,
-            sceneFilename,
-            scene,
-            (assets) => {
-                resolve(assets);
-            },
-            onProgress,
-            (scene, message, exception) => {
-                reject(exception || new Error(message));
-            },
-            pluginExtension,
-            name,
-            pluginOptions
-        );
+        try {
+            loadAssetContainerCoreAsync(
+                rootUrl,
+                sceneFilename,
+                scene,
+                (assets) => {
+                    resolve(assets);
+                },
+                onProgress,
+                (scene, message, exception) => {
+                    reject(exception || new Error(message));
+                },
+                pluginExtension,
+                name,
+                pluginOptions
+            ).catch((error) => reject(error));
+        } catch (error) {
+            reject(error);
+        }
     });
 }
 
-function importAnimations(
+async function importAnimations(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
@@ -1317,7 +1329,7 @@ function importAnimations(
     pluginExtension: Nullable<string> = null,
     name = "",
     pluginOptions: PluginOptions = {}
-): void {
+): Promise<void> {
     if (!scene) {
         Logger.Error("No scene available to load animations to");
         return;
@@ -1379,7 +1391,7 @@ function importAnimations(
         }
     };
 
-    loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
+    await loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1407,24 +1419,28 @@ function importAnimationsAsyncCore(
     pluginOptions?: PluginOptions
 ): Promise<Scene> {
     return new Promise((resolve, reject) => {
-        importAnimations(
-            rootUrl,
-            sceneFilename,
-            scene,
-            overwriteAnimations,
-            animationGroupLoadingMode,
-            targetConverter,
-            (scene) => {
-                resolve(scene);
-            },
-            onProgress,
-            (scene, message, exception) => {
-                reject(exception || new Error(message));
-            },
-            pluginExtension,
-            name,
-            pluginOptions
-        );
+        try {
+            importAnimations(
+                rootUrl,
+                sceneFilename,
+                scene,
+                overwriteAnimations,
+                animationGroupLoadingMode,
+                targetConverter,
+                (scene) => {
+                    resolve(scene);
+                },
+                onProgress,
+                (scene, message, exception) => {
+                    reject(exception || new Error(message));
+                },
+                pluginExtension,
+                name,
+                pluginOptions
+            ).catch((error) => reject(error));
+        } catch (error) {
+            reject(error);
+        }
     });
 }
 
@@ -1567,7 +1583,9 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): void {
-        importMeshAsync(meshNames, rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
+        importMeshAsync(meshNames, rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+            onError?.(EngineStore.LastCreatedScene!, error?.message, error)
+        );
     }
 
     /**
@@ -1615,7 +1633,9 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        loadScene(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name);
+        loadScene(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+            onError?.(EngineStore.LastCreatedScene!, error?.message, error)
+        );
     }
 
     /**
@@ -1661,7 +1681,9 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        appendAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
+        appendAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+            onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error)
+        );
     }
 
     /**
@@ -1707,7 +1729,9 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name);
+        loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
+            onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error)
+        );
     }
 
     /**
@@ -1759,7 +1783,19 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): void {
-        importAnimations(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onSuccess, onProgress, onError, pluginExtension, name);
+        importAnimations(
+            rootUrl,
+            sceneFilename,
+            scene,
+            overwriteAnimations,
+            animationGroupLoadingMode,
+            targetConverter,
+            onSuccess,
+            onProgress,
+            onError,
+            pluginExtension,
+            name
+        ).catch((error) => onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error));
     }
 
     /**


### PR DESCRIPTION
Several of the previously synchronous functions somewhat recently [became asynchronous](https://github.com/BabylonJS/Babylon.js/pull/15798). However, this left us in a state where thrown errors end up in ignored `Promise`s, and so you just see an unhandled error in the console log, rather than the error propagating to the caller through a final `Promise` and/or `onError` callback. This change tries to catch those missed cases and route them correctly, but at this point the code is very hard to reason about and understand where additional error handling is needed. Since there is no synchronous path anymore, we should rewrite a lot of this code to just use async/await, and have the callback based functions just be wrappers that still exist for back compat. This would make it way easier to understand and maintain the code. That said, this should probably be a post-8.0 release change.