### PR TITLE
Make sure an engine with exception is cleared

### DIFF
--- a/packages/dev/core/src/Misc/dumpTools.ts
+++ b/packages/dev/core/src/Misc/dumpTools.ts
@@ -37,10 +37,15 @@ async function _CreateDumpRenderer(): Promise<DumpToolsEngine> {
             };
             import("../Engines/thinEngine")
                 .then(({ ThinEngine: thinEngineClass }) => {
+                    const engineInstanceCount = EngineStore.Instances.length;
                     try {
                         canvas = new OffscreenCanvas(100, 100); // will be resized later
                         engine = new thinEngineClass(canvas, false, options);
                     } catch (e) {
+                        if (engineInstanceCount < EngineStore.Instances.length) {
+                            // The engine was created by another instance, let's use it
+                            EngineStore.Instances.pop()?.dispose();
+                        }
                         // The browser either does not support OffscreenCanvas or WebGL context in OffscreenCanvas, fallback on a regular canvas
                         canvas = document.createElement("canvas");
                         engine = new thinEngineClass(canvas, false, options);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/safari-mac-bug-glb-fails-to-load-after-create-screenshot-using-render-target/56381/12?u=raananw

As a side note, to test this I forced-threw an exception during engine construction (of course not commited :-) )