### PR TITLE
Preserve vertex buffer types in DracoEncoder

### DIFF
--- a/packages/dev/core/src/Buffers/bufferUtils.ts
+++ b/packages/dev/core/src/Buffers/bufferUtils.ts
@@ -2,8 +2,14 @@ import { Constants } from "../Engines/constants";
 import { Logger } from "../Misc/logger";
 import type { DataArray, FloatArray, IndicesArray, Nullable, TypedArray } from "../types";
 
+/**
+ * Union of TypedArrays that can be used for vertex data.
+ */
 export type VertexDataTypedArray = Exclude<TypedArray, Float64Array | BigInt64Array | BigUint64Array>;
 
+/**
+ * Interface for a constructor of a TypedArray.
+ */
 export interface TypedArrayConstructor<T extends TypedArray = TypedArray> {
     new (length: number): T;
     new (elements: Iterable<number>): T;

--- a/packages/dev/core/src/Meshes/Compression/dracoEncoder.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoEncoder.ts
@@ -41,7 +41,7 @@ function GetDracoAttributeName(kind: string): DracoAttributeName {
  * @internal
  */
 function PrepareIndicesForDraco(input: Mesh | Geometry): Nullable<Uint32Array | Uint16Array> {
-    let indices = input.getIndices();
+    let indices = input.getIndices(undefined, true);
 
     // Convert number[] and Int32Array types, if needed
     if (indices && !(indices instanceof Uint32Array) && !(indices instanceof Uint16Array)) {
@@ -78,7 +78,8 @@ function PrepareAttributesForDraco(input: Mesh | Geometry, excludedAttributes?: 
             vertexBuffer.byteOffset,
             vertexBuffer.byteStride,
             vertexBuffer.normalized,
-            input.getTotalVertices()
+            input.getTotalVertices(),
+            true
         );
         attributes.push({ kind: kind, dracoName: GetDracoAttributeName(kind), size: size, data: data });
     }
@@ -241,14 +242,12 @@ export class DracoEncoder extends DracoCodec {
                     worker.addEventListener("error", onError);
                     worker.addEventListener("message", onMessage);
 
-                    // Manually create copies of our attribute data and add them to the transfer list to ensure we only copy the ArrayBuffer data we need.
+                    // Build the transfer list. No need to copy, as the data was copied in previous steps.
                     const transferList = [];
                     attributes.forEach((attribute) => {
-                        attribute.data = attribute.data.slice();
                         transferList.push(attribute.data.buffer);
                     });
                     if (indices) {
-                        indices = indices.slice();
                         transferList.push(indices.buffer);
                     }
 

--- a/packages/dev/core/src/Meshes/Compression/dracoEncoder.types.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoEncoder.types.ts
@@ -1,4 +1,4 @@
-import type { VertexDataTypedArray } from "core/Buffers";
+import type { VertexDataTypedArray } from "core/Buffers/bufferUtils";
 import type { Nullable } from "core/types";
 
 /**

--- a/packages/dev/core/src/Meshes/Compression/dracoEncoder.types.ts
+++ b/packages/dev/core/src/Meshes/Compression/dracoEncoder.types.ts
@@ -1,3 +1,4 @@
+import type { VertexDataTypedArray } from "core/Buffers";
 import type { Nullable } from "core/types";
 
 /**
@@ -56,7 +57,7 @@ export interface IDracoAttributeData {
     /**
      * The buffer view of the attribute.
      */
-    data: Float32Array;
+    data: VertexDataTypedArray;
 }
 
 /**

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -84,7 +84,7 @@ export class KHR_draco_mesh_compression implements IGLTFExporterExtensionV2 {
             const accessor = accessors[primitive.indices];
             const bufferView = bufferManager.getBufferView(accessor);
             // Per exportIndices, indices must be either Uint16Array or Uint32Array
-            indices = bufferManager.getData(bufferView) as Uint32Array | Uint16Array;
+            indices = bufferManager.getData(bufferView).slice() as Uint32Array | Uint16Array;
 
             primitiveBufferViews.push(bufferView);
             primitiveAccessors.push(accessor);
@@ -97,7 +97,6 @@ export class KHR_draco_mesh_compression implements IGLTFExporterExtensionV2 {
             const bufferView = bufferManager.getBufferView(accessor);
 
             const size = GetAccessorElementCount(accessor.type);
-            // TODO: Add flag in DracoEncoder API to prevent copying data (a second time) to transferable buffer
             const data = GetTypedArrayData(
                 bufferManager.getData(bufferView),
                 size,
@@ -105,7 +104,8 @@ export class KHR_draco_mesh_compression implements IGLTFExporterExtensionV2 {
                 accessor.byteOffset || 0,
                 bufferView.byteStride || GetTypeByteLength(accessor.componentType) * size,
                 accessor.normalized || false,
-                accessor.count
+                accessor.count,
+                true
             );
 
             attributes.push({ kind: name, dracoName: getDracoAttributeName(name), size: GetAccessorElementCount(accessor.type), data: data });

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_draco_mesh_compression.ts
@@ -4,7 +4,7 @@ import { MeshPrimitiveMode } from "babylonjs-gltf2interface";
 import type { IAccessor, IBufferView, IKHRDracoMeshCompression, IMeshPrimitive } from "babylonjs-gltf2interface";
 import type { BufferManager } from "../bufferManager";
 import { DracoEncoder } from "core/Meshes/Compression/dracoEncoder";
-import { GetFloatData, GetTypeByteLength } from "core/Buffers/bufferUtils";
+import { GetTypedArrayData, GetTypeByteLength } from "core/Buffers/bufferUtils";
 import { GetAccessorElementCount } from "../glTFUtilities";
 import type { DracoAttributeName, IDracoAttributeData, IDracoEncoderOptions } from "core/Meshes/Compression/dracoEncoder.types";
 import { Logger } from "core/Misc/logger";
@@ -95,22 +95,20 @@ export class KHR_draco_mesh_compression implements IGLTFExporterExtensionV2 {
         for (const [name, accessorIndex] of Object.entries(primitive.attributes)) {
             const accessor = accessors[accessorIndex];
             const bufferView = bufferManager.getBufferView(accessor);
-            const data = bufferManager.getData(bufferView);
 
             const size = GetAccessorElementCount(accessor.type);
-            // TODO: Implement a way to preserve original data type, as Draco can handle more than just floats
             // TODO: Add flag in DracoEncoder API to prevent copying data (a second time) to transferable buffer
-            const floatData = GetFloatData(
-                data,
+            const data = GetTypedArrayData(
+                bufferManager.getData(bufferView),
                 size,
                 accessor.componentType,
                 accessor.byteOffset || 0,
                 bufferView.byteStride || GetTypeByteLength(accessor.componentType) * size,
                 accessor.normalized || false,
                 accessor.count
-            ) as Float32Array; // Because data is a TypedArray, GetFloatData will return a Float32Array
+            );
 
-            attributes.push({ kind: name, dracoName: getDracoAttributeName(name), size: GetAccessorElementCount(accessor.type), data: floatData });
+            attributes.push({ kind: name, dracoName: getDracoAttributeName(name), size: GetAccessorElementCount(accessor.type), data: data });
 
             primitiveBufferViews.push(bufferView);
             primitiveAccessors.push(accessor);


### PR DESCRIPTION
- Preserve original data type as much as possible
- Reduce copies made for transferring to worker