### PR TITLE
Make SceneLoader module level functions PascalCase and add GetRegisteredSceneLoaderPluginMetadata 

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -1651,7 +1651,7 @@ export class SceneLoader {
      * @param plugin defines the plugin to add
      */
     public static RegisterPlugin(plugin: ISceneLoaderPlugin | ISceneLoaderPluginAsync | ISceneLoaderPluginFactory): void {
-        registerSceneLoaderPlugin(plugin);
+        RegisterSceneLoaderPlugin(plugin);
     }
 
     /**

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -1539,7 +1539,7 @@ function importAnimationsSharedAsync(
 }
 
 /**
- * @deprecated Please use the module level functions such as LoadAssetContainerAsync as they are more efficient for bundler tree shaking and allow plugin options to be passed through.
+ * @deprecated The module level functions (such as LoadAssetContainerAsync) are more efficient for bundler tree shaking and allow plugin options to be passed through. Future improvements to scene loading will primarily be in the module level functions. The SceneLoader class will remain available, but it will be beneficial to prefer the module level functions.
  * Class used to load scene from various file formats using registered plugins
  * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes
  */

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -1539,6 +1539,7 @@ function importAnimationsSharedAsync(
 }
 
 /**
+ * @deprecated Please use the module level functions such as LoadAssetContainerAsync as they are more efficient for bundler tree shaking and allow plugin options to be passed through.
  * Class used to load scene from various file formats using registered plugins
  * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes
  */

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -1539,9 +1539,9 @@ function importAnimationsSharedAsync(
 }
 
 /**
- * @deprecated The module level functions (such as LoadAssetContainerAsync) are more efficient for bundler tree shaking and allow plugin options to be passed through. Future improvements to scene loading will primarily be in the module level functions. The SceneLoader class will remain available, but it will be beneficial to prefer the module level functions.
  * Class used to load scene from various file formats using registered plugins
  * @see https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes
+ * @deprecated The module level functions (such as LoadAssetContainerAsync) are more efficient for bundler tree shaking and allow plugin options to be passed through. Future improvements to scene loading will primarily be in the module level functions. The SceneLoader class will remain available, but it will be beneficial to prefer the module level functions.
  */
 export class SceneLoader {
     /**

--- a/packages/dev/loaders/src/OBJ/objFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.ts
@@ -3,7 +3,7 @@ import { Vector2 } from "core/Maths/math.vector";
 import { Tools } from "core/Misc/tools";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type { ISceneLoaderPluginAsync, ISceneLoaderPluginFactory, ISceneLoaderPlugin, ISceneLoaderAsyncResult } from "core/Loading/sceneLoader";
-import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
+import { RegisterSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
 import type { WebRequest } from "core/Misc/webRequest";
@@ -361,4 +361,4 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
 }
 
 //Add this loader into the register plugin
-registerSceneLoaderPlugin(new OBJFileLoader());
+RegisterSceneLoaderPlugin(new OBJFileLoader());

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -1,5 +1,5 @@
 import type { ISceneLoaderPluginAsync, ISceneLoaderPluginFactory, ISceneLoaderAsyncResult, ISceneLoaderProgressEvent, SceneLoaderPluginOptions } from "core/Loading/sceneLoader";
-import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
+import { RegisterSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { SPLATFileLoaderMetadata } from "./splatFileLoader.metadata";
 import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
 import { AssetContainer } from "core/assetContainer";
@@ -565,4 +565,4 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
 }
 
 // Add this loader into the register plugin
-registerSceneLoaderPlugin(new SPLATFileLoader());
+RegisterSceneLoaderPlugin(new SPLATFileLoader());

--- a/packages/dev/loaders/src/STL/stlFileLoader.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.ts
@@ -5,7 +5,7 @@ import { VertexBuffer } from "core/Buffers/buffer";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import { Mesh } from "core/Meshes/mesh";
 import type { ISceneLoaderPlugin } from "core/Loading/sceneLoader";
-import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
+import { RegisterSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
 import { STLFileLoaderMetadata } from "./stlFileLoader.metadata";
@@ -285,4 +285,4 @@ export class STLFileLoader implements ISceneLoaderPlugin {
     }
 }
 
-registerSceneLoaderPlugin(new STLFileLoader());
+RegisterSceneLoaderPlugin(new STLFileLoader());

--- a/packages/dev/loaders/src/dynamic.ts
+++ b/packages/dev/loaders/src/dynamic.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import type { ISceneLoaderPluginFactory, SceneLoaderPluginOptions } from "core/Loading/sceneLoader";
-import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
+import { RegisterSceneLoaderPlugin } from "core/Loading/sceneLoader";
 
 import { GLTFFileLoaderMetadata } from "./glTF/glTFFileLoader.metadata";
 import { OBJFileLoaderMetadata } from "./OBJ/objFileLoader.metadata";
@@ -16,7 +16,7 @@ import { registerBuiltInGLTFExtensions } from "./glTF/2.0/Extensions/dynamic";
  */
 export function registerBuiltInLoaders() {
     // Register the glTF loader (2.0) specifically/only.
-    registerSceneLoaderPlugin({
+    RegisterSceneLoaderPlugin({
         ...GLTFFileLoaderMetadata,
         createPlugin: async (options: SceneLoaderPluginOptions) => {
             const { GLTFFileLoader } = await import("./glTF/2.0/glTFLoader");
@@ -28,7 +28,7 @@ export function registerBuiltInLoaders() {
     registerBuiltInGLTFExtensions();
 
     // Register the OBJ loader.
-    registerSceneLoaderPlugin({
+    RegisterSceneLoaderPlugin({
         ...OBJFileLoaderMetadata,
         createPlugin: async () => {
             const { OBJFileLoader } = await import("./OBJ/objFileLoader");
@@ -37,7 +37,7 @@ export function registerBuiltInLoaders() {
     } satisfies ISceneLoaderPluginFactory);
 
     // Register the SPLAT loader.
-    registerSceneLoaderPlugin({
+    RegisterSceneLoaderPlugin({
         ...SPLATFileLoaderMetadata,
         createPlugin: async (options: SceneLoaderPluginOptions) => {
             const { SPLATFileLoader } = await import("./SPLAT/splatFileLoader");
@@ -46,7 +46,7 @@ export function registerBuiltInLoaders() {
     } satisfies ISceneLoaderPluginFactory);
 
     // Register the STL loader.
-    registerSceneLoaderPlugin({
+    RegisterSceneLoaderPlugin({
         ...STLFileLoaderMetadata,
         createPlugin: async () => {
             const { STLFileLoader } = await import("./STL/stlFileLoader");

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -10,7 +10,7 @@ import type { BaseTexture } from "core/Materials/Textures/baseTexture";
 import type { Material } from "core/Materials/material";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type { ISceneLoaderPluginFactory, ISceneLoaderPluginAsync, ISceneLoaderProgressEvent, ISceneLoaderAsyncResult, SceneLoaderPluginOptions } from "core/Loading/sceneLoader";
-import { registerSceneLoaderPlugin } from "core/Loading/sceneLoader";
+import { RegisterSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene, IDisposable } from "core/scene";
 import type { WebRequest } from "core/Misc/webRequest";
@@ -1392,4 +1392,4 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     private _endPerformanceCounterDisabled(counterName: string): void {}
 }
 
-registerSceneLoaderPlugin(new GLTFFileLoader());
+RegisterSceneLoaderPlugin(new GLTFFileLoader());

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -23,7 +23,7 @@ import type { MaterialVariantsController } from "loaders/glTF/2.0/Extensions/KHR
 import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
 import { PointerEventTypes } from "core/Events/pointerEvents";
 import { HemisphericLight } from "core/Lights/hemisphericLight";
-import { loadAssetContainerAsync } from "core/Loading/sceneLoader";
+import { LoadAssetContainerAsync } from "core/Loading/sceneLoader";
 import { ImageProcessingConfiguration } from "core/Materials/imageProcessingConfiguration";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { CubeTexture } from "core/Materials/Textures/cubeTexture";
@@ -1029,7 +1029,7 @@ export class Viewer implements IDisposable {
         this._snapshotHelper.disableSnapshotRendering();
 
         try {
-            const assetContainer = await loadAssetContainerAsync(source, this._scene, options);
+            const assetContainer = await LoadAssetContainerAsync(source, this._scene, options);
             assetContainer.animationGroups.forEach((group) => {
                 group.start(true, this.animationSpeed);
                 group.pause();


### PR DESCRIPTION
- To make the SceneLoader module more consistent with the rest of the API, I am updating the module level functions to be PascalCase. The camalCase ones are marked as deprecated, and the new PascalCase ones are not marked as experimental.
- Also marking the SceneLoader class as deprecated, suggesting using the module level functions instead.
- Exposing a new function GetRegisteredSceneLoaderPluginMetadata to get the metadata of the registered SceneLoader plugins. I want to use this for tooling like Sandbox so it doesn't have to hardcode a list of supported extensions. This adds no state, so it should have zero bundle impact for consumers that don't use it.