### PR TITLE
Viewer: Add removeEventListener typings

### DIFF
--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -77,6 +77,25 @@ export interface ViewerElementEventMap extends HTMLElementEventMap {
     selectedmaterialvariantchange: Event;
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
+export interface ViewerElement {
+    addEventListener<K extends keyof ViewerElementEventMap>(
+        type: K,
+        listener: (this: HTMLElement, ev: ViewerElementEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+
+    removeEventListener<K extends keyof ViewerElementEventMap>(
+        type: K,
+        listener: (this: HTMLElement, ev: ViewerElementEventMap[K]) => any,
+        options?: boolean | EventListenerOptions
+    ): void;
+
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
 /**
  * Base class for the viewer custom element.
  */
@@ -1031,26 +1050,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
             <slot name="progress-bar">${this._renderProgressBar()}</slot>
             <slot name="tool-bar">${this._renderToolbar()}</slot>
         `;
-    }
-
-    // eslint-disable-next-line babylonjs/available
-    override addEventListener<K extends keyof ViewerElementEventMap>(
-        type: K,
-        listener: (this: HTMLElement, ev: ViewerElementEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions
-    ): void;
-    override addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {
-        super.addEventListener(type as string, listener as EventListenerOrEventListenerObject, options as boolean | AddEventListenerOptions);
-    }
-
-    // eslint-disable-next-line babylonjs/available
-    override removeEventListener<K extends keyof ViewerElementEventMap>(
-        type: K,
-        listener: (this: HTMLElement, ev: ViewerElementEventMap[K]) => any,
-        options?: boolean | AddEventListenerOptions
-    ): void;
-    override removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {
-        super.removeEventListener(type as string, listener as EventListenerOrEventListenerObject, options as boolean | AddEventListenerOptions);
     }
 
     protected _dispatchCustomEvent<TEvent extends keyof ViewerElementEventMap>(type: TEvent, event: (type: TEvent) => ViewerElementEventMap[TEvent]) {

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1043,6 +1043,16 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
         super.addEventListener(type as string, listener as EventListenerOrEventListenerObject, options as boolean | AddEventListenerOptions);
     }
 
+    // eslint-disable-next-line babylonjs/available
+    override removeEventListener<K extends keyof ViewerElementEventMap>(
+        type: K,
+        listener: (this: HTMLElement, ev: ViewerElementEventMap[K]) => any,
+        options?: boolean | AddEventListenerOptions
+    ): void;
+    override removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void {
+        super.removeEventListener(type as string, listener as EventListenerOrEventListenerObject, options as boolean | AddEventListenerOptions);
+    }
+
     protected _dispatchCustomEvent<TEvent extends keyof ViewerElementEventMap>(type: TEvent, event: (type: TEvent) => ViewerElementEventMap[TEvent]) {
         this.dispatchEvent(event(type));
     }


### PR DESCRIPTION
Previously I had added strong typing for `addEventListener` for the `ViewerElement`'s custom events, but I forgot to do the same for `removeEventListener`. In this PR, I am adding `removeEventListener`, but I'm also moving this to be type only. Previously I did this typing by overriding the base `addEventListener` and calling it on `super`, but there is nothing actually needed at runtime for this, so we may as well remove any runtime impact (one extra frame on the callstack, a tiny bit of extra code in the final bundle).