### PR TITLE
NativeEngine captureGPUFrameTime + getGPUFrameTimeCounter

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -13,6 +13,12 @@ export type NativeProgram = NativeData;
 export type NativeUniform = NativeData;
 
 /** @internal */
+export type NativeFrameStats = {
+    /** @internal */
+    gpuTimeNs: number;
+};
+
+/** @internal */
 export interface INativeEngine {
     dispose(): void;
 
@@ -97,6 +103,8 @@ export interface INativeEngine {
 
     setCommandDataStream(dataStream: NativeDataStream): void;
     submitCommands(): void;
+
+    populateFrameStats(stats: NativeFrameStats): void;
 }
 
 /** @internal */

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -104,7 +104,7 @@ export interface INativeEngine {
     setCommandDataStream(dataStream: NativeDataStream): void;
     submitCommands(): void;
 
-    populateFrameStats(stats: NativeFrameStats): void;
+    populateFrameStats?(stats: NativeFrameStats): void;
 }
 
 /** @internal */

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -67,7 +67,7 @@ import type { WebGLHardwareTexture } from "./WebGL/webGLHardwareTexture";
 
 import "../Buffers/buffer.align";
 import { _GetCompatibleTextureLoader } from "core/Materials/Textures/Loaders/textureLoaderManager";
-import { _TimeToken } from "core/Instrumentation";
+import { _TimeToken } from "../Instrumentation/timeToken";
 
 // REVIEW: add a flag to effect to prevent multiple compilations of the same shader.
 declare module "../Materials/effect" {

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -2728,7 +2728,7 @@ export class NativeEngine extends Engine {
     }
 
     override endTimeQuery(token: _TimeToken): int {
-        this._engine.populateFrameStats(this._frameStats);
+        this._engine.populateFrameStats?.(this._frameStats);
         return this._frameStats.gpuTimeNs;
     }
 }


### PR DESCRIPTION
This change overrides `startTimeQuery` and `endTimeQuery` in `NativeEngine` such that `captureGPUFrameTime` and `getGPUFrameTimeCounter` work. They do so by calling the new `populateFrameStats` function on the native side of `NativeEngine`.
Corresponding BN change: https://github.com/BabylonJS/BabylonNative/pull/1458