### PR TITLE
SnapshotRenderingHelper: Don't force world matrix computation

### DIFF
--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -282,14 +282,14 @@ export class SnapshotRenderingHelper {
         if (Array.isArray(mesh)) {
             for (const m of mesh) {
                 if (!updateInstancedMeshes || !this._updateInstancedMesh(m)) {
-                    m.transferToEffect(m.computeWorldMatrix(true));
+                    m.transferToEffect(m.computeWorldMatrix());
                 }
             }
             return;
         }
 
         if (!updateInstancedMeshes || !this._updateInstancedMesh(mesh)) {
-            mesh.transferToEffect(mesh.computeWorldMatrix(true));
+            mesh.transferToEffect(mesh.computeWorldMatrix());
         }
     }
 


### PR DESCRIPTION
It should not be necessary to force the calculation of the world matrix, and the performances will be better.