### PR TITLE
Fix OnPickDownTrigger passing along a stale meshUnderPointer value on touch devices

### DIFF
--- a/packages/dev/core/src/Inputs/scene.inputManager.ts
+++ b/packages/dev/core/src/Inputs/scene.inputManager.ts
@@ -384,16 +384,28 @@ export class InputManager {
             const actionManager = pickResult.pickedMesh._getActionManagerForTrigger();
             if (actionManager) {
                 if (actionManager.hasPickTriggers) {
-                    actionManager.processTrigger(Constants.ACTION_OnPickDownTrigger, ActionEvent.CreateNew(pickResult.pickedMesh, evt, pickResult));
+                    actionManager.processTrigger(
+                        Constants.ACTION_OnPickDownTrigger,
+                        new ActionEvent(pickResult.pickedMesh, scene.pointerX, scene.pointerY, pickResult.pickedMesh, evt, pickResult)
+                    );
                     switch (evt.button) {
                         case 0:
-                            actionManager.processTrigger(Constants.ACTION_OnLeftPickTrigger, ActionEvent.CreateNew(pickResult.pickedMesh, evt, pickResult));
+                            actionManager.processTrigger(
+                                Constants.ACTION_OnLeftPickTrigger,
+                                new ActionEvent(pickResult.pickedMesh, scene.pointerX, scene.pointerY, pickResult.pickedMesh, evt, pickResult)
+                            );
                             break;
                         case 1:
-                            actionManager.processTrigger(Constants.ACTION_OnCenterPickTrigger, ActionEvent.CreateNew(pickResult.pickedMesh, evt, pickResult));
+                            actionManager.processTrigger(
+                                Constants.ACTION_OnCenterPickTrigger,
+                                new ActionEvent(pickResult.pickedMesh, scene.pointerX, scene.pointerY, pickResult.pickedMesh, evt, pickResult)
+                            );
                             break;
                         case 2:
-                            actionManager.processTrigger(Constants.ACTION_OnRightPickTrigger, ActionEvent.CreateNew(pickResult.pickedMesh, evt, pickResult));
+                            actionManager.processTrigger(
+                                Constants.ACTION_OnRightPickTrigger,
+                                new ActionEvent(pickResult.pickedMesh, scene.pointerX, scene.pointerY, pickResult.pickedMesh, evt, pickResult)
+                            );
                             break;
                     }
                 }


### PR DESCRIPTION
On touch devices, tapping on a mesh results in a pointer down without a previous pointer move operation.  _pointerDownEvent() in the webDeviceInputSystem will notify about a move input after processing a down input, but during the down input, we trigger the  OnPickDownTrigger handler and currently pass along stale information about the meshUnderPointer.  In mouse scenarios, this is unlikely to be a problem, since a move would have likely been processed before the down.  

With this change, the ActionEvent created to hand off to the OnPickDownTrigger handler will no longer ask the scene for the current meshUnderPointer, but instead will just use the picked mesh for that value, since that's always the most up to date, and always correct in the context of a down operation.

This issue was reported in the forum: https://forum.babylonjs.com/t/onpickdowntrigger-for-touch-devices/56497