### PR TITLE
Viewer: Bring back panning sensitivity adjustment

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1411,6 +1411,10 @@ export class Viewer implements IDisposable {
                     this._sceneMutated = false;
                     this._scene.render();
 
+                    // Update the camera panning sensitivity related properties based on the camera's distance from the target.
+                    this._camera.panningSensibility = 5000 / this._camera.radius;
+                    this._camera.speed = this._camera.radius * 0.2;
+
                     if (this.isAnimationPlaying) {
                         this.onAnimationProgressChanged.notifyObservers();
                         this._autoRotationBehavior.resetLastInteractionTime();


### PR DESCRIPTION
I accidentally removed this in a bad merge as part of https://github.com/BabylonJS/Babylon.js/pull/15864/files#diff-fd483dcfe4da7f71155ac0921ac2464a6da99751aec6af2b75fe06cf1537726bL1242-L1244. Just adding it back.