### PR TITLE
[new feature] add vertex color morph target

### DIFF
--- a/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/transformFeedbackBoundingHelper.ts
@@ -95,7 +95,8 @@ export class TransformFeedbackBoundingHelper implements IBoundingInfoHelperPlatf
                       false, // useNormalMorph
                       false, // useTangentMorph
                       false, // useUVMorph
-                      false // useUV2Morph
+                      false, // useUV2Morph
+                      false // useColorMorph
                   )
                 : 0;
 

--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -544,7 +544,7 @@ export class ThinEffectLayer {
 
         let uv1 = false;
         let uv2 = false;
-        let color = false;
+        const color = false;
 
         // Diffuse
         if (material) {

--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -544,6 +544,7 @@ export class ThinEffectLayer {
 
         let uv1 = false;
         let uv2 = false;
+        let color = false;
 
         // Diffuse
         if (material) {
@@ -652,7 +653,8 @@ export class ThinEffectLayer {
                   false, // useNormalMorph
                   false, // useTangentMorph
                   uv1, // useUVMorph
-                  uv2 // useUV2Morph
+                  uv2, // useUV2Morph
+                  color // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1596,7 +1596,7 @@ export class ShadowGenerator implements IShadowGenerator {
             let useNormal = false;
             let uv1 = false;
             let uv2 = false;
-            let color = false;
+            const color = false;
 
             // Normal bias.
             if (this.normalBias && mesh.isVerticesDataPresent(VertexBuffer.NormalKind)) {

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1679,7 +1679,7 @@ export class ShadowGenerator implements IShadowGenerator {
                       false, // useTangentMorph
                       uv1, // useUVMorph
                       uv2, // useUV2Morph
-                      color, // useColorMorph
+                      color // useColorMorph
                   )
                 : 0;
 

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1596,6 +1596,7 @@ export class ShadowGenerator implements IShadowGenerator {
             let useNormal = false;
             let uv1 = false;
             let uv2 = false;
+            let color = false;
 
             // Normal bias.
             if (this.normalBias && mesh.isVerticesDataPresent(VertexBuffer.NormalKind)) {
@@ -1677,7 +1678,8 @@ export class ShadowGenerator implements IShadowGenerator {
                       useNormal, // useNormalMorph
                       false, // useTangentMorph
                       uv1, // useUVMorph
-                      uv2 // useUV2Morph
+                      uv2, // useUV2Morph
+                      color, // useColorMorph
                   )
                 : 0;
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -35,11 +35,13 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         );
         this.registerInput("uv", NodeMaterialBlockConnectionPointTypes.Vector2);
         this.registerInput("uv2", NodeMaterialBlockConnectionPointTypes.Vector2);
+        this.registerInput("color", NodeMaterialBlockConnectionPointTypes.Color4)
         this.registerOutput("positionOutput", NodeMaterialBlockConnectionPointTypes.Vector3);
         this.registerOutput("normalOutput", NodeMaterialBlockConnectionPointTypes.Vector3);
         this.registerOutput("tangentOutput", NodeMaterialBlockConnectionPointTypes.Vector4);
         this.registerOutput("uvOutput", NodeMaterialBlockConnectionPointTypes.Vector2);
         this.registerOutput("uv2Output", NodeMaterialBlockConnectionPointTypes.Vector2);
+        this.registerOutput("colorOutput", NodeMaterialBlockConnectionPointTypes.Color4);
     }
 
     /**
@@ -85,6 +87,10 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         return this._inputs[4];
     }
 
+    public get color(): NodeMaterialConnectionPoint {
+        return this._inputs[5];
+    }
+
     /**
      * Gets the position output component
      */
@@ -118,6 +124,10 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
      */
     public get uv2Output(): NodeMaterialConnectionPoint {
         return this._outputs[4];
+    }
+
+    public get colorOutput(): NodeMaterialConnectionPoint {
+        return this._outputs[5];
     }
 
     public override initialize(state: NodeMaterialBuildState) {
@@ -195,6 +205,15 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
             }
             uv2Input.output.connectTo(this.uv2);
         }
+        if (!this.color.isConnected) {
+            let colorInput = material.getInputBlockByPredicate((b) => b.isAttribute && b.name === "color" && additionalFilteringInfo(b));
+
+            if (!colorInput) {
+                colorInput = new InputBlock("color");
+                colorInput.setAsAttribute("color");
+            }
+            colorInput.output.connectTo(this.color);
+        }
     }
 
     public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
@@ -234,11 +253,13 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         const tangent = this.tangent;
         const uv = this.uv;
         const uv2 = this.uv2;
+        const color = this.color;
         const positionOutput = this.positionOutput;
         const normalOutput = this.normalOutput;
         const tangentOutput = this.tangentOutput;
         const uvOutput = this.uvOutput;
         const uv2Output = this.uv2Output;
+        const colorOutput = this.colorOutput;
         const state = vertexShaderState;
         const repeatCount = defines.NUM_MORPH_INFLUENCERS as number;
 
@@ -248,6 +269,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         const supportTangents = manager && manager.supportsTangents;
         const supportUVs = manager && manager.supportsUVs;
         const supportUV2s = manager && manager.supportsUV2s;
+        const supportColors = manager && manager.supportsColors;
 
         let injectionCode = "";
 
@@ -310,6 +332,15 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 injectionCode += `${uv2Output.associatedVariableName} += (readVector3FromRawSampler(i, vertexID).xy - ${uv2.associatedVariableName}) * morphTargetInfluences[i];\n`;
                 injectionCode += `#endif\n`;
             }
+            injectionCode += `#ifdef MORPHTARGETTEXTURE_HASUV2S\n`;
+            injectionCode += `vertexID += 1.0;\n`;
+            injectionCode += `#endif\n`;
+
+            if (supportColors) {
+                injectionCode += `#ifdef MORPHTARGETS_COLOR\n`;
+                injectionCode += `${colorOutput.associatedVariableName} += (readVector4FromRawSampler(i, vertexID) - ${color.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[i];\n`;
+                injectionCode += `#endif\n`;
+            }
 
             injectionCode += "}\n";
         } else {
@@ -349,6 +380,12 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                     injectionCode += `${uv2Output.associatedVariableName}.xy += (uv2_${index} - ${uv2.associatedVariableName}.xy) * morphTargetInfluences[${index}];\n`;
                     injectionCode += `#endif\n`;
                 }
+
+                if (supportColors && defines["COLORS"]) {
+                    injectionCode += `#ifdef MORPHTARGETS_COLOR\n`;
+                    injectionCode += `${colorOutput.associatedVariableName} += (color${index} - ${color.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[${index}];\n`;
+                    injectionCode += `#endif\n`;
+                }
             }
         }
         injectionCode += `#endif\n`;
@@ -376,6 +413,10 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                 if (supportUV2s && defines["UV2"]) {
                     state.attributes.push(VertexBuffer.UV2Kind + "_" + index);
                 }
+
+                if (supportColors && defines["COLORS"]) {
+                    state.attributes.push(VertexBuffer.ColorKind + index);
+                }
             }
         }
     }
@@ -398,11 +439,13 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         const tangent = this.tangent;
         const uv = this.uv;
         const uv2 = this.uv2;
+        const color = this.color;
         const positionOutput = this.positionOutput;
         const normalOutput = this.normalOutput;
         const tangentOutput = this.tangentOutput;
         const uvOutput = this.uvOutput;
         const uv2Output = this.uv2Output;
+        const colorOutput = this.colorOutput;
         const comments = `//${this.name}`;
 
         state.uniforms.push("morphTargetInfluences");
@@ -436,6 +479,11 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         state.compilationString += `${state._declareOutput(uv2Output)} = ${uv2.associatedVariableName};\n`;
         state.compilationString += `#else\n`;
         state.compilationString += `${state._declareOutput(uv2Output)} = vec2(0., 0.);\n`;
+        state.compilationString += `#endif\n`;
+        state.compilationString += `#ifdef VERTEXCOLOR\n`;
+        state.compilationString += `${state._declareOutput(colorOutput)} = ${color.associatedVariableName};\n`;
+        state.compilationString += `#else\n`;
+        state.compilationString += `${state._declareOutput(colorOutput)} = vec4(0., 0., 0., 0.);\n`;
         state.compilationString += `#endif\n`;
 
         // Repeatable content

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -35,7 +35,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         );
         this.registerInput("uv", NodeMaterialBlockConnectionPointTypes.Vector2);
         this.registerInput("uv2", NodeMaterialBlockConnectionPointTypes.Vector2);
-        this.registerInput("color", NodeMaterialBlockConnectionPointTypes.Color4)
+        this.registerInput("color", NodeMaterialBlockConnectionPointTypes.Color4);
         this.registerOutput("positionOutput", NodeMaterialBlockConnectionPointTypes.Vector3);
         this.registerOutput("normalOutput", NodeMaterialBlockConnectionPointTypes.Vector3);
         this.registerOutput("tangentOutput", NodeMaterialBlockConnectionPointTypes.Vector4);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -87,6 +87,9 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         return this._inputs[4];
     }
 
+    /**
+     * Gets the color input component
+     */
     public get color(): NodeMaterialConnectionPoint {
         return this._inputs[5];
     }
@@ -126,6 +129,9 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         return this._outputs[4];
     }
 
+    /**
+     * Gets the color output component
+     */
     public get colorOutput(): NodeMaterialConnectionPoint {
         return this._outputs[5];
     }
@@ -381,7 +387,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                     injectionCode += `#endif\n`;
                 }
 
-                if (supportColors && defines["COLORS"]) {
+                if (supportColors && defines["VERTEXCOLOR_NME"]) {
                     injectionCode += `#ifdef MORPHTARGETS_COLOR\n`;
                     injectionCode += `${colorOutput.associatedVariableName} += (color${index} - ${color.associatedVariableName}) * ${uniformsPrefix}morphTargetInfluences[${index}];\n`;
                     injectionCode += `#endif\n`;
@@ -414,7 +420,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
                     state.attributes.push(VertexBuffer.UV2Kind + "_" + index);
                 }
 
-                if (supportColors && defines["COLORS"]) {
+                if (supportColors && defines["VERTEXCOLOR_NME"]) {
                     state.attributes.push(VertexBuffer.ColorKind + index);
                 }
             }
@@ -480,7 +486,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         state.compilationString += `#else\n`;
         state.compilationString += `${state._declareOutput(uv2Output)} = vec2(0., 0.);\n`;
         state.compilationString += `#endif\n`;
-        state.compilationString += `#ifdef VERTEXCOLOR\n`;
+        state.compilationString += `#ifdef VERTEXCOLOR_NME\n`;
         state.compilationString += `${state._declareOutput(colorOutput)} = ${color.associatedVariableName};\n`;
         state.compilationString += `#else\n`;
         state.compilationString += `${state._declareOutput(colorOutput)} = vec4(0., 0., 0., 0.);\n`;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -159,6 +159,7 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public MORPHTARGETS_UV = false;
     /** Morph target uv2 */
     public MORPHTARGETS_UV2 = false;
+    public MORPHTARGETS_COLOR = false;
     /** Morph target support positions */
     public MORPHTARGETTEXTURE_HASPOSITIONS = false;
     /** Morph target support normals */
@@ -169,6 +170,7 @@ export class NodeMaterialDefines extends MaterialDefines implements IImageProces
     public MORPHTARGETTEXTURE_HASUVS = false;
     /** Morph target support uv2s */
     public MORPHTARGETTEXTURE_HASUV2S = false;
+    public MORPHTARGETTEXTURE_HASCOLORS = false;
     /** Number of morph influencers */
     public NUM_MORPH_INFLUENCERS = 0;
     /** Using a texture to store morph target data */

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -242,11 +242,13 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;
     public MORPHTARGETS_UV2 = false;
+    public MORPHTARGETS_COLOR = false;
     public MORPHTARGETTEXTURE_HASPOSITIONS = false;
     public MORPHTARGETTEXTURE_HASNORMALS = false;
     public MORPHTARGETTEXTURE_HASTANGENTS = false;
     public MORPHTARGETTEXTURE_HASUVS = false;
     public MORPHTARGETTEXTURE_HASUV2S = false;
+    public MORPHTARGETTEXTURE_HASCOLORS = false;
     public NUM_MORPH_INFLUENCERS = 0;
     public MORPHTARGETS_TEXTURE = false;
 

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -28,6 +28,7 @@ const _TmpMorphInfluencers = {
     TANGENT: false,
     UV: false,
     UV2: false,
+    COLOR: false,
 };
 
 /**
@@ -88,7 +89,8 @@ export function PrepareDefinesAndAttributesForMorphTargets(
     useNormalMorph: boolean,
     useTangentMorph: boolean,
     useUVMorph: boolean,
-    useUV2Morph: boolean
+    useUV2Morph: boolean,
+    useColorMorph: boolean,
 ): number {
     const numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
     if (numMorphInfluencers <= 0) {
@@ -102,12 +104,14 @@ export function PrepareDefinesAndAttributesForMorphTargets(
     if (morphTargetManager.hasTangents) defines.push("#define MORPHTARGETTEXTURE_HASTANGENTS");
     if (morphTargetManager.hasUVs) defines.push("#define MORPHTARGETTEXTURE_HASUVS");
     if (morphTargetManager.hasUV2s) defines.push("#define MORPHTARGETTEXTURE_HASUV2S");
+    if (morphTargetManager.hasColors) defines.push("#define MORPHTARGETTEXTURE_HASCOLORS");
 
     if (morphTargetManager.supportsPositions && usePositionMorph) defines.push("#define MORPHTARGETS_POSITION");
     if (morphTargetManager.supportsNormals && useNormalMorph) defines.push("#define MORPHTARGETS_NORMAL");
     if (morphTargetManager.supportsTangents && useTangentMorph) defines.push("#define MORPHTARGETS_TANGENT");
     if (morphTargetManager.supportsUVs && useUVMorph) defines.push("#define MORPHTARGETS_UV");
     if (morphTargetManager.supportsUV2s && useUV2Morph) defines.push("#define MORPHTARGETS_UV2");
+    if (morphTargetManager.supportsColors && useColorMorph) defines.push("#define MORPHTARGETS_COLOR");
 
     defines.push("#define NUM_MORPH_INFLUENCERS " + numMorphInfluencers);
 
@@ -120,6 +124,7 @@ export function PrepareDefinesAndAttributesForMorphTargets(
     _TmpMorphInfluencers.TANGENT = useTangentMorph;
     _TmpMorphInfluencers.UV = useUVMorph;
     _TmpMorphInfluencers.UV2 = useUV2Morph;
+    _TmpMorphInfluencers.COLOR = useColorMorph;
 
     PrepareAttributesForMorphTargets(attribs, mesh, _TmpMorphInfluencers, usePositionMorph);
     return numMorphInfluencers;
@@ -137,6 +142,7 @@ export function PrepareAttributesForMorphTargetsInfluencers(attribs: string[], m
     _TmpMorphInfluencers.TANGENT = false;
     _TmpMorphInfluencers.UV = false;
     _TmpMorphInfluencers.UV2 = false;
+    _TmpMorphInfluencers.COLOR = false;
     PrepareAttributesForMorphTargets(attribs, mesh, _TmpMorphInfluencers, true);
 }
 
@@ -161,6 +167,7 @@ export function PrepareAttributesForMorphTargets(attribs: string[], mesh: Abstra
         const tangent = manager && manager.supportsTangents && defines["TANGENT"];
         const uv = manager && manager.supportsUVs && defines["UV1"];
         const uv2 = manager && manager.supportsUV2s && defines["UV2"];
+        const color = manager && manager.supportsColors && defines["COLOR"];
         for (let index = 0; index < influencers; index++) {
             if (position) {
                 attribs.push(Constants.PositionKind + index);
@@ -180,6 +187,10 @@ export function PrepareAttributesForMorphTargets(attribs: string[], mesh: Abstra
 
             if (uv2) {
                 attribs.push(Constants.UV2Kind + "_" + index);
+            }
+
+            if (color) {
+                attribs.push(Constants.ColorKind + index);
             }
 
             if (attribs.length > maxAttributesCount) {
@@ -764,12 +775,14 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_TANGENT"] = manager.supportsTangents && defines["TANGENT"];
         defines["MORPHTARGETS_NORMAL"] = manager.supportsNormals && defines["NORMAL"];
         defines["MORPHTARGETS_POSITION"] = manager.supportsPositions;
+        defines["MORPHTARGETS_COLOR"] = manager.supportsColors;
 
         defines["MORPHTARGETTEXTURE_HASUVS"] = manager.hasUVs;
         defines["MORPHTARGETTEXTURE_HASUV2S"] = manager.hasUV2s;
         defines["MORPHTARGETTEXTURE_HASTANGENTS"] = manager.hasTangents;
         defines["MORPHTARGETTEXTURE_HASNORMALS"] = manager.hasNormals;
         defines["MORPHTARGETTEXTURE_HASPOSITIONS"] = manager.hasPositions;
+        defines["MORPHTARGETTEXTURE_HASCOLORS"] = manager.hasColors;
 
         defines["NUM_MORPH_INFLUENCERS"] = manager.numMaxInfluencers || manager.numInfluencers;
         defines["MORPHTARGETS"] = defines["NUM_MORPH_INFLUENCERS"] > 0;
@@ -781,12 +794,14 @@ export function PrepareDefinesForMorphTargets(mesh: AbstractMesh, defines: any) 
         defines["MORPHTARGETS_TANGENT"] = false;
         defines["MORPHTARGETS_NORMAL"] = false;
         defines["MORPHTARGETS_POSITION"] = false;
+        defines["MORPHTARGETS_COLOR"] = false;
 
         defines["MORPHTARGETTEXTURE_HASUVS"] = false;
         defines["MORPHTARGETTEXTURE_HASUV2S"] = false;
         defines["MORPHTARGETTEXTURE_HASTANGENTS"] = false;
         defines["MORPHTARGETTEXTURE_HASNORMALS"] = false;
         defines["MORPHTARGETTEXTURE_HASPOSITIONS"] = false;
+        defines["MORPHTARGETTEXTURE_HAS_COLORS"] = false;
 
         defines["MORPHTARGETS"] = false;
         defines["NUM_MORPH_INFLUENCERS"] = 0;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -90,7 +90,7 @@ export function PrepareDefinesAndAttributesForMorphTargets(
     useTangentMorph: boolean,
     useUVMorph: boolean,
     useUV2Morph: boolean,
-    useColorMorph: boolean,
+    useColorMorph: boolean
 ): number {
     const numMorphInfluencers = morphTargetManager.numMaxInfluencers || morphTargetManager.numInfluencers;
     if (numMorphInfluencers <= 0) {

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -78,6 +78,7 @@ export function BindFogParameters(scene: Scene, mesh?: AbstractMesh, effect?: Ef
  * @param useTangentMorph Whether the tangent morph target is used
  * @param useUVMorph Whether the UV morph target is used
  * @param useUV2Morph Whether the UV2 morph target is used
+ * @param useColorMorph Whether the color morph target is used
  * @returns The maxSimultaneousMorphTargets for the effect
  */
 export function PrepareDefinesAndAttributesForMorphTargets(

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -787,7 +787,7 @@ export class ShaderMaterial extends PushMaterial {
                 tangent, // useTangentMorph
                 uv, // useUVMorph
                 uv2, // useUV2Morph
-                color, // useColorMorph
+                color // useColorMorph
             );
             if (manager.isUsingTextureForTargets) {
                 if (uniforms.indexOf("morphTargetTextureIndices") === -1) {

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -776,6 +776,7 @@ export class ShaderMaterial extends PushMaterial {
             const uv2 = defines.indexOf("#define UV2") !== -1;
             const tangent = defines.indexOf("#define TANGENT") !== -1;
             const normal = defines.indexOf("#define NORMAL") !== -1;
+            const color = defines.indexOf("#define VERTEXCOLOR") !== -1;
             numInfluencers = PrepareDefinesAndAttributesForMorphTargets(
                 manager,
                 defines,
@@ -785,7 +786,8 @@ export class ShaderMaterial extends PushMaterial {
                 normal, // useNormalMorph
                 tangent, // useTangentMorph
                 uv, // useUVMorph
-                uv2 // useUV2Morph
+                uv2, // useUV2Morph
+                color, // useColorMorph
             );
             if (manager.isUsingTextureForTargets) {
                 if (uniforms.indexOf("morphTargetTextureIndices") === -1) {

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -161,11 +161,13 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public MORPHTARGETS_TANGENT = false;
     public MORPHTARGETS_UV = false;
     public MORPHTARGETS_UV2 = false;
+    public MORPHTARGETS_COLOR = false;
     public MORPHTARGETTEXTURE_HASPOSITIONS = false;
     public MORPHTARGETTEXTURE_HASNORMALS = false;
     public MORPHTARGETTEXTURE_HASTANGENTS = false;
     public MORPHTARGETTEXTURE_HASUVS = false;
     public MORPHTARGETTEXTURE_HASUV2S = false;
+    public MORPHTARGETTEXTURE_HASCOLORS = false;
     public NUM_MORPH_INFLUENCERS = 0;
     public MORPHTARGETS_TEXTURE = false;
     public NONUNIFORMSCALING = false; // https://playground.babylonjs.com#V6DWIH

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -61,6 +61,9 @@ function applyMorph(data: FloatArray, kind: string, morphTargetManager: MorphTar
         case VertexBuffer.UVKind:
             getTargetData = (target) => target.getUVs();
             break;
+        case VertexBuffer.ColorKind:
+            getTargetData = (target) => target.getColors();
+            break;
         default:
             return;
     }

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -61,6 +61,9 @@ function applyMorph(data: FloatArray, kind: string, morphTargetManager: MorphTar
         case VertexBuffer.UVKind:
             getTargetData = (target) => target.getUVs();
             break;
+        case VertexBuffer.UV2Kind:
+            getTargetData = (target) => target.getUV2s();
+            break;
         case VertexBuffer.ColorKind:
             getTargetData = (target) => target.getColors();
             break;

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -3391,6 +3391,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 if (uvs) {
                     target.setUVs(separateVertices(uvs, 2));
                 }
+
+                const colors = target.getColors();
+                if (colors) {
+                    target.setColors(separateVertices(colors, 4));
+                }
             }
             this.morphTargetManager.synchronize();
         }
@@ -4128,6 +4133,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 if (uv2s) {
                     this.geometry.setVerticesData(VertexBuffer.UV2Kind + "_" + index, uv2s, false, 2);
                 }
+
+                const colors = morphTarget.getColors();
+                if (colors) {
+                    this.geometry.setVerticesData(VertexBuffer.ColorKind + index, colors, false, 4);
+                }
             }
         } else {
             let index = 0;
@@ -4147,6 +4157,9 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                 }
                 if (this.geometry.isVerticesDataPresent(VertexBuffer.UV2Kind + index)) {
                     this.geometry.removeVerticesData(VertexBuffer.UV2Kind + "_" + index);
+                }
+                if (this.geometry.isVerticesDataPresent(VertexBuffer.ColorKind + index)) {
+                    this.geometry.removeVerticesData(VertexBuffer.ColorKind + index);
                 }
                 index++;
             }

--- a/packages/dev/core/src/Morph/morphTarget.ts
+++ b/packages/dev/core/src/Morph/morphTarget.ts
@@ -278,6 +278,10 @@ export class MorphTarget implements IAnimatable {
         return this._uv2s;
     }
 
+    /**
+     * Affects color data to this target
+     * @param data defines the color data to use
+     */
     public setColors(data: Nullable<FloatArray>) {
         const hadColors = this.hasColors;
 
@@ -288,6 +292,10 @@ export class MorphTarget implements IAnimatable {
         }
     }
 
+    /**
+     * Gets the color data stored in this target
+     * @returns a FloatArray containing the color data (or null if not present)
+     */
     public getColors(): Nullable<FloatArray> {
         return this._colors;
     }

--- a/packages/dev/core/src/Morph/morphTarget.ts
+++ b/packages/dev/core/src/Morph/morphTarget.ts
@@ -163,7 +163,9 @@ export class MorphTarget implements IAnimatable {
                   ? this._uvs.length / 2
                   : this._uv2s
                     ? this._uv2s.length / 2
-                    : this._colors ? this._colors.length / 4 : 0;
+                    : this._colors
+                      ? this._colors.length / 4
+                      : 0;
     }
 
     /**

--- a/packages/dev/core/src/Morph/morphTarget.ts
+++ b/packages/dev/core/src/Morph/morphTarget.ts
@@ -28,6 +28,7 @@ export class MorphTarget implements IAnimatable {
     private _tangents: Nullable<FloatArray> = null;
     private _uvs: Nullable<FloatArray> = null;
     private _uv2s: Nullable<FloatArray> = null;
+    private _colors: Nullable<FloatArray> = null;
     private _influence: number;
     private _uniqueId = 0;
 
@@ -144,6 +145,10 @@ export class MorphTarget implements IAnimatable {
         return !!this._uv2s;
     }
 
+    public get hasColors(): boolean {
+        return !!this._colors;
+    }
+
     /**
      * Gets the number of vertices stored in this target
      */
@@ -158,7 +163,7 @@ export class MorphTarget implements IAnimatable {
                   ? this._uvs.length / 2
                   : this._uv2s
                     ? this._uv2s.length / 2
-                    : 0;
+                    : this._colors ? this._colors.length / 4 : 0;
     }
 
     /**
@@ -271,6 +276,20 @@ export class MorphTarget implements IAnimatable {
         return this._uv2s;
     }
 
+    public setColors(data: Nullable<FloatArray>) {
+        const hadColors = this.hasColors;
+
+        this._colors = data;
+
+        if (hadColors !== this.hasColors) {
+            this._onDataLayoutChanged.notifyObservers(undefined);
+        }
+    }
+
+    public getColors(): Nullable<FloatArray> {
+        return this._colors;
+    }
+
     /**
      * Clone the current target
      * @returns a new MorphTarget
@@ -283,6 +302,7 @@ export class MorphTarget implements IAnimatable {
         newOne._tangents = this._tangents;
         newOne._uvs = this._uvs;
         newOne._uv2s = this._uv2s;
+        newOne._colors = this._colors;
 
         return newOne;
     }
@@ -312,6 +332,9 @@ export class MorphTarget implements IAnimatable {
         }
         if (this.hasUV2s) {
             serializationObject.uv2s = Array.prototype.slice.call(this.getUV2s());
+        }
+        if (this.hasColors) {
+            serializationObject.colors = Array.prototype.slice.call(this.getColors());
         }
 
         // Animations
@@ -355,6 +378,9 @@ export class MorphTarget implements IAnimatable {
         }
         if (serializationObject.uv2s) {
             result.setUV2s(serializationObject.uv2s);
+        }
+        if (serializationObject.colors) {
+            result.setColors(serializationObject.colors);
         }
 
         // Animations
@@ -408,6 +434,9 @@ export class MorphTarget implements IAnimatable {
         }
         if (mesh.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
             result.setUV2s(<FloatArray>mesh.getVerticesData(VertexBuffer.UV2Kind));
+        }
+        if (mesh.isVerticesDataPresent(VertexBuffer.ColorKind)) {
+            result.setColors(<FloatArray>mesh.getVerticesData(VertexBuffer.ColorKind));
         }
 
         return result;

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -89,6 +89,9 @@ export class MorphTargetManager implements IDisposable {
      */
     public enableUV2Morphing = true;
 
+    /**
+     * Gets or sets a boolean indicating if colors must be morphed
+     */
     public enableColorMorphing = true;
 
     /**
@@ -207,6 +210,9 @@ export class MorphTargetManager implements IDisposable {
         return this._supportsUV2s && this.enableUV2Morphing;
     }
 
+    /**
+     * Gets a boolean indicating if this manager supports morphing of colors
+     */
     public get supportsColors(): boolean {
         return this._supportsColors && this.enableColorMorphing;
     }
@@ -246,6 +252,9 @@ export class MorphTargetManager implements IDisposable {
         return this._supportsUV2s;
     }
 
+    /**
+     * Gets a boolean indicating if this manager has data for morphing colors
+     */
     public get hasColors(): boolean {
         return this._supportsColors;
     }

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -32,6 +32,7 @@ export class MorphTargetManager implements IDisposable {
     private _supportsTangents = false;
     private _supportsUVs = false;
     private _supportsUV2s = false;
+    private _supportsColors = false;
     private _vertexCount = 0;
     private _uniqueId = 0;
     private _tempInfluences = new Array<number>();
@@ -87,6 +88,8 @@ export class MorphTargetManager implements IDisposable {
      * Gets or sets a boolean indicating if UV2 must be morphed
      */
     public enableUV2Morphing = true;
+
+    public enableColorMorphing = true;
 
     /**
      * Sets a boolean indicating that adding new target or updating an existing target will not update the underlying data buffers
@@ -204,6 +207,10 @@ export class MorphTargetManager implements IDisposable {
         return this._supportsUV2s && this.enableUV2Morphing;
     }
 
+    public get supportsColors(): boolean {
+        return this._supportsColors && this.enableColorMorphing;
+    }
+
     /**
      * Gets a boolean indicating if this manager has data for morphing positions
      */
@@ -237,6 +244,10 @@ export class MorphTargetManager implements IDisposable {
      */
     public get hasUV2s(): boolean {
         return this._supportsUV2s;
+    }
+
+    public get hasColors(): boolean {
+        return this._supportsColors;
     }
 
     /**
@@ -393,6 +404,7 @@ export class MorphTargetManager implements IDisposable {
         copy.enableTangentMorphing = this.enableTangentMorphing;
         copy.enableUVMorphing = this.enableUVMorphing;
         copy.enableUV2Morphing = this.enableUV2Morphing;
+        copy.enableColorMorphing = this.enableColorMorphing;
 
         return copy;
     }
@@ -490,6 +502,7 @@ export class MorphTargetManager implements IDisposable {
         this._supportsTangents = true;
         this._supportsUVs = true;
         this._supportsUV2s = true;
+        this._supportsColors = true;
         this._vertexCount = 0;
 
         this._targetStoreTexture?.dispose();
@@ -505,6 +518,7 @@ export class MorphTargetManager implements IDisposable {
             this._supportsTangents = this._supportsTangents && target.hasTangents;
             this._supportsUVs = this._supportsUVs && target.hasUVs;
             this._supportsUV2s = this._supportsUV2s && target.hasUV2s;
+            this._supportsColors = this._supportsColors && target.hasColors;
 
             const vertexCount = target.vertexCount;
             if (this._vertexCount === 0) {
@@ -524,7 +538,8 @@ export class MorphTargetManager implements IDisposable {
             this._supportsNormals && this._textureVertexStride++;
             this._supportsTangents && this._textureVertexStride++;
             this._supportsUVs && this._textureVertexStride++;
-            this.supportsUV2s && this._textureVertexStride++;
+            this._supportsUV2s && this._textureVertexStride++;
+            this._supportsColors && this._textureVertexStride++;
 
             this._textureWidth = this._vertexCount * this._textureVertexStride || 1;
             this._textureHeight = 1;
@@ -547,6 +562,7 @@ export class MorphTargetManager implements IDisposable {
                 const uvs = target.getUVs();
                 const tangents = target.getTangents();
                 const uv2s = target.getUV2s();
+                const colors = target.getColors();
 
                 offset = index * this._textureWidth * this._textureHeight * 4;
                 for (let vertex = 0; vertex < this._vertexCount; vertex++) {
@@ -580,6 +596,14 @@ export class MorphTargetManager implements IDisposable {
                     if (this._supportsUV2s && uv2s) {
                         data[offset] = uv2s[vertex * 2];
                         data[offset + 1] = uv2s[vertex * 2 + 1];
+                        offset += 4;
+                    }
+
+                    if (this._supportsColors && colors) {
+                        data[offset] = colors[vertex * 4];
+                        data[offset + 1] = colors[vertex * 4 + 1];
+                        data[offset + 2] = colors[vertex * 4 + 2];
+                        data[offset + 3] = colors[vertex * 4 + 3];
                         offset += 4;
                     }
                 }

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -212,7 +212,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
 
         let uv1 = false;
         let uv2 = false;
-        let color = false;
+        const color = false;
 
         // Alpha test
         if (material) {

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -269,7 +269,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
                   false, // useTangentMorph
                   uv1, // useUVMorph
                   uv2, // useUV2Morph
-                  color, // useColorMorph
+                  color // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/volumetricLightScatteringPostProcess.ts
@@ -212,6 +212,7 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
 
         let uv1 = false;
         let uv2 = false;
+        let color = false;
 
         // Alpha test
         if (material) {
@@ -267,7 +268,8 @@ export class VolumetricLightScatteringPostProcess extends PostProcess {
                   false, // useNormalMorph
                   false, // useTangentMorph
                   uv1, // useUVMorph
-                  uv2 // useUV2Morph
+                  uv2, // useUV2Morph
+                  color, // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -458,7 +458,7 @@ export class DepthRenderer {
                   false, // useTangentMorph
                   uv1, // useUVMorph
                   uv2, // useUV2Morph
-                  color, // useColorMorph
+                  color // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -405,6 +405,7 @@ export class DepthRenderer {
 
         let uv1 = false;
         let uv2 = false;
+        let color = false;
 
         // Alpha test
         if (material.needAlphaTestingForMesh(mesh) && material.getAlphaTestTexture()) {
@@ -456,7 +457,8 @@ export class DepthRenderer {
                   false, // useNormalMorph
                   false, // useTangentMorph
                   uv1, // useUVMorph
-                  uv2 // useUV2Morph
+                  uv2, // useUV2Morph
+                  color, // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -405,7 +405,7 @@ export class DepthRenderer {
 
         let uv1 = false;
         let uv2 = false;
-        let color = false;
+        const color = false;
 
         // Alpha test
         if (material.needAlphaTestingForMesh(mesh) && material.getAlphaTestTexture()) {

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -794,7 +794,7 @@ export class GeometryBufferRenderer {
                   false, // useTangentMorph
                   uv1, // useUVMorph
                   uv2, // useUV2Morph
-                  color, // useColorMorph
+                  color // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -556,7 +556,7 @@ export class GeometryBufferRenderer {
 
         let uv1 = false;
         let uv2 = false;
-        let color = false;
+        const color = false;
 
         if (material) {
             let needUv = false;

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -556,6 +556,7 @@ export class GeometryBufferRenderer {
 
         let uv1 = false;
         let uv2 = false;
+        let color = false;
 
         if (material) {
             let needUv = false;
@@ -792,7 +793,8 @@ export class GeometryBufferRenderer {
                   true, // useNormalMorph
                   false, // useTangentMorph
                   uv1, // useUVMorph
-                  uv2 // useUV2Morph
+                  uv2, // useUV2Morph
+                  color, // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -348,7 +348,7 @@ export class OutlineRenderer implements ISceneComponent {
                   false, // useTangentMorph
                   uv1, // useUVMorph
                   uv2, // useUV2Morph
-                  color, // useColorMorph
+                  color // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -289,6 +289,7 @@ export class OutlineRenderer implements ISceneComponent {
 
         let uv1 = false;
         let uv2 = false;
+        let color = false;
 
         // Alpha test
         if (material.needAlphaTestingForMesh(mesh)) {
@@ -346,7 +347,8 @@ export class OutlineRenderer implements ISceneComponent {
                   true, // useNormalMorph
                   false, // useTangentMorph
                   uv1, // useUVMorph
-                  uv2 // useUV2Morph
+                  uv2, // useUV2Morph
+                  color, // useColorMorph
               )
             : 0;
 

--- a/packages/dev/core/src/Rendering/outlineRenderer.ts
+++ b/packages/dev/core/src/Rendering/outlineRenderer.ts
@@ -289,7 +289,7 @@ export class OutlineRenderer implements ISceneComponent {
 
         let uv1 = false;
         let uv2 = false;
-        let color = false;
+        const color = false;
 
         // Alpha test
         if (material.needAlphaTestingForMesh(mesh)) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -37,6 +37,13 @@
 			#ifdef MORPHTARGETS_UV2
 				uv2Updated += (readVector3FromRawSampler(i, vertexID).xy - uv2) * morphTargetInfluences[i];
 			#endif
+			#ifdef MORPHTARGETTEXTURE_HASUV2S
+				vertexID += 1.0;
+			#endif
+
+			#ifdef MORPHTARGETS_COLOR
+				colorUpdated += (readVector4FromRawSampler(i, vertexID) - color) * morphTargetInfluences[i];
+			#endif
 		}
 		#endif
 	#else
@@ -58,6 +65,10 @@
 
 		#ifdef MORPHTARGETS_UV2
 		uv2Updated += (uv2_{X} - uv2) * morphTargetInfluences[{X}];
+		#endif
+
+		#ifdef MORPHTARGETS_COLOR
+		colorUpdated += (color{X} - color) * morphTargetInfluences[{X}];
 		#endif
 	#endif
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
@@ -13,5 +13,13 @@
 			vec3 textureUV = vec3((x + 0.5) / morphTargetTextureInfo.y, (y + 0.5) / morphTargetTextureInfo.z, morphTargetTextureIndices[targetIndex]);
 			return texture(morphTargets, textureUV).xyz;
 		}
+
+		vec4 readVector4FromRawSampler(int targetIndex, float vertexIndex)
+		{			
+			float y = floor(vertexIndex / morphTargetTextureInfo.y);
+			float x = vertexIndex - y * morphTargetTextureInfo.y;
+			vec3 textureUV = vec3((x + 0.5) / morphTargetTextureInfo.y, (y + 0.5) / morphTargetTextureInfo.z, morphTargetTextureIndices[targetIndex]);
+			return texture(morphTargets, textureUV);
+		}
 	#endif
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/vertexColorMixing.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/vertexColorMixing.fx
@@ -2,9 +2,9 @@
     vColor = vec4(1.0);
     #ifdef VERTEXCOLOR
         #ifdef VERTEXALPHA
-            vColor *= color;
+            vColor *= colorUpdated;
         #else
-            vColor.rgb *= color.rgb;
+            vColor.rgb *= colorUpdated.rgb;
         #endif
     #endif
 

--- a/packages/dev/core/src/Shaders/background.vertex.fx
+++ b/packages/dev/core/src/Shaders/background.vertex.fx
@@ -143,7 +143,7 @@ void main(void) {
 
     // Vertex color
 #ifdef VERTEXCOLOR
-    vColor = color;
+    vColor = colorUpdated;
 #endif
 
     // Point size

--- a/packages/dev/core/src/Shaders/color.vertex.fx
+++ b/packages/dev/core/src/Shaders/color.vertex.fx
@@ -35,6 +35,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>

--- a/packages/dev/core/src/Shaders/default.vertex.fx
+++ b/packages/dev/core/src/Shaders/default.vertex.fx
@@ -91,6 +91,9 @@ void main(void) {
 #ifdef UV2
     vec2 uv2Updated = uv2;
 #endif
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
 
 #include<morphTargetsVertexGlobal>
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]

--- a/packages/dev/core/src/Shaders/pbr.vertex.fx
+++ b/packages/dev/core/src/Shaders/pbr.vertex.fx
@@ -127,6 +127,9 @@ void main(void) {
 #ifdef UV2
     vec2 uv2Updated = uv2;
 #endif
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
 
 #include<morphTargetsVertexGlobal>
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -39,6 +39,10 @@
 			#ifdef MORPHTARGETS_UV2
 				uv2Updated = uv2Updated + (readVector3FromRawSampler(i, vertexID).xy - vertexInputs.uv2) * uniforms.morphTargetInfluences[i];
 			#endif
+
+			#ifdef MORPHTARGETS_COLOR
+				colorUpdated = colorUpdated + (readVector4FromRawSampler(i, vertexID) - vertexInputs.color) * uniforms.morphTargetInfluences[i];
+			#endif
 		}
 		#endif
 	#else
@@ -60,6 +64,10 @@
 
 		#ifdef MORPHTARGETS_UV2
 		    uv2Updated = uv2Updated + (vertexInputs.uv2_{X} - vertexInputs.uv2) * uniforms.morphTargetInfluences[{X}];
+		#endif
+
+		#ifdef MORPHTARGETS_COLOR
+		    colorUpdated = colorUpdated + (vertexInputs.color{X} - vertexInputs.color) * uniforms.morphTargetInfluences[{X}];
 		#endif
 	#endif
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
@@ -15,5 +15,13 @@
 			let textureUV = vec2<f32>((x + 0.5) / uniforms.morphTargetTextureInfo.y, (y + 0.5) / uniforms.morphTargetTextureInfo.z);
 			return textureSampleLevel(morphTargets, morphTargetsSampler, textureUV, i32(uniforms.morphTargetTextureIndices[targetIndex]), 0.0).xyz;
 		}
+
+		fn readVector4FromRawSampler(targetIndex : i32, vertexIndex : f32) -> vec3<f32>
+		{			
+			let y = floor(vertexIndex / uniforms.morphTargetTextureInfo.y);
+			let x = vertexIndex - y * uniforms.morphTargetTextureInfo.y;
+			let textureUV = vec2<f32>((x + 0.5) / uniforms.morphTargetTextureInfo.y, (y + 0.5) / uniforms.morphTargetTextureInfo.z);
+			return textureSampleLevel(morphTargets, morphTargetsSampler, textureUV, i32(uniforms.morphTargetTextureIndices[targetIndex]), 0.0);
+		}
 	#endif
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexGlobalDeclaration.fx
@@ -16,7 +16,7 @@
 			return textureSampleLevel(morphTargets, morphTargetsSampler, textureUV, i32(uniforms.morphTargetTextureIndices[targetIndex]), 0.0).xyz;
 		}
 
-		fn readVector4FromRawSampler(targetIndex : i32, vertexIndex : f32) -> vec3<f32>
+		fn readVector4FromRawSampler(targetIndex : i32, vertexIndex : f32) -> vec4<f32>
 		{			
 			let y = floor(vertexIndex / uniforms.morphTargetTextureInfo.y);
 			let x = vertexIndex - y * uniforms.morphTargetTextureInfo.y;

--- a/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
@@ -104,6 +104,15 @@ fn readVector3FromRawSampler(targetIndex : i32, vertexIndex : u32) -> vec3f
     let textureUV = vec2<i32>(i32(x), i32(y));
     return textureLoad(morphTargets, textureUV, i32(morphTargetTextureIndices[targetIndex]), 0).xyz;
 }
+
+fn readVector4FromRawSampler(targetIndex : i32, vertexIndex : u32) -> vec3f
+{			
+    let vertexID = f32(vertexIndex) * settings.morphTargetTextureInfo.x;
+    let y = floor(vertexID / settings.morphTargetTextureInfo.y);
+    let x = vertexID - y * settings.morphTargetTextureInfo.y;
+    let textureUV = vec2<i32>(i32(x), i32(y));
+    return textureLoad(morphTargets, textureUV, i32(morphTargetTextureIndices[targetIndex]), 0);
+}
 #endif
 
 

--- a/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
@@ -105,7 +105,7 @@ fn readVector3FromRawSampler(targetIndex : i32, vertexIndex : u32) -> vec3f
     return textureLoad(morphTargets, textureUV, i32(morphTargetTextureIndices[targetIndex]), 0).xyz;
 }
 
-fn readVector4FromRawSampler(targetIndex : i32, vertexIndex : u32) -> vec3f
+fn readVector4FromRawSampler(targetIndex : i32, vertexIndex : u32) -> vec4f
 {			
     let vertexID = f32(vertexIndex) * settings.morphTargetTextureInfo.x;
     let y = floor(vertexID / settings.morphTargetTextureInfo.y);

--- a/packages/dev/core/src/ShadersWGSL/color.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/color.vertex.fx
@@ -35,7 +35,7 @@ fn main(input : VertexInputs) -> FragmentInputs {
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
 #ifdef VERTEXCOLOR
-    vec4 colorUpdated = color;
+    var colorUpdated: vec4f = vertexInputs.color;
 #endif
 
 #include<instancesVertex>

--- a/packages/dev/core/src/ShadersWGSL/color.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/color.vertex.fx
@@ -34,6 +34,10 @@ fn main(input : VertexInputs) -> FragmentInputs {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>

--- a/packages/dev/core/src/ShadersWGSL/default.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.vertex.fx
@@ -90,6 +90,9 @@ fn main(input : VertexInputs) -> FragmentInputs {
 #ifdef UV2
     var uv2Updated: vec2f = vertexInputs.uv2;
 #endif
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
 
 #include<morphTargetsVertexGlobal>
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]

--- a/packages/dev/core/src/ShadersWGSL/default.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.vertex.fx
@@ -91,7 +91,7 @@ fn main(input : VertexInputs) -> FragmentInputs {
     var uv2Updated: vec2f = vertexInputs.uv2;
 #endif
 #ifdef VERTEXCOLOR
-    vec4 colorUpdated = color;
+    var colorUpdated: vec4f = vertexInputs.color;
 #endif
 
 #include<morphTargetsVertexGlobal>

--- a/packages/dev/core/src/ShadersWGSL/pbr.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.vertex.fx
@@ -124,7 +124,7 @@ fn main(input : VertexInputs) -> FragmentInputs {
     var uv2Updated: vec2f = vertexInputs.uv2;
 #endif
 #ifdef VERTEXCOLOR
-    vec4 colorUpdated = color;
+    var colorUpdated: vec4f = vertexInputs.color;
 #endif
 
 #include<morphTargetsVertexGlobal>

--- a/packages/dev/core/src/ShadersWGSL/pbr.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.vertex.fx
@@ -123,6 +123,9 @@ fn main(input : VertexInputs) -> FragmentInputs {
 #ifdef UV2
     var uv2Updated: vec2f = vertexInputs.uv2;
 #endif
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
 
 #include<morphTargetsVertexGlobal>
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1293,16 +1293,26 @@ export class GLTFLoader implements IGLTFLoader {
         });
 
         loadAttribute("COLOR_0", VertexBuffer.ColorKind, (babylonVertexBuffer, data) => {
-            const colors = new Float32Array((data.length / 3) * 4);
-            babylonVertexBuffer.forEach(data.length, (value, index) => {
-                const pixid = Math.floor(index / 3);
-                const channel = index % 3;
-                colors[4 * pixid + channel] = data[3 * pixid + channel] + value;
-            });
-            for (let i = 0; i < data.length / 3; ++i) {
-                colors[4 * i + 3] = 1;
+            let colors = null;
+            const componentSize = babylonVertexBuffer.getSize();
+            if (componentSize === 3) {
+                colors = new Float32Array((data.length / 3) * 4);
+                babylonVertexBuffer.forEach(data.length, (value, index) => {
+                    const pixid = Math.floor(index / 3);
+                    const channel = index % 3;
+                    colors[4 * pixid + channel] = data[3 * pixid + channel] + value;
+                });
+                for (let i = 0; i < data.length / 3; ++i) {
+                    colors[4 * i + 3] = 1;
+                }
+            } else if (componentSize === 4) {
+                colors = new Float32Array(data.length);
+                babylonVertexBuffer.forEach(data.length, (value, index) => {
+                    colors[index] = data[index] + value;
+                });
+            } else {
+                throw new Error(`${context}: Invalid number of components (${componentSize}) for COLOR_0 attribute`);
             }
-
             babylonMorphTarget.setColors(colors);
         });
 

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1293,7 +1293,7 @@ export class GLTFLoader implements IGLTFLoader {
         });
 
         loadAttribute("COLOR_0", VertexBuffer.ColorKind, (babylonVertexBuffer, data) => {
-            const colors = new Float32Array(data.length / 3 * 4);
+            const colors = new Float32Array((data.length / 3) * 4);
             babylonVertexBuffer.forEach(data.length, (value, index) => {
                 const pixid = Math.floor(index / 3);
                 const channel = index % 3;

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1292,6 +1292,20 @@ export class GLTFLoader implements IGLTFLoader {
             babylonMorphTarget.setUV2s(uvs);
         });
 
+        loadAttribute("COLOR_0", VertexBuffer.ColorKind, (babylonVertexBuffer, data) => {
+            const colors = new Float32Array(data.length / 3 * 4);
+            babylonVertexBuffer.forEach(data.length, (value, index) => {
+                const pixid = Math.floor(index / 3);
+                const channel = index % 3;
+                colors[4 * pixid + channel] = data[3 * pixid + channel] + value;
+            });
+            for (let i = 0; i < data.length / 3; ++i) {
+                colors[4 * i + 3] = 1;
+            }
+
+            babylonMorphTarget.setColors(colors);
+        });
+
         return Promise.all(promises).then(() => {});
     }
 

--- a/packages/dev/materials/src/cell/cell.vertex.fx
+++ b/packages/dev/materials/src/cell/cell.vertex.fx
@@ -58,6 +58,9 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
 
 #include<instancesVertex>
 #include<bonesVertex>

--- a/packages/dev/materials/src/fire/fire.vertex.fx
+++ b/packages/dev/materials/src/fire/fire.vertex.fx
@@ -58,6 +58,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/fur/fur.vertex.fx
+++ b/packages/dev/materials/src/fur/fur.vertex.fx
@@ -77,6 +77,10 @@ float Rand(vec3 rv) {
 void main(void) {
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 	#include<instancesVertex>
     #include<bonesVertex>
     #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/gradient/gradient.vertex.fx
+++ b/packages/dev/materials/src/gradient/gradient.vertex.fx
@@ -53,6 +53,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/lava/lava.vertex.fx
+++ b/packages/dev/materials/src/lava/lava.vertex.fx
@@ -171,6 +171,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/mix/mix.vertex.fx
+++ b/packages/dev/materials/src/mix/mix.vertex.fx
@@ -56,6 +56,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 	#include<instancesVertex>
     #include<bonesVertex>
     #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/simple/simple.vertex.fx
+++ b/packages/dev/materials/src/simple/simple.vertex.fx
@@ -58,6 +58,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/terrain/terrain.vertex.fx
+++ b/packages/dev/materials/src/terrain/terrain.vertex.fx
@@ -56,6 +56,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 	#include<instancesVertex>
     #include<bonesVertex>
     #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/triPlanar/triplanar.vertex.fx
+++ b/packages/dev/materials/src/triPlanar/triplanar.vertex.fx
@@ -62,6 +62,10 @@ void main(void)
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
 	#include<instancesVertex>
     #include<bonesVertex>
     #include<bakedVertexAnimation>

--- a/packages/dev/materials/src/water/water.vertex.fx
+++ b/packages/dev/materials/src/water/water.vertex.fx
@@ -77,6 +77,10 @@ void main(void) {
 
 #define CUSTOM_VERTEX_MAIN_BEGIN
 
+#ifdef VERTEXCOLOR
+    vec4 colorUpdated = color;
+#endif
+
     #include<instancesVertex>
     #include<bonesVertex>
     #include<bakedVertexAnimation>

--- a/packages/dev/serializers/src/glTF/2.0/glTFMorphTargetsUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMorphTargetsUtilities.ts
@@ -136,5 +136,32 @@ export function BuildMorphTargetBuffers(
         }
     }
 
+    if (morphTarget.hasColors) {
+        const morphColors = morphTarget.getColors()!;
+        const originalColors = mesh.getVerticesData(VertexBuffer.ColorKind, undefined, undefined, true);
+
+        if (originalColors) {
+            vertexCount = originalColors.length / 4;
+            const colorData = new Float32Array(vertexCount * 4);
+            vertexStart = 0;
+            for (let i = vertexStart; i < vertexCount; ++i) {
+                const originalColor = Vector3.FromArray(originalColors, i * 4);
+                const morphColor = Vector3.FromArray(morphColors, i * 4);
+
+                morphColor.subtractToRef(originalColor, difference);
+                colorData[i * 4] = difference.x;
+                colorData[i * 4 + 1] = difference.y;
+                colorData[i * 4 + 2] = difference.z;
+                colorData[i * 4 + 3] = 0;
+            }
+            const bufferView = bufferManager.createBufferView(colorData, floatSize * 4);
+            const accessor = bufferManager.createAccessor(bufferView, AccessorType.VEC4, AccessorComponentType.FLOAT, vertexCount, 0);
+            accessors.push(accessor);
+            result.attributes["COLOR_0"] = accessors.length - 1;
+        } else {
+            Tools.Warn(`Morph target colors for mesh ${mesh.name} were not exported. Mesh does not have colors vertex data`);
+        }
+    }
+
     return result;
 }


### PR DESCRIPTION
Any interest in having a morph target for vertex color?  There are some glTF viewers out there that will actually display animated point clouds if you add morph targets for POSITION and COLOR_0.  Two that I found are gestaltar and https://gltf-viewer.donmccurdy.com/.  Looks like babylon.js doesn't wire in color as a morph target, so I grepped through the code and put it in.

**Test plan**
I only tried it with a test glb with animated point clouds defined as morph targets.  I'm not sure how to correctly test all of this.