### PR TITLE
FrameGraph: add support for utility layer renderers

### DIFF
--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/utilityLayerRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/utilityLayerRendererBlock.ts
@@ -1,0 +1,102 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { NodeRenderGraphConnectionPoint, Scene, FrameGraph, NodeRenderGraphBuildState, FrameGraphTextureHandle, Camera } from "core/index";
+import { RegisterClass } from "../../../../Misc/typeStore";
+import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
+import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";
+import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
+import { FrameGraphUtilityLayerRendererTask } from "../../../Tasks/Rendering/utilityLayerRendererTask";
+
+/**
+ * Block used to render an utility layer in the frame graph
+ */
+export class NodeRenderGraphUtilityLayerRendererBlock extends NodeRenderGraphBlock {
+    protected override _frameGraphTask: FrameGraphUtilityLayerRendererTask;
+
+    /**
+     * Gets the frame graph task associated with this block
+     */
+    public override get task() {
+        return this._frameGraphTask;
+    }
+
+    /**
+     * Creates a new NodeRenderGraphUtilityLayerRendererBlock
+     * @param name defines the block name
+     * @param frameGraph defines the hosting frame graph
+     * @param scene defines the hosting scene
+     * @param handleEvents If the utility layer should handle events.
+     */
+    public constructor(name: string, frameGraph: FrameGraph, scene: Scene, handleEvents = true) {
+        super(name, frameGraph, scene);
+
+        this._additionalConstructionParameters = [handleEvents];
+
+        this.registerInput("destination", NodeRenderGraphBlockConnectionPointTypes.Texture);
+        this.registerInput("camera", NodeRenderGraphBlockConnectionPointTypes.Camera);
+        this._addDependenciesInput();
+        this.registerOutput("output", NodeRenderGraphBlockConnectionPointTypes.BasedOnInput);
+
+        this.destination.addAcceptedConnectionPointTypes(NodeRenderGraphBlockConnectionPointTypes.TextureAll);
+        this.output._typeConnectionSource = this.destination;
+
+        this._frameGraphTask = new FrameGraphUtilityLayerRendererTask(name, frameGraph, scene, handleEvents);
+    }
+
+    private _createTask(handleEvents: boolean) {
+        this._frameGraphTask.dispose();
+
+        this._frameGraphTask = new FrameGraphUtilityLayerRendererTask(this.name, this._frameGraph, this._scene, handleEvents);
+
+        this._additionalConstructionParameters = [handleEvents];
+    }
+
+    /** If the utility layer should handle events */
+    @editableInPropertyPage("Handle events", PropertyTypeForEdition.Boolean, "PROPERTIES")
+    public get handleEvents() {
+        return this._frameGraphTask.layer.handleEvents;
+    }
+
+    public set handleEvents(value: boolean) {
+        this._createTask(value);
+    }
+
+    /**
+     * Gets the current class name
+     * @returns the class name
+     */
+    public override getClassName() {
+        return "NodeRenderGraphUtilityLayerRendererBlock";
+    }
+
+    /**
+     * Gets the destination input component
+     */
+    public get destination(): NodeRenderGraphConnectionPoint {
+        return this._inputs[0];
+    }
+
+    /**
+     * Gets the camera input component
+     */
+    public get camera(): NodeRenderGraphConnectionPoint {
+        return this._inputs[1];
+    }
+
+    /**
+     * Gets the output component
+     */
+    public get output(): NodeRenderGraphConnectionPoint {
+        return this._outputs[0];
+    }
+
+    protected override _buildBlock(state: NodeRenderGraphBuildState) {
+        super._buildBlock(state);
+
+        this.output.value = this._frameGraphTask.outputTexture;
+
+        this._frameGraphTask.destinationTexture = this.destination.connectedPoint?.value as FrameGraphTextureHandle;
+        this._frameGraphTask.camera = this.camera.connectedPoint?.value as Camera;
+    }
+}
+
+RegisterClass("BABYLON.NodeRenderGraphUtilityLayerRendererBlock", NodeRenderGraphUtilityLayerRendererBlock);

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/index.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/index.ts
@@ -21,6 +21,7 @@ export * from "./Rendering/geometryRendererBlock";
 export * from "./Rendering/objectRendererBlock";
 export * from "./Rendering/shadowGeneratorBlock";
 export * from "./Rendering/taaObjectRendererBlock";
+export * from "./Rendering/utilityLayerRendererBlock";
 
 export * from "./Teleport/teleportInBlock";
 export * from "./Teleport/teleportOutBlock";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/utilityLayerRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/utilityLayerRendererTask.ts
@@ -1,0 +1,73 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { Camera, FrameGraph, FrameGraphTextureHandle, Scene } from "core/index";
+import { FrameGraphTask } from "../../frameGraphTask";
+import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";
+
+/**
+ * Task used to render an utility layer.
+ */
+export class FrameGraphUtilityLayerRendererTask extends FrameGraphTask {
+    /**
+     * The destination texture of the task.
+     */
+    public destinationTexture: FrameGraphTextureHandle;
+
+    /**
+     * The camera used to render the utility layer.
+     */
+    public camera: Camera;
+
+    /**
+     * The output texture of the task.
+     * This is the same texture as the destination texture, but the handles are different!
+     */
+    public readonly outputTexture: FrameGraphTextureHandle;
+
+    /**
+     * The utility layer renderer.
+     */
+    public readonly layer: UtilityLayerRenderer;
+
+    /**
+     * Creates a new utility layer renderer task.
+     * @param name The name of the task.
+     * @param frameGraph The frame graph the task belongs to.
+     * @param scene The scene the task belongs to.
+     * @param handleEvents If the utility layer should handle events.
+     */
+    constructor(name: string, frameGraph: FrameGraph, scene: Scene, handleEvents = true) {
+        super(name, frameGraph);
+
+        this.layer = new UtilityLayerRenderer(scene, handleEvents, true);
+        this.layer.utilityLayerScene._useCurrentFrameBuffer = true;
+
+        this.outputTexture = this._frameGraph.textureManager.createDanglingHandle();
+    }
+
+    public record(): void {
+        if (!this.destinationTexture || !this.camera) {
+            throw new Error("FrameGraphUtilityLayerRendererTask: destinationTexture and camera are required");
+        }
+
+        this._frameGraph.textureManager.resolveDanglingHandle(this.outputTexture, this.destinationTexture);
+
+        const pass = this._frameGraph.addRenderPass(this.name);
+
+        pass.setRenderTarget(this.outputTexture);
+        pass.setExecuteFunc((context) => {
+            this.layer.setRenderCamera(this.camera);
+
+            context.render(this.layer);
+        });
+
+        const passDisabled = this._frameGraph.addRenderPass(this.name + "_disabled", true);
+
+        passDisabled.setRenderTarget(this.outputTexture);
+        passDisabled.setExecuteFunc((_context) => {});
+    }
+
+    public override dispose(): void {
+        this.layer.dispose();
+        super.dispose();
+    }
+}

--- a/packages/dev/core/src/FrameGraph/frameGraph.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraph.ts
@@ -51,6 +51,13 @@ export class FrameGraph {
     }
 
     /**
+     * Gets the list of tasks in the frame graph
+     */
+    public get tasks() {
+        return this._tasks;
+    }
+
+    /**
      * Constructs the frame graph
      * @param engine defines the hosting engine
      * @param debugTextures defines a boolean indicating that textures created by the frame graph should be visible in the inspector

--- a/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
@@ -11,6 +11,7 @@ import type {
     Scene,
     FrameGraphRenderTarget,
     InternalTexture,
+    UtilityLayerRenderer,
     // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { Constants } from "../Engines/constants";
@@ -32,7 +33,7 @@ export class FrameGraphRenderContext extends FrameGraphContext {
     private _depthTest: boolean;
     private _depthWrite: boolean;
 
-    private static _IsObjectRenderer(value: Layer | ObjectRenderer): value is ObjectRenderer {
+    private static _IsObjectRenderer(value: Layer | ObjectRenderer | UtilityLayerRenderer): value is ObjectRenderer {
         return (value as ObjectRenderer).initRender !== undefined;
     }
 
@@ -262,7 +263,7 @@ export class FrameGraphRenderContext extends FrameGraphContext {
      * @param viewportWidth The width of the viewport (optional for Layer, but mandatory for ObjectRenderer)
      * @param viewportHeight The height of the viewport (optional for Layer, but mandatory for ObjectRenderer)
      */
-    public render(object: Layer | ObjectRenderer, viewportWidth?: number, viewportHeight?: number): void {
+    public render(object: Layer | ObjectRenderer | UtilityLayerRenderer, viewportWidth?: number, viewportHeight?: number): void {
         if (FrameGraphRenderContext._IsObjectRenderer(object)) {
             if (object.shouldRender()) {
                 this._scene.incrementRenderId();

--- a/packages/dev/core/src/FrameGraph/index.ts
+++ b/packages/dev/core/src/FrameGraph/index.ts
@@ -35,6 +35,7 @@ export * from "./Tasks/Rendering/geometryRendererTask";
 export * from "./Tasks/Rendering/objectRendererTask";
 export * from "./Tasks/Rendering/shadowGeneratorTask";
 export * from "./Tasks/Rendering/taaObjectRendererTask";
+export * from "./Tasks/Rendering/utilityLayerRendererTask";
 
 export * from "./frameGraph";
 export * from "./frameGraphContext";

--- a/packages/dev/core/src/Rendering/utilityLayerRenderer.ts
+++ b/packages/dev/core/src/Rendering/utilityLayerRenderer.ts
@@ -152,11 +152,13 @@ export class UtilityLayerRenderer implements IDisposable {
      * Instantiates a UtilityLayerRenderer
      * @param originalScene the original scene that will be rendered on top of
      * @param handleEvents boolean indicating if the utility layer should handle events
+     * @param manualRender boolean indicating if the utility layer should render manually.
      */
     constructor(
         /** the original scene that will be rendered on top of */
         public originalScene: Scene,
-        handleEvents: boolean = true
+        public readonly handleEvents: boolean = true,
+        manualRender = false
     ) {
         // Create scene which will be rendered in the foreground and remove it from being referenced by engine to avoid interfering with existing app
         this.utilityLayerScene = new Scene(originalScene.getEngine(), { virtual: true });
@@ -327,12 +329,14 @@ export class UtilityLayerRenderer implements IDisposable {
         // Render directly on top of existing scene without clearing
         this.utilityLayerScene.autoClear = false;
 
-        this._afterRenderObserver = this.originalScene.onAfterRenderCameraObservable.add((camera) => {
-            // Only render when the render camera finishes rendering
-            if (this.shouldRender && camera == this.getRenderCamera()) {
-                this.render();
-            }
-        });
+        if (!manualRender) {
+            this._afterRenderObserver = this.originalScene.onAfterRenderCameraObservable.add((camera) => {
+                // Only render when the render camera finishes rendering
+                if (this.shouldRender && camera == this.getRenderCamera()) {
+                    this.render();
+                }
+            });
+        }
 
         this._sceneDisposeObserver = this.originalScene.onDisposeObservable.add(() => {
             this.dispose();

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4412,14 +4412,19 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         }
     }
 
+    /** @internal */
+    public _useCurrentFrameBuffer = false;
+
     private _bindFrameBuffer(camera: Nullable<Camera>, clear = true) {
-        if (camera && camera._multiviewTexture) {
-            camera._multiviewTexture._bindFrameBuffer();
-        } else if (camera && camera.outputRenderTarget) {
-            camera.outputRenderTarget._bindFrameBuffer();
-        } else {
-            if (!this._engine._currentFrameBufferIsDefaultFrameBuffer()) {
-                this._engine.restoreDefaultFramebuffer();
+        if (!this._useCurrentFrameBuffer) {
+            if (camera && camera._multiviewTexture) {
+                camera._multiviewTexture._bindFrameBuffer();
+            } else if (camera && camera.outputRenderTarget) {
+                camera.outputRenderTarget._bindFrameBuffer();
+            } else {
+                if (!this._engine._currentFrameBufferIsDefaultFrameBuffer()) {
+                    this._engine.restoreDefaultFramebuffer();
+                }
             }
         }
         if (clear) {

--- a/packages/dev/gui/src/2D/FrameGraph/renderGraphGUIBlock.ts
+++ b/packages/dev/gui/src/2D/FrameGraph/renderGraphGUIBlock.ts
@@ -77,14 +77,9 @@ export class NodeRenderGraphGUIBlock extends NodeRenderGraphBlock {
     protected override _buildBlock(state: NodeRenderGraphBuildState) {
         super._buildBlock(state);
 
-        this._frameGraphTask.name = this.name;
-
         this.output.value = this._frameGraphTask.outputTexture; // the value of the output connection point is the "output" texture of the task
 
-        const destinationConnectedPoint = this.destination.connectedPoint;
-        if (destinationConnectedPoint) {
-            this._frameGraphTask.destinationTexture = destinationConnectedPoint.value as FrameGraphTextureHandle;
-        }
+        this._frameGraphTask.destinationTexture = this.destination.connectedPoint?.value as FrameGraphTextureHandle;
     }
 }
 

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx
@@ -22,6 +22,11 @@ import { GizmoCoordinatesMode } from "core/Gizmos/gizmo";
 import type { Bone } from "core/Bones/bone";
 
 import { setDebugNode } from "../treeNodeDebugger";
+import type { FrameGraph } from "core/FrameGraph/frameGraph";
+import { FrameGraphGeometryRendererTask } from "core/FrameGraph/Tasks/Rendering/geometryRendererTask";
+import { FrameGraphObjectRendererTask } from "core/FrameGraph/Tasks/Rendering/objectRendererTask";
+import { FrameGraphTAAObjectRendererTask } from "core/FrameGraph/Tasks/Rendering/taaObjectRendererTask";
+import { FrameGraphUtilityLayerRendererTask } from "core/FrameGraph/Tasks/Rendering/utilityLayerRendererTask";
 
 interface ISceneTreeItemComponentProps {
     scene: Scene;
@@ -38,6 +43,7 @@ export class SceneTreeItemComponent extends React.Component<
     { isSelected: boolean; isInPickingMode: boolean; gizmoMode: number; isInWorldCoodinatesMode: boolean }
 > {
     private _gizmoLayerOnPointerObserver: Nullable<Observer<PointerInfo>>;
+    private _gizmoLayerRenderObserver: Nullable<Observer<Scene>>;
     private _onPointerObserver: Nullable<Observer<PointerInfo>>;
     private _onSelectionChangeObserver: Nullable<Observer<any>>;
     private _selectedEntity: any;
@@ -163,6 +169,9 @@ export class SceneTreeItemComponent extends React.Component<
             this._gizmoLayerOnPointerObserver = null;
         }
 
+        scene.onAfterRenderObservable.remove(this._gizmoLayerRenderObserver);
+        this._gizmoLayerRenderObserver = null;
+
         if (this._onSelectionChangeObserver && this.props.onSelectionChangedObservable) {
             this.props.onSelectionChangedObservable.remove(this._onSelectionChangeObserver);
         }
@@ -261,6 +270,24 @@ export class SceneTreeItemComponent extends React.Component<
         this.setState({ isInPickingMode: !this.state.isInPickingMode });
     }
 
+    findCameraFromFrameGraph(frameGraph: FrameGraph): Nullable<Camera> {
+        const tasks = frameGraph.tasks;
+
+        for (let i = tasks.length - 1; i >= 0; i--) {
+            const task = tasks[i];
+            if (
+                task instanceof FrameGraphObjectRendererTask ||
+                task instanceof FrameGraphGeometryRendererTask ||
+                task instanceof FrameGraphTAAObjectRendererTask ||
+                task instanceof FrameGraphUtilityLayerRendererTask
+            ) {
+                return task.camera;
+            }
+        }
+
+        return null;
+    }
+
     setGizmoMode(mode: number) {
         const scene = this.props.scene;
 
@@ -273,8 +300,33 @@ export class SceneTreeItemComponent extends React.Component<
             this._gizmoLayerOnPointerObserver = null;
         }
 
+        scene.onAfterRenderObservable.remove(this._gizmoLayerRenderObserver);
+        this._gizmoLayerRenderObserver = null;
+
         if (!scene.reservedDataStore.gizmoManager) {
-            scene.reservedDataStore.gizmoManager = new GizmoManager(scene, undefined, new UtilityLayerRenderer(scene), new UtilityLayerRenderer(scene));
+            const manualRender = !!scene.frameGraph;
+            const layer1 = new UtilityLayerRenderer(scene, undefined, manualRender);
+            const layer2 = new UtilityLayerRenderer(scene, undefined, manualRender);
+
+            scene.reservedDataStore.gizmoManager = new GizmoManager(scene, undefined, layer1, layer2);
+
+            if (manualRender) {
+                let camera = this.findCameraFromFrameGraph(scene.frameGraph!);
+
+                if (!camera && scene.cameras.length > 0) {
+                    camera = scene.cameras[0];
+                }
+
+                if (camera) {
+                    layer1.setRenderCamera(camera);
+                    layer2.setRenderCamera(camera);
+                }
+
+                this._gizmoLayerRenderObserver = scene.onAfterRenderObservable.add(() => {
+                    layer1.render();
+                    layer2.render();
+                });
+            }
         }
 
         if (this.props.gizmoCamera) {

--- a/packages/tools/nodeRenderGraphEditor/src/blockTools.ts
+++ b/packages/tools/nodeRenderGraphEditor/src/blockTools.ts
@@ -27,6 +27,7 @@ import { NodeRenderGraphExecuteBlock } from "core/FrameGraph/Node/Blocks/execute
 import { NodeRenderGraphGlowLayerBlock } from "core/FrameGraph/Node/Blocks/Layers/glowLayerBlock";
 import { NodeRenderGraphHighlightLayerBlock } from "core/FrameGraph/Node/Blocks/Layers/highlightLayerBlock";
 import { NodeRenderGraphPassCubePostProcessBlock, NodeRenderGraphPassPostProcessBlock } from "core/FrameGraph/Node/Blocks/PostProcesses/passPostProcessBlock";
+import { NodeRenderGraphUtilityLayerRendererBlock } from "core/FrameGraph/Node/Blocks/Rendering/utilityLayerRendererBlock";
 
 /**
  * Static class for BlockTools
@@ -46,6 +47,8 @@ export class BlockTools {
                 return new NodeRenderGraphResourceContainerBlock("Resources", frameGraph, scene);
             case "ExecuteBlock":
                 return new NodeRenderGraphExecuteBlock("Execute", frameGraph, scene);
+            case "UtilityLayerRendererBlock":
+                return new NodeRenderGraphUtilityLayerRendererBlock("Utility Layer", frameGraph, scene);
             case "TextureBlock": {
                 return new NodeRenderGraphInputBlock("Texture", frameGraph, scene, NodeRenderGraphBlockConnectionPointTypes.Texture);
             }

--- a/packages/tools/nodeRenderGraphEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeRenderGraphEditor/src/components/nodeList/nodeListComponent.tsx
@@ -55,6 +55,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
         ExecuteBlock: "Block used to execute a custom function",
         GlowLayerBlock: "Adds a glow effect to a texture",
         HighlightLayerBlock: "Adds a highlight effect to a texture",
+        UtilityLayerRendererBlock: "Renders an utility layer",
     };
 
     private _customFrameList: { [key: string]: string };
@@ -161,7 +162,14 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
             Misc: ["ElbowBlock", "TeleportInBlock", "TeleportOutBlock", "GUIBlock", "ResourceContainerBlock", "CullBlock", "ExecuteBlock"],
             Textures: ["ClearBlock", "CopyTextureBlock", "GenerateMipmapsBlock"],
             Output_Nodes: ["OutputBlock"],
-            Rendering: ["ObjectRendererBlock", "GeometryRendererBlock", "TAAObjectRendererBlock", "ShadowGeneratorBlock", "CascadedShadowGeneratorBlock"],
+            Rendering: [
+                "ObjectRendererBlock",
+                "GeometryRendererBlock",
+                "TAAObjectRendererBlock",
+                "ShadowGeneratorBlock",
+                "CascadedShadowGeneratorBlock",
+                "UtilityLayerRendererBlock",
+            ],
             Layers: ["GlowLayerBlock", "HighlightLayerBlock"],
         };
 

--- a/packages/tools/nodeRenderGraphEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeRenderGraphEditor/src/components/preview/previewManager.ts
@@ -27,6 +27,8 @@ import type { NodeRenderGraphHighlightLayerBlock } from "core/FrameGraph/Node/Bl
 import { BoundingBox } from "core/Culling/boundingBox";
 import type { NodeRenderGraphExecuteBlock } from "core/FrameGraph/Node/Blocks/executeBlock";
 import type { Mesh } from "core/Meshes";
+import type { NodeRenderGraphUtilityLayerRendererBlock } from "core/FrameGraph/Node/Blocks/Rendering/utilityLayerRendererBlock";
+import { GizmoManager } from "core/Gizmos/gizmoManager";
 
 const useWebGPU = false;
 const debugTextures = false;
@@ -343,6 +345,14 @@ export class PreviewManager {
                     if (mesh) {
                         layer.addMesh(mesh, new Color3(0, 1, 0), false);
                     }
+                    break;
+                }
+                case "NodeRenderGraphUtilityLayerRendererBlock": {
+                    const layer = (block as NodeRenderGraphUtilityLayerRendererBlock).task.layer;
+                    const gizmoManager = new GizmoManager(this._scene, undefined, layer, layer);
+                    gizmoManager.positionGizmoEnabled = true;
+                    gizmoManager.rotationGizmoEnabled = true;
+                    gizmoManager.attachableMeshes = this._scene.meshes.filter((m) => m.getTotalVertices() > 0);
                     break;
                 }
             }


### PR DESCRIPTION
This allows using gizmos in a frame graph.

The PR also makes using gizmos from the inspector work when a frame graph is used at scene level (that is, when `scene.frameGraph` is set).