### PR TITLE
Fix Inspector metadata update

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/metadata/metadataPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/metadata/metadataPropertyGridComponent.tsx
@@ -68,7 +68,7 @@ export class MetadataGridComponent extends React.Component<
      */
     override componentDidUpdate(prevProps: Readonly<IMetadataComponentProps>): void {
         if (this.props.entity) {
-            if (!prevProps.entity || prevProps.entity.id !== this.props.entity.id) {
+            if (prevProps.entity !== this.props.entity) {
                 this.refreshSelected();
             }
         }


### PR DESCRIPTION
Fixes #16176

Previously the code was determining whether the selected node has changed (and the metadata should be updated) based on the node's `id`. `id` is not unique, so if two nodes have the same `id`, the metadata would not be updated when the selection changes between them. We could use `uniqueId`, but I don't see any reason we don't just compare the actual mesh object reference, so this is what I've done in this PR. As far as I can tell things are working as expected with this change.

CC @j-te since it looks like you implemented this (almost two years ago!).