### PR TITLE
Viewer: enable WebGPU by default (conditionally)

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -742,7 +742,11 @@ export class Viewer implements IDisposable {
     }
 
     private _updateAutoClear() {
-        this._scene.autoClear = !this._skybox || !this._skybox.isEnabled() || !this._skyboxVisible;
+        // NOTE: Not clearing (even when every pixel is rendered with an opaque color) results in rendering
+        //       artifacts in Chromium browsers on Intel-based Macs (see https://issues.chromium.org/issues/396612322).
+        //       The performance impact of clearing when not necessary is very small, so for now just always auto clear.
+        //this._scene.autoClear = !this._skybox || !this._skybox.isEnabled() || !this._skyboxVisible;
+        this._scene.autoClear = true;
         this._markSceneMutated();
     }
 

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -16,7 +16,15 @@ const defaultCanvasViewerOptions: CanvasViewerOptions = {};
  * @returns The default engine to use.
  */
 export function getDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
-    // TODO: When WebGPU is fully production ready, we may want to prefer it if it is supported by the browser.
+    // First check for WebGPU support.
+    if ("gpu" in navigator) {
+        // For now, only use WebGPU with chromium-based browsers.
+        // WebGPU can be enabled in other browsers once they are fully functional and the performance is at least as good as WebGL.
+        if ("chrome" in window) {
+            return "WebGPU";
+        }
+    }
+
     return "WebGL";
 }
 

--- a/packages/tools/viewer/test/apps/web/index.html
+++ b/packages/tools/viewer/test/apps/web/index.html
@@ -76,7 +76,6 @@
         <div id="moreUpperPageContent" style="width: 100%; height: 200vh; display: none"></div>
         <div id="viewerContainer" style="width: 100vw; height: 100vh">
             <babylon-viewer
-                engine="WebGPU"
                 source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
                 environment="../../../../../public/@babylonjs/viewer/assets/photoStudio.env"
                 animation-speed="1.5"


### PR DESCRIPTION
When the browser supports WebGPU, and when the browser is a chromium browser (the only browser with production ready WebGPU support that we have deeply tested), WebGPU is enabled by default. This improves performance of the Viewer in scenarios where there are many meshes/nodes since we also use snapshot rendering mode (WebGPU render bundles).

We did recently discover a bug where there are rendering artifacts when WebGPU is used on Intel-based Macs if we don't explicitly clear between frames (even if we render an opaque color to every pixel). So for now, we will always auto clear, even when it should not be necessary. There is a comment in the code linking to the chromium bug.