### PR TITLE
Set SPZ Niantic Sample as reference

### DIFF
--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -59,7 +59,7 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
 
     private _assetContainer: Nullable<AssetContainer> = null;
 
-    private _loadingOptions: SPLATLoadingOptions;
+    private readonly _loadingOptions: Readonly<SPLATLoadingOptions>;
     /**
      * Defines the extensions the splat loader is able to load.
      * force data to come in as an ArrayBuffer
@@ -76,6 +76,7 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
 
     private static readonly _DefaultLoadingOptions = {
         keepInRam: false,
+        flipY: false,
     } as const satisfies SPLATLoadingOptions;
 
     /** @internal */
@@ -83,19 +84,6 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
         return new SPLATFileLoader(options[SPLATFileLoaderMetadata.name]);
     }
 
-    /**
-     * set option flipY
-     */
-    public set flipY(flipY: boolean) {
-        this._loadingOptions.flipY = flipY;
-    }
-
-    /**
-     * get option flipY
-     */
-    public get flipY(): boolean {
-        return !!this._loadingOptions.flipY;
-    }
     /**
      * Imports  from the loaded gaussian splatting data and adds them to the scene
      * @param meshesNames a string or array of strings of the mesh names that should be loaded from the file

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -226,8 +226,8 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
         // positions
         for (let i = 0; i < splatCount; i++) {
             position[i * 8 + 0] = read24bComponent(ubuf, byteOffset + 0);
-            position[i * 8 + 1] = read24bComponent(ubuf, byteOffset + 3);
-            position[i * 8 + 2] = read24bComponent(ubuf, byteOffset + 6);
+            position[i * 8 + 1] = -read24bComponent(ubuf, byteOffset + 3);
+            position[i * 8 + 2] = -read24bComponent(ubuf, byteOffset + 6);
             byteOffset += 9;
         }
 
@@ -259,8 +259,8 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
         // convert quaternion
         for (let i = 0; i < splatCount; i++) {
             const x = ubuf[byteOffset + 0];
-            const y = ubuf[byteOffset + 1];
-            const z = ubuf[byteOffset + 2];
+            const y = 255 - ubuf[byteOffset + 1];
+            const z = 255 - ubuf[byteOffset + 2];
             const nx = x / 127.5 - 1;
             const ny = y / 127.5 - 1;
             const nz = z / 127.5 - 1;

--- a/packages/dev/loaders/src/SPLAT/splatLoadingOptions.ts
+++ b/packages/dev/loaders/src/SPLAT/splatLoadingOptions.ts
@@ -6,4 +6,8 @@ export type SPLATLoadingOptions = {
      * Defines if buffers should be kept in memory for editing purposes
      */
     keepInRam?: boolean;
+    /**
+     * Spatial Y Flip for splat position and orientation
+     */
+    flipY?: boolean;
 };


### PR DESCRIPTION
Coordinate system used for SPZ makes Niantic samples upside down.
This PR makes SDK samples to display correctly as it uses the same coordinate system.

An option is to change your conversion code (PLY->SPZ) to flip Y,Z components of positions and orientation.
Or, use the new plugin option to do the work at runtime.

Here is an example to do the flipping when your SPZ do not use same coord system as Niantic and your scenes appear upside down:
```
BABYLON.LoadAssetContainerAsync("https://raw.githubusercontent.com/CedricGuillemet/dump/master/racoonfamily.spz", scene, {
    pluginOptions:{
        splat:{
           flipY: true
        }
    }
});
```