### PR TITLE
Prevent multiple instances of Manifold from being created

### DIFF
--- a/packages/dev/core/src/Meshes/csg2.ts
+++ b/packages/dev/core/src/Meshes/csg2.ts
@@ -19,6 +19,12 @@ import { Vector3 } from "core/Maths/math.vector";
 let Manifold: any;
 
 /**
+ * Promise to wait for the manifold library to be ready
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+let ManifoldPromise: Promise<{ Manifold: any; Mesh: any }>;
+
+/**
  * Manifold mesh
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -463,11 +469,16 @@ export async function InitializeCSG2Async(options?: Partial<ICSG2Options>) {
         return; // Already initialized
     }
 
+    if (ManifoldPromise) {
+        await ManifoldPromise;
+        return;
+    }
+
     if (localOptions.manifoldInstance) {
         Manifold = localOptions.manifoldInstance;
         ManifoldMesh = localOptions.manifoldMeshInstance;
     } else {
-        const result = await _LoadScriptModuleAsync(
+        ManifoldPromise = _LoadScriptModuleAsync(
             `
             import Module from '${localOptions.manifoldUrl}/manifold.js';
             const wasm = await Module();
@@ -477,6 +488,7 @@ export async function InitializeCSG2Async(options?: Partial<ICSG2Options>) {
         `
         );
 
+        const result = await ManifoldPromise;
         Manifold = result.Manifold;
         ManifoldMesh = result.Mesh;
     }


### PR DESCRIPTION
Fixes the following error when trying to create many `BooleanGeometryBlocks` concurrently. 

```
manifold.js:8 wasm streaming compile failed: RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
```