### PR TITLE
Fix projection bug when dragging in default (viewport) plane

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -572,8 +572,11 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             this._pointA.addToRef(this._localAxis, this._lookAt);
             this._dragPlane.lookAt(this._lookAt);
         } else {
+            if (this._scene.activeCamera){
+                this._scene.activeCamera.getForwardRay().direction.normalizeToRef(this._localAxis);
+            }
             this._dragPlane.position.copyFrom(this._pointA);
-            this._dragPlane.lookAt(ray.origin);
+            this._dragPlane.lookAt(this._pointA.add(this._localAxis));
         }
         // Update the position of the drag plane so it doesn't get out of sync with the node (eg. when moving back and forth quickly)
         this._dragPlane.position.copyFrom(this.attachedNode.getAbsolutePosition());

--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -572,7 +572,7 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
             this._pointA.addToRef(this._localAxis, this._lookAt);
             this._dragPlane.lookAt(this._lookAt);
         } else {
-            if (this._scene.activeCamera){
+            if (this._scene.activeCamera) {
                 this._scene.activeCamera.getForwardRay().direction.normalizeToRef(this._localAxis);
             }
             this._dragPlane.position.copyFrom(this._pointA);


### PR DESCRIPTION
Forum discussion here: [Mesh drifts towards camera in default PointerDragBehavior axis mode](https://forum.babylonjs.com/t/mesh-drifts-towards-camera-in-default-pointerdragbehavior-axis-mode/56720/1)

The issue is that in the default mode (when no custom drag axis or plane normal is provided), the drag plane was being aligned by making it "look at" the camera's position. This meant that instead of being parallel to the camera’s clip (screen) plane, the drag plane always faced the camera. Because perspective cameras cause rays to converge, dragging objects off-center led to an inconsistent intersection between the pointer ray and the drag plane—resulting in the mesh drifting toward the camera.

This PR just explicitly aligns the drag plane with the camera’s forward direction (i.e., parallel to the view plane) rather than having it face the camera's position.