### PR TITLE
fix: update loading screen text when loader is currently shown

### DIFF
--- a/packages/dev/core/src/Loading/loadingScreen.ts
+++ b/packages/dev/core/src/Loading/loadingScreen.ts
@@ -263,7 +263,10 @@ export class DefaultLoadingScreen implements ILoadingScreen {
         this._loadingText = text;
 
         if (this._loadingTextDiv) {
-            this._loadingTextDiv.innerHTML = this._loadingText;
+            this._loadingDivToRenderingCanvasMap.forEach((_, loadingDiv) => {
+                // set loadingTextDiv of current loadingDiv
+                loadingDiv.children[0].innerHTML = this._loadingText;
+            });
         }
     }
 


### PR DESCRIPTION
When the loading screen is already displayed and visible, it's important to consider that the loading text is no longer the same as `this._loadingTextDiv`. Instead, a new instance of it is created by cloning the entire parent `loadingDiv` (line 197). So, for each canvas, this new instance should be updated.

Forum link: https://forum.babylonjs.com/t/engine-loadinguitext-broken/56741.