### PR TITLE
Viewer extract CreateHotSpotFromCamera as a utility function

### DIFF
--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -1,8 +1,8 @@
 export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, Model, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
 export type { CanvasViewerOptions } from "./viewerFactory";
-export type { HotSpot } from "./viewerElement";
+export type { HotSpot, ViewerElementEventMap } from "./viewerElement";
 
 export { Viewer, ViewerHotSpotResult } from "./viewer";
-export { HTML3DElement, ViewerElement, ViewerElementEventMap, CreateHotSpotFromCamera } from "./viewerElement";
+export { HTML3DElement, ViewerElement, CreateHotSpotFromCamera } from "./viewerElement";
 export { createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";

--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -3,6 +3,6 @@ export type { CanvasViewerOptions } from "./viewerFactory";
 export type { HotSpot } from "./viewerElement";
 
 export { Viewer, ViewerHotSpotResult } from "./viewer";
-export { HTML3DElement, ViewerElement } from "./viewerElement";
+export { HTML3DElement, ViewerElement, ViewerElementEventMap, CreateHotSpotFromCamera } from "./viewerElement";
 export { createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -364,10 +364,10 @@ export type Model = IDisposable & {
     /**
      * Compute and return the world bounds of the model.
      * The minimum and maximum extents, the size and the center.
-     * @param animationIndex The index of the animation group to consider when computing the bounding info.
+     * @param animationIndex The index of the animation group to use for computation. If omitted, the current selected animation is used.
      * @returns The computed bounding info for the model or null if no meshes are present in the asset container.
      */
-    getWorldBounds(animationIndex: number): Nullable<ViewerBoundingInfo>;
+    getWorldBounds(animationIndex?: number): Nullable<ViewerBoundingInfo>;
 
     /**
      * Resets the computed world bounds of the model.
@@ -1106,7 +1106,7 @@ export class Viewer implements IDisposable {
 
                     this._snapshotHelper.enableSnapshotRendering();
                 },
-                getWorldBounds: (animationIndex: number): Nullable<ViewerBoundingInfo> => {
+                getWorldBounds: (animationIndex: number = selectedAnimation): Nullable<ViewerBoundingInfo> => {
                     let worldBounds: Nullable<ViewerBoundingInfo> = cachedWorldBounds[animationIndex];
                     if (!worldBounds) {
                         worldBounds = computeModelsBoundingInfos([model]);

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -72,7 +72,7 @@ export type HotSpot = ViewerHotSpotQuery & {
  * @param predicate An optional predicate function used to determine eligible meshes for picking.
  * @returns A HotSpotobject containing the position, normal, and camera orbit parameters (alpha, beta, radius).
  */
-export async function createHotSpotFromCamera(
+export async function CreateHotSpotFromCamera(
     scene: Scene,
     camera: Camera,
     distanceReferencePoint: [x: number, y: number, z: number],
@@ -1416,7 +1416,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
             const worldBounds = model?.getWorldBounds(selectedAnimation);
             const centerArray = worldBounds ? worldBounds.center : [0, 0, 0];
             const predicate: MeshPredicate | undefined = model ? (mesh) => model.assetContainer.meshes.includes(mesh) : undefined;
-            return createHotSpotFromCamera(scene, camera, centerArray as [x: number, y: number, z: number], predicate);
+            return CreateHotSpotFromCamera(scene, camera, centerArray as [x: number, y: number, z: number], predicate);
         }
 
         return null;


### PR DESCRIPTION
- Exposed CreateHotSpotFromCamera as a module-level helper function.
- This change allows React-like apps to manage the `hotspots` attribute directly without using `cameras-as-hotspots`.