### PR TITLE
WebGPU: Fix crash when using clear coat bump

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
@@ -457,7 +457,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
             , clearCoatBumpMapData
             , fragmentInputs.vClearCoatBumpUV
             #if defined(TANGENT) && defined(NORMAL)
-                , vTBN
+                , mat3x3<f32>(input.vTBN0, input.vTBN1, input.vTBN2)
             #else
                 , uniforms.vClearCoatTangentSpaceParams
             #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/anisotropybarnlamp-glb-gives-an-error-in-webgpu-mode/56734

It crashed when the mesh had normals + tangents defined.