### PR TITLE
Add automatic adjustment for renderScale based on hardware scaling

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -108,6 +108,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
     private _cursorChanged = false;
     private _defaultMousePointerId = 0;
     private _rootChildrenHaveChanged: boolean = false;
+    private _adjustToEngineHardwareScalingLevel = false;
 
     /** @internal */
     public _capturedPointerIds = new Set<number>();
@@ -179,6 +180,23 @@ export class AdvancedDynamicTexture extends DynamicTexture {
      * If set to true, the POINTERTAP event type will be used for "click", instead of POINTERUP
      */
     public usePointerTapForClickEvent = false;
+
+    /**
+     * If set to true, the renderScale will be adjusted automatically to the engine's hardware scaling
+     * If this is set to true, manually setting the renderScale will be ignored
+     * This is useful when the engine's hardware scaling is set to a value other than 1
+     */
+    public get adjustToEngineHardwareScalingLevel(): boolean {
+        return this._adjustToEngineHardwareScalingLevel;
+    }
+
+    public set adjustToEngineHardwareScalingLevel(value: boolean) {
+        if (this._adjustToEngineHardwareScalingLevel === value) {
+            return;
+        }
+        this._adjustToEngineHardwareScalingLevel = value;
+        this._onResize();
+    }
     /**
      * Gets or sets a number used to scale rendering size (2 means that the texture will be twice bigger).
      * Useful when you want more antialiasing
@@ -703,6 +721,10 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         }
         // Check size
         const engine = scene.getEngine();
+        if (this.adjustToEngineHardwareScalingLevel) {
+            // force the renderScale to the engine's hardware scaling level
+            this._renderScale = engine.getHardwareScalingLevel();
+        }
         const textureSize = this.getSize();
         let renderWidth = engine.getRenderWidth() * this._renderScale;
         let renderHeight = engine.getRenderHeight() * this._renderScale;


### PR DESCRIPTION
Introduce a feature that automatically adjusts the renderScale according to the engine's hardware scaling level, enhancing rendering consistency across different hardware configurations.

See https://forum.babylonjs.com/t/gui-and-sethardwarescalinglevel/56216?u=raananw

Playground to test with: #3Q8PCL#296 
 - pointerdown will set the hardware scaling to a random value, GUI expected to always be the same size