### PR TITLE
Prevent duplicate notifications for removed anchors in WebXRAnchorSystem

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
@@ -54,6 +54,11 @@ export interface IWebXRAnchor {
      * Remove this anchor from the scene
      */
     remove(): void;
+
+    /**
+     * @internal - set to true when the anchor was removed
+     */
+    _removed: boolean;
 }
 
 /**
@@ -278,9 +283,10 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
         if (!this._options.doNotRemoveAnchorsOnSessionEnded) {
             while (this._trackedAnchors.length) {
                 const toRemove = this._trackedAnchors.pop();
-                if (toRemove) {
+                if (toRemove && !toRemove._removed) {
                     // as the xr frame loop is removed, we need to notify manually
                     this.onAnchorRemovedObservable.notifyObservers(toRemove);
+                    toRemove._removed = true;
                     // no need to call the remove fn as the anchor is already removed from the session
                 }
             }
@@ -308,14 +314,14 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
         const trackedAnchors = frame.trackedAnchors;
         if (trackedAnchors) {
             const toRemove = this._trackedAnchors
-                .filter((anchor) => !trackedAnchors.has(anchor.xrAnchor))
+                .filter((anchor) => anchor._removed)
                 .map((anchor) => {
-                    const index = this._trackedAnchors.indexOf(anchor);
-                    return index;
+                    return this._trackedAnchors.indexOf(anchor);
                 });
             let idxTracker = 0;
             toRemove.forEach((index) => {
                 const anchor = this._trackedAnchors.splice(index - idxTracker, 1)[0];
+                anchor.xrAnchor.delete();
                 this.onAnchorRemovedObservable.notifyObservers(anchor);
                 idxTracker++;
             });
@@ -325,7 +331,9 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
                     const newAnchor: Partial<IWebXRAnchor> = {
                         id: anchorIdProvider++,
                         xrAnchor: xrAnchor,
-                        remove: () => xrAnchor.delete(),
+                        remove: () => {
+                            newAnchor._removed = true;
+                        },
                     };
                     const anchor = this._updateAnchorWithXRFrame(xrAnchor, newAnchor, frame);
                     this._trackedAnchors.push(anchor);


### PR DESCRIPTION
Implement a mechanism to track removed anchors, preventing duplicate notifications when anchors are removed from the session. This change introduces an internal flag to indicate if an anchor has already been removed.

Fixes the issue presented here - https://forum.babylonjs.com/t/anchorsystem-anchor-remove-causes-crash-on-android/51672?u=raananw