### PR TITLE
TextInputLineComponent input handling

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -28,15 +28,22 @@ export interface ITextInputLineComponentProps {
     placeholder?: string;
     unit?: React.ReactNode;
     validator?: (value: string) => boolean;
+    onValidateChangeFailed?: (invalidValue: string) => void;
     multilines?: boolean;
     throttlePropertyChangedNotification?: boolean;
     throttlePropertyChangedNotificationDelay?: number;
     disabled?: boolean;
 }
 
+interface ITextInputLineComponentState {
+    input: string;
+    dragging: boolean;
+    inputValid: boolean;
+}
+
 let throttleTimerId = -1;
 
-export class TextInputLineComponent extends React.Component<ITextInputLineComponentProps, { value: string; dragging: boolean }> {
+export class TextInputLineComponent extends React.Component<ITextInputLineComponentProps, ITextInputLineComponentState> {
     private _localChange = false;
 
     constructor(props: ITextInputLineComponentProps) {
@@ -45,26 +52,22 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
         const emptyValue = this.props.numeric ? "0" : "";
 
         this.state = {
-            value: (this.props.value !== undefined ? this.props.value : this.props.target[this.props.propertyName!]) || emptyValue,
+            input: (this.props.value !== undefined ? this.props.value : this.props.target[this.props.propertyName!]) || emptyValue,
             dragging: false,
+            inputValid: true,
         };
     }
 
     override componentWillUnmount() {
+        this.updateValue(undefined, false);
         if (this.props.lockObject) {
             this.props.lockObject.lock = false;
         }
     }
 
-    override shouldComponentUpdate(nextProps: ITextInputLineComponentProps, nextState: { value: string; dragging: boolean }) {
+    override shouldComponentUpdate(nextProps: ITextInputLineComponentProps, nextState: ITextInputLineComponentState) {
         if (this._localChange) {
             this._localChange = false;
-            return true;
-        }
-
-        const newValue = nextProps.value !== undefined ? nextProps.value : nextProps.target[nextProps.propertyName!];
-        if (newValue !== nextState.value) {
-            nextState.value = newValue || "";
             return true;
         }
 
@@ -107,20 +110,26 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
         return 0;
     }
 
-    validateInput(value: string) {
+    updateInput(input: string) {
         if (this.props.disabled) {
             return;
         }
         if (this.props.numbersOnly) {
-            if (/[^0-9.px%-]/g.test(value)) {
+            if (/[^0-9.px%-]/g.test(input)) {
                 return;
             }
         }
+
         this._localChange = true;
-        this.setState({ value: value });
+        this.setState({
+            input,
+            inputValid: this.props.validator ? this.props.validator(input) : true,
+        });
     }
 
-    updateValue(value: string, valueToValidate?: string) {
+    updateValue(adjustedInput?: string, updateState: boolean = true) {
+        let value = adjustedInput ?? this.state.input;
+
         if (this.props.numbersOnly) {
             if (!value) {
                 value = "0";
@@ -148,10 +157,14 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
 
         const store = this.props.value !== undefined ? this.props.value : this.props.target[this.props.propertyName!];
 
-        if (this.props.validator && valueToValidate) {
-            if (this.props.validator(valueToValidate) == false) {
-                value = store;
-            }
+        if (updateState) {
+            this._localChange = true;
+            this.setState({ input: value });
+        }
+
+        if (this.props.validator && this.props.validator(value) == false && this.props.onValidateChangeFailed) {
+            this.props.onValidateChangeFailed(value);
+            return;
         }
 
         if (this.props.propertyName && !this.props.delayInput) {
@@ -178,14 +191,14 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
             this.props.arrowsIncrement(amount);
             return;
         }
-        const currentValue = this.getCurrentNumericValue(this.state.value);
+        const currentValue = this.getCurrentNumericValue(this.state.input);
         this.updateValue((currentValue + amount).toFixed(2));
     }
 
     onKeyDown(event: React.KeyboardEvent) {
         if (!this.props.disabled) {
             if (event.key === "Enter") {
-                this.updateValue(this.state.value);
+                this.updateValue();
             }
             if (this.props.arrows) {
                 if (event.key === "ArrowUp") {
@@ -201,8 +214,8 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
     }
 
     override render() {
-        const value = this.state.value === conflictingValuesPlaceholder ? "" : this.state.value;
-        const placeholder = this.state.value === conflictingValuesPlaceholder ? conflictingValuesPlaceholder : this.props.placeholder || "";
+        const value = this.state.input === conflictingValuesPlaceholder ? "" : this.state.input;
+        const placeholder = this.state.input === conflictingValuesPlaceholder ? conflictingValuesPlaceholder : this.props.placeholder || "";
         const step = this.props.step || (this.props.roundValues ? 1 : 0.01);
         const className = this.props.multilines ? "textInputArea" : this.props.unit !== undefined ? "textInputLine withUnits" : "textInputLine";
         return (
@@ -217,21 +230,16 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                     <>
                         <textarea
                             className={this.props.disabled ? "disabled" : ""}
-                            value={this.state.value}
+                            style={this.state.inputValid ? {} : { background: "lightpink" }}
+                            value={this.state.input}
                             onFocus={() => {
                                 if (this.props.lockObject) {
                                     this.props.lockObject.lock = true;
                                 }
                             }}
-                            onChange={(evt) => this.validateInput(evt.target.value)}
-                            onKeyDown={(evt) => {
-                                if (evt.keyCode !== 13) {
-                                    return;
-                                }
-                                this.updateValue(this.state.value);
-                            }}
+                            onChange={(evt) => this.updateInput(evt.target.value)}
                             onBlur={(evt) => {
-                                this.updateValue(evt.target.value, evt.target.value);
+                                this.updateValue();
                                 if (this.props.lockObject) {
                                     this.props.lockObject.lock = false;
                                 }
@@ -246,19 +254,20 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                     >
                         <input
                             className={this.props.disabled ? "disabled" : ""}
+                            style={this.state.inputValid ? {} : { background: "lightpink" }}
                             value={value}
                             onBlur={(evt) => {
                                 if (this.props.lockObject) {
                                     this.props.lockObject.lock = false;
                                 }
-                                this.updateValue((this.props.value !== undefined ? this.props.value : this.props.target[this.props.propertyName!]) || "", evt.target.value);
+                                this.updateValue();
                             }}
                             onFocus={() => {
                                 if (this.props.lockObject) {
                                     this.props.lockObject.lock = true;
                                 }
                             }}
-                            onChange={(evt) => this.validateInput(evt.target.value)}
+                            onChange={(evt) => this.updateInput(evt.target.value)}
                             onKeyDown={(evt) => this.onKeyDown(evt)}
                             placeholder={placeholder}
                             type={this.props.numeric ? "number" : "text"}

--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -27,8 +27,8 @@ export interface ITextInputLineComponentProps {
     max?: number;
     placeholder?: string;
     unit?: React.ReactNode;
-    validator?: (value: string) => boolean;
-    onValidateChangeFailed?: (invalidValue: string) => void;
+    validator?: (input: string) => boolean;
+    onValidateChangeFailed?: (invalidInput: string) => void;
     multilines?: boolean;
     throttlePropertyChangedNotification?: boolean;
     throttlePropertyChangedNotificationDelay?: number;
@@ -218,6 +218,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
         const placeholder = this.state.input === conflictingValuesPlaceholder ? conflictingValuesPlaceholder : this.props.placeholder || "";
         const step = this.props.step || (this.props.roundValues ? 1 : 0.01);
         const className = this.props.multilines ? "textInputArea" : this.props.unit !== undefined ? "textInputLine withUnits" : "textInputLine";
+        const style = { background: this.state.inputValid ? undefined : "lightpink" };
         return (
             <div className={className}>
                 {this.props.icon && <img src={this.props.icon} title={this.props.iconLabel} alt={this.props.iconLabel} color="black" className="icon" />}
@@ -230,7 +231,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                     <>
                         <textarea
                             className={this.props.disabled ? "disabled" : ""}
-                            style={this.state.inputValid ? {} : { background: "lightpink" }}
+                            style={style}
                             value={this.state.input}
                             onFocus={() => {
                                 if (this.props.lockObject) {
@@ -254,7 +255,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                     >
                         <input
                             className={this.props.disabled ? "disabled" : ""}
-                            style={this.state.inputValid ? {} : { background: "lightpink" }}
+                            style={style}
                             value={value}
                             onBlur={(evt) => {
                                 if (this.props.lockObject) {

--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -107,7 +107,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
         return 0;
     }
 
-    updateValue(value: string, valueToValidate?: string) {
+    validateInput(value: string) {
         if (this.props.disabled) {
             return;
         }
@@ -115,6 +115,13 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
             if (/[^0-9.px%-]/g.test(value)) {
                 return;
             }
+        }
+        this._localChange = true;
+        this.setState({ value: value });
+    }
+
+    updateValue(value: string, valueToValidate?: string) {
+        if (this.props.numbersOnly) {
             if (!value) {
                 value = "0";
             }
@@ -139,7 +146,6 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
             value = numericValue.toString();
         }
 
-        this._localChange = true;
         const store = this.props.value !== undefined ? this.props.value : this.props.target[this.props.propertyName!];
 
         if (this.props.validator && valueToValidate) {
@@ -147,8 +153,6 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                 value = store;
             }
         }
-
-        this.setState({ value: value });
 
         if (this.props.propertyName && !this.props.delayInput) {
             this.props.target[this.props.propertyName] = value;
@@ -214,7 +218,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                                     this.props.lockObject.lock = true;
                                 }
                             }}
-                            onChange={(evt) => this.updateValue(evt.target.value)}
+                            onChange={(evt) => this.validateInput(evt.target.value)}
                             onKeyDown={(evt) => {
                                 if (evt.keyCode !== 13) {
                                     return;
@@ -249,7 +253,7 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
                                     this.props.lockObject.lock = true;
                                 }
                             }}
-                            onChange={(evt) => this.updateValue(evt.target.value)}
+                            onChange={(evt) => this.validateInput(evt.target.value)}
                             onKeyDown={(evt) => this.onKeyDown(evt)}
                             placeholder={placeholder}
                             type={this.props.numeric ? "number" : "text"}

--- a/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textInputLineComponent.tsx
@@ -183,14 +183,19 @@ export class TextInputLineComponent extends React.Component<ITextInputLineCompon
     }
 
     onKeyDown(event: React.KeyboardEvent) {
-        if (!this.props.disabled && this.props.arrows) {
-            if (event.key === "ArrowUp") {
-                this.incrementValue(1);
-                event.preventDefault();
+        if (!this.props.disabled) {
+            if (event.key === "Enter") {
+                this.updateValue(this.state.value);
             }
-            if (event.key === "ArrowDown") {
-                this.incrementValue(-1);
-                event.preventDefault();
+            if (this.props.arrows) {
+                if (event.key === "ArrowUp") {
+                    this.incrementValue(1);
+                    event.preventDefault();
+                }
+                if (event.key === "ArrowDown") {
+                    this.incrementValue(-1);
+                    event.preventDefault();
+                }
             }
         }
     }

--- a/packages/tools/nodeEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/genericNodePropertyComponent.tsx
@@ -55,13 +55,10 @@ export class GeneralPropertyTabComponent extends React.Component<IPropertyCompon
                             lockObject={this.props.stateManager.lockObject}
                             onChange={() => this.props.stateManager.onUpdateRequiredObservable.notifyObservers(block)}
                             throttlePropertyChangedNotification={true}
-                            validator={(newName) => {
-                                if (!block.validateBlockName(newName)) {
-                                    this.props.stateManager.onErrorMessageDialogRequiredObservable.notifyObservers(`"${newName}" is a reserved name, please choose another`);
-                                    return false;
-                                }
-                                return true;
-                            }}
+                            validator={(newName) => block.validateBlockName(newName)}
+                            onValidateChangeFailed={(invalidInput) =>
+                                this.props.stateManager.onErrorMessageDialogRequiredObservable.notifyObservers(`"${invalidInput}" is a reserved name, please choose another`)
+                            }
                         />
                     )}
                     {block._originalTargetIsNeutral && (


### PR DESCRIPTION
Property updates were happening with each keystroke, resulting in errors while user was still typing for certain use cases.

* Restrict property update only to when: “Enter” pressed (single-line), arrows pressed, on lost focus, or on exit (new)
    * No more property updates every keystroke
    * No more property updates after “Enter” pressed for multiline inputs
* Restrict re-formatting to only when property updates
* Continue to check for certain illegal inputs per keystroke
* Allow user to keep editing invalid inputs
    * Add red highlight when input invalid
* onValidateChangeFailed parameter to separate error messages from input validation