### PR TITLE
Viewer: add support for hdr environments

### DIFF
--- a/packages/dev/core/src/Engines/AbstractEngine/abstractEngine.cubeTexture.ts
+++ b/packages/dev/core/src/Engines/AbstractEngine/abstractEngine.cubeTexture.ts
@@ -7,6 +7,7 @@ import { RandomGUID } from "../../Misc/guid";
 import type { IWebRequest } from "../../Misc/interfaces/iWebRequest";
 import { AbstractEngine } from "../abstractEngine";
 import { _GetCompatibleTextureLoader } from "core/Materials/Textures/Loaders/textureLoaderManager";
+import { GetExtensionFromUrl } from "core/Misc/urlTools";
 
 declare module "../../Engines/abstractEngine" {
     export interface AbstractEngine {
@@ -202,9 +203,7 @@ AbstractEngine.prototype.createCubeTextureBase = function (
         rootUrl = this._transformTextureUrl(rootUrl);
     }
 
-    const rootUrlWithoutUriParams = rootUrl.split("?")[0];
-    const lastDot = rootUrlWithoutUriParams.lastIndexOf(".");
-    const extension = forcedExtension ? forcedExtension : lastDot > -1 ? rootUrlWithoutUriParams.substring(lastDot).toLowerCase() : "";
+    const extension = forcedExtension ?? GetExtensionFromUrl(rootUrl);
 
     const loaderPromise = _GetCompatibleTextureLoader(extension);
 

--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -77,6 +77,7 @@ export * from "./equirectangularCapture";
 export * from "./decorators.serialization";
 export * from "./asyncLock";
 export * from "./bitArray";
+export * from "./urlTools";
 
 // RGBDTextureTools
 export * from "../Shaders/rgbdDecode.fragment";

--- a/packages/dev/core/src/Misc/urlTools.ts
+++ b/packages/dev/core/src/Misc/urlTools.ts
@@ -1,0 +1,11 @@
+/**
+ * Gets the file extension from a URL.
+ * @param url The URL to get the file extension from.
+ * @returns The file extension, or an empty string if no extension is found.
+ */
+export function GetExtensionFromUrl(url: string) {
+    const urlWithoutUriParams = url.split("?")[0];
+    const lastDot = urlWithoutUriParams.lastIndexOf(".");
+    const extension = lastDot > -1 ? urlWithoutUriParams.substring(lastDot).toLowerCase() : "";
+    return extension;
+}

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -143,7 +143,7 @@ async function createCubeTexture(url: string, scene: Scene, extension?: string) 
         if (extension === ".hdr") {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             const { HDRCubeTexture } = await import("core/Materials/Textures/hdrCubeTexture");
-            return () => new HDRCubeTexture(url, scene, 128, false, true, false, true);
+            return () => new HDRCubeTexture(url, scene, 256, false, true, false, true, undefined, undefined, undefined, true, true);
         } else {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             const { CubeTexture } = await import("core/Materials/Textures/cubeTexture");

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -137,7 +137,7 @@ function throwIfAborted(...abortSignals: (Nullable<AbortSignal> | undefined)[]):
     }
 }
 
-async function createCubeTexture(url: string, extension: string | undefined, scene: Scene) {
+async function createCubeTexture(url: string, scene: Scene, extension?: string) {
     extension = extension ?? GetExtensionFromUrl(url);
     const instantiateTexture = await (async () => {
         if (extension === ".hdr") {
@@ -1293,7 +1293,7 @@ export class Viewer implements IDisposable {
 
             try {
                 if (url) {
-                    const cubeTexture = await createCubeTexture(url, options.extension, this._scene);
+                    const cubeTexture = await createCubeTexture(url, this._scene, options.extension);
 
                     if (options.lighting) {
                         this._reflectionTexture = cubeTexture;


### PR DESCRIPTION
When loading an environment from a .hdr file, we need to use `HDRCubeMap` rather than `CubeMap`. To enable this:
1. Add a helper function for getting the file extension from a url.
1. Viewer tries to determine the extension from the environment url.
1. If the extension is `.hdr`, we use `HDRCubeMap` instead of `CubeMap`.
1. In either case, the necessary cube map texture module is dynamically imported.