### PR TITLE
IBL Shadows - Don't copy mips until effect is compiled

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
@@ -655,9 +655,11 @@ export class _IblShadowsVoxelRenderer {
                     this._voxelGridRT.render();
                 }
                 this._generateMipMaps();
-                this._copyMipMaps();
-                this._scene.onAfterRenderObservable.removeCallback(this._renderVoxelGridBound);
-                this._voxelizationInProgress = false;
+                this._copyMipEffectWrapper.effect.whenCompiledAsync().then(() => {
+                    this._copyMipMaps();
+                    this._scene.onAfterRenderObservable.removeCallback(this._renderVoxelGridBound);
+                    this._voxelizationInProgress = false;
+                });
             }
         }
     }


### PR DESCRIPTION
In the latest code, I'm hitting an error in the IBL shadows code because the effect is being used before it's compiled.
https://playground.babylonjs.com/#8R5SSE#536

This change should fix the issue.