### PR TITLE
Avoid exception during shader compilation context loss

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.functions.ts
+++ b/packages/dev/core/src/Engines/thinEngine.functions.ts
@@ -201,9 +201,11 @@ export function _isRenderingStateCompiled(pipelineContext: IPipelineContext, gl:
         return false;
     }
     const stateObject = getStateObject(gl);
-    if (gl.getProgramParameter(webGLPipelineContext.program!, stateObject.parallelShaderCompile!.COMPLETION_STATUS_KHR)) {
-        _finalizePipelineContext(webGLPipelineContext, gl, validateShaderPrograms);
-        return true;
+    if (stateObject && stateObject.parallelShaderCompile && stateObject.parallelShaderCompile.COMPLETION_STATUS_KHR && webGLPipelineContext.program) {
+        if (gl.getProgramParameter(webGLPipelineContext.program, stateObject.parallelShaderCompile.COMPLETION_STATUS_KHR)) {
+            _finalizePipelineContext(webGLPipelineContext, gl, validateShaderPrograms);
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
Enhance error handling to prevent exceptions when the rendering context is lost during shader compilation.