### PR TITLE
Viewer: small bug fixes + more tests

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -796,20 +796,19 @@ export class Viewer implements IDisposable {
      * The post processing configuration.
      */
     public get postProcessing(): PostProcessing {
-        let toneMapping: ToneMapping;
-        switch (this._toneMappingType) {
-            case ImageProcessingConfiguration.TONEMAPPING_STANDARD:
-                toneMapping = "standard";
-                break;
-            case ImageProcessingConfiguration.TONEMAPPING_ACES:
-                toneMapping = "aces";
-                break;
-            case ImageProcessingConfiguration.TONEMAPPING_KHR_PBR_NEUTRAL:
-                toneMapping = "neutral";
-                break;
-            default:
-                toneMapping = "none";
-                break;
+        let toneMapping: ToneMapping = "none";
+        if (this._toneMappingEnabled) {
+            switch (this._toneMappingType) {
+                case ImageProcessingConfiguration.TONEMAPPING_STANDARD:
+                    toneMapping = "standard";
+                    break;
+                case ImageProcessingConfiguration.TONEMAPPING_ACES:
+                    toneMapping = "aces";
+                    break;
+                case ImageProcessingConfiguration.TONEMAPPING_KHR_PBR_NEUTRAL:
+                    toneMapping = "neutral";
+                    break;
+            }
         }
 
         return {

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -759,7 +759,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
                 return null;
             }
 
-            const array = value.split(/\s+/);
+            const array = value.trim().split(/\s+/);
             if (array.length !== 3) {
                 throw new Error("cameraOrbit should be defined as 'alpha beta radius'");
             }
@@ -787,7 +787,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
                 return null;
             }
 
-            const array = value.split(/\s+/);
+            const array = value.trim().split(/\s+/);
             if (array.length !== 3) {
                 throw new Error("cameraTarget should be defined as 'x y z'");
             }

--- a/packages/tools/viewer/test/viewer.test.ts
+++ b/packages/tools/viewer/test/viewer.test.ts
@@ -46,7 +46,7 @@ test("animation-auto-play", async ({ page }) => {
         page,
         `
         <babylon-viewer
-            source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
+            source="https://assets.babylonjs.com/meshes/ufo.glb"
             animation-auto-play
         >
         </babylon-viewer>
@@ -61,13 +61,36 @@ test("animation-auto-play", async ({ page }) => {
     expect(isAnimationPlaying).toBeTruthy();
 });
 
-test("camera-orbit", async ({ page }) => {
+test('selected-animation="n"', async ({ page }) => {
     const viewerElementHandle = await attachViewerElement(
         page,
         `
         <babylon-viewer
-            source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
-            camera-orbit="1 2 3"
+            source="https://assets.babylonjs.com/meshes/ufo.glb"
+            selected-animation="1"
+        >
+        </babylon-viewer>
+        `
+    );
+
+    // Wait for the viewerDetails property to become defined
+    const selectedAnimation = await page.waitForFunction((viewerElement) => {
+        const viewerDetails = (viewerElement as ViewerElement).viewerDetails;
+        if (viewerDetails?.model) {
+            return viewerDetails.viewer.selectedAnimation;
+        }
+    }, viewerElementHandle);
+
+    expect(await selectedAnimation.jsonValue()).toEqual(1);
+});
+
+test('camera-orbit="a b r"', async ({ page }) => {
+    const viewerElementHandle = await attachViewerElement(
+        page,
+        `
+        <babylon-viewer
+            source="https://assets.babylonjs.com/meshes/boombox.glb"
+            camera-orbit=" 1 2 0.1 "
         >
         </babylon-viewer>
         `
@@ -81,16 +104,16 @@ test("camera-orbit", async ({ page }) => {
         }
     }, viewerElementHandle);
 
-    expect(await cameraPose.jsonValue()).toEqual([1, 2, 3]);
+    expect(await cameraPose.jsonValue()).toEqual([1, 2, 0.1]);
 });
 
-test("camera-target", async ({ page }) => {
+test('camera-target="x y z"', async ({ page }) => {
     const viewerElementHandle = await attachViewerElement(
         page,
         `
         <babylon-viewer
-            source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"
-            camera-target="1 2 3"
+            source="https://assets.babylonjs.com/meshes/boombox.glb"
+            camera-target=" 1 2 3 "
         >
         </babylon-viewer>
         `
@@ -105,4 +128,50 @@ test("camera-target", async ({ page }) => {
     }, viewerElementHandle);
 
     expect(await cameraPose.jsonValue()).toEqual([1, 2, 3]);
+});
+
+test('tone-mapping="none"', async ({ page }) => {
+    const viewerElementHandle = await attachViewerElement(
+        page,
+        `
+        <babylon-viewer
+            source="https://assets.babylonjs.com/meshes/boombox.glb"
+            tone-mapping="none"
+        >
+        </babylon-viewer>
+        `
+    );
+
+    // Wait for the viewerDetails property to become defined
+    const toneMapping = await page.waitForFunction((viewerElement) => {
+        const viewerDetails = (viewerElement as ViewerElement).viewerDetails;
+        if (viewerDetails?.model) {
+            return viewerDetails.viewer.postProcessing.toneMapping;
+        }
+    }, viewerElementHandle);
+
+    expect(await toneMapping.jsonValue()).toEqual("none");
+});
+
+test('material-variant="name"', async ({ page }) => {
+    const viewerElementHandle = await attachViewerElement(
+        page,
+        `
+        <babylon-viewer
+            source="https://assets.babylonjs.com/meshes/shoe_variants.glb"
+            material-variant="street"
+        >
+        </babylon-viewer>
+        `
+    );
+
+    // Wait for the viewerDetails property to become defined
+    const materialVariant = await page.waitForFunction((viewerElement) => {
+        const viewerDetails = (viewerElement as ViewerElement).viewerDetails;
+        if (viewerDetails?.model) {
+            return viewerDetails.viewer.selectedMaterialVariant;
+        }
+    }, viewerElementHandle);
+
+    expect(await materialVariant.jsonValue()).toEqual("street");
 });


### PR DESCRIPTION
Fixing a couple minor Viewer bugs and adding some related tests:
1. Camera orbit/target attributes are specified as "alpha beta radius" and "x y z". However, if there was any extra leading/trailing white space, it would fail to parse.
2. When setting tone-mapping to "none", it would apply the value, but then the lower level `Viewer` would return the previous value from the `postProcessing.toneMapping` property.