### PR TITLE
Reset model error

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1224,6 +1224,7 @@ export class Viewer implements IDisposable {
             await this.resetEnvironment({ lighting: true }, abortSignal);
         }
 
+        this._markSceneMutated();
         this._startSceneOptimizer(true);
     }
 

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1146,6 +1146,7 @@ export class Viewer implements IDisposable {
                     }
 
                     this._snapshotHelper.enableSnapshotRendering();
+                    this._markSceneMutated();
                 },
                 getWorldBounds: (animationIndex: number = selectedAnimation): Nullable<ViewerBoundingInfo> => {
                     let worldBounds: Nullable<ViewerBoundingInfo> = cachedWorldBounds[animationIndex];
@@ -1224,7 +1225,6 @@ export class Viewer implements IDisposable {
             await this.resetEnvironment({ lighting: true }, abortSignal);
         }
 
-        this._markSceneMutated();
         this._startSceneOptimizer(true);
     }
 

--- a/packages/tools/viewer/test/apps/web/index.html
+++ b/packages/tools/viewer/test/apps/web/index.html
@@ -143,6 +143,7 @@
             <button onClick="onSuspendRendering()">Suspend Rendering</button>
             <button onClick="onResumeRendering()">Resume Rendering</button>
             <button onClick="onMarkSceneMutated()">Mark Scene Mutated</button>
+            <button onClick="resetModel()">Reset Model</button>
             <div>
                 <span>Environment Intensity</span>
                 <input type="range" id="environmentIntensityInput" min="0" max="2" step="0.01" oninput="onEnvironmentIntensity()" />
@@ -334,6 +335,11 @@
 
             globalThis.onMarkSceneMutated = () => {
                 viewerElement.viewerDetails.markSceneMutated();
+            };
+
+            globalThis.resetModel = () => {
+                console.log("reset model");
+                viewerElement.viewerDetails.viewer.resetModel();
             };
 
             globalThis.onEnvironmentIntensity = () => {


### PR DESCRIPTION
Fix the first issue when the scene was not marked as mutated when `resetModel` was called.
There is still an issue in WebGPU :

```
Uncaught TypeError: Cannot read properties of undefined (reading 'Scene')
    at WebGPUDrawContext.setBuffer (webgpuDrawContext.ts:84:60)
    at WebGPUEngine.bindUniformBufferBase (webgpuEngine.ts:1843:34)
    at Effect.bindUniformBuffer (effect.ts:1027:22)
    at UniformBuffer.bindUniformBuffer (uniformBuffer.ts:1148:33)
    at UniformBuffer.update (uniformBuffer.ts:649:14)
    at Scene.finalizeSceneUbo (scene.ts:1168:13)
    at Scene._renderForCamera (scene.ts:4587:18)
    at Scene._processSubCameras (scene.ts:4620:18)
    at Scene.render (scene.ts:5015:22)
    at render (viewer.ts:1549:33)
```

Probably just a top level issue but I'm not sure I have the technical level if it is WebGPU related. 