### PR TITLE
Viewer: PascalCase functions and @experimental protected API

### DIFF
--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -4,5 +4,5 @@ export type { HotSpot, ViewerElementEventMap } from "./viewerElement";
 
 export { Viewer, ViewerHotSpotResult } from "./viewer";
 export { HTML3DElement, ViewerElement, CreateHotSpotFromCamera } from "./viewerElement";
-export { createViewerForCanvas } from "./viewerFactory";
+export { CreateViewerForCanvas as createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -128,7 +128,7 @@ export type PostProcessing = {
  * @param value The value to check.
  * @returns True if the value is a valid tone mapping option, otherwise false.
  */
-export function isToneMapping(value: string): value is ToneMapping {
+export function IsToneMapping(value: string): value is ToneMapping {
     return toneMappingOptions.includes(value as ToneMapping);
 }
 

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -15,7 +15,7 @@ const defaultCanvasViewerOptions: CanvasViewerOptions = { antialias: true, adapt
  * Chooses a default engine for the current browser environment.
  * @returns The default engine to use.
  */
-export function getDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
+export function GetDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
     // First check for WebGPU support.
     if ("gpu" in navigator) {
         // For now, only use WebGPU with chromium-based browsers.
@@ -37,7 +37,7 @@ export function getDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
  * @param options The options to use when creating the Viewer and binding it to the specified canvas.
  * @returns A Viewer instance that is bound to the specified canvas.
  */
-export function createViewerForCanvas<DerivedViewer extends Viewer>(
+export function CreateViewerForCanvas<DerivedViewer extends Viewer>(
     canvas: HTMLCanvasElement,
     options: CanvasViewerOptions & {
         /**
@@ -46,12 +46,12 @@ export function createViewerForCanvas<DerivedViewer extends Viewer>(
         viewerClass: new (...args: ConstructorParameters<typeof Viewer>) => DerivedViewer;
     }
 ): Promise<DerivedViewer>;
-export function createViewerForCanvas(canvas: HTMLCanvasElement, options?: CanvasViewerOptions): Promise<Viewer>;
+export function CreateViewerForCanvas(canvas: HTMLCanvasElement, options?: CanvasViewerOptions): Promise<Viewer>;
 
 /**
  * @internal
  */
-export async function createViewerForCanvas(
+export async function CreateViewerForCanvas(
     canvas: HTMLCanvasElement,
     options?: CanvasViewerOptions & { viewerClass?: new (...args: ConstructorParameters<typeof Viewer>) => Viewer }
 ): Promise<Viewer> {
@@ -60,7 +60,7 @@ export async function createViewerForCanvas(
 
     // Create an engine instance.
     let engine: AbstractEngine;
-    switch (options.engine ?? getDefaultEngine()) {
+    switch (options.engine ?? GetDefaultEngine()) {
         case "WebGL": {
             // eslint-disable-next-line @typescript-eslint/naming-convention, no-case-declarations
             const { Engine } = await import("core/Engines/engine");


### PR DESCRIPTION
1. Switch the exported functions to PascalCase to match the rest of the Babylon API. Only one function is actually part of the public API.
2. Mark the protected APIs as experimental for now. Also add some doc comments.