### PR TITLE
Make prefiltering using CDF default to supersample

### DIFF
--- a/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/hdrCubeTexture.ts
@@ -160,7 +160,10 @@ export class HDRCubeTexture extends BaseTexture {
 
         this._noMipmap = noMipmap;
         this._size = size;
-        this._supersample = supersample;
+        // CDF is very sensitive to lost precision due to downsampling. This can result in
+        // noticeable brightness differences with different resolutions. Enabling supersampling
+        // mitigates this.
+        this._supersample = supersample || prefilterUsingCdf;
         this._generateHarmonics = generateHarmonics;
 
         this._texture = this._getFromCache(url, this._noMipmap, undefined, undefined, undefined, this.isCube);

--- a/packages/dev/core/src/Shaders/iblCdfDebug.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblCdfDebug.fragment.fx
@@ -37,7 +37,8 @@ void main(void) {
   vec2 uv =
       vec2((offsetX + vUV.x) * widthScale, (offsetY + vUV.y) * heightScale);
   vec3 backgroundColour = texture2D(textureSampler, vUV).rgb;
-
+  int cdfxWidth = textureSize(cdfx, 0).x;
+  int cdfyHeight = textureSize(cdfy, 0).y;
   const float iblStart = 1.0 - cdfyVSize;
   const float pdfStart = 1.0 - 2.0 * cdfyVSize;
   const float cdfyStart = 1.0 - 3.0 * cdfyVSize;
@@ -76,11 +77,11 @@ void main(void) {
   } else if (uv.y > pdfStart) {
     colour += pdfColour;
   } else if (uv.y > cdfyStart && uv.x < 0.5) {
-    colour.r += 0.003 * cdfyColour;
+    colour.r += cdfyColour / float(cdfyHeight);
   } else if (uv.y > cdfyStart && uv.x > 0.5) {
     colour.r += icdfyColour;
   } else if (uv.y > cdfxStart) {
-    colour.r += 0.00003 * cdfxColour;
+    colour.r += cdfxColour / float(cdfxWidth);
   } else if (uv.y > icdfxStart) {
     colour.r += icdfxColour;
   }

--- a/packages/dev/core/src/ShadersWGSL/iblCdfDebug.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblCdfDebug.fragment.fx
@@ -40,7 +40,8 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   var uv: vec2f =
        vec2f((uniforms.sizeParams.x + input.vUV.x) * uniforms.sizeParams.z, (uniforms.sizeParams.y + input.vUV.y) * uniforms.sizeParams.w);
   var backgroundColour: vec3f = textureSample(textureSampler, textureSamplerSampler, input.vUV).rgb;
-
+  var cdfxWidth: u32 = textureDimensions(cdfx, 0).x;
+  var cdfyHeight: u32 = textureDimensions(cdfy, 0).y;
   const iblStart: f32 = 1.0 - cdfyVSize;
   const pdfStart: f32 = 1.0 - 2.0 * cdfyVSize;
   const cdfyStart: f32 = 1.0 - 3.0 * cdfyVSize;
@@ -75,11 +76,11 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
   } else if (uv.y > pdfStart) {
     colour += pdfColour;
   } else if (uv.y > cdfyStart && uv.x < 0.5) {
-    colour.r += 0.003 * cdfyColour;
+    colour.r += cdfyColour / f32(cdfyHeight);
   } else if (uv.y > cdfyStart && uv.x > 0.5) {
     colour.r += icdfyColour;
   } else if (uv.y > cdfxStart) {
-    colour.r += 0.00003 * cdfxColour;
+    colour.r += cdfxColour / f32(cdfxWidth);
   } else if (uv.y > icdfxStart) {
     colour.r += icdfxColour;
   }


### PR DESCRIPTION
I've noticed an issue with the CDF irradiance filtering when the cube texture size is below 256. The resulting irradiance brightness varies considerably (and usually gets darker) with different resolutions. The issue seems to be that the conversion from equirectangular to cubemap loses some of the bright spots in the original map (or changes the balance of bright pixels to dark ones). This is an especially big problem for mobile devices since the prefiltered cubemap can't seem to be bigger than 64 without causing the WebGL context to be lost.

The 'supersample' option when creating an HDRCubeTexture fixes this issue entirely as it compensates for the missing resolution with more samples. For this reason, I think it makes sense to force supersampling when CDF filtering is enabled.