### PR TITLE
Update playground for audio engine compatibility

### DIFF
--- a/packages/dev/core/src/Audio/Interfaces/IAudioEngineOptions.ts
+++ b/packages/dev/core/src/Audio/Interfaces/IAudioEngineOptions.ts
@@ -5,10 +5,12 @@
 export interface IAudioEngineOptions {
     /**
      * Specifies an existing Audio Context for the audio engine
+     * @deprecated Please use AudioEngineV2 instead
      */
     audioContext?: AudioContext;
     /**
      * Specifies a destination node for the audio engine
+     * @deprecated Please use AudioEngineV2 instead
      */
     audioDestination?: AudioDestinationNode | MediaStreamAudioDestinationNode;
 }

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -1899,6 +1899,7 @@ export abstract class AbstractEngine {
 
     /**
      * Gets the audio context specified in engine initialization options
+     * @deprecated please use AudioEngineV2 instead
      * @returns an Audio Context
      */
     public getAudioContext(): Nullable<AudioContext> {
@@ -1907,6 +1908,7 @@ export abstract class AbstractEngine {
 
     /**
      * Gets the audio destination specified in engine initialization options
+     * @deprecated please use AudioEngineV2 instead
      * @returns an audio destination node
      */
     public getAudioDestination(): Nullable<AudioDestinationNode | MediaStreamAudioDestinationNode> {
@@ -2718,6 +2720,7 @@ export abstract class AbstractEngine {
     /**
      * Gets the audio engine
      * @see https://doc.babylonjs.com/features/featuresDeepDive/audio/playingSoundsMusic
+     * @deprecated please use AudioEngineV2 instead
      * @ignorenaming
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -2726,6 +2729,7 @@ export abstract class AbstractEngine {
     /**
      * Default AudioEngine factory responsible of creating the Audio Engine.
      * By default, this will create a BabylonJS Audio Engine if the workload has been embedded.
+     * @deprecated please use AudioEngineV2 instead
      */
     public static AudioEngineFactory: (
         hostElement: Nullable<HTMLElement>,

--- a/packages/dev/core/src/Engines/engine.common.ts
+++ b/packages/dev/core/src/Engines/engine.common.ts
@@ -69,10 +69,6 @@ export function _CommonInit(commonEngine: AbstractEngine, canvas: HTMLCanvasElem
         _DisableTouchAction(canvas);
     }
 
-    // Create Audio Engine if needed.
-    if (!AbstractEngine.audioEngine && creationOptions.audioEngine && AbstractEngine.AudioEngineFactory) {
-        AbstractEngine.audioEngine = AbstractEngine.AudioEngineFactory(commonEngine.getRenderingCanvas(), commonEngine.getAudioContext(), commonEngine.getAudioDestination());
-    }
     if (IsDocumentAvailable()) {
         // Fullscreen
         commonEngine._onFullscreenChange = () => {

--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -48,7 +48,6 @@ import {
     _CommonInit,
 } from "./engine.common";
 import { PerfCounter } from "../Misc/perfCounter";
-import "../Audio/audioEngine";
 import { _retryWithInterval } from "core/Misc/timingTools";
 
 /**


### PR DESCRIPTION
Enhance the playground to support both the new and old audio engine implementations, including deprecation notices for the old audio engine methods.

Now if a playground references the BABYLON.Sound class, the old audioEngine will be initialized. Until then, no audio engine will be created.

A second change is disposing all available NEW audio engines before the playground starts, as disposing the audio engine is independent from the Engine class.