### PR TITLE
Restore missing export for glTF exporter

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/index.ts
+++ b/packages/dev/serializers/src/glTF/2.0/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/no-internal-modules */
 export * from "./glTFData";
 export * from "./glTFSerializer";
 export { _SolveMetallic, _ConvertToGLTFPBRMetallicRoughness } from "./glTFMaterialExporter";
+export * from "./Extensions/index";


### PR DESCRIPTION
Extensions register themselves with the GLTF exporter, so they must be included in the index.ts.