### PR TITLE
Allow engine instance to be passed to LoadImage

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -1700,7 +1700,8 @@ export abstract class AbstractEngine {
                         onInternalError,
                         scene ? scene.offlineProvider : null,
                         mimeType,
-                        texture.invertY && this._features.needsInvertingBitmap ? { imageOrientation: "flipY" } : undefined
+                        texture.invertY && this._features.needsInvertingBitmap ? { imageOrientation: "flipY" } : undefined,
+                        this
                     );
                 }
             } else if (typeof buffer === "string" || buffer instanceof ArrayBuffer || ArrayBuffer.isView(buffer) || buffer instanceof Blob) {
@@ -1710,7 +1711,8 @@ export abstract class AbstractEngine {
                     onInternalError,
                     scene ? scene.offlineProvider : null,
                     mimeType,
-                    texture.invertY && this._features.needsInvertingBitmap ? { imageOrientation: "flipY" } : undefined
+                    texture.invertY && this._features.needsInvertingBitmap ? { imageOrientation: "flipY" } : undefined,
+                    this
                 );
             } else if (buffer) {
                 onload(buffer);
@@ -2547,6 +2549,7 @@ export abstract class AbstractEngine {
      * @param offlineProvider offline provider for caching
      * @param mimeType optional mime type
      * @param imageBitmapOptions optional the options to use when creating an ImageBitmap
+     * @param engine the engine instance to use
      * @returns the HTMLImageElement of the loaded image
      * @internal
      */
@@ -2556,7 +2559,8 @@ export abstract class AbstractEngine {
         onError: (message?: string, exception?: any) => void,
         offlineProvider: Nullable<IOfflineProvider>,
         mimeType?: string,
-        imageBitmapOptions?: ImageBitmapOptions
+        imageBitmapOptions?: ImageBitmapOptions,
+        engine?: AbstractEngine
     ): Nullable<HTMLImageElement> {
         throw _WarnImport("FileTools");
     }

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -196,6 +196,7 @@ export const LoadImageConfiguration: {
  * @param offlineProvider offline provider for caching
  * @param mimeType optional mime type
  * @param imageBitmapOptions
+ * @param engine the engine instance to use
  * @returns the HTMLImageElement of the loaded image
  * @internal
  */
@@ -205,9 +206,9 @@ export const LoadImage = (
     onError: (message?: string, exception?: any) => void,
     offlineProvider: Nullable<IOfflineProvider>,
     mimeType: string = "",
-    imageBitmapOptions?: ImageBitmapOptions
+    imageBitmapOptions?: ImageBitmapOptions,
+    engine = EngineStore.LastCreatedEngine
 ): Nullable<HTMLImageElement> => {
-    const engine = EngineStore.LastCreatedEngine;
     if (typeof HTMLImageElement === "undefined" && !engine?._features.forceBitmapOverHTMLImageElement) {
         onError("LoadImage is only supported in web or BabylonNative environments.");
         return null;


### PR DESCRIPTION
This is to address https://forum.babylonjs.com/t/viewer-v2-began-to-ask-for-the-standard-material/56950

Currently when using multiple WebGPUEngine instances, it's quite easy to get into a scenario where creating a texture fails. This is due to a confluence of other issues:
1. `LoadImage` uses `EngineStore.LastEngine` and accesses `engine._features`
2. `EngineStore.LastEngine` is set synchronously when the engine is constructed, but `WebGPUEngine` sets `_features` asynchronously during `initAsync`.
3. We don't have the `strictPropertyInitialization` TS flag enabled, which means it's easy for these kinds of issues to slip through (where `_features` is declared as non-nullable but in fact can be null/undefined).

Targeted fix is to just allow an engine instance to be passed to `LoadImage`, and doing so in the specific code path that is failing. 