### PR TITLE
Refactor error handling and add DataSwitch block

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/flowGraphDataSwitchBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/flowGraphDataSwitchBlock.ts
@@ -1,0 +1,92 @@
+import { FlowGraphBlock, type IFlowGraphBlockConfiguration } from "core/FlowGraph/flowGraphBlock";
+import type { FlowGraphContext } from "core/FlowGraph/flowGraphContext";
+import type { FlowGraphDataConnection } from "core/FlowGraph/flowGraphDataConnection";
+import { RichTypeAny } from "core/FlowGraph/flowGraphRichTypes";
+import type { FlowGraphNumber } from "core/FlowGraph/utils";
+import { getNumericValue, isNumeric } from "core/FlowGraph/utils";
+import { FlowGraphBlockNames } from "../flowGraphBlockNames";
+import { RegisterClass } from "core/Misc/typeStore";
+
+export interface IFlowGraphDataSwitchBlockConfiguration<T> extends IFlowGraphBlockConfiguration {
+    /**
+     * The possible values for the selection.
+     *
+     */
+    cases: FlowGraphNumber[];
+
+    /**
+     * If true, the cases will be treated as integers, meaning 1.1, 1.0, 0.1e1  and 1 will a single case - "1".
+     * This is the default behavior in glTF interactivity.
+     */
+    treatCasesAsIntegers?: boolean;
+}
+/**
+ * This block conditionally outputs one of its inputs, based on a condition and a list of cases.
+ *
+ * This of it as a passive (data) version of the switch statement in programming languages.
+ */
+export class FlowGraphDataSwitchBlock<T> extends FlowGraphBlock {
+    /**
+     * Current selection value.
+     */
+    public readonly case: FlowGraphDataConnection<FlowGraphNumber>;
+
+    /**
+     * Input: default value to output if no case is matched.
+     */
+    public readonly default: FlowGraphDataConnection<T>;
+
+    /**
+     * Output: the value that is output based on the selection.
+     */
+    public readonly value: FlowGraphDataConnection<T | undefined>;
+
+    private _inputCases: Map<number, FlowGraphDataConnection<T>> = new Map();
+
+    constructor(
+        /**
+         * the configuration of the block
+         */
+        public override config: IFlowGraphDataSwitchBlockConfiguration<T>
+    ) {
+        super(config);
+
+        this.case = this.registerDataInput("case", RichTypeAny, NaN);
+        this.default = this.registerDataInput("default", RichTypeAny);
+        this.value = this.registerDataOutput("value", RichTypeAny);
+
+        // iterate the set not using for of
+        (this.config.cases || []).forEach((caseValue) => {
+            // if treat as integers, make sure not to set it again if it exists
+            caseValue = getNumericValue(caseValue);
+            if (this.config.treatCasesAsIntegers) {
+                caseValue = caseValue | 0;
+                if (this._inputCases.has(caseValue)) {
+                    return;
+                }
+            }
+            this._inputCases.set(getNumericValue(caseValue), this.registerDataInput(`in_${caseValue}`, RichTypeAny));
+        });
+    }
+
+    public override _updateOutputs(context: FlowGraphContext): void {
+        const selectionValue = this.case.getValue(context);
+        let outputValue: T | undefined;
+        if (isNumeric(selectionValue)) {
+            outputValue = this._getOutputValueForCase(getNumericValue(selectionValue), context);
+        } else {
+            outputValue = this.default.getValue(context);
+        }
+
+        this.value.setValue(outputValue, context);
+    }
+
+    private _getOutputValueForCase(caseValue: number, context: FlowGraphContext): T | undefined {
+        return this._inputCases.get(caseValue)?.getValue(context);
+    }
+
+    public override getClassName(): string {
+        return FlowGraphBlockNames.DataSwitch;
+    }
+}
+RegisterClass(FlowGraphBlockNames.DataSwitch, FlowGraphDataSwitchBlock);

--- a/packages/dev/core/src/FlowGraph/Blocks/Data/flowGraphDataSwitchBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/flowGraphDataSwitchBlock.ts
@@ -65,7 +65,7 @@ export class FlowGraphDataSwitchBlock<T> extends FlowGraphBlock {
                     return;
                 }
             }
-            this._inputCases.set(getNumericValue(caseValue), this.registerDataInput(`in_${caseValue}`, RichTypeAny));
+            this._inputCases.set(caseValue, this.registerDataInput(`in_${caseValue}`, RichTypeAny));
         });
     }
 

--- a/packages/dev/core/src/FlowGraph/Blocks/Data/index.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/index.ts
@@ -6,6 +6,7 @@ export * from "./flowGraphGetPropertyBlock";
 export * from "../Execution/flowGraphSetPropertyBlock";
 export * from "./flowGraphConstantBlock";
 export * from "./flowGraphGetAssetBlock";
+export * from "./flowGraphDataSwitchBlock";
 // eslint-disable-next-line import/no-internal-modules
 export * from "./Math/index";
 // eslint-disable-next-line import/no-internal-modules

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphStopAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphStopAnimationBlock.ts
@@ -70,19 +70,17 @@ export class FlowGraphStopAnimationBlock extends FlowGraphAsyncExecutionBlock {
         // check the values
         if (!animationToStopValue) {
             Logger.Warn("No animation group provided to stop.");
-            this.error.payload = { message: "No animation group provided to stop." };
-            this.error._activateSignal(context);
+            return this._reportError(context, "No animation group provided to stop.");
         }
         if (isNaN(stopTime)) {
-            Logger.Warn("Invalid stop time provided.");
-            this.error.payload = { message: "Invalid stop time provided." };
-            this.error._activateSignal(context);
+            return this._reportError(context, "Invalid stop time.");
         }
         if (stopTime > 0) {
             this._startPendingTasks(context);
         } else {
             this._stopAnimation(animationToStopValue, context);
         }
+        // note that out will not be triggered in case of an error
         this.out._activateSignal(context);
     }
 

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.ts
@@ -25,7 +25,7 @@ export class FlowGraphCancelDelayBlock extends FlowGraphExecutionBlockWithOutSig
     public _execute(context: FlowGraphContext, _callingSignal: FlowGraphSignalConnection): void {
         const delayIndex = this.delayIndex.getValue(context);
         if (delayIndex <= 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
-            return this.error._activateSignal(context);
+            return this._reportError(context, "Invalid delay index");
         }
         const timers = context._getExecutionVariable(this, "pendingDelays", [] as AdvancedTimer[]);
         const timer = timers[delayIndex];

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphSetDelayBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphSetDelayBlock.ts
@@ -42,15 +42,13 @@ export class FlowGraphSetDelayBlock extends FlowGraphAsyncExecutionBlock {
     public _preparePendingTasks(context: FlowGraphContext): void {
         const duration = this.duration.getValue(context);
         if (duration < 0 || isNaN(duration) || !isFinite(duration)) {
-            this.error.payload = { message: "Invalid duration" };
-            return this.error._activateSignal(context);
+            return this._reportError(context, "Invalid duration in SetDelay block");
         }
 
         // active delays are global to the context
         const activeDelays: number = context._getGlobalContextVariable("activeDelays", 0);
         if (activeDelays >= FlowGraphSetDelayBlock.MaxParallelDelayCount) {
-            this.error.payload = { message: "Max parallel delays reached" };
-            return this.error._activateSignal(context);
+            return this._reportError(context, "Max parallel delays reached");
         }
         // get the last global delay index
         const lastDelayIndex: number = context._getGlobalContextVariable("lastDelayIndex", -1);

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphThrottleBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphThrottleBlock.ts
@@ -39,7 +39,7 @@ export class FlowGraphThrottleBlock extends FlowGraphExecutionBlockWithOutSignal
         // in seconds
         const durationValue = this.duration.getValue(context);
         if (durationValue <= 0 || isNaN(durationValue) || !isFinite(durationValue)) {
-            return this.error._activateSignal(context);
+            return this._reportError(context, "Invalid duration in Throttle block");
         }
         const lastRemainingTime = context._getExecutionVariable(this, "lastRemainingTime", NaN);
         // Using Date.now() to get ms since epoch. not using performance.now() because its precision is not needed here

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetPropertyBlock.ts
@@ -75,8 +75,7 @@ export class FlowGraphSetPropertyBlock<P extends any, O extends FlowGraphAssetTy
                 this._setPropertyValue(target, this.propertyName.getValue(context), value);
             }
         } catch (e) {
-            this.error.payload = e;
-            this.error._activateSignal(context);
+            this._reportError(context, e);
         }
         this.out._activateSignal(context);
     }

--- a/packages/dev/core/src/FlowGraph/Blocks/flowGraphBlockFactory.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/flowGraphBlockFactory.ts
@@ -286,6 +286,8 @@ export function blockFactory(blockName: FlowGraphBlockNames | string): () => Pro
             return async () => (await import("./Data/Utils/flowGraphIndexOfBlock")).FlowGraphIndexOfBlock;
         case FlowGraphBlockNames.FunctionReference:
             return async () => (await import("./Data/Utils/flowGraphFunctionReferenceBlock")).FlowGraphFunctionReferenceBlock;
+        case FlowGraphBlockNames.DataSwitch:
+            return async () => (await import("./Data/flowGraphDataSwitchBlock")).FlowGraphDataSwitchBlock;
         default:
             // check if the block is a custom block
             if (customBlocks[blockName]) {

--- a/packages/dev/core/src/FlowGraph/Blocks/flowGraphBlockNames.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/flowGraphBlockNames.ts
@@ -142,4 +142,5 @@ export const enum FlowGraphBlockNames {
     IndexOf = "FlowGraphIndexOfBlock",
     FunctionReference = "FlowGraphFunctionReference",
     BezierCurveEasing = "FlowGraphBezierCurveEasing",
+    DataSwitch = "FlowGraphDataSwitchBlock",
 }

--- a/packages/dev/core/src/FlowGraph/flowGraphExecutionBlock.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphExecutionBlock.ts
@@ -75,6 +75,11 @@ export abstract class FlowGraphExecutionBlock extends FlowGraphBlock {
         }
     }
 
+    protected _reportError(context: FlowGraphContext, error: Error | string) {
+        this.error.payload = typeof error === "string" ? new Error(error) : error;
+        this.error._activateSignal(context);
+    }
+
     /**
      * Given a name of a signal input, return that input if it exists
      * @param name the name of the input

--- a/packages/dev/core/src/FlowGraph/utils.ts
+++ b/packages/dev/core/src/FlowGraph/utils.ts
@@ -71,9 +71,9 @@ export function _areSameIntegerClass(className: string, className2: string) {
  */
 export function isNumeric(a: FlowGraphMathOperationType, validIfNaN?: boolean): a is FlowGraphNumber {
     const isNumeric = typeof a === "number" || typeof (a as FlowGraphInteger)?.value === "number";
-    // if (isNumeric && !validIfNaN) {
-    //     return !isNaN(getNumericValue(a as FlowGraphNumber));
-    // }
+    if (isNumeric && !validIfNaN) {
+        return !isNaN(getNumericValue(a as FlowGraphNumber));
+    }
     return isNumeric;
 }
 

--- a/packages/dev/core/src/FlowGraph/utils.ts
+++ b/packages/dev/core/src/FlowGraph/utils.ts
@@ -66,10 +66,15 @@ export function _areSameIntegerClass(className: string, className2: string) {
 /**
  * Check if an object has a numeric value.
  * @param a the object to check if it is a number.
+ * @param validIfNaN whether to consider NaN as a valid number.
  * @returns whether a is a FlowGraphNumber (Integer or number).
  */
-export function isNumeric(a: FlowGraphMathOperationType): a is FlowGraphNumber {
-    return typeof a === "number" || typeof (a as FlowGraphInteger)?.value === "number";
+export function isNumeric(a: FlowGraphMathOperationType, validIfNaN?: boolean): a is FlowGraphNumber {
+    const isNumeric = typeof a === "number" || typeof (a as FlowGraphInteger)?.value === "number";
+    // if (isNumeric && !validIfNaN) {
+    //     return !isNaN(getNumericValue(a as FlowGraphNumber));
+    // }
+    return isNumeric;
 }
 
 /**

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -1500,6 +1500,43 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
             return serializedObjects;
         },
     },
+    "math/switch": {
+        blocks: [FlowGraphBlockNames.DataSwitch],
+        configuration: {
+            cases: { name: "cases", inOptions: true, defaultValue: [] },
+        },
+        inputs: {
+            values: {
+                selection: { name: "case" },
+            },
+        },
+        validation(gltfBlock) {
+            if (gltfBlock.configuration && gltfBlock.configuration.cases) {
+                const cases = gltfBlock.configuration.cases.value;
+                const onlyIntegers = cases.every((caseValue) => {
+                    // case value should be an integer. Since Number.isInteger(1.0) is true, we need to check if toString has only digits.
+                    return typeof caseValue === "number" && /^\d+$/.test(caseValue.toString());
+                });
+                if (!onlyIntegers) {
+                    gltfBlock.configuration.cases.value = [] as number[];
+                    return true;
+                }
+                // check for duplicates
+                const uniqueCases = new Set(cases);
+                gltfBlock.configuration.cases.value = Array.from(uniqueCases) as number[];
+            }
+            return true;
+        },
+        extraProcessor(_gltfBlock, _declaration, _mapping, _arrays, serializedObjects) {
+            const serializedObject = serializedObjects[0];
+            serializedObject.signalInputs.forEach((input) => {
+                if (input.name !== "default" && input.name !== "case") {
+                    input.name = "in_" + input.name;
+                }
+            });
+            return serializedObjects;
+        },
+    },
 };
 
 function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a"], inferType?: boolean): IGLTFToFlowGraphMapping {

--- a/packages/dev/loaders/test/unit/Interactivity/objectModel.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/objectModel.test.ts
@@ -374,7 +374,7 @@ describe("glTF interactivity Object Model", () => {
             [{ signature: "float3" }, { signature: "float" }]
         );
 
-        // wait for 1 second
+        // wait for 1 second + buffer
         await new Promise((resolve) => setTimeout(resolve, 1000 + 300));
         expect(calls[0]).toEqual(new Vector3(1, 2, 3));
         calls.forEach((call, idx) => {


### PR DESCRIPTION
Centralized error handling improves consistency across animation and control flow blocks. 
Introduced FlowGraphDataSwitchBlock for conditional data output based on specified cases.
DataSwith (math/switch in KHR_interactivit-ish) is needed to stay conform with the specs.