### PR TITLE
Add audio analyzer feature to audio engine v2 sound and bus classes

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractAudioBus.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractAudioBus.ts
@@ -55,6 +55,7 @@ export abstract class AbstractAudioBus extends AbstractNamedAudioNode {
     public override dispose(): void {
         super.dispose();
 
+        this._analyzer?.dispose();
         this._analyzer = null;
 
         this._subGraph.dispose();

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractAudioBus.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractAudioBus.ts
@@ -1,7 +1,14 @@
+import type { Nullable } from "../../types";
 import { AbstractNamedAudioNode, AudioNodeType } from "./abstractAudioNode";
 import type { AudioEngineV2 } from "./audioEngineV2";
 import type { _AbstractAudioSubGraph } from "./subNodes/abstractAudioSubGraph";
+import type { IVolumeAudioOptions } from "./subNodes/volumeAudioSubNode";
 import { _GetVolumeAudioProperty, _GetVolumeAudioSubNode } from "./subNodes/volumeAudioSubNode";
+import type { IAudioAnalyzerOptions } from "./subProperties/abstractAudioAnalyzer";
+import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
+
+/** @internal */
+export interface IAbstractAudioBusOptions extends IAudioAnalyzerOptions, IVolumeAudioOptions {}
 
 /**
  * Abstract class representing an audio bus with volume control.
@@ -10,10 +17,19 @@ import { _GetVolumeAudioProperty, _GetVolumeAudioSubNode } from "./subNodes/volu
  * sounds together and apply effects to them.
  */
 export abstract class AbstractAudioBus extends AbstractNamedAudioNode {
+    private _analyzer: Nullable<_AudioAnalyzer> = null;
+
     protected abstract _subGraph: _AbstractAudioSubGraph;
 
     protected constructor(name: string, engine: AudioEngineV2) {
         super(name, engine, AudioNodeType.HAS_INPUTS_AND_OUTPUTS);
+    }
+
+    /**
+     * The analyzer features of the bus.
+     */
+    public get analyzer(): _AudioAnalyzer {
+        return this._analyzer ?? (this._analyzer = new _AudioAnalyzer(this._subGraph));
     }
 
     /**
@@ -38,6 +54,9 @@ export abstract class AbstractAudioBus extends AbstractNamedAudioNode {
      */
     public override dispose(): void {
         super.dispose();
+
+        this._analyzer = null;
+
         this._subGraph.dispose();
     }
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -8,8 +8,10 @@ import type { AudioEngineV2 } from "./audioEngineV2";
 import type { _AbstractAudioSubGraph } from "./subNodes/abstractAudioSubGraph";
 import type { IVolumeAudioOptions } from "./subNodes/volumeAudioSubNode";
 import { _GetVolumeAudioProperty, _GetVolumeAudioSubNode } from "./subNodes/volumeAudioSubNode";
+import type { IAudioAnalyzerOptions } from "./subProperties/abstractAudioAnalyzer";
 import type { AbstractSpatialAudio, ISpatialAudioOptions } from "./subProperties/abstractSpatialAudio";
 import type { AbstractStereoAudio, IStereoAudioOptions } from "./subProperties/abstractStereoAudio";
+import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
 
 /** @internal */
 export interface IAbstractSoundOptionsBase {
@@ -38,7 +40,7 @@ export interface IAbstractSoundPlayOptionsBase {
 /**
  * Options for creating a sound.
  */
-export interface IAbstractSoundOptions extends IAbstractSoundOptionsBase, IAbstractSoundPlayOptions, ISpatialAudioOptions, IStereoAudioOptions {
+export interface IAbstractSoundOptions extends IAbstractSoundOptionsBase, IAbstractSoundPlayOptions, IAudioAnalyzerOptions, ISpatialAudioOptions, IStereoAudioOptions {
     /**
      * The output bus for the sound. Defaults to `null`.
      * - If not set or `null`, the sound is automatically connected to the audio engine's default main bus.
@@ -62,6 +64,7 @@ export interface IAbstractSoundStoredOptions extends IAbstractSoundOptionsBase, 
  * Abstract class representing a sound in the audio engine.
  */
 export abstract class AbstractSound extends AbstractNamedAudioNode {
+    private _analyzer: Nullable<_AudioAnalyzer> = null;
     private _newestInstance: Nullable<_AbstractSoundInstance> = null;
     private _outBus: Nullable<PrimaryAudioBus> = null;
     private _privateInstances = new Set<_AbstractSoundInstance>();
@@ -78,6 +81,13 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
 
     protected constructor(name: string, engine: AudioEngineV2) {
         super(name, engine, AudioNodeType.HAS_INPUTS_AND_OUTPUTS); // Inputs are for instances.
+    }
+
+    /**
+     * The analyzer features of the sound.
+     */
+    public get analyzer(): _AudioAnalyzer {
+        return this._analyzer ?? (this._analyzer = new _AudioAnalyzer(this._subGraph));
     }
 
     /**
@@ -158,7 +168,7 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
     }
 
     /**
-     * The spatial properties of the sound.
+     * The spatial features of the sound.
      */
     public abstract spatial: AbstractSpatialAudio;
 
@@ -181,7 +191,7 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
     }
 
     /**
-     * The stereo properties of the sound.
+     * The stereo features of the sound.
      */
     public abstract stereo: AbstractStereoAudio;
 
@@ -210,6 +220,7 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
 
         this.stop();
 
+        this._analyzer = null;
         this._newestInstance = null;
         this._outBus = null;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -220,7 +220,9 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
 
         this.stop();
 
+        this._analyzer?.dispose();
         this._analyzer = null;
+
         this._newestInstance = null;
         this._outBus = null;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/audioBus.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/audioBus.ts
@@ -1,8 +1,8 @@
 import type { Nullable } from "../../types";
+import type { IAbstractAudioBusOptions } from "./abstractAudioBus";
 import { AbstractAudioBus } from "./abstractAudioBus";
 import type { AudioEngineV2 } from "./audioEngineV2";
 import type { MainAudioBus } from "./mainAudioBus";
-import type { IVolumeAudioOptions } from "./subNodes/volumeAudioSubNode";
 import type { AbstractSpatialAudio, ISpatialAudioOptions } from "./subProperties/abstractSpatialAudio";
 import type { AbstractStereoAudio, IStereoAudioOptions } from "./subProperties/abstractStereoAudio";
 
@@ -12,7 +12,7 @@ export type PrimaryAudioBus = MainAudioBus | AudioBus;
 /**
  * Options for creating an audio bus.
  */
-export interface IAudioBusOptions extends ISpatialAudioOptions, IStereoAudioOptions, IVolumeAudioOptions {
+export interface IAudioBusOptions extends IAbstractAudioBusOptions, ISpatialAudioOptions, IStereoAudioOptions {
     /**
      * The output bus of the audio bus. Defaults to the audio engine's default main bus.
      * @see {@link AudioEngineV2.defaultMainBus}
@@ -66,12 +66,12 @@ export abstract class AudioBus extends AbstractAudioBus {
     }
 
     /**
-     * The spatial audio properties of the audio bus.
+     * The spatial features of the audio bus.
      */
     public abstract readonly spatial: AbstractSpatialAudio;
 
     /**
-     * The stereo audio properties of the audio bus.
+     * The stereo features of the audio bus.
      */
     public abstract readonly stereo: AbstractStereoAudio;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/mainAudioBus.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/mainAudioBus.ts
@@ -1,11 +1,11 @@
 import { AbstractAudioBus } from "./abstractAudioBus";
 import type { AudioEngineV2 } from "./audioEngineV2";
-import type { IVolumeAudioOptions } from "./subNodes/volumeAudioSubNode";
+import type { IAbstractAudioBusOptions } from "./abstractAudioBus";
 
 /**
  * Options for creating a main audio bus.
  */
-export interface IMainAudioBusOptions extends IVolumeAudioOptions {}
+export interface IMainAudioBusOptions extends IAbstractAudioBusOptions {}
 
 /**
  * Abstract class representing a main audio bus.

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
@@ -56,24 +56,12 @@ export abstract class _AbstractAudioSubGraph {
      * @internal
      */
     public createAndAddSubNode(name: AudioSubNode): Promise<_AbstractAudioSubNode> {
-        const promise = this._createSubNode(name);
-
-        if (!promise) {
-            return Promise.reject(`Failed to create subnode "${name}"`);
-        }
-
-        this._createSubNodePromises[name] = new Promise((resolve, reject) => {
-            promise
-                .then((node) => {
-                    this._addSubNode(node);
-                    resolve(node);
-                })
-                .catch((error) => {
-                    reject(error);
-                });
+        this._createSubNodePromises[name] ||= this._createSubNode(name).then((node) => {
+            this._addSubNode(node);
+            return node;
         });
 
-        return promise;
+        return this._createSubNodePromises[name];
     }
 
     /**
@@ -124,7 +112,7 @@ export abstract class _AbstractAudioSubGraph {
         this._onSubNodesChanged();
     }
 
-    protected abstract _createSubNode(name: string): Nullable<Promise<_AbstractAudioSubNode>>;
+    protected abstract _createSubNode(name: string): Promise<_AbstractAudioSubNode>;
 
     /**
      * Called when sub-nodes are added or removed.

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
@@ -99,8 +99,29 @@ export abstract class _AbstractAudioSubGraph {
      *
      * @internal
      * */
-    public getSubNode<T extends AbstractNamedAudioNode>(name: string): Nullable<T> {
+    public getSubNode<T extends _AbstractAudioSubNode>(name: string): Nullable<T> {
         return (this._subNodes[name] as T) ?? null;
+    }
+
+    /**
+     * Removes a sub node from the sub graph.
+     *
+     * @param subNode - The sub node to remove
+     * @returns A promise that resolves when the sub node is removed
+     *
+     * @internal
+     */
+    public async removeSubNode(subNode: _AbstractAudioSubNode): Promise<void> {
+        await this._createSubNodePromisesResolved();
+
+        const name = subNode.name;
+        if (this._subNodes[name]) {
+            delete this._subNodes[name];
+        }
+
+        delete this._createSubNodePromises[name];
+
+        this._onSubNodesChanged();
     }
 
     protected abstract _createSubNode(name: string): Nullable<Promise<_AbstractAudioSubNode>>;

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
@@ -20,6 +20,7 @@ import type { AudioSubNode } from "./audioSubNode";
  */
 export abstract class _AbstractAudioSubGraph {
     private _createSubNodePromises: { [key: string]: Promise<_AbstractAudioSubNode> } = {};
+    private _isDisposed = false;
     private _subNodes: { [key: string]: AbstractNamedAudioNode } = {};
 
     /**
@@ -70,6 +71,8 @@ export abstract class _AbstractAudioSubGraph {
      * @internal
      */
     public dispose() {
+        this._isDisposed = true;
+
         const subNodes = Object.values(this._subNodes);
         for (const subNode of subNodes) {
             subNode.dispose();
@@ -125,6 +128,11 @@ export abstract class _AbstractAudioSubGraph {
     }
 
     private _addSubNode(node: AbstractNamedAudioNode): void {
+        if (this._isDisposed) {
+            node.dispose();
+            return;
+        }
+
         this._subNodes[node.name] = node;
 
         node.onDisposeObservable.addOnce(this._onSubNodeDisposed);

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/audioAnalyzerSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/audioAnalyzerSubNode.ts
@@ -1,0 +1,47 @@
+import type { Nullable } from "../../../types";
+import type { AudioEngineV2 } from "../audioEngineV2";
+import type { AudioAnalyzerFFTSizeType, IAudioAnalyzerOptions } from "../subProperties/abstractAudioAnalyzer";
+import { _AudioAnalyzerDefaults } from "../subProperties/abstractAudioAnalyzer";
+import type { _AbstractAudioSubGraph } from "./abstractAudioSubGraph";
+import { _AbstractAudioSubNode } from "./abstractAudioSubNode";
+import { AudioSubNode } from "./audioSubNode";
+
+/** @internal */
+export abstract class _AudioAnalyzerSubNode extends _AbstractAudioSubNode {
+    protected constructor(engine: AudioEngineV2) {
+        super(AudioSubNode.ANALYZER, engine);
+    }
+
+    public abstract fftSize: AudioAnalyzerFFTSizeType;
+    public abstract minDecibels: number;
+    public abstract maxDecibels: number;
+    public abstract smoothing: number;
+
+    public abstract getByteFrequencyData(): Uint8Array;
+    public abstract getFloatFrequencyData(): Float32Array;
+
+    /** @internal */
+    public setOptions(options: Partial<IAudioAnalyzerOptions>): void {
+        this.fftSize = options.analyzerFFTSize ?? _AudioAnalyzerDefaults.fftSize;
+        this.minDecibels = options.analyzerMinDecibels ?? _AudioAnalyzerDefaults.minDecibels;
+        this.maxDecibels = options.analyzerMaxDecibels ?? _AudioAnalyzerDefaults.maxDecibels;
+        this.smoothing = options.analyzerSmoothing ?? _AudioAnalyzerDefaults.smoothing;
+    }
+}
+
+/** @internal */
+export function _GetAudioAnalyzerSubNode(subGraph: _AbstractAudioSubGraph): Nullable<_AudioAnalyzerSubNode> {
+    return subGraph.getSubNode<_AudioAnalyzerSubNode>(AudioSubNode.ANALYZER);
+}
+
+/** @internal */
+export function _GetAudioAnalyzerProperty<K extends keyof typeof _AudioAnalyzerDefaults>(subGraph: _AbstractAudioSubGraph, property: K): (typeof _AudioAnalyzerDefaults)[K] {
+    return _GetAudioAnalyzerSubNode(subGraph)?.[property] ?? _AudioAnalyzerDefaults[property];
+}
+
+/** @internal */
+export function _SetAudioAnalyzerProperty<K extends keyof typeof _AudioAnalyzerDefaults>(subGraph: _AbstractAudioSubGraph, property: K, value: _AudioAnalyzerSubNode[K]): void {
+    subGraph.callOnSubNode<_AudioAnalyzerSubNode>(AudioSubNode.ANALYZER, (node) => {
+        node[property] = value;
+    });
+}

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/audioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/audioSubNode.ts
@@ -1,5 +1,6 @@
 /** @internal */
 export const enum AudioSubNode {
+    ANALYZER = "Analyzer",
     STEREO = "Stereo",
     SPATIAL = "Spatial",
     VOLUME = "Volume",

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/stereoAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/stereoAudioSubNode.ts
@@ -12,7 +12,7 @@ export abstract class _StereoAudioSubNode extends _AbstractAudioSubNode {
         super(AudioSubNode.STEREO, engine);
     }
 
-    abstract pan: number;
+    public abstract pan: number;
 
     /** @internal */
     public setOptions(options: Partial<IStereoAudioOptions>): void {

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractAudioAnalyzer.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractAudioAnalyzer.ts
@@ -1,0 +1,107 @@
+export type AudioAnalyzerFFTSizeType = 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768;
+
+export const _AudioAnalyzerDefaults = {
+    fftSize: 2048 as AudioAnalyzerFFTSizeType,
+    minDecibels: -100 as number,
+    maxDecibels: -30 as number,
+    smoothing: 0.8 as number,
+} as const;
+
+/**
+ * Options for the AudioAnalyzer
+ */
+export interface IAudioAnalyzerOptions {
+    /**
+     * Enable the audio analyzer. Defaults to false.
+     */
+    analyzerEnabled: boolean;
+    /**
+     * The size of the FFT (fast fourier transform) to use when converting time-domain data to frequency-domain data. Default is 2048.
+     */
+    analyzerFFTSize: AudioAnalyzerFFTSizeType;
+
+    /**
+     * The minimum decibel value for the range of the analyzer. Default is -100.
+     */
+    analyzerMinDecibels: number;
+
+    /**
+     * The maximum decibel value for the range of the analyzer. Default is -30.
+     */
+    analyzerMaxDecibels: number;
+
+    /**
+     * A number between 0 and 1 that determines how quickly the analyzer's value changes. Default is 0.8.
+     */
+    analyzerSmoothing: number;
+}
+
+/**
+ * @param options The audio analyzer options to check.
+ * @returns `true` if audio analyzer options are defined, otherwise `false`.
+ */
+export function _HasAudioAnalyzerOptions(options: Partial<IAudioAnalyzerOptions>): boolean {
+    return (
+        options.analyzerEnabled ||
+        options.analyzerFFTSize !== undefined ||
+        options.analyzerMinDecibels !== undefined ||
+        options.analyzerMaxDecibels !== undefined ||
+        options.analyzerSmoothing !== undefined
+    );
+}
+
+/**
+ * An AudioAnalyzer converts time-domain audio data into the frequency-domain.
+ */
+export abstract class AbstractAudioAnalyzer {
+    /**
+     * The size of the FFT (fast fourier transform) to use when converting time-domain data to frequency-domain data. Default is 2048.
+     */
+    public abstract fftSize: AudioAnalyzerFFTSizeType;
+
+    /**
+     * The number of data values that will be returned when calling getByteFrequencyData() or getFloatFrequencyData(). This is always half the `fftSize`.
+     */
+    public get frequencyBinCount(): number {
+        return this.fftSize / 2;
+    }
+
+    /**
+     * Whether the analyzer is enabled or not.
+     * - The `getByteFrequencyData` and `getFloatFrequencyData` functions return `null` if the analyzer is not enabled.
+     * @see {@link enable}
+     */
+    public abstract isEnabled: boolean;
+
+    /**
+     * The minimum decibel value for the range of the analyzer. Default is -100.
+     */
+    public abstract minDecibels: number;
+
+    /**
+     * The maximum decibel value for the range of the analyzer. Default is -30.
+     */
+    public abstract maxDecibels: number;
+
+    /**
+     * A number between 0 and 1 that determines how quickly the analyzer's value changes. Default is 0.8.
+     */
+    public abstract smoothing: number;
+
+    /**
+     * Enables the analyzer
+     */
+    public abstract enable(): Promise<void>;
+
+    /**
+     * Gets the current frequency data as a byte array
+     * @returns a Uint8Array if the analyzer is enabled, otherwise `null`
+     */
+    public abstract getByteFrequencyData(): Uint8Array;
+
+    /**
+     * Gets the current frequency data as a float array
+     * @returns a Float32Array if the analyzer is enabled, otherwise `null`
+     */
+    public abstract getFloatFrequencyData(): Float32Array;
+}

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractAudioAnalyzer.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractAudioAnalyzer.ts
@@ -89,6 +89,11 @@ export abstract class AbstractAudioAnalyzer {
     public abstract smoothing: number;
 
     /**
+     * Releases associated resources.
+     */
+    public abstract dispose(): void;
+
+    /**
      * Enables the analyzer
      */
     public abstract enable(): Promise<void>;

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
@@ -75,6 +75,15 @@ export class _AudioAnalyzer extends AbstractAudioAnalyzer {
     }
 
     /** @internal */
+    public dispose(): void {
+        const subNode = _GetAudioAnalyzerSubNode(this._subGraph);
+        if (subNode) {
+            this._subGraph.removeSubNode(subNode);
+            subNode.dispose();
+        }
+    }
+
+    /** @internal */
     public async enable(): Promise<void> {
         const subNode = _GetAudioAnalyzerSubNode(this._subGraph);
         if (!subNode) {

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
@@ -9,14 +9,16 @@ import { AudioSubNode } from "../subNodes/audioSubNode";
 let _emptyByteFrequencyData: Nullable<Uint8Array> = null;
 let _emptyFloatFrequencyData: Nullable<Float32Array> = null;
 
-function _GetEmptyByteFrequencyData(): Uint8Array {
+/** @internal */
+export function _GetEmptyByteFrequencyData(): Uint8Array {
     if (!_emptyByteFrequencyData) {
         _emptyByteFrequencyData = new Uint8Array();
     }
     return _emptyByteFrequencyData;
 }
 
-function _GetEmptyFloatFrequencyData(): Float32Array {
+/** @internal */
+export function _GetEmptyFloatFrequencyData(): Float32Array {
     if (!_emptyFloatFrequencyData) {
         _emptyFloatFrequencyData = new Float32Array();
     }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
@@ -1,0 +1,107 @@
+import { Logger } from "../../../Misc/logger";
+import type { Nullable } from "../../../types";
+import type { AudioAnalyzerFFTSizeType } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
+import { AbstractAudioAnalyzer } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
+import type { _AbstractAudioSubGraph } from "../subNodes/abstractAudioSubGraph";
+import { _GetAudioAnalyzerProperty, _GetAudioAnalyzerSubNode, _SetAudioAnalyzerProperty } from "../subNodes/audioAnalyzerSubNode";
+import { AudioSubNode } from "../subNodes/audioSubNode";
+
+let _emptyByteFrequencyData: Nullable<Uint8Array> = null;
+let _emptyFloatFrequencyData: Nullable<Float32Array> = null;
+
+function _GetEmptyByteFrequencyData(): Uint8Array {
+    if (!_emptyByteFrequencyData) {
+        _emptyByteFrequencyData = new Uint8Array();
+    }
+    return _emptyByteFrequencyData;
+}
+
+function _GetEmptyFloatFrequencyData(): Float32Array {
+    if (!_emptyFloatFrequencyData) {
+        _emptyFloatFrequencyData = new Float32Array();
+    }
+    return _emptyFloatFrequencyData;
+}
+
+/** @internal */
+export class _AudioAnalyzer extends AbstractAudioAnalyzer {
+    private _subGraph: _AbstractAudioSubGraph;
+
+    /** @internal */
+    public constructor(subGraph: _AbstractAudioSubGraph) {
+        super();
+        this._subGraph = subGraph;
+    }
+
+    /** @internal */
+    public get fftSize(): AudioAnalyzerFFTSizeType {
+        return _GetAudioAnalyzerProperty(this._subGraph, "fftSize");
+    }
+
+    public set fftSize(value: AudioAnalyzerFFTSizeType) {
+        _SetAudioAnalyzerProperty(this._subGraph, "fftSize", value);
+    }
+
+    /** @internal */
+    public get isEnabled(): boolean {
+        return _GetAudioAnalyzerSubNode(this._subGraph) !== null;
+    }
+
+    /** @internal */
+    public get minDecibels(): number {
+        return _GetAudioAnalyzerProperty(this._subGraph, "minDecibels");
+    }
+
+    public set minDecibels(value: number) {
+        _SetAudioAnalyzerProperty(this._subGraph, "minDecibels", value);
+    }
+
+    /** @internal */
+    public get maxDecibels(): number {
+        return _GetAudioAnalyzerProperty(this._subGraph, "maxDecibels");
+    }
+
+    public set maxDecibels(value: number) {
+        _SetAudioAnalyzerProperty(this._subGraph, "maxDecibels", value);
+    }
+
+    /** @internal */
+    public get smoothing(): number {
+        return _GetAudioAnalyzerProperty(this._subGraph, "smoothing");
+    }
+
+    public set smoothing(value: number) {
+        _SetAudioAnalyzerProperty(this._subGraph, "smoothing", value);
+    }
+
+    /** @internal */
+    public async enable(): Promise<void> {
+        const subNode = _GetAudioAnalyzerSubNode(this._subGraph);
+        if (!subNode) {
+            await this._subGraph.createAndAddSubNode(AudioSubNode.ANALYZER);
+        }
+        return Promise.resolve();
+    }
+
+    /** @internal */
+    public getByteFrequencyData(): Uint8Array {
+        const subNode = _GetAudioAnalyzerSubNode(this._subGraph);
+        if (!subNode) {
+            Logger.Warn("AudioAnalyzer not enabled");
+            this.enable();
+            return _GetEmptyByteFrequencyData();
+        }
+        return subNode.getByteFrequencyData();
+    }
+
+    /** @internal */
+    public getFloatFrequencyData(): Float32Array {
+        const subNode = _GetAudioAnalyzerSubNode(this._subGraph);
+        if (!subNode) {
+            Logger.Warn("AudioAnalyzer not enabled");
+            this.enable();
+            return _GetEmptyFloatFrequencyData();
+        }
+        return subNode.getFloatFrequencyData();
+    }
+}

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/index.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/index.ts
@@ -1,3 +1,4 @@
+export * from "./abstractAudioAnalyzer";
 export * from "./abstractSpatialAudio";
 export * from "./abstractSpatialAudioListener";
 export * from "./abstractStereoAudio";

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioAnalyzerSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioAnalyzerSubNode.ts
@@ -1,6 +1,7 @@
 import type { Nullable } from "../../../types";
 import { _AudioAnalyzerSubNode } from "../../abstractAudio/subNodes/audioAnalyzerSubNode";
 import type { AudioAnalyzerFFTSizeType } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
+import { _GetEmptyByteFrequencyData, _GetEmptyFloatFrequencyData } from "../../abstractAudio/subProperties/audioAnalyzer";
 import type { _WebAudioEngine } from "../webAudioEngine";
 import type { IWebAudioInNode } from "../webAudioNode";
 
@@ -104,7 +105,7 @@ export class _WebAudioAnalyzerSubNode extends _AudioAnalyzerSubNode implements I
     }
 
     private _clearArrays(): void {
-        this._byteFrequencyData?.set([]);
-        this._floatFrequencyData?.set([]);
+        this._byteFrequencyData?.set(_GetEmptyByteFrequencyData());
+        this._floatFrequencyData?.set(_GetEmptyFloatFrequencyData());
     }
 }

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioAnalyzerSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioAnalyzerSubNode.ts
@@ -1,0 +1,110 @@
+import type { Nullable } from "../../../types";
+import { _AudioAnalyzerSubNode } from "../../abstractAudio/subNodes/audioAnalyzerSubNode";
+import type { AudioAnalyzerFFTSizeType } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
+import type { _WebAudioEngine } from "../webAudioEngine";
+import type { IWebAudioInNode } from "../webAudioNode";
+
+/** @internal */
+export async function _CreateAudioAnalyzerSubNodeAsync(engine: _WebAudioEngine): Promise<_AudioAnalyzerSubNode> {
+    return new _WebAudioAnalyzerSubNode(engine);
+}
+
+/** @internal */
+export class _WebAudioAnalyzerSubNode extends _AudioAnalyzerSubNode implements IWebAudioInNode {
+    private readonly _analyzerNode: AnalyserNode;
+    private _byteFrequencyData: Nullable<Uint8Array> = null;
+    private _floatFrequencyData: Nullable<Float32Array> = null;
+
+    /** @internal */
+    public constructor(engine: _WebAudioEngine) {
+        super(engine);
+
+        this._analyzerNode = new AnalyserNode(engine.audioContext);
+    }
+
+    /** @internal */
+    public get fftSize(): AudioAnalyzerFFTSizeType {
+        return this._analyzerNode.fftSize as AudioAnalyzerFFTSizeType;
+    }
+
+    public set fftSize(value: AudioAnalyzerFFTSizeType) {
+        if (value === this._analyzerNode.fftSize) {
+            return;
+        }
+
+        this._analyzerNode.fftSize = value;
+
+        this._clearArrays();
+    }
+
+    /** @internal */
+    public get inNode(): AudioNode {
+        return this._analyzerNode;
+    }
+
+    /** @internal */
+    public get minDecibels(): number {
+        return this._analyzerNode.minDecibels;
+    }
+
+    public set minDecibels(value: number) {
+        this._analyzerNode.minDecibels = value;
+    }
+
+    /** @internal */
+    public get maxDecibels(): number {
+        return this._analyzerNode.maxDecibels;
+    }
+
+    public set maxDecibels(value: number) {
+        this._analyzerNode.maxDecibels = value;
+    }
+
+    /** @internal */
+    public get smoothing(): number {
+        return this._analyzerNode.smoothingTimeConstant;
+    }
+
+    public set smoothing(value: number) {
+        this._analyzerNode.smoothingTimeConstant = value;
+    }
+
+    /** @internal */
+    public override dispose(): void {
+        super.dispose();
+
+        this._clearArrays();
+        this._byteFrequencyData = null;
+        this._floatFrequencyData = null;
+
+        this._analyzerNode.disconnect();
+    }
+
+    /** @internal */
+    public getClassName(): string {
+        return "_WebAudioAnalyzerSubNode";
+    }
+
+    /** @internal */
+    public getByteFrequencyData(): Uint8Array {
+        if (!this._byteFrequencyData || this._byteFrequencyData.length === 0) {
+            this._byteFrequencyData = new Uint8Array(this._analyzerNode.frequencyBinCount);
+        }
+        this._analyzerNode.getByteFrequencyData(this._byteFrequencyData);
+        return this._byteFrequencyData;
+    }
+
+    /** @internal */
+    public getFloatFrequencyData(): Float32Array {
+        if (!this._floatFrequencyData || this._floatFrequencyData.length === 0) {
+            this._floatFrequencyData = new Float32Array(this._analyzerNode.frequencyBinCount);
+        }
+        this._analyzerNode.getFloatFrequencyData(this._floatFrequencyData);
+        return this._floatFrequencyData;
+    }
+
+    private _clearArrays(): void {
+        this._byteFrequencyData?.set([]);
+        this._floatFrequencyData?.set([]);
+    }
+}

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBaseSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBaseSubGraph.ts
@@ -1,18 +1,22 @@
-import type { Nullable } from "core/types";
+import type { Nullable } from "../../../types";
 import type { AbstractAudioNode } from "../../abstractAudio/abstractAudioNode";
 import { _AbstractAudioSubGraph } from "../../abstractAudio/subNodes/abstractAudioSubGraph";
 import type { _AbstractAudioSubNode } from "../../abstractAudio/subNodes/abstractAudioSubNode";
+import { _GetAudioAnalyzerSubNode } from "../../abstractAudio/subNodes/audioAnalyzerSubNode";
 import { AudioSubNode } from "../../abstractAudio/subNodes/audioSubNode";
 import type { IVolumeAudioOptions } from "../../abstractAudio/subNodes/volumeAudioSubNode";
 import { _GetVolumeAudioSubNode } from "../../abstractAudio/subNodes/volumeAudioSubNode";
+import type { IAudioAnalyzerOptions } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
+import { _HasAudioAnalyzerOptions } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
 import type { IWebAudioInNode, IWebAudioSuperNode } from "../webAudioNode";
 import type { _VolumeWebAudioSubNode } from "./volumeWebAudioSubNode";
 import { _CreateVolumeAudioSubNodeAsync } from "./volumeWebAudioSubNode";
+import { _CreateAudioAnalyzerSubNodeAsync } from "./webAudioAnalyzerSubNode";
 
 /**
  * Options for creating a WebAudioBaseSubGraph.
  */
-export interface IWebAudioBaseSubGraphOptions extends IVolumeAudioOptions {}
+export interface IWebAudioBaseSubGraphOptions extends IAudioAnalyzerOptions, IVolumeAudioOptions {}
 
 /** @internal */
 export abstract class _WebAudioBaseSubGraph extends _AbstractAudioSubGraph {
@@ -28,8 +32,24 @@ export abstract class _WebAudioBaseSubGraph extends _AbstractAudioSubGraph {
 
     /** @internal */
     public async init(options: Partial<IWebAudioBaseSubGraphOptions>): Promise<void> {
-        this._createAndAddSubNode(AudioSubNode.VOLUME);
+        const hasAnalyzerOptions = _HasAudioAnalyzerOptions(options);
+
+        if (hasAnalyzerOptions) {
+            this.createAndAddSubNode(AudioSubNode.ANALYZER);
+        }
+
+        this.createAndAddSubNode(AudioSubNode.VOLUME);
+
         await this._createSubNodePromisesResolved();
+
+        if (hasAnalyzerOptions) {
+            const analyzerNode = _GetAudioAnalyzerSubNode(this);
+            if (!analyzerNode) {
+                throw new Error("No analyzer subnode.");
+            }
+
+            analyzerNode.setOptions(options);
+        }
 
         const volumeNode = _GetVolumeAudioSubNode(this);
         if (!volumeNode) {
@@ -71,10 +91,21 @@ export abstract class _WebAudioBaseSubGraph extends _AbstractAudioSubGraph {
 
     protected _createSubNode(name: string): Nullable<Promise<_AbstractAudioSubNode>> {
         switch (name) {
+            case AudioSubNode.ANALYZER:
+                return _CreateAudioAnalyzerSubNodeAsync(this._owner.engine);
             case AudioSubNode.VOLUME:
                 return _CreateVolumeAudioSubNodeAsync(this._owner.engine);
             default:
                 return null;
+        }
+    }
+
+    protected _onSubNodesChanged(): void {
+        const analyzerNode = _GetAudioAnalyzerSubNode(this);
+        const volumeNode = _GetVolumeAudioSubNode(this);
+
+        if (analyzerNode && volumeNode) {
+            volumeNode.connect(analyzerNode);
         }
     }
 }

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBaseSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBaseSubGraph.ts
@@ -89,14 +89,14 @@ export abstract class _WebAudioBaseSubGraph extends _AbstractAudioSubGraph {
         return this._outNode;
     }
 
-    protected _createSubNode(name: string): Nullable<Promise<_AbstractAudioSubNode>> {
+    protected _createSubNode(name: string): Promise<_AbstractAudioSubNode> {
         switch (name) {
             case AudioSubNode.ANALYZER:
                 return _CreateAudioAnalyzerSubNodeAsync(this._owner.engine);
             case AudioSubNode.VOLUME:
                 return _CreateVolumeAudioSubNodeAsync(this._owner.engine);
             default:
-                return null;
+                throw new Error(`Unknown subnode name: ${name}`);
         }
     }
 

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
@@ -35,10 +35,10 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
         let hasStereoOptions = false;
 
         if ((hasSpatialOptions = _HasSpatialAudioOptions(options))) {
-            this._createAndAddSubNode(AudioSubNode.SPATIAL);
+            this.createAndAddSubNode(AudioSubNode.SPATIAL);
         }
         if ((hasStereoOptions = _HasStereoAudioOptions(options))) {
-            this._createAndAddSubNode(AudioSubNode.STEREO);
+            this.createAndAddSubNode(AudioSubNode.STEREO);
         }
 
         await this._createSubNodePromisesResolved();
@@ -74,6 +74,8 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
     }
 
     protected override _onSubNodesChanged(): void {
+        super._onSubNodesChanged();
+
         const spatialNode = _GetSpatialAudioSubNode(this);
         const stereoNode = _GetStereoAudioSubNode(this);
         const volumeNode = _GetVolumeAudioSubNode(this);

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
@@ -56,12 +56,11 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
         return this._inNode;
     }
 
-    protected override _createSubNode(name: string): Nullable<Promise<_AbstractAudioSubNode>> {
-        const node = super._createSubNode(name);
-
-        if (node) {
+    protected override _createSubNode(name: string): Promise<_AbstractAudioSubNode> {
+        try {
+            const node = super._createSubNode(name);
             return node;
-        }
+        } catch (e) {}
 
         switch (name) {
             case AudioSubNode.SPATIAL:
@@ -69,7 +68,7 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
             case AudioSubNode.STEREO:
                 return _CreateStereoAudioSubNodeAsync(this._owner.engine);
             default:
-                return null;
+                throw new Error(`Unknown subnode name: ${name}`);
         }
     }
 


### PR DESCRIPTION
Adds a lazy-loaded `analyzer` property to the sound and bus classes in the new audio engine, and adds analyzer-related init options.