### PR TITLE
Fix dynamically imported shaders

### DIFF
--- a/packages/dev/core/src/Materials/effectRenderer.ts
+++ b/packages/dev/core/src/Materials/effectRenderer.ts
@@ -581,7 +581,7 @@ export class EffectWrapper {
         if (this.options.extraInitializationsAsync) {
             extraInitializationsAsync = async () => {
                 waitImportsLoaded?.();
-                await this.options.extraInitializationsAsync;
+                await this.options.extraInitializationsAsync();
             };
         } else {
             extraInitializationsAsync = waitImportsLoaded;


### PR DESCRIPTION
I recently added support for hdr environments to the Viewer. It looked like everything was working, but I later noticed errors in the browser console like indicating several expected shaders did not exist (no idea why these don't show up in the VSCode debug console, which is why I missed it originally). When I dug into this, I found that in fact dynamically importing most shaders is currently broken, and has been for about 4 months. The issue is that after a refactor, we ended up with code that awaits a function rather than awaiting the result of the function because the actual invocation of the function was missing. That means the code that tries to dynamically import shaders never even executes. I would have thought this would break a lot of scenarios (basically any consumer that is not relying on side effects to statically import the shaders), so I'm quite surprised it went unnoticed this long. 🤷🏻‍♂️