### PR TITLE
Cleanup WebGPU invertYPreMultiplyAlpha

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -100,7 +100,7 @@ const invertYPreMultiplyAlphaFragmentSource = `
         var color: vec4f = textureLoad(img, vec2i(input.position.xy), 0);
     #endif
     #ifdef PREMULTIPLYALPHA
-        fragmentOutputs.color = vec4f(color.rgb * color.a, color.a);
+        color = vec4f(color.rgb * color.a, color.a);
     #endif
         fragmentOutputs.color = color;
     }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -741,41 +741,6 @@ export class WebGPUTextureManager {
         }
     }
 
-    public copyWithInvertY(srcTextureView: GPUTextureView, format: GPUTextureFormat, renderPassDescriptor: GPURenderPassDescriptor, commandEncoder?: GPUCommandEncoder): void {
-        const useOwnCommandEncoder = commandEncoder === undefined;
-        const [pipeline, bindGroupLayout] = this._getPipeline(format, PipelineType.InvertYPremultiplyAlpha, { invertY: true, premultiplyAlpha: false });
-
-        if (useOwnCommandEncoder) {
-            commandEncoder = this._device.createCommandEncoder({});
-        }
-
-        commandEncoder!.pushDebugGroup?.(`internal copy texture with invertY`);
-
-        const passEncoder = commandEncoder!.beginRenderPass(renderPassDescriptor);
-
-        const bindGroup = this._device.createBindGroup({
-            layout: bindGroupLayout,
-            entries: [
-                {
-                    binding: 0,
-                    resource: srcTextureView,
-                },
-            ],
-        });
-
-        passEncoder.setPipeline(pipeline);
-        passEncoder.setBindGroup(0, bindGroup);
-        passEncoder.draw(4, 1, 0, 0);
-        passEncoder.end();
-
-        commandEncoder!.popDebugGroup?.();
-
-        if (useOwnCommandEncoder) {
-            this._device.queue.submit([commandEncoder!.finish()]);
-            commandEncoder = null as any;
-        }
-    }
-
     //------------------------------------------------------------------------------
     //                               Creation
     //------------------------------------------------------------------------------


### PR DESCRIPTION
As I mentioned on the [forum](https://forum.babylonjs.com/t/text-is-not-shown-in-3d-gui-using-webgpu/57005) text in 3D GUI is not shown on my machine when using WebGPU.

1. After a debugging session I found the issue in the shader, we used clip space coordinates with textureLoad which takes texture coordinates. It seems that most GPUs (but not my AMD 780M) optimise textures to use clip space dimensions.
2. Looks like after [discussion](https://github.com/gpuweb/gpuweb/issues/2324) with webGPU 4 years ago they implemented flipY flag, so now we can simply use `this._device.queue.copyExternalImageToTexture({ source: imageBitmap, flipY: true }, ...);` for most of cases, except for `imageBitmap as Uint8Array` as we can't call it with `Uint8Array`
3. I noticed that the result of `PREMULTIPLYALPHA` (in `invertYPreMultiplyAlphaFragmentSource`) is not used because it is always overwritten by `color`
4. Looks like copyWithInvertY is unused

Thanks, feel free to change the code if I made a mistake


