### PR TITLE
Node Editor : Enhancing Node Manipulation 

### DIFF
--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
@@ -1055,7 +1055,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
         }
 
         // Selection?
-        if (evt.currentTarget === this._hostCanvas && !evt.shiftKey && evt.button == 0) {
+        if (evt.currentTarget === this._hostCanvas && this._multiKeyIsPressed) {
             this._selectionBox = this.props.stateManager.hostDocument.createElement("div");
             this._selectionBox.classList.add(styles["selection-box"]);
             this._selectionContainer.appendChild(this._selectionBox);
@@ -1067,10 +1067,6 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             this._selectionBox.style.top = `${this._selectionStartY / this.zoom}px`;
             this._selectionBox.style.width = "0px";
             this._selectionBox.style.height = "0px";
-            // Loose select
-            if (!evt.ctrlKey) {
-                this.props.stateManager.onSelectionChangedObservable.notifyObservers(null);
-            }
             return;
         }
 
@@ -1090,6 +1086,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             return;
         }
 
+        this.props.stateManager.onSelectionChangedObservable.notifyObservers(null);
         this._mouseStartPointX = evt.clientX;
         this._mouseStartPointY = evt.clientY;
     }

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
@@ -828,21 +828,11 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
                 return;
             }
 
-            graph.setNode(node.id.toString(), {
-                id: node.id,
-                type: "node",
-                width: node.width,
-                height: node.height,
-            });
+            graph.setNode(node.id.toString(), { id: node.id, type: "node", width: node.width, height: node.height });
         });
 
         this._frames.forEach((frame) => {
-            graph.setNode(frame.id.toString(), {
-                id: frame.id,
-                type: "frame",
-                width: frame.element.clientWidth,
-                height: frame.element.clientHeight,
-            });
+            graph.setNode(frame.id.toString(), { id: frame.id, type: "frame", width: frame.element.clientWidth, height: frame.element.clientHeight });
         });
 
         this._nodes.forEach((node) => {
@@ -1065,7 +1055,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
         }
 
         // Selection?
-        if (evt.currentTarget === this._hostCanvas && this._multiKeyIsPressed) {
+        if (evt.currentTarget === this._hostCanvas && !evt.shiftKey && evt.button == 0) {
             this._selectionBox = this.props.stateManager.hostDocument.createElement("div");
             this._selectionBox.classList.add(styles["selection-box"]);
             this._selectionContainer.appendChild(this._selectionBox);
@@ -1077,6 +1067,10 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             this._selectionBox.style.top = `${this._selectionStartY / this.zoom}px`;
             this._selectionBox.style.width = "0px";
             this._selectionBox.style.height = "0px";
+            // Loose select
+            if (!evt.ctrlKey) {
+                this.props.stateManager.onSelectionChangedObservable.notifyObservers(null);
+            }
             return;
         }
 
@@ -1096,7 +1090,6 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             return;
         }
 
-        this.props.stateManager.onSelectionChangedObservable.notifyObservers(null);
         this._mouseStartPointX = evt.clientX;
         this._mouseStartPointY = evt.clientY;
     }
@@ -1121,10 +1114,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
                     const port = this._candidateLink.portA;
                     const frame = this.frames.find((frame: GraphFrame) => frame.id === port.parentFrameId);
                     if (frame) {
-                        const data: FramePortData = {
-                            frame,
-                            port,
-                        };
+                        const data: FramePortData = { frame, port };
                         this.props.stateManager.onSelectionChangedObservable.notifyObservers({ selection: data });
                     }
                 } else if (this._candidateLink.portA instanceof NodePort) {

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -539,7 +539,7 @@ export class GraphNode {
         }
 
         // Move attached (Shift / Alt)
-        let attached: Array<GraphNode> = [];
+        const attached: Array<GraphNode> = [];
         if (evt.shiftKey) {
             this._attach(attached, false);
         } else if (evt.altKey) {

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -546,8 +546,10 @@ export class GraphNode {
             this._attach(attached, true);
         }
         for (const attachedNode of attached) {
-            attachedNode.x += newX;
-            attachedNode.y += newY;
+            if (!this._ownerCanvas.selectedNodes.includes(attachedNode)) {
+                attachedNode.x += newX;
+                attachedNode.y += newY;
+            }
         }
 
         // Move frame


### PR DESCRIPTION
This PR follows this topic from the forum :
https://forum.babylonjs.com/t/node-editors-enhancing-node-manipulation/50573/3

- Default box selection with left click (leaving wheel click for panning)
- Moving a node holding SHIFT will bring the parent nodes
- Moving a node holding ALT will bring the children nodes

`NB` For some reason, some old code was not formatted