### PR TITLE
Add support for loading and exporting large OBJ files

### DIFF
--- a/packages/dev/serializers/src/OBJ/objSerializer.ts
+++ b/packages/dev/serializers/src/OBJ/objSerializer.ts
@@ -18,8 +18,7 @@ export class OBJExport {
      * @param globalposition defines if the exported positions are globals or local to the exported mesh
      * @returns the OBJ content
      */
-    public static OBJ(meshes: Mesh[], materials?: boolean, matlibname?: string, globalposition?: boolean): string {
-        const output: string[] = [];
+    public static *OBJ(meshes: Mesh[], materials?: boolean, matlibname?: string, globalposition?: boolean): Generator<string> {
         let v = 1;
         // keep track of uv index in case mixed meshes are passed in
         let textureV = 1;
@@ -28,12 +27,12 @@ export class OBJExport {
             if (!matlibname) {
                 matlibname = "mat";
             }
-            output.push("mtllib " + matlibname + ".mtl");
+            yield "mtllib " + matlibname + ".mtl";
         }
         for (let j = 0; j < meshes.length; j++) {
             const mesh = meshes[j];
             const objectName = mesh.name || `mesh${j}}`;
-            output.push(`o ${objectName}`);
+            yield `o ${objectName}`;
 
             //Uses the position of the item in the scene, to the file (this back to normal in the end)
             let inverseTransform: Nullable<Matrix> = null;
@@ -51,7 +50,7 @@ export class OBJExport {
                 const mat = mesh.material;
 
                 if (mat) {
-                    output.push("usemtl " + mat.id);
+                    yield "usemtl " + mat.id;
                 }
             }
             const g: Nullable<Geometry> = mesh.geometry;
@@ -77,18 +76,18 @@ export class OBJExport {
             const handednessSign = useRightHandedSystem ? 1 : -1;
 
             for (let i = 0; i < trunkVerts.length; i += 3) {
-                output.push("v " + trunkVerts[i] * handednessSign + " " + trunkVerts[i + 1] + " " + trunkVerts[i + 2]);
+                yield "v " + trunkVerts[i] * handednessSign + " " + trunkVerts[i + 1] + " " + trunkVerts[i + 2];
                 currentV++;
             }
 
             if (trunkNormals != null) {
                 for (let i = 0; i < trunkNormals.length; i += 3) {
-                    output.push("vn " + trunkNormals[i] * handednessSign + " " + trunkNormals[i + 1] + " " + trunkNormals[i + 2]);
+                    yield "vn " + trunkNormals[i] * handednessSign + " " + trunkNormals[i + 1] + " " + trunkNormals[i + 2];
                 }
             }
             if (trunkUV != null) {
                 for (let i = 0; i < trunkUV.length; i += 2) {
-                    output.push("vt " + trunkUV[i] + " " + trunkUV[i + 1]);
+                    yield "vt " + trunkUV[i] + " " + trunkUV[i + 1];
                     currentTextureV++;
                 }
             }
@@ -107,26 +106,7 @@ export class OBJExport {
                 const faceUVs = trunkUV != null ? textureIndices : blanks;
                 const faceNormals = trunkNormals != null ? indices : blanks;
 
-                output.push(
-                    "f " +
-                        facePositions[0] +
-                        "/" +
-                        faceUVs[0] +
-                        "/" +
-                        faceNormals[0] +
-                        " " +
-                        facePositions[1] +
-                        "/" +
-                        faceUVs[1] +
-                        "/" +
-                        faceNormals[1] +
-                        " " +
-                        facePositions[2] +
-                        "/" +
-                        faceUVs[2] +
-                        "/" +
-                        faceNormals[2]
-                );
+                yield `f ${facePositions[0]}/${faceUVs[0]}/${faceNormals[0]} ${facePositions[1]}/${faceUVs[1]}/${faceNormals[1]} ${facePositions[2]}/${faceUVs[2]}/${faceNormals[2]}`;
             }
             //back de previous matrix, to not change the original mesh in the scene
             if (globalposition && inverseTransform) {
@@ -135,8 +115,6 @@ export class OBJExport {
             v += currentV;
             textureV += currentTextureV;
         }
-        const text: string = output.join("\n");
-        return text;
     }
 
     /**


### PR DESCRIPTION
This pull request introduces support for loading and exporting large OBJ files without requiring the entire file to be loaded into memory as a single string.

**Loading Enhancements**
The default behavior remains unchanged when using BABYLON.SceneLoader, ensuring full backward compatibility.

However, SceneLoader still fetches the entire file, as I could not find a way to prevent this.

To leverage an incremental reading and building mechanism, the OBJFileLoader class should be used directly, importing meshes without the data parameter:

```
const objLoader = new BABYLON.OBJFileLoader();
const { meshes: newMeshes } = await objLoader.importMeshAsync(null, scene, null, "https://file.obj");
```
This new loading mechanism supports both .obj and .obj.gz files, allowing seamless handling of compressed OBJ files.

**Parsing Fixes**
Fixed an issue where some OBJ files with multiple space-separated values (e.g., f 1 4 5) were incorrectly parsed.
The new behavior correctly normalizes them to f 1 4 5, addressing a case that was not handled by the existing solidParser string manipulation methods.


**Exporting Changes (Breaking Change)**
The export method has been modified to return an iterator instead of a full OBJ string.

This change aligns with the new incremental approach, allowing the data to be processed in chunks instead of requiring full memory allocation.

The new export method is not backward-compatible but enables efficient writing via a stream writer to output the data progressively to a file or another destination.

For those who still need the full OBJ as a string, it can easily be converted using:


`const obj = [...BABYLON.OBJExport.OBJ(meshes)].join("\n");`
