### PR TITLE
Skip legacy audio engine init in playgrounds that explicitly turn it off

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -287,7 +287,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                     window.engine = await asyncEngineCreation();
                     
                     const engineOptions = window.engine.getCreationOptions();
-                    if (engineOptions.audioEngine === undefined || engineOptions.audioEngine === true) {
+                    if (engineOptions.audioEngine !== false) {
                         ${audioInit}
                     }`;
                 code += "\r\nif (!engine) throw 'engine should not be null.';";

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -286,7 +286,10 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
                     window.engine = await asyncEngineCreation();
                     
-                    ${audioInit}`;
+                    const engineOptions = window.engine.getCreationOptions();
+                    if (engineOptions.audioEngine === undefined || engineOptions.audioEngine === true) {
+                        ${audioInit}
+                    }`;
                 code += "\r\nif (!engine) throw 'engine should not be null.';";
 
                 globalObject.startRenderLoop = (engine: Engine, canvas: HTMLCanvasElement) => {


### PR DESCRIPTION
There is currently no way to disable the old audio engine in playgrounds that include `BABYLON.Sound`, even if the playground supplies a `createEngine` function and explicitly sets the `audioEngine` option to `false`.

This change fixes the issue by only doing the backcompat init of the old audio engine if the engine's `audioEngine` option is undefined or explicitly set to `true`. This causes backcompat init of the old audio engine to be skipped when the engine's `audioEngine` option is explicitly set to `false`.

#### Forum post:
https://forum.babylonjs.com/t/audioenginev2-how-to-attach-sound-to-mesh-in-a-new-way/57027/12

Tested with playground https://playground.babylonjs.com/#QARKUZ#5.