### PR TITLE
Allow old audio engine to be enabled using engine's `audioEngine` option

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -2026,7 +2026,7 @@ export abstract class AbstractEngine {
         options.deterministicLockstep = options.deterministicLockstep ?? false;
         options.lockstepMaxSteps = options.lockstepMaxSteps ?? 4;
         options.timeStep = options.timeStep ?? 1 / 60;
-        options.audioEngine = options.audioEngine ?? true;
+        options.audioEngine = options.audioEngine ?? false;
         options.stencil = options.stencil ?? true;
 
         this._audioContext = options.audioEngineOptions?.audioContext ?? null;

--- a/packages/dev/core/src/Engines/engine.common.ts
+++ b/packages/dev/core/src/Engines/engine.common.ts
@@ -69,6 +69,11 @@ export function _CommonInit(commonEngine: AbstractEngine, canvas: HTMLCanvasElem
         _DisableTouchAction(canvas);
     }
 
+    // Create Audio Engine if needed.
+    if (!AbstractEngine.audioEngine && creationOptions.audioEngine && AbstractEngine.AudioEngineFactory) {
+        AbstractEngine.audioEngine = AbstractEngine.AudioEngineFactory(commonEngine.getRenderingCanvas(), commonEngine.getAudioContext(), commonEngine.getAudioDestination());
+    }
+
     if (IsDocumentAvailable()) {
         // Fullscreen
         commonEngine._onFullscreenChange = () => {


### PR DESCRIPTION
The old audio engine is not being enabled when the graphics engine is constructed with the `audioEngine` option set to `true`. This change fixes it while keeping the desired behavior of not enabling the old audio engine by default anymore, which was done to pave the way for the new audio engine.

Partially reverts https://github.com/BabylonJS/Babylon.js/pull/16249 to address issues reported on forum:
- https://forum.babylonjs.com/t/legacy-audio-engine-enabled-not-working/57059.
- https://forum.babylonjs.com/t/audioenginev2-how-to-attach-sound-to-mesh-in-a-new-way/57027/5
