### PR TITLE
Fix spatial audio init issues

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/abstractAudioSubGraph.ts
@@ -31,9 +31,24 @@ export abstract class _AbstractAudioSubGraph {
      *
      * @internal
      */
-    public async callOnSubNode<T extends _AbstractAudioSubNode>(name: AudioSubNode, callback: (node: T) => void): Promise<void> {
-        await this._createSubNodePromisesResolved();
-        callback(this.getSubNode(name) || ((await this.createAndAddSubNode(name)) as T));
+    public callOnSubNode<T extends _AbstractAudioSubNode>(name: AudioSubNode, callback: (node: T) => void): void {
+        const node = this.getSubNode(name);
+        if (node) {
+            callback(node as T);
+            return;
+        }
+
+        this._createSubNodePromisesResolved().then(() => {
+            const node = this.getSubNode(name);
+            if (node) {
+                callback(node as T);
+                return;
+            }
+
+            this.createAndAddSubNode(name).then((node) => {
+                callback(node as T);
+            });
+        });
     }
 
     /**

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -20,13 +20,17 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
         super();
 
         const subNode = _GetSpatialAudioSubNode(subGraph);
-        if (!subNode) {
-            throw new Error("Sub node not found");
-        }
+        if (subNode) {
+            this._position = subNode.position.clone();
+            this._rotation = subNode.rotation.clone();
+            this._rotationQuaternion = subNode.rotationQuaternion.clone();
+        } else {
+            this._position = _SpatialAudioDefaults.position.clone();
+            this._rotation = _SpatialAudioDefaults.rotation.clone();
+            this._rotationQuaternion = _SpatialAudioDefaults.rotationQuaternion.clone();
 
-        this._position = subNode.position.clone();
-        this._rotation = subNode.rotation.clone();
-        this._rotationQuaternion = subNode.rotationQuaternion.clone();
+            subGraph.createAndAddSubNode(AudioSubNode.SPATIAL);
+        }
 
         this._subGraph = subGraph;
     }

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBaseSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBaseSubGraph.ts
@@ -35,10 +35,10 @@ export abstract class _WebAudioBaseSubGraph extends _AbstractAudioSubGraph {
         const hasAnalyzerOptions = _HasAudioAnalyzerOptions(options);
 
         if (hasAnalyzerOptions) {
-            this.createAndAddSubNode(AudioSubNode.ANALYZER);
+            await this.createAndAddSubNode(AudioSubNode.ANALYZER);
         }
 
-        this.createAndAddSubNode(AudioSubNode.VOLUME);
+        await this.createAndAddSubNode(AudioSubNode.VOLUME);
 
         await this._createSubNodePromisesResolved();
 

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
@@ -30,16 +30,16 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
 
     /** @internal */
     public override async init(options: Partial<IWebAudioBusAndSoundSubGraphOptions>): Promise<void> {
-        super.init(options);
+        await super.init(options);
 
         let hasSpatialOptions = false;
         let hasStereoOptions = false;
 
         if ((hasSpatialOptions = _HasSpatialAudioOptions(options))) {
-            this.createAndAddSubNode(AudioSubNode.SPATIAL);
+            await this.createAndAddSubNode(AudioSubNode.SPATIAL);
         }
         if ((hasStereoOptions = _HasStereoAudioOptions(options))) {
-            this.createAndAddSubNode(AudioSubNode.STEREO);
+            await this.createAndAddSubNode(AudioSubNode.STEREO);
         }
 
         await this._createSubNodePromisesResolved();


### PR DESCRIPTION
If spatial audio is not enabled at init time using the `spatialEnabled` option, accessing the `spatial` property on a sound or bus throws error "Sub node not found".

This change fixes the issue by creating the underlying spatial audio subnode if it doesn't exist, instead of throwing an error.