### PR TITLE
Add missing audio engine import

### DIFF
--- a/packages/dev/core/src/Engines/engine.ts
+++ b/packages/dev/core/src/Engines/engine.ts
@@ -17,6 +17,7 @@ import { WebGLDataBuffer } from "../Meshes/WebGL/webGLDataBuffer";
 import { Logger } from "../Misc/logger";
 import type { RenderTargetWrapper } from "./renderTargetWrapper";
 import { WebGLHardwareTexture } from "./WebGL/webGLHardwareTexture";
+import "../Audio/audioEngine";
 
 import "./Extensions/engine.alpha";
 import "./Extensions/engine.rawTexture";


### PR DESCRIPTION
Add missing `audioEngine` import. It contains a side effect to instantiate the `AudioEngineFactory`.

Without this side effect, the [condition](https://github.com/BabylonJS/Babylon.js/pull/16278/files#diff-4588999019dadda63f4c625f29f8d6bd9d9f979a8b6881f30c54a555db79a7b0R73) `&& AbstractEngine.AudioEngineFactory`  is never met and the old audio engine is not created.

Forum link: https://forum.babylonjs.com/t/audioenginev2-how-to-attach-sound-to-mesh-in-a-new-way/57027/20.