### PR TITLE
Correctly support global matrix in glTF interactivity

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/flowGraphCachedOperationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/flowGraphCachedOperationBlock.ts
@@ -4,6 +4,7 @@ import { FlowGraphBlock } from "../../flowGraphBlock";
 import type { FlowGraphContext } from "../../flowGraphContext";
 import type { FlowGraphDataConnection } from "../../flowGraphDataConnection";
 import type { RichType } from "../../flowGraphRichTypes";
+import { RichTypeBoolean } from "../../flowGraphRichTypes";
 
 const cacheName = "cachedOperationValue";
 const cacheExecIdName = "cachedExecutionId";
@@ -17,10 +18,16 @@ export abstract class FlowGraphCachedOperationBlock<OutputT> extends FlowGraphBl
      */
     public readonly value: FlowGraphDataConnection<OutputT>;
 
+    /**
+     * Output connection: Whether the value is valid.
+     */
+    public readonly isValid: FlowGraphDataConnection<boolean>;
+
     constructor(outputRichType: RichType<OutputT>, config?: IFlowGraphBlockConfiguration) {
         super(config);
 
         this.value = this.registerDataOutput("value", outputRichType);
+        this.isValid = this.registerDataOutput("isValid", RichTypeBoolean);
     }
 
     /**
@@ -28,18 +35,28 @@ export abstract class FlowGraphCachedOperationBlock<OutputT> extends FlowGraphBl
      * Operation to realize
      * @param context the graph context
      */
-    public abstract _doOperation(context: FlowGraphContext): OutputT;
+    public abstract _doOperation(context: FlowGraphContext): OutputT | undefined;
 
     public override _updateOutputs(context: FlowGraphContext) {
         const cachedExecutionId = context._getExecutionVariable(this, cacheExecIdName, -1);
         const cachedValue = context._getExecutionVariable<Nullable<OutputT>>(this, cacheName, null);
         if (cachedValue !== undefined && cachedValue !== null && cachedExecutionId === context.executionId) {
+            this.isValid.setValue(true, context);
             this.value.setValue(cachedValue, context);
         } else {
-            const calculatedValue = this._doOperation(context);
-            context._setExecutionVariable(this, cacheName, calculatedValue);
-            context._setExecutionVariable(this, cacheExecIdName, context.executionId);
-            this.value.setValue(calculatedValue, context);
+            try {
+                const calculatedValue = this._doOperation(context);
+                if (calculatedValue === undefined || calculatedValue === null) {
+                    this.isValid.setValue(false, context);
+                    return;
+                }
+                context._setExecutionVariable(this, cacheName, calculatedValue);
+                context._setExecutionVariable(this, cacheExecIdName, context.executionId);
+                this.value.setValue(calculatedValue, context);
+                this.isValid.setValue(true, context);
+            } catch (e) {
+                this.isValid.setValue(false, context);
+            }
         }
     }
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/objectModelMapping.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/objectModelMapping.ts
@@ -323,7 +323,7 @@ const nodesTree: IGLTFObjectModelTreeNodesObject = {
         // readonly!
         matrix: {
             type: "Matrix",
-            get: (node: INode) => Matrix.Compose(node._babylonTransformNode?.scaling!, node._babylonTransformNode?.rotationQuaternion!, node._babylonTransformNode?.position!),
+            get: (node: INode) => node._babylonTransformNode?._localMatrix.clone(),
             getTarget: (node: INode) => node._babylonTransformNode,
             isReadOnly: true,
         },
@@ -971,14 +971,17 @@ function _GenerateTextureMap(textureType: keyof PBRMaterial, textureInObject?: s
                 const texture = _GetTexture(material, payload, textureType, textureInObject);
                 (texture.uOffset = value.x), (texture.vOffset = value.y);
             },
-            getPropertyName: [() => `${textureType}.${textureInObject}.uOffset`, () => `${textureType}.${textureInObject}.vOffset`],
+            getPropertyName: [
+                () => `${textureType}${textureInObject ? "." + textureInObject : ""}.uOffset`,
+                () => `${textureType}${textureInObject ? "." + textureInObject : ""}.vOffset`,
+            ],
         },
         rotation: {
             type: "number",
             get: (material, _index?, payload?) => _GetTexture(material, payload, textureType, textureInObject)?.wAng,
             getTarget: _GetMaterial,
             set: (value, material, _index?, payload?) => (_GetTexture(material, payload, textureType, textureInObject).wAng = value),
-            getPropertyName: [() => `${textureType}.${textureInObject}.wAng`],
+            getPropertyName: [() => `${textureType}${textureInObject ? "." + textureInObject : ""}.wAng`],
         },
         scale: {
             componentsCount: 2,
@@ -992,7 +995,10 @@ function _GenerateTextureMap(textureType: keyof PBRMaterial, textureInObject?: s
                 const texture = _GetTexture(material, payload, textureType, textureInObject);
                 (texture.uScale = value.x), (texture.vScale = value.y);
             },
-            getPropertyName: [() => `${textureType}.${textureInObject}.uScale`, () => `${textureType}.${textureInObject}.vScale`],
+            getPropertyName: [
+                () => `${textureType}${textureInObject ? "." + textureInObject : ""}.uScale`,
+                () => `${textureType}${textureInObject ? "." + textureInObject : ""}.vScale`,
+            ],
         },
     };
 }


### PR DESCRIPTION
Because of babylon's RHS->LHS conversion of any glTF scene, there was an issue with using the global matrix compared to local matrix in glTF interactivity (or more percise in the glTF json pointer system).

Local matrix is actually in RHS, as the node itself doesn't change the properties provided from glTF. However, globalMatrix was (incorrectly) in LHS. The solution is to provide the global matrix in RHS as well. I am doing it by inverting the root node's transformation and multiplying it. This way we support RHS (identity) and LHS (rotation/scaling combination).

This PR also changes the JSONPointer block and the getproperty block to be a cached operation, meaning calculations will only be done once per execusion. This will optimize the execusion.