### PR TITLE
Viewer: add the concept of a faulted state and a reload button

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1403,6 +1403,7 @@ export class Viewer implements IDisposable {
         this.animationProgress = 0;
 
         this._loadEnvironmentAbortController?.abort(new AbortError("Thew viewer is being disposed."));
+        this._loadSkyboxAbortController?.abort(new AbortError("Thew viewer is being disposed."));
         this._loadModelAbortController?.abort(new AbortError("Thew viewer is being disposed."));
 
         this._renderLoopController?.dispose();

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -7,8 +7,12 @@ import { Viewer } from "./viewer";
 /**
  * Options for creating a Viewer instance that is bound to an HTML canvas.
  */
-export type CanvasViewerOptions = ViewerOptions &
-    (({ engine?: undefined } & AbstractEngineOptions) | ({ engine: "WebGL" } & EngineOptions) | ({ engine: "WebGPU" } & WebGPUEngineOptions));
+export type CanvasViewerOptions = ViewerOptions & { onFaulted?: (error: Error) => void } & (
+        | ({ engine?: undefined } & AbstractEngineOptions)
+        | ({ engine: "WebGL" } & EngineOptions)
+        | ({ engine: "WebGPU" } & WebGPUEngineOptions)
+    );
+
 const defaultCanvasViewerOptions: CanvasViewerOptions = {
     antialias: true,
     adaptToDeviceRatio: true,
@@ -78,6 +82,14 @@ export async function CreateViewerForCanvas(
             engine = webGPUEngine;
             break;
         }
+    }
+
+    if (options.onFaulted) {
+        const onFaulted = options.onFaulted;
+        const contextLostObserver = engine.onContextLostObservable.addOnce(() => {
+            onFaulted(new Error("The engine context was lost."));
+        });
+        disposeActions.push(() => contextLostObserver.remove());
     }
 
     // Override the onInitialized callback to add in some specific behavior.


### PR DESCRIPTION
If there are too many Viewer instances, we can get into a faulted state (e.g. webgl context lost, but maybe other things in the future). This PR adds the concept of the Viewer entering a faulted state, and the Viewer element handles this and shows a reload button. The reload button will recreate the underlying Viewer, which may in turn cause another Viewer instance to go into a faulted state and get a reload button.