### PR TITLE
MeshBuilder.ExtrudeShape : fixed capFunction type syntax

### DIFF
--- a/packages/dev/core/src/Meshes/Builders/shapeBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/shapeBuilder.ts
@@ -48,7 +48,7 @@ export function ExtrudeShape(
         invertUV?: boolean;
         firstNormal?: Vector3;
         adjustFrame?: boolean;
-        capFunction?: Function;
+        capFunction?: Nullable<{ (shapePath: Vector3[]): Vector3[] }>;
     },
     scene: Nullable<Scene> = null
 ): Mesh {
@@ -140,7 +140,7 @@ export function ExtrudeShapeCustom(
         invertUV?: boolean;
         firstNormal?: Vector3;
         adjustFrame?: boolean;
-        capFunction?: Function;
+        capFunction?: Nullable<{ (shapePath: Vector3[]): Vector3[] }>;
     },
     scene: Nullable<Scene> = null
 ): Mesh {
@@ -212,7 +212,7 @@ function _ExtrudeShapeGeneric(
     backUVs: Nullable<Vector4>,
     firstNormal: Nullable<Vector3>,
     adjustFrame: boolean,
-    capFunction: Nullable<Function>
+    capFunction: Nullable<{ (shapePath: Vector3[]): Vector3[] }>
 ): Mesh {
     // extrusion geometry
     const extrusionPathArray = (


### PR DESCRIPTION
Following [comment](https://github.com/BabylonJS/Babylon.js/pull/16291#discussion_r1992255272) from @sebavan on the PR [Added new param capFunction in MeshBuilder.ExtrudeShape #16291](https://github.com/BabylonJS/Babylon.js/pull/16291)

Fixed syntax for capFunction

`NB`: I'm more used to Arrow Function Syntax :
```typescript
capFunction?: Nullable<(vectors: Vector3[]) => Vector3[]>
```
But I used Callable Object Syntax, in order to align consistency with the already existing `scaleFunction` and `rotationFunction` of the same options object :
```typescript
options: {
    shape: Vector3[];
    path: Vector3[];
    scaleFunction?: Nullable<{ (i: number, distance: number): number }>;
    rotationFunction?: Nullable<{ (i: number, distance: number): number }>;
    ribbonCloseArray?: boolean;
    // [...]
    adjustFrame?: boolean;
    capFunction?: Nullable<{ (shapePath: Vector3[]): Vector3[] }>;
}
```