### PR TITLE
Fix matrix multiplication order in FlowGraph classes

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
@@ -146,7 +146,7 @@ export class FlowGraphMultiplyBlock extends FlowGraphBinaryOperationBlock<FlowGr
             } else {
                 a = a as Matrix;
                 b = b as Matrix;
-                return a.multiply(b);
+                return b.multiply(a);
             }
         } else {
             return (a as number) * (b as number);

--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMatrixMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMatrixMathBlocks.ts
@@ -96,7 +96,7 @@ export class FlowGraphMatrixMultiplicationBlock extends FlowGraphBinaryOperation
             getRichTypeByFlowGraphType(config?.matrixType || FlowGraphTypes.Matrix),
             getRichTypeByFlowGraphType(config?.matrixType || FlowGraphTypes.Matrix),
             getRichTypeByFlowGraphType(config?.matrixType || FlowGraphTypes.Matrix),
-            (a, b) => a.multiply(b as any),
+            (a, b) => b.multiply(a as any),
             FlowGraphBlockNames.MatrixMultiplication,
             config
         );

--- a/packages/dev/core/src/FlowGraph/CustomTypes/flowGraphMatrix.ts
+++ b/packages/dev/core/src/FlowGraph/CustomTypes/flowGraphMatrix.ts
@@ -60,6 +60,7 @@ export interface IFlowGraphMatrix<VectorType> {
 
     /**
      * Multiplies this matrix with another matrix.
+     * To staz conform with the Matrix class, this does B * A
      *
      * @param other - The matrix to multiply with.
      * @returns The result matrix.
@@ -204,14 +205,14 @@ export class FlowGraphMatrix2D implements IFlowGraphMatrix<Vector2> {
     }
 
     public multiplyToRef(other: FlowGraphMatrix2D, result: FlowGraphMatrix2D): FlowGraphMatrix2D {
-        const m = this._m;
-        const o = other._m;
+        const otherMatrix = other._m;
+        const thisMatrix = this._m;
         const r = result._m;
-
-        r[0] = m[0] * o[0] + m[1] * o[2];
-        r[1] = m[0] * o[1] + m[1] * o[3];
-        r[2] = m[2] * o[0] + m[3] * o[2];
-        r[3] = m[2] * o[1] + m[3] * o[3];
+        // other * this
+        r[0] = otherMatrix[0] * thisMatrix[0] + otherMatrix[1] * thisMatrix[2];
+        r[1] = otherMatrix[0] * thisMatrix[1] + otherMatrix[1] * thisMatrix[3];
+        r[2] = otherMatrix[2] * thisMatrix[0] + otherMatrix[3] * thisMatrix[2];
+        r[3] = otherMatrix[2] * thisMatrix[1] + otherMatrix[3] * thisMatrix[3];
 
         return result;
     }
@@ -339,21 +340,21 @@ export class FlowGraphMatrix3D implements IFlowGraphMatrix<Vector3> {
     }
 
     public multiplyToRef(other: FlowGraphMatrix3D, result: FlowGraphMatrix3D): FlowGraphMatrix3D {
-        const m = this._m;
-        const o = other.m;
+        const otherMatrix = other._m;
+        const thisMatrix = this._m;
         const r = result.m;
 
-        r[0] = m[0] * o[0] + m[1] * o[3] + m[2] * o[6];
-        r[1] = m[0] * o[1] + m[1] * o[4] + m[2] * o[7];
-        r[2] = m[0] * o[2] + m[1] * o[5] + m[2] * o[8];
+        r[0] = otherMatrix[0] * thisMatrix[0] + otherMatrix[1] * thisMatrix[3] + otherMatrix[2] * thisMatrix[6];
+        r[1] = otherMatrix[0] * thisMatrix[1] + otherMatrix[1] * thisMatrix[4] + otherMatrix[2] * thisMatrix[7];
+        r[2] = otherMatrix[0] * thisMatrix[2] + otherMatrix[1] * thisMatrix[5] + otherMatrix[2] * thisMatrix[8];
 
-        r[3] = m[3] * o[0] + m[4] * o[3] + m[5] * o[6];
-        r[4] = m[3] * o[1] + m[4] * o[4] + m[5] * o[7];
-        r[5] = m[3] * o[2] + m[4] * o[5] + m[5] * o[8];
+        r[3] = otherMatrix[3] * thisMatrix[0] + otherMatrix[4] * thisMatrix[3] + otherMatrix[5] * thisMatrix[6];
+        r[4] = otherMatrix[3] * thisMatrix[1] + otherMatrix[4] * thisMatrix[4] + otherMatrix[5] * thisMatrix[7];
+        r[5] = otherMatrix[3] * thisMatrix[2] + otherMatrix[4] * thisMatrix[5] + otherMatrix[5] * thisMatrix[8];
 
-        r[6] = m[6] * o[0] + m[7] * o[3] + m[8] * o[6];
-        r[7] = m[6] * o[1] + m[7] * o[4] + m[8] * o[7];
-        r[8] = m[6] * o[2] + m[7] * o[5] + m[8] * o[8];
+        r[6] = otherMatrix[6] * thisMatrix[0] + otherMatrix[7] * thisMatrix[3] + otherMatrix[8] * thisMatrix[6];
+        r[7] = otherMatrix[6] * thisMatrix[1] + otherMatrix[7] * thisMatrix[4] + otherMatrix[8] * thisMatrix[7];
+        r[8] = otherMatrix[6] * thisMatrix[2] + otherMatrix[7] * thisMatrix[5] + otherMatrix[8] * thisMatrix[8];
 
         return result;
     }

--- a/packages/dev/loaders/test/unit/Interactivity/interactivity.math nodes.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/interactivity.math nodes.test.ts
@@ -1359,11 +1359,11 @@ describe("Interactivity math nodes", () => {
                         // matrix4d
                         a: {
                             type: 0,
-                            value: randomMatrix1,
+                            value: randomMatrix2,
                         },
                         b: {
                             type: 0,
-                            value: randomMatrix2,
+                            value: randomMatrix1,
                         },
                     },
                 },


### PR DESCRIPTION
Correct the matrix multiplication order in FlowGraph blocks and matrix classes to ensure consistent behavior across the application.

This is because Babylon defines `a.multiply(b)` as b * a.