### PR TITLE
Enhance matrix validation and type transformation features

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMatrixMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMatrixMathBlocks.ts
@@ -155,7 +155,12 @@ export class FlowGraphMatrixDecomposeBlock extends FlowGraphBlock {
             const rotation = cachedRotation || new Quaternion();
             const scaling = cachedScaling || new Vector3();
             // check matrix last column components should be 0,0,0,1
-            if (matrix.m[3] !== 0 || matrix.m[7] !== 0 || matrix.m[11] !== 0 || matrix.m[15] !== 1) {
+            // round them to 4 decimal places
+            const m3 = Math.round(matrix.m[3] * 10000) / 10000;
+            const m7 = Math.round(matrix.m[7] * 10000) / 10000;
+            const m11 = Math.round(matrix.m[11] * 10000) / 10000;
+            const m15 = Math.round(matrix.m[15] * 10000) / 10000;
+            if (m3 !== 0 || m7 !== 0 || m11 !== 0 || m15 !== 1) {
                 this.isValid.setValue(false, context);
                 this.position.setValue(Vector3.Zero(), context);
                 this.rotationQuaternion.setValue(Quaternion.Identity(), context);

--- a/packages/dev/core/src/FlowGraph/flowGraphRichTypes.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphRichTypes.ts
@@ -30,6 +30,12 @@ export const enum FlowGraphTypes {
  * such as its name and a default value constructor.
  */
 export class RichType<T> {
+    /**
+     * A function that can be used to transform a value of any type into a value of this rich type.
+     * This can be used, for example, between vector4 and quaternion.
+     */
+    public typeTransformer: (value: any) => T;
+
     constructor(
         /**
          * The name given to the type.
@@ -81,7 +87,16 @@ export const RichTypeColor3: RichType<Color3> = new RichType(FlowGraphTypes.Colo
 export const RichTypeColor4: RichType<Color4> = new RichType(FlowGraphTypes.Color4, new Color4(0, 0, 0, 0), Constants.ANIMATIONTYPE_COLOR4);
 
 export const RichTypeQuaternion: RichType<Quaternion> = new RichType(FlowGraphTypes.Quaternion, Quaternion.Identity(), Constants.ANIMATIONTYPE_QUATERNION);
-
+RichTypeQuaternion.typeTransformer = (value: any) => {
+    if (value.getClassName && value.getClassName() === FlowGraphTypes.Vector4) {
+        return Quaternion.FromArray(value.asArray());
+    } else if (value.getClassName && value.getClassName() === FlowGraphTypes.Vector3) {
+        return Quaternion.FromEulerVector(value);
+    } else if (value.getClassName && value.getClassName() === FlowGraphTypes.Matrix) {
+        return Quaternion.FromRotationMatrix(value);
+    }
+    return value;
+};
 export const RichTypeFlowGraphInteger: RichType<FlowGraphInteger> = new RichType(FlowGraphTypes.Integer, new FlowGraphInteger(0), Constants.ANIMATIONTYPE_FLOAT);
 
 /**


### PR DESCRIPTION
Round the last column components of the matrix for improved validation checks, add a type transformer to facilitate value transformations in RichType, and correct a typo in the isDisabled property while introducing a lastValue for debugging purposes.

Also introducing a multi-type connection transformer. The idea here is that it is possible that a data input of specific type will be connected to a data input connection of another type. We have specific blocks for that, but in some cases, like quaternion and vector4, it can be supported out of the box directly in the connection. This PR adds a type transformer to quaternion input/output data connections. If a data connection of type quaternion is connected to a vector4, it will be converted to the right type.