### PR TITLE
Fix usdz exporter for models with Color3 vertex attributes

### DIFF
--- a/packages/dev/serializers/src/USDZ/usdzExporter.ts
+++ b/packages/dev/serializers/src/USDZ/usdzExporter.ts
@@ -181,7 +181,7 @@ function BuildAdditionalAttributes(geometry: Geometry, options: IUSDZExportOptio
 
     if (colorAttribute) {
         string += `
-	color3f[] primvars:displayColor = [${BuildVector3Array(colorAttribute, options, 4)}] (
+	color3f[] primvars:displayColor = [${BuildVector3Array(colorAttribute, options, colorAttribute.length / geometry.getTotalVertices())}] (
 		interpolation = "vertex"
 		)`;
     }


### PR DESCRIPTION
Code was broken when color attribute was Color3 instead of Color4. Added a check to adjust stride appropriately.  