### PR TITLE
Add a _hasDefaultMaterial property

### DIFF
--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1710,7 +1710,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
             }
             for (const subMesh of mesh.subMeshes) {
                 // We want to skip the submeshes which are not using this material or which have not yet rendered at least once
-                const material = subMesh.getMaterial() || scene.defaultMaterial;
+                const material = subMesh.getMaterial() || (scene._hasDefaultMaterial ? scene.defaultMaterial : null);
                 if (material !== this) {
                     continue;
                 }

--- a/packages/dev/core/src/Meshes/subMesh.ts
+++ b/packages/dev/core/src/Meshes/subMesh.ts
@@ -301,7 +301,7 @@ export class SubMesh implements ICullable {
         const rootMaterial = this._renderingMesh.getMaterialForRenderPass(this._engine.currentRenderPassId) ?? this._renderingMesh.material;
 
         if (!rootMaterial) {
-            return getDefaultMaterial ? this._mesh.getScene().defaultMaterial : null;
+            return getDefaultMaterial && this._mesh.getScene()._hasDefaultMaterial ? this._mesh.getScene().defaultMaterial : null;
         } else if (this._isMultiMaterial(rootMaterial)) {
             const effectiveMaterial = rootMaterial.getSubMaterial(this.materialIndex);
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -180,6 +180,8 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         throw _WarnImport("StandardMaterial");
     }
 
+    private static readonly _OriginalDefaultMaterialFactory = Scene.DefaultMaterialFactory;
+
     // eslint-disable-next-line jsdoc/require-returns-check
     /**
      * Factory used to create the a collision coordinator.
@@ -1383,6 +1385,11 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
         this._activeCamera = value;
         this.onActiveCameraChanged.notifyObservers(this);
+    }
+
+    /** @internal */
+    public get _hasDefaultMaterial() {
+        return Scene.DefaultMaterialFactory !== Scene._OriginalDefaultMaterialFactory;
     }
 
     private _defaultMaterial: Material;

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/animationPropertyGridComponent.tsx
@@ -144,7 +144,8 @@ export class AnimationGridComponent extends React.Component<IAnimationGridCompon
         const animatable = this.props.animatable;
         const animatableAsAny = this.props.animatable as any;
 
-        const animatablesForTarget = this.props.scene.getAllAnimatablesByTarget(animatable);
+        // NOTE: getAllAnimatablesByTarget is not defined unless animatable has been imported (and its side effects executed)
+        const animatablesForTarget = this.props.scene.getAllAnimatablesByTarget?.(animatable) ?? [];
         this._isPlaying = animatablesForTarget.length > 0;
 
         if (this._isPlaying) {


### PR DESCRIPTION
Addressing https://forum.babylonjs.com/t/viewer-v2-began-to-ask-for-the-standard-material/56950/6

A recent [PR](https://github.com/BabylonJS/Babylon.js/pull/16277/files#diff-2cc63980f0d7bff0a7a002d34348349697af415faa1e4e79a99b51e3deb2853eR1713) introduced a call to `scene.defaultMaterial` in a very common code path. If `StandardMaterial` has not been imported, `scene.defaultMaterial` throws. This change fixes that.
- Add a `_hasDefaultMaterial` internal property (could make it non-internal if we want it to be part of the public API). This works by seeing if `Scene.DefaultMaterialFactory` has been assigned to something other than the default value. This makes it so that even if `Scene.DefaultMaterialFactory` has been set to a factory function other than the one in `StandardMaterial`, it still works (e.g. default material does not have to be `StandardMaterial` for this mechanism to work).
- A couple places on the common hot path that recently started accessing `Scene.defaultMaterial` now check `_hasDefaultMaterial` first. This is just a property evaluation, so I think the perf impact should be negligible.
- I had "fixed" this problem in the Viewer first by setting `Scene.blockMaterialDirtyMechanism` when creating the skybox material, but I kept that change anyway because I think it is slightly better. It's the same thing the glTF loader does for example.
- While testing this to make sure it doesn't regress the point mode fix from the previous PR, I noticed that inspector fails if `animatable.ts` has not been imported (e.g. if you didn't explicitly import it yourself or load a model with animations). So I also included a very small change to fix this.

I'd like to get this PR in since it is a bug reported on the forum, and see about adding a Viewer test that can catch this separately. But we can block this PR on adding a test if anyone feels strongly about tying them together.