### PR TITLE
Add observer for when IBL shadow voxelization is complete

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -154,6 +154,11 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
     public onNewIblReadyObservable: Observable<void> = new Observable<void>();
 
     /**
+     * Observable that triggers when the voxelization is complete
+     */
+    public onVoxelizationCompleteObservable: Observable<void> = new Observable<void>();
+
+    /**
      * The current world-space size of that the voxel grid covers in the scene.
      */
     public voxelGridSize: number = 1.0;
@@ -687,6 +692,9 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             return;
         }
         this._voxelRenderer.updateVoxelGrid(this._shadowCastingMeshes);
+        this._voxelRenderer.onVoxelizationCompleteObservable.addOnce(() => {
+            this.onVoxelizationCompleteObservable.notifyObservers();
+        });
         this._updateSSShadowParams();
     }
 
@@ -740,22 +748,10 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
 
         // Setup the geometry buffer target formats
         const textureTypesAndFormats: { [key: number]: { textureType: number; textureFormat: number } } = {};
-        textureTypesAndFormats[GeometryBufferRenderer.SCREENSPACE_DEPTH_TEXTURE_TYPE] = {
-            textureFormat: Constants.TEXTUREFORMAT_R,
-            textureType: Constants.TEXTURETYPE_FLOAT,
-        };
-        textureTypesAndFormats[GeometryBufferRenderer.VELOCITY_LINEAR_TEXTURE_TYPE] = {
-            textureFormat: Constants.TEXTUREFORMAT_RG,
-            textureType: Constants.TEXTURETYPE_HALF_FLOAT,
-        };
-        textureTypesAndFormats[GeometryBufferRenderer.POSITION_TEXTURE_TYPE] = {
-            textureFormat: Constants.TEXTUREFORMAT_RGBA,
-            textureType: Constants.TEXTURETYPE_HALF_FLOAT,
-        };
-        textureTypesAndFormats[GeometryBufferRenderer.NORMAL_TEXTURE_TYPE] = {
-            textureFormat: Constants.TEXTUREFORMAT_RGBA,
-            textureType: Constants.TEXTURETYPE_HALF_FLOAT,
-        };
+        textureTypesAndFormats[GeometryBufferRenderer.SCREENSPACE_DEPTH_TEXTURE_TYPE] = { textureFormat: Constants.TEXTUREFORMAT_R, textureType: Constants.TEXTURETYPE_FLOAT };
+        textureTypesAndFormats[GeometryBufferRenderer.VELOCITY_LINEAR_TEXTURE_TYPE] = { textureFormat: Constants.TEXTUREFORMAT_RG, textureType: Constants.TEXTURETYPE_HALF_FLOAT };
+        textureTypesAndFormats[GeometryBufferRenderer.POSITION_TEXTURE_TYPE] = { textureFormat: Constants.TEXTUREFORMAT_RGBA, textureType: Constants.TEXTURETYPE_HALF_FLOAT };
+        textureTypesAndFormats[GeometryBufferRenderer.NORMAL_TEXTURE_TYPE] = { textureFormat: Constants.TEXTUREFORMAT_RGBA, textureType: Constants.TEXTURETYPE_HALF_FLOAT };
         const geometryBufferRenderer = scene.enableGeometryBufferRenderer(undefined, Constants.TEXTUREFORMAT_DEPTH32_FLOAT, textureTypesAndFormats);
         if (!geometryBufferRenderer) {
             Logger.Error("Geometry buffer renderer is required for IBL shadows to work.");

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
@@ -11,6 +11,7 @@ import type { Mesh } from "../../Meshes/mesh";
 import type { Scene } from "../../scene";
 import { Texture } from "../../Materials/Textures/texture";
 import { Logger } from "../../Misc/logger";
+import { Observable } from "../../Misc/observable";
 import { PostProcess } from "../../PostProcesses/postProcess";
 import type { PostProcessOptions } from "../../PostProcesses/postProcess";
 import { ProceduralTexture } from "../../Materials/Textures/Procedurals/proceduralTexture";
@@ -51,6 +52,11 @@ export class _IblShadowsVoxelRenderer {
             return this._voxelGridZaxis;
         }
     }
+
+    /**
+     * Observable that triggers when the voxelization is complete
+     */
+    public onVoxelizationCompleteObservable: Observable<void> = new Observable<void>();
 
     /**
      * The debug pass post process
@@ -659,6 +665,7 @@ export class _IblShadowsVoxelRenderer {
                     this._copyMipMaps();
                     this._scene.onAfterRenderObservable.removeCallback(this._renderVoxelGridBound);
                     this._voxelizationInProgress = false;
+                    this.onVoxelizationCompleteObservable.notifyObservers();
                 });
             }
         }


### PR DESCRIPTION
When updating the voxelization for IBL shadows, the process can take a few frames. It's useful to know when it's finished if the user wants to hide/show the shadows or take other actions.