### PR TITLE
Node Graph Editor : new smart expand of selections with SHIFT

### DIFF
--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphCanvas.tsx
@@ -55,6 +55,8 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
     private _candidateLinkedHasMoved = false;
     private _x = 0;
     private _y = 0;
+    private _lastx = 0;
+    private _lasty = 0;
     private _zoom = 1;
     private _selectedNodes: GraphNode[] = [];
     private _selectedLink: Nullable<NodeLink> = null;
@@ -69,6 +71,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
     private _nodeDataContentList = new Array<any>();
 
     private _altKeyIsPressed = false;
+    private _shiftKeyIsPressed = false;
     private _multiKeyIsPressed = false;
     private _oldY = -1;
 
@@ -234,7 +237,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
                         }
                     } else {
                         if (selection instanceof GraphFrame) {
-                            if (this._multiKeyIsPressed || forceKeepSelection) {
+                            if (this._multiKeyIsPressed || this._shiftKeyIsPressed || forceKeepSelection) {
                                 if (!this._selectedFrameAndNodesConflict([selection], this._selectedNodes) && !this._selectedFrames.includes(selection)) {
                                     this._selectedFrames.push(selection);
                                 }
@@ -245,7 +248,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
                                 this._selectedPort = null;
                             }
                         } else if (selection instanceof GraphNode) {
-                            if (this._multiKeyIsPressed || forceKeepSelection) {
+                            if (this._multiKeyIsPressed || this._shiftKeyIsPressed || forceKeepSelection) {
                                 if (!this._selectedFrameAndNodesConflict(this._selectedFrames, [selection]) && !this._selectedNodes.includes(selection)) {
                                     this._selectedNodes.push(selection);
                                 }
@@ -274,6 +277,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             "keydown",
             (evt) => {
                 this._altKeyIsPressed = evt.altKey;
+                this._shiftKeyIsPressed = evt.shiftKey;
                 this._multiKeyIsPressed = evt.ctrlKey || evt.metaKey;
             },
             false
@@ -282,6 +286,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             "blur",
             () => {
                 this._altKeyIsPressed = false;
+                this._shiftKeyIsPressed = false;
                 this._multiKeyIsPressed = false;
             },
             false
@@ -727,6 +732,7 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
 
     onKeyUp() {
         this._altKeyIsPressed = false;
+        this._shiftKeyIsPressed = false;
         this._multiKeyIsPressed = false;
         this._oldY = -1;
     }
@@ -1086,14 +1092,20 @@ export class GraphCanvasComponent extends React.Component<IGraphCanvasComponentP
             return;
         }
 
-        this.props.stateManager.onSelectionChangedObservable.notifyObservers(null);
         this._mouseStartPointX = evt.clientX;
         this._mouseStartPointY = evt.clientY;
+        this._lastx = this.x;
+        this._lasty = this.y;
     }
 
     onUp(evt: React.PointerEvent) {
         if (this.stateManager.modalIsDisplayed) {
             return;
+        }
+
+        // Un select with no move click, 1 pixel tolerance
+        if (!this._selectionBox && !this._frameCandidate && Math.abs(this.x - this._lastx) < 2 && Math.abs(this.y - this._lasty) < 2) {
+            this.props.stateManager.onSelectionChangedObservable.notifyObservers(null);
         }
 
         this._mouseStartPointX = null;

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -52,7 +52,6 @@ export class GraphNode {
     private _onUpdateRequiredObserver: Nullable<Observer<Nullable<INodeData>>>;
     private _onHighlightNodeObserver: Nullable<Observer<any>>;
     private _ownerCanvas: GraphCanvasComponent;
-    private _isSelected: boolean;
     private _displayManager: Nullable<IDisplayManager> = null;
     private _isVisible = true;
     private _enclosingFrameId = -1;
@@ -171,10 +170,6 @@ export class GraphNode {
         return this.content.name;
     }
 
-    public get isSelected() {
-        return this._isSelected;
-    }
-
     public get enclosingFrameId() {
         return this._enclosingFrameId;
     }
@@ -183,17 +178,7 @@ export class GraphNode {
         this._enclosingFrameId = value;
     }
 
-    public set isSelected(value: boolean) {
-        this.setIsSelected(value, false);
-    }
-
     public setIsSelected(value: boolean, marqueeSelection: boolean) {
-        if (this._isSelected === value) {
-            return;
-        }
-
-        this._isSelected = value;
-
         if (!value) {
             this._visual.classList.remove(localStyles["selected"]);
             const indexInSelection = this._ownerCanvas.selectedNodes.indexOf(this);
@@ -506,17 +491,13 @@ export class GraphNode {
                 // Simple click
                 const middle = this._searchMiddle(last);
                 for (const node of middle) {
-                    if (!node.isSelected) {
-                        this._stateManager.onSelectionChangedObservable.notifyObservers({ selection: node });
-                    }
+                    this._stateManager.onSelectionChangedObservable.notifyObservers({ selection: node });
                 }
             } else {
                 // Double click
                 const queue = this._expand(last);
                 for (const node of queue) {
-                    if (!node.isSelected) {
-                        this._stateManager.onSelectionChangedObservable.notifyObservers({ selection: node });
-                    }
+                    this._stateManager.onSelectionChangedObservable.notifyObservers({ selection: node });
                 }
             }
         }

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -421,7 +421,7 @@ export class GraphNode {
 
     // Search nodes is direction of node from this
     private _expand(node: GraphNode) {
-        let queue: GraphNode[] = [];
+        const queue: GraphNode[] = [];
         let right = undefined;
         for (const link of this.links) {
             if (link.nodeA == this && link.nodeB == node) {

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -57,6 +57,7 @@ export class GraphNode {
     private _isVisible = true;
     private _enclosingFrameId = -1;
     private _visualPropertiesRefresh: Array<() => void> = [];
+    private _lastClick = 0.0;
 
     public addClassToVisual(className: string) {
         this._visual.classList.add(className);
@@ -418,6 +419,72 @@ export class GraphNode {
         this.content.prepareHeaderIcon(this._headerIcon, this._headerIconImg);
     }
 
+    // Search nodes is direction of node from this
+    private _expand(node: GraphNode) {
+        let queue: GraphNode[] = [];
+        let right = undefined;
+        for (const link of this.links) {
+            if (link.nodeA == this && link.nodeB == node) {
+                right = false;
+            }
+            if (link.nodeB == this && link.nodeA == node) {
+                right = true;
+            }
+        }
+        if (right != undefined) {
+            const loop = (right: boolean) => {
+                const last = queue[queue.length - 1];
+                for (const link of last.links) {
+                    if (right && link.nodeA == last && link.nodeB != undefined) {
+                        queue.push(link.nodeB);
+                        loop(right);
+                    }
+                    if (!right && link.nodeB == last && link.nodeA != undefined) {
+                        queue.push(link.nodeA);
+                        loop(right);
+                    }
+                }
+            };
+            queue.push(node);
+            loop(right);
+        }
+        return queue;
+    }
+
+    // Search nodes between node and this
+    private _searchMiddle(node: GraphNode) {
+        let middle: GraphNode[] = [];
+        const loop = (nodes: GraphNode[], right: boolean) => {
+            const last = nodes[nodes.length - 1];
+            for (const link of last.links) {
+                const newNodes = Object.assign([], nodes);
+                if (right && link.nodeA == last && link.nodeB != undefined) {
+                    newNodes.push(link.nodeB);
+                    if (link.nodeB == this) {
+                        middle = newNodes;
+                        return;
+                    } else {
+                        loop(newNodes, right);
+                    }
+                }
+                if (!right && link.nodeB == last && link.nodeA != undefined) {
+                    newNodes.push(link.nodeA);
+                    if (link.nodeA == this) {
+                        middle = newNodes;
+                        return;
+                    } else {
+                        loop(newNodes, right);
+                    }
+                }
+            }
+        };
+        loop([node], true);
+        if (!middle.length) {
+            loop([node], false);
+        }
+        return middle;
+    }
+
     private _onDown(evt: PointerEvent) {
         // Check if this is coming from the port
         if (evt.target && (evt.target as HTMLElement).nodeName === "IMG" && (evt.target as HTMLElement).draggable) {
@@ -431,6 +498,29 @@ export class GraphNode {
             this.setIsSelected(false, false);
         }
 
+        // Shift key
+        if (evt.shiftKey && this._ownerCanvas.selectedNodes.length > 1) {
+            // Last selected
+            const last = this._ownerCanvas.selectedNodes[this._ownerCanvas.selectedNodes.length - 2];
+            if (performance.now() - this._lastClick > 300) {
+                // Simple click
+                const middle = this._searchMiddle(last);
+                for (const node of middle) {
+                    if (!node.isSelected) {
+                        this._stateManager.onSelectionChangedObservable.notifyObservers({ selection: node });
+                    }
+                }
+            } else {
+                // Double click
+                const queue = this._expand(last);
+                for (const node of queue) {
+                    if (!node.isSelected) {
+                        this._stateManager.onSelectionChangedObservable.notifyObservers({ selection: node });
+                    }
+                }
+            }
+        }
+
         evt.stopPropagation();
 
         for (const selectedNode of this._ownerCanvas.selectedNodes) {
@@ -441,6 +531,8 @@ export class GraphNode {
         this._mouseStartPointY = evt.clientY;
 
         this._visual.setPointerCapture(evt.pointerId);
+
+        this._lastClick = performance.now();
     }
 
     public cleanAccumulation(useCeil = false) {
@@ -509,50 +601,20 @@ export class GraphNode {
         this._stateManager.onNodeMovedObservable.notifyObservers(this);
     }
 
-    private _attach(attached: GraphNode[], right: boolean) {
-        for (const link of this.links) {
-            if (right && link.nodeA == this && link.nodeB != undefined && !attached.includes(link.nodeB)) {
-                attached.push(link.nodeB);
-                link.nodeB._attach(attached, right);
-            }
-            if (!right && link.nodeB == this && link.nodeA != undefined && !attached.includes(link.nodeA)) {
-                attached.push(link.nodeA);
-                link.nodeA._attach(attached, right);
-            }
-        }
-    }
-
     private _onMove(evt: PointerEvent) {
         this._ownerCanvas._targetLinkCandidate = null;
         if (this._mouseStartPointX === null || this._mouseStartPointY === null || evt.ctrlKey) {
             return;
         }
 
-        // Delta
+        // Move
         const newX = (evt.clientX - this._mouseStartPointX) / this._ownerCanvas.zoom;
         const newY = (evt.clientY - this._mouseStartPointY) / this._ownerCanvas.zoom;
 
-        // Move selected
         for (const selectedNode of this._ownerCanvas.selectedNodes) {
             selectedNode.x += newX;
             selectedNode.y += newY;
         }
-
-        // Move attached (Shift / Alt)
-        const attached: Array<GraphNode> = [];
-        if (evt.shiftKey) {
-            this._attach(attached, false);
-        } else if (evt.altKey) {
-            this._attach(attached, true);
-        }
-        for (const attachedNode of attached) {
-            if (!this._ownerCanvas.selectedNodes.includes(attachedNode)) {
-                attachedNode.x += newX;
-                attachedNode.y += newY;
-            }
-        }
-
-        // Move frame
         for (const frame of this._ownerCanvas.selectedFrames) {
             frame._moveFrame(newX, newY);
         }


### PR DESCRIPTION
Following discussion with @PatrickRyanMS in this topic : [Node Editors : Enhancing Node Manipulation](https://forum.babylonjs.com/t/node-editors-enhancing-node-manipulation/50573)

I edited the behavior to do like so :

- No more use if `ALT` key
- Select with `SHIFT` adds to the selection, just like `CTRL`
- `_searchMiddle` : In addition, select with `SHIFT` will look for a direct link from `LAST_SELECTED` to `SELECTED`, and select all in between
- `_expand` : If 2 nodes A & B are neightboors, select A, `SHIFT` and `DOUBLE CLICK` B --> Will select all in direction of B, following links