### PR TITLE
Add an option for specifying the default material variant

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
@@ -40,6 +40,11 @@ declare module "../../glTFFileLoader" {
         // NOTE: Don't use NAME here as it will break the UMD type declarations.
         ["KHR_materials_variants"]: Partial<{
             /**
+             * Specifies the name of the variant that should be selected by default.
+             */
+            defaultVariant: string;
+
+            /**
              * Defines a callback that will be called if material variants are loaded.
              * @experimental
              */
@@ -218,7 +223,12 @@ export class KHR_materials_variants implements IGLTFLoaderExtension {
     public onReady(): void {
         const rootNode = this._loader.rootBabylonMesh;
         if (rootNode) {
-            this._loader.parent.extensionOptions[NAME]?.onLoaded?.({
+            const options = this._loader.parent.extensionOptions[NAME];
+            if (options?.defaultVariant) {
+                KHR_materials_variants.SelectVariant(rootNode, options.defaultVariant);
+            }
+
+            options?.onLoaded?.({
                 get variants() {
                     return KHR_materials_variants.GetAvailableVariants(rootNode);
                 },


### PR DESCRIPTION
This is not a bug fix, but a small improvement that became apparent when I was creating a demo for loader options. In addition to being able to provide a callback option to receive a material variants controller, you should also be able to simply specify the default material variant.