### PR TITLE
Correct CDN BASE URL handling for versions, snapshots, and local environments

### DIFF
--- a/packages/tools/guiEditor/public/index.js
+++ b/packages/tools/guiEditor/public/index.js
@@ -86,6 +86,18 @@ let checkBabylonVersionAsync = function () {
 
     return new Promise((resolve) => {
         loadInSequence(frameworkScripts, 0, resolve);
+    }).then(() => {
+        // if local, set the default base URL
+        if (snapshot) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/" + snapshot;
+        } else if (version) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
+        } else if (activeVersion === "local") {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+        }
     });
 };
 

--- a/packages/tools/nodeEditor/public/index.js
+++ b/packages/tools/nodeEditor/public/index.js
@@ -88,6 +88,18 @@ let checkBabylonVersionAsync = function () {
 
     return new Promise((resolve) => {
         loadInSequence(frameworkScripts, 0, resolve);
+    }).then(() => {
+        // if local, set the default base URL
+        if (snapshot) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/" + snapshot;
+        } else if (version) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
+        } else if (activeVersion === "local") {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+        }
     });
 };
 

--- a/packages/tools/nodeGeometryEditor/public/index.js
+++ b/packages/tools/nodeGeometryEditor/public/index.js
@@ -91,6 +91,18 @@ let checkBabylonVersionAsync = function () {
 
     return new Promise((resolve) => {
         loadInSequence(frameworkScripts, 0, resolve);
+    }).then(() => {
+        // if local, set the default base URL
+        if (snapshot) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/" + snapshot;
+        } else if (version) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
+        } else if (activeVersion === "local") {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+        }
     });
 };
 

--- a/packages/tools/nodeRenderGraphEditor/public/index.js
+++ b/packages/tools/nodeRenderGraphEditor/public/index.js
@@ -82,6 +82,18 @@ let checkBabylonVersionAsync = function () {
 
     return new Promise((resolve) => {
         loadInSequence(frameworkScripts, 0, resolve);
+    }).then(() => {
+        // if local, set the default base URL
+        if (snapshot) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/" + snapshot;
+        } else if (version) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
+        } else if (activeVersion === "local") {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+        }
     });
 };
 

--- a/packages/tools/sandbox/public/index.js
+++ b/packages/tools/sandbox/public/index.js
@@ -95,6 +95,18 @@ let checkBabylonVersionAsync = function () {
 
     return new Promise((resolve, _reject) => {
         loadInSequence(versions, 0, resolve);
+    }).then(() => {
+        // if local, set the default base URL
+        if (snapshot) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/" + snapshot;
+        } else if (version) {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
+        } else if (activeVersion === "local") {
+            // eslint-disable-next-line no-undef
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+        }
     });
 };
 


### PR DESCRIPTION
Update the logic to set the correct base URL for Babylon tools based on the current environment, ensuring proper loading of resources for snapshots, specific versions, and local setups.