### PR TITLE
Get old audio engine working in playgrounds that use `BABYLON.Sound`

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -2026,7 +2026,6 @@ export abstract class AbstractEngine {
         options.deterministicLockstep = options.deterministicLockstep ?? false;
         options.lockstepMaxSteps = options.lockstepMaxSteps ?? 4;
         options.timeStep = options.timeStep ?? 1 / 60;
-        options.audioEngine = options.audioEngine ?? false;
         options.stencil = options.stencil ?? true;
 
         this._audioContext = options.audioEngineOptions?.audioContext ?? null;


### PR DESCRIPTION
The previous change to the `audioEngine` option that changes its default from `true` to `false` broke the playground code that initializes the old audio engine when `BABYLON.Sound` is found in the playground's user code.

This change fixes the issue by leaving the `audioEngine` undefined if it is not defined in the playground's user code. This gets the playground's old audio engine init code working correctly without breaking the edge cases fixed in similar previous PRs.