### PR TITLE
Viewer and Configurator small improvements

### DIFF
--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
@@ -36,7 +36,7 @@ import { LoadModel, PickModel } from "../../modelLoader";
 import { ExpandableMessageLineComponent } from "../misc/ExpandableMessageLineComponent";
 import { FontAwesomeIconButton } from "../misc/FontAwesomeIconButton";
 
-const defaultModelUrl = "https://assets.babylonjs.com/meshes/aerobatic_plane.glb";
+const defaultModelUrl = "https://assets.babylonjs.com/meshes/Demos/optimized/acrobaticPlane_variants.glb";
 
 type HotSpotInfo = { name: string; id: string; data: HotSpot };
 
@@ -50,16 +50,6 @@ const toneMappingOptions = [
 const hotSpotTypeOptions = [{ label: "Surface", value: "surface" }] as const satisfies IInspectableOptions[];
 
 const hotSpotsDndModifers = [restrictToVerticalAxis, restrictToParentElement];
-
-function createDefaultAnnotation(hotSpotName: string) {
-    return `
-    <div style="display: flex">
-      <svg style="width: 20px; height: 20px; transform: translate(-50%, -50%)">
-        <ellipse cx="10" cy="10" rx="8" ry="8" fill="red" stroke="white" stroke-width="3" />
-      </svg>
-      <span style="color: black; background: white; border-radius: 6px; padding: 0px 3px; transform: translate(0%, -50%)">${hotSpotName}</span>
-    </div>` as const;
-}
 
 function useConfiguration<T>(
     defaultState: T,
@@ -376,7 +366,7 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         [viewer]
     );
 
-    const skyboxIntensityConfig = useConfiguration(
+    const environmentIntensityConfig = useConfiguration(
         viewer.environmentConfig.intensity,
         () => viewer.environmentConfig.intensity,
         (intensity) => (viewer.environmentConfig = { intensity }),
@@ -385,7 +375,7 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         [viewer]
     );
 
-    const skyboxRotationConfig = useConfiguration(
+    const environmentRotationConfig = useConfiguration(
         viewer.environmentConfig.rotation,
         () => viewer.environmentConfig.rotation,
         (rotation) => (viewer.environmentConfig = { rotation }),
@@ -596,11 +586,11 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
             if (skyboxBlurConfig.canReset) {
                 attributes.push(`skybox-blur="${skyboxBlurConfig.configuredState}"`);
             }
-            if (skyboxIntensityConfig.canReset) {
-                attributes.push(`skybox-intensity="${skyboxIntensityConfig.configuredState}"`);
+            if (environmentIntensityConfig.canReset) {
+                attributes.push(`skybox-intensity="${environmentIntensityConfig.configuredState}"`);
             }
-            if (skyboxRotationConfig.canReset) {
-                attributes.push(`skybox-rotation="${skyboxRotationConfig.configuredState}"`);
+            if (environmentRotationConfig.canReset) {
+                attributes.push(`skybox-rotation="${environmentRotationConfig.configuredState}"`);
             }
         } else {
             if (clearColorConfig.canReset) {
@@ -698,8 +688,8 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         skyboxUrlConfig.configuredState,
         hasSkybox,
         skyboxBlurConfig.configuredState,
-        skyboxIntensityConfig.configuredState,
-        skyboxRotationConfig.configuredState,
+        environmentIntensityConfig.configuredState,
+        environmentRotationConfig.configuredState,
         clearColorConfig.configuredState,
         toneMappingConfig.configuredState,
         contrastConfig.configuredState,
@@ -721,9 +711,7 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         if (hotspots.length === 0) {
             return "";
         }
-        const annotations = hotspots
-            .map((hotspot) => `  <babylon-viewer-annotation hotSpot="${hotspot.name}">${createDefaultAnnotation(hotspot.name)}\n  </babylon-viewer-annotation>`)
-            .join("\n");
+        const annotations = hotspots.map((hotspot) => `  <babylon-viewer-annotation hotSpot="${hotspot.name}"></babylon-viewer-annotation>`).join("\n");
         return `\n  <!-- Annotations are optional HTML child elements that track hot spots. -->\n${annotations}`;
     }, [hotspots]);
 
@@ -905,7 +893,6 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         for (const hotspot of hotspots) {
             const annotation = new HTML3DAnnotationElement();
             annotation.hotSpot = hotspot.name;
-            annotation.innerHTML = createDefaultAnnotation(hotspot.name);
             viewerElement.appendChild(annotation);
         }
     }, [viewerElement, hotspots]);
@@ -930,8 +917,8 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         skyboxUrlConfig.reset();
         onSyncEnvironmentChanged();
         skyboxBlurConfig.reset();
-        skyboxIntensityConfig.reset();
-        skyboxRotationConfig.reset();
+        environmentIntensityConfig.reset();
+        environmentRotationConfig.reset();
         clearColorConfig.reset();
         toneMappingConfig.reset();
         contrastConfig.reset();
@@ -949,8 +936,8 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
         skyboxUrlConfig.reset,
         onSyncEnvironmentChanged,
         skyboxBlurConfig.reset,
-        skyboxIntensityConfig.reset,
-        skyboxRotationConfig.reset,
+        environmentIntensityConfig.reset,
+        environmentRotationConfig.reset,
         clearColorConfig.reset,
         toneMappingConfig.reset,
         contrastConfig.reset,
@@ -1041,7 +1028,7 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
                         <div>
                             <div style={{ flex: 1 }}>
                                 <SliderLineComponent
-                                    label="Skybox Blur"
+                                    label="Blur"
                                     directValue={skyboxBlurConfig.configuredState}
                                     minimum={0}
                                     maximum={1}
@@ -1054,45 +1041,50 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
                             </div>
                             <FontAwesomeIconButton title="Reset skybox blur" icon={faTrashCan} disabled={!skyboxBlurConfig.canReset} onClick={skyboxBlurConfig.reset} />
                         </div>
-                        <div>
-                            <div style={{ flex: 1 }}>
-                                <SliderLineComponent
-                                    label="Skybox Intensity"
-                                    directValue={skyboxIntensityConfig.configuredState}
-                                    minimum={0}
-                                    maximum={5}
-                                    step={0.01}
-                                    decimalCount={2}
-                                    target={viewerDetails.scene}
-                                    onChange={skyboxIntensityConfig.update}
-                                    lockObject={lockObject}
-                                />
-                            </div>
-                            <FontAwesomeIconButton
-                                title="Reset skybox intensity"
-                                icon={faTrashCan}
-                                disabled={!skyboxIntensityConfig.canReset}
-                                onClick={skyboxIntensityConfig.reset}
-                            />
-                        </div>
-                        <div>
-                            <div style={{ flex: 1 }}>
-                                <SliderLineComponent
-                                    label="Skybox Rotation"
-                                    directValue={skyboxRotationConfig.configuredState}
-                                    minimum={0}
-                                    maximum={2 * Math.PI}
-                                    step={0.01}
-                                    decimalCount={2}
-                                    target={viewerDetails.scene}
-                                    onChange={skyboxRotationConfig.update}
-                                    lockObject={lockObject}
-                                />
-                            </div>
-                            <FontAwesomeIconButton title="Reset skybox rotation" icon={faTrashCan} disabled={!skyboxRotationConfig.canReset} onClick={skyboxRotationConfig.reset} />
-                        </div>
                     </>
                 )}
+                <div>
+                    <div style={{ flex: 1 }}>
+                        <SliderLineComponent
+                            label="Intensity"
+                            directValue={environmentIntensityConfig.configuredState}
+                            minimum={0}
+                            maximum={5}
+                            step={0.01}
+                            decimalCount={2}
+                            target={viewerDetails.scene}
+                            onChange={environmentIntensityConfig.update}
+                            lockObject={lockObject}
+                        />
+                    </div>
+                    <FontAwesomeIconButton
+                        title="Reset skybox intensity"
+                        icon={faTrashCan}
+                        disabled={!environmentIntensityConfig.canReset}
+                        onClick={environmentIntensityConfig.reset}
+                    />
+                </div>
+                <div>
+                    <div style={{ flex: 1 }}>
+                        <SliderLineComponent
+                            label="Rotation"
+                            directValue={environmentRotationConfig.configuredState}
+                            minimum={0}
+                            maximum={2 * Math.PI}
+                            step={0.01}
+                            decimalCount={2}
+                            target={viewerDetails.scene}
+                            onChange={environmentRotationConfig.update}
+                            lockObject={lockObject}
+                        />
+                    </div>
+                    <FontAwesomeIconButton
+                        title="Reset skybox rotation"
+                        icon={faTrashCan}
+                        disabled={!environmentRotationConfig.canReset}
+                        onClick={environmentRotationConfig.reset}
+                    />
+                </div>
                 <div style={{ height: "auto" }}>
                     <div style={{ flex: 1 }}>
                         <Color4LineComponent

--- a/packages/tools/viewer/src/viewerAnnotationElement.ts
+++ b/packages/tools/viewer/src/viewerAnnotationElement.ts
@@ -18,6 +18,8 @@ export class HTML3DAnnotationElement extends LitElement {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public static override styles = css`
         :host {
+            --annotation-foreground-color: black;
+            --annotation-background-color: white;
             display: inline-block;
             position: absolute;
             transition: opacity 0.25s;
@@ -40,7 +42,8 @@ export class HTML3DAnnotationElement extends LitElement {
             font-size: 14px;
             padding: 0px 6px;
             border-radius: 6px;
-            background-color: white;
+            color: var(--annotation-foreground-color);
+            background-color: var(--annotation-background-color);
         }
 
         .annotation::after {

--- a/packages/tools/viewer/src/viewerAnnotationElement.ts
+++ b/packages/tools/viewer/src/viewerAnnotationElement.ts
@@ -22,14 +22,36 @@ export class HTML3DAnnotationElement extends LitElement {
             position: absolute;
             transition: opacity 0.25s;
         }
+
         :host([hidden]) {
             display: none;
         }
+
         :host(:state(back-facing)) {
             opacity: 0.2;
         }
+
         :host(:state(invalid)) {
             display: none;
+        }
+
+        .annotation {
+            transform: translate(-50%, -135%);
+            font-size: 14px;
+            padding: 0px 6px;
+            border-radius: 6px;
+            background-color: white;
+        }
+
+        .annotation::after {
+            content: "";
+            position: absolute;
+            left: 50%;
+            height: 60%;
+            aspect-ratio: 1;
+            transform: translate(-50%, 110%) rotate(-45deg);
+            background-color: inherit;
+            clip-path: polygon(0 0, 100% 100%, 0 100%, 0 0);
         }
     `;
 
@@ -119,7 +141,7 @@ export class HTML3DAnnotationElement extends LitElement {
     /** @internal */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     protected override render() {
-        return html` <slot></slot> `;
+        return html` <slot><div aria-label="${this.hotSpot} annotation" part="annotation" class="annotation">${this.hotSpot}</div></slot> `;
     }
 
     /** @internal */

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1142,7 +1142,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     protected _renderReloadButton(): TemplateResult {
         return html`${this._isFaulted
             ? html`
-                  <button class="reload-button" @click="${this._setupViewer}">
+                  <button aria-label="Reload" part="reload-button" class="reload-button" @click="${this._setupViewer}">
                       <svg viewBox="0 0 24 24">
                           <path d="${arrowClockwiseFilledIcon}" fill="currentColor"></path>
                       </svg>

--- a/packages/tools/viewer/test/apps/web/index.html
+++ b/packages/tools/viewer/test/apps/web/index.html
@@ -42,6 +42,10 @@
                 background-image: url("https://raw.githubusercontent.com/BabylonJS/Assets/master/textures/Checker_albedo.png");
             }
 
+            babylon-viewer-annotation[hotspot="thruster"]::part(annotation) {
+                background-color: orange;
+            }
+
             /* babylon-viewer-annotation:state(back-facing) {
                 display: none;
              } */
@@ -123,12 +127,8 @@
                         </svg>
                     </div>
                 </babylon-viewer-annotation>
-                <babylon-viewer-annotation hotspot="thruster">
-                    <div style="background-color: aliceblue; border-radius: 8px; padding: 3px 6px">Thruster</div>
-                </babylon-viewer-annotation>
-                <babylon-viewer-annotation hotspot="poi">
-                    <div style="background-color: aliceblue; border-radius: 8px; padding: 3px 6px">World Space POI</div>
-                </babylon-viewer-annotation>
+                <babylon-viewer-annotation hotspot="thruster"></babylon-viewer-annotation>
+                <babylon-viewer-annotation hotspot="poi"></babylon-viewer-annotation>
             </babylon-viewer>
         </div>
         <div id="moreLowerPageContent" style="width: 100%; height: 200vh; display: none"></div>


### PR DESCRIPTION
- Configurator: Switch to the updated airplane model as the default configurator model.
- Configurator: Move environment intensity/rotation out of the section that is conditional on having a skybox (they apply to both lighting and skybox).
- Viewer: Add a simple default UI for viewer annotations (hotspot name with a little down arrow, as seen below). This default UI can have custom styling applied to it, or it can be fully replaced with custom UI by simply adding child elements to `<babylon-viewer-annotation>` (as seen in the index.html of the test app).

Default annotation example:
![image](https://github.com/user-attachments/assets/df2edd46-61d9-4b02-8eab-90defebfeaaa)
