### PR TITLE
Improve audio engine API

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -40,7 +40,7 @@ export class _SpatialAudioAttacherComponent {
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the scene node's bounding box for positioning. Defaults to `false`.
-     * @param attachmentType Whather to attach to the scene node's position and/or rotation. Defaults to `PositionAndRotation`.
+     * @param attachmentType Whether to attach to the scene node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
     public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean, attachmentType: SpatialAudioAttachmentType): void {
         if (this._sceneNode === sceneNode) {

--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -90,14 +90,14 @@ export class _SpatialAudioAttacherComponent {
             }
 
             this._spatialAudioNode.position.copyFrom(this._position);
-            this._spatialAudioNode.updatePosition();
+            this._spatialAudioNode._updatePosition();
         }
 
         if (this._attachmentType & SpatialAudioAttachmentType.Rotation) {
             this._sceneNode?.getWorldMatrix().decompose(undefined, this._rotationQuaternion, undefined);
 
             this._spatialAudioNode.rotationQuaternion.copyFrom(this._rotationQuaternion);
-            this._spatialAudioNode.updateRotation();
+            this._spatialAudioNode._updateRotation();
         }
     }
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -34,12 +34,23 @@ export class _SpatialAudioAttacherComponent {
 
     /**
      * Attaches a scene object.
+     *
+     * If `sceneNode` is `null` it is the same as calling `detach()`.
+     *
      * @param sceneNode The scene node to attach to.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
      * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
-    public attach(sceneNode: Node, useBoundingBox: boolean, attachmentType: SpatialAudioAttachmentType): void {
+    public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean, attachmentType: SpatialAudioAttachmentType): void {
+        if (this._sceneNode === sceneNode) {
+            return;
+        }
+
         this.detach();
+
+        if (!sceneNode) {
+            return;
+        }
 
         this._attachmentType = attachmentType;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -26,20 +26,21 @@ export class _SpatialAudioAttacherComponent {
     }
 
     /**
-     * Returns `true` if the audio listener or source is attached to an entity; otherwise returns `false`.
+     * Returns `true` if attached to a scene node; otherwise returns `false`.
      */
     public get isAttached(): boolean {
         return this._sceneNode !== null;
     }
 
     /**
-     * Attaches a scene object.
+     * Attaches to a scene node.
      *
+     * Detaches automatically before attaching to the given scene node.
      * If `sceneNode` is `null` it is the same as calling `detach()`.
      *
-     * @param sceneNode The scene node to attach to.
-     * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
-     * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
+     * @param sceneNode The scene node to attach to, or `null` to detach.
+     * @param useBoundingBox Whether to use the scene node's bounding box for positioning. Defaults to `false`.
+     * @param attachmentType Whather to attach to the scene node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
     public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean, attachmentType: SpatialAudioAttachmentType): void {
         if (this._sceneNode === sceneNode) {
@@ -61,7 +62,7 @@ export class _SpatialAudioAttacherComponent {
     }
 
     /**
-     * Detaches the attached entity.
+     * Detaches from the scene node if attached.
      */
     public detach() {
         this._sceneNode?.onDisposeObservable.removeCallback(this.dispose);
@@ -76,7 +77,9 @@ export class _SpatialAudioAttacherComponent {
     };
 
     /**
-     * Updates the audio listener or source.
+     * Updates the position and rotation of the associated audio engine object in the audio rendering graph.
+     *
+     * This is called automatically by default and only needs to be called manually if automatic updates are disabled.
      */
     public update() {
         if (this._attachmentType & SpatialAudioAttachmentType.Position) {

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
@@ -23,9 +23,9 @@ export abstract class _SpatialAudioSubNode extends _AbstractAudioSubNode {
     public abstract coneOuterVolume: number;
     public abstract distanceModel: DistanceModelType;
     public abstract maxDistance: number;
+    public abstract minDistance: number;
     public abstract panningModel: PanningModelType;
     public abstract position: Vector3;
-    public abstract referenceDistance: number;
     public abstract rolloffFactor: number;
     public abstract rotation: Vector3;
     public abstract rotationQuaternion: Quaternion;
@@ -67,8 +67,8 @@ export abstract class _SpatialAudioSubNode extends _AbstractAudioSubNode {
         this.coneOuterVolume = options.spatialConeOuterVolume ?? _SpatialAudioDefaults.coneOuterVolume;
         this.distanceModel = options.spatialDistanceModel ?? _SpatialAudioDefaults.distanceModel;
         this.maxDistance = options.spatialMaxDistance ?? _SpatialAudioDefaults.maxDistance;
+        this.minDistance = options.spatialMinDistance ?? _SpatialAudioDefaults.minDistance;
         this.panningModel = options.spatialPanningModel ?? _SpatialAudioDefaults.panningModel;
-        this.referenceDistance = options.spatialReferenceDistance ?? _SpatialAudioDefaults.referenceDistance;
         this.rolloffFactor = options.spatialRolloffFactor ?? _SpatialAudioDefaults.rolloffFactor;
 
         if (options.spatialPosition) {

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
@@ -91,13 +91,13 @@ export abstract class _SpatialAudioSubNode extends _AbstractAudioSubNode {
         if (this.isAttached) {
             this._attacherComponent?.update();
         } else {
-            this.updatePosition();
-            this.updateRotation();
+            this._updatePosition();
+            this._updateRotation();
         }
     }
 
-    public abstract updatePosition(): void;
-    public abstract updateRotation(): void;
+    public abstract _updatePosition(): void;
+    public abstract _updateRotation(): void;
 }
 
 /** @internal */

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
@@ -37,7 +37,7 @@ export abstract class _SpatialAudioSubNode extends _AbstractAudioSubNode {
     }
 
     /** @internal */
-    public attach(sceneNode: Node, useBoundingBox: boolean, attachmentType: SpatialAudioAttachmentType): void {
+    public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean, attachmentType: SpatialAudioAttachmentType): void {
         this.detach();
 
         if (!this._attacherComponent) {

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -7,7 +7,7 @@ export const _SpatialAudioDefaults = {
     coneInnerAngle: 6.28318530718 as number,
     coneOuterAngle: 6.28318530718 as number,
     coneOuterVolume: 0 as number,
-    distanceModel: "inverse" as DistanceModelType,
+    distanceModel: "linear" as DistanceModelType,
     maxDistance: 10000 as number,
     panningModel: "equalpower" as PanningModelType,
     position: Vector3.Zero(),

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -1,5 +1,6 @@
 import { Quaternion, Vector3 } from "../../../Maths/math.vector";
 import type { Node } from "../../../node";
+import type { Nullable } from "../../../types";
 import type { SpatialAudioAttachmentType } from "../../spatialAudioAttachmentType";
 
 export const _SpatialAudioDefaults = {
@@ -226,11 +227,14 @@ export abstract class AbstractSpatialAudio {
 
     /**
      * Attaches the audio source to a scene object.
-     * @param sceneNode The scene node to attach the audio source to.
+     *
+     * If `sceneNode` is `null` it is the same as calling `detach()`.
+     *
+     * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
      * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
-    public abstract attach(sceneNode: Node, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
+    public abstract attach(sceneNode: Nullable<Node>, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
 
     /**
      * Detaches the audio source from the currently attached graphics node.

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -226,8 +226,9 @@ export abstract class AbstractSpatialAudio {
     public abstract rotationQuaternion: Quaternion;
 
     /**
-     * Attaches the audio source to a scene object.
+     * Attaches to a scene node.
      *
+     * Detaches automatically before attaching to the given scene node.
      * If `sceneNode` is `null` it is the same as calling `detach()`.
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
@@ -237,11 +238,14 @@ export abstract class AbstractSpatialAudio {
     public abstract attach(sceneNode: Nullable<Node>, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
 
     /**
-     * Detaches the audio source from the currently attached graphics node.
+     * Detaches from the scene node if attached.
      */
     public abstract detach(): void;
+
     /**
-     * Updates the position and rotation in the audio engine to the current values.
+     * Updates the position and rotation of the associated audio engine object in the audio rendering graph.
+     *
+     * This is called automatically by default and only needs to be called manually if automatic updates are disabled.
      */
     public abstract update(): void;
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -233,7 +233,7 @@ export abstract class AbstractSpatialAudio {
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
-     * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
+     * @param attachmentType Whether to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
     public abstract attach(sceneNode: Nullable<Node>, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -9,9 +9,9 @@ export const _SpatialAudioDefaults = {
     coneOuterVolume: 0 as number,
     distanceModel: "linear" as DistanceModelType,
     maxDistance: 10000 as number,
+    minDistance: 1 as number,
     panningModel: "equalpower" as PanningModelType,
     position: Vector3.Zero(),
-    referenceDistance: 1 as number,
     rolloffFactor: 1 as number,
     rotation: Vector3.Zero(),
     rotationQuaternion: new Quaternion(),
@@ -49,7 +49,7 @@ export interface ISpatialAudioOptions {
      * - `"exponential"`: The volume is reduced exponentially as the source moves away from the listener.
      *
      * @see {@link spatialMaxDistance}
-     * @see {@link spatialReferenceDistance}
+     * @see {@link spatialMinDistance}
      * @see {@link spatialRolloffFactor}
      */
     spatialDistanceModel: "linear" | "inverse" | "exponential";
@@ -91,7 +91,7 @@ export interface ISpatialAudioOptions {
      * - This value is used by all distance models.
      * @see {@link spatialDistanceModel}
      */
-    spatialReferenceDistance: number;
+    spatialMinDistance: number;
     /**
      * How quickly the volume is reduced as the source moves away from the listener. Defaults to 1.
      * - This value is used by all distance models.
@@ -121,10 +121,10 @@ export function _HasSpatialAudioOptions(options: Partial<ISpatialAudioOptions>):
         options.spatialConeOuterVolume !== undefined ||
         options.spatialDistanceModel !== undefined ||
         options.spatialMaxDistance !== undefined ||
+        options.spatialMinDistance !== undefined ||
         options.spatialMinUpdateTime !== undefined ||
         options.spatialPanningModel !== undefined ||
         options.spatialPosition !== undefined ||
-        options.spatialReferenceDistance !== undefined ||
         options.spatialRolloffFactor !== undefined ||
         options.spatialRotation !== undefined ||
         options.spatialRotationQuaternion !== undefined
@@ -164,7 +164,7 @@ export abstract class AbstractSpatialAudio {
      * - `"exponential"`: The volume is reduced exponentially as the source moves away from the listener.
      *
      * @see {@link spatialMaxDistance}
-     * @see {@link spatialReferenceDistance}
+     * @see {@link spatialMinDistance}
      * @see {@link spatialRolloffFactor}
      */
     public abstract distanceModel: "linear" | "inverse" | "exponential";
@@ -180,6 +180,13 @@ export abstract class AbstractSpatialAudio {
      * @see {@link distanceModel}
      */
     public abstract maxDistance: number;
+
+    /**
+     * The distance for reducing volume as the audio source moves away from the listener – i.e. the distance the volume reduction starts at. Defaults to 1.
+     * - This value is used by all distance models.
+     * @see {@link distanceModel}
+     */
+    public abstract minDistance: number;
 
     /**
      * The minimum update time in seconds of the spatialization if it is attached to a mesh or transform node. Defaults to `0`.
@@ -200,13 +207,6 @@ export abstract class AbstractSpatialAudio {
      * The spatial position. Defaults to (0, 0, 0).
      */
     public abstract position: Vector3;
-
-    /**
-     * The distance for reducing volume as the audio source moves away from the listener – i.e. the distance the volume reduction starts at. Defaults to 1.
-     * - This value is used by all distance models.
-     * @see {@link distanceModel}
-     */
-    public abstract referenceDistance: number;
 
     /**
      * How quickly the volume is reduced as the source moves away from the listener. Defaults to 1.

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudioListener.ts
@@ -87,8 +87,9 @@ export abstract class AbstractSpatialAudioListener {
     public abstract rotationQuaternion: Quaternion;
 
     /**
-     * Attaches the audio source to a scene object.
+     * Attaches to a scene node.
      *
+     * Detaches automatically before attaching to the given scene node.
      * If `sceneNode` is `null` it is the same as calling `detach()`.
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
@@ -98,12 +99,14 @@ export abstract class AbstractSpatialAudioListener {
     public abstract attach(sceneNode: Nullable<Node>, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
 
     /**
-     * Detaches the audio source from the currently attached graphics node.
+     * Detaches from the scene node if attached.
      */
     public abstract detach(): void;
 
     /**
-     * Updates the position and rotation in the audio engine to the current values.
+     * Updates the position and rotation of the associated audio engine object in the audio rendering graph.
+     *
+     * This is called automatically by default and only needs to be called manually if automatic updates are disabled.
      */
     public abstract update(): void;
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudioListener.ts
@@ -1,5 +1,6 @@
 import { Quaternion, Vector3 } from "../../../Maths/math.vector";
 import type { Node } from "../../../node";
+import type { Nullable } from "../../../types";
 import type { SpatialAudioAttachmentType } from "../../spatialAudioAttachmentType";
 
 export const _SpatialAudioListenerDefaults = {
@@ -87,11 +88,14 @@ export abstract class AbstractSpatialAudioListener {
 
     /**
      * Attaches the audio source to a scene object.
-     * @param sceneNode The scene node to attach the audio source to.
+     *
+     * If `sceneNode` is `null` it is the same as calling `detach()`.
+     *
+     * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
      * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
-    public abstract attach(sceneNode: Node, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
+    public abstract attach(sceneNode: Nullable<Node>, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
 
     /**
      * Detaches the audio source from the currently attached graphics node.

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudioListener.ts
@@ -94,7 +94,7 @@ export abstract class AbstractSpatialAudioListener {
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
-     * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
+     * @param attachmentType Whether to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
     public abstract attach(sceneNode: Nullable<Node>, useBoundingBox?: boolean, attachmentType?: SpatialAudioAttachmentType): void;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -148,11 +148,14 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
 
     /**
      * Attaches the audio source to a scene object.
-     * @param sceneNode The scene node to attach the audio source to.
+     *
+     * If `sceneNode` is `null` it is the same as calling `detach()`.
+     *
+     * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
      * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
-    public attach(sceneNode: Node, useBoundingBox: boolean = false, attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation): void {
+    public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean = false, attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation): void {
         _GetSpatialAudioSubNode(this._subGraph)?.attach(sceneNode, useBoundingBox, attachmentType);
     }
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -195,7 +195,7 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
         const position = subNode.position;
         if (!position.equalsWithEpsilon(this._position)) {
             subNode.position.copyFrom(this._position);
-            subNode.updatePosition();
+            subNode._updatePosition();
         }
     }
 
@@ -210,10 +210,10 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
 
         if (!subNode.rotationQuaternion.equalsWithEpsilon(this._rotationQuaternion)) {
             subNode.rotationQuaternion.copyFrom(this._rotationQuaternion);
-            subNode.updateRotation();
+            subNode._updateRotation();
         } else if (!subNode.rotation.equalsWithEpsilon(this._rotation)) {
             subNode.rotation.copyFrom(this._rotation);
-            subNode.updateRotation();
+            subNode._updateRotation();
         }
     }
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -90,6 +90,15 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
     }
 
     /** @internal */
+    public get minDistance(): number {
+        return _GetSpatialAudioProperty(this._subGraph, "minDistance");
+    }
+
+    public set minDistance(value: number) {
+        _SetSpatialAudioProperty(this._subGraph, "minDistance", value);
+    }
+
+    /** @internal */
     public get panningModel(): PanningModelType {
         return _GetSpatialAudioProperty(this._subGraph, "panningModel");
     }
@@ -106,15 +115,6 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
     public set position(value: Vector3) {
         this._position = value;
         this._updatePosition();
-    }
-
-    /** @internal */
-    public get referenceDistance(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "referenceDistance");
-    }
-
-    public set referenceDistance(value: number) {
-        _SetSpatialAudioProperty(this._subGraph, "referenceDistance", value);
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -147,8 +147,9 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
     }
 
     /**
-     * Attaches the audio source to a scene object.
+     * Attaches to a scene node.
      *
+     * Detaches automatically before attaching to the given scene node.
      * If `sceneNode` is `null` it is the same as calling `detach()`.
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
@@ -160,7 +161,7 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
     }
 
     /**
-     * Detaches the audio source from the currently attached graphics node.
+     * Detaches from the scene node if attached.
      */
     public detach(): void {
         _GetSpatialAudioSubNode(this._subGraph)?.detach();

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -154,7 +154,7 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
-     * @param attachmentType Whather to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
+     * @param attachmentType Whether to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
     public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean = false, attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation): void {
         _GetSpatialAudioSubNode(this._subGraph)?.attach(sceneNode, useBoundingBox, attachmentType);

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudioListener.ts
@@ -71,6 +71,6 @@ export abstract class _SpatialAudioListener extends AbstractSpatialAudioListener
         this.update();
     }
 
-    public abstract updatePosition(): void;
-    public abstract updateRotation(): void;
+    public abstract _updatePosition(): void;
+    public abstract _updateRotation(): void;
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudioListener.ts
@@ -21,8 +21,9 @@ export abstract class _SpatialAudioListener extends AbstractSpatialAudioListener
     }
 
     /**
-     * Attaches the audio source to a scene object.
+     * Attaches to a scene node.
      *
+     * Detaches automatically before attaching to the given scene node.
      * If `sceneNode` is `null` it is the same as calling `detach()`.
      *
      * @param sceneNode The scene node to attach to, or `null` to detach.
@@ -37,7 +38,7 @@ export abstract class _SpatialAudioListener extends AbstractSpatialAudioListener
     }
 
     /**
-     * Detaches the audio source from the currently attached camera, mesh or transform node.
+     * Detaches from the scene node if attached.
      */
     public detach(): void {
         this._attacherComponent?.detach();

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudioListener.ts
@@ -22,11 +22,14 @@ export abstract class _SpatialAudioListener extends AbstractSpatialAudioListener
 
     /**
      * Attaches the audio source to a scene object.
-     * @param sceneNode The scene node to attach the audio source to.
+     *
+     * If `sceneNode` is `null` it is the same as calling `detach()`.
+     *
+     * @param sceneNode The scene node to attach to, or `null` to detach.
      * @param useBoundingBox Whether to use the bounding box of the node for positioning. Defaults to `false`.
      * @param attachmentType Whether to attach to the node's position and/or rotation. Defaults to `PositionAndRotation`.
      */
-    public attach(sceneNode: Node, useBoundingBox: boolean = false, attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation): void {
+    public attach(sceneNode: Nullable<Node>, useBoundingBox: boolean = false, attachmentType: SpatialAudioAttachmentType = SpatialAudioAttachmentType.PositionAndRotation): void {
         if (!this._attacherComponent) {
             this._attacherComponent = new _SpatialAudioAttacherComponent(this);
         }

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
@@ -86,6 +86,15 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     }
 
     /** @internal */
+    public get minDistance(): number {
+        return this.node.refDistance;
+    }
+
+    public set minDistance(value: number) {
+        this.node.refDistance = value;
+    }
+
+    /** @internal */
     public get maxDistance(): number {
         return this.node.maxDistance;
     }
@@ -101,15 +110,6 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
 
     public set panningModel(value: "equalpower" | "HRTF") {
         this.node.panningModel = value;
-    }
-
-    /** @internal */
-    public get referenceDistance(): number {
-        return this.node.refDistance;
-    }
-
-    public set referenceDistance(value: number) {
-        this.node.refDistance = value;
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
@@ -132,7 +132,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     }
 
     /** @internal */
-    public updatePosition(): void {
+    public _updatePosition(): void {
         if (this._lastPosition.equalsWithEpsilon(this.position)) {
             return;
         }
@@ -145,7 +145,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     }
 
     /** @internal */
-    public updateRotation(): void {
+    public _updateRotation(): void {
         if (!this._lastRotationQuaternion.equalsWithEpsilon(this.rotationQuaternion)) {
             TmpQuaternion.copyFrom(this.rotationQuaternion);
             this._lastRotationQuaternion.copyFrom(this.rotationQuaternion);

--- a/packages/dev/core/src/AudioV2/webAudio/subProperties/spatialWebAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subProperties/spatialWebAudioListener.ts
@@ -62,13 +62,13 @@ class _SpatialWebAudioListener extends _SpatialAudioListener {
         if (this.isAttached) {
             this._attacherComponent?.update();
         } else {
-            this.updatePosition();
-            this.updateRotation();
+            this._updatePosition();
+            this._updateRotation();
         }
     }
 
     /** @internal */
-    public updatePosition(): void {
+    public _updatePosition(): void {
         if (this._lastPosition.equalsWithEpsilon(this.position)) {
             return;
         }
@@ -82,7 +82,7 @@ class _SpatialWebAudioListener extends _SpatialAudioListener {
     }
 
     /** @internal */
-    public updateRotation(): void {
+    public _updateRotation(): void {
         if (!this._lastRotationQuaternion.equalsWithEpsilon(this.rotationQuaternion)) {
             TmpQuaternion.copyFrom(this.rotationQuaternion);
             this._lastRotationQuaternion.copyFrom(this.rotationQuaternion);


### PR DESCRIPTION
Makes improvements to the new audio engine API based on user testing and feedback. See forum thread https://forum.babylonjs.com/t/properly-setup-spatial-audio/57064.

This change brings in the following API improvements:
- [Make spatial audio attach function's sceneNode parameter nullable](https://github.com/BabylonJS/Babylon.js/commit/57ad4de4bf91b2f168d858f29ab901411a2452c8)
- [Improve spatial audio code docs](https://github.com/BabylonJS/Babylon.js/commit/2d751bd346654dc6de9dc091c5826ebd25621008)
- [Prefix internal spatial audio updatePosition/Rotation with underscore](https://github.com/BabylonJS/Babylon.js/commit/0701bf2f1887846681752e1a2dc771cd596c26d0)
- [Change spatial audio distanceModel default from "inverse" to "linear"](https://github.com/BabylonJS/Babylon.js/commit/0f4d52cbdd0a938f8d7a2b6103548fd1d5a3e9f9)
- [Rename spatial audio referenceDistance to minDistance](https://github.com/BabylonJS/Babylon.js/commit/e2508b4ccb9f07930c81025de343ab832def5023)
