### PR TITLE
Daily interactivity fixes

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
@@ -126,7 +126,7 @@ export class FlowGraphPlayAnimationBlock extends FlowGraphAsyncExecutionBlock {
             const from = this.from.getValue(context) ?? 0;
             // not accepting 0
             const to = this.to.getValue(context) || animationGroupToUse.to;
-            const loop = this.loop.getValue(context);
+            const loop = !isFinite(to) || this.loop.getValue(context);
             this.currentAnimationGroup.setValue(animationGroupToUse, context);
 
             const currentlyRunningAnimationGroups = context._getGlobalContextVariable("currentlyRunningAnimationGroups", []) as number[];

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/dynamic.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/dynamic.ts
@@ -180,4 +180,14 @@ export function registerBuiltInGLTFExtensions() {
         const { KHR_node_hoverability } = await import("./KHR_node_hoverability");
         return new KHR_node_hoverability(loader);
     });
+
+    registerGLTFExtension("KHR_interactivity", true, async (loader) => {
+        const { KHR_interactivity } = await import("./KHR_interactivity");
+        return new KHR_interactivity(loader);
+    });
+
+    registerGLTFExtension("KHR_node_selectability", true, async (loader) => {
+        const { KHR_node_selectability } = await import("./KHR_node_selectability");
+        return new KHR_node_selectability(loader);
+    });
 }


### PR DESCRIPTION
Introduce KHR_interactivity and KHR_node_selectability extensions to the GLTF loader. Fix the loop condition in FlowGraphPlayAnimationBlock to correctly handle non-finite 'to' values.