### PR TITLE
Viewer and configurator tiny fixes

### DIFF
--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.scss
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.scss
@@ -83,8 +83,8 @@
         }
 
         .docs {
-            transform: scale(0.9);
-            transform-origin: center;
+            transform: scale(1.3);
+            transform-origin: right center;
         }
     }
 

--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
@@ -8,7 +8,7 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import { closestCenter, DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { faFileLines } from "@fortawesome/free-regular-svg-icons";
+import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
 import { faBullseye, faCamera, faCheck, faCopy, faGripVertical, faRotateLeft, faSquarePlus, faTrashCan, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useCallback, useEffect, useMemo, useRef, useState, type FunctionComponent } from "react";
@@ -961,7 +961,7 @@ export const Configurator: FunctionComponent<{ viewerElement: ViewerElement; vie
                 <div className="configuratorHeader">
                     <img className="logo" src="https://www.babylonjs.com/Assets/logo-babylonjs-social-twitter.png" />
                     <div className="title">VIEWER CONFIGURATOR</div>
-                    <FontAwesomeIconButton className="docs" title="Documentation" icon={faFileLines} onClick={openDocumentation} />
+                    <FontAwesomeIconButton className="docs" title="Documentation" icon={faQuestionCircle} onClick={openDocumentation} />
                 </div>
                 <LineContainerComponent title="HTML SNIPPET">
                     <div className="flexColumn">

--- a/packages/tools/viewer/src/viewerAnnotationElement.ts
+++ b/packages/tools/viewer/src/viewerAnnotationElement.ts
@@ -59,6 +59,11 @@ export class HTML3DAnnotationElement extends LitElement {
     `;
 
     private readonly _internals = this.attachInternals();
+    private readonly _mutationObserver = new MutationObserver((mutations) => {
+        if (mutations.some((mutation) => mutation.type === "childList")) {
+            this._sanitizeInnerHTML();
+        }
+    });
     private _viewerAttachment: Nullable<IDisposable> = null;
     private _connectingAbortController: Nullable<AbortController> = null;
     private _updateAnnotation: Nullable<() => void> = null;
@@ -95,6 +100,9 @@ export class HTML3DAnnotationElement extends LitElement {
                 console.warn("The babylon-viewer-annotation element must be a child of a babylon-viewer element.");
                 return;
             }
+
+            this._mutationObserver.observe(this, { childList: true, characterData: true });
+            this._sanitizeInnerHTML();
 
             const viewerElement = this.parentElement;
             const hotSpotResult = new ViewerHotSpotResult();
@@ -153,6 +161,12 @@ export class HTML3DAnnotationElement extends LitElement {
         super.update(changedProperties);
         if (changedProperties.has("hotSpot")) {
             this._updateAnnotation?.();
+        }
+    }
+
+    private _sanitizeInnerHTML() {
+        if (this.innerHTML.trim().length === 0) {
+            this.innerHTML = "";
         }
     }
 }

--- a/packages/tools/viewer/test/apps/web/index.html
+++ b/packages/tools/viewer/test/apps/web/index.html
@@ -127,7 +127,8 @@
                         </svg>
                     </div>
                 </babylon-viewer-annotation>
-                <babylon-viewer-annotation hotspot="thruster"></babylon-viewer-annotation>
+                <babylon-viewer-annotation hotspot="thruster">
+                </babylon-viewer-annotation>
                 <babylon-viewer-annotation hotspot="poi"></babylon-viewer-annotation>
             </babylon-viewer>
         </div>


### PR DESCRIPTION
1. The default viewer annotation UI does not show up if the `innerHTML` is white space only (e.g. code formatting). It seems this is just how slots work with html custom elements, but this is not how we want the viewer annotations to work. This change just sets the `innerHTML` to empty string if it is only white space so the default annotation UI still shows up (e.g. it is not replaced by html white space).
2. Changed the help icon in the Viewer Configurator based on bug bash feedback.
![image](https://github.com/user-attachments/assets/ed66b8ef-6f62-4db0-8eef-8c838d0671e9)
