### PR TITLE
Expose OBJFileLoader options to scene loader APIs

### DIFF
--- a/packages/dev/loaders/src/OBJ/objFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.ts
@@ -2,7 +2,7 @@ import type { Nullable } from "core/types";
 import { Vector2 } from "core/Maths/math.vector";
 import { Tools } from "core/Misc/tools";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
-import type { ISceneLoaderPluginAsync, ISceneLoaderPluginFactory, ISceneLoaderPlugin, ISceneLoaderAsyncResult } from "core/Loading/sceneLoader";
+import type { ISceneLoaderPluginAsync, ISceneLoaderPluginFactory, ISceneLoaderPlugin, ISceneLoaderAsyncResult, SceneLoaderPluginOptions } from "core/Loading/sceneLoader";
 import { RegisterSceneLoaderPlugin } from "core/Loading/sceneLoader";
 import { AssetContainer } from "core/assetContainer";
 import type { Scene } from "core/scene";
@@ -20,7 +20,7 @@ declare module "core/Loading/sceneLoader" {
         /**
          * Defines options for the obj loader.
          */
-        [OBJFileLoaderMetadata.name]: {};
+        [OBJFileLoaderMetadata.name]: Partial<OBJLoadingOptions>;
     }
 }
 
@@ -100,8 +100,8 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
      *
      * @param loadingOptions options for loading and parsing OBJ/MTL files.
      */
-    constructor(loadingOptions?: OBJLoadingOptions) {
-        this._loadingOptions = loadingOptions || OBJFileLoader._DefaultLoadingOptions;
+    constructor(loadingOptions?: Partial<Readonly<OBJLoadingOptions>>) {
+        this._loadingOptions = { ...OBJFileLoader._DefaultLoadingOptions, ...(loadingOptions ?? {}) };
     }
 
     private static get _DefaultLoadingOptions(): OBJLoadingOptions {
@@ -146,12 +146,9 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         });
     }
 
-    /**
-     * Instantiates a OBJ file loader plugin.
-     * @returns the created plugin
-     */
-    createPlugin(): ISceneLoaderPluginAsync | ISceneLoaderPlugin {
-        return new OBJFileLoader(OBJFileLoader._DefaultLoadingOptions);
+    /** @internal */
+    createPlugin(options: SceneLoaderPluginOptions): ISceneLoaderPluginAsync | ISceneLoaderPlugin {
+        return new OBJFileLoader(options[OBJFileLoaderMetadata.name]);
     }
 
     /**

--- a/packages/dev/loaders/src/dynamic.ts
+++ b/packages/dev/loaders/src/dynamic.ts
@@ -30,9 +30,9 @@ export function registerBuiltInLoaders() {
     // Register the OBJ loader.
     RegisterSceneLoaderPlugin({
         ...OBJFileLoaderMetadata,
-        createPlugin: async () => {
+        createPlugin: async (options: SceneLoaderPluginOptions) => {
             const { OBJFileLoader } = await import("./OBJ/objFileLoader");
-            return new OBJFileLoader();
+            return new OBJFileLoader(options[OBJFileLoaderMetadata.name]);
         },
     } satisfies ISceneLoaderPluginFactory);
 


### PR DESCRIPTION
This is a small change that exposes the existing ObjFileLoader options through the new scene loader functions. The focus at the time was glTF and this just wasn't on the radar, but there is a real use case for it now.
- Allow a subset of options to be passed to OBJFileLoader. Any that are missing will get the default. This is fully backward compatible with the existing API.
- Plumb OBJFileLoader options through the dynamic loader factory (same as other loader plugins).