### PR TITLE
Ensure FloatLineComponent has lock when a key is pressed

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/floatLineComponent.tsx
@@ -169,6 +169,11 @@ export class FloatLineComponent extends React.Component<IFloatLineComponentProps
     }
 
     onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+        // While we do lock when getting focus, it's possible that as the user changes this value,
+        // that the UI hosting us has reacted by hiding another line component, and that line component
+        // will release the lock we took. Since the user is typing now, we ensure we have the lock.
+        this.lock();
+
         const step = parseFloat(this.props.step || this.props.isInteger ? "1" : "0.01");
         const handleArrowKey = (sign: number) => {
             if (event.shiftKey) {


### PR DESCRIPTION
There's a bug when another line component is unmounted while the user has focus in the FloatLineComponent (which can happen when the values the user is typing cause another control to be removed). This ensures that the FloatLineComponent has the lock when the user types in it.