### PR TITLE
Make sound `pitch` and `playbackRate` properties change continuously

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -286,6 +286,21 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
         this._state = instance.state;
     }
 
+    protected _getNewestInstance(): Nullable<_AbstractSoundInstance> {
+        if (this._instances.size === 0) {
+            return null;
+        }
+
+        if (!this._newestInstance) {
+            const it = this._instances.values();
+            for (let next = it.next(); !next.done; next = it.next()) {
+                this._newestInstance = next.value;
+            }
+        }
+
+        return this._newestInstance;
+    }
+
     protected _setState(state: SoundState): void {
         this._state = state;
     }
@@ -302,21 +317,6 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
                 instance.stop();
             }
         }
-    }
-
-    private _getNewestInstance(): Nullable<_AbstractSoundInstance> {
-        if (this._instances.size === 0) {
-            return null;
-        }
-
-        if (!this._newestInstance) {
-            const it = this._instances.values();
-            for (let next = it.next(); !next.done; next = it.next()) {
-                this._newestInstance = next.value;
-            }
-        }
-
-        return this._newestInstance;
     }
 
     private _onInstanceEnded: (instance: _AbstractSoundInstance) => void = (instance) => {

--- a/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
@@ -144,6 +144,11 @@ export abstract class StaticSound extends AbstractSound {
 
     public set pitch(value: number) {
         this._options.pitch = value;
+
+        const instance = this._getNewestInstance() as _StaticSoundInstance;
+        if (instance) {
+            instance.pitch = value;
+        }
     }
 
     /**
@@ -156,6 +161,11 @@ export abstract class StaticSound extends AbstractSound {
 
     public set playbackRate(value: number) {
         this._options.playbackRate = value;
+
+        const instance = this._getNewestInstance() as _StaticSoundInstance;
+        if (instance) {
+            instance.playbackRate = value;
+        }
     }
 
     protected abstract override _createInstance(): _StaticSoundInstance;

--- a/packages/dev/core/src/AudioV2/abstractAudio/staticSoundInstance.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/staticSoundInstance.ts
@@ -12,6 +12,9 @@ export interface IStaticSoundInstanceOptions extends IAbstractSoundInstanceOptio
 export abstract class _StaticSoundInstance extends _AbstractSoundInstance {
     protected abstract override readonly _options: IStaticSoundInstanceOptions;
 
+    public abstract pitch: number;
+    public abstract playbackRate: number;
+
     public abstract override play(options: Partial<IStaticSoundPlayOptions>): void;
     public abstract override stop(options?: Partial<IStaticSoundStopOptions>): void;
 }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -324,6 +324,22 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
     }
 
     /** @internal */
+    public set pitch(value: number) {
+        this._options.pitch = value;
+        if (this._sourceNode) {
+            this._sourceNode.detune.value = value;
+        }
+    }
+
+    /** @internal */
+    public set playbackRate(value: number) {
+        this._options.playbackRate = value;
+        if (this._sourceNode) {
+            this._sourceNode.playbackRate.value = value;
+        }
+    }
+
+    /** @internal */
     public get startTime(): number {
         if (this._state === SoundState.Stopped) {
             return 0;


### PR DESCRIPTION
Users expect the `StaticSound.pitch` and `playback` properties to update while a sound is playing, but they don't. They're only updated when playback starts.

This change addresses user needs by updating the pitch and playback rate of the newest sound playback instance immediately instead of only when the `play` function is called.