### PR TITLE
Fix spatial audio `attach` feature position tracking

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -86,7 +86,7 @@ export class _SpatialAudioAttacherComponent {
             if (this._useBoundingBox && (this._sceneNode as AbstractMesh).getBoundingInfo) {
                 this._position.copyFrom((this._sceneNode as AbstractMesh).getBoundingInfo().boundingBox.centerWorld);
             } else {
-                this._position.copyFrom((this._sceneNode as any).position);
+                this._sceneNode?.getWorldMatrix().getTranslationToRef(this._position);
             }
 
             this._spatialAudioNode.position.copyFrom(this._position);

--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -94,7 +94,7 @@ export class _SpatialAudioAttacherComponent {
         }
 
         if (this._attachmentType & SpatialAudioAttachmentType.Rotation) {
-            this._sceneNode?.getWorldMatrix().decompose(undefined, this._rotationQuaternion, undefined);
+            this._sceneNode?.getWorldMatrix().decompose(undefined, this._rotationQuaternion);
 
             this._spatialAudioNode.rotationQuaternion.copyFrom(this._rotationQuaternion);
             this._spatialAudioNode._updateRotation();


### PR DESCRIPTION
Use the attached scene node's world position for the spatial audio position, not the scene node's local position.