### PR TITLE
Fix Havok shape memory leak

### DIFF
--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1637,6 +1637,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * This method is useful for releasing a physics shape from the physics engine, freeing up resources and preventing memory leaks.
      */
     public disposeShape(shape: PhysicsShape): void {
+        this._shapes.delete(shape._pluginData[0]);
         this._hknp.HP_Shape_Release(shape._pluginData);
         shape._pluginData = undefined;
     }


### PR DESCRIPTION
In the Havok Plugin class, we are not doing a delete after a set on the shape map.

disposeShape seems like the right place to call delete.
