### PR TITLE
Make sure lerna updates major version correctly

### DIFF
--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -35,6 +35,8 @@
         "@babylonjs/loaders": "^7.23.1"
     },
     "devDependencies": {
+        "@babylonjs/core": "^7.53.3",
+        "@babylonjs/loaders": "^7.53.3",
         "@dev/build-tools": "^1.0.0",
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^26.0.1",


### PR DESCRIPTION
As I was testing updating a new major version I found out this package is not conform with lerna's requiremenets. Updating a major version without the dev dependency defined made lerna fail the update.

This will not influence consumers of this package, and will not influence development as well.

TL;dr - without this change we can't release 8.0.0 automatically and will need to run everything manually. 