### PR TITLE
Remove duplicate registration of KHR_interactivity

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/dynamic.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/dynamic.ts
@@ -181,11 +181,6 @@ export function registerBuiltInGLTFExtensions() {
         return new KHR_node_hoverability(loader);
     });
 
-    registerGLTFExtension("KHR_interactivity", true, async (loader) => {
-        const { KHR_interactivity } = await import("./KHR_interactivity");
-        return new KHR_interactivity(loader);
-    });
-
     registerGLTFExtension("KHR_node_selectability", true, async (loader) => {
         const { KHR_node_selectability } = await import("./KHR_node_selectability");
         return new KHR_node_selectability(loader);


### PR DESCRIPTION
This was recently added near the end of the file, but it was already being registered on line 49. This resulted in a warning in the console about the double registration.