### PR TITLE
Add audio engine v2 unmute UI

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -13,6 +13,7 @@ import { _HasSpatialAudioListenerOptions } from "../abstractAudio/subProperties/
 import type { _SpatialAudioListener } from "../abstractAudio/subProperties/spatialAudioListener";
 import { _CreateSpatialAudioListener } from "./subProperties/spatialWebAudioListener";
 import { _WebAudioMainOut } from "./webAudioMainOut";
+import { _WebAudioUnmuteUI } from "./webAudioUnmuteUI";
 
 /**
  * Options for creating a v2 audio engine that uses the WebAudio API.
@@ -22,6 +23,14 @@ export interface IWebAudioEngineOptions extends IAudioEngineV2Options {
      * The audio context to be used by the engine.
      */
     audioContext: AudioContext;
+    /**
+     * The default UI's parent element. Defaults to the last created graphics engine's canvas if it exists; otherwise the HTML document's body.
+     */
+    defaultUIParentElement?: HTMLElement;
+    /**
+     * Set to `true` to disable the default UI. Defaults to `false`.
+     */
+    disableDefaultUI?: boolean;
     /**
      * Set to `true` to automatically resume the audio context when the user interacts with the page. Defaults to `true`.
      */
@@ -72,6 +81,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private _resumePromise: Nullable<Promise<void>> = null;
     private readonly _listenerAutoUpdate: boolean = true;
     private readonly _listenerMinUpdateTime: number = 0;
+    private _unmuteUI: Nullable<_WebAudioUnmuteUI> = null;
     private readonly _validFormats = new Set<string>();
     private _volume = 1;
 
@@ -103,6 +113,10 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
         this._volume = options.volume ?? 1;
         this.audioContext = options.audioContext ?? new AudioContext();
+
+        if (!options.disableDefaultUI) {
+            this._unmuteUI = new _WebAudioUnmuteUI(this, options.defaultUIParentElement);
+        }
     }
 
     /** @internal */
@@ -236,6 +250,9 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
         document.removeEventListener("click", this._onUserGesture);
         this.audioContext.removeEventListener("statechange", this._onAudioContextStateChange);
+
+        this._unmuteUI?.dispose();
+        this._unmuteUI = null;
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioUnmuteUI.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioUnmuteUI.ts
@@ -1,0 +1,62 @@
+import type { Nullable } from "../../types";
+import { EngineStore } from "../../Engines/engineStore";
+import type { _WebAudioEngine } from "./webAudioEngine";
+
+/**
+ * Adds a UI button that starts the audio engine's underlying audio context when the user presses it.
+ * @internal
+ */
+export class _WebAudioUnmuteUI {
+    private _button: Nullable<HTMLButtonElement> = null;
+    private _engine: _WebAudioEngine;
+    private _style: Nullable<HTMLStyleElement> = null;
+
+    /** @internal */
+    public constructor(engine: _WebAudioEngine, parentElement?: HTMLElement) {
+        this._engine = engine;
+
+        const style = document.createElement("style");
+        style.appendChild(
+            document.createTextNode(
+                `.babylonUnmute{position:absolute;left:20px;top:20px;height:40px;width:60px;background-color:rgba(51,51,51,0.7);background-image:url("data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2239%22%20height%3D%2232%22%20viewBox%3D%220%200%2039%2032%22%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M9.625%2018.938l-0.031%200.016h-4.953q-0.016%200-0.031-0.016v-12.453q0-0.016%200.031-0.016h4.953q0.031%200%200.031%200.016v12.453zM12.125%207.688l8.719-8.703v27.453l-8.719-8.719-0.016-0.047v-9.938zM23.359%207.875l1.406-1.406%204.219%204.203%204.203-4.203%201.422%201.406-4.219%204.219%204.219%204.203-1.484%201.359-4.141-4.156-4.219%204.219-1.406-1.422%204.219-4.203z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");background-size:80%;background-repeat:no-repeat;background-position:center;background-position-y:4px;border:none;outline:none;transition:transform 0.125s ease-out;cursor:pointer;z-index:9999;}.babylonUnmute:hover{transform:scale(1.05)}`
+            )
+        );
+        document.getElementsByTagName("head")[0].appendChild(style);
+
+        this._button = document.createElement("button");
+        this._button.className = "babylonUnmute";
+        this._button.id = "babylonUnmuteButton";
+
+        this._button.addEventListener("click", () => {
+            this._engine.unlock();
+        });
+
+        const parent = parentElement || EngineStore.LastCreatedEngine?.getInputElement()?.parentElement || document.body;
+        parent.appendChild(this._button);
+
+        this._engine.stateChangedObservable.add(this._onStateChanged);
+    }
+
+    /** @internal */
+    public dispose(): void {
+        this._button?.remove();
+        this._button = null;
+
+        this._style?.remove();
+        this._style = null;
+
+        this._engine.stateChangedObservable.removeCallback(this._onStateChanged);
+    }
+
+    private _onStateChanged = () => {
+        if (!this._button) {
+            return;
+        }
+
+        if (this._engine.state === "running") {
+            this._button.style.display = "none";
+        } else {
+            this._button.style.display = "block";
+        }
+    };
+}

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioUnmuteUI.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioUnmuteUI.ts
@@ -21,7 +21,7 @@ export class _WebAudioUnmuteUI {
                 `.babylonUnmute{position:absolute;left:20px;top:20px;height:40px;width:60px;background-color:rgba(51,51,51,0.7);background-image:url("data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2239%22%20height%3D%2232%22%20viewBox%3D%220%200%2039%2032%22%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M9.625%2018.938l-0.031%200.016h-4.953q-0.016%200-0.031-0.016v-12.453q0-0.016%200.031-0.016h4.953q0.031%200%200.031%200.016v12.453zM12.125%207.688l8.719-8.703v27.453l-8.719-8.719-0.016-0.047v-9.938zM23.359%207.875l1.406-1.406%204.219%204.203%204.203-4.203%201.422%201.406-4.219%204.219%204.219%204.203-1.484%201.359-4.141-4.156-4.219%204.219-1.406-1.422%204.219-4.203z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");background-size:80%;background-repeat:no-repeat;background-position:center;background-position-y:4px;border:none;outline:none;transition:transform 0.125s ease-out;cursor:pointer;z-index:9999;}.babylonUnmute:hover{transform:scale(1.05)}`
             )
         );
-        document.getElementsByTagName("head")[0].appendChild(this._style);
+        document.head.appendChild(this._style);
 
         this._button = document.createElement("button");
         this._button.className = "babylonUnmute";

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioUnmuteUI.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioUnmuteUI.ts
@@ -15,13 +15,13 @@ export class _WebAudioUnmuteUI {
     public constructor(engine: _WebAudioEngine, parentElement?: HTMLElement) {
         this._engine = engine;
 
-        const style = document.createElement("style");
-        style.appendChild(
+        this._style = document.createElement("style");
+        this._style.appendChild(
             document.createTextNode(
                 `.babylonUnmute{position:absolute;left:20px;top:20px;height:40px;width:60px;background-color:rgba(51,51,51,0.7);background-image:url("data:image/svg+xml;charset=UTF-8,%3Csvg%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2239%22%20height%3D%2232%22%20viewBox%3D%220%200%2039%2032%22%3E%3Cpath%20fill%3D%22white%22%20d%3D%22M9.625%2018.938l-0.031%200.016h-4.953q-0.016%200-0.031-0.016v-12.453q0-0.016%200.031-0.016h4.953q0.031%200%200.031%200.016v12.453zM12.125%207.688l8.719-8.703v27.453l-8.719-8.719-0.016-0.047v-9.938zM23.359%207.875l1.406-1.406%204.219%204.203%204.203-4.203%201.422%201.406-4.219%204.219%204.219%204.203-1.484%201.359-4.141-4.156-4.219%204.219-1.406-1.422%204.219-4.203z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E");background-size:80%;background-repeat:no-repeat;background-position:center;background-position-y:4px;border:none;outline:none;transition:transform 0.125s ease-out;cursor:pointer;z-index:9999;}.babylonUnmute:hover{transform:scale(1.05)}`
             )
         );
-        document.getElementsByTagName("head")[0].appendChild(style);
+        document.getElementsByTagName("head")[0].appendChild(this._style);
 
         this._button = document.createElement("button");
         this._button.className = "babylonUnmute";


### PR DESCRIPTION
Adds an unmute UI button for audio engine v2.

The button is the same as the old audio engine's button to make it easier to eventually reimplement the old audio engine using the new audio engine.