### PR TITLE
Fix camera behavior on Firefox on MacOS when using CTRL while dragging

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -8,6 +8,7 @@ import type { ICameraInput } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo, PointerTouch } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
 import type { IPointerEvent } from "../../Events/deviceInputEvents";
+import { IsNavigatorAvailable } from "../../Misc/domManagement";
 
 /**
  * Base class for Camera Pointer Inputs.
@@ -63,6 +64,10 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
         this._metaKey = false;
         this._shiftKey = false;
         this._buttonsPressed = 0;
+
+        const isUsingFirefox = IsNavigatorAvailable() && navigator.userAgent && navigator.userAgent.indexOf("Firefox") !== -1;
+        const usingMacOS = IsNavigatorAvailable() && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
+        const allowAnyButtonForPointerUp = isUsingFirefox && usingMacOS;
 
         this._pointerInput = (p) => {
             const evt = <IPointerEvent>p.event;
@@ -131,7 +136,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 }
             } else if (p.type === PointerEventTypes.POINTERDOUBLETAP) {
                 this.onDoubleTap(evt.pointerType);
-            } else if (p.type === PointerEventTypes.POINTERUP && (this._currentActiveButton === evt.button || isTouch)) {
+            } else if (p.type === PointerEventTypes.POINTERUP && (this._currentActiveButton === evt.button || isTouch || allowAnyButtonForPointerUp)) {
                 try {
                     srcElement?.releasePointerCapture(evt.pointerId);
                 } catch (e) {

--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -35,7 +35,10 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
      */
     protected _buttonsPressed: number;
 
-    private _currentActiveButton: number = -1;
+    /**
+     * Which pointer ID is currently down (only for mouse events, not used for touch events)
+     */
+    private _currentMousePointerIdDown: number = -1;
     private _contextMenuBind: EventListener;
 
     /**
@@ -64,10 +67,6 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
         this._metaKey = false;
         this._shiftKey = false;
         this._buttonsPressed = 0;
-
-        const isUsingFirefox = IsNavigatorAvailable() && navigator.userAgent && navigator.userAgent.indexOf("Firefox") !== -1;
-        const usingMacOS = IsNavigatorAvailable() && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
-        const allowAnyButtonForPointerUp = isUsingFirefox && usingMacOS;
 
         this._pointerInput = (p) => {
             const evt = <IPointerEvent>p.event;
@@ -100,7 +99,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 this._pointB?.pointerId !== evt.pointerId
             ) {
                 return; // If we get a non-down event for a touch that we're not tracking, ignore it
-            } else if (p.type === PointerEventTypes.POINTERDOWN && (this._currentActiveButton === -1 || isTouch)) {
+            } else if (p.type === PointerEventTypes.POINTERDOWN && (this._currentMousePointerIdDown === -1 || isTouch)) {
                 try {
                     srcElement?.setPointerCapture(evt.pointerId);
                 } catch (e) {
@@ -125,8 +124,8 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                     return; // We are already tracking two pointers so ignore this one
                 }
 
-                if (this._currentActiveButton === -1 && !isTouch) {
-                    this._currentActiveButton = evt.button;
+                if (this._currentMousePointerIdDown === -1 && !isTouch) {
+                    this._currentMousePointerIdDown = evt.pointerId;
                 }
                 this.onButtonDown(evt);
 
@@ -136,7 +135,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                 }
             } else if (p.type === PointerEventTypes.POINTERDOUBLETAP) {
                 this.onDoubleTap(evt.pointerType);
-            } else if (p.type === PointerEventTypes.POINTERUP && (this._currentActiveButton === evt.button || isTouch || allowAnyButtonForPointerUp)) {
+            } else if (p.type === PointerEventTypes.POINTERUP && (this._currentMousePointerIdDown === evt.pointerId || isTouch)) {
                 try {
                     srcElement?.releasePointerCapture(evt.pointerId);
                 } catch (e) {
@@ -182,7 +181,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                     previousMultiTouchPanPosition = null;
                 }
 
-                this._currentActiveButton = -1;
+                this._currentMousePointerIdDown = -1;
                 this.onButtonUp(evt);
 
                 if (!noPreventDefault) {
@@ -277,7 +276,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
         this._metaKey = false;
         this._shiftKey = false;
         this._buttonsPressed = 0;
-        this._currentActiveButton = -1;
+        this._currentMousePointerIdDown = -1;
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -8,7 +8,6 @@ import type { ICameraInput } from "../../Cameras/cameraInputsManager";
 import type { PointerInfo, PointerTouch } from "../../Events/pointerEvents";
 import { PointerEventTypes } from "../../Events/pointerEvents";
 import type { IPointerEvent } from "../../Events/deviceInputEvents";
-import { IsNavigatorAvailable } from "../../Misc/domManagement";
 
 /**
  * Base class for Camera Pointer Inputs.


### PR DESCRIPTION
With this change, the camera mouse pointer behavior no longer expects the button is pointer up to be the same button as the one that was in pointer down. This is because on Firefox on MacOS, the user can hold down control during mouse down and it's treated as the right mouse button, and then release the control key, then release the mouse, and the mouse up will be reported as the left mouse button. Now we only care about matching the pointerId, not the button number, when determining if we should cancel the drag. That means the clicking another button on the mouse during a drag will cancel the drag for cameras.