### PR TITLE
PBR materials: Fix refraction color calculation

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockSubSurface.fx
@@ -468,7 +468,7 @@ struct subSurfaceOutParams
             outParams.refractionTransmittance = refractionTransmittance;
         #endif
 
-        outParams.finalRefraction = environmentRefraction.rgb * refractionTransmittance * vLightingIntensity.z;
+        outParams.finalRefraction = environmentRefraction.rgb * refractionTransmittance;
 
         #if DEBUGMODE > 0
             outParams.environmentRefraction = environmentRefraction;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockSubSurface.fx
@@ -492,7 +492,7 @@ struct subSurfaceOutParams
             outParams.refractionTransmittance = refractionTransmittance;
         #endif
 
-        outParams.finalRefraction = environmentRefraction.rgb * refractionTransmittance * vLightingIntensity.z;
+        outParams.finalRefraction = environmentRefraction.rgb * refractionTransmittance;
 
         #if DEBUGMODE > 0
             outParams.environmentRefraction = environmentRefraction;

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -277,10 +277,7 @@ class TransmissionHelper {
 
         let sceneImageProcessingapplyByPostProcess: boolean;
 
-        let saveSceneEnvIntensity: number;
         this._opaqueRenderTarget.onBeforeBindObservable.add((opaqueRenderTarget) => {
-            saveSceneEnvIntensity = this._scene.environmentIntensity;
-            this._scene.environmentIntensity = 1.0;
             sceneImageProcessingapplyByPostProcess = this._scene.imageProcessingConfiguration.applyByPostProcess;
             if (!this._options.clearColor) {
                 this._scene.clearColor.toLinearSpaceToRef(opaqueRenderTarget.clearColor, this._scene.getEngine().useExactSrgbConversions);
@@ -291,7 +288,6 @@ class TransmissionHelper {
             this._scene.imageProcessingConfiguration._applyByPostProcess = true;
         });
         this._opaqueRenderTarget.onAfterUnbindObservable.add(() => {
-            this._scene.environmentIntensity = saveSceneEnvIntensity;
             this._scene.imageProcessingConfiguration._applyByPostProcess = sceneImageProcessingapplyByPostProcess;
         });
 


### PR DESCRIPTION
We incorrectly scaled the refraction color with the environment map intensity.

As a result, I reverted #10537, which was the wrong fix.

Note that this is a breaking change, but with limited consequences because it can only occur when `scene.environmentIntensity != 1` and when using refraction in a PBR material.