### PR TITLE
Ramp audio parameter values to avoid audible discontinuities

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
@@ -26,6 +26,10 @@ export function LastCreatedAudioEngine(): Nullable<AudioEngineV2> {
  */
 export interface IAudioEngineV2Options extends ISpatialAudioListenerOptions {
     /**
+     * The smoothing duration to use when changing audio parameters, in seconds. Defaults to `0.01` (10 milliseconds).
+     */
+    parameterRampDuration: number;
+    /**
      * The initial output volume of the audio engine. Defaults to `1`.
      */
     volume: number;
@@ -51,8 +55,14 @@ export abstract class AudioEngineV2 {
 
     private _defaultMainBus: Nullable<MainAudioBus> = null;
 
-    protected constructor() {
+    private _parameterRampDuration: number = 0.01;
+
+    protected constructor(options: Partial<IAudioEngineV2Options>) {
         Instances.push(this);
+
+        if (typeof options.parameterRampDuration === "number") {
+            this._parameterRampDuration = options.parameterRampDuration;
+        }
     }
 
     /**
@@ -104,6 +114,17 @@ export abstract class AudioEngineV2 {
      * The output volume of the audio engine.
      */
     public abstract volume: number;
+
+    /**
+     * The smoothing duration to use when changing audio parameters, in seconds. Defaults to `0.01` (10 milliseconds).
+     */
+    public get parameterRampDuration(): number {
+        return this._parameterRampDuration;
+    }
+
+    public set parameterRampDuration(value: number) {
+        this._parameterRampDuration = value;
+    }
 
     /**
      * Creates a new audio bus.

--- a/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
@@ -61,7 +61,7 @@ export abstract class AudioEngineV2 {
         Instances.push(this);
 
         if (typeof options.parameterRampDuration === "number") {
-            this._parameterRampDuration = options.parameterRampDuration;
+            this.parameterRampDuration = options.parameterRampDuration;
         }
     }
 
@@ -123,7 +123,7 @@ export abstract class AudioEngineV2 {
     }
 
     public set parameterRampDuration(value: number) {
-        this._parameterRampDuration = value;
+        this._parameterRampDuration = Math.max(0, value);
     }
 
     /**

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
@@ -28,6 +28,9 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     private _lastRotationQuaternion: Quaternion = new Quaternion();
 
     /** @internal */
+    public override readonly engine: _WebAudioEngine;
+
+    /** @internal */
     public readonly position = _SpatialAudioDefaults.position.clone();
     /** @internal */
     public readonly rotation: Vector3 = _SpatialAudioDefaults.rotation.clone();
@@ -137,9 +140,9 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
             return;
         }
 
-        this.node.positionX.value = this.position.x;
-        this.node.positionY.value = this.position.y;
-        this.node.positionZ.value = this.position.z;
+        this.engine._setAudioParam(this.node.positionX, this.position.x);
+        this.engine._setAudioParam(this.node.positionY, this.position.y);
+        this.engine._setAudioParam(this.node.positionZ, this.position.z);
 
         this._lastPosition.copyFrom(this.position);
     }
@@ -159,9 +162,9 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         Matrix.FromQuaternionToRef(TmpQuaternion, TmpMatrix);
         Vector3.TransformNormalToRef(Vector3.RightReadOnly, TmpMatrix, TmpVector);
 
-        this.node.orientationX.value = TmpVector.x;
-        this.node.orientationY.value = TmpVector.y;
-        this.node.orientationZ.value = TmpVector.z;
+        this.engine._setAudioParam(this.node.orientationX, TmpVector.x);
+        this.engine._setAudioParam(this.node.orientationY, TmpVector.y);
+        this.engine._setAudioParam(this.node.orientationZ, TmpVector.z);
     }
 
     protected override _connect(node: IWebAudioInNode): boolean {

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/stereoWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/stereoWebAudioSubNode.ts
@@ -9,6 +9,11 @@ export async function _CreateStereoAudioSubNodeAsync(engine: _WebAudioEngine): P
 
 /** @internal */
 export class _StereoWebAudioSubNode extends _StereoAudioSubNode {
+    private _pan: number = 0;
+
+    /** @internal */
+    public override readonly engine: _WebAudioEngine;
+
     /** @internal */
     public readonly node: StereoPannerNode;
 
@@ -21,12 +26,13 @@ export class _StereoWebAudioSubNode extends _StereoAudioSubNode {
 
     /** @internal */
     public get pan(): number {
-        return this.node.pan.value;
+        return this._pan;
     }
 
     /** @internal */
     public set pan(value: number) {
-        this.node.pan.value = value;
+        this._pan = value;
+        this.engine._setAudioParam(this.node.pan, value);
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/volumeWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/volumeWebAudioSubNode.ts
@@ -9,6 +9,11 @@ export async function _CreateVolumeAudioSubNodeAsync(engine: _WebAudioEngine): P
 
 /** @internal */
 export class _VolumeWebAudioSubNode extends _VolumeAudioSubNode implements IWebAudioSubNode {
+    private _volume: number = 1;
+
+    /** @internal */
+    public override readonly engine: _WebAudioEngine;
+
     /** @internal */
     public readonly node: GainNode;
 
@@ -21,12 +26,13 @@ export class _VolumeWebAudioSubNode extends _VolumeAudioSubNode implements IWebA
 
     /** @internal */
     public get volume(): number {
-        return this.node.gain.value;
+        return this._volume;
     }
 
     /** @internal */
     public set volume(value: number) {
-        this.node.gain.value = value;
+        this._volume = value;
+        this.engine._setAudioParam(this.node.gain, value);
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/subProperties/spatialWebAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subProperties/spatialWebAudioListener.ts
@@ -25,6 +25,9 @@ class _SpatialWebAudioListener extends _SpatialAudioListener {
     private _updaterComponent: _SpatialWebAudioUpdaterComponent;
 
     /** @internal */
+    public readonly engine: _WebAudioEngine;
+
+    /** @internal */
     public readonly position: Vector3 = Vector3.Zero();
     /** @internal */
     public readonly rotation: Vector3 = Vector3.Zero();
@@ -34,6 +37,8 @@ class _SpatialWebAudioListener extends _SpatialAudioListener {
     /** @internal */
     public constructor(engine: _WebAudioEngine, autoUpdate: boolean, minUpdateTime: number) {
         super();
+
+        this.engine = engine;
 
         this._audioContext = engine.audioContext;
         this._updaterComponent = new _SpatialWebAudioUpdaterComponent(this, autoUpdate, minUpdateTime);
@@ -74,9 +79,10 @@ class _SpatialWebAudioListener extends _SpatialAudioListener {
         }
 
         const listener = this._audioContext.listener;
-        listener.positionX.value = this.position.x;
-        listener.positionY.value = this.position.y;
-        listener.positionZ.value = this.position.z;
+
+        this.engine._setAudioParam(listener.positionX, this.position.x);
+        this.engine._setAudioParam(listener.positionY, this.position.y);
+        this.engine._setAudioParam(listener.positionZ, this.position.z);
 
         this._lastPosition.copyFrom(this.position);
     }
@@ -98,13 +104,13 @@ class _SpatialWebAudioListener extends _SpatialAudioListener {
 
         // NB: The WebAudio API is right-handed.
         Vector3.TransformNormalToRef(Vector3.RightHandedForwardReadOnly, TmpMatrix, TmpVector);
-        listener.forwardX.value = TmpVector.x;
-        listener.forwardY.value = TmpVector.y;
-        listener.forwardZ.value = TmpVector.z;
+        this.engine._setAudioParam(listener.forwardX, TmpVector.x);
+        this.engine._setAudioParam(listener.forwardY, TmpVector.y);
+        this.engine._setAudioParam(listener.forwardZ, TmpVector.z);
 
         Vector3.TransformNormalToRef(Vector3.Up(), TmpMatrix, TmpVector);
-        listener.upX.value = TmpVector.x;
-        listener.upY.value = TmpVector.y;
-        listener.upZ.value = TmpVector.z;
+        this.engine._setAudioParam(listener.upX, TmpVector.x);
+        this.engine._setAudioParam(listener.upY, TmpVector.y);
+        this.engine._setAudioParam(listener.upZ, TmpVector.z);
     }
 }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -102,7 +102,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
     /** @internal */
     public constructor(options: Partial<IWebAudioEngineOptions> = {}) {
-        super();
+        super(options);
 
         if (typeof options.listenerAutoUpdate === "boolean") {
             this._listenerAutoUpdate = options.listenerAutoUpdate;
@@ -324,6 +324,11 @@ export class _WebAudioEngine extends AudioEngineV2 {
     /** @internal */
     public removeNode(node: AbstractNamedAudioNode): void {
         this._removeNode(node);
+    }
+
+    /** @internal */
+    public _setAudioParam(audioParam: AudioParam, value: number) {
+        audioParam.linearRampToValueAtTime(value, this.currentTime + this.parameterRampDuration);
     }
 
     private _initAudioContext: () => Promise<void> = async () => {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioMainOut.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioMainOut.ts
@@ -6,6 +6,10 @@ import type { IWebAudioInNode } from "./webAudioNode";
 export class _WebAudioMainOut extends _MainAudioOut implements IWebAudioInNode {
     private _destinationNode: AudioDestinationNode;
     private _gainNode: GainNode;
+    private _volume: number = 1;
+
+    /** @internal */
+    public override readonly engine: _WebAudioEngine;
 
     /** @internal */
     public constructor(engine: _WebAudioEngine) {
@@ -26,12 +30,13 @@ export class _WebAudioMainOut extends _MainAudioOut implements IWebAudioInNode {
 
     /** @internal */
     public get volume(): number {
-        return this._gainNode.gain.value;
+        return this._volume;
     }
 
     /** @internal */
     public set volume(value: number) {
-        this._gainNode.gain.value = value;
+        this._volume = value;
+        this.engine._setAudioParam(this._gainNode.gain, value);
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -327,7 +327,7 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
     public set pitch(value: number) {
         this._options.pitch = value;
         if (this._sourceNode) {
-            this._sourceNode.detune.value = value;
+            this.engine._setAudioParam(this._sourceNode.detune, value);
         }
     }
 
@@ -335,7 +335,7 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
     public set playbackRate(value: number) {
         this._options.playbackRate = value;
         if (this._sourceNode) {
-            this._sourceNode.playbackRate.value = value;
+            this.engine._setAudioParam(this._sourceNode.playbackRate, value);
         }
     }
 


### PR DESCRIPTION
Audio parameter changes are currently performed at the graphics frame rate, which is too slow to avoid audible discontinuities in the audio output stream. This results in audio artifacts like "crackles", "zippers" and "pops", which lower the quality of the audio output and damage audio hardware over time.

To avoid these issues, this change uses linear ramps when changing audio parameter values so they are performed at the audio sample rate, typically 48000 times per second or higher.