### PR TITLE
Remove wait ring at the end of code run process

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -108,6 +108,13 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         });
     }
 
+    private _notifyError(message: string) {
+        this.props.globalState.onErrorObservable.notifyObservers({
+            message: message,
+        });
+        this.props.globalState.onDisplayWaitRingObservable.notifyObservers(false);
+    }
+
     private async _compileAndRunAsync() {
         this.props.globalState.onErrorObservable.notifyObservers(null);
 
@@ -261,10 +268,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             }
 
             if (!createSceneFunction) {
-                this.props.globalState.onErrorObservable.notifyObservers({
-                    message: "You must provide a function named createScene.",
-                });
-                return;
+                return this._notifyError("You must provide a function named createScene.");
             } else {
                 // Write an "initFunction" that creates engine and scene
                 // using the appropriate default or user-provided functions.
@@ -341,17 +345,11 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 this._engine = globalObject.engine;
 
                 if (!this._engine) {
-                    this.props.globalState.onErrorObservable.notifyObservers({
-                        message: "createEngine function must return an engine.",
-                    });
-                    return;
+                    return this._notifyError("createEngine function must return an engine.");
                 }
 
                 if (!globalObject.scene) {
-                    this.props.globalState.onErrorObservable.notifyObservers({
-                        message: createSceneFunction + " function must return a scene.",
-                    });
-                    return;
+                    return this._notifyError("createScene function must return a scene.");
                 }
 
                 let sceneToRenderCode = "sceneToRender = scene";
@@ -378,10 +376,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             }
 
             if (checkSceneCount && this._engine.scenes.length === 0) {
-                this.props.globalState.onErrorObservable.notifyObservers({
-                    message: "You must at least create a scene.",
-                });
-                return;
+                return this._notifyError("You must at least create a scene.");
             }
 
             if (this._engine.scenes[0] && displayInspector) {
@@ -389,10 +384,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             }
 
             if (checkCamera && this._engine.scenes[0].activeCamera == null) {
-                this.props.globalState.onErrorObservable.notifyObservers({
-                    message: "You must at least create a camera.",
-                });
-                return;
+                return this._notifyError("You must at least create a camera.");
             } else if (globalObject.scene.then) {
                 globalObject.scene.then(() => {
                     if (this._engine!.scenes[0] && displayInspector) {

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -109,7 +109,6 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
     }
 
     private async _compileAndRunAsync() {
-        this.props.globalState.onDisplayWaitRingObservable.notifyObservers(false);
         this.props.globalState.onErrorObservable.notifyObservers(null);
 
         const displayInspector = this._scene?.debugLayer.isVisible();
@@ -410,6 +409,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             console.error(err, "Retrying if possible. If this error persists please notify the team.");
             this.props.globalState.onErrorObservable.notifyObservers(this._tmpErrorEvent || err);
         }
+        this.props.globalState.onDisplayWaitRingObservable.notifyObservers(false);
     }
 
     public override render() {


### PR DESCRIPTION
The initial wait ring of the playground is being removed when the code starts executing. This is an issue for TS-based playgrounds because of the language initialization.

This removes the wait ring at the end of the load process or when an error is triggered. This will make sure the wait ring is there until it is no longer needed.