### PR TITLE
Revert "AbstractEngine and Viewer v2 resize fixes (#16372)"

### DIFF
--- a/packages/tools/viewer-configurator/src/App.scss
+++ b/packages/tools/viewer-configurator/src/App.scss
@@ -1,5 +1,4 @@
 .appContainer {
-    width: 100%;
     height: 100%;
 }
 

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1539,7 +1539,6 @@ export class Viewer implements IDisposable {
                 // Resume rendering with the hardware scaling level from prior to suspending.
                 this._engine.setHardwareScalingLevel(this._lastHardwareScalingLevel);
                 this._engine.performanceMonitor.enable();
-                this._snapshotHelper.enableSnapshotRendering();
                 this._startSceneOptimizer();
             };
 
@@ -1550,7 +1549,6 @@ export class Viewer implements IDisposable {
                 // Take note of the current hardware scaling level for when rendering is resumed.
                 this._lastHardwareScalingLevel = this._engine.getHardwareScalingLevel();
                 this._stopSceneOptimizer();
-                this._snapshotHelper.disableSnapshotRendering();
                 // We want a high quality render right before suspending, so set the hardware scaling level back to the default,
                 // disable the performance monitor (so the SceneOptimizer doesn't take into account this potentially slower frame),
                 // and then render the scene once.


### PR DESCRIPTION
Reverting https://github.com/BabylonJS/Babylon.js/pull/16372 as @sebavan spotted a bug. We'll re-introduce this change probably tomorrow with an additional fix.