### PR TITLE
Fix regex pattern for template replacement in FlowGraphConsoleLogBlock

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphConsoleLogBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphConsoleLogBlock.ts
@@ -79,7 +79,7 @@ export class FlowGraphConsoleLogBlock extends FlowGraphExecutionBlockWithOutSign
                 const value = this.getDataInput(match)?.getValue(context);
                 if (value !== undefined) {
                     // replace all
-                    template = template.replace(new RegExp(`{${match}}`, "g"), value.toString());
+                    template = template.replace(new RegExp(`\\{${match}\\}`, "g"), value.toString());
                 }
             }
             return template;


### PR DESCRIPTION
This Regexp will work if the match is anything other than numbers. Once it is numbers it is used as the `{n}` regex pattern. This fixes the issue.