### PR TITLE
Enhance FlowGraphSetVariableBlock to support setting multiple variables

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -1090,10 +1090,33 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
                 flowGraphType: "string",
                 inOptions: true,
                 isVariable: true,
-                dataTransformer(index, parser) {
+                dataTransformer(index: number[], parser): string[] {
                     return [parser.getVariableName(index[0])];
                 },
             },
+        },
+    },
+    "variable/setMultiple": {
+        blocks: [FlowGraphBlockNames.SetVariable],
+        configuration: {
+            variables: {
+                name: "variables",
+                gltfType: "number",
+                flowGraphType: "string",
+                inOptions: true,
+                dataTransformer(index: number[][], parser): string[][] {
+                    return [index[0].map((i) => parser.getVariableName(i))];
+                },
+            },
+        },
+        extraProcessor(_gltfBlock, _declaration, _mapping, parser, serializedObjects) {
+            // variable/get configuration
+            const serializedGetVariable = serializedObjects[0];
+            serializedGetVariable.dataInputs.forEach((input) => {
+                input.name = parser.getVariableName(+input.name);
+            });
+
+            return serializedObjects;
         },
     },
     "variable/interpolate": {

--- a/packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts
@@ -753,6 +753,62 @@ describe("Flow Nodes", () => {
         expect(log).toHaveBeenCalledWith(1);
     });
 
+    test("variable/get and variable/setMultiple", async () => {
+        await generateSimpleNodeGraph(
+            [{ op: "variable/setMultiple" }, { op: "variable/get" }, { op: "flow/log", extension: "BABYLON" }],
+            [
+                {
+                    declaration: 0,
+                    configuration: {
+                        variables: {
+                            value: [0, 1], //the index of the variable
+                        },
+                    },
+                    values: {
+                        0: {
+                            type: 0,
+                            value: [4],
+                        },
+                        1: {
+                            type: 0,
+                            value: [5],
+                        },
+                    },
+                    flows: {
+                        out: {
+                            node: 2,
+                            socket: "in",
+                        },
+                    },
+                },
+                {
+                    declaration: 1,
+                    configuration: {
+                        variable: {
+                            value: [1], //the index of the variable
+                        },
+                    },
+                },
+                {
+                    declaration: 2,
+                    values: {
+                        message: {
+                            node: 1,
+                            socket: "value",
+                        },
+                    },
+                },
+            ],
+            [{ signature: "float" }],
+            [
+                { type: 0, value: [2] },
+                { type: 0, value: [3] },
+            ]
+        );
+
+        expect(log).toHaveBeenCalledWith(5);
+    });
+
     test("variable/interpolate with float", async () => {
         // linear interpolation from 1 to 5 in 1 second
         await generateSimpleNodeGraph(


### PR DESCRIPTION
Adding new glTF interactivity node, variable/setMultiple - added here - https://github.com/KhronosGroup/glTF/pull/2293/commits/5ef1fad30cb0862d7ff5c680e85e61fa9a258316

This change allows setting more than one variable at a single call using the set variable block. This is important, for example, when storing all results of a matrix decompose call. If we can't set multiple variables, the matrix will need to be decomposed 3 times, storing all 3 variables.