### PR TITLE
Don't apply devicePixelRatio to canvas width/height in AbstractEngine.resize

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -2065,15 +2065,9 @@ export abstract class AbstractEngine {
         if (IsWindowObjectExist() && IsDocumentAvailable()) {
             // make sure it is a Node object, and is a part of the document.
             if (this._renderingCanvas) {
-                const boundingRect = this._renderingCanvas.getBoundingClientRect
-                    ? this._renderingCanvas.getBoundingClientRect()
-                    : {
-                          // fallback to last solution in case the function doesn't exist
-                          width: this._renderingCanvas.width * this._hardwareScalingLevel,
-                          height: this._renderingCanvas.height * this._hardwareScalingLevel,
-                      };
-                width = this._renderingCanvas.clientWidth || boundingRect.width || this._renderingCanvas.width || 100;
-                height = this._renderingCanvas.clientHeight || boundingRect.height || this._renderingCanvas.height || 100;
+                const boundingRect = this._renderingCanvas.getBoundingClientRect?.();
+                width = this._renderingCanvas.clientWidth || boundingRect?.width || this._renderingCanvas.width * this._hardwareScalingLevel || 100;
+                height = this._renderingCanvas.clientHeight || boundingRect?.height || this._renderingCanvas.height * this._hardwareScalingLevel || 100;
             } else {
                 width = window.innerWidth;
                 height = window.innerHeight;


### PR DESCRIPTION
This is a subset of https://github.com/BabylonJS/Babylon.js/pull/16372, since we found one issue with it (adaptToDeviceRatio + limitDeviceRatio behavior changed).

This change contains only the part that prevents the devicePixelRatio scaling from being applied to the width/height when those values come from the canvas width/height, which is the native pixel size, not the css size. Otherwise, every call to resize will scale the canvas and it just gets bigger and bigger until it crashes the browser. This will happen if the canvas width or height is 0, which we initially discovered when testing the Viewer Configurator on iOS (where the width ends up being 0 because the side pane takes up the full horizontal width of the device). However, you can easily repro this in other tools. For example, if you put Playground on a high dpi device (DPR>1), reduce the width of the window, toggle to only show the code (now the canvas css width is 0), and then resize the window, the canvas width will explode:
<img width="387" alt="image" src="https://github.com/user-attachments/assets/e5464ad9-bc45-4c99-8168-c0cde03c6464" />
