### PR TITLE
Fix Viewer toolbar width regression

### DIFF
--- a/packages/tools/viewer-configurator/src/App.scss
+++ b/packages/tools/viewer-configurator/src/App.scss
@@ -1,4 +1,5 @@
 .appContainer {
+    width: 100%;
     height: 100%;
 }
 

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1539,6 +1539,7 @@ export class Viewer implements IDisposable {
                 // Resume rendering with the hardware scaling level from prior to suspending.
                 this._engine.setHardwareScalingLevel(this._lastHardwareScalingLevel);
                 this._engine.performanceMonitor.enable();
+                this._snapshotHelper.enableSnapshotRendering();
                 this._startSceneOptimizer();
             };
 
@@ -1549,6 +1550,7 @@ export class Viewer implements IDisposable {
                 // Take note of the current hardware scaling level for when rendering is resumed.
                 this._lastHardwareScalingLevel = this._engine.getHardwareScalingLevel();
                 this._stopSceneOptimizer();
+                this._snapshotHelper.disableSnapshotRendering();
                 // We want a high quality render right before suspending, so set the hardware scaling level back to the default,
                 // disable the performance monitor (so the SceneOptimizer doesn't take into account this potentially slower frame),
                 // and then render the scene once.

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -328,7 +328,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
         .bar {
             position: absolute;
             width: calc(100% - 24px);
-            min-width: 150px;
+            min-width: 370px;
             max-width: 1280px;
             left: 50%;
             transform: translateX(-50%);
@@ -402,7 +402,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
             border-color: var(--ui-foreground-color);
             height: 48px;
             bottom: 12px;
-            min-width: 370px;
             color: var(--ui-foreground-color);
             -webkit-tap-highlight-color: transparent;
         }


### PR DESCRIPTION
A recent change resulted in the Viewer toolbar having a min-width set even when there is no animation. In this case, the tool-bar should be allowed to be narrower since it may only have a single reset button.

This change also brings over two fixes that were included in https://github.com/BabylonJS/Babylon.js/pull/16372, which was rolled back:
- Explicitly set the width of the Configurator app level div to 100%.
- Disable/enable snapshot rendering on suspend/resume. This ensures we can correctly render the final high res frame (before suspend completes) within a single frame (e.g. single call to scene.render). It will be slightly slower since it is not using snapshot rendering, but this is fine for rendering a single frame (fast snapshot rendering is mostly useful for continuous rendering).