### PR TITLE
Fix: avoid alpha check when texture is not ready

### DIFF
--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -421,7 +421,6 @@ export class SpriteManager implements ISpriteManager {
 
     private _checkTextureAlpha(sprite: Sprite, ray: Ray, distance: number, min: Vector3, max: Vector3) {
         if (!sprite.useAlphaForPicking || !this.texture?.isReady()) {
-
             return true;
         }
 

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -420,7 +420,7 @@ export class SpriteManager implements ISpriteManager {
     }
 
     private _checkTextureAlpha(sprite: Sprite, ray: Ray, distance: number, min: Vector3, max: Vector3) {
-        if (!sprite.useAlphaForPicking || !this.texture) {
+        if (!sprite.useAlphaForPicking || !this.texture || !this.texture.isReady()) {
             return true;
         }
 

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -420,7 +420,8 @@ export class SpriteManager implements ISpriteManager {
     }
 
     private _checkTextureAlpha(sprite: Sprite, ray: Ray, distance: number, min: Vector3, max: Vector3) {
-        if (!sprite.useAlphaForPicking || !this.texture || !this.texture.isReady()) {
+        if (!sprite.useAlphaForPicking || !this.texture?.isReady()) {
+
             return true;
         }
 


### PR DESCRIPTION
Adds a guard in `SpriteManager._checkTextureAlpha()` to skip alpha checking if the texture isn't ready. This prevents picking errors.

Fixes the following WebGL error:

//[.WebGL-0x12c00c41100] GL_INVALID_FRAMEBUFFER_OPERATION: Framebuffer is incomplete: Attachment has zero size.
