### PR TITLE
Fix TextLineComponent imports to work outside of the repo

### DIFF
--- a/packages/dev/sharedUiComponents/src/lines/textLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textLineComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import copyIcon from "shared-ui-components/imgs/copy.svg";
-import { copyCommandToClipboard } from "shared-ui-components/copyCommandToClipboard";
-import { MergeClassNames } from "shared-ui-components/styleHelper";
+import copyIcon from "../imgs/copy.svg";
+import { copyCommandToClipboard } from "../copyCommandToClipboard";
+import { MergeClassNames } from "../styleHelper";
 
 interface ITextLineComponentProps {
     label?: string;


### PR DESCRIPTION
When importing @babylonjs/shared-ui-components from another repo, the build is failing because textLineComponent.js is referencing imports in this form:
import copyIcon from "shared-ui-components/imgs/copy.svg";

This works in the Babylon repo because that name is mapped to the right path, but doesn't work when used in another repo. This change fixes the imports to be relative paths instead.