### PR TITLE
Some fixes before release for glTF interactivity

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -1555,7 +1555,7 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         },
         extraProcessor(_gltfBlock, _declaration, _mapping, _arrays, serializedObjects) {
             const serializedObject = serializedObjects[0];
-            serializedObject.signalInputs.forEach((input) => {
+            serializedObject.dataInputs.forEach((input) => {
                 if (input.name !== "default" && input.name !== "case") {
                     input.name = "in_" + input.name;
                 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/objectModelMapping.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/objectModelMapping.ts
@@ -323,7 +323,7 @@ const nodesTree: IGLTFObjectModelTreeNodesObject = {
         // readonly!
         matrix: {
             type: "Matrix",
-            get: (node: INode) => node._babylonTransformNode?._localMatrix.clone(),
+            get: (node: INode) => Matrix.Compose(node._babylonTransformNode?.scaling!, node._babylonTransformNode?.rotationQuaternion!, node._babylonTransformNode?.position!),
             getTarget: (node: INode) => node._babylonTransformNode,
             isReadOnly: true,
         },


### PR DESCRIPTION
Improve transformation handling by using `Matrix.Compose` in the matrix getter and correct input processing to utilize `dataInputs` instead of `signalInputs`.