### PR TITLE
Change static sound `playbackRate` and `pitch` settings API

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
@@ -25,6 +25,13 @@ export interface IStaticSoundOptionsBase {
      *
      */
     loopStart: number;
+}
+
+/**
+ * Options stored in a static sound.
+ * @internal
+ */
+export interface IStaticSoundStoredOptions extends IAbstractSoundStoredOptions, IStaticSoundOptionsBase {
     /**
      * The pitch of the sound, in cents. Defaults to `0`.
      * - Can be combined with {@link playbackRate}.
@@ -37,14 +44,6 @@ export interface IStaticSoundOptionsBase {
     playbackRate: number;
 }
 
-/** @internal */
-export interface IStaticSoundPlayOptionsBase {
-    /**
-     * The time to wait before playing the sound, in seconds. Defaults to `0`.
-     */
-    waitTime: number;
-}
-
 /**
  * Options for creating a static sound.
  */
@@ -53,7 +52,12 @@ export interface IStaticSoundOptions extends IAbstractSoundOptions, IStaticSound
 /**
  * Options for playing a static sound.
  */
-export interface IStaticSoundPlayOptions extends IAbstractSoundPlayOptions, IStaticSoundOptionsBase, IStaticSoundPlayOptionsBase {}
+export interface IStaticSoundPlayOptions extends IAbstractSoundPlayOptions, IStaticSoundOptionsBase {
+    /**
+     * The time to wait before playing the sound, in seconds. Defaults to `0`.
+     */
+    waitTime: number;
+}
 
 /**
  * Options for stopping a static sound.
@@ -64,12 +68,6 @@ export interface IStaticSoundStopOptions {
      */
     waitTime: number;
 }
-
-/**
- * Options stored in a static sound.
- * @internal
- */
-export interface IStaticSoundStoredOptions extends IAbstractSoundStoredOptions, IStaticSoundOptionsBase {}
 
 /**
  * Abstract class representing a static sound.
@@ -145,9 +143,9 @@ export abstract class StaticSound extends AbstractSound {
     public set pitch(value: number) {
         this._options.pitch = value;
 
-        const instance = this._getNewestInstance() as _StaticSoundInstance;
-        if (instance) {
-            instance.pitch = value;
+        let it = this._instances.values();
+        for (let instance = it.next(); !instance.done; instance = it.next()) {
+            instance.value.pitch = value;
         }
     }
 
@@ -162,9 +160,9 @@ export abstract class StaticSound extends AbstractSound {
     public set playbackRate(value: number) {
         this._options.playbackRate = value;
 
-        const instance = this._getNewestInstance() as _StaticSoundInstance;
-        if (instance) {
-            instance.playbackRate = value;
+        let it = this._instances.values();
+        for (let instance = it.next(); !instance.done; instance = it.next()) {
+            instance.value.playbackRate = value;
         }
     }
 
@@ -185,8 +183,6 @@ export abstract class StaticSound extends AbstractSound {
         options.loop ??= this.loop;
         options.loopStart ??= this.loopStart;
         options.loopEnd ??= this.loopEnd;
-        options.pitch ??= this.pitch;
-        options.playbackRate ??= this.playbackRate;
         options.startOffset ??= this.startOffset;
         options.volume ??= 1;
         options.waitTime ??= 0;

--- a/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
@@ -143,7 +143,7 @@ export abstract class StaticSound extends AbstractSound {
     public set pitch(value: number) {
         this._options.pitch = value;
 
-        let it = this._instances.values();
+        const it = this._instances.values();
         for (let instance = it.next(); !instance.done; instance = it.next()) {
             instance.value.pitch = value;
         }
@@ -160,7 +160,7 @@ export abstract class StaticSound extends AbstractSound {
     public set playbackRate(value: number) {
         this._options.playbackRate = value;
 
-        let it = this._instances.values();
+        const it = this._instances.values();
         for (let instance = it.next(); !instance.done; instance = it.next()) {
             instance.value.playbackRate = value;
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -325,7 +325,6 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
 
     /** @internal */
     public set pitch(value: number) {
-        this._options.pitch = value;
         if (this._sourceNode) {
             this.engine._setAudioParam(this._sourceNode.detune, value);
         }
@@ -333,7 +332,6 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
 
     /** @internal */
     public set playbackRate(value: number) {
-        this._options.playbackRate = value;
         if (this._sourceNode) {
             this.engine._setAudioParam(this._sourceNode.playbackRate, value);
         }
@@ -383,12 +381,6 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
         }
         if (options.loopEnd !== undefined) {
             this._options.loopEnd = options.loopEnd;
-        }
-        if (options.pitch !== undefined) {
-            this._options.pitch = options.pitch;
-        }
-        if (options.playbackRate !== undefined) {
-            this._options.playbackRate = options.playbackRate;
         }
         if (options.startOffset !== undefined) {
             this._options.startOffset = options.startOffset;
@@ -514,11 +506,11 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
         }
 
         const node = this._sourceNode;
-        node.detune.value = this._options.pitch;
+        node.detune.value = this._sound.pitch;
         node.loop = this._options.loop;
         node.loopEnd = this._options.loopEnd;
         node.loopStart = this._options.loopStart;
-        node.playbackRate.value = this._options.playbackRate;
+        node.playbackRate.value = this._sound.playbackRate;
     }
 
     private _onEngineStateChanged = () => {


### PR DESCRIPTION
The static sound `playbackRate` and `pitch` options are confusing when it comes to sound instances. Changing those options on a sound with multiple instances playing only updates the most recent instance, but it should update all instances.

Similarly, allowing the `playbackRate` and `pitch` options to be set in the `play` function is confusing because the parent sound's properties will override the new instance's option set by the `play` function, which will cause the playback rate and pitch to change unexpectedly when the sound's properties are changed.

This change fixes these issues by making the static sound's `playbackRate` and `pitch` properties apply to all playing instances, and by removing the `playbackRate` and `pitch` options from the `play` function.