### PR TITLE
Mesh picking: Fix calculation of the world normal when picking thin instances

### DIFF
--- a/packages/dev/core/src/Collisions/pickingInfo.ts
+++ b/packages/dev/core/src/Collisions/pickingInfo.ts
@@ -125,6 +125,7 @@ export class PickingInfo {
         const transformNormalToWorld = (pickedMesh: AbstractMesh, n: Vector3) => {
             if (this.thinInstanceIndex !== -1) {
                 const tm = (pickedMesh as Mesh).thinInstanceGetWorldMatrices()[this.thinInstanceIndex];
+
                 if (tm) {
                     Vector3.TransformNormalToRef(n, tm, n);
                 }

--- a/packages/dev/core/src/Collisions/pickingInfo.ts
+++ b/packages/dev/core/src/Collisions/pickingInfo.ts
@@ -122,6 +122,13 @@ export class PickingInfo {
         }
 
         const transformNormalToWorld = (pickedMesh: AbstractMesh, n: Vector3) => {
+            if (this.thinInstanceIndex !== -1) {
+                const tm = (pickedMesh as Mesh).thinInstanceGetWorldMatrices()[this.thinInstanceIndex];
+                if (tm) {
+                    Vector3.TransformNormalToRef(n, tm, n);
+                }
+            }
+
             let wm = pickedMesh.getWorldMatrix();
 
             if (pickedMesh.nonUniformScaling) {

--- a/packages/dev/core/src/Collisions/pickingInfo.ts
+++ b/packages/dev/core/src/Collisions/pickingInfo.ts
@@ -4,6 +4,7 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
 import type { TransformNode } from "../Meshes/transformNode";
 import { VertexBuffer } from "../Buffers/buffer";
 import type { Sprite } from "../Sprites/sprite";
+import type { Mesh } from "../Meshes/mesh";
 
 import type { Ray } from "../Culling/ray";
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/wrong-result-of-pickinginfo-getnormal-with-thin-instances/57393