### PR TITLE
Playground: Fix crash in 4.2.1

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -289,8 +289,8 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
                     window.engine = await asyncEngineCreation();
                     
-                    const engineOptions = window.engine.getCreationOptions();
-                    if (engineOptions.audioEngine !== false) {
+                    const engineOptions = window.engine.getCreationOptions?.();
+                    if (!engineOptions || engineOptions.audioEngine !== false) {
                         ${audioInit}
                     }`;
                 code += "\r\nif (!engine) throw 'engine should not be null.';";


### PR DESCRIPTION
See https://forum.babylonjs.com/t/playground-window-engine-getcreationoptions-is-not-a-function/57395