### PR TITLE
NME: Fix crash when iridescence and clearcoat are used at the same time

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/iridescenceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/iridescenceBlock.ts
@@ -134,10 +134,11 @@ export class IridescenceBlock extends NodeMaterialBlock {
                 , specularEnvironmentR0
                 #ifdef CLEARCOAT
                     , NdotVUnclamped
+                    , vClearCoatParams
                 #endif                
             );
 
-            float iridescenceIntensity = iridescenceOut.iridescenceIntensity;
+            ${isWebGPU ? "let" : "float"} iridescenceIntensity = iridescenceOut.iridescenceIntensity;
             specularEnvironmentR0 = iridescenceOut.specularEnvironmentR0;
         #endif\n`;
 

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -1295,6 +1295,11 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
             ],
         });
 
+        // ____________________ Clear Coat Initialization Code _____________________
+        const clearcoatBlock = this.clearcoat.isConnected ? (this.clearcoat.connectedPoint?.ownerBlock as ClearCoatBlock) : null;
+
+        state.compilationString += ClearCoatBlock._GetInitializationCode(state, clearcoatBlock);
+
         // _____________________________ Iridescence _______________________________
         const iridescenceBlock = this.iridescence.isConnected ? (this.iridescence.connectedPoint?.ownerBlock as IridescenceBlock) : null;
         state.compilationString += IridescenceBlock.GetCode(iridescenceBlock, state);
@@ -1304,7 +1309,6 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         });
 
         // _____________________________ Clear Coat ____________________________
-        const clearcoatBlock = this.clearcoat.isConnected ? (this.clearcoat.connectedPoint?.ownerBlock as ClearCoatBlock) : null;
         const generateTBNSpace = !this.perturbedNormal.isConnected && !this.anisotropy.isConnected;
         const isTangentConnectedToPerturbNormal =
             this.perturbedNormal.isConnected && (this.perturbedNormal.connectedPoint?.ownerBlock as PerturbNormalBlock).worldTangent?.isConnected;

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockIridescence.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockIridescence.fx
@@ -21,6 +21,7 @@ struct iridescenceOutParams
         #endif
         #ifdef CLEARCOAT
             , in float NdotVUnclamped
+            , in vec2 vClearCoatParams
             #ifdef CLEARCOAT_TEXTURE
                 , in vec2 clearCoatMapData
             #endif

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -413,6 +413,7 @@ void main(void) {
             #endif
             #ifdef CLEARCOAT
                 , NdotVUnclamped
+                , vClearCoatParams
                 #ifdef CLEARCOAT_TEXTURE
                     , clearCoatMapData
                 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockIridescence.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockIridescence.fx
@@ -9,7 +9,7 @@ struct iridescenceOutParams
 #ifdef IRIDESCENCE
     fn iridescenceBlock(
         vIridescenceParams: vec4f
-        , viewAngle: f32
+        , viewAngle_: f32
         , specularEnvironmentR0: vec3f
         #ifdef IRIDESCENCE_TEXTURE
             , iridescenceMapData: vec2f
@@ -19,6 +19,7 @@ struct iridescenceOutParams
         #endif
         #ifdef CLEARCOAT
             , NdotVUnclamped: f32
+            , vClearCoatParams: vec2f
             #ifdef CLEARCOAT_TEXTURE
                 , clearCoatMapData: vec2f
             #endif
@@ -32,6 +33,8 @@ struct iridescenceOutParams
         var iridescenceThicknessMin: f32 = vIridescenceParams.z;
         var iridescenceThicknessMax: f32 = vIridescenceParams.w;
         var iridescenceThicknessWeight: f32 = 1.;
+
+        var viewAngle = viewAngle_;
 
         #ifdef IRIDESCENCE_TEXTURE
             iridescenceIntensity *= iridescenceMapData.x;

--- a/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
@@ -406,6 +406,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
             #endif
             #ifdef CLEARCOAT
                 , NdotVUnclamped
+                , uniforms.vClearCoatParams
                 #ifdef CLEARCOAT_TEXTURE
                     , clearCoatMapData
                 #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/node-material-compilation-error-with-iridescence-block/57401