### PR TITLE
PBR sub-surface: Add switch for back compatibility

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/subSurfaceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/subSurfaceBlock.ts
@@ -13,6 +13,7 @@ import type { ReflectionBlock } from "./reflectionBlock";
 import type { Nullable } from "../../../../types";
 import { RefractionBlock } from "./refractionBlock";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
+import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 
 /**
  * Block used to implement the sub surface module of the PBR material
@@ -47,6 +48,12 @@ export class SubSurfaceBlock extends NodeMaterialBlock {
             new NodeMaterialConnectionPointCustomObject("subsurface", this, NodeMaterialConnectionPointDirection.Output, SubSurfaceBlock, "SubSurfaceBlock")
         );
     }
+
+    /**
+     * Set it to true if your rendering in 8.0+ is different from that in 7 when you use sub-surface properties (transmission, refraction, etc.)
+     */
+    @editableInPropertyPage("Apply albedo after sub-surface", PropertyTypeForEdition.Boolean, "ADVANCED")
+    public applyAlbedoAfterSubSurface: boolean = false;
 
     /**
      * Initialize the block and prepare the context for build
@@ -138,6 +145,7 @@ export class SubSurfaceBlock extends NodeMaterialBlock {
         defines.setValue("SS_TRANSLUCENCYINTENSITY_TEXTURE", false, true);
         defines.setValue("SS_USE_GLTF_TEXTURES", false, true);
         defines.setValue("SS_DISPERSION", this.dispersion.isConnected, true);
+        defines.setValue("SS_APPLY_ALBEDO_AFTER_SUBSURFACE", this.applyAlbedoAfterSubSurface, true);
     }
 
     /**

--- a/packages/dev/core/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSubSurfaceConfiguration.ts
@@ -58,6 +58,7 @@ export class MaterialSubSurfaceDefines extends MaterialDefines {
     public SS_USE_THICKNESS_AS_DEPTH = false;
 
     public SS_USE_GLTF_TEXTURES = false;
+    public SS_APPLY_ALBEDO_AFTER_SUBSURFACE = false;
 }
 
 /**
@@ -333,6 +334,14 @@ export class PBRSubSurfaceConfiguration extends MaterialPluginBase {
     @expandToProperty("_markAllSubMeshesAsTexturesDirty")
     public useGltfStyleTextures: boolean = true;
 
+    /**
+     * This property only exists for backward compatibility reasons.
+     * Set it to true if your rendering in 8.0+ is different from that in 7 when you use sub-surface properties (transmission, refraction, etc.). Default is false.
+     * Note however that the PBR calculation is wrong when this property is set to true, so only use it if you want to mimic the 7.0 behavior.
+     */
+    @serialize()
+    public applyAlbedoAfterSubSurface = false;
+
     private _scene: Scene;
 
     /** @internal */
@@ -437,6 +446,7 @@ export class PBRSubSurfaceConfiguration extends MaterialPluginBase {
             defines.SS_TRANSLUCENCYCOLOR_TEXTURE = false;
             defines.SS_TRANSLUCENCYCOLOR_TEXTUREDIRECTUV = 0;
             defines.SS_TRANSLUCENCYCOLOR_TEXTURE_GAMMA = false;
+            defines.SS_APPLY_ALBEDO_AFTER_SUBSURFACE = false;
             return;
         }
 
@@ -466,6 +476,7 @@ export class PBRSubSurfaceConfiguration extends MaterialPluginBase {
             defines.SS_USE_LOCAL_REFRACTIONMAP_CUBIC = false;
             defines.SS_USE_THICKNESS_AS_DEPTH = false;
             defines.SS_TRANSLUCENCYCOLOR_TEXTURE = false;
+            defines.SS_APPLY_ALBEDO_AFTER_SUBSURFACE = this.applyAlbedoAfterSubSurface;
 
             if (defines._areTexturesDirty) {
                 if (scene.texturesEnabled) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockFinalLitComponents.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockFinalLitComponents.fx
@@ -31,7 +31,9 @@ aggShadow = aggShadow / numLights;
         #endif
     #endif
 
-    finalIrradiance *= surfaceAlbedo.rgb;
+    #ifndef SS_APPLY_ALBEDO_AFTER_SUBSURFACE
+        finalIrradiance *= surfaceAlbedo.rgb;
+    #endif
 
     #if defined(SS_REFRACTION)
         finalIrradiance *= subSurfaceOut.refractionFactorForIrradiance;
@@ -40,6 +42,10 @@ aggShadow = aggShadow / numLights;
     #if defined(SS_TRANSLUCENCY)
         finalIrradiance *= (1.0 - subSurfaceOut.translucencyIntensity);
         finalIrradiance += subSurfaceOut.refractionIrradiance;
+    #endif
+
+    #ifdef SS_APPLY_ALBEDO_AFTER_SUBSURFACE
+        finalIrradiance *= surfaceAlbedo.rgb;
     #endif
 
     finalIrradiance *= vLightingIntensity.z;

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockFinalLitComponents.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockFinalLitComponents.fx
@@ -31,7 +31,9 @@ aggShadow = aggShadow / numLights;
         #endif
     #endif
 
-    finalIrradiance *= surfaceAlbedo.rgb;
+    #ifndef SS_APPLY_ALBEDO_AFTER_SUBSURFACE
+        finalIrradiance *= surfaceAlbedo.rgb;
+    #endif
 
     #if defined(SS_REFRACTION)
         finalIrradiance *= subSurfaceOut.refractionFactorForIrradiance;
@@ -40,6 +42,10 @@ aggShadow = aggShadow / numLights;
     #if defined(SS_TRANSLUCENCY)
         finalIrradiance *= (1.0 - subSurfaceOut.translucencyIntensity);
         finalIrradiance += subSurfaceOut.refractionIrradiance;
+    #endif
+
+    #ifdef SS_APPLY_ALBEDO_AFTER_SUBSURFACE
+        finalIrradiance *= surfaceAlbedo.rgb;
     #endif
 
     finalIrradiance *= uniforms.vLightingIntensity.z;


### PR DESCRIPTION
#16337 was a bug fix but a breaking change, so we're adding a toggle to be able to revert to the old buggy behavior in case it's easier for people than to fix their setup.

Just set `mat.subSurface.applyAlbedoAfterSubSurface = true` to switch to the old behavior.