### PR TITLE
FrameGraph: Fix code generated for input blocks by NRGE

### DIFF
--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlock.ts
@@ -569,7 +569,7 @@ export class NodeRenderGraphBlock {
             codeString += `// ${this.comments}\n`;
         }
         const className = this.getClassName();
-        if (className === "RenderGraphInputBlock") {
+        if (className === "NodeRenderGraphInputBlock") {
             const block = this as unknown as NodeRenderGraphInputBlock;
             const blockType = block.type;
 

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlockConnectionPoint.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlockConnectionPoint.ts
@@ -305,7 +305,7 @@ export class NodeRenderGraphConnectionPoint {
     public connectTo(connectionPoint: NodeRenderGraphConnectionPoint, ignoreConstraints = false): NodeRenderGraphConnectionPoint {
         if (!ignoreConstraints && !this.canConnectTo(connectionPoint)) {
             // eslint-disable-next-line no-throw-literal
-            throw "Cannot connect these two connectors.";
+            throw `Cannot connect these two connectors. source: "${this.ownerBlock.name}".${this.name}, target: "${connectionPoint.ownerBlock.name}".${connectionPoint.name}`;
         }
 
         this._endpoints.push(connectionPoint);

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -603,7 +603,7 @@ export class NodeMaterialConnectionPoint {
     public connectTo(connectionPoint: NodeMaterialConnectionPoint, ignoreConstraints = false): NodeMaterialConnectionPoint {
         if (!ignoreConstraints && !this.canConnectTo(connectionPoint)) {
             // eslint-disable-next-line no-throw-literal
-            throw "Cannot connect these two connectors.";
+            throw `Cannot connect these two connectors. source: "${this.ownerBlock.name}".${this.name}, target: "${connectionPoint.ownerBlock.name}".${connectionPoint.name}`;
         }
 
         this._endpoints.push(connectionPoint);

--- a/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometryBlockConnectionPoint.ts
@@ -350,7 +350,7 @@ export class NodeGeometryConnectionPoint {
     public connectTo(connectionPoint: NodeGeometryConnectionPoint, ignoreConstraints = false): NodeGeometryConnectionPoint {
         if (!ignoreConstraints && !this.canConnectTo(connectionPoint)) {
             // eslint-disable-next-line no-throw-literal
-            throw "Cannot connect these two connectors.";
+            throw `Cannot connect these two connectors. source: "${this.ownerBlock.name}".${this.name}, target: "${connectionPoint.ownerBlock.name}".${connectionPoint.name}`;
         }
 
         this._endpoints.push(connectionPoint);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/cannot-connect-these-two-connectors-when-generate-code/57466