### PR TITLE
Fix the correct link for guiEditor

### DIFF
--- a/packages/tools/guiEditor/src/components/commandBarComponent.tsx
+++ b/packages/tools/guiEditor/src/components/commandBarComponent.tsx
@@ -154,7 +154,7 @@ export class CommandBarComponent extends React.Component<ICommandBarComponentPro
                                 {
                                     label: "Help",
                                     onClick: () => {
-                                        window.open("https://doc.babylonjs.com/toolsAndResources/tools/guiEditor", "_blank");
+                                        window.open("https://doc.babylonjs.com/toolsAndResources/guiEditor", "_blank");
                                     },
                                 },
                                 {


### PR DESCRIPTION
Change the correct guiEditor link from `https://doc.babylonjs.com/toolsAndResources/tools/guiEditor` to `https://doc.babylonjs.com/toolsAndResources/guiEditor`