### PR TITLE
Native: Canvas context.filter

### DIFF
--- a/packages/dev/core/src/Engines/ICanvas.ts
+++ b/packages/dev/core/src/Engines/ICanvas.ts
@@ -365,6 +365,11 @@ export interface ICanvasRenderingContext {
     fillStyle: string | ICanvasGradient;
 
     /**
+     * Provides filter effects such as blurring and grayscaling. It is similar to the CSS filter property and accepts the same values.
+     */
+    filter: string;
+
+    /**
      * Alpha value that is applied to shapes and images before they are composited onto the canvas. Default 1.0 (opaque).
      */
     globalAlpha: number;


### PR DESCRIPTION
Adds `filter` https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/filter
This calls to BabylonNative as implemented in https://github.com/BabylonJS/BabylonNative/pull/1489