### PR TITLE
Cloning instanced meshes: don't try to clone the geometry object

### DIFF
--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -562,6 +562,7 @@ export class InstancedMesh extends AbstractMesh {
                 "worldMatrixFromCache",
                 "hasThinInstances",
                 "hasBoundingInfo",
+                "geometry",
             ],
             []
         );


### PR DESCRIPTION
See https://forum.babylonjs.com/t/spamming-warning-on-instancedmesh-clone/57520