### PR TITLE
Improve ArcRotateCamera interpolation logic

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -616,6 +616,13 @@ export class ArcRotateCamera extends TargetCamera {
     private _isInterpolating = false;
 
     /**
+     * If true, indicates the camera is currently interpolating to a new pose.
+     */
+    public get isInterpolating(): boolean {
+        return this._isInterpolating;
+    }
+
+    /**
      * Gets the bouncing behavior of the camera if it has been enabled.
      * @see https://doc.babylonjs.com/features/featuresDeepDive/behaviors/cameraBehaviors#bouncing-behavior
      */

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -56,6 +56,11 @@ export function ComputeBeta(verticalOffset: number, radius: number): number {
     return Math.acos(verticalOffset / radius);
 }
 
+// Returns the value if not NaN, otherwise returns the fallback value.
+function checkNaN(value: number, fallback: number): number {
+    return isNaN(value) ? fallback : value;
+}
+
 /**
  * This represents an orbital type of camera.
  *
@@ -912,16 +917,11 @@ export class ArcRotateCamera extends TargetCamera {
         }
 
         // If NaN is passed in for a goal value, keep the current goal value.
-        const selectGoalValue = (newGoal: number, currentGoal: number): number => (isNaN(newGoal) ? currentGoal : newGoal);
-
-        this._goalAlpha = selectGoalValue(alpha, this._goalAlpha);
-        this._goalBeta = selectGoalValue(beta, this._goalBeta);
-        this._goalRadius = selectGoalValue(radius, this._goalRadius);
-        this._goalTarget.set(selectGoalValue(target?.x, this._goalTarget.x), selectGoalValue(target?.y, this._goalTarget.y), selectGoalValue(target?.z, this._goalTarget.z));
-        this._goalTargetScreenOffset.set(
-            selectGoalValue(targetScreenOffset?.x, this._goalTargetScreenOffset.x),
-            selectGoalValue(targetScreenOffset?.y, this._goalTargetScreenOffset.y)
-        );
+        this._goalAlpha = checkNaN(alpha, this._goalAlpha);
+        this._goalBeta = checkNaN(beta, this._goalBeta);
+        this._goalRadius = checkNaN(radius, this._goalRadius);
+        this._goalTarget.set(checkNaN(target?.x, this._goalTarget.x), checkNaN(target?.y, this._goalTarget.y), checkNaN(target?.z, this._goalTarget.z));
+        this._goalTargetScreenOffset.set(checkNaN(targetScreenOffset?.x, this._goalTargetScreenOffset.x), checkNaN(targetScreenOffset?.y, this._goalTargetScreenOffset.y));
 
         this._goalAlpha = Clamp(this._goalAlpha, this.lowerAlphaLimit ?? -Infinity, this.upperAlphaLimit ?? Infinity);
         this._goalBeta = Clamp(this._goalBeta, this.lowerBetaLimit ?? -Infinity, this.upperBetaLimit ?? Infinity);
@@ -1121,20 +1121,19 @@ export class ArcRotateCamera extends TargetCamera {
             const dt = this._scene.getEngine().getDeltaTime() / 1000;
             const t = 1 - Math.pow(2, -dt / this._currentInterpolationFactor);
 
-            // If the goal is NaN, it means we are not interpolating to a new value, so we can use the current value.
-            const selectGoalValue = (goal: number, current: number): number => (isNaN(goal) ? current : goal);
+            // NOTE: If the goal is NaN, it means we are not interpolating to a new value, so we can use the current value. Hence the calls to checkNaN.
 
             // Get the goal radius immediately as we'll need it for determining interpolation termination for the target.
-            const goalRadius = selectGoalValue(this._goalRadius, this.radius);
+            const goalRadius = checkNaN(this._goalRadius, this.radius);
 
             // Interpolate the target if we haven't reached the goal yet.
             if (!isNaN(this._goalTarget.x) || !isNaN(this._goalTarget.y) || !isNaN(this._goalTarget.z)) {
                 isInterpolating = true;
 
                 const goalTarget = TmpVectors.Vector3[0].set(
-                    selectGoalValue(this._goalTarget.x, this._target.x),
-                    selectGoalValue(this._goalTarget.y, this._target.y),
-                    selectGoalValue(this._goalTarget.z, this._target.z)
+                    checkNaN(this._goalTarget.x, this._target.x),
+                    checkNaN(this._goalTarget.y, this._target.y),
+                    checkNaN(this._goalTarget.z, this._target.z)
                 );
                 this.setTarget(Vector3.Lerp(this.target, goalTarget, t), undefined, undefined, true);
 
@@ -1152,8 +1151,8 @@ export class ArcRotateCamera extends TargetCamera {
 
                 // Using quaternion for smoother interpolation (and no Euler angles modulo)
                 const goalRotation = Quaternion.RotationAlphaBetaGammaToRef(
-                    selectGoalValue(this._goalAlpha, this.alpha),
-                    selectGoalValue(this._goalBeta, this.beta),
+                    checkNaN(this._goalAlpha, this.alpha),
+                    checkNaN(this._goalBeta, this.beta),
                     0,
                     TmpVectors.Quaternion[0]
                 );
@@ -1192,8 +1191,8 @@ export class ArcRotateCamera extends TargetCamera {
                 isInterpolating = true;
 
                 const goalTargetScreenOffset = TmpVectors.Vector2[0].set(
-                    selectGoalValue(this._goalTargetScreenOffset.x, this.targetScreenOffset.x),
-                    selectGoalValue(this._goalTargetScreenOffset.y, this.targetScreenOffset.y)
+                    checkNaN(this._goalTargetScreenOffset.x, this.targetScreenOffset.x),
+                    checkNaN(this._goalTargetScreenOffset.y, this.targetScreenOffset.y)
                 );
                 Vector2.LerpToRef(this.targetScreenOffset, goalTargetScreenOffset, t, this.targetScreenOffset);
 

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -927,8 +927,8 @@ export class ArcRotateCamera extends TargetCamera {
         this._goalAlpha = checkNaN(alpha, this._goalAlpha);
         this._goalBeta = checkNaN(beta, this._goalBeta);
         this._goalRadius = checkNaN(radius, this._goalRadius);
-        this._goalTarget.set(checkNaN(target?.x, this._goalTarget.x), checkNaN(target?.y, this._goalTarget.y), checkNaN(target?.z, this._goalTarget.z));
-        this._goalTargetScreenOffset.set(checkNaN(targetScreenOffset?.x, this._goalTargetScreenOffset.x), checkNaN(targetScreenOffset?.y, this._goalTargetScreenOffset.y));
+        this._goalTarget.set(checkNaN(target.x, this._goalTarget.x), checkNaN(target.y, this._goalTarget.y), checkNaN(target.z, this._goalTarget.z));
+        this._goalTargetScreenOffset.set(checkNaN(targetScreenOffset.x, this._goalTargetScreenOffset.x), checkNaN(targetScreenOffset.y, this._goalTargetScreenOffset.y));
 
         this._goalAlpha = Clamp(this._goalAlpha, this.lowerAlphaLimit ?? -Infinity, this.upperAlphaLimit ?? Infinity);
         this._goalBeta = Clamp(this._goalBeta, this.lowerBetaLimit ?? -Infinity, this.upperBetaLimit ?? Infinity);

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1135,8 +1135,6 @@ export class ArcRotateCamera extends TargetCamera {
 
             // Interpolate the target if we haven't reached the goal yet.
             if (!isNaN(this._goalTarget.x) || !isNaN(this._goalTarget.y) || !isNaN(this._goalTarget.z)) {
-                isInterpolating = true;
-
                 const goalTarget = TmpVectors.Vector3[0].set(
                     checkNaN(this._goalTarget.x, this._target.x),
                     checkNaN(this._goalTarget.y, this._target.y),
@@ -1149,13 +1147,13 @@ export class ArcRotateCamera extends TargetCamera {
                 if ((Vector3.Distance(this.target, goalTarget) * 10) / goalRadius < Epsilon) {
                     this._goalTarget.set(NaN, NaN, NaN);
                     this.setTarget(goalTarget.clone(), undefined, undefined, true);
+                } else {
+                    isInterpolating = true;
                 }
             }
 
             // Interpolate the rotation if we haven't reached the goal yet.
             if (!isNaN(this._goalAlpha) || !isNaN(this._goalBeta)) {
-                isInterpolating = true;
-
                 // Using quaternion for smoother interpolation (and no Euler angles modulo)
                 const goalRotation = Quaternion.RotationAlphaBetaGammaToRef(
                     checkNaN(this._goalAlpha, this.alpha),
@@ -1177,26 +1175,26 @@ export class ArcRotateCamera extends TargetCamera {
                     const goalAlphaBetaGamma = goalRotation.toAlphaBetaGammaToRef(TmpVectors.Vector3[0]);
                     this.alpha = goalAlphaBetaGamma.x;
                     this.beta = goalAlphaBetaGamma.y;
+                } else {
+                    isInterpolating = true;
                 }
             }
 
             // Interpolate the radius if we haven't reached the goal yet.
             if (!isNaN(this._goalRadius)) {
-                isInterpolating = true;
-
                 this.radius += (goalRadius - this.radius) * t;
 
                 // Terminate the radius interpolation when we are 99.9% of the way to the goal radius, at which point it is visually indistinguishable from the goal.
                 if (Math.abs(goalRadius / this.radius - 1) < Epsilon) {
                     this._goalRadius = NaN;
                     this.radius = goalRadius;
+                } else {
+                    isInterpolating = true;
                 }
             }
 
             // Interpolate the target screen offset if we haven't reached the goal yet.
             if (!isNaN(this._goalTargetScreenOffset.x) || !isNaN(this._goalTargetScreenOffset.y)) {
-                isInterpolating = true;
-
                 const goalTargetScreenOffset = TmpVectors.Vector2[0].set(
                     checkNaN(this._goalTargetScreenOffset.x, this.targetScreenOffset.x),
                     checkNaN(this._goalTargetScreenOffset.y, this.targetScreenOffset.y)
@@ -1207,6 +1205,8 @@ export class ArcRotateCamera extends TargetCamera {
                 if (Vector2.Distance(this.targetScreenOffset, goalTargetScreenOffset) < Epsilon) {
                     this._goalTargetScreenOffset.set(NaN, NaN);
                     this.targetScreenOffset.copyFrom(goalTargetScreenOffset);
+                } else {
+                    isInterpolating = true;
                 }
             }
 

--- a/packages/dev/core/test/unit/Cameras/babylon.arcRotateCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/babylon.arcRotateCameraInputs.test.ts
@@ -5,7 +5,8 @@ import { DeviceType, PointerInput } from "core/DeviceInput/InputDevices/deviceEn
 import { NullEngine } from "core/Engines/nullEngine";
 import { PointerEventTypes, PointerInfo } from "core/Events";
 import type { IMouseEvent } from "core/Events/deviceInputEvents";
-import { Vector3 } from "core/Maths/math.vector";
+import { Vector2, Vector3 } from "core/Maths/math.vector";
+import { WithinEpsilon } from "core/Maths/math.scalar.functions";
 import { Scene } from "core/scene";
 import type { Nullable } from "core/types";
 import { TestDeviceInputSystem } from "../DeviceInput/testDeviceInputSystem";
@@ -13,7 +14,25 @@ import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { Frustum } from "core/Maths";
 import { StandardMaterial } from "core/Materials";
 
-describe("ArcRotateCameraMouseInput", () => {
+function waitForCondition(condition: () => boolean, timeout: number = 5000, interval: number = 50): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const startTime = Date.now();
+
+        const checkCondition = () => {
+            if (condition()) {
+                resolve();
+            } else if (Date.now() - startTime >= timeout) {
+                reject(new Error(`Timeout waiting for condition to become true: ${condition}`));
+            } else {
+                setTimeout(checkCondition, interval);
+            }
+        };
+
+        checkCondition();
+    });
+}
+
+describe("ArcRotateCamera", () => {
     let engine: Nullable<NullEngine> = null;
     let scene: Nullable<Scene> = null;
     let camera: Nullable<ArcRotateCamera> = null;
@@ -31,6 +50,7 @@ describe("ArcRotateCameraMouseInput", () => {
         camera = new ArcRotateCamera("camera", 0, 0, 10, Vector3.Zero(), scene);
         camera.setTarget(Vector3.Zero());
         camera.attachControl();
+        camera.restoreStateInterpolationFactor = 0.01;
     });
 
     afterEach(() => {
@@ -39,173 +59,225 @@ describe("ArcRotateCameraMouseInput", () => {
         engine?.dispose();
     });
 
-    it("ignores any touch inputs after the second", () => {
-        let radius = camera!.radius;
-        const alpha = camera!.alpha;
-        const beta = camera!.beta;
-        const testDeviceInputSystem = new TestDeviceInputSystem(
-            engine!,
-            () => {},
-            () => {},
-            () => {}
-        );
-        testDeviceInputSystem.connectDevice(DeviceType.Touch, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
-        testDeviceInputSystem.connectDevice(DeviceType.Touch, 1, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+    describe("MouseInput", () => {
+        it("ignores any touch inputs after the second", () => {
+            let radius = camera!.radius;
+            const alpha = camera!.alpha;
+            const beta = camera!.beta;
+            const testDeviceInputSystem = new TestDeviceInputSystem(
+                engine!,
+                () => {},
+                () => {},
+                () => {}
+            );
+            testDeviceInputSystem.connectDevice(DeviceType.Touch, 0, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+            testDeviceInputSystem.connectDevice(DeviceType.Touch, 1, TestDeviceInputSystem.MAX_POINTER_INPUTS);
 
-        // First touch events
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 0, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 0, false);
+            // First touch events
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 1, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 0, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 0, false);
 
-        const downEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 1, testDeviceInputSystem);
-        const downPI1 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt1 as IMouseEvent, new PickingInfo());
+            const downEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 1, testDeviceInputSystem);
+            const downPI1 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt1 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 15, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 15, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Horizontal, 15, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.Vertical, 15, false);
 
-        const moveEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.Move, 1, testDeviceInputSystem);
-        const movePI1 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt1 as IMouseEvent, new PickingInfo());
+            const moveEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.Move, 1, testDeviceInputSystem);
+            const movePI1 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt1 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 0, PointerInput.LeftClick, 0, false);
 
-        const upEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 0, testDeviceInputSystem);
-        const upPI1 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt1 as IMouseEvent, new PickingInfo());
+            const upEvt1 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 0, PointerInput.LeftClick, 0, testDeviceInputSystem);
+            const upPI1 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt1 as IMouseEvent, new PickingInfo());
 
-        // Second touch events
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 1, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 127, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 127, false);
+            // Second touch events
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 1, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 127, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 127, false);
 
-        const downEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 1, testDeviceInputSystem);
-        const downPI2 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt2 as IMouseEvent, new PickingInfo());
+            const downEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 1, testDeviceInputSystem);
+            const downPI2 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt2 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 112, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 112, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Horizontal, 112, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.Vertical, 112, false);
 
-        const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.Move, 1, testDeviceInputSystem);
-        const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2 as IMouseEvent, new PickingInfo());
+            const moveEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.Move, 1, testDeviceInputSystem);
+            const movePI2 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt2 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 1, PointerInput.LeftClick, 0, false);
 
-        const upEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 0, testDeviceInputSystem);
-        const upPI2 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt2 as IMouseEvent, new PickingInfo());
+            const upEvt2 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 1, PointerInput.LeftClick, 0, testDeviceInputSystem);
+            const upPI2 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt2 as IMouseEvent, new PickingInfo());
 
-        // Third touch events
-        testDeviceInputSystem.connectDevice(DeviceType.Touch, 2, TestDeviceInputSystem.MAX_POINTER_INPUTS);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 1, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
+            // Third touch events
+            testDeviceInputSystem.connectDevice(DeviceType.Touch, 2, TestDeviceInputSystem.MAX_POINTER_INPUTS);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 1, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
 
-        const downEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
-        const downPI3 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt3 as IMouseEvent, new PickingInfo());
+            const downEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 1, testDeviceInputSystem);
+            const downPI3 = new PointerInfo(PointerEventTypes.POINTERDOWN, downEvt3 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 50, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 50, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 50, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 50, false);
 
-        const moveEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
-        const movePI3 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt3 as IMouseEvent, new PickingInfo());
+            const moveEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+            const movePI3 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt3 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.LeftClick, 0, false);
 
-        const upEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
-        const upPI3 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt3 as IMouseEvent, new PickingInfo());
+            const upEvt3 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.LeftClick, 0, testDeviceInputSystem);
+            const upPI3 = new PointerInfo(PointerEventTypes.POINTERUP, upEvt3 as IMouseEvent, new PickingInfo());
 
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
-        testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Horizontal, 64, false);
+            testDeviceInputSystem.changeInput(DeviceType.Touch, 2, PointerInput.Vertical, 64, false);
 
-        const moveEvt4 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
-        const movePI4 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt4 as IMouseEvent, new PickingInfo());
+            const moveEvt4 = DeviceEventFactory.CreateDeviceEvent(DeviceType.Touch, 2, PointerInput.Move, 1, testDeviceInputSystem);
+            const movePI4 = new PointerInfo(PointerEventTypes.POINTERMOVE, moveEvt4 as IMouseEvent, new PickingInfo());
 
-        // Start pinch gesture
-        scene?.onPointerObservable.notifyObservers(downPI1);
-        scene?.onPointerObservable.notifyObservers(downPI2);
-        scene?.onPointerObservable.notifyObservers(movePI1);
-        scene?.onPointerObservable.notifyObservers(movePI2);
-        scene?.render();
-        expect(camera!.radius).toBeGreaterThan(radius);
+            // Start pinch gesture
+            scene?.onPointerObservable.notifyObservers(downPI1);
+            scene?.onPointerObservable.notifyObservers(downPI2);
+            scene?.onPointerObservable.notifyObservers(movePI1);
+            scene?.onPointerObservable.notifyObservers(movePI2);
+            scene?.render();
+            expect(camera!.radius).toBeGreaterThan(radius);
 
-        radius = camera!.radius;
+            radius = camera!.radius;
 
-        // Remove any pending movement
-        camera!.inertialRadiusOffset = 0;
+            // Remove any pending movement
+            camera!.inertialRadiusOffset = 0;
 
-        // Move third while first and second are still down
-        // No changes should occur
-        scene?.onPointerObservable.notifyObservers(downPI3);
-        scene?.onPointerObservable.notifyObservers(movePI3);
-        scene?.render();
-        expect(camera!.radius).toEqual(radius);
+            // Move third while first and second are still down
+            // No changes should occur
+            scene?.onPointerObservable.notifyObservers(downPI3);
+            scene?.onPointerObservable.notifyObservers(movePI3);
+            scene?.render();
+            expect(camera!.radius).toEqual(radius);
 
-        // Release first only, no radius changes should occur
-        scene?.onPointerObservable.notifyObservers(upPI1);
-        scene?.onPointerObservable.notifyObservers(movePI4);
-        scene?.render();
-        expect(camera!.radius).toEqual(radius);
+            // Release first only, no radius changes should occur
+            scene?.onPointerObservable.notifyObservers(upPI1);
+            scene?.onPointerObservable.notifyObservers(movePI4);
+            scene?.render();
+            expect(camera!.radius).toEqual(radius);
 
-        // Release second, no radius changes should occur
-        scene?.onPointerObservable.notifyObservers(upPI2);
-        scene?.onPointerObservable.notifyObservers(movePI3);
-        scene?.onPointerObservable.notifyObservers(upPI3);
-        scene?.render();
-        expect(camera!.radius).toEqual(radius);
+            // Release second, no radius changes should occur
+            scene?.onPointerObservable.notifyObservers(upPI2);
+            scene?.onPointerObservable.notifyObservers(movePI3);
+            scene?.onPointerObservable.notifyObservers(upPI3);
+            scene?.render();
+            expect(camera!.radius).toEqual(radius);
 
-        // Once all are released, third should be able to move the camera
-        scene?.onPointerObservable.notifyObservers(downPI3);
-        scene?.onPointerObservable.notifyObservers(movePI3);
-        scene?.onPointerObservable.notifyObservers(upPI3);
-        scene?.render();
+            // Once all are released, third should be able to move the camera
+            scene?.onPointerObservable.notifyObservers(downPI3);
+            scene?.onPointerObservable.notifyObservers(movePI3);
+            scene?.onPointerObservable.notifyObservers(upPI3);
+            scene?.render();
 
-        expect(camera!.alpha).toBeGreaterThan(alpha);
-        expect(camera!.beta).toBeGreaterThan(beta);
+            expect(camera!.alpha).toBeGreaterThan(alpha);
+            expect(camera!.beta).toBeGreaterThan(beta);
+        });
+
+        it("correctly zooms when zoomOn is called", () => {
+            let outOfBoundsPoints = 0;
+            let inBoundsPoints = 0;
+
+            if (camera && scene && StandardMaterial) {
+                // Create box to check zoomOn against
+                const box = MeshBuilder.CreateBox("box", { height: 1, width: 2, depth: 1 }, scene);
+                // Set angles such that the box's mix/max points are not technically
+                // the farthest points in screen/camera space
+                camera.alpha = Math.PI / 3;
+                camera.beta = Math.PI / 2.5;
+                camera.radius = 0.01;
+                box.position = new Vector3(0, 0.5, 0);
+                scene.render();
+
+                // Get frustum planes from camera transformation matrix
+                let transformMatrix = camera.getTransformationMatrix();
+                let frustumPlanes = Frustum.GetPlanes(transformMatrix);
+
+                // Get all bounding box points and check if they are in the frustum
+                // both before and after zoomOn
+                const pointsToCheck = box.getBoundingInfo().boundingBox.vectorsWorld;
+
+                // Before zoomOn
+                for (const point of pointsToCheck) {
+                    if (!Frustum.IsPointInFrustum(point, frustumPlanes)) {
+                        outOfBoundsPoints++;
+                    }
+                }
+
+                scene.render();
+                camera.zoomOn([box]);
+                scene.render();
+
+                // Update frustum planes and transformation matrix
+                transformMatrix = camera.getTransformationMatrix();
+                frustumPlanes = Frustum.GetPlanes(transformMatrix);
+
+                // After zoomOn
+                for (const point of pointsToCheck) {
+                    if (Frustum.IsPointInFrustum(point, frustumPlanes)) {
+                        inBoundsPoints++;
+                    }
+                }
+            }
+
+            expect(outOfBoundsPoints).toEqual(8);
+            expect(inBoundsPoints).toEqual(8);
+        });
     });
 
-    it("correctly zooms when zoomOn is called", () => {
-        let outOfBoundsPoints = 0;
-        let inBoundsPoints = 0;
+    describe("Interpolation", () => {
+        it("arrives at goal", async () => {
+            engine!.runRenderLoop(() => {
+                scene!.render();
+            });
 
-        if (camera && scene && StandardMaterial) {
-            // Create box to check zoomOn against
-            const box = MeshBuilder.CreateBox("box", { height: 1, width: 2, depth: 1 }, scene);
-            // Set angles such that the box's mix/max points are not technically
-            // the farthest points in screen/camera space
-            camera.alpha = Math.PI / 3;
-            camera.beta = Math.PI / 2.5;
-            camera.radius = 0.01;
-            box.position = new Vector3(0, 0.5, 0);
-            scene.render();
+            camera!.interpolateTo(1, 2, 3, new Vector3(4, 5, 6), new Vector2(7, 8), 0.01);
+            await waitForCondition(() => !camera!.isInterpolating);
 
-            // Get frustum planes from camera transformation matrix
-            let transformMatrix = camera.getTransformationMatrix();
-            let frustumPlanes = Frustum.GetPlanes(transformMatrix);
+            expect(WithinEpsilon(camera!.alpha, 1)).toBe(true);
+            expect(WithinEpsilon(camera!.beta, 2)).toBe(true);
+            expect(WithinEpsilon(camera!.radius, 3)).toBe(true);
+            expect(WithinEpsilon(camera!.target.x, 4)).toBe(true);
+            expect(WithinEpsilon(camera!.target.y, 5)).toBe(true);
+            expect(WithinEpsilon(camera!.target.z, 6)).toBe(true);
+            expect(WithinEpsilon(camera!.targetScreenOffset.x, 7)).toBe(true);
+            expect(WithinEpsilon(camera!.targetScreenOffset.y, 8)).toBe(true);
+        });
 
-            // Get all bounding box points and check if they are in the frustum
-            // both before and after zoomOn
-            const pointsToCheck = box.getBoundingInfo().boundingBox.vectorsWorld;
+        it("undefined uses current value", async () => {
+            engine!.runRenderLoop(() => {
+                scene!.render();
+            });
 
-            // Before zoomOn
-            for (const point of pointsToCheck) {
-                if (!Frustum.IsPointInFrustum(point, frustumPlanes)) {
-                    outOfBoundsPoints++;
-                }
-            }
+            camera!.alpha = 1;
+            camera!.interpolateTo(2);
+            camera!.interpolateTo(undefined, 2);
 
-            scene.render();
-            camera.zoomOn([box]);
-            scene.render();
+            await waitForCondition(() => !camera!.isInterpolating);
 
-            // Update frustum planes and transformation matrix
-            transformMatrix = camera.getTransformationMatrix();
-            frustumPlanes = Frustum.GetPlanes(transformMatrix);
+            expect(WithinEpsilon(camera!.alpha, 1)).toBe(true);
+            expect(WithinEpsilon(camera!.beta, 2)).toBe(true);
+        });
 
-            // After zoomOn
-            for (const point of pointsToCheck) {
-                if (Frustum.IsPointInFrustum(point, frustumPlanes)) {
-                    inBoundsPoints++;
-                }
-            }
-        }
+        it("NaN uses current goal", async () => {
+            engine!.runRenderLoop(() => {
+                scene!.render();
+            });
 
-        expect(outOfBoundsPoints).toEqual(8);
-        expect(inBoundsPoints).toEqual(8);
+            camera!.alpha = 1;
+            camera!.interpolateTo(2);
+            camera!.interpolateTo(NaN, 2);
+
+            await waitForCondition(() => !camera!.isInterpolating);
+
+            expect(WithinEpsilon(camera!.alpha, 2)).toBe(true);
+            expect(WithinEpsilon(camera!.beta, 2)).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
This PR makes several improvements to the existing ArcRotateCamera interpolation logic:
- Allows overlapping interpolations. For example, if you start an interpolation of alpha, and before it is finished start an interpolation of the y component of the target, it previously would always stop the previous interpolation. Now it is possible for them to overlap, but passing in `NaN` for the components you don't want to interpolate. This is perhaps a little unusual, but it's the least disruptive to the API. Still, open to alternate suggestions.
- Ensures the camera orbit/target/etc. eventually reach the actual interpolation goal values. Previously, it would stop the interpolation when it was "close," but not actually bring the values to the final goal values.
- Because of the previous point, I had to improve the logic for determining when we are "close" to the final goal values, to ensure "close" is visually indistinguishable from the final value.
  - For target, it is relative to the radius. This ensures it visually always looks the same regardless of scale.
  - For rotation, it is just an absolute value (0.0002 radians), which was chosen empirically by just seeing what looked visually indistinguishable.
  - For radius, it is when we are 99.9% of the way to the goal, which again should work well regardless of scale.
  - For target screen offset, it is just an absolute value, same as previous actually.
- Swaps the order to applying user input and applying interpolation. This way, if there is any user input, we don't add in a small and unnecessary and incorrect interpolation first (size of the change depends on frame time). Also, it means we don't need to repeat the checks for user input twice.
- Add a `stopInterpolation` function to make it easier to interrupt an in-progress interpolation.
- Unit tests for the interpolation logic.