### PR TITLE
Use also environmentIntensity for environment level in viewer

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -786,6 +786,7 @@ export class Viewer implements IDisposable {
             this._reflectionsIntensity = value;
 
             this._snapshotHelper.disableSnapshotRendering();
+            this._scene.environmentIntensity = this._reflectionsIntensity;
             if (this._skyboxTexture) {
                 this._skyboxTexture.level = this._reflectionsIntensity;
             }


### PR DESCRIPTION
So far the environment could not be fully dimmed and there still was some lighting going on the meshes materials.
Use of `environmentIntensity` as this answer indicate https://forum.babylonjs.com/t/pbr-material-not-black-when-hdr-environment-texture-level-is-set-to-0-and-all-lights-are-turned-off/24212/2