### PR TITLE
NME: Fix wrong generated code for ColorConverter and ColorMerger

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/colorConverterBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorConverterBlock.ts
@@ -70,6 +70,16 @@ export class ColorConverterBlock extends NodeMaterialBlock {
         return name;
     }
 
+    protected override _outputRename(name: string) {
+        if (name === "rgb") {
+            return "rgbOut";
+        }
+        if (name === "hsl") {
+            return "hslOut";
+        }
+        return name;
+    }
+
     protected override _buildBlock(state: NodeMaterialBuildState) {
         super._buildBlock(state);
 

--- a/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/colorMergerBlock.ts
@@ -116,6 +116,13 @@ export class ColorMergerBlock extends NodeMaterialBlock {
         return name;
     }
 
+    protected override _outputRename(name: string) {
+        if (name === "rgb") {
+            return "rgbOut";
+        }
+        return name;
+    }
+
     private _buildSwizzle(len: number) {
         const swizzle = this.rSwizzle + this.gSwizzle + this.bSwizzle + this.aSwizzle;
         return "." + swizzle.substring(0, len);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/nme-generates-deprecated-code-for-some-blocs/57548