### PR TITLE
Fix lazy loaded property values in audio engine

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/audioAnalyzerSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/audioAnalyzerSubNode.ts
@@ -35,11 +35,6 @@ export function _GetAudioAnalyzerSubNode(subGraph: _AbstractAudioSubGraph): Null
 }
 
 /** @internal */
-export function _GetAudioAnalyzerProperty<K extends keyof typeof _AudioAnalyzerDefaults>(subGraph: _AbstractAudioSubGraph, property: K): (typeof _AudioAnalyzerDefaults)[K] {
-    return _GetAudioAnalyzerSubNode(subGraph)?.[property] ?? _AudioAnalyzerDefaults[property];
-}
-
-/** @internal */
 export function _SetAudioAnalyzerProperty<K extends keyof typeof _AudioAnalyzerDefaults>(subGraph: _AbstractAudioSubGraph, property: K, value: _AudioAnalyzerSubNode[K]): void {
     subGraph.callOnSubNode<_AudioAnalyzerSubNode>(AudioSubNode.ANALYZER, (node) => {
         node[property] = value;

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
@@ -106,11 +106,6 @@ export function _GetSpatialAudioSubNode(subGraph: _AbstractAudioSubGraph): Nulla
 }
 
 /** @internal */
-export function _GetSpatialAudioProperty<K extends keyof typeof _SpatialAudioDefaults>(subGraph: _AbstractAudioSubGraph, property: K): (typeof _SpatialAudioDefaults)[K] {
-    return _GetSpatialAudioSubNode(subGraph)?.[property] ?? _SpatialAudioDefaults[property];
-}
-
-/** @internal */
 export function _SetSpatialAudioProperty<K extends keyof typeof _SpatialAudioDefaults>(subGraph: _AbstractAudioSubGraph, property: K, value: _SpatialAudioSubNode[K]): void {
     subGraph.callOnSubNode<_SpatialAudioSubNode>(AudioSubNode.SPATIAL, (node) => {
         node[property] = value;

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/stereoAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/stereoAudioSubNode.ts
@@ -26,11 +26,6 @@ export function _GetStereoAudioSubNode(subGraph: _AbstractAudioSubGraph): Nullab
 }
 
 /** @internal */
-export function _GetStereoAudioProperty<K extends keyof typeof _StereoAudioDefaults>(subGraph: _AbstractAudioSubGraph, property: K): (typeof _StereoAudioDefaults)[K] {
-    return _GetStereoAudioSubNode(subGraph)?.[property] ?? _StereoAudioDefaults[property];
-}
-
-/** @internal */
 export function _SetStereoAudioProperty<K extends keyof typeof _StereoAudioDefaults>(subGraph: _AbstractAudioSubGraph, property: K, value: _StereoAudioSubNode[K]): void {
     subGraph.callOnSubNode<_StereoAudioSubNode>(AudioSubNode.STEREO, (node) => {
         node[property] = value;

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/audioAnalyzer.ts
@@ -1,9 +1,9 @@
 import { Logger } from "../../../Misc/logger";
 import type { Nullable } from "../../../types";
 import type { AudioAnalyzerFFTSizeType } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
-import { AbstractAudioAnalyzer } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
+import { _AudioAnalyzerDefaults, AbstractAudioAnalyzer } from "../../abstractAudio/subProperties/abstractAudioAnalyzer";
 import type { _AbstractAudioSubGraph } from "../subNodes/abstractAudioSubGraph";
-import { _GetAudioAnalyzerProperty, _GetAudioAnalyzerSubNode, _SetAudioAnalyzerProperty } from "../subNodes/audioAnalyzerSubNode";
+import { _GetAudioAnalyzerSubNode, _SetAudioAnalyzerProperty } from "../subNodes/audioAnalyzerSubNode";
 import { AudioSubNode } from "../subNodes/audioSubNode";
 
 let _emptyByteFrequencyData: Nullable<Uint8Array> = null;
@@ -27,6 +27,10 @@ export function _GetEmptyFloatFrequencyData(): Float32Array {
 
 /** @internal */
 export class _AudioAnalyzer extends AbstractAudioAnalyzer {
+    private _fftSize: AudioAnalyzerFFTSizeType = _AudioAnalyzerDefaults.fftSize;
+    private _maxDecibels: number = _AudioAnalyzerDefaults.maxDecibels;
+    private _minDecibels: number = _AudioAnalyzerDefaults.minDecibels;
+    private _smoothing: number = _AudioAnalyzerDefaults.smoothing;
     private _subGraph: _AbstractAudioSubGraph;
 
     /** @internal */
@@ -37,10 +41,11 @@ export class _AudioAnalyzer extends AbstractAudioAnalyzer {
 
     /** @internal */
     public get fftSize(): AudioAnalyzerFFTSizeType {
-        return _GetAudioAnalyzerProperty(this._subGraph, "fftSize");
+        return this._fftSize;
     }
 
     public set fftSize(value: AudioAnalyzerFFTSizeType) {
+        this._fftSize = value;
         _SetAudioAnalyzerProperty(this._subGraph, "fftSize", value);
     }
 
@@ -51,28 +56,31 @@ export class _AudioAnalyzer extends AbstractAudioAnalyzer {
 
     /** @internal */
     public get minDecibels(): number {
-        return _GetAudioAnalyzerProperty(this._subGraph, "minDecibels");
+        return this._minDecibels;
     }
 
     public set minDecibels(value: number) {
+        this._minDecibels = value;
         _SetAudioAnalyzerProperty(this._subGraph, "minDecibels", value);
     }
 
     /** @internal */
     public get maxDecibels(): number {
-        return _GetAudioAnalyzerProperty(this._subGraph, "maxDecibels");
+        return this._maxDecibels;
     }
 
     public set maxDecibels(value: number) {
+        this._maxDecibels = value;
         _SetAudioAnalyzerProperty(this._subGraph, "maxDecibels", value);
     }
 
     /** @internal */
     public get smoothing(): number {
-        return _GetAudioAnalyzerProperty(this._subGraph, "smoothing");
+        return this._smoothing;
     }
 
     public set smoothing(value: number) {
+        this._smoothing = value;
         _SetAudioAnalyzerProperty(this._subGraph, "smoothing", value);
     }
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -5,12 +5,20 @@ import { SpatialAudioAttachmentType } from "../../spatialAudioAttachmentType";
 import type { _AbstractAudioSubGraph } from "../subNodes/abstractAudioSubGraph";
 import { AudioSubNode } from "../subNodes/audioSubNode";
 import type { _SpatialAudioSubNode } from "../subNodes/spatialAudioSubNode";
-import { _GetSpatialAudioProperty, _GetSpatialAudioSubNode, _SetSpatialAudioProperty } from "../subNodes/spatialAudioSubNode";
+import { _GetSpatialAudioSubNode, _SetSpatialAudioProperty } from "../subNodes/spatialAudioSubNode";
 import { _SpatialAudioDefaults, AbstractSpatialAudio } from "./abstractSpatialAudio";
 
 /** @internal */
 export abstract class _SpatialAudio extends AbstractSpatialAudio {
+    private _coneInnerAngle: number = _SpatialAudioDefaults.coneInnerAngle;
+    private _coneOuterAngle: number = _SpatialAudioDefaults.coneOuterAngle;
+    private _coneOuterVolume: number = _SpatialAudioDefaults.coneOuterVolume;
+    private _distanceModel: DistanceModelType = _SpatialAudioDefaults.distanceModel;
+    private _maxDistance: number = _SpatialAudioDefaults.maxDistance;
+    private _minDistance: number = _SpatialAudioDefaults.minDistance;
+    private _panningModel: PanningModelType = _SpatialAudioDefaults.panningModel;
     private _position: Vector3;
+    private _rolloffFactor: number = _SpatialAudioDefaults.rolloffFactor;
     private _rotation: Vector3;
     private _rotationQuaternion: Quaternion;
     private _subGraph: _AbstractAudioSubGraph;
@@ -37,37 +45,41 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
 
     /** @internal */
     public get coneInnerAngle(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "coneInnerAngle") ?? _SpatialAudioDefaults.coneInnerAngle;
+        return this._coneInnerAngle;
     }
 
     public set coneInnerAngle(value: number) {
+        this._coneInnerAngle = value;
         _SetSpatialAudioProperty(this._subGraph, "coneInnerAngle", value);
     }
 
     /** @internal */
     public get coneOuterAngle(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "coneOuterAngle");
+        return this._coneOuterAngle;
     }
 
     public set coneOuterAngle(value: number) {
+        this._coneOuterAngle = value;
         _SetSpatialAudioProperty(this._subGraph, "coneOuterAngle", value);
     }
 
     /** @internal */
     public get coneOuterVolume(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "coneOuterVolume");
+        return this._coneOuterVolume;
     }
 
     public set coneOuterVolume(value: number) {
+        this._coneOuterVolume = value;
         _SetSpatialAudioProperty(this._subGraph, "coneOuterVolume", value);
     }
 
     /** @internal */
     public get distanceModel(): DistanceModelType {
-        return _GetSpatialAudioProperty(this._subGraph, "distanceModel");
+        return this._distanceModel;
     }
 
     public set distanceModel(value: DistanceModelType) {
+        this._distanceModel = value;
         _SetSpatialAudioProperty(this._subGraph, "distanceModel", value);
     }
 
@@ -78,7 +90,7 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
 
     /** @internal */
     public get maxDistance(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "maxDistance") ?? _SpatialAudioDefaults.maxDistance;
+        return this._maxDistance;
     }
 
     public set maxDistance(value: number) {
@@ -86,24 +98,27 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
             value = 0.000001;
         }
 
+        this._maxDistance = value;
         _SetSpatialAudioProperty(this._subGraph, "maxDistance", value);
     }
 
     /** @internal */
     public get minDistance(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "minDistance");
+        return this._minDistance;
     }
 
     public set minDistance(value: number) {
+        this._minDistance = value;
         _SetSpatialAudioProperty(this._subGraph, "minDistance", value);
     }
 
     /** @internal */
     public get panningModel(): PanningModelType {
-        return _GetSpatialAudioProperty(this._subGraph, "panningModel");
+        return this._panningModel;
     }
 
     public set panningModel(value: PanningModelType) {
+        this._panningModel = value;
         _SetSpatialAudioProperty(this._subGraph, "panningModel", value);
     }
 
@@ -119,10 +134,11 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
 
     /** @internal */
     public get rolloffFactor(): number {
-        return _GetSpatialAudioProperty(this._subGraph, "rolloffFactor");
+        return this._rolloffFactor;
     }
 
     public set rolloffFactor(value: number) {
+        this._rolloffFactor = value;
         _SetSpatialAudioProperty(this._subGraph, "rolloffFactor", value);
     }
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/stereoAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/stereoAudio.ts
@@ -1,9 +1,10 @@
-import { AbstractStereoAudio } from "../../abstractAudio/subProperties/abstractStereoAudio";
+import { _StereoAudioDefaults, AbstractStereoAudio } from "../../abstractAudio/subProperties/abstractStereoAudio";
 import type { _AbstractAudioSubGraph } from "../subNodes/abstractAudioSubGraph";
-import { _GetStereoAudioProperty, _SetStereoAudioProperty } from "../subNodes/stereoAudioSubNode";
+import { _SetStereoAudioProperty } from "../subNodes/stereoAudioSubNode";
 
 /** @internal */
 export class _StereoAudio extends AbstractStereoAudio {
+    private _pan: number = _StereoAudioDefaults.pan;
     private _subGraph: _AbstractAudioSubGraph;
 
     /** @internal */
@@ -14,10 +15,11 @@ export class _StereoAudio extends AbstractStereoAudio {
 
     /** @internal */
     public get pan(): number {
-        return _GetStereoAudioProperty(this._subGraph, "pan");
+        return this._pan;
     }
 
     public set pan(value: number) {
+        this._pan = value;
         _SetStereoAudioProperty(this._subGraph, "pan", value);
     }
 }


### PR DESCRIPTION
Asynchronously loaded subproperties like sound and bus `analyzer`, `spatial` and `stereo`, do not return the same values set on them until the async load completes. This makes it so a property's getter does not immediately return the value given to its setter. For example `analyzer.fftSize = 128; console.log(analyzer.fftSize);` prints the default `2048` until the async `analyzer` subproperty init is complete. This is confusing for users.

This change fixes the issue by using backing variables for properties on lazy-loaded sound and bus subproperties.