### PR TITLE
Viewer: More options + reset logic in Viewer layer

### DIFF
--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -1,8 +1,19 @@
-export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, Model, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
+export type {
+    CameraAutoOrbit,
+    EnvironmentOptions,
+    HotSpot,
+    LoadModelOptions,
+    Model,
+    PostProcessing,
+    ToneMapping,
+    ViewerDetails,
+    ViewerHotSpotQuery,
+    ViewerOptions,
+} from "./viewer";
 export type { CanvasViewerOptions } from "./viewerFactory";
 export type { ViewerElementEventMap } from "./viewerElement";
 
-export { CreateHotSpotFromCamera, DefaultViewerOptions, HotSpot, Viewer, ViewerHotSpotResult } from "./viewer";
+export { CreateHotSpotFromCamera, DefaultViewerOptions, Viewer, ViewerHotSpotResult } from "./viewer";
 export { HTML3DElement, ViewerElement } from "./viewerElement";
 export { CreateViewerForCanvas as createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";

--- a/packages/tools/viewer/src/index.ts
+++ b/packages/tools/viewer/src/index.ts
@@ -1,8 +1,8 @@
 export type { CameraAutoOrbit, EnvironmentOptions, LoadModelOptions, Model, PostProcessing, ToneMapping, ViewerDetails, ViewerHotSpotQuery, ViewerOptions } from "./viewer";
 export type { CanvasViewerOptions } from "./viewerFactory";
-export type { HotSpot, ViewerElementEventMap } from "./viewerElement";
+export type { ViewerElementEventMap } from "./viewerElement";
 
-export { Viewer, ViewerHotSpotResult } from "./viewer";
-export { HTML3DElement, ViewerElement, CreateHotSpotFromCamera } from "./viewerElement";
+export { CreateHotSpotFromCamera, DefaultViewerOptions, HotSpot, Viewer, ViewerHotSpotResult } from "./viewer";
+export { HTML3DElement, ViewerElement } from "./viewerElement";
 export { CreateViewerForCanvas as createViewerForCanvas } from "./viewerFactory";
 export { HTML3DAnnotationElement } from "./viewerAnnotationElement";

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -218,6 +218,20 @@ function computeModelsBoundingInfos(models: readonly Model[]): Nullable<ViewerBo
     return reduceMeshesExtendsToBoundingInfo(maxExtents);
 }
 
+// This helper function is used in functions that are naturally void returning, but need to call an async Promise returning function.
+// If there is any error (other than AbortError) in the async function, it will be logged.
+function observePromise(promise: Promise<unknown>): void {
+    (async () => {
+        try {
+            await promise;
+        } catch (error) {
+            if (!(error instanceof AbortError)) {
+                Logger.Error(error);
+            }
+        }
+    })();
+}
+
 /**
  * Generates a HotSpot from a camera by computing its spherical coordinates (alpha, beta, radius) relative to a target point.
  *
@@ -808,7 +822,7 @@ export class Viewer implements IDisposable {
 
             scene.onNewCameraAddedObservable.add((camera) => {
                 if (this.camerasAsHotSpots) {
-                    this._addCameraHotSpot(camera, this._camerasAsHotSpotsAbortController?.signal);
+                    observePromise(this._addCameraHotSpot(camera, this._camerasAsHotSpotsAbortController?.signal));
                 }
             });
 
@@ -1647,24 +1661,20 @@ export class Viewer implements IDisposable {
     /**
      * Resets the viewer to its initial state based on the options passed in to the constructor.
      * @param flags The flags that specify which parts of the viewer to reset. If no flags are provided, all parts will be reset.
+     * - "source": Reset the loaded model.
+     * - "environment": Reset environment related state.
+     * - "animation": Reset animation related state.
+     * - "camera": Reset camera related state.
+     * - "post-processing": Reset post-processing related state.
+     * - "material-variant": Reset material variant related state.
      */
     public reset(...flags: ResetFlag[]) {
         this._reset(true, ...flags);
     }
 
     private _reset(interpolate: boolean, ...flags: ResetFlag[]) {
-        const handleLoadError = async (promise: Promise<unknown>) => {
-            try {
-                await promise;
-            } catch (error) {
-                if (!(error instanceof AbortError)) {
-                    Logger.Error(error);
-                }
-            }
-        };
-
         if (flags.length === 0 || flags.includes("source")) {
-            handleLoadError(this._updateModel(this._options?.source));
+            observePromise(this._updateModel(this._options?.source));
         }
 
         if (flags.length === 0 || flags.includes("environment")) {
@@ -1676,10 +1686,10 @@ export class Viewer implements IDisposable {
                 visible: this._options?.environmentConfig?.visible ?? DefaultViewerOptions.environmentConfig.visible,
             };
             if (this._options?.environmentLighting === this._options?.environmentSkybox) {
-                handleLoadError(this._updateEnvironment(this._options?.environmentLighting, { lighting: true, skybox: true }, this._loadEnvironmentAbortController?.signal));
+                observePromise(this._updateEnvironment(this._options?.environmentLighting, { lighting: true, skybox: true }, this._loadEnvironmentAbortController?.signal));
             } else {
-                handleLoadError(this._updateEnvironment(this._options?.environmentLighting, { lighting: true }, this._loadEnvironmentAbortController?.signal));
-                handleLoadError(this._updateEnvironment(this._options?.environmentSkybox, { skybox: true }, this._loadSkyboxAbortController?.signal));
+                observePromise(this._updateEnvironment(this._options?.environmentLighting, { lighting: true }, this._loadEnvironmentAbortController?.signal));
+                observePromise(this._updateEnvironment(this._options?.environmentSkybox, { skybox: true }, this._loadSkyboxAbortController?.signal));
             }
         }
 
@@ -1741,6 +1751,7 @@ export class Viewer implements IDisposable {
         this._loadEnvironmentAbortController?.abort(new AbortError("Thew viewer is being disposed."));
         this._loadSkyboxAbortController?.abort(new AbortError("Thew viewer is being disposed."));
         this._loadModelAbortController?.abort(new AbortError("Thew viewer is being disposed."));
+        this._camerasAsHotSpotsAbortController?.abort(new AbortError("Thew viewer is being disposed."));
 
         this._renderLoopController?.dispose();
         this._activeModel?.dispose();
@@ -1758,6 +1769,9 @@ export class Viewer implements IDisposable {
         this.onAnimationSpeedChanged.clear();
         this.onIsAnimationPlayingChanged.clear();
         this.onAnimationProgressChanged.clear();
+        this.onSelectedMaterialVariantChanged.clear();
+        this.onHotSpotsChanged.clear();
+        this.onCamerasAsHotSpotsChanged.clear();
         this.onLoadingProgressChanged.clear();
 
         this._imageProcessingConfigurationObserver.remove();

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -575,7 +575,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
      */
     public queryHotSpot(name: string, result: ViewerHotSpotResult): boolean {
         if (this._viewerDetails) {
-            return this._viewerDetails.viewer.queryHotSpot(name, result) != null;
+            return this._viewerDetails.viewer.queryHotSpot(name, result);
         }
         return false;
     }
@@ -868,7 +868,7 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
      * - [ResetFlag] - A space separated list of reset flags that reset various aspects of the viewer state.
      */
     @property({ attribute: "reset-mode", converter: coerceResetMode })
-    public resetMode: "auto" | "reframe" | [ResetFlag, ...flags: ResetFlag[]] = "auto";
+    public resetMode: ResetMode = "auto";
 
     @query("#canvasContainer")
     private _canvasContainer: HTMLDivElement | undefined;


### PR DESCRIPTION
This PR aims to solve a couple of different but overlapping problems:
- More flexibility in the reset logic (forum issue: https://forum.babylonjs.com/t/viewer-v2-reset-button-to-the-initial-explicitly-specified-camera-pose/56925)
- Make it possible to initialize the Viewer from JSON (allows the Viewer Configurator to be used with all layers of the Viewer, not just the HTML layer, and also creates a path for saving/loading to/from snippet server)

Changes to the Configurator will come in a subsequent PR. For this PR, the overall changes are as follows:
## Viewer
- Flesh out `ViewerOptions` with *most* properties of the Viewer.
- Expose a `DefaultViewerOptions` object, which is used for Viewer initialization and will also be used by the Configurator.
- Add a `reset` function that helps reset Viewer state to the initial state (based on passed in options and default options).
- Use this reset state and logic in the Viewer layer and remove old `UpdateModelOptions` that was needed to coordinate reset logic that was spread across `Viewer` and `ViewerElement`.
- Update the `resetCamera` function to be more configurable (reframe the camera (current logic), reset the camera to the initial state, or pick a reasonable default based on Viewer state).
- Add an `updateCamera` function that will interpolate to a new pose.
- Remove `FramingBehavior`. It was used in early versions of the Viewer, but at this point the Viewer's framing logic has superseded `FramingBehavior` and it is no longer needed.
- Move all hotspot state and logic down to the Viewer layer.

## ViewerFactory
- Wrap the passed through options in a `Proxy`, which makes is possible for the higher layers (e.g. `ViewerElement`) to override the default options dynamically (used to allow element attributes to behave as default options).

## ViewerElement
- Initialize properties/attributes based on the passed in options (since they now have most of the Viewer properties).
- Pass `ViewerOptions` down that return attributes if they are set, otherwise the passed in option value. This makes it so if an attribute is dynamically updated, it becomes the configured value that is used by the reset logic.
- Change `camera-orbit` and `camera-target` to be custom handled attributes (not reactive properties). There is a lot of special handling to get the desired behavior for camera pose, so the reactive property pattern is not helpful anymore.
- Add a `resetMode` property/attribute, and a `reset` function. The behavior of the `reset` function (called when the reset button is clicked) depends on the `resetMode`. This is what finally addresses the forum issue.
- Remove `syncToAttribute` logic that was previously used for reset logic (since reset logic moved down to the Viewer layer).
- Remove logic to reset camera state, since it also moved down to the Viewer layer.
- Remove `UpdateModelOptions` related args previously passed to `Viewer.loadModel` as this is now all handled in the Viewer layer.
- Remove all hotspot implementation since it is now handled in the Viewer layer.