### PR TITLE
Post Processes: Fix scale being overwritten by default (1,1) values

### DIFF
--- a/packages/dev/core/src/Materials/effectRenderer.ts
+++ b/packages/dev/core/src/Materials/effectRenderer.ts
@@ -634,9 +634,10 @@ export class EffectWrapper {
 
     /**
      * Binds the data to the effect.
+     * @param noDefaultBindings if true, the default bindings (scale and alpha mode) will not be set.
      */
-    public bind() {
-        if (this.options.useAsPostProcess) {
+    public bind(noDefaultBindings = false) {
+        if (this.options.useAsPostProcess && !noDefaultBindings) {
             this.options.engine.setAlphaMode(this.alphaMode);
             this.drawWrapper.effect!.setFloat2("scale", 1, 1);
         }

--- a/packages/dev/core/src/PostProcesses/postProcess.ts
+++ b/packages/dev/core/src/PostProcesses/postProcess.ts
@@ -1072,6 +1072,8 @@ export class PostProcess {
             this.getEngine().setAlphaConstants(this.alphaConstants.r, this.alphaConstants.g, this.alphaConstants.b, this.alphaConstants.a);
         }
 
+        this._engine.setAlphaMode(this.alphaMode);
+
         // Bind the output texture of the preivous post process as the input to this post process.
         let source: RenderTargetWrapper;
         if (this._shareOutputWithPostProcess) {
@@ -1090,7 +1092,7 @@ export class PostProcess {
         this._effectWrapper.drawWrapper.effect!.setVector2("scale", this._scaleRatio);
         this.onApplyObservable.notifyObservers(this._effectWrapper.drawWrapper.effect!);
 
-        this._effectWrapper.bind();
+        this._effectWrapper.bind(true);
 
         return this._effectWrapper.drawWrapper.effect;
     }

--- a/packages/dev/core/src/PostProcesses/thinBlackAndWhitePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBlackAndWhitePostProcess.ts
@@ -49,8 +49,8 @@ export class ThinBlackAndWhitePostProcess extends EffectWrapper {
      */
     public degree = 1;
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
         this._drawWrapper.effect!.setFloat("degree", this.degree);
     }
 }

--- a/packages/dev/core/src/PostProcesses/thinBloomMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBloomMergePostProcess.ts
@@ -38,8 +38,8 @@ export class ThinBloomMergePostProcess extends EffectWrapper {
     /** Weight of the bloom to be added to the original input. */
     public weight = 1;
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
         this._drawWrapper.effect!.setFloat("bloomWeight", this.weight);
     }
 }

--- a/packages/dev/core/src/PostProcesses/thinBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBlurPostProcess.ts
@@ -131,8 +131,8 @@ export class ThinBlurPostProcess extends EffectWrapper {
         return this._packedFloat;
     }
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
         this._drawWrapper.effect!.setFloat2("delta", (1 / this.textureWidth) * this.direction.x, (1 / this.textureHeight) * this.direction.y);
     }
 

--- a/packages/dev/core/src/PostProcesses/thinChromaticAberrationPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinChromaticAberrationPostProcess.ts
@@ -71,8 +71,8 @@ export class ThinChromaticAberrationPostProcess extends EffectWrapper {
     /** The height of the screen to apply the effect on */
     public screenHeight: number;
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         const effect = this._drawWrapper.effect!;
 

--- a/packages/dev/core/src/PostProcesses/thinCircleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinCircleOfConfusionPostProcess.ts
@@ -92,8 +92,8 @@ export class ThinCircleOfConfusionPostProcess extends EffectWrapper {
      */
     public focalLength = 50;
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         const options = this.options as ThinCircleOfConfusionPostProcessOptions;
 

--- a/packages/dev/core/src/PostProcesses/thinExtractHighlightsPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinExtractHighlightsPostProcess.ts
@@ -53,8 +53,8 @@ export class ThinExtractHighlightsPostProcess extends EffectWrapper {
     /** @internal */
     public _exposure = 1;
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         const effect = this._drawWrapper.effect!;
 

--- a/packages/dev/core/src/PostProcesses/thinSSRBlurCombinerPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRBlurCombinerPostProcess.ts
@@ -177,8 +177,8 @@ export class ThinSSRBlurCombinerPostProcess extends EffectWrapper {
         this._updateEffectDefines();
     }
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         const effect = this._drawWrapper.effect!;
 

--- a/packages/dev/core/src/PostProcesses/thinSSRBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRBlurPostProcess.ts
@@ -52,8 +52,8 @@ export class ThinSSRBlurPostProcess extends EffectWrapper {
 
     public blurStrength = 0.03;
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         this._drawWrapper.effect!.setFloat2(
             "texelOffsetScale",

--- a/packages/dev/core/src/PostProcesses/thinSSRPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRPostProcess.ts
@@ -397,8 +397,8 @@ export class ThinSSRPostProcess extends EffectWrapper {
         this._updateEffectDefines();
     }
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         const effect = this._drawWrapper.effect!;
 

--- a/packages/dev/core/src/PostProcesses/thinTAAPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinTAAPostProcess.ts
@@ -165,8 +165,8 @@ export class ThinTAAPostProcess extends EffectWrapper {
         this._hs.next();
     }
 
-    public override bind() {
-        super.bind();
+    public override bind(noDefaultBindings = false) {
+        super.bind(noDefaultBindings);
 
         if (this.disabled) {
             return;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/environment-texture-flipped-when-created-using-imagebitmap/57572