### PR TITLE
fix SPZ loading

### DIFF
--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -185,7 +185,7 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
 
     private _parseSPZ(data: ArrayBuffer, scene: Scene): Promise<ParsedPLY> {
         const ubuf = new Uint8Array(data);
-        const ubufu32 = new Uint32Array(data);
+        const ubufu32 = new Uint32Array(data.slice(0, 12)); // Only need ubufu32[0] to [2]
         // debug infos
         const splatCount = ubufu32[2];
 


### PR DESCRIPTION
Fixed an issue where an error occurred when trying to convert to Uint32Array when the data size was not a multiple of 4.