### PR TITLE
fix: only reload viewer when an engine was already set

### DIFF
--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -960,8 +960,8 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
         if (changedProperties.get("renderWhenIdle") != null) {
             needsReload = true;
         } else if (changedProperties.has("engine")) {
-            const previous = changedProperties.get("engine") ?? GetDefaultEngine();
-            if (this.engine !== previous) {
+            const previous = changedProperties.get("engine");
+            if (previous && this.engine !== previous) {
                 needsReload = true;
             }
         }


### PR DESCRIPTION
With the new initialization method, `_setupViewer` was called twice once in the `connectedCallback` and once in `update` method.

It was very noticable with heavy model.

Now, the `update` method will only tearDown and reload the viewer when the engine was previously set : `previous !== undefined`

Tested with :
- no engine set on the attribute
- engine set with `WebGPU`
- engien set with `WebGL` 