### PR TITLE
glTF Loader: Get `mimeType` from URI if not defined

### DIFF
--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -893,11 +893,12 @@ export class Texture extends BaseTexture {
         }
 
         if (Texture.SerializeBuffers || Texture.ForceSerializeBuffers) {
-            if (typeof this._buffer === "string" && (this._buffer as string).substring(0, 5) === "data:") {
+            if (typeof this._buffer === "string" && this._buffer.startsWith("data:")) {
                 serializationObject.base64String = this._buffer;
                 serializationObject.name = serializationObject.name.replace("data:", "");
             } else if (this.url && this.url.startsWith("data:") && this._buffer instanceof Uint8Array) {
-                serializationObject.base64String = "data:image/png;base64," + EncodeArrayBufferToBase64(this._buffer);
+                const mimeType = this.mimeType || "image/png";
+                serializationObject.base64String = `data:${mimeType};base64,${EncodeArrayBufferToBase64(this._buffer)}`;
             } else if (Texture.ForceSerializeBuffers || (this.url && this.url.startsWith("blob:")) || this._forceSerialize) {
                 serializationObject.base64String =
                     !this._engine || this._engine._features.supportSyncTextureRead ? GenerateBase64StringFromTexture(this) : GenerateBase64StringFromTextureAsync(this);

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -763,6 +763,42 @@ export const RequestFile = (
 };
 
 /**
+ * Reads the mime type from a URL, if available.
+ * @param url
+ * @returns
+ */
+export const GetMimeType = (url: string): string | undefined => {
+    const { match, type } = TestBase64DataUrl(url);
+    if (match) {
+        return type;
+    }
+
+    const lastDot = url.lastIndexOf(".");
+    if (lastDot === -1) {
+        return undefined;
+    }
+
+    const extension = url.substring(lastDot + 1).toLowerCase();
+    switch (extension) {
+        case "glb":
+            return "model/gltf-binary";
+        case "bin":
+            return "application/octet-stream";
+        case "gltf":
+            return "model/gltf+json";
+        case "jpg":
+        case "jpeg":
+            return "image/jpeg";
+        case "png":
+            return "image/png";
+        case "webp":
+            return "image/webp";
+        default:
+            return undefined;
+    }
+};
+
+/**
  * Checks if the loaded document was accessed via `file:`-Protocol.
  * @returns boolean
  * @internal

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -770,11 +770,11 @@ export const RequestFile = (
 export const GetMimeType = (url: string): string | undefined => {
     const { match, type } = TestBase64DataUrl(url);
     if (match) {
-        return type;
+        return type || undefined;
     }
 
     const lastDot = url.lastIndexOf(".");
-    if (lastDot === -1) {
+    if (lastDot === -1 || lastDot === url.length - 1) {
         return undefined;
     }
 

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -774,11 +774,8 @@ export const GetMimeType = (url: string): string | undefined => {
     }
 
     const lastDot = url.lastIndexOf(".");
-    if (lastDot === -1 || lastDot === url.length - 1) {
-        return undefined;
-    }
-
     const extension = url.substring(lastDot + 1).toLowerCase();
+
     switch (extension) {
         case "glb":
             return "model/gltf-binary";

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -68,7 +68,7 @@ import type { IGLTFLoaderExtension } from "./glTFLoaderExtension";
 import type { IGLTFLoader, IGLTFLoaderData } from "../glTFFileLoader";
 import { GLTFFileLoader, GLTFLoaderState, GLTFLoaderCoordinateSystemMode, GLTFLoaderAnimationStartMode } from "../glTFFileLoader";
 import type { IDataBuffer } from "core/Misc/dataReader";
-import { DecodeBase64UrlToBinary, IsBase64DataUrl, LoadFileError } from "core/Misc/fileTools";
+import { DecodeBase64UrlToBinary, GetMimeType, IsBase64DataUrl, LoadFileError } from "core/Misc/fileTools";
 import { Logger } from "core/Misc/logger";
 import type { Light } from "core/Lights/light";
 import { BoundingInfo } from "core/Culling/boundingInfo";
@@ -2463,7 +2463,7 @@ export class GLTFLoader implements IGLTFLoader {
                     deferred.reject(new Error(`${context}: ${exception && exception.message ? exception.message : message || "Failed to load texture"}`));
                 }
             },
-            mimeType: image.mimeType,
+            mimeType: image.mimeType ?? GetMimeType(image.uri ?? ""),
             loaderOptions: textureLoaderOptions,
             useSRGBBuffer: !!useSRGBBuffer && this._parent.useSRGBBuffers,
         };

--- a/packages/dev/serializers/src/glTF/2.0/glTFData.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFData.ts
@@ -1,23 +1,5 @@
-import { ImageMimeType } from "babylonjs-gltf2interface";
+import { GetMimeType } from "core/Misc/fileTools";
 import { Tools } from "core/Misc/tools";
-
-function GetMimeType(fileName: string): string | undefined {
-    if (fileName.endsWith(".glb")) {
-        return "model/gltf-binary";
-    } else if (fileName.endsWith(".bin")) {
-        return "application/octet-stream";
-    } else if (fileName.endsWith(".gltf")) {
-        return "model/gltf+json";
-    } else if (fileName.endsWith(".jpeg") || fileName.endsWith(".jpg")) {
-        return ImageMimeType.JPEG;
-    } else if (fileName.endsWith(".png")) {
-        return ImageMimeType.PNG;
-    } else if (fileName.endsWith(".webp")) {
-        return ImageMimeType.WEBP;
-    }
-
-    return undefined;
-}
 
 /**
  * Class for holding and downloading glTF file data


### PR DESCRIPTION
glTF images that did not specify a `mimeType` would not set the `Texture.mimeType` field. This happens with GLBs, for example. While the field isn't required, it helps with export. The glTF exporter uses this field to try to preserve the original mime type when re-encoding the images-- if undefined, they'll default to PNG. The Babylon exporter should also be using this information when serializing its image buffers.