### PR TITLE
Fix double disconnect issue in `AbstractSound` class

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -333,6 +333,6 @@ export abstract class AbstractSound extends AbstractNamedAudioNode {
     };
 
     private _onOutBusDisposed = () => {
-        this.outBus = null;
+        this._outBus = null;
     };
 }


### PR DESCRIPTION
When a sound's output bus is disposed, the sound tries to disconnect the underlying web audio nodes after the bus has already disconnected them.

This change fixes the issue by setting the sound's `_outBus` property directly instead of using the `outBus` setter, which disconnects the underlying web audio nodes.