### PR TITLE
Prepare for support of NodeNext and Node16 module resolutions

### DIFF
--- a/packages/dev/buildTools/src/addJSToCompiledFiles.ts
+++ b/packages/dev/buildTools/src/addJSToCompiledFiles.ts
@@ -8,6 +8,7 @@ function processSource(sourceCode: string, forceMJS: boolean) {
     const extension = forceMJS ? ".mjs" : ".js";
     return (
         sourceCode
+            // replace imports and exports with js extensions
             .replace(/((import|export).*["'](@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?)("|');/g, `$1${extension}$5;`)
             .replace(/((import|export)\(["']((@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?))(["'])\)/g, `$1${extension}$6)`)
             // also declare module imports

--- a/packages/dev/buildTools/src/addJSToCompiledFiles.ts
+++ b/packages/dev/buildTools/src/addJSToCompiledFiles.ts
@@ -6,10 +6,14 @@ import { checkArgs } from "./utils.js";
 
 function processSource(sourceCode: string, forceMJS: boolean) {
     const extension = forceMJS ? ".mjs" : ".js";
-    return sourceCode
-        .replace(/((import|export).*["'](@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?)("|');/g, `$1${extension}$5;`)
-        .replace(/((import|export)\(["']((@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?))(["'])\)/g, `$1${extension}$6)`)
-        .replace(new RegExp(`(${extension}){2,}`, "g"), extension);
+    return (
+        sourceCode
+            .replace(/((import|export).*["'](@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?)("|');/g, `$1${extension}$5;`)
+            .replace(/((import|export)\(["']((@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?))(["'])\)/g, `$1${extension}$6)`)
+            // also declare module imports
+            .replace(/declare module ["']((@babylonjs\/.*\/|\.{1,2}\/)((?!\.scss|\.svg|\.png|\.jpg).)*?)["']/g, `declare module "$1${extension}"`)
+            .replace(new RegExp(`(${extension}){2,}`, "g"), extension)
+    );
 }
 
 export function addJsExtensionsToCompiledFiles(files: string[], forceMJS: boolean) {
@@ -42,7 +46,7 @@ export const addJsExtensionsToCompiledFilesCommand = () => {
     let pathForFiles = checkArgs(["--path-of-sources", "-pos"], false, true);
     const forceMJS = !!checkArgs("--mjs", true);
     if (!pathForFiles) {
-        pathForFiles = "./**/*.js";
+        pathForFiles = "./**/*.{js,d.ts}";
         console.log("No path specified, using default: " + pathForFiles);
     }
     if (typeof pathForFiles === "string") {


### PR DESCRIPTION
Details in this issue - #13797 , which this PR fixes.

Merging this PR will technically make babylon compatible with typescript 4.7 and above. For context, 4.7 is 3 years old.

What this change does it add .js extensions to imports in the .d.ts files generated in the public es6 packages.