### PR TITLE
glTF Exporter: Missing node metadata export

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -404,7 +404,7 @@ export class GLTFExporter {
         this._options = {
             shouldExportNode: () => true,
             shouldExportAnimation: () => true,
-            metadataSelector: (metadata) => metadata,
+            metadataSelector: (metadata) => metadata?.gltf?.extras,
             animationSampleRate: 1 / 60,
             exportWithoutWaitingForScene: false,
             exportUnusedUVs: false,
@@ -811,11 +811,7 @@ export class GLTFExporter {
 
         // Scene metadata
         if (this._babylonScene.metadata) {
-            if (this._options.metadataSelector) {
                 scene.extras = this._options.metadataSelector(this._babylonScene.metadata);
-            } else if (this._babylonScene.metadata.gltf) {
-                scene.extras = this._babylonScene.metadata.gltf.extras;
-            }
         }
 
         //  TODO:

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -811,7 +811,7 @@ export class GLTFExporter {
 
         // Scene metadata
         if (this._babylonScene.metadata) {
-                scene.extras = this._options.metadataSelector(this._babylonScene.metadata);
+            scene.extras = this._options.metadataSelector(this._babylonScene.metadata);
         }
 
         //  TODO:
@@ -1214,6 +1214,10 @@ export class GLTFExporter {
 
         if (babylonNode.name) {
             node.name = babylonNode.name;
+        }
+
+        if (babylonNode.metadata) {
+            node.extras = this._options.metadataSelector(babylonNode.metadata);
         }
 
         if (babylonNode instanceof TransformNode) {

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1219,6 +1219,7 @@ export class GLTFExporter {
             node.name = babylonNode.name;
         }
 
+        // Node metadata
         if (babylonNode.metadata) {
             const extras = this._options.metadataSelector(babylonNode.metadata);
             if (extras) {

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -811,7 +811,10 @@ export class GLTFExporter {
 
         // Scene metadata
         if (this._babylonScene.metadata) {
-            scene.extras = this._options.metadataSelector(this._babylonScene.metadata);
+            const extras = this._options.metadataSelector(this._babylonScene.metadata);
+            if (extras) {
+                scene.extras = extras;
+            }
         }
 
         //  TODO:
@@ -1217,7 +1220,10 @@ export class GLTFExporter {
         }
 
         if (babylonNode.metadata) {
-            node.extras = this._options.metadataSelector(babylonNode.metadata);
+            const extras = this._options.metadataSelector(babylonNode.metadata);
+            if (extras) {
+                node.extras = extras;
+            }
         }
 
         if (babylonNode instanceof TransformNode) {

--- a/packages/dev/serializers/src/glTF/2.0/glTFSerializer.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFSerializer.ts
@@ -28,9 +28,10 @@ export interface IExportOptions {
     shouldExportAnimation?(animation: Animation): boolean;
 
     /**
-     * Function used to extract the part of node's metadata that will be exported into glTF node extras
+     * Function to extract the part of the scene or node's `metadata` that will populate the corresponding
+     * glTF object's `extras` field. If not defined, `node.metadata.gltf.extras` will be used.
      * @param metadata source metadata to read from
-     * @returns the data to store to glTF node extras
+     * @returns the data to store into the glTF extras field
      */
     metadataSelector?(metadata: any): any;
 

--- a/packages/dev/serializers/test/integration/glTFSerializer.test.ts
+++ b/packages/dev/serializers/test/integration/glTFSerializer.test.ts
@@ -509,6 +509,30 @@ describe("Babylon glTF Serializer", () => {
             expect(assertionData.extensions["KHR_lights_punctual"].lights).toHaveLength(3);
             expect(assertionData.nodes).toHaveLength(3);
         });
+        it("serializes scene and node metadata", async () => {
+            const assertionData = await page.evaluate(async () => {
+                window.scene!.metadata = { gltf: { extras: { high: "five" } } };
+                const box = BABYLON.CreateBox("box");
+                box.metadata = { test: "test" };
+                const box2 = BABYLON.CreateBox("box2");
+                box2.metadata = { gltf: { extras: { foo: 2, bar: "baz" } } };
+                const glTFData = await BABYLON.GLTF2Export.GLTFAsync(window.scene!, "test");
+                const jsonString = glTFData.files["test.gltf"] as string;
+                return JSON.parse(jsonString);
+            });
+            const scene = assertionData.scenes[0];
+            const box1 = assertionData.nodes.find((node: any) => node.name == "box");
+            const box2 = assertionData.nodes.find((node: any) => node.name == "box2");
+            expect(scene).toBeDefined();
+            expect(scene.extras).toBeDefined();
+            expect(scene.extras.high).toEqual("five");
+            expect(box1).toBeDefined();
+            expect(box1.extras).toBeUndefined();
+            expect(box2).toBeDefined();
+            expect(box2.extras).toBeDefined();
+            expect(box2.extras.foo).toEqual(2);
+            expect(box2.extras.bar).toEqual("baz");
+        });
         it("should export instances as nodes pointing to same mesh", async () => {
             const instanceCount = 3;
             const assertionData = await page.evaluate(async (instanceCount) => {


### PR DESCRIPTION
- Restore missing node `metadata` export
- Use metadata.gltf.extras as default metadataSelector() target
- Add test

Marking as breaking change out of caution. We technically changed the default behavior of metadata selection in the glTF serializer rework (pre-8.0), and this PR undoes that.