### PR TITLE
glTF Exporter: Replace AbstractMesh with Mesh to capture InstancedMesh

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -43,6 +43,7 @@ import type { TrianglePickingPredicate } from "../Culling/ray";
 import type { RenderingGroup } from "../Rendering/renderingGroup";
 import type { IEdgesRendererOptions } from "../Rendering/edgesRenderer";
 import type { MorphTarget } from "../Morph/morphTarget";
+import type { Geometry } from "./geometry";
 import { nativeOverride } from "../Misc/decorators";
 import { AbstractEngine } from "core/Engines/abstractEngine";
 
@@ -1091,7 +1092,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
      * @returns a string representation of the current mesh
      */
     public override toString(fullDetails?: boolean): string {
-        let ret = "Name: " + this.name + ", isInstance: " + (this.getClassName() !== "InstancedMesh" ? "YES" : "NO");
+        let ret = "Name: " + this.name + ", isInstance: " + (this.getClassName() === "InstancedMesh" ? "YES" : "NO");
         ret += ", # of submeshes: " + (this.subMeshes ? this.subMeshes.length : 0);
 
         const skeleton = this._internalAbstractMeshDataInfo._skeleton;
@@ -1299,6 +1300,11 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     public getLOD(camera: Camera): Nullable<AbstractMesh> {
         return this;
     }
+
+    /**
+     * The mesh's internal Geometry object. Implemented by child classes.
+     */
+    public abstract get geometry(): Nullable<Geometry>;
 
     /**
      * Returns 0 by default. Implemented by child classes

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -202,7 +202,7 @@ export class InstancedMesh extends AbstractMesh {
     /**
      * Gets the mesh internal Geometry object
      */
-    public get geometry(): Nullable<Geometry> {
+    public override get geometry(): Nullable<Geometry> {
         return this._sourceMesh._geometry;
     }
 

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1212,7 +1212,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
     /**
      * Gets the mesh internal Geometry object
      */
-    public get geometry(): Nullable<Geometry> {
+    public override get geometry(): Nullable<Geometry> {
         return this._geometry;
     }
 
@@ -1387,7 +1387,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /**
      * Returns a positive integer : the total number of indices in this mesh geometry.
-     * @returns the numner of indices or zero if the mesh has no geometry.
+     * @returns the number of indices or zero if the mesh has no geometry.
      */
     public override getTotalIndices(): number {
         if (!this._geometry) {

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -26,7 +26,8 @@ import { VertexBuffer } from "core/Buffers/buffer";
 import type { Node } from "core/node";
 import { TransformNode } from "core/Meshes/transformNode";
 import type { SubMesh } from "core/Meshes/subMesh";
-import { Mesh } from "core/Meshes/mesh";
+import type { Mesh } from "core/Meshes/mesh";
+import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { InstancedMesh } from "core/Meshes/instancedMesh";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";
 import type { Texture } from "core/Materials/Textures/texture";
@@ -85,14 +86,14 @@ class ExporterState {
 
     private _remappedBufferView = new Map<Buffer, Map<VertexBuffer, IBufferView>>();
 
-    private _meshMorphTargetMap = new Map<Mesh, IMorphTargetData[]>();
+    private _meshMorphTargetMap = new Map<AbstractMesh, IMorphTargetData[]>();
 
     private _vertexMapColorAlpha = new Map<VertexBuffer, boolean>();
 
     private _exportedNodes = new Set<Node>();
 
     // Babylon mesh -> glTF mesh index
-    private _meshMap = new Map<Mesh, number>();
+    private _meshMap = new Map<AbstractMesh, number>();
 
     public constructor(convertToRightHanded: boolean, wasAddedByNoopNode: boolean) {
         this.convertToRightHanded = convertToRightHanded;
@@ -193,15 +194,15 @@ class ExporterState {
         return this._vertexMapColorAlpha.set(vertexBuffer, hasAlpha);
     }
 
-    public getMesh(mesh: Mesh): number | undefined {
+    public getMesh(mesh: AbstractMesh): number | undefined {
         return this._meshMap.get(mesh);
     }
 
-    public setMesh(mesh: Mesh, meshIndex: number): void {
+    public setMesh(mesh: AbstractMesh, meshIndex: number): void {
         this._meshMap.set(mesh, meshIndex);
     }
 
-    public bindMorphDataToMesh(mesh: Mesh, morphData: IMorphTargetData) {
+    public bindMorphDataToMesh(mesh: AbstractMesh, morphData: IMorphTargetData) {
         const morphTargets = this._meshMorphTargetMap.get(mesh) || [];
         this._meshMorphTargetMap.set(mesh, morphTargets);
         if (morphTargets.indexOf(morphData) === -1) {
@@ -209,7 +210,7 @@ class ExporterState {
         }
     }
 
-    public getMorphTargetsFromMesh(mesh: Mesh): IMorphTargetData[] | undefined {
+    public getMorphTargetsFromMesh(mesh: AbstractMesh): IMorphTargetData[] | undefined {
         return this._meshMorphTargetMap.get(mesh);
     }
 }
@@ -895,11 +896,11 @@ export class GLTFExporter {
     private _collectBuffers(
         babylonNode: Node,
         bufferToVertexBuffersMap: Map<Buffer, VertexBuffer[]>,
-        vertexBufferToMeshesMap: Map<VertexBuffer, Mesh[]>,
-        morphTargetsToMeshesMap: Map<MorphTarget, Mesh[]>,
+        vertexBufferToMeshesMap: Map<VertexBuffer, AbstractMesh[]>,
+        morphTargetsToMeshesMap: Map<MorphTarget, AbstractMesh[]>,
         state: ExporterState
     ): void {
-        if (this._shouldExportNode(babylonNode) && babylonNode instanceof Mesh && babylonNode.geometry) {
+        if (this._shouldExportNode(babylonNode) && babylonNode instanceof AbstractMesh && babylonNode.geometry) {
             const vertexBuffers = babylonNode.geometry.getVertexBuffers();
             if (vertexBuffers) {
                 for (const kind in vertexBuffers) {
@@ -945,8 +946,8 @@ export class GLTFExporter {
 
     private _exportBuffers(babylonRootNodes: Node[], state: ExporterState): void {
         const bufferToVertexBuffersMap = new Map<Buffer, VertexBuffer[]>();
-        const vertexBufferToMeshesMap = new Map<VertexBuffer, Mesh[]>();
-        const morphTagetsMeshesMap = new Map<MorphTarget, Mesh[]>();
+        const vertexBufferToMeshesMap = new Map<VertexBuffer, AbstractMesh[]>();
+        const morphTagetsMeshesMap = new Map<MorphTarget, AbstractMesh[]>();
 
         for (const babylonNode of babylonRootNodes) {
             this._collectBuffers(babylonNode, bufferToVertexBuffersMap, vertexBufferToMeshesMap, morphTagetsMeshesMap, state);
@@ -1224,8 +1225,8 @@ export class GLTFExporter {
         if (babylonNode instanceof TransformNode) {
             this._setNodeTransformation(node, babylonNode, state.convertToRightHanded);
 
-            if (babylonNode instanceof Mesh || babylonNode instanceof InstancedMesh) {
-                const babylonMesh = babylonNode instanceof Mesh ? babylonNode : babylonNode.sourceMesh;
+            if (babylonNode instanceof AbstractMesh) {
+                const babylonMesh = babylonNode instanceof InstancedMesh ? babylonNode.sourceMesh : (babylonNode as Mesh);
                 if (babylonMesh.subMeshes && babylonMesh.subMeshes.length > 0) {
                     node.mesh = await this._exportMeshAsync(babylonMesh, state);
                 }
@@ -1431,7 +1432,7 @@ export class GLTFExporter {
         this._meshes.push(mesh);
         state.setMesh(babylonMesh, meshIndex);
 
-        const indices = babylonMesh.isUnIndexed ? null : babylonMesh.getIndices();
+        const indices = babylonMesh._unIndexed ? null : babylonMesh.getIndices();
         const vertexBuffers = babylonMesh.geometry?.getVertexBuffers();
         const morphTargets = state.getMorphTargetsFromMesh(babylonMesh);
 

--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -947,10 +947,10 @@ export class GLTFExporter {
     private _exportBuffers(babylonRootNodes: Node[], state: ExporterState): void {
         const bufferToVertexBuffersMap = new Map<Buffer, VertexBuffer[]>();
         const vertexBufferToMeshesMap = new Map<VertexBuffer, AbstractMesh[]>();
-        const morphTagetsMeshesMap = new Map<MorphTarget, AbstractMesh[]>();
+        const morphTargetsMeshesMap = new Map<MorphTarget, AbstractMesh[]>();
 
         for (const babylonNode of babylonRootNodes) {
-            this._collectBuffers(babylonNode, bufferToVertexBuffersMap, vertexBufferToMeshesMap, morphTagetsMeshesMap, state);
+            this._collectBuffers(babylonNode, bufferToVertexBuffersMap, vertexBufferToMeshesMap, morphTargetsMeshesMap, state);
         }
 
         const buffers = Array.from(bufferToVertexBuffersMap.keys());
@@ -1099,10 +1099,10 @@ export class GLTFExporter {
         }
 
         // Build morph targets buffers
-        const morphTargets = Array.from(morphTagetsMeshesMap.keys());
+        const morphTargets = Array.from(morphTargetsMeshesMap.keys());
 
         for (const morphTarget of morphTargets) {
-            const meshes = morphTagetsMeshesMap.get(morphTarget);
+            const meshes = morphTargetsMeshesMap.get(morphTarget);
 
             if (!meshes) {
                 continue;
@@ -1432,7 +1432,7 @@ export class GLTFExporter {
         this._meshes.push(mesh);
         state.setMesh(babylonMesh, meshIndex);
 
-        const indices = babylonMesh._unIndexed ? null : babylonMesh.getIndices();
+        const indices = babylonMesh.isUnIndexed ? null : babylonMesh.getIndices();
         const vertexBuffers = babylonMesh.geometry?.getVertexBuffers();
         const morphTargets = state.getMorphTargetsFromMesh(babylonMesh);
 

--- a/packages/dev/serializers/src/glTF/2.0/glTFMorphTargetsUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMorphTargetsUtilities.ts
@@ -33,6 +33,12 @@ export function BuildMorphTargetBuffers(
         name: morphTarget.name,
     };
 
+    const geometry = mesh.geometry;
+    if (!geometry) {
+        Tools.Warn("Attempted to export morph target data from a mesh without geometry. This should not happen.");
+        return result;
+    }
+
     const flipX = convertToRightHanded ? -1 : 1;
     const floatSize = 4;
     const difference = Vector3.Zero();
@@ -41,7 +47,7 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasPositions) {
         const morphPositions = morphTarget.getPositions()!;
-        const originalPositions = mesh.geometry?.getVerticesData(VertexBuffer.PositionKind); // Bypasses mesh's instance data
+        const originalPositions = geometry.getVerticesData(VertexBuffer.PositionKind); // Bypasses any instance data of mesh
 
         if (originalPositions) {
             const positionData = new Float32Array(originalPositions.length);
@@ -80,7 +86,7 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasNormals) {
         const morphNormals = morphTarget.getNormals()!;
-        const originalNormals = mesh.geometry?.getVerticesData(VertexBuffer.NormalKind);
+        const originalNormals = geometry.getVerticesData(VertexBuffer.NormalKind);
 
         if (originalNormals) {
             const normalData = new Float32Array(originalNormals.length);
@@ -107,7 +113,7 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasTangents) {
         const morphTangents = morphTarget.getTangents()!;
-        const originalTangents = mesh.geometry?.getVerticesData(VertexBuffer.TangentKind);
+        const originalTangents = geometry.getVerticesData(VertexBuffer.TangentKind);
 
         if (originalTangents) {
             vertexCount = originalTangents.length / 4;
@@ -138,8 +144,8 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasColors) {
         const morphColors = morphTarget.getColors()!;
-        const originalColors = mesh.geometry?.getVerticesData(VertexBuffer.ColorKind);
-        const buffer = mesh.geometry?.getVertexBuffer(VertexBuffer.ColorKind);
+        const originalColors = geometry.getVerticesData(VertexBuffer.ColorKind);
+        const buffer = geometry.getVertexBuffer(VertexBuffer.ColorKind);
 
         if (originalColors && buffer) {
             const componentSize = buffer.getSize();

--- a/packages/dev/serializers/src/glTF/2.0/glTFMorphTargetsUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMorphTargetsUtilities.ts
@@ -4,7 +4,7 @@ import type { MorphTarget } from "core/Morph/morphTarget";
 import type { BufferManager } from "./bufferManager";
 
 import { NormalizeTangent } from "./glTFUtilities";
-import type { Mesh } from "core/Meshes/mesh";
+import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import { VertexBuffer } from "core/Buffers/buffer";
 import { Vector3, Vector4 } from "core/Maths/math.vector";
 import { Tools } from "core/Misc/tools";
@@ -21,7 +21,7 @@ export interface IMorphTargetData {
 
 export function BuildMorphTargetBuffers(
     morphTarget: MorphTarget,
-    mesh: Mesh,
+    mesh: AbstractMesh,
     bufferManager: BufferManager,
     bufferViews: IBufferView[],
     accessors: IAccessor[],
@@ -41,7 +41,7 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasPositions) {
         const morphPositions = morphTarget.getPositions()!;
-        const originalPositions = mesh.getVerticesData(VertexBuffer.PositionKind, undefined, undefined, true);
+        const originalPositions = mesh.geometry?.getVerticesData(VertexBuffer.PositionKind); // Bypasses mesh's instance data
 
         if (originalPositions) {
             const positionData = new Float32Array(originalPositions.length);
@@ -80,7 +80,7 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasNormals) {
         const morphNormals = morphTarget.getNormals()!;
-        const originalNormals = mesh.getVerticesData(VertexBuffer.NormalKind, undefined, undefined, true);
+        const originalNormals = mesh.geometry?.getVerticesData(VertexBuffer.NormalKind);
 
         if (originalNormals) {
             const normalData = new Float32Array(originalNormals.length);
@@ -107,7 +107,7 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasTangents) {
         const morphTangents = morphTarget.getTangents()!;
-        const originalTangents = mesh.getVerticesData(VertexBuffer.TangentKind, undefined, undefined, true);
+        const originalTangents = mesh.geometry?.getVerticesData(VertexBuffer.TangentKind);
 
         if (originalTangents) {
             vertexCount = originalTangents.length / 4;
@@ -138,9 +138,8 @@ export function BuildMorphTargetBuffers(
 
     if (morphTarget.hasColors) {
         const morphColors = morphTarget.getColors()!;
-        const originalColors = mesh.getVerticesData(VertexBuffer.ColorKind, undefined, undefined, true);
-
-        const buffer = mesh.getVertexBuffer(VertexBuffer.ColorKind, true);
+        const originalColors = mesh.geometry?.getVerticesData(VertexBuffer.ColorKind);
+        const buffer = mesh.geometry?.getVertexBuffer(VertexBuffer.ColorKind);
 
         if (originalColors && buffer) {
             const componentSize = buffer.getSize();

--- a/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -8,8 +8,7 @@ import { Quaternion, TmpVectors, Matrix, Vector3 } from "core/Maths/math.vector"
 import { VertexBuffer } from "core/Buffers/buffer";
 import { Material } from "core/Materials/material";
 import { TransformNode } from "core/Meshes/transformNode";
-import { Mesh } from "core/Meshes/mesh";
-import { InstancedMesh } from "core/Meshes/instancedMesh";
+import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { EnumerateFloatValues } from "core/Buffers/bufferUtils";
 import type { Node } from "core/node";
 
@@ -30,7 +29,7 @@ const defaultScale = Vector3.One();
  * @param meshes the meshes that use the vertex buffer
  * @returns the information necessary to enumerate the vertex buffer
  */
-export function GetVertexBufferInfo(vertexBuffer: VertexBuffer, meshes: Mesh[]) {
+export function GetVertexBufferInfo(vertexBuffer: VertexBuffer, meshes: AbstractMesh[]) {
     const { byteOffset, byteStride, type, normalized } = vertexBuffer;
     const componentCount = vertexBuffer.getSize();
     const totalVertices = meshes.reduce((max, current) => {
@@ -303,7 +302,7 @@ export function IsNoopNode(node: Node, useRightHandedSystem: boolean): boolean {
     }
 
     // Geometry
-    if ((node instanceof Mesh && node.geometry) || (node instanceof InstancedMesh && node.sourceMesh.geometry)) {
+    if (node instanceof AbstractMesh && node.geometry) {
         return false;
     }
 


### PR DESCRIPTION
Fixes issue where InstancedMeshes exported without their source mesh would error.

This could have been solved by just adding `|| node instanceof InstancedMesh` in `_collectBuffers`, but there's no reason to not use `AbstractMesh` throughout the exporter, so opted for that instead. 