### PR TITLE
Attach playwright audio test result .wav files to test info on failure

### DIFF
--- a/packages/tools/babylonServer/public/audiov2-test.js
+++ b/packages/tools/babylonServer/public/audiov2-test.js
@@ -74,6 +74,10 @@ class AudioV2Test {
     }
 
     static async GetResultAsync() {
+        if (audioTestResult) {
+            return audioTestResult;
+        }
+
         // Wait for sounds to finish playing.
         for (const sound of audioTestSounds) {
             if (sound.state !== BABYLON.SoundState.STOPPED) {

--- a/packages/tools/tests/test/audioV2/audioEngineV2.listener.test.ts
+++ b/packages/tools/tests/test/audioV2/audioEngineV2.listener.test.ts
@@ -26,6 +26,7 @@ test("Sound at position (0, 0, -1) with no listener options set should be 1x vol
     // Test against 0.7 because the 1.0 amplitude sound is evenly distributed between the two speakers.
     expect(volumes[L]).toBeCloseTo(0.7, VolumePrecision);
     expect(volumes[R]).toBeCloseTo(0.7, VolumePrecision);
+    expect(true).toBe(false);
 });
 
 test("Sound at position (0, 0, 0) with listener position option set to (1, 0, 0) should be 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {

--- a/packages/tools/tests/test/audioV2/audioEngineV2.listener.test.ts
+++ b/packages/tools/tests/test/audioV2/audioEngineV2.listener.test.ts
@@ -26,7 +26,6 @@ test("Sound at position (0, 0, -1) with no listener options set should be 1x vol
     // Test against 0.7 because the 1.0 amplitude sound is evenly distributed between the two speakers.
     expect(volumes[L]).toBeCloseTo(0.7, VolumePrecision);
     expect(volumes[R]).toBeCloseTo(0.7, VolumePrecision);
-    expect(true).toBe(false);
 });
 
 test("Sound at position (0, 0, 0) with listener position option set to (1, 0, 0) should be 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {

--- a/packages/tools/tests/test/audioV2/utils/audioEngineV2.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/audioEngineV2.utils.ts
@@ -1,11 +1,26 @@
 import type { Nullable } from "@dev/core/types";
-import { test } from "@playwright/test";
+import { test, TestInfo } from "@playwright/test";
 import { getGlobalConfig } from "@tools/test-tools";
 
 /**
  * The maximum pulse volume in the sound test file containing the pulse train.
  */
 const MaxPulseVolume = 0.1;
+
+export class AudioTestConfig {
+    public baseUrl = getGlobalConfig().baseUrl;
+    public soundsUrl = getGlobalConfig().assetsUrl + "/sound/testing/audioV2/";
+
+    public pulseTrainSoundFile = "square-1-khz-0.1-amp-for-10-seconds.flac";
+}
+
+export class AudioTestResult {
+    public length: number = 0;
+    public numberOfChannels: number = 0;
+    public sampleRate: number = 0;
+    public samples: Nullable<Float32Array[]> = null;
+    public volumeCurves: Nullable<Float32Array[]> = null;
+}
 
 // Declarations for babylonServer/public/audiov2-test.js
 declare global {
@@ -45,27 +60,24 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.afterEach(async ({ page }) => {
+    if (test.info().status === "failed") {
+        let result: AudioTestResult = (<any>test.info()).audioTestResult;
+
+        if (!result) {
+            result = await page.evaluate(async () => {
+                return await AudioV2Test.GetResultAsync();
+            });
+        }
+
+        SaveAudioTestResult(test.info(), result);
+    }
+
     await page.evaluate(async () => {
         await AudioV2Test.AfterEachAsync();
     });
 
     await page.close();
 });
-
-export class AudioTestConfig {
-    public baseUrl = getGlobalConfig().baseUrl;
-    public soundsUrl = getGlobalConfig().assetsUrl + "/sound/testing/audioV2/";
-
-    public pulseTrainSoundFile = "square-1-khz-0.1-amp-for-10-seconds.flac";
-}
-
-export class AudioTestResult {
-    public length: number = 0;
-    public numberOfChannels: number = 0;
-    public sampleRate: number = 0;
-    public samples: Nullable<Float32Array[]> = null;
-    public volumeCurves: Nullable<Float32Array[]> = null;
-}
 
 /**
  * Gets the volumes of the given result's samples.
@@ -127,6 +139,10 @@ function GetVolumeCurves(result: AudioTestResult): Float32Array[] {
         updateCurve();
 
         result.volumeCurves[channel] = curve;
+
+        // Save the audio test result to the test info so it can be retrieved in `test.afterEach` and attached to the
+        // report if needed.
+        (<any>test.info()).audioTestResult = result;
     }
 
     return result.volumeCurves;
@@ -155,4 +171,97 @@ export function GetVolumesAtTime(result: AudioTestResult, time: number): number[
     }
 
     return volumes;
+}
+
+/**
+ * Creates WAVE file data from the given samples.
+ */
+class WaveFileData {
+    private _data: DataView;
+    private _dataLength: number = 0;
+    private _pos: number = 0;
+
+    public readonly data: ArrayBuffer;
+
+    public constructor(samples: Float32Array[], length: number, numberOfChannels: number, sampleRate: number) {
+        const BytesPerSample = 2;
+        const WavHeaderSize = 44;
+
+        this._dataLength = WavHeaderSize + length * numberOfChannels * BytesPerSample;
+        this.data = new ArrayBuffer(this._dataLength);
+        this._data = new DataView(this.data);
+
+        // Write WAVE header.
+        this._setUint32(0x46464952); // "RIFF"
+        this._setUint32(this._dataLength - 8); // Data length - 8 bytes for "RIFF" and "WAVE"
+        this._setUint32(0x45564157); // "WAVE"
+
+        // Write "fmt " chunk.
+        this._setUint32(0x20746d66); // "fmt "
+        this._setUint32(16); // Length = 16
+        this._setUint16(1); // PCM (uncompressed)
+        this._setUint16(numberOfChannels);
+        this._setUint32(sampleRate);
+        this._setUint32(sampleRate * numberOfChannels * BytesPerSample); // Average bytes per second
+        this._setUint16(numberOfChannels * BytesPerSample); // Block-align
+        this._setUint16(8 * BytesPerSample); // Bit-depth
+
+        // Write "data" chunk.
+        this._setUint32(0x61746164); // "data"
+        this._setUint32(this._dataLength - this._pos - 4); // Chunk length
+
+        // Write interleaved data.
+        const interleavedSamples = new Float32Array(length * numberOfChannels);
+        for (let i = 0; i < length; i++) {
+            for (let channel = 0; channel < numberOfChannels; channel++) {
+                interleavedSamples[i * numberOfChannels + channel] = samples[channel][i];
+            }
+        }
+        for (let i = 0; i < interleavedSamples.length; i++) {
+            const sample = Math.max(-1, Math.min(1, interleavedSamples[i])); // Clamp
+            const intSample = (0.5 + sample < 0 ? sample * 32768 : sample * 32767) | 0; // Scale to 16-bit signed int
+            this._setInt16(intSample); // Write 16-bit sample
+        }
+    }
+
+    private _setInt16(value: number): void {
+        this._data.setInt16(this._pos, value, true);
+        this._pos += 2;
+    }
+
+    private _setUint16(value: number): void {
+        this._data.setUint16(this._pos, value, true);
+        this._pos += 2;
+    }
+
+    private _setUint32(value: number): void {
+        this._data.setUint32(this._pos, value, true);
+        this._pos += 4;
+    }
+}
+
+/**
+ * Saves the audio test result as .wav files and attaches them to the given test info so they are added to the report.
+ *
+ * @param testInfo - the test info to attach the files to
+ * @param result - the audio test result to save
+ */
+export function SaveAudioTestResult(testInfo: TestInfo, result: AudioTestResult): void {
+    if (result.length > 0 && result.numberOfChannels > 0) {
+        if (result.samples) {
+            const waveFileData = new WaveFileData(result.samples, result.length, result.numberOfChannels, result.sampleRate);
+            testInfo.attach("audio-samples.wav", {
+                body: Buffer.from(waveFileData.data),
+                contentType: "audio/wav",
+            });
+        }
+
+        if (result.volumeCurves) {
+            const waveFileData = new WaveFileData(result.volumeCurves, result.length, result.numberOfChannels, result.sampleRate);
+            testInfo.attach("audio-volume-curves.wav", {
+                body: Buffer.from(waveFileData.data),
+                contentType: "audio/wav",
+            });
+        }
+    }
 }


### PR DESCRIPTION
This change makes the playwright audio test result data available in the test report when an audio test fails. It attaches the captured audio output as a .wav file, and the resulting volume curves as a .wav file if they were used by the test.