### PR TITLE
Interactivity fixes

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
@@ -768,7 +768,7 @@ export class FlowGraphIsNanBlock extends FlowGraphUnaryOperationBlock<FlowGraphN
     }
 
     private _polymorphicIsNan(a: FlowGraphNumber) {
-        if (isNumeric(a)) {
+        if (isNumeric(a, true)) {
             return isNaN(getNumericValue(a));
         } else {
             throw new Error(`Cannot get NaN of ${a}`);

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphInterpolationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphInterpolationBlock.ts
@@ -81,7 +81,7 @@ export class FlowGraphInterpolationBlock<T> extends FlowGraphBlock {
      * If provided, this function will be used to create the animation object(s).
      */
     public readonly customBuildAnimation: FlowGraphDataConnection<
-        () => (keys: any[], fps: number, animationType: number, easingFunction?: EasingFunction) => Animation | Animation[]
+        (target: any, propertname: any, context: FlowGraphContext) => (keys: any[], fps: number, animationType: number, easingFunction?: EasingFunction) => Animation | Animation[]
     >;
 
     /**
@@ -157,7 +157,7 @@ export class FlowGraphInterpolationBlock<T> extends FlowGraphBlock {
         }
         const customBuildAnimation = this.customBuildAnimation.getValue(context);
         if (customBuildAnimation) {
-            return customBuildAnimation()(keys, 60, type.animationType, easingFunction);
+            return customBuildAnimation(null, null, context)(keys, 60, type.animationType, easingFunction);
         }
         if (typeof propertyName === "string") {
             const animation = Animation.CreateAnimation(propertyName, type.animationType, 60, easingFunction);

--- a/packages/dev/core/src/FlowGraph/flowGraphPathConverterComponent.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphPathConverterComponent.ts
@@ -6,7 +6,7 @@ import { FlowGraphInteger } from "./CustomTypes/flowGraphInteger";
 import { RichTypeFlowGraphInteger } from "./flowGraphRichTypes";
 import type { IObjectAccessor } from "./typeDefinitions";
 
-const pathHasTemplatesRegex = new RegExp(/\/\{(\w+)\}\//g);
+const pathHasTemplatesRegex = new RegExp(/\/\{(\w+)\}(?=\/|$)/g);
 
 /**
  * @experimental

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -1322,7 +1322,7 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
     },
     "pointer/interpolate": {
         // interpolate, parse the pointer and play the animation generated. 3 blocks!
-        blocks: [FlowGraphBlockNames.ValueInterpolation, FlowGraphBlockNames.JsonPointerParser, FlowGraphBlockNames.PlayAnimation, FlowGraphBlockNames.Easing],
+        blocks: [FlowGraphBlockNames.ValueInterpolation, FlowGraphBlockNames.JsonPointerParser, FlowGraphBlockNames.PlayAnimation, FlowGraphBlockNames.BezierCurveEasing],
         configuration: {
             pointer: { name: "jsonPointer", toBlock: FlowGraphBlockNames.JsonPointerParser },
         },
@@ -1331,8 +1331,8 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
                 value: { name: "value_1" },
                 "[segment]": { name: "$1", toBlock: FlowGraphBlockNames.JsonPointerParser },
                 duration: { name: "duration_1", gltfType: "number" /*, inOptions: true */ },
-                p1: { name: "controlPoint1", toBlock: FlowGraphBlockNames.Easing },
-                p2: { name: "controlPoint2", toBlock: FlowGraphBlockNames.Easing },
+                p1: { name: "controlPoint1", toBlock: FlowGraphBlockNames.BezierCurveEasing },
+                p2: { name: "controlPoint2", toBlock: FlowGraphBlockNames.BezierCurveEasing },
             },
             flows: {
                 in: { name: "in", toBlock: FlowGraphBlockNames.PlayAnimation },

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -264,11 +264,6 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
     },
     "event/send": {
         blocks: [FlowGraphBlockNames.SendCustomEvent],
-        outputs: {
-            flows: {
-                out: { name: "done" },
-            },
-        },
         extraProcessor(gltfBlock, declaration, _mapping, parser, serializedObjects) {
             // set eventId and eventData. The configuration object of the glTF should have a single object.
             // validate that we are running it on the right block.

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/interactivityGraphParser.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/interactivityGraphParser.ts
@@ -154,6 +154,10 @@ export class InteractivityGraphToFlowGraphParser {
                     break;
             }
         }
+        // in case of NaN, Infinity, we need to parse the string to the object itself
+        if (type.elementType === "number" && typeof value[0] === "string") {
+            value[0] = parseFloat(value[0]);
+        }
         return { type: type.flowGraphType, value: dataTransform ? dataTransform(value, this) : value };
     }
 

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/gltfPathToObjectConverter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/gltfPathToObjectConverter.ts
@@ -91,12 +91,10 @@ export class GLTFPathToObjectConverter<T, BabylonType, BabylonValue> implements 
                 if (objectTree === undefined) {
                     // check if the path is in the exception list. If it is, break and return the last object that was found
                     const exception = OptionalPathExceptionsList.find((e) => e.regex.test(path));
-                    if (exception) {
-                        break;
+                    if (!exception) {
+                        throw new Error(`Path ${path} is invalid`);
                     }
-                    throw new Error(`Path ${path} is invalid`);
-                }
-                if (!isLength) {
+                } else if (!isLength) {
                     objectTree = objectTree?.[part];
                 }
             }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/gltfPathToObjectConverter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/gltfPathToObjectConverter.ts
@@ -3,6 +3,20 @@ import type { IGLTF } from "../glTFLoaderInterfaces";
 import type { IObjectAccessor } from "core/FlowGraph/typeDefinitions";
 
 /**
+ * Adding an exception here will break traversing through the glTF object tree.
+ * This is used for properties that might not be in the glTF object model, but are optional and have a default value.
+ * For example, the path /nodes/\{\}/extensions/KHR_node_visibility/visible is optional - the object can be deferred without the object fully existing.
+ */
+export const OptionalPathExceptionsList: {
+    regex: RegExp;
+}[] = [
+    {
+        // get the node as object when reading an extension
+        regex: new RegExp(`^/nodes/\\d+/extensions/`),
+    },
+];
+
+/**
  * A converter that takes a glTF Object Model JSON Pointer
  * and transforms it into an ObjectAccessorContainer, allowing
  * objects referenced in the glTF to be associated with their
@@ -75,6 +89,11 @@ export class GLTFPathToObjectConverter<T, BabylonType, BabylonValue> implements 
             }
             if (!ignoreObjectTree) {
                 if (objectTree === undefined) {
+                    // check if the path is in the exception list. If it is, break and return the last object that was found
+                    const exception = OptionalPathExceptionsList.find((e) => e.regex.test(path));
+                    if (exception) {
+                        break;
+                    }
                     throw new Error(`Path ${path} is invalid`);
                 }
                 if (!isLength) {


### PR DESCRIPTION
A few fixes after testing some more demo files:

1. Extension path matching is optional in certain cases. So even if a value doesn't exist in the glTF tree itself, we should still be able to get and set it. Good examples are selectability and visibility - both exist on the babylon object, but are optional in the glTF tree.
2. Parsing NaN and Infinity now works (if they are provided as strings)
3. Interpolation block was not providing the context to the animation function
4. Matcher for json pointer didn't work correctly if the matched item was at the end of the string
5. pointer/interpolate should use the BezierEasing and not the normal easing block
6. Small fix for out flow of the send event block.