### PR TITLE
Fix flaky playwright audio tests

### DIFF
--- a/packages/tools/tests/test/audioV2/utils/audioEngineV2.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/audioEngineV2.utils.ts
@@ -109,9 +109,8 @@ function GetVolumeCurves(result: AudioTestResult): Float32Array[] {
 
         let currentPolarity = samples[0] > 0;
         let iPulseStart = 0;
-        let iPulseEnd = 0;
 
-        const updateCurve = () => {
+        const updateCurve = (iPulseEnd: number) => {
             const pulseLength = iPulseEnd - iPulseStart;
             if (pulseLength > 0) {
                 let totalVolume = 0;
@@ -126,17 +125,15 @@ function GetVolumeCurves(result: AudioTestResult): Float32Array[] {
             }
         };
 
-        for (let i = 0; i < result.length; i++) {
-            if (currentPolarity === samples[i] > 0) {
-                iPulseEnd = i;
-            } else {
-                updateCurve();
+        let i = 0;
+        for (; i < result.length; i++) {
+            if (currentPolarity !== samples[i] > 0) {
+                updateCurve(i);
                 iPulseStart = i;
-                iPulseEnd = i;
                 currentPolarity = !currentPolarity;
             }
         }
-        updateCurve();
+        updateCurve(i);
 
         result.volumeCurves[channel] = curve;
 

--- a/packages/tools/tests/test/audioV2/utils/audioEngineV2.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/audioEngineV2.utils.ts
@@ -108,18 +108,18 @@ function GetVolumeCurves(result: AudioTestResult): Float32Array[] {
         let curve = new Float32Array(result.length);
 
         let currentPolarity = samples[0] > 0;
-        let iPulseStart = 0;
+        let pulseStartIndex = 0;
 
-        const updateCurve = (iPulseEnd: number) => {
-            const pulseLength = iPulseEnd - iPulseStart;
+        const updateCurve = (pulseEndIndex: number) => {
+            const pulseLength = pulseEndIndex - pulseStartIndex;
             if (pulseLength > 0) {
                 let totalVolume = 0;
-                for (let j = iPulseStart; j < iPulseEnd; j++) {
+                for (let j = pulseStartIndex; j < pulseEndIndex; j++) {
                     totalVolume += Math.abs(samples[j]);
                 }
                 const avgVolume = totalVolume / pulseLength;
 
-                for (let j = iPulseStart; j < iPulseEnd; j++) {
+                for (let j = pulseStartIndex; j < pulseEndIndex; j++) {
                     curve[j] = avgVolume;
                 }
             }
@@ -129,7 +129,7 @@ function GetVolumeCurves(result: AudioTestResult): Float32Array[] {
         for (; i < result.length; i++) {
             if (currentPolarity !== samples[i] > 0) {
                 updateCurve(i);
-                iPulseStart = i;
+                pulseStartIndex = i;
                 currentPolarity = !currentPolarity;
             }
         }


### PR DESCRIPTION
The playwright audio tests expecting volume curve values are flaky because the volume curve analysis algorithm is leaving a zero volume gap sample between each pulse. If the time the volume is checked at falls on that gap, the test fails.

This change fixes the issue by removing the gap in the volume curve and writing the average volume sample values across the entire span of the pulse without skipping a sample between pulses.