### PR TITLE
Prevent floats and integers from working together in glTF interactivity

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
@@ -28,6 +28,12 @@ export interface IFlowGraphMathBlockConfiguration extends IFlowGraphBlockConfigu
      * The type of the variable.
      */
     type?: FlowGraphTypes;
+
+    /**
+     * If true, the block will not allow integer and float arithmetic.
+     * This is the behavior in glTF interactivity.
+     */
+    preventIntegerFloatArithmetic?: boolean;
 }
 
 /**
@@ -59,7 +65,11 @@ export class FlowGraphAddBlock extends FlowGraphBinaryOperationBlock<FlowGraphMa
             // this is a simple add, and should be also supported between Quat and Vector4. Therefore -
             return (a as Quaternion).add(b as Quaternion);
         } else {
-            return (a as number) + (b as number);
+            // at this point at least one of the variables is a number.
+            if (this.config?.preventIntegerFloatArithmetic && typeof a !== typeof b) {
+                throw new Error("Cannot add different types of numbers.");
+            }
+            return getNumericValue(a as number) + getNumericValue(b as number);
         }
     }
 }
@@ -93,7 +103,11 @@ export class FlowGraphSubtractBlock extends FlowGraphBinaryOperationBlock<FlowGr
             // this is a simple subtract, and should be also supported between Quat and Vector4. Therefore -
             return (a as Quaternion).subtract(b as Quaternion);
         } else {
-            return (a as number) - (b as number);
+            // at this point at least one of the variables is a number.
+            if (this.config?.preventIntegerFloatArithmetic && typeof a !== typeof b) {
+                throw new Error("Cannot add different types of numbers.");
+            }
+            return getNumericValue(a as number) - getNumericValue(b as number);
         }
     }
 }
@@ -149,7 +163,11 @@ export class FlowGraphMultiplyBlock extends FlowGraphBinaryOperationBlock<FlowGr
                 return b.multiply(a);
             }
         } else {
-            return (a as number) * (b as number);
+            // at this point at least one of the variables is a number.
+            if (this.config?.preventIntegerFloatArithmetic && typeof a !== typeof b) {
+                throw new Error("Cannot add different types of numbers.");
+            }
+            return getNumericValue(a as number) * getNumericValue(b as number);
         }
     }
 }
@@ -208,7 +226,11 @@ export class FlowGraphDivideBlock extends FlowGraphBinaryOperationBlock<FlowGrap
                 return a.divide(b);
             }
         } else {
-            return (a as number) / (b as number);
+            // at this point at least one of the variables is a number.
+            if (this.config?.preventIntegerFloatArithmetic && typeof a !== typeof b) {
+                throw new Error("Cannot add different types of numbers.");
+            }
+            return getNumericValue(a as number) / getNumericValue(b as number);
         }
     }
 }
@@ -519,7 +541,7 @@ function _componentWiseBinaryOperation(a: FlowGraphMathOperationType, b: FlowGra
             a = a as FlowGraphMatrix3D;
             return new FlowGraphMatrix3D(a.m.map((v, i) => op(v, (b as FlowGraphMatrix3D).m[i])));
         default:
-            return op(a as number, b as number);
+            return op(getNumericValue(a as number), getNumericValue(b as number));
     }
 }
 
@@ -609,7 +631,7 @@ function _componentWiseTernaryOperation(
         case FlowGraphTypes.Matrix3D:
             return new FlowGraphMatrix3D((a as FlowGraphMatrix3D).m.map((v, i) => op(v, (b as FlowGraphMatrix3D).m[i], (c as FlowGraphMatrix3D).m[i])));
         default:
-            return op(a as number, b as number, c as number);
+            return op(getNumericValue(a as number), getNumericValue(b as number), getNumericValue(c as number));
     }
 }
 
@@ -684,6 +706,9 @@ export class FlowGraphEqualityBlock extends FlowGraphBinaryOperationBlock<FlowGr
     private _polymorphicEq(a: FlowGraphMathOperationType, b: FlowGraphMathOperationType) {
         const aClassName = _getClassNameOf(a);
         const bClassName = _getClassNameOf(b);
+        if (typeof a !== typeof b) {
+            return false;
+        }
         if (_areSameVectorClass(aClassName, bClassName) || _areSameMatrixClass(aClassName, bClassName) || _areSameIntegerClass(aClassName, bClassName)) {
             return (a as Vector3).equals(b as Vector3);
         } else {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -390,7 +390,7 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
             // make sure types are the same
             if (gltfBlock.values) {
                 const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
-                const allSameType = types.every((type) => type === types[0]);
+                const allSameType = types.every((type) => type === undefined || type === types[0]);
                 if (!allSameType) {
                     return { valid: false, error: "All inputs must be of the same type" };
                 }
@@ -1621,6 +1621,7 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
                 // make sure types are the same
                 if (gltfBlock.values) {
                     const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
+                    console.log(types);
                     const allSameType = types.every((type) => type === undefined || type === types[0]);
                     if (!allSameType) {
                         return { valid: false, error: "All inputs must be of the same type" };

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -140,7 +140,7 @@ export interface IGLTFToFlowGraphMapping {
      * @param glTFObject the glTF object
      * @returns true if validated, false if not.
      */
-    validation?: (gltfBlock: IKHRInteractivity_Node, interactivityGraph: IKHRInteractivity_Graph, glTFObject?: IGLTF) => boolean;
+    validation?: (gltfBlock: IKHRInteractivity_Node, interactivityGraph: IKHRInteractivity_Graph, glTFObject?: IGLTF) => { valid: boolean; error?: string };
 
     /**
      * This is used if we need extra information for the constructor/options that is not provided directly by the glTF node.
@@ -293,24 +293,24 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         validation(gltfBlock, interactivityGraph) {
             if (!gltfBlock.configuration) {
                 Logger.Error("Receive event should have a configuration object");
-                return false;
+                return { valid: false, error: "Receive event should have a configuration object" };
             }
             const eventConfiguration = gltfBlock.configuration["event"];
             if (!eventConfiguration) {
                 Logger.Error("Receive event should have a single configuration object, the event itself");
-                return false;
+                return { valid: false, error: "Receive event should have a single configuration object, the event itself" };
             }
             const eventId = eventConfiguration.value[0];
             if (typeof eventId !== "number") {
                 Logger.Error("Event id should be a number");
-                return false;
+                return { valid: false, error: "Event id should be a number" };
             }
             const event = interactivityGraph.events?.[eventId];
             if (!event) {
                 Logger.Error(`Event with id ${eventId} not found`);
-                return false;
+                return { valid: false, error: `Event with id ${eventId} not found` };
             }
-            return true;
+            return { valid: true };
         },
         extraProcessor(gltfBlock, declaration, _mapping, parser, serializedObjects) {
             // set eventId and eventData. The configuration object of the glTF should have a single object.
@@ -385,6 +385,17 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
                 serializedObjects[0].config.type = _parser.arrays.types[type].flowGraphType;
             }
             return serializedObjects;
+        },
+        validation(gltfBlock) {
+            // make sure types are the same
+            if (gltfBlock.values) {
+                const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
+                const allSameType = types.every((type) => type === types[0]);
+                if (!allSameType) {
+                    return { valid: false, error: "All inputs must be of the same type" };
+                }
+            }
+            return { valid: true };
         },
     },
     "math/div": getSimpleInputMapping(FlowGraphBlockNames.Divide, ["a", "b"], true),
@@ -932,13 +943,13 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
                 });
                 if (!onlyIntegers) {
                     gltfBlock.configuration.cases.value = [] as number[];
-                    return true;
+                    return { valid: true };
                 }
                 // check for duplicates
                 const uniqueCases = new Set(cases);
                 gltfBlock.configuration.cases.value = Array.from(uniqueCases) as number[];
             }
-            return true;
+            return { valid: true };
         },
         extraProcessor(gltfBlock, declaration, _mapping, _arrays, serializedObjects) {
             // convert all names of output flow to out_$1 apart from "default"
@@ -1033,7 +1044,7 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
                 };
                 gltfBlock.configuration.inputFlows.value = [0];
             }
-            return true;
+            return { valid: true };
         },
     },
     "flow/throttle": {
@@ -1060,9 +1071,9 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         validation(gltfBlock) {
             if (!gltfBlock.configuration?.variable?.value) {
                 Logger.Error("Variable get block should have a variable configuration");
-                return false;
+                return { valid: false, error: "Variable get block should have a variable configuration" };
             }
-            return true;
+            return { valid: true };
         },
         configuration: {
             variable: {
@@ -1541,13 +1552,13 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
                 });
                 if (!onlyIntegers) {
                     gltfBlock.configuration.cases.value = [] as number[];
-                    return true;
+                    return { valid: true };
                 }
                 // check for duplicates
                 const uniqueCases = new Set(cases);
                 gltfBlock.configuration.cases.value = Array.from(uniqueCases) as number[];
             }
-            return true;
+            return { valid: true };
         },
         extraProcessor(_gltfBlock, _declaration, _mapping, _arrays, serializedObjects) {
             const serializedObject = serializedObjects[0];
@@ -1584,7 +1595,7 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
                 value: { name: "value" },
             },
         },
-        extraProcessor(_gltfBlock, _declaration, _mapping, _parser, serializedObjects) {
+        extraProcessor(gltfBlock, _declaration, _mapping, _parser, serializedObjects) {
             if (inferType) {
                 // configure it to work the way glTF specifies
                 serializedObjects[0].config = serializedObjects[0].config || {};
@@ -1592,9 +1603,9 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
                 // try to infer the type or fallback to Integer
                 // check the gltf block for the inputs, see if they have a type
                 let type = -1;
-                Object.keys(_gltfBlock.values || {}).find((value) => {
-                    if (_gltfBlock.values?.[value].type !== undefined) {
-                        type = _gltfBlock.values[value].type;
+                Object.keys(gltfBlock.values || {}).find((value) => {
+                    if (gltfBlock.values?.[value].type !== undefined) {
+                        type = gltfBlock.values[value].type;
                         return true;
                     }
                     return false;
@@ -1604,6 +1615,17 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
                 }
             }
             return serializedObjects;
+        },
+        validation(gltfBlock) {
+            // make sure types are the same
+            if (gltfBlock.values) {
+                const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
+                const allSameType = types.every((type) => type === types[0]);
+                if (!allSameType) {
+                    return { valid: false, error: "All inputs must be of the same type" };
+                }
+            }
+            return { valid: true };
         },
     };
 }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -370,6 +370,7 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
             // configure it to work the way glTF specifies
             serializedObjects[0].config = serializedObjects[0].config || {};
             serializedObjects[0].config.useMatrixPerComponent = true;
+            serializedObjects[0].config.preventIntegerFloatArithmetic = true;
             // try to infer the type or fallback to Integer
             // check the gltf block for the inputs, see if they have a type
             let type = -1;
@@ -1587,6 +1588,7 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
             if (inferType) {
                 // configure it to work the way glTF specifies
                 serializedObjects[0].config = serializedObjects[0].config || {};
+                serializedObjects[0].config.preventIntegerFloatArithmetic = true;
                 // try to infer the type or fallback to Integer
                 // check the gltf block for the inputs, see if they have a type
                 let type = -1;

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -1621,7 +1621,7 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
                 // make sure types are the same
                 if (gltfBlock.values) {
                     const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
-                    const allSameType = types.every((type) => type === types[0]);
+                    const allSameType = types.every((type) => type === undefined || type === types[0]);
                     if (!allSameType) {
                         return { valid: false, error: "All inputs must be of the same type" };
                     }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -1617,12 +1617,14 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
             return serializedObjects;
         },
         validation(gltfBlock) {
-            // make sure types are the same
-            if (gltfBlock.values) {
-                const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
-                const allSameType = types.every((type) => type === types[0]);
-                if (!allSameType) {
-                    return { valid: false, error: "All inputs must be of the same type" };
+            if (inferType) {
+                // make sure types are the same
+                if (gltfBlock.values) {
+                    const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
+                    const allSameType = types.every((type) => type === types[0]);
+                    if (!allSameType) {
+                        return { valid: false, error: "All inputs must be of the same type" };
+                    }
                 }
             }
             return { valid: true };

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/interactivityGraphParser.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/interactivityGraphParser.ts
@@ -210,8 +210,9 @@ export class InteractivityGraphToFlowGraphParser {
                 throw new Error("Error parsing nodes");
             }
             if (mapping.flowGraphMapping.validation) {
-                if (!mapping.flowGraphMapping.validation(node, this._interactivityGraph, this._gltf)) {
-                    throw new Error(`Error validating interactivity node ${node}`);
+                const validationResult = mapping.flowGraphMapping.validation(node, this._interactivityGraph, this._gltf);
+                if (!validationResult.valid) {
+                    throw new Error(`Error validating interactivity node ${this._interactivityGraph.declarations?.[node.declaration].op} - ${validationResult.error}`);
                 }
             }
             const blocks: ISerializedFlowGraphBlock[] = [];

--- a/packages/dev/loaders/test/unit/Interactivity/testData.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/testData.ts
@@ -52,15 +52,15 @@ export const mathExample: IKHRInteractivity_Graph = {
             // was type: "math/dot"
             declaration: 1,
             values: {
-                a: { value: [10, 10, 10], type: 4 },
-                b: { value: [1, 2, 3], type: 4 },
+                a: { value: [10, 10, 10], type: 1 },
+                b: { value: [1, 2, 3], type: 1 },
             },
         },
         {
             // was type: "math/mul"
             declaration: 2,
             values: {
-                b: { value: [2], type: 2 },
+                b: { value: [2], type: 0 },
                 a: { node: 1, socket: "value" },
             },
         },
@@ -68,7 +68,7 @@ export const mathExample: IKHRInteractivity_Graph = {
             // was type: "math/sub"
             declaration: 3,
             values: {
-                b: { value: [78], type: 2 },
+                b: { value: [78], type: 0 },
                 a: { node: 2, socket: "value" },
             },
         },
@@ -80,7 +80,7 @@ export const mathExample: IKHRInteractivity_Graph = {
             },
         },
     ],
-    types: [{ signature: "bool" }, { signature: "int" }, { signature: "float" }, { signature: "float2" }, { signature: "float3" }],
+    types: [{ signature: "float" }, { signature: "float3" }],
 };
 
 export const intMathExample: IKHRInteractivity_Graph = {


### PR DESCRIPTION
Introduce a configuration option to disallow arithmetic operations between integers and floats, aligning behavior with glTF specifications. Update relevant classes and functions to enforce this restriction.