### PR TITLE
Clear engine and webgl state on program delete

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.functions.ts
+++ b/packages/dev/core/src/Engines/thinEngine.functions.ts
@@ -351,7 +351,7 @@ function _compileRawShader(source: string, type: string, gl: WebGLContext, _cont
 /**
  * @internal
  */
-export function _setProgram(program: WebGLProgram, gl: WebGLContext): void {
+export function _setProgram(program: Nullable<WebGLProgram>, gl: WebGLContext): void {
     gl.useProgram(program);
 }
 

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1941,7 +1941,9 @@ export class ThinEngine extends AbstractEngine {
             webGLPipelineContext.program.__SPECTOR_rebuildProgram = null;
             resetCachedPipeline(webGLPipelineContext);
             if (this._gl) {
-                this._setProgram(null);
+                if (this._currentProgram === webGLPipelineContext.program) {
+                    this._setProgram(null);
+                }
                 this._gl.deleteProgram(webGLPipelineContext.program);
             }
         }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1943,7 +1943,7 @@ export class ThinEngine extends AbstractEngine {
             if (this._gl) {
                 this._gl.deleteProgram(webGLPipelineContext.program);
                 if (this._currentProgram === webGLPipelineContext.program) {
-                    this._gl.useProgram(null);
+                    _setProgram(null!, this._gl);
                     this._currentProgram = null;
                 }
             }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1942,6 +1942,10 @@ export class ThinEngine extends AbstractEngine {
             resetCachedPipeline(webGLPipelineContext);
             if (this._gl) {
                 this._gl.deleteProgram(webGLPipelineContext.program);
+                if (this._currentProgram === webGLPipelineContext.program) {
+                    this._gl.useProgram(null);
+                    this._currentProgram = null;
+                }
             }
         }
     }

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -1941,11 +1941,8 @@ export class ThinEngine extends AbstractEngine {
             webGLPipelineContext.program.__SPECTOR_rebuildProgram = null;
             resetCachedPipeline(webGLPipelineContext);
             if (this._gl) {
+                this._setProgram(null);
                 this._gl.deleteProgram(webGLPipelineContext.program);
-                if (this._currentProgram === webGLPipelineContext.program) {
-                    _setProgram(null!, this._gl);
-                    this._currentProgram = null;
-                }
             }
         }
     }
@@ -3717,7 +3714,7 @@ export class ThinEngine extends AbstractEngine {
         texture?.release();
     }
 
-    protected _setProgram(program: WebGLProgram): void {
+    protected _setProgram(program: Nullable<WebGLProgram>): void {
         if (this._currentProgram !== program) {
             _setProgram(program, this._gl);
             this._currentProgram = program;


### PR DESCRIPTION
Maintain correct state of WebGL context after shader program is deleted. 
This may help when WebGL context is shared with other engines.