### PR TITLE
Sandbox: adapt panning sensitivity based on radius (same as viewer)

### DIFF
--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -371,7 +371,10 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
                 this.onSceneLoaded(fileName);
 
                 scene.whenReadyAsync().then(() => {
+                    const camera = scene.activeCamera! as ArcRotateCamera;
                     this._engine.runRenderLoop(() => {
+                        // Adapt the camera sensibility based on the distance to the object
+                        camera.panningSensibility = 5000 / camera.radius;
                         scene.render();
                     });
                 });


### PR DESCRIPTION
The viewer adapts the camera's panning sensitivity based on the radius of the object being viewed, and this change duplicates that logic for the sandbox.