### PR TITLE
Fix for null TypeError in dynamicTexture

### DIFF
--- a/packages/dev/core/src/Materials/Textures/dynamicTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/dynamicTexture.ts
@@ -202,6 +202,11 @@ export class DynamicTexture extends Texture {
      * @param allowGPUOptimization true to allow some specific GPU optimizations (subject to engine feature "allowGPUOptimizationsForGUI" being true)
      */
     public update(invertY?: boolean, premulAlpha = false, allowGPUOptimization = false): void {
+        // When disposed, this._texture will be null.
+        if (!this._texture) {
+            return;
+        }
+
         this._getEngine()!.updateDynamicTexture(
             this._texture,
             this._canvas,


### PR DESCRIPTION
It's possible that when rapidly disposing a dynamicTexture, a delayed callback gets ran on the disposed instance, resulting in a TypeError exception caused by accessing a null instance. The specific case that was causing this issue was when `Tools.SetImmediate` is used to pend some future work to `update` the dynamic texture, and by the time this delayed callback was running, the dynamicTexture had already been disposed.

The fix here is to early out of the `update` function if `this._texture` is already null. This simply avoids dereferencing a null engine when calling `_getEngine().updateDynamicTexture(this._texture, ...)`. In any case, `updateDynamicTexture` itself already early outs when the texture parameter is null, so it should not change that behavior.