### PR TITLE
Refactor type validation logic for uniformity checks

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -389,13 +389,8 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         validation(gltfBlock) {
             // make sure types are the same
             if (gltfBlock.values) {
-                const types = Object.keys(gltfBlock.values)
-                    .map((key) => gltfBlock.values![key].type)
-                    .filter((type) => type !== undefined);
-                const allSameType = types.every((type) => type === types[0]);
-                if (!allSameType) {
-                    return { valid: false, error: "All inputs must be of the same type" };
-                }
+                // make sure types are the same
+                return ValidateTypes(gltfBlock);
             }
             return { valid: true };
         },
@@ -1621,19 +1616,24 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
         validation(gltfBlock) {
             if (inferType) {
                 // make sure types are the same
-                if (gltfBlock.values) {
-                    const types = Object.keys(gltfBlock.values)
-                        .map((key) => gltfBlock.values![key].type)
-                        .filter((type) => type !== undefined);
-                    const allSameType = types.every((type) => type === types[0]);
-                    if (!allSameType) {
-                        return { valid: false, error: "All inputs must be of the same type" };
-                    }
-                }
+                return ValidateTypes(gltfBlock);
             }
             return { valid: true };
         },
     };
+}
+
+function ValidateTypes(gltfBlock: IKHRInteractivity_Node): { valid: boolean; error?: string } {
+    if (gltfBlock.values) {
+        const types = Object.keys(gltfBlock.values)
+            .map((key) => gltfBlock.values![key].type)
+            .filter((type) => type !== undefined);
+        const allSameType = types.every((type) => type === types[0]);
+        if (!allSameType) {
+            return { valid: false, error: "All inputs must be of the same type" };
+        }
+    }
+    return { valid: true };
 }
 
 export function getAllSupportedNativeNodeTypes(): string[] {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -389,8 +389,10 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         validation(gltfBlock) {
             // make sure types are the same
             if (gltfBlock.values) {
-                const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
-                const allSameType = types.every((type) => type === undefined || type === types[0]);
+                const types = Object.keys(gltfBlock.values)
+                    .map((key) => gltfBlock.values![key].type)
+                    .filter((type) => type !== undefined);
+                const allSameType = types.every((type) => type === types[0]);
                 if (!allSameType) {
                     return { valid: false, error: "All inputs must be of the same type" };
                 }
@@ -1620,8 +1622,10 @@ function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a
             if (inferType) {
                 // make sure types are the same
                 if (gltfBlock.values) {
-                    const types = Object.keys(gltfBlock.values).map((key) => gltfBlock.values![key].type);
-                    const allSameType = types.every((type) => type === undefined || type === types[0]);
+                    const types = Object.keys(gltfBlock.values)
+                        .map((key) => gltfBlock.values![key].type)
+                        .filter((type) => type !== undefined);
+                    const allSameType = types.every((type) => type === types[0]);
                     if (!allSameType) {
                         return { valid: false, error: "All inputs must be of the same type" };
                     }


### PR DESCRIPTION
Ensure all input types are defined before checking for uniformity, improving the validation process for input types.

Small fix for PR #16486