### PR TITLE
Speed up playwright audio tests

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -160,7 +160,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
     /** @internal */
     public get state(): AudioEngineV2State {
-        return this._audioContext.state;
+        // Always return "running" for OfflineAudioContext so sound `play` calls work while the context is suspended.
+        return <any>this._audioContext instanceof OfflineAudioContext ? "running" : this._audioContext.state;
     }
 
     /** @internal */
@@ -245,7 +246,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
         this._listener?.dispose();
         this._listener = null;
 
-        if (this._audioContext.state !== "closed") {
+        // Note that OfflineAudioContext does not have a `close` method.
+        if (this._audioContext.state !== "closed" && this._audioContext.close) {
             this._audioContext.close();
         }
 

--- a/packages/tools/babylonServer/public/audiov2-test.js
+++ b/packages/tools/babylonServer/public/audiov2-test.js
@@ -5,16 +5,26 @@ var audioRecorderDestination;
 var audioTestConfig;
 var audioTestResult;
 var audioTestSounds = [];
+var audioTestSuspendTime = 0;
 var BABYLON;
 
 const SilenceAudioOutput = true;
+
+/**
+ * The maximum pulse volume in the sound test file containing the pulse train.
+ */
+const MaxPulseVolume = 0.1;
+
+const PulseGapLengthThresholdInMilliseconds = 0.01;
+const PulseTrainLengthInSamples = 90;
+const PulseVolumeThreshold = 0.05;
 
 class AudioV2Test {
     static #AddSound(sound) {
         audioTestSounds.push(sound);
 
         // Start the audio recorder after the sound loads to avoid capturing silence while we wait.
-        if (audioRecorder.state === "inactive") {
+        if (audioContext instanceof AudioContext && audioRecorder.state === "inactive") {
             audioRecorder.start();
         }
     }
@@ -44,39 +54,46 @@ class AudioV2Test {
         audioRecorderDestination = null;
         audioTestConfig = null;
         audioTestResult = null;
-
         audioTestSounds.length = 0;
+        audioTestSuspendTime = 0;
 
         audioEngine?.dispose();
         audioEngine = null;
     }
 
-    static async BeforeEachAsync() {
-        audioContext = new AudioContext();
+    static async CreateAudioEngineAsync(contextType, duration, options = {}) {
+        if (contextType === "Realtime" || contextType === "StreamingSound") {
+            audioContext = new AudioContext();
 
-        // Firefox doesn't always start the audio context immediately, so wait for it to start here.
-        await new Promise((resolve) => {
-            const onStateChange = () => {
-                if (audioContext.state === "running") {
-                    audioContext.removeEventListener("statechange", onStateChange);
-                    resolve();
-                }
-            };
-            audioContext.addEventListener("statechange", onStateChange);
-        });
-    }
+            // Firefox doesn't always start the audio context immediately, so wait for it to start here.
+            await new Promise((resolve) => {
+                const onStateChange = () => {
+                    if (audioContext.state === "running") {
+                        audioContext.removeEventListener("statechange", onStateChange);
+                        resolve();
+                    }
+                };
+                audioContext.addEventListener("statechange", onStateChange);
+            });
+        } else {
+            if (!duration) {
+                duration = audioTestConfig.defaultOfflineContextDuration;
+            }
+            audioContext = new OfflineAudioContext(2, 44100 * duration, 44100);
+        }
 
-    static async CreateAudioEngineAsync(options = {}) {
         options.audioContext = audioContext;
         audioEngine = await BABYLON.CreateAudioEngineAsync(options);
 
-        audioRecorderDestination = new MediaStreamAudioDestinationNode(audioContext);
-        audioRecorder = new MediaRecorder(audioRecorderDestination.stream);
-        const nodeToCapture = audioEngine.mainOut._inNode;
-        nodeToCapture.connect(audioRecorderDestination);
+        if (audioContext instanceof AudioContext) {
+            audioRecorderDestination = new MediaStreamAudioDestinationNode(audioContext);
+            audioRecorder = new MediaRecorder(audioRecorderDestination.stream);
+            const nodeToCapture = audioEngine.mainOut._inNode;
+            nodeToCapture.connect(audioRecorderDestination);
 
-        if (SilenceAudioOutput) {
-            nodeToCapture.disconnect(audioContext.destination);
+            if (SilenceAudioOutput) {
+                nodeToCapture.disconnect(audioContext.destination);
+            }
         }
 
         return audioEngine;
@@ -132,48 +149,216 @@ class AudioV2Test {
         return sound;
     }
 
+    /**
+     * Gets the pulse counts of the test result's samples.
+     *
+     * Consecutive pulses are counted as a group, with the number of pulses in the group being the count. The group is
+     * ended when a silence of at least `PulseGapLengthThresholdInMilliseconds` is detected or the end of the captured
+     * audio is reached.
+     *
+     * For example, the shape of the returned pulse count arrays for a test result containing 2 channels with 3 groups of
+     * pulses detected as 5 pulses in the first group, 6 in the second and 7 in the third group, would look like this:
+     * [[5, 6, 7], [5, 6, 7]] ... assuming both test result channels contain the same audio output, which is typical.
+     *
+     * @returns an array containing the pulse counts for each channel in the test result's samples
+     */
+    static async GetPulseCountsAsync() {
+        const result = await AudioV2Test.GetResultAsync();
+
+        if (!result || !result.samples?.length || !result.numberOfChannels) {
+            return [];
+        }
+
+        const pulseCounts = [];
+        pulseCounts.length = audioTestResult.numberOfChannels;
+
+        const PulseGapLengthThresholdInSamples = PulseGapLengthThresholdInMilliseconds * result.sampleRate;
+
+        for (let channel = 0; channel < result.numberOfChannels; channel++) {
+            let channelPulseCounts = [];
+            const samples = result.samples[channel];
+
+            let pulseStart = -1;
+            let pulseEnd = -1;
+            let pulseCount = 0;
+
+            let i = 0;
+            for (; i < result.length; i++) {
+                if (Math.abs(samples[i]) > PulseVolumeThreshold) {
+                    if (pulseStart === -1) {
+                        pulseStart = i;
+
+                        if (pulseEnd !== -1) {
+                            const silenceLengthInSamples = i - pulseEnd;
+                            if (silenceLengthInSamples > PulseGapLengthThresholdInSamples) {
+                                channelPulseCounts.push(pulseCount);
+                                pulseCount = 0;
+                            }
+                        }
+                    } else {
+                        pulseEnd = i;
+                    }
+                } else if (i - pulseStart > PulseTrainLengthInSamples) {
+                    if (pulseStart !== -1) {
+                        pulseCount++;
+                        pulseStart = -1;
+                    }
+                }
+            }
+
+            if (pulseEnd !== -1) {
+                const silenceLengthInSamples = i - pulseEnd;
+                if (silenceLengthInSamples > PulseGapLengthThresholdInSamples) {
+                    channelPulseCounts.push(pulseCount);
+                }
+            }
+
+            pulseCounts[channel] = channelPulseCounts;
+        }
+
+        return pulseCounts;
+    }
+
+    /**
+     * Gets the volumes of the test result's samples.
+     *
+     * The volume of each pulse is calculated by taking the absolute value of the samples and averaging them over the pulse length.
+     *
+     * The average volume is stored in the `volumeCurves` array for each channel, and is repeated for each sample in the pulse making
+     * the resulting `volumeCurves` array length the same as the result's `samples` array, which makes it easier to find the
+     * resulting volume at a given time.
+     *
+     * @returns an array containing the volume of each pulse aligned with channels and samples in the test result's samples
+     */
+    static async #GetVolumeCurvesAsync() {
+        const result = await AudioV2Test.GetResultAsync();
+
+        if (!result || !result.samples?.length) {
+            return [];
+        }
+
+        if (result.volumeCurves) {
+            return result.volumeCurves;
+        }
+
+        result.volumeCurves = [];
+        result.volumeCurves.length = result.numberOfChannels;
+
+        for (let channel = 0; channel < result.numberOfChannels; channel++) {
+            const samples = result.samples[channel];
+
+            let curve = new Float32Array(result.length);
+
+            let currentPolarity = samples[0] > 0;
+            let pulseStartIndex = 0;
+
+            const updateCurve = (pulseEndIndex) => {
+                const pulseLength = pulseEndIndex - pulseStartIndex;
+                if (pulseLength > 2) {
+                    // Don't include the first and last samples in the average volume calculation. They are typically
+                    // values transitioning across the zero line when the polarity changes, and are not representative of
+                    // the actual pulse volume.
+                    let totalVolume = 0;
+                    for (let j = pulseStartIndex + 1; j < pulseEndIndex - 1; j++) {
+                        totalVolume += Math.abs(samples[j]);
+                    }
+                    const avgVolume = totalVolume / (pulseLength - 2);
+
+                    for (let j = pulseStartIndex; j < pulseEndIndex; j++) {
+                        curve[j] = avgVolume;
+                    }
+                }
+            };
+
+            let i = 0;
+            for (; i < result.length; i++) {
+                if (currentPolarity !== samples[i] > 0) {
+                    updateCurve(i);
+                    pulseStartIndex = i;
+                    currentPolarity = !currentPolarity;
+                }
+            }
+            updateCurve(i);
+
+            result.volumeCurves[channel] = curve;
+        }
+
+        return result.volumeCurves;
+    }
+
+    /**
+     * Gets the volumes of the test result's samples at a given time.
+     *
+     * @param time - the time in seconds to get the volumes at
+     * @returns an array containing the volume of each channel at the given time
+     */
+    static async GetVolumesAtTimeAsync(time) {
+        const result = await AudioV2Test.GetResultAsync();
+
+        const volumes = [];
+        volumes.length = result.numberOfChannels;
+
+        const sampleIndex = Math.floor(time * result.sampleRate);
+        const volumeCurves = await AudioV2Test.#GetVolumeCurvesAsync();
+
+        for (let channel = 0; channel < result.numberOfChannels; channel++) {
+            const curve = volumeCurves[channel];
+            if (curve && sampleIndex < curve.length) {
+                volumes[channel] = curve[sampleIndex] / MaxPulseVolume;
+            } else {
+                volumes[channel] = 0;
+            }
+        }
+
+        return volumes;
+    }
+
     static async GetResultAsync() {
         if (audioTestResult) {
             return audioTestResult;
         }
 
-        // Wait for sounds to finish playing.
-        for (let i = 0; i < audioTestSounds.length; i++) {
-            const sound = audioTestSounds[i];
-            if (sound.state !== BABYLON.SoundState.Stopped) {
-                await new Promise((resolve) => {
-                    sound.onEndedObservable.addOnce(() => {
-                        resolve();
-                    });
-                });
-            }
-        }
-
-        // Get rendered audio.
         let renderedBuffer;
-        await new Promise((resolve) => {
-            audioRecorder.addEventListener(
-                "dataavailable",
-                async (event) => {
-                    const arrayBuffer = await event.data.arrayBuffer();
-                    if (arrayBuffer.byteLength === 0) {
-                        throw new Error("No audio data.");
-                    }
 
-                    renderedBuffer = await audioContext.decodeAudioData(arrayBuffer);
-                    resolve();
-                },
-                { once: true }
-            );
-            audioRecorder.stop();
-        });
+        if (audioContext instanceof OfflineAudioContext) {
+            renderedBuffer = await audioContext.startRendering();
+        } else if (audioContext instanceof AudioContext) {
+            // Wait for sounds to finish playing.
+            for (let i = 0; i < audioTestSounds.length; i++) {
+                const sound = audioTestSounds[i];
+                if (sound.state !== BABYLON.SoundState.Stopped) {
+                    await new Promise((resolve) => {
+                        sound.onEndedObservable.addOnce(() => {
+                            resolve();
+                        });
+                    });
+                }
+            }
 
-        if (!renderedBuffer) {
-            throw new Error("No buffer rendered.");
-        }
+            // Get rendered audio.
+            await new Promise((resolve) => {
+                audioRecorder.addEventListener(
+                    "dataavailable",
+                    async (event) => {
+                        const arrayBuffer = await event.data.arrayBuffer();
+                        if (arrayBuffer.byteLength === 0) {
+                            throw new Error("No audio data.");
+                        }
 
-        if (renderedBuffer.length === 0) {
-            throw new Error("No audio data in rendered buffer.");
+                        renderedBuffer = await audioContext.decodeAudioData(arrayBuffer);
+                        resolve();
+                    },
+                    { once: true }
+                );
+                audioRecorder.stop();
+            });
+
+            if (!renderedBuffer) {
+                throw new Error("No buffer rendered.");
+            }
+            if (renderedBuffer.length === 0) {
+                throw new Error("No audio data in rendered buffer.");
+            }
         }
 
         const capturedAudio = new Array(renderedBuffer.numberOfChannels);
@@ -194,11 +379,31 @@ class AudioV2Test {
         });
     }
 
-    static async WaitAsync(seconds) {
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve();
-            }, seconds * 1000);
-        });
+    static async WaitAsync(seconds, callback) {
+        if (!audioContext) {
+            throw new Error("Audio context is not initialized.");
+        }
+
+        if (audioContext instanceof AudioContext) {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    if (callback) {
+                        callback();
+                    }
+                    resolve();
+                }, seconds * 1000);
+            });
+        } else if (audioContext instanceof OfflineAudioContext) {
+            audioTestSuspendTime += seconds;
+
+            audioContext.suspend(audioTestSuspendTime).then(() => {
+                if (callback) {
+                    callback();
+                    audioContext.resume();
+                }
+            });
+        } else {
+            throw new Error("Unknown audio context type.");
+        }
     }
 }

--- a/packages/tools/tests/test/audioV2/audioEngineV2.listener.test.ts
+++ b/packages/tools/tests/test/audioV2/audioEngineV2.listener.test.ts
@@ -1,4 +1,4 @@
-import { Channel, GetVolumesAtTime, InitAudioV2Tests, VolumePrecision } from "./utils/audioV2.utils";
+import { Channel, EvaluateVolumesAtTimeAsync, InitAudioV2Tests, VolumePrecision } from "./utils/audioV2.utils";
 
 import { expect, test } from "@playwright/test";
 
@@ -6,18 +6,17 @@ InitAudioV2Tests();
 
 test.describe("AudioEngineV2 listener", () => {
     test("Sound at position (0, 0, -1) with no listener options set should be 1x volume in left and right speakers", async ({ page }) => {
-        const result = await page.evaluate(async () => {
+        await page.evaluate(async () => {
             await AudioV2Test.CreateAudioEngineAsync();
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, -1) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         // Test against 0.7 because the 1.0 amplitude sound is evenly distributed between the two speakers.
         expect(volumes[Channel.L]).toBeCloseTo(0.7, VolumePrecision);
@@ -25,92 +24,87 @@ test.describe("AudioEngineV2 listener", () => {
     });
 
     test("Sound at position (0, 0, 0) with listener position option set to (1, 0, 0) should be 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {
-        const result = await page.evaluate(async () => {
-            await AudioV2Test.CreateAudioEngineAsync({ listenerPosition: new BABYLON.Vector3(1, 0, 0) });
+        await page.evaluate(async () => {
+            await AudioV2Test.CreateAudioEngineAsync(undefined, undefined, { listenerPosition: new BABYLON.Vector3(1, 0, 0) });
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, 0) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
     });
 
     test("Sound at position (0, 0, 0) with listener position option set to (-1, 0, 0) should be 0 volume in left speaker and 1x volume in right speaker", async ({ page }) => {
-        const result = await page.evaluate(async () => {
-            await AudioV2Test.CreateAudioEngineAsync({ listenerPosition: new BABYLON.Vector3(-1, 0, 0) });
+        await page.evaluate(async () => {
+            await AudioV2Test.CreateAudioEngineAsync(undefined, undefined, { listenerPosition: new BABYLON.Vector3(-1, 0, 0) });
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, 0) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);
     });
 
     test("Sound at position (0, 0, -1) with listener rotation option set to 90 degrees should be 0 volume in left speaker and 1x volume in right speaker", async ({ page }) => {
-        const result = await page.evaluate(async () => {
-            await AudioV2Test.CreateAudioEngineAsync({ listenerRotation: new BABYLON.Vector3(0, 0.5 * Math.PI, 0) });
+        await page.evaluate(async () => {
+            await AudioV2Test.CreateAudioEngineAsync(undefined, undefined, { listenerRotation: new BABYLON.Vector3(0, 0.5 * Math.PI, 0) });
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, -1) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);
     });
 
     test("Sound at position (0, 0, -1) with listener rotation option set to -90 degrees should be 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {
-        const result = await page.evaluate(async () => {
-            await AudioV2Test.CreateAudioEngineAsync({ listenerRotation: new BABYLON.Vector3(0, -0.5 * Math.PI, 0) });
+        await page.evaluate(async () => {
+            await AudioV2Test.CreateAudioEngineAsync(undefined, undefined, { listenerRotation: new BABYLON.Vector3(0, -0.5 * Math.PI, 0) });
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, -1) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
     });
 
     test("Sound at position (0, 0, 0) with listener position property set to (1, 0, 0) should be 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {
-        const result = await page.evaluate(async () => {
+        await page.evaluate(async () => {
             const audioEngine = await AudioV2Test.CreateAudioEngineAsync();
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, 0) });
 
             audioEngine.listener.position = new BABYLON.Vector3(1, 0, 0);
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
@@ -119,20 +113,19 @@ test.describe("AudioEngineV2 listener", () => {
     test("Sound at position (0, 0, 0) with listener position property set to (1, 0, 0) via Vector3.set should be 1x volume in left speaker and 0 volume in right speaker", async ({
         page,
     }) => {
-        const result = await page.evaluate(async () => {
+        await page.evaluate(async () => {
             const audioEngine = await AudioV2Test.CreateAudioEngineAsync();
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, 0) });
 
             audioEngine.listener.position.set(1, 0, 0);
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
@@ -141,7 +134,7 @@ test.describe("AudioEngineV2 listener", () => {
     test("Sound at position (0, 0, 0) with `listenerAttachedMesh` option set to mesh at position (1, 0, 0) should be 1x volume in left speaker and 0 volume in right speaker", async ({
         page,
     }) => {
-        const result = await page.evaluate(async () => {
+        await page.evaluate(async () => {
             const canvas = document.createElement("canvas");
             const engine = new BABYLON.Engine(canvas, true);
             const scene = new BABYLON.Scene(engine);
@@ -149,18 +142,17 @@ test.describe("AudioEngineV2 listener", () => {
             mesh.position.x = 1;
             mesh.computeWorldMatrix(true);
 
-            const audioEngine = await AudioV2Test.CreateAudioEngineAsync({ listenerEnabled: true });
+            const audioEngine = await AudioV2Test.CreateAudioEngineAsync(undefined, undefined, { listenerEnabled: true });
             audioEngine.listener.attach(mesh);
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, 0) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
@@ -169,7 +161,7 @@ test.describe("AudioEngineV2 listener", () => {
     test("Sound at position (0, 0, -1) with `listenerAttachedMesh` option set to mesh rotated 90 degrees should be 0 volume in left speaker and 1x volume in right speaker", async ({
         page,
     }) => {
-        const result = await page.evaluate(async () => {
+        await page.evaluate(async () => {
             const canvas = document.createElement("canvas");
             const engine = new BABYLON.Engine(canvas, true);
             const scene = new BABYLON.Scene(engine);
@@ -177,18 +169,17 @@ test.describe("AudioEngineV2 listener", () => {
             mesh.rotation.y = 0.5 * Math.PI;
             mesh.computeWorldMatrix(true);
 
-            const audioEngine = await AudioV2Test.CreateAudioEngineAsync({ listenerEnabled: true });
+            const audioEngine = await AudioV2Test.CreateAudioEngineAsync(undefined, undefined, { listenerEnabled: true });
             audioEngine.listener.attach(mesh);
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulseTrainSoundFile, { spatialPosition: new BABYLON.Vector3(0, 0, -1) });
 
             sound.play();
-            await AudioV2Test.WaitAsync(1);
-            sound.stop();
-
-            return await AudioV2Test.GetResultAsync();
+            await AudioV2Test.WaitAsync(1, () => {
+                sound.stop();
+            });
         });
 
-        const volumes = GetVolumesAtTime(result, 0.5);
+        const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
         expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
         expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.stereo.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.stereo.ts
@@ -1,172 +1,163 @@
 import { EvaluateAbstractAudioNodeTestAsync } from "../utils/abstractAudioNode.utils";
 import type { AudioNodeType } from "../utils/audioV2.utils";
-import { Channel, GetVolumesAtTime, VolumePrecision } from "../utils/audioV2.utils";
+import { Channel, EvaluateVolumesAtTimeAsync, VolumePrecision } from "../utils/audioV2.utils";
 
 import { expect, test } from "@playwright/test";
 
 export const AddSharedAbstractAudioNodeStereoTests = (audioNodeType: AudioNodeType) => {
     test.describe(`${audioNodeType} stereo`, () => {
         test("Stereo pan should default to 0 and play sound at 1x volume in both speakers", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);
         });
 
         test("Setting `stereoPan` option to -1 should play sound at 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { stereoPan: -1 });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
         });
 
         test("Setting `stereoPan` option to 1 should play sound at 0 volume in left speaker and 1x volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { stereoPan: 1 });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);
         });
 
         test("Setting `stereoPan` option to -0.5 should play sound at 0.91x volume in left speaker and 0.38x volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { stereoPan: -0.5 });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0.91, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0.38, VolumePrecision);
         });
 
         test("Setting `stereoPan` option to 0.5 should play sound at 0.38x volume in left speaker and 0.91x volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { stereoPan: 0.5 });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0.38, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0.91, VolumePrecision);
         });
 
         test("Setting `stereo.pan` property to -1 should play sound at 1x volume in left speaker and 0 volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 outputNode.stereo.pan = -1;
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0, VolumePrecision);
         });
 
         test("Setting `stereo.pan` property to 1 should play sound at 0 volume in left speaker and 1x volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 outputNode.stereo.pan = 1;
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);
         });
 
         test("Setting `stereo.pan` property to -0.5 should play sound at 0.91x volume in left speaker and 0.38x volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 outputNode.stereo.pan = -0.5;
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0.91, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0.38, VolumePrecision);
         });
 
         test("Setting `stereo.pan` property to 0.5 should play sound at 0.38x volume in left speaker and 0.91x volume in right speaker", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 outputNode.stereo.pan = 0.5;
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0.38, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0.91, VolumePrecision);

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -1,60 +1,57 @@
 import { EvaluateAbstractAudioNodeTestAsync } from "../utils/abstractAudioNode.utils";
 import type { AudioNodeType } from "../utils/audioV2.utils";
-import { Channel, GetVolumesAtTime, VolumePrecision } from "../utils/audioV2.utils";
+import { Channel, EvaluateVolumesAtTimeAsync, VolumePrecision } from "../utils/audioV2.utils";
 
 import { expect, test } from "@playwright/test";
 
 export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeType) => {
     test.describe(`${audioNodeType} volume`, () => {
         test("Volume should default to 1 and play sound at 1x volume", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
         });
 
         test("Setting `volume` to 0.5 should play sound at 0.5x volume ", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 outputNode.volume = 0.5;
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
         });
 
         test("Setting `volume` to 2 should play sound at 2x volume ", async ({ page }) => {
-            const result = await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
                 const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile);
 
                 outputNode.volume = 2;
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
             });
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(2, 0);
         });

--- a/packages/tools/tests/test/audioV2/shared/abstractSound.currentTime.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSound.currentTime.ts
@@ -7,7 +7,7 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
     test.describe(`${soundType} currentTime`, () => {
         test("The `currentTime` property should equal the current playback time while playing", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
@@ -21,7 +21,7 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("The `currentTime` property should equal 0 when stopped", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
@@ -36,7 +36,7 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("The `currentTime` property should equal the paused time of the sound in seconds while paused", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
@@ -51,7 +51,7 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("The `currentTime` property should equal the current playback time when paused and played again", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
@@ -69,7 +69,7 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("The `currentTime` property should equal the sound's `startOffset` option", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { startOffset: 1 });
 
                 sound.play();
@@ -84,8 +84,8 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("The `currentTime` property should equal the most recently started instance's current time", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
+                const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { preloadCount: 2 });
 
                 sound.play();
                 await AudioV2Test.WaitAsync(1);
@@ -101,13 +101,11 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("Setting the `currentTime` property before playing should seek to the given time", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.currentTime = 1;
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([2, 3]);
@@ -115,14 +113,13 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("Setting the `currentTime` property while playing should seek to the given time", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.currentTime = 1.5;
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.currentTime = 1.5;
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 3]);
@@ -130,16 +127,15 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("Setting the `currentTime` property while paused should seek to the given time", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.pause();
-                sound.currentTime = soundType === "StaticSound" ? 2 : 1.5;
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.pause();
+                    sound.currentTime = soundType === "StaticSound" ? 2 : 1.5;
+                    sound.play();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 3]);
@@ -147,16 +143,15 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
 
         test("Setting the `currentTime` property while stopped should seek to the given time", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.stop();
-                sound.currentTime = soundType === "StaticSound" ? 2 : 1.5;
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.stop();
+                    sound.currentTime = soundType === "StaticSound" ? 2 : 1.5;
+                    sound.play();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 3]);

--- a/packages/tools/tests/test/audioV2/shared/abstractSound.playback.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSound.playback.ts
@@ -1,5 +1,5 @@
 import { EvaluatePulseCountTestAsync } from "../utils/abstractSound.utils";
-import { AudioTestResult, Channel, GetVolumesAtTime, SoundType, VolumePrecision } from "../utils/audioV2.utils";
+import { Channel, EvaluateVolumesAtTimeAsync, SoundType, VolumePrecision } from "../utils/audioV2.utils";
 
 import { expect, test } from "@playwright/test";
 
@@ -7,12 +7,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
     test.describe(`${soundType} playback`, () => {
         test("Create sound with audio engine parameter not set", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([1, 2, 3]);
@@ -20,10 +18,8 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with `autoplay` option set to `true`", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { autoplay: true });
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([1, 2, 3]);
@@ -31,12 +27,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound and call `play` on it using `await`", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([1, 2, 3]);
@@ -44,12 +38,12 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound and call `play` on it using `then`", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
 
-                return new Promise<AudioTestResult>((resolve) => {
+                await new Promise<void>((resolve) => {
                     AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile).then(async (sound) => {
                         sound.play();
-                        resolve(await AudioV2Test.GetResultAsync());
+                        resolve();
                     });
                 });
             });
@@ -59,14 +53,13 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound and call `play` on it twice", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.play();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 1, 2, 2, 3, 3]);
@@ -74,16 +67,16 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound, call `play` on it twice, and call `stop` on it", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.play();
+                });
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.stop();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 1]);
@@ -91,14 +84,13 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with `loop` option set to true", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { loop: true });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(3.9);
-                sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(3.9, () => {
+                    sound.stop();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 2, 3, 1]);
@@ -106,33 +98,30 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with `startOffset` option set to 1", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { startOffset: 1 });
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([2, 3]);
         });
 
         test("Play sound with `volume` parameter set to 0.5", async ({ page }) => {
-            const result = await page.evaluate(
+            await page.evaluate(
                 async ({ soundType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync();
+                    await AudioV2Test.CreateAudioEngineAsync(soundType);
                     const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulseTrainSoundFile);
 
                     sound.play({ volume: 0.5 });
-                    await AudioV2Test.WaitAsync(1);
-                    sound.stop();
-
-                    return await AudioV2Test.GetResultAsync();
+                    await AudioV2Test.WaitAsync(1, () => {
+                        sound.stop();
+                    });
                 },
                 { soundType }
             );
 
-            const volumes = GetVolumesAtTime(result, 0.5);
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
             expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
             expect(volumes[Channel.R]).toBeCloseTo(0.5, VolumePrecision);
@@ -140,12 +129,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Play sound with `startOffset` option set to 1", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { startOffset: 1 });
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([2, 3]);
@@ -153,12 +140,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with sources set to one mp3 file URL with no query parameters", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateSoundAsync([audioTestConfig.pulsed1CountSoundFile]);
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([1]);
@@ -166,12 +151,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with sources set to one mp3 file URL with query parameters", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, ["pulsed-1.mp3?param1=1&param2=2"]);
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([1]);
@@ -179,12 +162,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with sources set to ogg and mp3 files", async ({ browserName, page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, ["pulsed-1.ogg", "pulsed-2.mp3"]);
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             // Webkit doesn't support .ogg files, so the .mp3 file 2nd in the list should play.
@@ -198,8 +179,8 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with source array set to ogg/ac3 and mp3 files, with skipCodecCheck set to true", async ({ browserName, page }) => {
             const raisedException = await page.evaluate(
-                async ({ browserName }) => {
-                    await AudioV2Test.CreateAudioEngineAsync();
+                async ({ browserName, soundType }) => {
+                    await AudioV2Test.CreateAudioEngineAsync(soundType);
 
                     try {
                         await AudioV2Test.CreateAbstractSoundAsync(
@@ -213,24 +194,24 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
                     return false;
                 },
-                { browserName }
+                { browserName, soundType }
             );
 
-            expect(raisedException).toEqual(true);
+            expect(raisedException).toEqual(soundType === "StaticSound" ? true : false);
         });
 
         test("Play sound, pause it, and resume it", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.pause();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.resume();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.pause();
+                });
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.resume();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 2, 3]);
@@ -238,16 +219,16 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Play sound, pause it, and resume it by calling play", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.pause();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.pause();
+                });
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.play();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 2, 3]);
@@ -255,14 +236,13 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with `maxInstances` set to 1", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { maxInstances: 1 });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(1);
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.play();
+                });
             });
 
             expect(pulses[Channel.L]).toEqual([1, 1, 2, 3]);
@@ -270,16 +250,16 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with `maxInstances` set to 2", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile, { maxInstances: 2 });
 
                 sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.play();
-                await AudioV2Test.WaitAsync(0.5);
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.play();
+                });
+                await AudioV2Test.WaitAsync(0.5, () => {
+                    sound.play();
+                });
             });
 
             // Pulse count output for each instance:
@@ -291,12 +271,10 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
 
         test("Create sound with url containing a # character", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
-                await AudioV2Test.CreateAudioEngineAsync();
+                await AudioV2Test.CreateAudioEngineAsync(soundType);
                 const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.hashedSoundFile);
 
                 sound.play();
-
-                return await AudioV2Test.GetResultAsync();
             });
 
             expect(pulses[Channel.L]).toEqual([2]);

--- a/packages/tools/tests/test/audioV2/staticSound.currentTime.test.ts
+++ b/packages/tools/tests/test/audioV2/staticSound.currentTime.test.ts
@@ -9,7 +9,7 @@ AddSharedAbstractSoundCurrentTimeTests("StaticSound");
 test.describe("StaticSound currentTime", () => {
     test("The `currentTime` property should equal the `play` function's `waitTime` parameter", async ({ page }) => {
         const result = await page.evaluate(async () => {
-            await AudioV2Test.CreateAudioEngineAsync();
+            await AudioV2Test.CreateAudioEngineAsync("Realtime");
             const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
 
             sound.play({ waitTime: 1 });

--- a/packages/tools/tests/test/audioV2/staticSound.playback.test.ts
+++ b/packages/tools/tests/test/audioV2/staticSound.playback.test.ts
@@ -1,5 +1,5 @@
 import { AddSharedAbstractSoundPlaybackTests } from "./shared/abstractSound.playback";
-import { Channel, GetPulseCounts, InitAudioV2Tests } from "./utils/audioV2.utils";
+import { Channel, EvaluatePulseCountsAsync, InitAudioV2Tests } from "./utils/audioV2.utils";
 
 import { expect, test } from "@playwright/test";
 
@@ -8,157 +8,119 @@ AddSharedAbstractSoundPlaybackTests("StaticSound");
 
 test.describe("StaticSound playback", () => {
     test("Play sound and call `stop` with `waitTime` parameter set to 1.8", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
 
-                sound.play();
-                sound.stop({ waitTime: 1.8 });
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+            sound.stop({ waitTime: 1.8 });
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2]);
     });
 
     test("Play two sounds, with the second sound's `waitTime` parameter set to 3", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
 
-                sound.play();
-                sound.play({ waitTime: 3 });
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+            sound.play({ waitTime: 3 });
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2, 3, 1, 2, 3]);
     });
 
     test("Create sound with `autoplay` and `duration` options set", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { autoplay: true, duration: 1.9 });
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { autoplay: true, duration: 1.9 });
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2]);
     });
 
     test("Create sound with `loopStart` and `loopEnd` options set", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { loop: true, loopStart: 1, loopEnd: 2 });
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { loop: true, loopStart: 1, loopEnd: 2 });
 
-                sound.play();
-                await AudioV2Test.WaitAsync(2.8);
+            sound.play();
+            await AudioV2Test.WaitAsync(2.8, () => {
                 sound.stop();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            });
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2, 2]);
     });
 
     test("Create sound with `pitch` option set to 1200", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountHalfSpeedSoundFile, { pitch: 1200 });
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountHalfSpeedSoundFile, { pitch: 1200 });
 
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2, 3]);
     });
 
     test("Create sound with `playbackRate` option set to 2", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountHalfSpeedSoundFile, { playbackRate: 2 });
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountHalfSpeedSoundFile, { playbackRate: 2 });
 
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2, 3]);
     });
 
     test("Create sound with `playbackRate` option set to 1.5 and `pitch` option set to 500", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountHalfSpeedSoundFile, { playbackRate: 1.5, pitch: 500 });
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountHalfSpeedSoundFile, { playbackRate: 1.5, pitch: 500 });
 
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2, 3]);
     });
 
     test("Play sound with `duration` option set to 1.9", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { duration: 1.9 });
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { duration: 1.9 });
 
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2]);
     });
 
     test("Create 2 sounds using same buffer and play them 500 ms apart", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const sound1 = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
-                const sound2 = await AudioV2Test.CreateSoundAsync(sound1.buffer);
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound1 = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile);
+            const sound2 = await AudioV2Test.CreateSoundAsync(sound1.buffer);
 
-                sound1.play();
-                await AudioV2Test.WaitAsync(0.5);
+            sound1.play();
+            await AudioV2Test.WaitAsync(0.5, () => {
                 sound2.play();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            });
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 1, 2, 2, 3, 3]);
     });
 
     test("Create sound with `source` parameter set to a buffer", async ({ page }) => {
-        const pulses = GetPulseCounts(
-            await page.evaluate(async () => {
-                await AudioV2Test.CreateAudioEngineAsync();
-                const buffer = await BABYLON.CreateSoundBufferAsync(audioTestConfig.soundsUrl + audioTestConfig.pulsed3CountSoundFile);
-                const sound = await AudioV2Test.CreateSoundAsync(buffer);
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const buffer = await BABYLON.CreateSoundBufferAsync(audioTestConfig.soundsUrl + audioTestConfig.pulsed3CountSoundFile);
+            const sound = await AudioV2Test.CreateSoundAsync(buffer);
 
-                sound.play();
-
-                return await AudioV2Test.GetResultAsync();
-            })
-        );
+            sound.play();
+        });
 
         expect(pulses[Channel.L]).toEqual([1, 2, 3]);
     });

--- a/packages/tools/tests/test/audioV2/utils/abstractAudioNode.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/abstractAudioNode.utils.ts
@@ -2,10 +2,10 @@ import type { AudioNodeType } from "./audioV2.utils";
 
 import { Page } from "@playwright/test";
 
-export const EvaluateAbstractAudioNodeTestAsync = async <T>(
+export const EvaluateAbstractAudioNodeTestAsync = async (
     page: Page,
     audioNodeType: AudioNodeType,
-    testFn: ({ audioNodeType }: { audioNodeType: AudioNodeType }) => Promise<T>
+    testFn: ({ audioNodeType }: { audioNodeType: AudioNodeType }) => Promise<void>
 ) => {
     return await page.evaluate(testFn, { audioNodeType });
 };

--- a/packages/tools/tests/test/audioV2/utils/abstractSound.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/abstractSound.utils.ts
@@ -1,5 +1,4 @@
-import type { AudioTestResult, SoundType } from "./audioV2.utils";
-import { GetPulseCounts } from "./audioV2.utils";
+import type { SoundType } from "./audioV2.utils";
 
 import { Page } from "@playwright/test";
 
@@ -7,6 +6,12 @@ export const EvaluateTestAsync = async <T>(page: Page, soundType: SoundType, tes
     return await page.evaluate(testFn, { soundType });
 };
 
-export const EvaluatePulseCountTestAsync = async (page: Page, soundType: SoundType, testFn: ({ soundType }: { soundType: SoundType }) => Promise<AudioTestResult>) => {
-    return GetPulseCounts(await EvaluateTestAsync(page, soundType, testFn));
+export const EvaluatePulseCountTestAsync = async (page: Page, soundType: SoundType, testFn: ({ soundType }: { soundType: SoundType }) => Promise<void>) => {
+    await EvaluateTestAsync(page, soundType, testFn);
+
+    const pulses = await page.evaluate(() => {
+        return AudioV2Test.GetPulseCountsAsync();
+    });
+
+    return pulses;
 };

--- a/packages/tools/tests/test/audioV2/utils/audioV2.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/audioV2.utils.ts
@@ -1,7 +1,8 @@
 import type { Nullable } from "@dev/core/types";
-import { test, TestInfo } from "@playwright/test";
+import { test, Page, TestInfo } from "@playwright/test";
 import { getGlobalConfig } from "@tools/test-tools";
 
+export type AudioContextType = "Realtime" | "Offline";
 export type AudioNodeType = "AudioBus" | "AudioEngineV2" | "MainAudioBus" | "StaticSound" | "StreamingSound";
 export type SoundType = "StaticSound" | "StreamingSound";
 
@@ -15,22 +16,15 @@ export const enum Channel {
 /** The number of decimal places used for volume comparisons using `expect(...).toBeCloseTo(...)`. */
 export const VolumePrecision = 1;
 
-/**
- * The maximum pulse volume in the sound test file containing the pulse train.
- */
-const MaxPulseVolume = 0.1;
-
-const PulseGapLengthThresholdInMilliseconds = 0.01;
-const PulseTrainLengthInSamples = 90;
-const PulseVolumeThreshold = 0.05;
-
 export class AudioTestConfig {
     public baseUrl = getGlobalConfig().baseUrl;
     public soundsUrl = getGlobalConfig().assetsUrl + "/sound/testing/audioV2/";
 
-    public formatAc3SoundFile = "ac3.ac3";
-    public formatMp3SoundFile = "mp3.mp3";
-    public formatOggSoundFile = "ogg.ogg";
+    public defaultOfflineContextDuration = 10;
+
+    public formatAc3SoundFile = "../ac3.ac3";
+    public formatMp3SoundFile = "../mp3.mp3";
+    public formatOggSoundFile = "../ogg.ogg";
     public hashedSoundFile = "pulsed#2.mp3";
     public pulsed1CountSoundFile = "pulsed-1.mp3";
     public pulsed3CountHalfSpeedSoundFile = "pulsed-3-count--1-second-each--0.5-speed.mp3";
@@ -54,32 +48,49 @@ declare global {
     class AudioV2Test {
         public static AfterEachAsync(): Promise<void>;
         public static BeforeEachAsync(): Promise<void>;
-        public static CreateAudioEngineAsync(options?: Partial<BABYLON.IWebAudioEngineOptions>): Promise<BABYLON.AudioEngineV2>;
-        public static CreateAbstractSoundAsync(
-            soundType: SoundType,
-            source: string | string[],
-            options?: Partial<BABYLON.IStaticSoundOptions | BABYLON.IStreamingSoundOptions>
-        ): Promise<BABYLON.AbstractSound>;
         public static CreateAbstractSoundAndOutputNodeAsync(
             audioNodeType: AudioNodeType,
             source: string | string[],
             options?: Partial<BABYLON.IStaticSoundOptions | BABYLON.IStreamingSoundOptions> | Partial<BABYLON.IAudioBusOptions>
         ): Promise<{ sound: BABYLON.AbstractSound; outputNode: { spatial: BABYLON.AbstractSpatialAudio; stereo: BABYLON.AbstractStereoAudio; volume: number } }>;
+        public static CreateAbstractSoundAsync(
+            soundType: SoundType,
+            source: string | string[],
+            options?: Partial<BABYLON.IStaticSoundOptions | BABYLON.IStreamingSoundOptions>
+        ): Promise<BABYLON.AbstractSound>;
+        public static CreateAudioEngineAsync(
+            contextType?: AudioContextType | AudioNodeType | SoundType,
+            duration?: number,
+            options?: Partial<BABYLON.IWebAudioEngineOptions>
+        ): Promise<BABYLON.AudioEngineV2>;
         public static CreateSoundAsync(source: string | string[] | BABYLON.StaticSoundBuffer, options?: Partial<BABYLON.IStaticSoundOptions>): Promise<BABYLON.StaticSound>;
         public static CreateStreamingSoundAsync(source: string | string[], options?: Partial<BABYLON.IStreamingSoundOptions>): Promise<BABYLON.StreamingSound>;
+        public static GetPulseCountsAsync(): Promise<number[][]>;
         public static GetResultAsync(): Promise<AudioTestResult>;
-        public static WaitAsync(seconds: number): Promise<void>;
+        public static GetVolumesAtTimeAsync(time: number): Promise<number[]>;
+        public static WaitAsync(seconds: number, callback?: () => void): Promise<void>;
     }
 }
 
 export const InitAudioV2Tests = () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto(getGlobalConfig().baseUrl + `/empty.html`, {
-            timeout: 0,
+        await page.route("http://run.test/script.html", async (route) => {
+            route.fulfill({
+                status: 200,
+                contentType: "text/html",
+                body: `
+                <script src="${getGlobalConfig().baseUrl}/babylon.js"></script>
+                <script src="${getGlobalConfig().baseUrl}/audiov2-test.js"></script>
+                <body>
+                </body>
+            `,
+            });
         });
 
+        await page.goto("http://run.test/script.html");
+
         await page.waitForFunction(() => {
-            return window.BABYLON;
+            return window.BABYLON && AudioV2Test;
         });
 
         page.setDefaultTimeout(0);
@@ -87,27 +98,16 @@ export const InitAudioV2Tests = () => {
         await page.evaluate(
             async ({ config }: { config: AudioTestConfig }) => {
                 audioTestConfig = config;
-
-                await BABYLON.Tools.LoadScriptAsync(audioTestConfig.baseUrl + "/audiov2-test.js");
-                await AudioV2Test.BeforeEachAsync();
             },
             { config: new AudioTestConfig() }
         );
-
-        await page.waitForFunction(() => {
-            return AudioV2Test;
-        });
     });
 
     test.afterEach(async ({ page }) => {
         if (test.info().status === "failed") {
-            let result: AudioTestResult = (<any>test.info()).audioTestResult;
-
-            if (!result) {
-                result = await page.evaluate(async () => {
-                    return await AudioV2Test.GetResultAsync();
-                });
-            }
+            let result = await page.evaluate(async () => {
+                return await AudioV2Test.GetResultAsync();
+            });
 
             SaveAudioTestResult(test.info(), result);
         }
@@ -131,155 +131,25 @@ export const InitAudioV2Tests = () => {
  * pulses detected as 5 pulses in the first group, 6 in the second and 7 in the third group, would look like this:
  * [[5, 6, 7], [5, 6, 7]] ... assuming both test result channels contain the same audio output, which is typical.
  *
- * @param result - the test result containing the samples to calculate the pulse counts from
  * @returns an array containing the pulse counts for each channel in the given result's samples
  */
-export function GetPulseCounts(result: AudioTestResult): number[][] {
-    if (!result.samples?.length || !result.numberOfChannels) {
-        return [];
-    }
-
-    const pulseCounts = new Array<number[]>(result.numberOfChannels);
-
-    const PulseGapLengthThresholdInSamples = PulseGapLengthThresholdInMilliseconds * result.sampleRate;
-
-    for (let channel = 0; channel < result.numberOfChannels; channel++) {
-        let channelPulseCounts: number[] = [];
-        const samples = result.samples[channel];
-
-        let pulseStart = -1;
-        let pulseEnd = -1;
-        let pulseCount = 0;
-
-        let i = 0;
-        for (; i < result.length; i++) {
-            if (Math.abs(samples[i]) > PulseVolumeThreshold) {
-                if (pulseStart === -1) {
-                    pulseStart = i;
-
-                    if (pulseEnd !== -1) {
-                        const silenceLengthInSamples = i - pulseEnd;
-                        if (silenceLengthInSamples > PulseGapLengthThresholdInSamples) {
-                            channelPulseCounts.push(pulseCount);
-                            pulseCount = 0;
-                        }
-                    }
-                } else {
-                    pulseEnd = i;
-                }
-            } else if (i - pulseStart > PulseTrainLengthInSamples) {
-                if (pulseStart !== -1) {
-                    pulseCount++;
-                    pulseStart = -1;
-                }
-            }
-        }
-
-        if (pulseEnd !== -1) {
-            const silenceLengthInSamples = i - pulseEnd;
-            if (silenceLengthInSamples > PulseGapLengthThresholdInSamples) {
-                channelPulseCounts.push(pulseCount);
-            }
-        }
-
-        pulseCounts[channel] = channelPulseCounts;
-    }
-
-    return pulseCounts;
+export async function EvaluatePulseCountsAsync(page: Page, testFn: () => Promise<void>): Promise<number[][]> {
+    await page.evaluate(testFn);
+    return await page.evaluate(async () => {
+        return await AudioV2Test.GetPulseCountsAsync();
+    });
 }
 
 /**
- * Gets the volumes of the given result's samples.
+ * Gets the volumes of the audio test result's samples at a given time.
  *
- * The volume of each pulse is calculated by taking the absolute value of the samples and averaging them over the pulse length.
- *
- * The average volume is stored in the `volumeCurves` array for each channel, and is repeated for each sample in the pulse making
- * the resulting `volumeCurves` array length the same as the result's `samples` array, which makes it easier to find the
- * resulting volume at a given time.
- *
- * @param result - the test result containing the samples to calculate the volume from
- * @returns an array containing the volume of each pulse aligned with channels and samples in the given result's samples
- */
-function GetVolumeCurves(result: AudioTestResult): Float32Array[] {
-    if (!result.samples?.length) {
-        return [];
-    }
-
-    if (result.volumeCurves) {
-        return result.volumeCurves;
-    }
-
-    result.volumeCurves = new Array<Float32Array>(result.samples.length);
-
-    for (let channel = 0; channel < result.numberOfChannels; channel++) {
-        const samples = result.samples[channel];
-
-        let curve = new Float32Array(result.length);
-
-        let currentPolarity = samples[0] > 0;
-        let pulseStartIndex = 0;
-
-        const updateCurve = (pulseEndIndex: number) => {
-            const pulseLength = pulseEndIndex - pulseStartIndex;
-            if (pulseLength > 2) {
-                // Don't include the first and last samples in the average volume calculation. They are typically
-                // values transitioning across the zero line when the polarity changes, and are not representative of
-                // the actual pulse volume.
-                let totalVolume = 0;
-                for (let j = pulseStartIndex + 1; j < pulseEndIndex - 1; j++) {
-                    totalVolume += Math.abs(samples[j]);
-                }
-                const avgVolume = totalVolume / (pulseLength - 2);
-
-                for (let j = pulseStartIndex; j < pulseEndIndex; j++) {
-                    curve[j] = avgVolume;
-                }
-            }
-        };
-
-        let i = 0;
-        for (; i < result.length; i++) {
-            if (currentPolarity !== samples[i] > 0) {
-                updateCurve(i);
-                pulseStartIndex = i;
-                currentPolarity = !currentPolarity;
-            }
-        }
-        updateCurve(i);
-
-        result.volumeCurves[channel] = curve;
-
-        // Save the audio test result to the test info so it can be retrieved in `test.afterEach` and attached to the
-        // report if needed.
-        (<any>test.info()).audioTestResult = result;
-    }
-
-    return result.volumeCurves;
-}
-
-/**
- * Gets the volumes of the given result's samples at a given time.
- *
- * @param result - the test result containing the samples to calculate the volume from
  * @param time - the time in seconds to get the volumes at
  * @returns an array containing the volume of each channel at the given time
  */
-export function GetVolumesAtTime(result: AudioTestResult, time: number): number[] {
-    const volumes = new Array<number>(result.numberOfChannels);
-
-    const sampleIndex = Math.floor(time * result.sampleRate);
-    const volumeCurves = GetVolumeCurves(result);
-
-    for (let channel = 0; channel < result.numberOfChannels; channel++) {
-        const curve = volumeCurves[channel];
-        if (curve && sampleIndex < curve.length) {
-            volumes[channel] = curve[sampleIndex] / MaxPulseVolume;
-        } else {
-            volumes[channel] = 0;
-        }
-    }
-
-    return volumes;
+export function EvaluateVolumesAtTimeAsync(page: Page, seconds: number): Promise<number[]> {
+    return page.evaluate(async (time: number) => {
+        return await AudioV2Test.GetVolumesAtTimeAsync(time);
+    }, seconds);
 }
 
 /**


### PR DESCRIPTION
This change does 3 things to speed up the playwright audio tests:

1. Loads only the bare minimum html needed to run the tests:
	- The tests are currently loading empty.html from the CDN, which downloads a lot more than the audio tests need.
	- This change loads custom html with an empty body and 2 scripts from the CDN; babylon.js and audiov2-test.js.

2. Uses the WebAudio API `OfflineAudioContext` in place of the realtime `AudioContext` where possible.
	- The `OfflineAudioContext` renders audio faster than realtime and can be used for most of the audio tests. Notable exceptions are the streaming sound tests and the current time tests.

3. Passes less test result info from the playwright browser back to Node:
	- The tests are currently passing the captured audio to Node after every test, which is expensive.
	- This change does the required audio processing in the playwright browser and only passes the result back to Node, which is much smaller than the entire captured audio array.

This takes the AudioEngineCI pipeline "run tests" step from 38 minutes to 12.