### PR TITLE
update treeitemselectablecomponent to accept shiftclick to expand all

### DIFF
--- a/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/treeItemSelectableComponent.tsx
@@ -22,7 +22,7 @@ export interface ITreeItemSelectableComponentProps {
     filter: Nullable<string>;
 }
 
-export class TreeItemSelectableComponent extends React.Component<ITreeItemSelectableComponentProps, { isExpanded: boolean; isSelected: boolean }> {
+export class TreeItemSelectableComponent extends React.Component<ITreeItemSelectableComponentProps, { isExpanded: boolean; mustExpand: boolean; isSelected: boolean }> {
     private _wasSelected = false;
     private _thisRef: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
 
@@ -32,11 +32,12 @@ export class TreeItemSelectableComponent extends React.Component<ITreeItemSelect
         this.state = {
             isSelected: this.props.entity === this.props.selectedEntity,
             isExpanded: this.props.mustExpand || Tools.LookForItem(this.props.entity, this.props.selectedEntity),
+            mustExpand: this.props.mustExpand || false,
         };
     }
 
-    switchExpandedState(): void {
-        this.setState({ isExpanded: !this.state.isExpanded });
+    switchExpandedState(mustExpand: boolean): void {
+        this.setState({ isExpanded: !this.state.isExpanded, mustExpand: mustExpand });
     }
 
     override shouldComponentUpdate(nextProps: ITreeItemSelectableComponentProps, nextState: { isExpanded: boolean; isSelected: boolean }) {
@@ -105,7 +106,7 @@ export class TreeItemSelectableComponent extends React.Component<ITreeItemSelect
                 <TreeItemSelectableComponent
                     globalState={this.props.globalState}
                     gizmoCamera={this.props.gizmoCamera}
-                    mustExpand={this.props.mustExpand}
+                    mustExpand={this.state.mustExpand}
                     extensibilityGroups={this.props.extensibilityGroups}
                     selectedEntity={this.props.selectedEntity}
                     key={i}
@@ -159,7 +160,13 @@ export class TreeItemSelectableComponent extends React.Component<ITreeItemSelect
             <div ref={this._thisRef}>
                 <div className={this.state.isSelected ? "itemContainer selected" : "itemContainer"} style={marginStyle}>
                     {hasChildren && (
-                        <div className="arrow icon" onClick={() => this.switchExpandedState()}>
+                        <div
+                            className="arrow icon"
+                            onClick={(event) => {
+                                const expandChildren = event.shiftKey;
+                                this.switchExpandedState(expandChildren);
+                            }}
+                        >
                             {chevron}
                         </div>
                     )}


### PR DESCRIPTION
Adding ability to shift+click on the plus sign in the inspector to expand all the children 

Note that the top-level 'expandAll' will still supersede this 