### PR TITLE
Fix sandbox animation issue

### DIFF
--- a/packages/tools/sandbox/src/components/animationBar.tsx
+++ b/packages/tools/sandbox/src/components/animationBar.tsx
@@ -31,6 +31,7 @@ export class AnimationBar extends React.Component<IAnimationBarProps, { groupInd
         this.state = { groupIndex: 0 };
 
         props.globalState.onSceneLoaded.add((info) => {
+            this.setState({ groupIndex: 0 });
             this.registerBeforeRender(info.scene);
         });
 


### PR DESCRIPTION
The sandbox errors out when the following steps occur:
1. Load a model with multiple animations.
2. Select the 2nd animation, or any animation other than the 1st.
3. Load a model with one animation.

The animation group index set on the 1st model does not get updated when a new scene is loaded which makes the animation renderer index into a non-existent animation group after the 2nd model is loaded.

This change fixes the issue by resetting the animation state's `groupIndex` to `0` when a new model/scene is loaded.