### PR TITLE
NodeMaterial: Add structural support for building SFE-readable GLSL

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
@@ -1,6 +1,7 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
+import { SfeSyntaxDefine } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
@@ -165,10 +166,6 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
             }
         }
 
-        this._mainUVName = "vMain" + uvInput.associatedVariableName;
-
-        state._emitVaryingFromString(this._mainUVName, NodeMaterialBlockConnectionPointTypes.Vector2);
-
         state.compilationString += `${this._mainUVName} = ${uvInput.associatedVariableName}.xy;\n`;
 
         if (!this._outputs.some((o) => o.isConnectedInVertexShader)) {
@@ -257,6 +254,13 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
             state.sharedData.blocksWithDefines.push(this);
         }
 
+        // SFE: We rely on the default postprocess.vertex shader to supply our varying, which is named vUV.
+        this._mainUVName = state.isSFEMode ? "vUV" : "vMain" + this.uv.associatedVariableName;
+
+        // SFE: Wrap the varying in a define, as it won't be needed there.
+        const define = state.isSFEMode ? SfeSyntaxDefine : undefined;
+        state._emitVaryingFromString(this._mainUVName, NodeMaterialBlockConnectionPointTypes.Vector2, define, true);
+
         if (state.target !== NodeMaterialBlockTargets.Fragment) {
             // Vertex
             state._emit2DSampler(this._samplerName);
@@ -269,7 +273,9 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
             return;
         }
 
-        state._emit2DSampler(this._samplerName);
+        // SFE: Append `// main` to denote this as the main input texture to composite.
+        const annotation = state.isSFEMode ? "// main" : undefined;
+        state._emit2DSampler(this._samplerName, undefined, undefined, annotation);
 
         this._linearDefineName = state._getFreeDefineName("ISLINEAR");
         this._gammaDefineName = state._getFreeDefineName("ISGAMMA");

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
@@ -1,7 +1,7 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
-import { SfeSyntaxDefine } from "../../nodeMaterialBuildState";
+import { SfeModeDefine } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
@@ -258,7 +258,7 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         this._mainUVName = state.isSFEMode ? "vUV" : "vMain" + this.uv.associatedVariableName;
 
         // SFE: Wrap the varying in a define, as it won't be needed there.
-        const define = state.isSFEMode ? SfeSyntaxDefine : undefined;
+        const define = state.isSFEMode ? SfeModeDefine : undefined;
         state._emitVaryingFromString(this._mainUVName, NodeMaterialBlockConnectionPointTypes.Vector2, define, true);
 
         if (state.target !== NodeMaterialBlockTargets.Fragment) {

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -1,6 +1,7 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
+import { SfeSyntaxDefine } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { RegisterClass } from "../../../../Misc/typeStore";
@@ -180,6 +181,15 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
         if (state.shaderLanguage === ShaderLanguage.WGSL) {
             state.compilationString += `var fragmentOutputsColor : vec4<f32>;\r\n`;
             outputString = "fragmentOutputsColor";
+        } else if (state.isSFEMode) {
+            // SFE: Use an intermediate variable to control whether to use gl_FragColor or return the color
+            state.compilationString += `vec4 outColor = vec4(0.0);`;
+            outputString = "outColor";
+            state._injectAtEnd += `\n#ifndef ${SfeSyntaxDefine}\n`;
+            state._injectAtEnd += `gl_FragColor = outColor;\n`;
+            state._injectAtEnd += `#else\n`;
+            state._injectAtEnd += `return outColor;\n`;
+            state._injectAtEnd += `#endif\n`;
         }
 
         const vec4 = state._getShaderType(NodeMaterialBlockConnectionPointTypes.Vector4);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -1,7 +1,7 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
-import { SfeSyntaxDefine } from "../../nodeMaterialBuildState";
+import { SfeModeDefine } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { RegisterClass } from "../../../../Misc/typeStore";
@@ -185,7 +185,7 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
             // SFE: Use an intermediate variable to control whether to use gl_FragColor or return the color
             state.compilationString += `vec4 outColor = vec4(0.0);`;
             outputString = "outColor";
-            state._injectAtEnd += `\n#ifndef ${SfeSyntaxDefine}\n`;
+            state._injectAtEnd += `\n#ifndef ${SfeModeDefine}\n`;
             state._injectAtEnd += `gl_FragColor = outColor;\n`;
             state._injectAtEnd += `#else\n`;
             state._injectAtEnd += `return outColor;\n`;

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -20,10 +20,13 @@ import { ShaderLanguage } from "../../../../Materials/shaderLanguage";
 
 const remapAttributeName: { [name: string]: string } = {
     position2d: "position",
+    // From particle.vertex:
     particle_uv: "vUV",
     particle_color: "vColor",
     particle_texturemask: "textureMask",
     particle_positionw: "vPositionW",
+    // From postprocess.vertex:
+    postprocess_uv: "vUV",
 };
 
 const attributeInFragmentOnly: { [name: string]: boolean } = {
@@ -31,6 +34,7 @@ const attributeInFragmentOnly: { [name: string]: boolean } = {
     particle_color: true,
     particle_texturemask: true,
     particle_positionw: true,
+    postprocess_uv: true,
 };
 
 const attributeAsUniform: { [name: string]: boolean } = {
@@ -145,6 +149,7 @@ export class InputBlock extends NodeMaterialBlock {
                     case "position2d":
                     case "particle_uv":
                     case "splatScale":
+                    case "postprocess_uv":
                         this._type = NodeMaterialBlockConnectionPointTypes.Vector2;
                         return this._type;
                     case "matricesIndices":

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -437,12 +437,8 @@ export class InputBlock extends NodeMaterialBlock {
         }
     }
 
-    private _emitDefine(define: string): string {
-        if (define[0] === "!") {
-            return `#ifndef ${define.substring(1)}\n`;
-        }
-
-        return `#ifdef ${define}\n`;
+    private _emitDefine(define: string, notDefine = false): string {
+        return `${notDefine ? "#ifndef" : "#ifdef"} ${define}\n`;
     }
 
     public override initialize() {
@@ -516,7 +512,7 @@ export class InputBlock extends NodeMaterialBlock {
         return attributeInFragmentOnly[this.name];
     }
 
-    private _emit(state: NodeMaterialBuildState, define?: string) {
+    private _emit(state: NodeMaterialBuildState) {
         // Uniforms
         if (this.isUniform) {
             if (!this._associatedVariableName) {
@@ -536,19 +532,12 @@ export class InputBlock extends NodeMaterialBlock {
                 return;
             }
 
-            state.uniforms.push(this.associatedVariableName);
-            if (define) {
-                state._uniformDeclaration += this._emitDefine(define);
-            }
-            const shaderType = state._getShaderType(this.type);
+            // SFE: Mark the current value of the uniform as its default value.
+            const annotation = state.isSFEMode ? `// { "default": ${JSON.stringify(this.valueCallback?.() ?? this.value)} }` : undefined;
+            state._emitUniformFromString(this._associatedVariableName, this.type, undefined, undefined, annotation);
+
             if (state.shaderLanguage === ShaderLanguage.WGSL) {
-                state._uniformDeclaration += `uniform ${this._associatedVariableName}: ${shaderType};\n`;
                 this._prefix = "uniforms.";
-            } else {
-                state._uniformDeclaration += `uniform ${shaderType} ${this.associatedVariableName};\n`;
-            }
-            if (define) {
-                state._uniformDeclaration += `#endif\n`;
             }
 
             // well known
@@ -579,15 +568,15 @@ export class InputBlock extends NodeMaterialBlock {
                 // Attribute for fragment need to be carried over by varyings
                 if (attributeInFragmentOnly[this.name]) {
                     if (attributeAsUniform[this.name]) {
-                        state._emitUniformFromString(this.declarationVariableName, this.type, define);
+                        state._emitUniformFromString(this.declarationVariableName, this.type);
                         if (state.shaderLanguage === ShaderLanguage.WGSL) {
                             this._prefix = `vertexInputs.`;
                         }
                     } else {
-                        state._emitVaryingFromString(this.declarationVariableName, this.type, define);
+                        state._emitVaryingFromString(this.declarationVariableName, this.type);
                     }
                 } else {
-                    this._emit(state._vertexState, define);
+                    this._emit(state._vertexState);
                 }
                 return;
             }
@@ -601,28 +590,25 @@ export class InputBlock extends NodeMaterialBlock {
             if (attributeInFragmentOnly[this.name]) {
                 if (attributeAsUniform[this.name]) {
                     if (!alreadyDeclared) {
-                        state._emitUniformFromString(this.declarationVariableName, this.type, define);
+                        state._emitUniformFromString(this.declarationVariableName, this.type);
                     }
                     if (state.shaderLanguage === ShaderLanguage.WGSL) {
                         this._prefix = `uniforms.`;
                     }
                 } else {
                     if (!alreadyDeclared) {
-                        state._emitVaryingFromString(this.declarationVariableName, this.type, define);
+                        state._emitVaryingFromString(this.declarationVariableName, this.type);
                     }
                     if (state.shaderLanguage === ShaderLanguage.WGSL) {
                         this._prefix = `fragmentInputs.`;
                     }
                 }
             } else {
-                if (define && !alreadyDeclared) {
-                    state._attributeDeclaration += this._emitDefine(define);
-                }
                 if (state.shaderLanguage === ShaderLanguage.WGSL) {
                     if (!alreadyDeclared) {
                         const defineName = attributeDefine[this.name];
                         if (defineName) {
-                            state._attributeDeclaration += `#ifdef ${defineName}\n`;
+                            state._attributeDeclaration += this._emitDefine(defineName);
                             state._attributeDeclaration += `attribute ${this.declarationVariableName}: ${state._getShaderType(this.type)};\n`;
                             state._attributeDeclaration += `#else\n`;
                             state._attributeDeclaration += `var<private> ${this.declarationVariableName}: ${state._getShaderType(this.type)} = ${state._getShaderType(this.type)}(0.);\n`;
@@ -636,7 +622,7 @@ export class InputBlock extends NodeMaterialBlock {
                     if (!alreadyDeclared) {
                         const defineName = attributeDefine[this.name];
                         if (defineName) {
-                            state._attributeDeclaration += `#ifdef ${defineName}\n`;
+                            state._attributeDeclaration += this._emitDefine(defineName);
                             state._attributeDeclaration += `attribute ${state._getShaderType(this.type)} ${this.declarationVariableName};\n`;
                             state._attributeDeclaration += `#else\n`;
                             state._attributeDeclaration += `${state._getShaderType(this.type)} ${this.declarationVariableName} = ${state._getShaderType(this.type)}(0.);\n`;
@@ -645,9 +631,6 @@ export class InputBlock extends NodeMaterialBlock {
                             state._attributeDeclaration += `attribute ${state._getShaderType(this.type)} ${this.declarationVariableName};\n`;
                         }
                     }
-                }
-                if (define && !alreadyDeclared) {
-                    state._attributeDeclaration += `#endif\n`;
                 }
             }
         }

--- a/packages/dev/core/src/Materials/Node/Enums/nodeMaterialModes.ts
+++ b/packages/dev/core/src/Materials/Node/Enums/nodeMaterialModes.ts
@@ -12,4 +12,6 @@ export enum NodeMaterialModes {
     ProceduralTexture = 3,
     /** For gaussian splatting */
     GaussianSplatting = 4,
+    /** For SFE */
+    SFE = 5,
 }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -910,7 +910,7 @@ export class NodeMaterial extends PushMaterial {
         this._buildWasSuccessful = false;
         const engine = this.getScene().getEngine();
 
-        const allowEmptyVertexProgram = this._mode === NodeMaterialModes.Particle;
+        const allowEmptyVertexProgram = this._mode === NodeMaterialModes.Particle || this._mode === NodeMaterialModes.SFE;
 
         if (this._vertexOutputNodes.length === 0 && !allowEmptyVertexProgram) {
             // eslint-disable-next-line no-throw-literal

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -653,6 +653,7 @@ export class NodeMaterialBlock {
             "uv6",
             "position2d",
             "particle_uv",
+            "postprocess_uv",
             "matricesIndices",
             "matricesWeights",
             "world0",

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -97,6 +97,13 @@ export class NodeMaterialBuildState {
     }
 
     /**
+     * Gets whether the current compilation should inject SFE syntax or not
+     */
+    public get isSFEMode() {
+        return this.sharedData.nodeMaterial.mode === NodeMaterialModes.SFE;
+    }
+
+    /**
      * Finalize the compilation strings
      * @param state defines the current compilation state
      */

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -6,6 +6,10 @@ import type { NodeMaterialConnectionPoint } from "./nodeMaterialBlockConnectionP
 import { ShaderStore as EngineShaderStore } from "../../Engines/shaderStore";
 import { Constants } from "../../Engines/constants";
 import type { NodeMaterialBlock } from "./nodeMaterialBlock";
+import { NodeMaterialModes } from "./Enums/nodeMaterialModes";
+
+/** @internal */
+export const SfeSyntaxDefine = "USE_SFE_SYNTAX";
 
 /**
  * Class used to store node based material build state
@@ -111,15 +115,25 @@ export class NodeMaterialBuildState {
         const emitComments = state.sharedData.emitComments;
         const isFragmentMode = this.target === NodeMaterialBlockTargets.Fragment;
 
+        let entryPointString = `\n${emitComments ? "//Entry point\n" : ""}`;
         if (this.shaderLanguage === ShaderLanguage.WGSL) {
             if (isFragmentMode) {
-                this.compilationString = `\n${emitComments ? "//Entry point\n" : ""}@fragment\nfn main(input: FragmentInputs) -> FragmentOutputs {\n${this.sharedData.varyingInitializationsFragment}${this.compilationString}`;
+                entryPointString = `@fragment\nfn main(input: FragmentInputs) -> FragmentOutputs {\n${this.sharedData.varyingInitializationsFragment}`;
             } else {
-                this.compilationString = `\n${emitComments ? "//Entry point\n" : ""}@vertex\nfn main(input: VertexInputs) -> FragmentInputs{\n${this.compilationString}`;
+                entryPointString = `@vertex\nfn main(input: VertexInputs) -> FragmentInputs{\n`;
             }
+        } else if (this.isSFEMode) {
+            // SFE: Replace the entry with a helper function
+            entryPointString += `#ifdef ${SfeSyntaxDefine}\n`;
+            entryPointString += `vec4 nmeMain(vec2 vUV) { // main\n`;
+            entryPointString += `#else\n`;
+            entryPointString += `void main(void) {\n`;
+            entryPointString += `#endif\n`;
         } else {
-            this.compilationString = `\n${emitComments ? "//Entry point\n" : ""}void main(void) {\n${this.compilationString}`;
+            entryPointString = `void main(void) {\n`;
         }
+
+        this.compilationString = entryPointString + this.compilationString;
 
         if (this._constantDeclaration) {
             this.compilationString = `\n${emitComments ? "//Constants\n" : ""}${this._constantDeclaration}\n${this.compilationString}`;
@@ -171,6 +185,10 @@ export class NodeMaterialBuildState {
                 const extension = this.extensions[extensionName];
                 this.compilationString = `\n${extension}\n${this.compilationString}`;
             }
+        }
+
+        if (this.isSFEMode) {
+            this.compilationString = `\n// { "smartFilterBlockType": "${this.sharedData.nodeMaterial.name}", "namespace": "Babylon.NME.Test" }\n${this.compilationString}`;
         }
 
         this._builtCompilationString = this.compilationString;
@@ -226,7 +244,7 @@ export class NodeMaterialBuildState {
     /**
      * @internal
      */
-    public _emit2DSampler(name: string, define = "", force = false) {
+    public _emit2DSampler(name: string, define = "", force = false, annotation?: string) {
         if (this.samplers.indexOf(name) < 0 || force) {
             if (define) {
                 this._samplerDeclaration += `#if ${define}\n`;
@@ -236,7 +254,7 @@ export class NodeMaterialBuildState {
                 this._samplerDeclaration += `var ${name + Constants.AUTOSAMPLERSUFFIX}: sampler;\n`;
                 this._samplerDeclaration += `var ${name}: texture_2d<f32>;\n`;
             } else {
-                this._samplerDeclaration += `uniform sampler2D ${name};\n`;
+                this._samplerDeclaration += `uniform sampler2D ${name}; ${annotation ? annotation : ""}\n`;
             }
 
             if (define) {
@@ -558,7 +576,7 @@ export class NodeMaterialBuildState {
     /**
      * @internal
      */
-    public _emitUniformFromString(name: string, type: NodeMaterialBlockConnectionPointTypes, define: string = "", notDefine = false) {
+    public _emitUniformFromString(name: string, type: NodeMaterialBlockConnectionPointTypes, define: string = "", notDefine = false, annotation?: string) {
         if (this.uniforms.indexOf(name) !== -1) {
             return;
         }
@@ -571,6 +589,9 @@ export class NodeMaterialBuildState {
             } else {
                 this._uniformDeclaration += `${notDefine ? "#ifndef" : "#ifdef"} ${define}\n`;
             }
+        }
+        if (annotation) {
+            this._uniformDeclaration += `${annotation}\n`;
         }
         const shaderType = this._getShaderType(type);
         if (this.shaderLanguage === ShaderLanguage.WGSL) {
@@ -619,7 +640,7 @@ export class NodeMaterialBuildState {
         if (this.shaderLanguage === ShaderLanguage.WGSL) {
             return `${isConst ? "const" : "var"} ${name}: ${this._getShaderType(type)}`;
         } else {
-            return `${this._getShaderType(type)} ${name}`;
+            return `${isConst ? "const " : ""}${this._getShaderType(type)} ${name}`;
         }
     }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -9,7 +9,7 @@ import type { NodeMaterialBlock } from "./nodeMaterialBlock";
 import { NodeMaterialModes } from "./Enums/nodeMaterialModes";
 
 /** @internal */
-export const SfeSyntaxDefine = "USE_SFE_SYNTAX";
+export const SfeModeDefine = "USE_SFE_FRAMEWORK";
 
 /**
  * Class used to store node based material build state
@@ -124,7 +124,7 @@ export class NodeMaterialBuildState {
             }
         } else if (this.isSFEMode) {
             // SFE: Replace the entry with a helper function
-            entryPointString += `#ifdef ${SfeSyntaxDefine}\n`;
+            entryPointString += `#ifdef ${SfeModeDefine}\n`;
             entryPointString += `vec4 nmeMain(vec2 vUV) { // main\n`;
             entryPointString += `#else\n`;
             entryPointString += `void main(void) {\n`;


### PR DESCRIPTION
This PR includes "just the basics" for generating GLSL following a framework that SFE can read. 

- Add support for SFE-readable GLSL, which can be toggled via a define
- Add separate UV attribute remap to correspond to `postprocess.vertex`'s UV varying, which is used by SFE shaders by default.
- Prepare CurrentScreenBlock to be used with SFE NodeMaterials
- Cleanup unused code surrounding `define`s in InputBlock