### PR TITLE
Expose processed shaders in NodeMaterial

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1837,6 +1837,18 @@ export class NodeMaterial extends PushMaterial {
     }
 
     /**
+     * Get a string representing the fragment shader used by the engine for the current node graph
+     * @internal
+     */
+    public async _getProcessedFragmentAsync(): Promise<string> {
+        if (!this._buildWasSuccessful) {
+            this.build();
+        }
+
+        return this._fragmentCompilationState.getProcessedShaderAsync();
+    }
+
+    /**
      * Binds the world matrix to the material
      * @param world defines the world transformation matrix
      */


### PR DESCRIPTION
Exposes an (internal) NodeMaterial method to retrieve the processed fragment shader in use. This will be a quick way to process the define that is needed to export SFE-compatible GLSL.

I tucked away the process logic in NodeMaterialBuildState to be with the rest of the shader-building code.