### PR TITLE
NME: Support core SFE mode

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1245,7 +1245,7 @@ export class NodeMaterial extends PushMaterial {
         textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         textureFormat = Constants.TEXTUREFORMAT_RGBA
     ): Nullable<PostProcess> {
-        if (this.mode !== NodeMaterialModes.PostProcess) {
+        if (this.mode !== NodeMaterialModes.PostProcess && this.mode !== NodeMaterialModes.SFE) {
             Logger.Log("Incompatible material mode");
             return null;
         }
@@ -1280,7 +1280,10 @@ export class NodeMaterial extends PushMaterial {
 
         this._processDefines(dummyMesh, defines);
 
-        Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString, this.shaderLanguage);
+        // If no vertex shader emitted, fallback to default postprocess vertex shader
+        const vertexCode = this._sharedData.checks.emitVertex ? this._vertexCompilationState._builtCompilationString : undefined;
+
+        Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, vertexCode, this.shaderLanguage);
 
         if (!postProcess) {
             postProcess = new PostProcess(
@@ -1295,7 +1298,7 @@ export class NodeMaterial extends PushMaterial {
                 reusable,
                 defines.toString(),
                 textureType,
-                tempName,
+                vertexCode ? tempName : "postprocess",
                 { maxSimultaneousLights: this.maxSimultaneousLights },
                 false,
                 textureFormat,

--- a/packages/dev/core/src/Materials/Node/nodeMaterialDefault.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialDefault.ts
@@ -8,6 +8,11 @@ import { SplatReaderBlock } from "./Blocks/GaussianSplatting/splatReaderBlock";
 import { NodeMaterialModes } from "./Enums/nodeMaterialModes";
 import { NodeMaterialSystemValues } from "./Enums/nodeMaterialSystemValues";
 import type { NodeMaterial } from "./nodeMaterial";
+import { MultiplyBlock } from "./Blocks/multiplyBlock";
+import { Texture } from "../Textures/texture";
+import { Tools } from "core/Misc/tools";
+import { CurrentScreenBlock } from "./Blocks/Dual/currentScreenBlock";
+import { Color4 } from "core/Maths/math.color";
 
 /**
  * Clear the material and set it to a default state for gaussian splatting
@@ -67,4 +72,36 @@ export function SetToDefaultGaussianSplatting(nodeMaterial: NodeMaterial): void 
     nodeMaterial.addOutputNode(fragmentOutput);
 
     nodeMaterial._mode = NodeMaterialModes.GaussianSplatting;
+}
+
+/**
+ * Clear the material and set it to a default state for Smart Filter effects
+ * @param nodeMaterial node material to use
+ */
+export function SetToDefaultSFE(nodeMaterial: NodeMaterial): void {
+    nodeMaterial.clear();
+
+    nodeMaterial.editorData = null;
+
+    const uv = new InputBlock("uv");
+    uv.setAsAttribute("postprocess_uv");
+
+    const currentScreen = new CurrentScreenBlock("Main Input Texture");
+    uv.connectTo(currentScreen);
+    const textureUrl = Tools.GetAssetUrl("https://assets.babylonjs.com/core/nme/currentScreenPostProcess.png");
+    currentScreen.texture = new Texture(textureUrl, nodeMaterial.getScene());
+
+    const color = new InputBlock("Color4");
+    color.value = new Color4(1, 0, 0, 1);
+
+    const multiply = new MultiplyBlock("Multiply");
+    color.connectTo(multiply);
+    currentScreen.connectTo(multiply);
+
+    const fragmentOutput = new FragmentOutputBlock("FragmentOutput");
+    multiply.connectTo(fragmentOutput);
+
+    nodeMaterial.addOutputNode(fragmentOutput);
+
+    nodeMaterial._mode = NodeMaterialModes.SFE;
 }

--- a/packages/tools/nodeEditor/public/index.js
+++ b/packages/tools/nodeEditor/public/index.js
@@ -194,6 +194,9 @@ checkBabylonVersionAsync().then(() => {
                         case BABYLON.NodeMaterialModes.PostProcess:
                             nodeMaterial.setToDefaultPostProcess();
                             break;
+                        case BABYLON.NodeMaterialModes.SFE:
+                            BABYLON.SetToDefaultSFE(nodeMaterial);
+                            break;
                         case BABYLON.NodeMaterialModes.Particle:
                             nodeMaterial.setToDefaultParticle();
                             break;

--- a/packages/tools/nodeEditor/src/blockTools.ts
+++ b/packages/tools/nodeEditor/src/blockTools.ts
@@ -616,6 +616,11 @@ export class BlockTools {
                 pos.setAsAttribute("particle_positionw");
                 return pos;
             }
+            case "ScreenUVBlock": {
+                const uv = new InputBlock("uv");
+                uv.setAsAttribute("postprocess_uv");
+                return uv;
+            }
             case "ParticleRampGradientBlock":
                 return new ParticleRampGradientBlock("ParticleRampGradient");
             case "ParticleBlendMultiplyBlock":

--- a/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -156,6 +156,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
         ParticleRampGradientBlock: "The particle ramp gradient block",
         ParticleBlendMultiplyBlock: "The particle blend multiply block",
         ParticlePositionWorldBlock: "The world position of the particle",
+        ScreenUVBlock: "The screen quad's UV texture coordinates",
         GaussianSplattingBlock: "The gaussian splatting block",
         GaussianBlock: "The gaussian color computation block",
         SplatReaderBlock: "The gaussian splat reader block",
@@ -461,6 +462,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 "ParticleTextureMaskBlock",
                 "ParticleUVBlock",
             ],
+            SFE: ["ScreenUVBlock"],
             GaussianSplatting: ["GaussianSplattingBlock", "SplatIndexBlock", "SplatReaderBlock", "GaussianBlock"],
             PBR: ["PBRMetallicRoughnessBlock", "AnisotropyBlock", "ClearCoatBlock", "IridescenceBlock", "ReflectionBlock", "RefractionBlock", "SheenBlock", "SubSurfaceBlock"],
             PostProcess: ["ScreenPositionBlock", "CurrentScreenBlock", "PrePassTextureBlock"],
@@ -482,12 +484,24 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
 
         switch (this.props.globalState.mode) {
             case NodeMaterialModes.Material:
+                delete allBlocks["SFE"];
                 delete allBlocks["PostProcess"];
                 delete allBlocks["Particle"];
                 delete allBlocks["Procedural__Texture"];
                 delete allBlocks["GaussianSplatting"];
                 break;
+            case NodeMaterialModes.SFE:
+                delete allBlocks["PostProcess"];
+                delete allBlocks["Animation"];
+                delete allBlocks["Mesh"];
+                delete allBlocks["Particle"];
+                delete allBlocks["Procedural__Texture"];
+                delete allBlocks["PBR"];
+                delete allBlocks["GaussianSplatting"];
+                allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassOutputBlock"), 1);
+                break;
             case NodeMaterialModes.PostProcess:
+                delete allBlocks["SFE"];
                 delete allBlocks["Animation"];
                 delete allBlocks["Mesh"];
                 delete allBlocks["Particle"];
@@ -497,6 +511,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassOutputBlock"), 1);
                 break;
             case NodeMaterialModes.ProceduralTexture:
+                delete allBlocks["SFE"];
                 delete allBlocks["Animation"];
                 delete allBlocks["Mesh"];
                 delete allBlocks["Particle"];
@@ -506,6 +521,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassOutputBlock"), 1);
                 break;
             case NodeMaterialModes.Particle:
+                delete allBlocks["SFE"];
                 delete allBlocks["Animation"];
                 delete allBlocks["Mesh"];
                 delete allBlocks["PostProcess"];
@@ -518,6 +534,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassOutputBlock"), 1);
                 break;
             case NodeMaterialModes.GaussianSplatting:
+                delete allBlocks["SFE"];
                 delete allBlocks["Animation"];
                 delete allBlocks["Mesh"];
                 delete allBlocks["PostProcess"];

--- a/packages/tools/nodeEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeEditor/src/components/preview/previewManager.ts
@@ -379,6 +379,7 @@ export class PreviewManager {
                 this._handleAnimations();
                 break;
             }
+            case NodeMaterialModes.SFE:
             case NodeMaterialModes.PostProcess:
             case NodeMaterialModes.ProceduralTexture: {
                 this._camera.radius = 4;
@@ -674,6 +675,7 @@ export class PreviewManager {
             }
 
             switch (this._globalState.mode) {
+                case NodeMaterialModes.SFE:
                 case NodeMaterialModes.PostProcess: {
                     this._globalState.onIsLoadingChanged.notifyObservers(false);
 

--- a/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -440,7 +440,7 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
             { label: "Particle", value: NodeMaterialModes.Particle },
             { label: "Procedural", value: NodeMaterialModes.ProceduralTexture },
             { label: "Gaussian Splatting", value: NodeMaterialModes.GaussianSplatting },
-            { label: "SFE", value: NodeMaterialModes.SFE },
+            { label: "Smart Filters", value: NodeMaterialModes.SFE },
         ];
 
         const engineList = [

--- a/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -39,7 +39,7 @@ import type { LockObject } from "shared-ui-components/tabs/propertyGrids/lockObj
 import { TextLineComponent } from "shared-ui-components/lines/textLineComponent";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { SliderLineComponent } from "shared-ui-components/lines/sliderLineComponent";
-import { SetToDefaultGaussianSplatting } from "core/Materials/Node/nodeMaterialDefault";
+import { SetToDefaultGaussianSplatting, SetToDefaultSFE } from "core/Materials/Node/nodeMaterialDefault";
 interface IPropertyTabComponentProps {
     globalState: GlobalState;
     lockObject: LockObject;
@@ -356,6 +356,9 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                 case NodeMaterialModes.PostProcess:
                     this.props.globalState.nodeMaterial!.setToDefaultPostProcess();
                     break;
+                case NodeMaterialModes.SFE:
+                    SetToDefaultSFE(this.props.globalState.nodeMaterial!);
+                    break;
                 case NodeMaterialModes.Particle:
                     this.props.globalState.nodeMaterial!.setToDefaultParticle();
                     break;
@@ -437,6 +440,7 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
             { label: "Particle", value: NodeMaterialModes.Particle },
             { label: "Procedural", value: NodeMaterialModes.ProceduralTexture },
             { label: "Gaussian Splatting", value: NodeMaterialModes.GaussianSplatting },
+            { label: "SFE", value: NodeMaterialModes.SFE },
         ];
 
         const engineList = [
@@ -507,6 +511,9 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                                     case NodeMaterialModes.PostProcess:
                                         this.props.globalState.nodeMaterial!.setToDefaultPostProcess();
                                         break;
+                                    case NodeMaterialModes.SFE:
+                                        SetToDefaultSFE(this.props.globalState.nodeMaterial!);
+                                        break;
                                     case NodeMaterialModes.Particle:
                                         this.props.globalState.nodeMaterial!.setToDefaultParticle();
                                         break;
@@ -575,6 +582,16 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                                 this.save();
                             }}
                         />
+                        {this.props.globalState.mode === NodeMaterialModes.SFE && (
+                            <ButtonLineComponent
+                                label="Export shaders for SFE"
+                                onClick={async () => {
+                                    this.props.globalState.nodeMaterial.build();
+                                    const fragment = await this.props.globalState.nodeMaterial!._getProcessedFragmentAsync();
+                                    StringTools.DownloadAsFile(this.props.globalState.hostDocument, fragment, "nme.block.glsl");
+                                }}
+                            />
+                        )}
                         <ButtonLineComponent
                             label="Generate code"
                             onClick={() => {

--- a/packages/tools/nodeEditor/src/graphSystem/display/inputDisplayManager.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/display/inputDisplayManager.ts
@@ -16,6 +16,7 @@ const inputNameToAttributeValue: { [name: string]: string } = {
     particle_color: "color",
     particle_texturemask: "textureMask",
     particle_positionw: "positionW",
+    postprocess_uv: "uv",
 };
 
 const inputNameToAttributeName: { [name: string]: string } = {
@@ -24,6 +25,7 @@ const inputNameToAttributeName: { [name: string]: string } = {
     particle_color: "particle",
     particle_texturemask: "particle",
     particle_positionw: "particle",
+    postprocess_uv: "screen",
 };
 
 export class InputDisplayManager implements IDisplayManager {

--- a/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
@@ -94,7 +94,8 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                     this.textureBlock instanceof ReflectionTextureBlock ||
                         this.textureBlock instanceof ReflectionBlock ||
                         this.textureBlock instanceof RefractionBlock ||
-                        globalState.mode === NodeMaterialModes.PostProcess
+                        globalState.mode === NodeMaterialModes.PostProcess ||
+                        globalState.mode === NodeMaterialModes.SFE
                 );
                 texture = this.textureBlock.texture;
                 texture.coordinatesMode = Texture.EQUIRECTANGULAR_MODE;


### PR DESCRIPTION
This PR adds everything needed to support the “happy path” for creating SFE-compatible shaders in the Node Material Editor. In other words, all the core pieces are in place to build a default SFE NodeMaterial, as long as everything is set up correctly.

That said, there aren’t any UI guardrails yet — it’s still possible to break things or go off track. Guardrails and validation will come in future PRs.

- Add `ScreenUVBlock`, which corresponds to the UV varying passed by `postprocess.vertex`, which is used by Smart Filters
- Reuse `NodeMaterialModes.PostProcess` logic for creating the effect in the preview canvas. This avoid adding any more SFE-specific logic to `NodeMaterial` proper.
- Add `Export to SFE` button