### PR TITLE
Add missing blend modes to the particle system dropdown

### DIFF
--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -9,15 +9,27 @@ export class Constants {
     public static readonly ALPHA_DISABLE = 0;
     /** Defines that alpha blending is SRC ALPHA * SRC + DEST */
     public static readonly ALPHA_ADD = 1;
-    /** Defines that alpha blending is SRC ALPHA * SRC + (1 - SRC ALPHA) * DEST */
+    /**
+     *  Defines that alpha blending is SRC ALPHA * SRC + (1 - SRC ALPHA) * DEST
+     *  Blends src and dest using src alpha. Go-to for transparency. 100% alpha means source, 0% alpha means background. Glass, UI fade, smoke
+     */
     public static readonly ALPHA_COMBINE = 2;
-    /** Defines that alpha blending is DEST - SRC * DEST */
+    /**
+     * Defines that alpha blending is DEST - SRC * DEST
+     * Subtracts source from destination, leading to darker results
+     * */
     public static readonly ALPHA_SUBTRACT = 3;
     /** Defines that alpha blending is SRC * DEST */
     public static readonly ALPHA_MULTIPLY = 4;
-    /** Defines that alpha blending is SRC ALPHA * SRC + (1 - SRC) * DEST */
+    /**
+     * Defines that alpha blending is SRC ALPHA * SRC + (1 - SRC) * DEST
+     * Prioritizes area with high source alpha, strongly emphasizes the source
+     */
     public static readonly ALPHA_MAXIMIZED = 5;
-    /** Defines that alpha blending is SRC + DEST */
+    /**
+     * Defines that alpha blending is SRC + DEST
+     * Source color is added to the destination color without alpha affecting the result. Great for additive glow effects (fire, magic, lasers)
+     */
     public static readonly ALPHA_ONEONE = 6;
     /** Defines that alpha blending is SRC + (1 - SRC ALPHA) * DEST */
     public static readonly ALPHA_PREMULTIPLIED = 7;
@@ -26,16 +38,21 @@ export class Constants {
      * Alpha will be set to (1 - SRC ALPHA) * DEST ALPHA
      */
     public static readonly ALPHA_PREMULTIPLIED_PORTERDUFF = 8;
-    /** Defines that alpha blending is CST * SRC + (1 - CST) * DEST */
+    /**
+     * Defines that alpha blending is CST * SRC + (1 - CST) * DEST
+     * Where CST is user-supplied color
+     */
     public static readonly ALPHA_INTERPOLATE = 9;
     /**
      * Defines that alpha blending is SRC + (1 - SRC) * DEST
      * Alpha will be set to SRC ALPHA + (1 - SRC ALPHA) * DEST ALPHA
+     * Brightens, good for soft light or UI highlights (like photoshop's screen blend)
      */
     public static readonly ALPHA_SCREENMODE = 10;
     /**
      * Defines that alpha blending is SRC + DST
      * Alpha will be set to SRC ALPHA + DST ALPHA
+     * Straight addition of color and alpha- use when you want both source and destination colors and opacities to stack
      */
     public static readonly ALPHA_ONEONE_ONEONE = 11;
     /**
@@ -45,26 +62,31 @@ export class Constants {
     public static readonly ALPHA_ALPHATOCOLOR = 12;
     /**
      * Defines that alpha blending is SRC * (1 - DST) + DST * (1 - SRC)
+     * Result is between source and destination, used for experimental blending or styled effects
      */
     public static readonly ALPHA_REVERSEONEMINUS = 13;
     /**
      * Defines that alpha blending is SRC + DST * (1 - SRC ALPHA)
      * Alpha will be set to SRC ALPHA + DST ALPHA * (1 - SRC ALPHA)
+     * Smooths blending between source and destination, useful in layered alpha masks
      */
     public static readonly ALPHA_SRC_DSTONEMINUSSRCALPHA = 14;
     /**
      * Defines that alpha blending is SRC + DST
      * Alpha will be set to SRC ALPHA
+     * Color stacks, but only source alpha is kept
      */
     public static readonly ALPHA_ONEONE_ONEZERO = 15;
     /**
      * Defines that alpha blending is SRC * (1 - DST) + DST * (1 - SRC)
      * Alpha will be set to DST ALPHA
+     * Produces inverted look (negative space), like 'exclusion' mode in photoshop
      */
     public static readonly ALPHA_EXCLUSION = 16;
     /**
      * Defines that alpha blending is SRC * SRC ALPHA + DST * (1 - SRC ALPHA)
      * Alpha will be set to SRC ALPHA + (1 - SRC ALPHA) * DST ALPHA
+     * Great for layered rendering (particles, fog volumes), accumulates transparency in a more physically accurate way
      */
     public static readonly ALPHA_LAYER_ACCUMULATE = 17;
 

--- a/packages/dev/core/src/Particles/IParticleSystem.ts
+++ b/packages/dev/core/src/Particles/IParticleSystem.ts
@@ -76,7 +76,7 @@ export interface IParticleSystem {
     particleTexture: Nullable<BaseTexture>;
 
     /**
-     * Blend mode use to render the particle, it can be either ParticleSystem.BLENDMODE_ONEONE, ParticleSystem.BLENDMODE_STANDARD or ParticleSystem.BLENDMODE_ADD.
+     * Blend mode use to render the particle. It can be any of the ParticleSystem.BLENDMODE_* constants
      */
     blendMode: number;
 

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -454,23 +454,27 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         );
     }
 
-    protected _blendModeParticleToEngineConst = (blendMode: number) => {
+    protected _setEngineBasedOnBlendMode = (blendMode: number) => {
+        let mode;
         switch (blendMode) {
             case BaseParticleSystem.BLENDMODE_ADD:
-                return Constants.ALPHA_ADD;
+                mode = Constants.ALPHA_ADD;
             case BaseParticleSystem.BLENDMODE_ONEONE:
-                return Constants.ALPHA_ONEONE;
+                mode = Constants.ALPHA_ONEONE;
             case BaseParticleSystem.BLENDMODE_STANDARD:
-                return Constants.ALPHA_COMBINE;
+                mode = Constants.ALPHA_COMBINE;
             case BaseParticleSystem.BLENDMODE_MULTIPLY:
-                return Constants.ALPHA_MULTIPLY;
+                mode = Constants.ALPHA_MULTIPLY;
             case BaseParticleSystem.BLENDMODE_SUBTRACT:
-                return Constants.ALPHA_SUBTRACT;
+                mode = Constants.ALPHA_SUBTRACT;
+            case BaseParticleSystem.BLENDMODE_MULTIPLYADD:
+                break; // There is no equivalent engine const for multiplyAdd - the logic lives within the particle system
             default:
                 // For all other blend modes that were added after the initial particleSystem implementation,
                 // the ParticleSystem.BLENDMODE_FOO are already mapped to the underlying Constants.ALPHA_FOO
-                return blendMode;
+                mode = blendMode;
         }
+        mode && this._engine.setAlphaMode(mode);
     };
     /**
      * Defines the delay in milliseconds before starting the system (0 by default)

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -57,7 +57,7 @@ export class BaseParticleSystem implements IClipPlanesHolder {
      * Subtracts source (particle) from destination (current color), leading to darker results
      * - NOTE: Init as 9 but mapped to ALPHA_SUBTRACT for backwards compatibility
      */
-    public static BLENDMODE_SUBTRACT = 5;
+    public static BLENDMODE_SUBTRACT = 9;
     /**
      * Prioritizes area with high source (particle) alpha, strongly emphasizes the particle
      */

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -34,11 +34,11 @@ import { RegisterClass } from "../Misc/typeStore";
  */
 export class BaseParticleSystem implements IClipPlanesHolder {
     /**
-     * Source color is added to the destination color without alpha affecting the result
+     * Source color is added to the destination color without alpha affecting the result. Great for additive glow effects (fire, magic, lasers)
      */
     public static BLENDMODE_ONEONE = 0;
     /**
-     * Blend current color and particle color using particle’s alpha
+     * Blend current color and particle color using particle’s alpha. Same as Constants.ALPHA_COMBINE, the go-to for transparency. 100% alpha means source, 0% alpha means background. Glass, UI fade, smoke
      */
     public static BLENDMODE_STANDARD = 1;
     /**
@@ -49,11 +49,59 @@ export class BaseParticleSystem implements IClipPlanesHolder {
      * Multiply current color with particle color
      */
     public static BLENDMODE_MULTIPLY = 3;
-
     /**
      * Multiply current color with particle color then add current color and particle color multiplied by particle’s alpha
      */
     public static BLENDMODE_MULTIPLYADD = 4;
+    /**
+     * Subtracts source (particle) from destination (current color), leading to darker results
+     * - NOTE: Init as 9 but mapped to ALPHA_SUBTRACT for backwards compatibility
+     */
+    public static BLENDMODE_SUBTRACT = 5;
+    /**
+     * Prioritizes area with high source (particle) alpha, strongly emphasizes the particle
+     */
+    public static BLENDMODE_MAXIMIZED = Constants.ALPHA_MAXIMIZED;
+    /**
+     * Assumes source colors are already multiplied by alpha, saves perf if texture are premultiplied
+     */
+    public static BLENDMODE_PREMULTIPLIED = Constants.ALPHA_PREMULTIPLIED;
+    /**
+     * Assumes source colors are already multiplied , precise porter-duff alpha behavior
+     */
+    public static BLENDMODE_PREMULTIPLIED_PORTERDUFF = Constants.ALPHA_PREMULTIPLIED_PORTERDUFF;
+    /**
+     * Brightens, good for soft light or UI highlights (like photoshop's screen blend)
+     */
+    public static BLENDMODE_SCREENMODE = Constants.ALPHA_SCREENMODE;
+    /**
+     * Straight addition of color and alpha- use when you want both source and destination colors and opacities to stack
+     */
+    public static BLENDMODE_ONEONE_ONEONE = Constants.ALPHA_ONEONE_ONEONE;
+    /**
+     * Converts alpha into color
+     */
+    public static BLENDMODE_ALPHATOCOLOR = Constants.ALPHA_ALPHATOCOLOR;
+    /**
+     * Result is between source and destination, used for experimental blending or styled effects
+     */
+    public static BLENDMODE_REVERSEONEMINUS = Constants.ALPHA_REVERSEONEMINUS;
+    /**
+     * Smooths blending between source and destination, useful in layered alpha masks
+     */
+    public static BLENDMODE_SRC_DSTONEMINUSSRCALPHA = Constants.ALPHA_SRC_DSTONEMINUSSRCALPHA;
+    /**
+     * Color stacks, but only source alpha is kept
+     */
+    public static BLENDMODE_ONEONE_ONEZERO = Constants.ALPHA_ONEONE_ONEZERO;
+    /**
+     * LIke 'exclusion' mode in photoshop, produces inverted look (negative space)
+     */
+    public static BLENDMODE_EXCLUSION = Constants.ALPHA_EXCLUSION;
+    /**
+     * Great for layered rendering (particles, fog volumes), accumulates transparency in a more physically accurate way
+     */
+    public static BLENDMODE_LAYER_ACCUMULATE = Constants.ALPHA_LAYER_ACCUMULATE;
 
     /**
      * List of animations used by the particle system.
@@ -406,6 +454,24 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         );
     }
 
+    protected _blendModeParticleToEngineConst = (blendMode: number) => {
+        switch (blendMode) {
+            case BaseParticleSystem.BLENDMODE_ADD:
+                return Constants.ALPHA_ADD;
+            case BaseParticleSystem.BLENDMODE_ONEONE:
+                return Constants.ALPHA_ONEONE;
+            case BaseParticleSystem.BLENDMODE_STANDARD:
+                return Constants.ALPHA_COMBINE;
+            case BaseParticleSystem.BLENDMODE_MULTIPLY:
+                return Constants.ALPHA_MULTIPLY;
+            case BaseParticleSystem.BLENDMODE_SUBTRACT:
+                return Constants.ALPHA_SUBTRACT;
+            default:
+                // For all other blend modes that were added after the initial particleSystem implementation,
+                // the ParticleSystem.BLENDMODE_FOO are already mapped to the underlying Constants.ALPHA_FOO
+                return blendMode;
+        }
+    };
     /**
      * Defines the delay in milliseconds before starting the system (0 by default)
      */

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -459,14 +459,19 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         switch (blendMode) {
             case BaseParticleSystem.BLENDMODE_ADD:
                 mode = Constants.ALPHA_ADD;
+                break;
             case BaseParticleSystem.BLENDMODE_ONEONE:
                 mode = Constants.ALPHA_ONEONE;
+                break;
             case BaseParticleSystem.BLENDMODE_STANDARD:
                 mode = Constants.ALPHA_COMBINE;
+                break;
             case BaseParticleSystem.BLENDMODE_MULTIPLY:
                 mode = Constants.ALPHA_MULTIPLY;
+                break;
             case BaseParticleSystem.BLENDMODE_SUBTRACT:
                 mode = Constants.ALPHA_SUBTRACT;
+                break;
             case BaseParticleSystem.BLENDMODE_MULTIPLYADD:
                 break; // There is no equivalent engine const for multiplyAdd - the logic lives within the particle system
             default:
@@ -474,7 +479,7 @@ export class BaseParticleSystem implements IClipPlanesHolder {
                 // the ParticleSystem.BLENDMODE_FOO are already mapped to the underlying Constants.ALPHA_FOO
                 mode = blendMode;
         }
-        mode && this._engine.setAlphaMode(mode);
+        mode !== undefined && this._engine.setAlphaMode(mode);
     };
     /**
      * Defines the delay in milliseconds before starting the system (0 by default)

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -412,7 +412,7 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         );
     }
 
-    protected _setEngineBasedOnBlendMode = (blendMode: number): void => {
+    protected _setEngineBasedOnBlendMode(blendMode: number): void {
         switch (blendMode) {
             case BaseParticleSystem.BLENDMODE_MULTIPLYADD:
                 // Don't want to update engine since there is no equivalent engine alpha mode, instead it gets handled within particleSystem
@@ -438,7 +438,7 @@ export class BaseParticleSystem implements IClipPlanesHolder {
                 break;
         }
         this._engine.setAlphaMode(blendMode);
-    };
+    }
 
     /**
      * Defines the delay in milliseconds before starting the system (0 by default)

--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -1703,7 +1703,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         // Draw order
-        this._engine.setAlphaMode(this._blendModeParticleToEngineConst(blendMode));
+        this._setEngineBasedOnBlendMode(blendMode);
 
         // Bind source VAO
         this._platform.bindDrawBuffers(this._targetIndex, effect, this._scene?.forceWireframe ? this._linesIndexBufferUseInstancing : null);

--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -1703,20 +1703,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         // Draw order
-        switch (blendMode) {
-            case ParticleSystem.BLENDMODE_ADD:
-                this._engine.setAlphaMode(Constants.ALPHA_ADD);
-                break;
-            case ParticleSystem.BLENDMODE_ONEONE:
-                this._engine.setAlphaMode(Constants.ALPHA_ONEONE);
-                break;
-            case ParticleSystem.BLENDMODE_STANDARD:
-                this._engine.setAlphaMode(Constants.ALPHA_COMBINE);
-                break;
-            case ParticleSystem.BLENDMODE_MULTIPLY:
-                this._engine.setAlphaMode(Constants.ALPHA_MULTIPLY);
-                break;
-        }
+        this._engine.setAlphaMode(this._blendModeParticleToEngineConst(blendMode));
 
         // Bind source VAO
         this._platform.bindDrawBuffers(this._targetIndex, effect, this._scene?.forceWireframe ? this._linesIndexBufferUseInstancing : null);

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -2078,7 +2078,7 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
         }
 
         // Draw order
-        this._engine.setAlphaMode(this._blendModeParticleToEngineConst(blendMode));
+        this._setEngineBasedOnBlendMode(blendMode);
 
         if (this._onBeforeDrawParticlesObservable) {
             this._onBeforeDrawParticlesObservable.notifyObservers(effect);

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -2078,20 +2078,7 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
         }
 
         // Draw order
-        switch (blendMode) {
-            case BaseParticleSystem.BLENDMODE_ADD:
-                engine.setAlphaMode(Constants.ALPHA_ADD);
-                break;
-            case BaseParticleSystem.BLENDMODE_ONEONE:
-                engine.setAlphaMode(Constants.ALPHA_ONEONE);
-                break;
-            case BaseParticleSystem.BLENDMODE_STANDARD:
-                engine.setAlphaMode(Constants.ALPHA_COMBINE);
-                break;
-            case BaseParticleSystem.BLENDMODE_MULTIPLY:
-                engine.setAlphaMode(Constants.ALPHA_MULTIPLY);
-                break;
-        }
+        this._engine.setAlphaMode(this._blendModeParticleToEngineConst(blendMode));
 
         if (this._onBeforeDrawParticlesObservable) {
             this._onBeforeDrawParticlesObservable.notifyObservers(effect);

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/commonMaterialPropertyGridComponent.tsx
@@ -20,6 +20,7 @@ import { TextInputLineComponent } from "shared-ui-components/lines/textInputLine
 import { AnimationGridComponent } from "../animations/animationPropertyGridComponent";
 import { HexLineComponent } from "shared-ui-components/lines/hexLineComponent";
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
+import { alphaModeOptions } from "shared-ui-components/constToOptionsMaps";
 
 interface ICommonMaterialPropertyGridComponentProps {
     globalState: GlobalState;
@@ -40,25 +41,6 @@ const transparencyModeOptions = [
     { label: "Alpha test", value: PBRMaterial.PBRMATERIAL_ALPHATEST },
     { label: "Alpha blend", value: PBRMaterial.PBRMATERIAL_ALPHABLEND },
     { label: "Alpha blend and test", value: PBRMaterial.PBRMATERIAL_ALPHATESTANDBLEND },
-];
-
-const alphaModeOptions = [
-    { label: "Combine", value: Constants.ALPHA_COMBINE },
-    { label: "One one", value: Constants.ALPHA_ONEONE },
-    { label: "Add", value: Constants.ALPHA_ADD },
-    { label: "Subtract", value: Constants.ALPHA_SUBTRACT },
-    { label: "Multiply", value: Constants.ALPHA_MULTIPLY },
-    { label: "Maximized", value: Constants.ALPHA_MAXIMIZED },
-    { label: "Pre-multiplied", value: Constants.ALPHA_PREMULTIPLIED },
-    { label: "Pre-multiplied Porter Duff", value: Constants.ALPHA_PREMULTIPLIED_PORTERDUFF },
-    { label: "Screen mode", value: Constants.ALPHA_SCREENMODE },
-    { label: "OneOne OneOne", value: Constants.ALPHA_ONEONE_ONEONE },
-    { label: "Alpha to color", value: Constants.ALPHA_ALPHATOCOLOR },
-    { label: "Reverse one minus", value: Constants.ALPHA_REVERSEONEMINUS },
-    { label: "Source+Dest * (1 - SourceAlpha)", value: Constants.ALPHA_SRC_DSTONEMINUSSRCALPHA },
-    { label: "OneOne OneZero", value: Constants.ALPHA_ONEONE_ONEZERO },
-    { label: "Exclusion", value: Constants.ALPHA_EXCLUSION },
-    { label: "Layer accumulate", value: Constants.ALPHA_LAYER_ACCUMULATE },
 ];
 
 const depthfunctionOptions = [

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/particleSystems/particleSystemPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/particleSystems/particleSystemPropertyGridComponent.tsx
@@ -42,6 +42,7 @@ import { ParticleHelper } from "core/Particles/particleHelper";
 import { Color4LineComponent } from "shared-ui-components/lines/color4LineComponent";
 import { Constants } from "core/Engines/constants";
 import { Texture } from "core/Materials/Textures/texture";
+import { blendModeOptions } from "shared-ui-components/constToOptionsMaps";
 
 interface IParticleSystemPropertyGridComponentProps {
     globalState: GlobalState;
@@ -50,6 +51,16 @@ interface IParticleSystemPropertyGridComponentProps {
     onSelectionChangedObservable?: Observable<any>;
     onPropertyChangedObservable?: Observable<PropertyChangedEvent>;
 }
+
+const particleEmitterTypeOptions = [
+    { label: "Box", value: 0 },
+    { label: "Cone", value: 1 },
+    { label: "Cylinder", value: 2 },
+    { label: "Hemispheric", value: 3 },
+    { label: "Mesh", value: 4 },
+    { label: "Point", value: 5 },
+    { label: "Sphere", value: 6 },
+];
 
 export class ParticleSystemPropertyGridComponent extends React.Component<IParticleSystemPropertyGridComponentProps> {
     private _snippetUrl = Constants.SnippetUrl;
@@ -312,24 +323,6 @@ export class ParticleSystemPropertyGridComponent extends React.Component<IPartic
 
     override render() {
         const system = this.props.system;
-
-        const blendModeOptions = [
-            { label: "Add", value: ParticleSystem.BLENDMODE_ADD },
-            { label: "Multiply", value: ParticleSystem.BLENDMODE_MULTIPLY },
-            { label: "Multiply Add", value: ParticleSystem.BLENDMODE_MULTIPLYADD },
-            { label: "OneOne", value: ParticleSystem.BLENDMODE_ONEONE },
-            { label: "Standard", value: ParticleSystem.BLENDMODE_STANDARD },
-        ];
-
-        const particleEmitterTypeOptions = [
-            { label: "Box", value: 0 },
-            { label: "Cone", value: 1 },
-            { label: "Cylinder", value: 2 },
-            { label: "Hemispheric", value: 3 },
-            { label: "Mesh", value: 4 },
-            { label: "Point", value: 5 },
-            { label: "Sphere", value: 6 },
-        ];
 
         const meshEmitters = this.props.system.getScene()!.meshes.filter((m) => !!m.name);
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/sprites/spriteManagerPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/sprites/spriteManagerPropertyGridComponent.tsx
@@ -20,6 +20,7 @@ import { Tools } from "core/Misc/tools";
 import { FileButtonLine } from "shared-ui-components/lines/fileButtonLineComponent";
 import { Constants } from "core/Engines/constants";
 import { OptionsLine } from "shared-ui-components/lines/optionsLineComponent";
+import { alphaModeOptions } from "shared-ui-components/constToOptionsMaps";
 
 interface ISpriteManagerPropertyGridComponentProps {
     globalState: GlobalState;
@@ -152,16 +153,6 @@ export class SpriteManagerPropertyGridComponent extends React.Component<ISpriteM
 
     override render() {
         const spriteManager = this.props.spriteManager;
-
-        const alphaModeOptions = [
-            { label: "Combine", value: Constants.ALPHA_COMBINE },
-            { label: "One one", value: Constants.ALPHA_ONEONE },
-            { label: "Add", value: Constants.ALPHA_ADD },
-            { label: "Subtract", value: Constants.ALPHA_SUBTRACT },
-            { label: "Multiply", value: Constants.ALPHA_MULTIPLY },
-            { label: "Maximized", value: Constants.ALPHA_MAXIMIZED },
-            { label: "Pre-multiplied", value: Constants.ALPHA_PREMULTIPLIED },
-        ];
 
         return (
             <>

--- a/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
+++ b/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
@@ -1,0 +1,20 @@
+import { ParticleSystem } from "core/Particles";
+
+export const blendModeOptions = [
+    { label: "Combine (Standard)", value: ParticleSystem.BLENDMODE_STANDARD },
+    { label: "One one", value: ParticleSystem.BLENDMODE_ONEONE },
+    { label: "Add", value: ParticleSystem.BLENDMODE_ADD },
+    { label: "Subtract", value: ParticleSystem.BLENDMODE_SUBTRACT },
+    { label: "Multiply", value: ParticleSystem.BLENDMODE_MULTIPLY },
+    { label: "Maximized", value: ParticleSystem.BLENDMODE_MAXIMIZED },
+    { label: "Pre-multiplied", value: ParticleSystem.BLENDMODE_PREMULTIPLIED },
+    { label: "Pre-multiplied Porter Duff", value: ParticleSystem.BLENDMODE_PREMULTIPLIED_PORTERDUFF },
+    { label: "Screen mode", value: ParticleSystem.BLENDMODE_SCREENMODE },
+    { label: "OneOne OneOne", value: ParticleSystem.BLENDMODE_ONEONE_ONEONE },
+    { label: "Alpha to color", value: ParticleSystem.BLENDMODE_ALPHATOCOLOR },
+    { label: "Reverse one minus", value: ParticleSystem.BLENDMODE_REVERSEONEMINUS },
+    { label: "Source+Dest * (1 - SourceAlpha)", value: ParticleSystem.BLENDMODE_SRC_DSTONEMINUSSRCALPHA },
+    { label: "OneOne OneZero", value: ParticleSystem.BLENDMODE_ONEONE_ONEZERO },
+    { label: "Exclusion", value: ParticleSystem.BLENDMODE_EXCLUSION },
+    { label: "Layer accumulate", value: ParticleSystem.BLENDMODE_LAYER_ACCUMULATE },
+];

--- a/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
+++ b/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
@@ -1,5 +1,9 @@
+import { Constants } from "core/Engines";
 import { ParticleSystem } from "core/Particles";
 
+/**
+ * Used to populated the blendMode dropdown in our various tools (Node Editor, Inspector, etc.)
+ */
 export const blendModeOptions = [
     { label: "Combine (Standard)", value: ParticleSystem.BLENDMODE_STANDARD },
     { label: "One one", value: ParticleSystem.BLENDMODE_ONEONE },
@@ -17,4 +21,26 @@ export const blendModeOptions = [
     { label: "OneOne OneZero", value: ParticleSystem.BLENDMODE_ONEONE_ONEZERO },
     { label: "Exclusion", value: ParticleSystem.BLENDMODE_EXCLUSION },
     { label: "Layer accumulate", value: ParticleSystem.BLENDMODE_LAYER_ACCUMULATE },
+];
+
+/**
+ * Used to populated the alphaMode dropdown in our various tools (Node Editor, Inspector, etc.)
+ */
+export const alphaModeOptions = [
+    { label: "Combine", value: Constants.ALPHA_COMBINE },
+    { label: "One one", value: Constants.ALPHA_ONEONE },
+    { label: "Add", value: Constants.ALPHA_ADD },
+    { label: "Subtract", value: Constants.ALPHA_SUBTRACT },
+    { label: "Multiply", value: Constants.ALPHA_MULTIPLY },
+    { label: "Maximized", value: Constants.ALPHA_MAXIMIZED },
+    { label: "Pre-multiplied", value: Constants.ALPHA_PREMULTIPLIED },
+    { label: "Pre-multiplied Porter Duff", value: Constants.ALPHA_PREMULTIPLIED_PORTERDUFF },
+    { label: "Screen mode", value: Constants.ALPHA_SCREENMODE },
+    { label: "OneOne OneOne", value: Constants.ALPHA_ONEONE_ONEONE },
+    { label: "Alpha to color", value: Constants.ALPHA_ALPHATOCOLOR },
+    { label: "Reverse one minus", value: Constants.ALPHA_REVERSEONEMINUS },
+    { label: "Source+Dest * (1 - SourceAlpha)", value: Constants.ALPHA_SRC_DSTONEMINUSSRCALPHA },
+    { label: "OneOne OneZero", value: Constants.ALPHA_ONEONE_ONEZERO },
+    { label: "Exclusion", value: Constants.ALPHA_EXCLUSION },
+    { label: "Layer accumulate", value: Constants.ALPHA_LAYER_ACCUMULATE },
 ];

--- a/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
+++ b/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
@@ -5,11 +5,12 @@ import { ParticleSystem } from "core/Particles";
  * Used to populated the blendMode dropdown in our various tools (Node Editor, Inspector, etc.)
  */
 export const blendModeOptions = [
-    { label: "Combine (Standard)", value: ParticleSystem.BLENDMODE_STANDARD },
-    { label: "One one", value: ParticleSystem.BLENDMODE_ONEONE },
     { label: "Add", value: ParticleSystem.BLENDMODE_ADD },
-    { label: "Subtract", value: ParticleSystem.BLENDMODE_SUBTRACT },
     { label: "Multiply", value: ParticleSystem.BLENDMODE_MULTIPLY },
+    { label: "Multiply add", value: ParticleSystem.BLENDMODE_MULTIPLYADD },
+    { label: "One one", value: ParticleSystem.BLENDMODE_ONEONE },
+    { label: "Standard)", value: ParticleSystem.BLENDMODE_STANDARD },
+    { label: "Subtract", value: ParticleSystem.BLENDMODE_SUBTRACT },
     { label: "Maximized", value: ParticleSystem.BLENDMODE_MAXIMIZED },
     { label: "Pre-multiplied", value: ParticleSystem.BLENDMODE_PREMULTIPLIED },
     { label: "Pre-multiplied Porter Duff", value: ParticleSystem.BLENDMODE_PREMULTIPLIED_PORTERDUFF },

--- a/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
+++ b/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
@@ -9,7 +9,7 @@ export const blendModeOptions = [
     { label: "Multiply", value: ParticleSystem.BLENDMODE_MULTIPLY },
     { label: "Multiply add", value: ParticleSystem.BLENDMODE_MULTIPLYADD },
     { label: "One one", value: ParticleSystem.BLENDMODE_ONEONE },
-    { label: "Standard)", value: ParticleSystem.BLENDMODE_STANDARD },
+    { label: "Standard", value: ParticleSystem.BLENDMODE_STANDARD },
     { label: "Subtract", value: ParticleSystem.BLENDMODE_SUBTRACT },
     { label: "Maximized", value: ParticleSystem.BLENDMODE_MAXIMIZED },
     { label: "Pre-multiplied", value: ParticleSystem.BLENDMODE_PREMULTIPLIED },

--- a/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
+++ b/packages/dev/sharedUiComponents/src/constToOptionsMaps.ts
@@ -2,46 +2,43 @@ import { Constants } from "core/Engines";
 import { ParticleSystem } from "core/Particles";
 
 /**
+ * Used by both particleSystem and alphaBlendModes
+ */
+export const commonBlendModes = [
+    { label: "Maximized", value: Constants.ALPHA_MAXIMIZED },
+    { label: "Pre-multiplied", value: Constants.ALPHA_PREMULTIPLIED },
+    { label: "Pre-multiplied Porter Duff", value: Constants.ALPHA_PREMULTIPLIED_PORTERDUFF },
+    { label: "Screen Mode", value: Constants.ALPHA_SCREENMODE },
+    { label: "OneOne OneOne", value: Constants.ALPHA_ONEONE_ONEONE },
+    { label: "Alpha to Color", value: Constants.ALPHA_ALPHATOCOLOR },
+    { label: "Reverse One Minus", value: Constants.ALPHA_REVERSEONEMINUS },
+    { label: "Source+Dest * (1 - SourceAlpha)", value: Constants.ALPHA_SRC_DSTONEMINUSSRCALPHA },
+    { label: "OneOne OneZero", value: Constants.ALPHA_ONEONE_ONEZERO },
+    { label: "Exclusion", value: Constants.ALPHA_EXCLUSION },
+    { label: "Layer Accumulate", value: Constants.ALPHA_LAYER_ACCUMULATE },
+];
+
+/**
  * Used to populated the blendMode dropdown in our various tools (Node Editor, Inspector, etc.)
+ * The below ParticleSystem consts were defined before new Engine alpha blend modes were added, so we have to reference
+ * the ParticleSystem.FOO consts explicitly (as the underlying const values are different - they get mapped to engine consts within baseParticleSystem.ts)
  */
 export const blendModeOptions = [
     { label: "Add", value: ParticleSystem.BLENDMODE_ADD },
     { label: "Multiply", value: ParticleSystem.BLENDMODE_MULTIPLY },
-    { label: "Multiply add", value: ParticleSystem.BLENDMODE_MULTIPLYADD },
-    { label: "One one", value: ParticleSystem.BLENDMODE_ONEONE },
+    { label: "Multiply Add", value: ParticleSystem.BLENDMODE_MULTIPLYADD },
+    { label: "One One", value: ParticleSystem.BLENDMODE_ONEONE },
     { label: "Standard", value: ParticleSystem.BLENDMODE_STANDARD },
     { label: "Subtract", value: ParticleSystem.BLENDMODE_SUBTRACT },
-    { label: "Maximized", value: ParticleSystem.BLENDMODE_MAXIMIZED },
-    { label: "Pre-multiplied", value: ParticleSystem.BLENDMODE_PREMULTIPLIED },
-    { label: "Pre-multiplied Porter Duff", value: ParticleSystem.BLENDMODE_PREMULTIPLIED_PORTERDUFF },
-    { label: "Screen mode", value: ParticleSystem.BLENDMODE_SCREENMODE },
-    { label: "OneOne OneOne", value: ParticleSystem.BLENDMODE_ONEONE_ONEONE },
-    { label: "Alpha to color", value: ParticleSystem.BLENDMODE_ALPHATOCOLOR },
-    { label: "Reverse one minus", value: ParticleSystem.BLENDMODE_REVERSEONEMINUS },
-    { label: "Source+Dest * (1 - SourceAlpha)", value: ParticleSystem.BLENDMODE_SRC_DSTONEMINUSSRCALPHA },
-    { label: "OneOne OneZero", value: ParticleSystem.BLENDMODE_ONEONE_ONEZERO },
-    { label: "Exclusion", value: ParticleSystem.BLENDMODE_EXCLUSION },
-    { label: "Layer accumulate", value: ParticleSystem.BLENDMODE_LAYER_ACCUMULATE },
-];
+].concat(commonBlendModes);
 
 /**
  * Used to populated the alphaMode dropdown in our various tools (Node Editor, Inspector, etc.)
  */
 export const alphaModeOptions = [
     { label: "Combine", value: Constants.ALPHA_COMBINE },
-    { label: "One one", value: Constants.ALPHA_ONEONE },
+    { label: "One One", value: Constants.ALPHA_ONEONE },
     { label: "Add", value: Constants.ALPHA_ADD },
     { label: "Subtract", value: Constants.ALPHA_SUBTRACT },
     { label: "Multiply", value: Constants.ALPHA_MULTIPLY },
-    { label: "Maximized", value: Constants.ALPHA_MAXIMIZED },
-    { label: "Pre-multiplied", value: Constants.ALPHA_PREMULTIPLIED },
-    { label: "Pre-multiplied Porter Duff", value: Constants.ALPHA_PREMULTIPLIED_PORTERDUFF },
-    { label: "Screen mode", value: Constants.ALPHA_SCREENMODE },
-    { label: "OneOne OneOne", value: Constants.ALPHA_ONEONE_ONEONE },
-    { label: "Alpha to color", value: Constants.ALPHA_ALPHATOCOLOR },
-    { label: "Reverse one minus", value: Constants.ALPHA_REVERSEONEMINUS },
-    { label: "Source+Dest * (1 - SourceAlpha)", value: Constants.ALPHA_SRC_DSTONEMINUSSRCALPHA },
-    { label: "OneOne OneZero", value: Constants.ALPHA_ONEONE_ONEZERO },
-    { label: "Exclusion", value: Constants.ALPHA_EXCLUSION },
-    { label: "Layer accumulate", value: Constants.ALPHA_LAYER_ACCUMULATE },
-];
+].concat(commonBlendModes);

--- a/packages/tools/nodeEditor/src/components/preview/previewAreaComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/preview/previewAreaComponent.tsx
@@ -4,7 +4,6 @@ import { DataStorage } from "core/Misc/dataStorage";
 import type { Observer } from "core/Misc/observable";
 import type { Nullable } from "core/types";
 import { NodeMaterialModes } from "core/Materials/Node/Enums/nodeMaterialModes";
-import { ParticleSystem } from "core/Particles/particleSystem";
 
 import doubleSided from "./svgs/doubleSided.svg";
 import depthPass from "./svgs/depthPass.svg";
@@ -13,6 +12,7 @@ import directionalRight from "./svgs/directionalRight.svg";
 import directionalLeft from "./svgs/directionalLeft.svg";
 import background from "./svgs/icon-ibl.svg";
 import { OptionsLine } from "shared-ui-components/lines/optionsLineComponent";
+import { blendModeOptions } from "shared-ui-components/constToOptionsMaps";
 
 interface IPreviewAreaComponentProps {
     globalState: GlobalState;
@@ -104,14 +104,6 @@ export class PreviewAreaComponent extends React.Component<IPreviewAreaComponentP
     }
 
     override render() {
-        const blendModeOptions = [
-            { label: "Add", value: ParticleSystem.BLENDMODE_ADD },
-            { label: "Multiply", value: ParticleSystem.BLENDMODE_MULTIPLY },
-            { label: "Multiply Add", value: ParticleSystem.BLENDMODE_MULTIPLYADD },
-            { label: "OneOne", value: ParticleSystem.BLENDMODE_ONEONE },
-            { label: "Standard", value: ParticleSystem.BLENDMODE_STANDARD },
-        ];
-
         return (
             <>
                 <div id="preview">

--- a/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -19,7 +19,6 @@ import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { NodeMaterialModes } from "core/Materials/Node/Enums/nodeMaterialModes";
 import { PreviewType } from "../preview/previewType";
 import { InputsPropertyTabComponent } from "./inputsPropertyTabComponent";
-import { Constants } from "core/Engines/constants";
 import { LogEntry } from "../log/logComponent";
 import "./propertyTab.scss";
 import { GraphNode } from "shared-ui-components/nodeGraphSystem/graphNode";
@@ -40,6 +39,8 @@ import { TextLineComponent } from "shared-ui-components/lines/textLineComponent"
 import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponent";
 import { SliderLineComponent } from "shared-ui-components/lines/sliderLineComponent";
 import { SetToDefaultGaussianSplatting, SetToDefaultSFE } from "core/Materials/Node/nodeMaterialDefault";
+import { alphaModeOptions } from "shared-ui-components/constToOptionsMaps";
+
 interface IPropertyTabComponentProps {
     globalState: GlobalState;
     lockObject: LockObject;
@@ -446,16 +447,6 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
         const engineList = [
             { label: "WebGL", value: 0 },
             { label: "WebGPU", value: 1 },
-        ];
-
-        const alphaModeOptions = [
-            { label: "Combine", value: Constants.ALPHA_COMBINE },
-            { label: "One one", value: Constants.ALPHA_ONEONE },
-            { label: "Add", value: Constants.ALPHA_ADD },
-            { label: "Subtract", value: Constants.ALPHA_SUBTRACT },
-            { label: "Multiply", value: Constants.ALPHA_MULTIPLY },
-            { label: "Maximized", value: Constants.ALPHA_MAXIMIZED },
-            { label: "Pre-multiplied", value: Constants.ALPHA_PREMULTIPLIED },
         ];
 
         return (


### PR DESCRIPTION
- Move the mappings of const to label into sharedui component package
- Add missing blendmode support to baseparticlesystem
- Plumb all alphablendmodes to node editor (missed in last PR)