### PR TITLE
Fix rotation values in GaussianSplattingMesh to use negative values f…

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -1005,10 +1005,10 @@ export class GaussianSplattingMesh extends Mesh {
                     r1 = value;
                     break;
                 case PLYValue.ROT_2:
-                    r2 = value;
+                    r2 = -value;
                     break;
                 case PLYValue.ROT_3:
-                    r3 = value;
+                    r3 = -value;
                     break;
             }
             if (sh && property.value >= PLYValue.SH_0 && property.value <= PLYValue.SH_44) {


### PR DESCRIPTION
…or ROT_2 and ROT_3 cases

I noticed that the appearance differs between ply and spz.
It seems that the rot (rotation) of ply needs to be adjusted.

## Lego left=ply, right=spz

### Before(differ):
https://sandbox.babylonjs.com/?version=8.3.1
<img width="1686" alt="image" src="https://github.com/user-attachments/assets/78c5cda1-4b92-4b96-987d-fa2f493ca946" />

After(same):
https://sandbox.babylonjs.com/?snapshot=refs/pull/16521/merge
<img width="1679" alt="image" src="https://github.com/user-attachments/assets/de204459-0709-4814-bb9e-e59aee79f4f2" />


## Debug
- Before(differ): https://playground.babylonjs.com/?version=8.3.1#3QY4KP#6
- After(same): https://playground.babylonjs.com/?snapshot=refs/pull/16521/merge#3QY4KP#6





