### PR TITLE
Fixed issue in the .babylon serializer

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1204,7 +1204,7 @@ export class Geometry implements IGetSetVerticesData {
 
         if (this.isVerticesDataPresent(VertexBuffer.MatricesIndicesKind)) {
             serializationObject.matricesIndices = this._toNumberArray(this.getVerticesData(VertexBuffer.MatricesIndicesKind));
-            serializationObject.matricesIndices._isExpanded = true;
+            serializationObject.matricesIndicesExpanded = true;
             if (this.isVertexBufferUpdatable(VertexBuffer.MatricesIndicesKind)) {
                 serializationObject.matricesIndices._updatable = true;
             }
@@ -1446,7 +1446,7 @@ export class Geometry implements IGetSetVerticesData {
             }
 
             if (parsedGeometry.matricesIndices) {
-                if (!parsedGeometry.matricesIndices._isExpanded) {
+                if (!parsedGeometry.matricesIndices._isExpanded && !parsedGeometry.matricesIndicesExpanded) {
                     const floatIndices = [];
 
                     for (let i = 0; i < parsedGeometry.matricesIndices.length; i++) {
@@ -1461,12 +1461,13 @@ export class Geometry implements IGetSetVerticesData {
                     mesh.setVerticesData(VertexBuffer.MatricesIndicesKind, floatIndices, parsedGeometry.matricesIndices._updatable);
                 } else {
                     delete parsedGeometry.matricesIndices._isExpanded;
+                    delete parsedGeometry.matricesIndicesExpanded;
                     mesh.setVerticesData(VertexBuffer.MatricesIndicesKind, parsedGeometry.matricesIndices, parsedGeometry.matricesIndices._updatable);
                 }
             }
 
             if (parsedGeometry.matricesIndicesExtra) {
-                if (!parsedGeometry.matricesIndicesExtra._isExpanded) {
+                if (!parsedGeometry.matricesIndicesExtra._isExpanded && !parsedGeometry.matricesIndicesExtraExpanded) {
                     const floatIndices = [];
 
                     for (let i = 0; i < parsedGeometry.matricesIndicesExtra.length; i++) {
@@ -1481,6 +1482,7 @@ export class Geometry implements IGetSetVerticesData {
                     mesh.setVerticesData(VertexBuffer.MatricesIndicesExtraKind, floatIndices, parsedGeometry.matricesIndicesExtra._updatable);
                 } else {
                     delete parsedGeometry.matricesIndices._isExpanded;
+                    delete parsedGeometry.matricesIndicesExtraExpande;
                     mesh.setVerticesData(VertexBuffer.MatricesIndicesExtraKind, parsedGeometry.matricesIndicesExtra, parsedGeometry.matricesIndicesExtra._updatable);
                 }
             }

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1467,7 +1467,7 @@ export class Geometry implements IGetSetVerticesData {
             }
 
             if (parsedGeometry.matricesIndicesExtra) {
-                if (!parsedGeometry.matricesIndicesExtra._isExpanded && !parsedGeometry.matricesIndicesExtraExpanded) {
+                if (!(parsedGeometry.matricesIndicesExtraExpanded || parsedGeometry.matricesIndicesExtra._isExpanded)) {
                     const floatIndices = [];
 
                     for (let i = 0; i < parsedGeometry.matricesIndicesExtra.length; i++) {

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1135,70 +1135,70 @@ export class Geometry implements IGetSetVerticesData {
         if (this.isVerticesDataPresent(VertexBuffer.PositionKind)) {
             serializationObject.positions = this._toNumberArray(this.getVerticesData(VertexBuffer.PositionKind));
             if (this.isVertexBufferUpdatable(VertexBuffer.PositionKind)) {
-                serializationObject.positions._updatable = true;
+                serializationObject.positionsUpdatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.NormalKind)) {
             serializationObject.normals = this._toNumberArray(this.getVerticesData(VertexBuffer.NormalKind));
             if (this.isVertexBufferUpdatable(VertexBuffer.NormalKind)) {
-                serializationObject.normals._updatable = true;
+                serializationObject.normalsUpdatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.TangentKind)) {
             serializationObject.tangents = this._toNumberArray(this.getVerticesData(VertexBuffer.TangentKind));
             if (this.isVertexBufferUpdatable(VertexBuffer.TangentKind)) {
-                serializationObject.tangents._updatable = true;
+                serializationObject.tangentsUpdatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UVKind)) {
             serializationObject.uvs = this._toNumberArray(this.getVerticesData(VertexBuffer.UVKind));
             if (this.isVertexBufferUpdatable(VertexBuffer.UVKind)) {
-                serializationObject.uvs._updatable = true;
+                serializationObject.uvsUpdatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV2Kind)) {
             serializationObject.uvs2 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV2Kind));
             if (this.isVertexBufferUpdatable(VertexBuffer.UV2Kind)) {
-                serializationObject.uvs2._updatable = true;
+                serializationObject.uvs2Updatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV3Kind)) {
             serializationObject.uvs3 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV3Kind));
             if (this.isVertexBufferUpdatable(VertexBuffer.UV3Kind)) {
-                serializationObject.uvs3._updatable = true;
+                serializationObject.uvs3Updatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV4Kind)) {
             serializationObject.uvs4 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV4Kind));
             if (this.isVertexBufferUpdatable(VertexBuffer.UV4Kind)) {
-                serializationObject.uvs4._updatable = true;
+                serializationObject.uvs4Updatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV5Kind)) {
             serializationObject.uvs5 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV5Kind));
             if (this.isVertexBufferUpdatable(VertexBuffer.UV5Kind)) {
-                serializationObject.uvs5._updatable = true;
+                serializationObject.uvs5Updatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.UV6Kind)) {
             serializationObject.uvs6 = this._toNumberArray(this.getVerticesData(VertexBuffer.UV6Kind));
             if (this.isVertexBufferUpdatable(VertexBuffer.UV6Kind)) {
-                serializationObject.uvs6._updatable = true;
+                serializationObject.uvs6Updatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.ColorKind)) {
             serializationObject.colors = this._toNumberArray(this.getVerticesData(VertexBuffer.ColorKind));
             if (this.isVertexBufferUpdatable(VertexBuffer.ColorKind)) {
-                serializationObject.colors._updatable = true;
+                serializationObject.colorsUpdatable = true;
             }
         }
 
@@ -1206,14 +1206,14 @@ export class Geometry implements IGetSetVerticesData {
             serializationObject.matricesIndices = this._toNumberArray(this.getVerticesData(VertexBuffer.MatricesIndicesKind));
             serializationObject.matricesIndicesExpanded = true;
             if (this.isVertexBufferUpdatable(VertexBuffer.MatricesIndicesKind)) {
-                serializationObject.matricesIndices._updatable = true;
+                serializationObject.matricesIndicesUpdatable = true;
             }
         }
 
         if (this.isVerticesDataPresent(VertexBuffer.MatricesWeightsKind)) {
             serializationObject.matricesWeights = this._toNumberArray(this.getVerticesData(VertexBuffer.MatricesWeightsKind));
             if (this.isVertexBufferUpdatable(VertexBuffer.MatricesWeightsKind)) {
-                serializationObject.matricesWeights._updatable = true;
+                serializationObject.matricesWeightsUpdatable = true;
             }
         }
 
@@ -1409,36 +1409,36 @@ export class Geometry implements IGetSetVerticesData {
                 }
             }
         } else if (parsedGeometry.positions && parsedGeometry.normals && parsedGeometry.indices) {
-            mesh.setVerticesData(VertexBuffer.PositionKind, parsedGeometry.positions, parsedGeometry.positions._updatable);
+            mesh.setVerticesData(VertexBuffer.PositionKind, parsedGeometry.positions, parsedGeometry.positions._updatable || parsedGeometry.positionsUpdatable);
 
-            mesh.setVerticesData(VertexBuffer.NormalKind, parsedGeometry.normals, parsedGeometry.normals._updatable);
+            mesh.setVerticesData(VertexBuffer.NormalKind, parsedGeometry.normals, parsedGeometry.normals._updatable || parsedGeometry.normalsUpdatable);
 
             if (parsedGeometry.tangents) {
-                mesh.setVerticesData(VertexBuffer.TangentKind, parsedGeometry.tangents, parsedGeometry.tangents._updatable);
+                mesh.setVerticesData(VertexBuffer.TangentKind, parsedGeometry.tangents, parsedGeometry.tangents._updatable || parsedGeometry.tangentsUpdatable);
             }
 
             if (parsedGeometry.uvs) {
-                mesh.setVerticesData(VertexBuffer.UVKind, parsedGeometry.uvs, parsedGeometry.uvs._updatable);
+                mesh.setVerticesData(VertexBuffer.UVKind, parsedGeometry.uvs, parsedGeometry.uvs._updatable || parsedGeometry.uvsUpdatable);
             }
 
             if (parsedGeometry.uvs2) {
-                mesh.setVerticesData(VertexBuffer.UV2Kind, parsedGeometry.uvs2, parsedGeometry.uvs2._updatable);
+                mesh.setVerticesData(VertexBuffer.UV2Kind, parsedGeometry.uvs2, parsedGeometry.uvs2._updatable || parsedGeometry.uvs2Updatable);
             }
 
             if (parsedGeometry.uvs3) {
-                mesh.setVerticesData(VertexBuffer.UV3Kind, parsedGeometry.uvs3, parsedGeometry.uvs3._updatable);
+                mesh.setVerticesData(VertexBuffer.UV3Kind, parsedGeometry.uvs3, parsedGeometry.uvs3._updatable || parsedGeometry.uvs3Updatable);
             }
 
             if (parsedGeometry.uvs4) {
-                mesh.setVerticesData(VertexBuffer.UV4Kind, parsedGeometry.uvs4, parsedGeometry.uvs4._updatable);
+                mesh.setVerticesData(VertexBuffer.UV4Kind, parsedGeometry.uvs4, parsedGeometry.uvs4._updatable || parsedGeometry.uvs4Updatable);
             }
 
             if (parsedGeometry.uvs5) {
-                mesh.setVerticesData(VertexBuffer.UV5Kind, parsedGeometry.uvs5, parsedGeometry.uvs5._updatable);
+                mesh.setVerticesData(VertexBuffer.UV5Kind, parsedGeometry.uvs5, parsedGeometry.uvs5._updatable || parsedGeometry.uvs5Updatable);
             }
 
             if (parsedGeometry.uvs6) {
-                mesh.setVerticesData(VertexBuffer.UV6Kind, parsedGeometry.uvs6, parsedGeometry.uvs6._updatable);
+                mesh.setVerticesData(VertexBuffer.UV6Kind, parsedGeometry.uvs6, parsedGeometry.uvs6._updatable || parsedGeometry.uvs6Updatable);
             }
 
             if (parsedGeometry.colors) {
@@ -1458,11 +1458,15 @@ export class Geometry implements IGetSetVerticesData {
                         floatIndices.push((matricesIndex >> 24) & 0xff); // & 0xFF to convert to v + 256 if v < 0
                     }
 
-                    mesh.setVerticesData(VertexBuffer.MatricesIndicesKind, floatIndices, parsedGeometry.matricesIndices._updatable);
+                    mesh.setVerticesData(VertexBuffer.MatricesIndicesKind, floatIndices, parsedGeometry.matricesIndices._updatable || parsedGeometry.matricesIndicesUpdatable);
                 } else {
                     delete parsedGeometry.matricesIndices._isExpanded;
                     delete parsedGeometry.matricesIndicesExpanded;
-                    mesh.setVerticesData(VertexBuffer.MatricesIndicesKind, parsedGeometry.matricesIndices, parsedGeometry.matricesIndices._updatable);
+                    mesh.setVerticesData(
+                        VertexBuffer.MatricesIndicesKind,
+                        parsedGeometry.matricesIndices,
+                        parsedGeometry.matricesIndices._updatable || parsedGeometry.matricesIndicesUpdatable
+                    );
                 }
             }
 
@@ -1479,11 +1483,19 @@ export class Geometry implements IGetSetVerticesData {
                         floatIndices.push((matricesIndex >> 24) & 0xff); // & 0xFF to convert to v + 256 if v < 0
                     }
 
-                    mesh.setVerticesData(VertexBuffer.MatricesIndicesExtraKind, floatIndices, parsedGeometry.matricesIndicesExtra._updatable);
+                    mesh.setVerticesData(
+                        VertexBuffer.MatricesIndicesExtraKind,
+                        floatIndices,
+                        parsedGeometry.matricesIndicesExtra._updatable || parsedGeometry.matricesIndicesExtraUpdatable
+                    );
                 } else {
                     delete parsedGeometry.matricesIndices._isExpanded;
                     delete parsedGeometry.matricesIndicesExtraExpanded;
-                    mesh.setVerticesData(VertexBuffer.MatricesIndicesExtraKind, parsedGeometry.matricesIndicesExtra, parsedGeometry.matricesIndicesExtra._updatable);
+                    mesh.setVerticesData(
+                        VertexBuffer.MatricesIndicesExtraKind,
+                        parsedGeometry.matricesIndicesExtra,
+                        parsedGeometry.matricesIndicesExtra._updatable || parsedGeometry.matricesIndicesExtraUpdatable
+                    );
                 }
             }
 

--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1482,7 +1482,7 @@ export class Geometry implements IGetSetVerticesData {
                     mesh.setVerticesData(VertexBuffer.MatricesIndicesExtraKind, floatIndices, parsedGeometry.matricesIndicesExtra._updatable);
                 } else {
                     delete parsedGeometry.matricesIndices._isExpanded;
-                    delete parsedGeometry.matricesIndicesExtraExpande;
+                    delete parsedGeometry.matricesIndicesExtraExpanded;
                     mesh.setVerticesData(VertexBuffer.MatricesIndicesExtraKind, parsedGeometry.matricesIndicesExtra, parsedGeometry.matricesIndicesExtra._updatable);
                 }
             }

--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -1399,7 +1399,7 @@ export class VertexData implements IVertexDataLike {
 
         if (this.matricesIndices) {
             serializationObject.matricesIndices = Array.from(this.matricesIndices);
-            serializationObject.matricesIndices._isExpanded = true;
+            serializationObject.matricesIndicesExpanded = true;
         }
 
         if (this.matricesWeights) {
@@ -1408,7 +1408,7 @@ export class VertexData implements IVertexDataLike {
 
         if (this.matricesIndicesExtra) {
             serializationObject.matricesIndicesExtra = Array.from(this.matricesIndicesExtra);
-            serializationObject.matricesIndicesExtra._isExpanded = true;
+            serializationObject.matricesIndicesExtraExpanded = true;
         }
 
         if (this.matricesWeightsExtra) {


### PR DESCRIPTION
When serializing to .babylon file we are setting the _isExpanded property directly in the array object to flag if matrices indices are in compact or expanded form. However, JSON.stringify will remove those properties since it does not support properties in array objects. I'm moving those flags to the serializationObject itself to allows it to be properly exported. I'm also keeping the deserializer for it just in case someone has a file that somehow has that property in the array. 

Releated to Exporters PR: https://github.com/BabylonJS/Exporters/pull/1137