### PR TITLE
IBL Shadows - Init passes only after voxelization

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
@@ -208,18 +208,10 @@ export class _IblShadowsAccumulationPass {
         this._setOutputTextureBindings();
 
         this._renderPipeline.onVoxelizationCompleteObservable.addOnce(() => {
-            let counter = 0;
-            this._scene.onBeforeRenderObservable.add(() => {
-                counter = 0;
-            });
-            // onAfterRenderTargetsRenderObservable is called twice during a frame and we only want to render
-            // on the second call, after the scene has been rendered to the GBuffer.
-            this._scene.onAfterRenderTargetsRenderObservable.add(() => {
-                if (++counter == 2) {
-                    if (this.enabled && this._outputTexture.isReady() && this._outputTexture.getEffect()?.isReady()) {
-                        if (this._setOutputTextureBindings()) {
-                            this._outputTexture.render();
-                        }
+            this._scene.geometryBufferRenderer!.getGBuffer().onAfterRenderObservable.add(() => {
+                if (this.enabled && this._outputTexture.isReady() && this._outputTexture.getEffect()?.isReady()) {
+                    if (this._setOutputTextureBindings()) {
+                        this._outputTexture.render();
                     }
                 }
             });

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -1125,6 +1125,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
         this._dummyTexture3d.dispose();
         this.onNewIblReadyObservable.clear();
         this.onShadowTextureReadyObservable.clear();
+        this.onVoxelizationCompleteObservable.clear();
         super.dispose();
     }
 }

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
@@ -162,16 +162,10 @@ export class _IblShadowsSpatialBlurPass {
         this._setBindings();
 
         this._renderPipeline.onVoxelizationCompleteObservable.addOnce(() => {
-            let counter = 0;
-            this._scene.onBeforeRenderObservable.add(() => {
-                counter = 0;
-            });
-            this._scene.onAfterRenderTargetsRenderObservable.add(() => {
-                if (++counter == 2) {
-                    if (this.enabled && this._outputTexture.isReady()) {
-                        if (this._setBindings()) {
-                            this._outputTexture.render();
-                        }
+            this._scene.geometryBufferRenderer!.getGBuffer().onAfterRenderObservable.add(() => {
+                if (this.enabled && this._outputTexture.isReady() && this._outputTexture.getEffect()?.isReady()) {
+                    if (this._setBindings()) {
+                        this._outputTexture.render();
                     }
                 }
             });

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
@@ -161,33 +161,37 @@ export class _IblShadowsSpatialBlurPass {
         // Need to set all the textures first so that the effect gets created with the proper uniforms.
         this._setBindings();
 
-        let counter = 0;
-        this._scene.onBeforeRenderObservable.add(() => {
-            counter = 0;
-        });
-        this._scene.onAfterRenderTargetsRenderObservable.add(() => {
-            if (++counter == 2) {
-                if (this.enabled && this._outputTexture.isReady()) {
-                    this._setBindings();
-                    this._outputTexture.render();
+        this._renderPipeline.onVoxelizationCompleteObservable.addOnce(() => {
+            let counter = 0;
+            this._scene.onBeforeRenderObservable.add(() => {
+                counter = 0;
+            });
+            this._scene.onAfterRenderTargetsRenderObservable.add(() => {
+                if (++counter == 2) {
+                    if (this.enabled && this._outputTexture.isReady()) {
+                        if (this._setBindings()) {
+                            this._outputTexture.render();
+                        }
+                    }
                 }
-            }
+            });
         });
     }
 
-    private _setBindings() {
+    private _setBindings(): boolean {
         this._outputTexture.setTexture("voxelTracingSampler", this._renderPipeline._getVoxelTracingTexture());
         const iterationCount = 1;
         this._blurParameters.set(iterationCount, this._worldScale, 0.0, 0.0);
         this._outputTexture.setVector4("blurParameters", this._blurParameters);
         const geometryBufferRenderer = this._scene.geometryBufferRenderer;
         if (!geometryBufferRenderer) {
-            return;
+            return false;
         }
         const depthIndex = geometryBufferRenderer.getTextureIndex(GeometryBufferRenderer.SCREENSPACE_DEPTH_TEXTURE_TYPE);
         this._outputTexture.setTexture("depthSampler", geometryBufferRenderer.getGBuffer().textures[depthIndex]);
         const wnormalIndex = geometryBufferRenderer.getTextureIndex(GeometryBufferRenderer.NORMAL_TEXTURE_TYPE);
         this._outputTexture.setTexture("worldNormalSampler", geometryBufferRenderer.getGBuffer().textures[wnormalIndex]);
+        return true;
     }
 
     /**
@@ -199,6 +203,10 @@ export class _IblShadowsSpatialBlurPass {
             width: Math.max(1.0, Math.floor(this._engine.getRenderWidth() * scaleFactor)),
             height: Math.max(1.0, Math.floor(this._engine.getRenderHeight() * scaleFactor)),
         };
+        // Don't resize if the size is the same as the current size.
+        if (this._outputTexture.getSize().width === newSize.width && this._outputTexture.getSize().height === newSize.height) {
+            return;
+        }
         this._outputTexture.resize(newSize, false);
     }
 

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
@@ -324,19 +324,12 @@ export class _IblShadowsVoxelTracingPass {
         // Need to set all the textures first so that the effect gets created with the proper uniforms.
         this._setBindings(this._scene.activeCamera!);
 
-        // Don't start rendering until the first vozelization is done. Trigger these from the render pipeline.
-        // disable them during re-voxelization? For rapid re-voxelization, that might not be great.
+        // Don't start rendering until the first vozelization is done.
         this._renderPipeline.onVoxelizationCompleteObservable.addOnce(() => {
-            let counter = 0;
-            this._scene.onBeforeRenderObservable.add(() => {
-                counter = 0;
-            });
-            this._scene.onAfterRenderTargetsRenderObservable.add(() => {
-                if (++counter == 2) {
-                    if (this.enabled && this._outputTexture.isReady()) {
-                        if (this._setBindings(this._scene.activeCamera!)) {
-                            this._outputTexture.render();
-                        }
+            this._scene.geometryBufferRenderer!.getGBuffer().onAfterRenderObservable.add(() => {
+                if (this.enabled && this._outputTexture.isReady() && this._outputTexture.getEffect()?.isReady()) {
+                    if (this._setBindings(this._scene.activeCamera!)) {
+                        this._outputTexture.render();
                     }
                 }
             });


### PR DESCRIPTION
Okay, I've been investigating the issue where the shadow accumulation isn't working initially after loading the [IBL Shadow Demo playground](https://playground.babylonjs.com/#8R5SSE#618). On some loads, the shadows will appear noisy and not accumulate over multiple frames. Note that this issue never happens if you have Spector.js enabled, which is why I had such a hard time reproducing it originally.
The actual issue is that the uniform, `accumulationParameters` fails to be set with 
`WebGL: INVALID_OPERATION: uniform4f: location is not from the associated program`

Even though this fails, the uniform value is still cached and Babylon doesn't set the uniform again until the value changes. That is why accumulation appears to be disabled until you move the camera (which causes the uniform to change and update).
I have not been able to figure out _why_ the uniform set fails in the first place. It seems to be consistently the 3rd render that fails. Before that, the uniform is set successfully and, as far as I can tell, the shader program isn't updated after that point. And after the failure, the uniform can be set again.

The one thing that I was able to change to make the issue seem to go away was to put enough of a delay on the rendering of the accumulation pass. I've added logic to only start rendering the accumulation pass once the first voxelization is complete. This is fine since we can't render shadows until this is done anyway but I don't know why it should fix the problem.