### PR TITLE
Fix gpu picking instances when instances are disposed

### DIFF
--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -317,13 +317,14 @@ export class GPUPicker {
                 id++;
 
                 if (mesh.hasInstances) {
-                    const instances = (mesh as Mesh).instances;
-                    const colorData = this._generateColorData(instances.length, id, index, GPUPicker._TempColor.r, GPUPicker._TempColor.g, GPUPicker._TempColor.b, (i, id) => {
-                        const instance = instances[i];
+					const numInstances = (mesh as Mesh).instances.filter(instance => this._pickableMeshes.indexOf(instance) !== -1).length;
+					const allInstancesForPick = this._pickableMeshes.filter(m => m.isAnInstance && (m as InstancedMesh).sourceMesh === mesh);
+                    const colorData = this._generateColorData(numInstances, id, index, GPUPicker._TempColor.r, GPUPicker._TempColor.g, GPUPicker._TempColor.b, (i, id) => {
+                        const instance = allInstancesForPick[i];
                         this._idMap[id] = this._pickableMeshes.indexOf(instance);
                     });
 
-                    id += instances.length;
+                    id += numInstances;
                     const engine = mesh.getEngine();
 
                     const buffer = new VertexBuffer(engine, colorData, this._attributeName, false, false, 4, true);

--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -317,8 +317,8 @@ export class GPUPicker {
                 id++;
 
                 if (mesh.hasInstances) {
-					const numInstances = (mesh as Mesh).instances.filter(instance => this._pickableMeshes.indexOf(instance) !== -1).length;
-					const allInstancesForPick = this._pickableMeshes.filter(m => m.isAnInstance && (m as InstancedMesh).sourceMesh === mesh);
+                    const numInstances = (mesh as Mesh).instances.filter(instance => this._pickableMeshes.indexOf(instance) !== -1).length;
+                    const allInstancesForPick = this._pickableMeshes.filter(m => m.isAnInstance && (m as InstancedMesh).sourceMesh === mesh);
                     const colorData = this._generateColorData(numInstances, id, index, GPUPicker._TempColor.r, GPUPicker._TempColor.g, GPUPicker._TempColor.b, (i, id) => {
                         const instance = allInstancesForPick[i];
                         this._idMap[id] = this._pickableMeshes.indexOf(instance);


### PR DESCRIPTION
From: https://forum.babylonjs.com/t/removing-thin-instances-vs-gpupicker/57989/5

Disposing an instance fouls up the gpu picking result. Fixed correct mapping of color id of instances to pickable instances.