### PR TITLE
SH fix for compressed .PLY

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/gaussianSplatting.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/gaussianSplatting.vertex.fx
@@ -53,7 +53,7 @@ fn main(input : VertexInputs) -> FragmentInputs {
 
     var dir: vec3f = normalize(normWorldRot * (worldPos.xyz - scene.vEyePosition.xyz));
     dir *= vec3f(1.,1.,-1.); // convert to Babylon Space
-    vertexOutputs.vColor = vec4f(computeSH(splat, splat.color.xyz, dir), 1.0);
+    vertexOutputs.vColor = vec4f(computeSH(splat, splat.color.xyz, dir), splat.color.w);
 #else
     vertexOutputs.vColor = splat.color;
 #endif

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -491,6 +491,7 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
         const enum ElementMode {
             Vertex = 0,
             Chunk = 1,
+            SH = 2,
         }
 
         let chunkMode = ElementMode.Chunk;
@@ -507,8 +508,9 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
                 } else if (chunkMode == ElementMode.Vertex) {
                     vertexProperties.push({ name, type, offset: rowVertexOffset });
                     rowVertexOffset += offsets[type];
+                } else if (chunkMode == ElementMode.SH) {
+                    vertexProperties.push({ name, type, offset: rowVertexOffset });
                 }
-
                 if (!offsets[type]) {
                     Logger.Warn(`Unsupported property type: ${type}.`);
                 }
@@ -518,6 +520,8 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
                     chunkMode = ElementMode.Chunk;
                 } else if (type == "vertex") {
                     chunkMode = ElementMode.Vertex;
+                } else if (type == "sh") {
+                    chunkMode = ElementMode.SH;
                 }
             }
         }


### PR DESCRIPTION
followup https://forum.babylonjs.com/t/gaussian-splatting-seems-to-not-work-since-version-8/57903/4
waiting for feedback from @SonnyC56
Fixed CompressedPLY orientation and SH parsing
Fixed WGSL opacity with SH
