### PR TITLE
Use texture format when calling gl.readPixels

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.readTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.readTexture.ts
@@ -72,6 +72,7 @@ ThinEngine.prototype._readTexturePixelsSync = function (
     }
 
     let readType = texture.type !== undefined ? this._getWebGLTextureType(texture.type) : gl.UNSIGNED_BYTE;
+    let readFormat = texture.format !== undefined ? this._getInternalFormat(texture.format) " gl.RGBA;
 
     if (!noDataConversion) {
         switch (readType) {
@@ -96,7 +97,7 @@ ThinEngine.prototype._readTexturePixelsSync = function (
         this.flushFramebuffer();
     }
 
-    gl.readPixels(x, y, width, height, gl.RGBA, readType, <DataView>buffer);
+    gl.readPixels(x, y, width, height, readFormat, readType, <DataView>buffer);
     gl.bindFramebuffer(gl.FRAMEBUFFER, this._currentFramebuffer);
 
     return buffer;

--- a/packages/dev/core/src/Engines/Extensions/engine.readTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.readTexture.ts
@@ -72,7 +72,7 @@ ThinEngine.prototype._readTexturePixelsSync = function (
     }
 
     let readType = texture.type !== undefined ? this._getWebGLTextureType(texture.type) : gl.UNSIGNED_BYTE;
-    let readFormat = texture.format !== undefined ? this._getInternalFormat(texture.format) : gl.RGBA;
+    const readFormat = texture.format !== undefined ? this._getInternalFormat(texture.format) : gl.RGBA;
 
     if (!noDataConversion) {
         switch (readType) {

--- a/packages/dev/core/src/Engines/Extensions/engine.readTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.readTexture.ts
@@ -72,7 +72,7 @@ ThinEngine.prototype._readTexturePixelsSync = function (
     }
 
     let readType = texture.type !== undefined ? this._getWebGLTextureType(texture.type) : gl.UNSIGNED_BYTE;
-    let readFormat = texture.format !== undefined ? this._getInternalFormat(texture.format) " gl.RGBA;
+    let readFormat = texture.format !== undefined ? this._getInternalFormat(texture.format) : gl.RGBA;
 
     if (!noDataConversion) {
         switch (readType) {


### PR DESCRIPTION
This branch simply allows to use the internal gl texture format when calling gl.readPixels instead of the default gl.RGBA.
If the format for the texture is not defined, the fallback format gl.RGBA is then used.