### PR TITLE
Delay canvas creation after WorkbenchEditor has been mounted

### DIFF
--- a/packages/tools/guiEditor/src/guiEditor.ts
+++ b/packages/tools/guiEditor/src/guiEditor.ts
@@ -63,15 +63,9 @@ export class GUIEditor {
         globalState.hostWindow = hostElement.ownerDocument!.defaultView!;
         globalState.registerEventListeners();
 
-        const graphEditor = React.createElement(WorkbenchEditor, {
-            globalState,
-        });
-
-        const root = createRoot(hostElement);
-        root.render(graphEditor);
-        // create the middle workbench canvas
-        if (!globalState.guiTexture) {
-            setTimeout(async () => {
+        const onReady = async () => {
+            // create the middle workbench canvas
+            if (!globalState.guiTexture) {
                 globalState.workbench.createGUICanvas(embed);
                 if (options.currentSnippetToken) {
                     try {
@@ -80,8 +74,16 @@ export class GUIEditor {
                         //swallow and continue
                     }
                 }
-            });
-        }
+            }
+        };
+
+        const graphEditor = React.createElement(WorkbenchEditor, {
+            globalState,
+            onReady,
+        });
+
+        const root = createRoot(hostElement);
+        root.render(graphEditor);
 
         if (options.customLoadObservable) {
             options.customLoadObservable.add(() => {

--- a/packages/tools/guiEditor/src/workbenchEditor.tsx
+++ b/packages/tools/guiEditor/src/workbenchEditor.tsx
@@ -25,6 +25,7 @@ import type { Observer } from "core/Misc/observable";
 
 interface IGraphEditorProps {
     globalState: GlobalState;
+    onReady?: () => Promise<void>;
 }
 
 interface IGraphEditorState {
@@ -51,6 +52,7 @@ export class WorkbenchEditor extends React.Component<IGraphEditorProps, IGraphEd
         }
         document.addEventListener("keydown", this.addToolControls);
         document.addEventListener("keyup", this.removePressToolControls);
+        this.props.onReady?.();
     }
 
     override componentWillUnmount() {


### PR DESCRIPTION
Proposed solution for: https://forum.babylonjs.com/t/gui-babylonjs-com-is-not-working-on-safari-not-sure-if-other-browsers-effected/58089.