### PR TITLE
Pass "allowCanvas" into override serialize functions.

### DIFF
--- a/packages/dev/gui/src/2D/controls/button.ts
+++ b/packages/dev/gui/src/2D/controls/button.ts
@@ -182,9 +182,10 @@ export class Button extends Rectangle {
      * Serializes the current button
      * @param serializationObject defines the JSON serialized object
      * @param force force serialization even if isSerializable === false
+     * @param allowCanvas defines if the control is allowed to use a Canvas2D object to serialize
      */
-    public override serialize(serializationObject: any, force: boolean) {
-        super.serialize(serializationObject, force);
+    public override serialize(serializationObject: any, force: boolean, allowCanvas: boolean) {
+        super.serialize(serializationObject, force, allowCanvas);
         if (!this.isSerializable && !force) {
             return;
         }

--- a/packages/dev/gui/src/2D/controls/grid.ts
+++ b/packages/dev/gui/src/2D/controls/grid.ts
@@ -554,9 +554,10 @@ export class Grid extends Container {
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
      * @param force force serialization even if isSerializable === false
+     * @param allowCanvas defines if the control is allowed to use a Canvas2D object to serialize
      */
-    public override serialize(serializationObject: any, force: boolean) {
-        super.serialize(serializationObject, force);
+    public override serialize(serializationObject: any, force: boolean, allowCanvas: boolean) {
+        super.serialize(serializationObject, force, allowCanvas);
         if (!this.isSerializable && !force) {
             return;
         }

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -250,6 +250,7 @@ export class StackPanel extends Container {
      * Serializes the current control
      * @param serializationObject defined the JSON serialized object
      * @param force force serialization even if isSerializable === false
+     * @param allowCanvas defines if the control is allowed to use a Canvas2D object to serialize
      */
     public override serialize(serializationObject: any, force: boolean, allowCanvas: boolean) {
         super.serialize(serializationObject, force, allowCanvas);

--- a/packages/dev/gui/src/2D/controls/stackPanel.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.ts
@@ -251,8 +251,8 @@ export class StackPanel extends Container {
      * @param serializationObject defined the JSON serialized object
      * @param force force serialization even if isSerializable === false
      */
-    public override serialize(serializationObject: any, force: boolean) {
-        super.serialize(serializationObject, force);
+    public override serialize(serializationObject: any, force: boolean, allowCanvas: boolean) {
+        super.serialize(serializationObject, force, allowCanvas);
         if (!this.isSerializable && !force) {
             return;
         }


### PR DESCRIPTION
Fixes a bug with instances of BabylonJS running in a "Canvas-less" environment crashing when trying to serialize buttons.

Right now, when using the serialize() function in buttons, they ignore the "allowCanvas" parameter which was added in #15033 

Link to BabylonJS Forum discussion: 
https://forum.babylonjs.com/t/skip-canvas-being-used-during-control-serialize/49302/13?u=jamessimo

