### PR TITLE
Get WebAudio working on iOS when ringer switch is turned off

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -74,6 +74,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private _invalidFormats = new Set<string>();
     private readonly _isUsingOfflineAudioContext: boolean = false;
     private _listener: Nullable<_SpatialAudioListener> = null;
+    private readonly _listenerAutoUpdate: boolean = true;
+    private readonly _listenerMinUpdateTime: number = 0;
     private _mainOut: _WebAudioMainOut;
     private _pauseCalled = false;
     private _resumeOnInteraction = true;
@@ -81,8 +83,6 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private _resumeOnPauseRetryInterval = 1000;
     private _resumeOnPauseTimerId: any = null;
     private _resumePromise: Nullable<Promise<void>> = null;
-    private readonly _listenerAutoUpdate: boolean = true;
-    private readonly _listenerMinUpdateTime: number = 0;
     private _unmuteUI: Nullable<_WebAudioUnmuteUI> = null;
     private readonly _validFormats = new Set<string>();
     private _volume = 1;


### PR DESCRIPTION
WebAudio on iOS is disabled when the device's ringer switch is turned off. This is confusing for users because non-WebAudio audio plays when the ringer switch is off, which sets the expectation that WebAudio should work with the ringer off as well.

This change fixes the issue by creating a silent HTMLAudioElement and playing it when the audio engine receives a user gesture. This has the side effect of enabling WebAudio on iOS, even when the ring switch is off.