### PR TITLE
BVH loader `loadAsserContainerAsync` support

### DIFF
--- a/packages/dev/loaders/src/BVH/bvhFileLoader.ts
+++ b/packages/dev/loaders/src/BVH/bvhFileLoader.ts
@@ -72,7 +72,7 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
             return Promise.reject("BVH loader expects string data.");
         }
         try {
-            const skeleton = ReadBvh(data, scene, this._loadingOptions);
+            const skeleton = ReadBvh(data, scene, null, this._loadingOptions);
             return Promise.resolve({
                 meshes: [],
                 particleSystems: [],
@@ -82,7 +82,7 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
                 geometries: [],
                 lights: [],
                 spriteManagers: [],
-            });
+            } as ISceneLoaderAsyncResult);
         } catch (e) {
             return Promise.reject(e);
         }
@@ -116,7 +116,7 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         }
         const assetContainer = new AssetContainer(scene);
         try {
-            const skeleton = ReadBvh(data, scene, this._loadingOptions);
+            const skeleton = ReadBvh(data, scene, assetContainer, this._loadingOptions);
             assetContainer.skeletons.push(skeleton);
             return Promise.resolve(assetContainer);
         } catch (e) {

--- a/packages/dev/loaders/src/BVH/bvhLoader.ts
+++ b/packages/dev/loaders/src/BVH/bvhLoader.ts
@@ -8,6 +8,7 @@ import type { Scene } from "core/scene";
 import type { Nullable } from "core/types";
 import type { BVHLoadingOptions } from "./bvhLoadingOptions";
 import { Tools } from "core/Misc/tools";
+import { AssetContainer } from "core/assetContainer";
 
 const _XPosition = "Xposition";
 const _YPosition = "Yposition";
@@ -327,15 +328,19 @@ function ReadNode(lines: string[], firstLine: string, parent: Nullable<IBVHNode>
  * Reads a BVH file, returns a skeleton
  * @param text - The BVH file content
  * @param scene - The scene to add the skeleton to
+ * @param assetContainer - The asset container to add the skeleton to
  * @param loadingOptions - The loading options
  * @returns The skeleton
  */
-export function ReadBvh(text: string, scene: Scene, loadingOptions: BVHLoadingOptions): Skeleton {
+export function ReadBvh(text: string, scene: Scene, assetContainer: Nullable<AssetContainer>, loadingOptions: BVHLoadingOptions): Skeleton {
     const lines = text.split("\n");
 
     const { loopMode } = loadingOptions;
 
+    scene._blockEntityCollection = !!assetContainer;
     const skeleton = new Skeleton("", "", scene);
+    skeleton._parentContainer = assetContainer;
+    scene._blockEntityCollection = false;
 
     const context = new LoaderContext(skeleton);
     context.loopMode = loopMode;


### PR DESCRIPTION
from #16540

In the current BVH loader, the skeleton will be added to the scene twice when load with `loadAssetContainerAsync`.

To solve this, I applied the same approach as the gltf loader's Skeleton creation method.
https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts#L1378-L1381