### PR TITLE
Move back to old API till all use cases are clear

### DIFF
--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -2238,7 +2238,7 @@
         {
             "title": "custom-handling-of-materials-for-render-target-pass",
             "renderCount": 60,
-            "playgroundId": "#FIVL25#22"
+            "playgroundId": "#FIVL25#21"
         },
         {
             "title": "dissolve-effect-with-node-material-and-glow-layer",


### PR DESCRIPTION
The new change worked with standard http protocol, but is not back-compat with the file: protocol. In order to be 100% sure all use cases are covered, I am reverting the change for the time being.