### PR TITLE
Allow moving engines when using offline storage

### DIFF
--- a/packages/tools/babylonServer/src/sceneJs.js
+++ b/packages/tools/babylonServer/src/sceneJs.js
@@ -24,7 +24,12 @@ const runScene = async () => {
         engine.dispose();
         engine = undefined;
     }
-    engine = createEngine(); // Generate the BABYLON 3D engine
+    const createdEngine = createEngine(); // Generate the BABYLON 3D engine
+    if (createdEngine.then) {
+        engine = await createdEngine;
+    } else {
+        engine = createdEngine;
+    }
     if (playgroundId) {
         window.engine = engine;
         window.canvas = canvas;


### PR DESCRIPTION
There are a few issues addressed here.

The first - this issue cannot be reproduced on the playground because of the `indexOf(".babylon")`. In this case any file hostes on our CDNs will be "true", as it has `.babylonjs.com` in the URL.

The second - when NOT in the playground, WebGPU loads images as array buffers whereas WebGL engine loads images as Blobs. This is the way they are stored in the DB. So when WebGPU is the first engine, the data is stored as array buffer. Now, when moving to WebGL2 engine, the data will be loaded as ArrayBuffer and not a Blob.

This PR adds 2 fallbacks - if the file loaded is a blob and array buffer is needed, it does that, and if the image is loaded and requires a Blob, it will create a blob if the data is an ArrayBuffer.

Solving https://forum.babylonjs.com/t/switching-engines-vs-createobjecturl/58247?u=raananw