### PR TITLE
Fixes Area Lights for NME

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
@@ -96,6 +96,9 @@ preLightingInfo computeHemisphericPreLightingInfo(vec4 lightData, vec3 V, vec3 N
 #if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 #include<ltcHelperFunctions>
 
+uniform sampler2D areaLightsLTC1Sampler;
+uniform sampler2D areaLightsLTC2Sampler;
+
 preLightingInfo computeAreaPreLightingInfo(sampler2D ltc1, sampler2D ltc2, vec3 viewDirectionW, vec3 vNormal, vec3 vPosition, vec4 lightData, vec3 halfWidth, vec3 halfHeight, float roughness )
 {
 	preLightingInfo result;

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrFragmentSamplersDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrFragmentSamplersDeclaration.fx
@@ -85,11 +85,6 @@
     uniform sampler2D environmentBrdfSampler;
 #endif
 
-#if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
-    uniform sampler2D areaLightsLTC1Sampler;
-    uniform sampler2D areaLightsLTC2Sampler;
-#endif
-
 // SUBSURFACE
 #ifdef SUBSURFACE
     #ifdef SS_REFRACTION

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingSetupFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingSetupFunctions.fx
@@ -94,6 +94,11 @@ fn computeHemisphericPreLightingInfo(lightData: vec4f, V: vec3f, N: vec3f) -> pr
 #if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 #include<ltcHelperFunctions>
 
+var areaLightsLTC1SamplerSampler: sampler;
+var areaLightsLTC1Sampler: texture_2d<f32>;
+var areaLightsLTC2SamplerSampler: sampler;
+var areaLightsLTC2Sampler: texture_2d<f32>;
+
 fn computeAreaPreLightingInfo(ltc1: texture_2d<f32>, ltc1Sampler:sampler, ltc2:texture_2d<f32>, ltc2Sampler:sampler, viewDirectionW: vec3f, vNormal:vec3f, vPosition:vec3f, lightCenter:vec3f, halfWidth:vec3f,  halfHeight:vec3f, roughness:f32) -> preLightingInfo {
     var result: preLightingInfo;
 	var data: areaLightData = computeAreaLightSpecularDiffuseFresnel(ltc1, ltc1Sampler, ltc2, ltc2Sampler, viewDirectionW, vNormal, vPosition, lightCenter, halfWidth, halfHeight, roughness);

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrFragmentSamplersDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrFragmentSamplersDeclaration.fx
@@ -91,13 +91,6 @@
     var environmentBrdfSampler: texture_2d<f32>;
 #endif
 
-#if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
-    var areaLightsLTC1SamplerSampler: sampler;
-    var areaLightsLTC1Sampler: texture_2d<f32>;
-    var areaLightsLTC2SamplerSampler: sampler;
-    var areaLightsLTC2Sampler: texture_2d<f32>;
-#endif
-
 
 // SUBSURFACE
 #ifdef SUBSURFACE


### PR DESCRIPTION
The samplers required by Area Lights are placed in files that might not always be included when using NME. I'm moving them to always be paired with the appropriate area Lights functions to make sure we always have the samplers available.

Fixes issue reported from forum: https://forum.babylonjs.com/t/triplanar-node-material-area-lights-issue/58296