### PR TITLE
Clamp NdotV to 0.0 for diffuse roughness

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflection.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflection.fx
@@ -334,7 +334,7 @@
                     vec3 clampedAlbedo = clamp(surfaceAlbedo, vec3(0.1), vec3(1.0));
                     diffuseRoughnessTerm = diffuseBRDF_EON(clampedAlbedo, diffuseRoughness, NoL, NoV, LoV) * PI;
                     diffuseRoughnessTerm = diffuseRoughnessTerm / clampedAlbedo;
-                    diffuseRoughnessTerm = mix(vec3(1.0), diffuseRoughnessTerm, sqrt(min(mag * NoV, 1.0)));
+                    diffuseRoughnessTerm = mix(vec3(1.0), diffuseRoughnessTerm, sqrt(clamp(mag * NoV, 0.0, 1.0)));
                 #elif BASE_DIFFUSE_MODEL == BRDF_DIFFUSE_MODEL_BURLEY
                     vec3 H = (irradianceView + Ls)*0.5;
                     float VoH = dot(irradianceView, H);

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockReflection.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockReflection.fx
@@ -356,7 +356,7 @@
                     var clampedAlbedo: vec3f = clamp(surfaceAlbedo, vec3f(0.1), vec3f(1.0));
                     diffuseRoughnessTerm = diffuseBRDF_EON(clampedAlbedo, diffuseRoughness, NoL, NoV, LoV) * PI;
                     diffuseRoughnessTerm = diffuseRoughnessTerm / clampedAlbedo;
-                    diffuseRoughnessTerm = mix(vec3f(1.0), diffuseRoughnessTerm, sqrt(min(mag * NoV, 1.0f)));
+                    diffuseRoughnessTerm = mix(vec3f(1.0), diffuseRoughnessTerm, sqrt(clamp(mag * NoV, 0.0, 1.0f)));
                 #elif BASE_DIFFUSE_MODEL == BRDF_DIFFUSE_MODEL_BURLEY
                     var H: vec3f = (irradianceView + Ls) * 0.5f;
                     var VoH: f32 = dot(irradianceView, H);


### PR DESCRIPTION
For prefiltered IBL, using the "dominant direction" approximation for diffuse roughness, slightly negative NdotV values weren't being handled, resulting in artifacts.

<img width="85" alt="Screenshot 2025-05-07 at 1 54 25 PM" src="https://github.com/user-attachments/assets/cf10f92c-1199-4a8d-848e-fe011f8ca157" />

<img width="86" alt="Screenshot 2025-05-07 at 1 54 04 PM" src="https://github.com/user-attachments/assets/00e56376-05a0-4ad1-af31-4da6aae20137" />
