### PR TITLE
Add linear hex value to color picker when color is stored in linear mode

### DIFF
--- a/packages/dev/sharedUiComponents/src/colorPicker/colorPicker.scss
+++ b/packages/dev/sharedUiComponents/src/colorPicker/colorPicker.scss
@@ -150,12 +150,18 @@
             opacity: 0.5;
         }
     }
+    .color-picker-hex-row {
+        display: flex; /* Use flexbox to align items in a row */
+        flex-direction: row;
+        gap: 16px; /* Add spacing between the two hex pickers */
+        align-items: center; /* Align items vertically in the center */
+    }
 
     .color-picker-hex {
         grid-row: 4;
         grid-column: 1;
         display: grid;
-        grid-template-columns: 20% 80%;
+        grid-template-columns: 30% 70%;
         grid-template-rows: 100%;
 
         .color-picker-hex-label {

--- a/packages/dev/sharedUiComponents/src/colorPicker/colorPicker.tsx
+++ b/packages/dev/sharedUiComponents/src/colorPicker/colorPicker.tsx
@@ -197,7 +197,6 @@ export class ColorPicker extends React.Component<IColorPickerProps, IColorPicker
                         ></div>
                     </div>
                 </div>
-                <div className="color-picker-alpha"></div>
                 <div className="color-picker-rgb">
                     <div className="red">
                         <ColorComponentEntry
@@ -252,27 +251,51 @@ export class ColorPicker extends React.Component<IColorPickerProps, IColorPicker
                         />
                     </div>
                 </div>
-                <div className="color-picker-hex">
-                    <div className="color-picker-hex-label">Hex</div>
-                    <div className="color-picker-hex-value">
-                        <HexColor
-                            lockObject={this.props.lockObject}
-                            expectedLength={hasAlpha ? 8 : 6}
-                            value={colorHex}
-                            onChange={(value) => {
-                                if (hasAlpha) {
-                                    const color4 = Color4.FromHexString(value);
-                                    this.setState({ color: new Color3(color4.r, color4.g, color4.b), alpha: color4.a });
-                                } else {
-                                    this.setState({ color: Color3.FromHexString(value) });
-                                }
-                            }}
-                        />
+                <div className="color-picker-hex-row">
+                    <div className="color-picker-hex">
+                        <div className="color-picker-hex-label">Gamma Hex</div>
+                        <div className="color-picker-hex-value">
+                            <HexColor
+                                lockObject={this.props.lockObject}
+                                expectedLength={hasAlpha ? 8 : 6}
+                                value={colorHex}
+                                onChange={(value) => {
+                                    if (hasAlpha) {
+                                        const color4 = Color4.FromHexString(value);
+                                        this.setState({ color: new Color3(color4.r, color4.g, color4.b), alpha: color4.a });
+                                    } else {
+                                        this.setState({ color: Color3.FromHexString(value) });
+                                    }
+                                }}
+                            />
+                        </div>
                     </div>
+                    {this.props.linearhint && (
+                        <div className="color-picker-hex">
+                            <div className="color-picker-hex-label">Linear Hex</div>
+                            <div className="color-picker-hex-value">
+                                <HexColor
+                                    lockObject={this.props.lockObject}
+                                    expectedLength={hasAlpha ? 8 : 6}
+                                    value={Color4.FromHexString(colorHex).toLinearSpace().toHexString()}
+                                    onChange={(value) => {
+                                        if (hasAlpha) {
+                                            const color4 = Color4.FromHexString(value).toGammaSpace();
+                                            this.setState({ color: new Color3(color4.r, color4.g, color4.b), alpha: color4.a });
+                                        } else {
+                                            this.setState({ color: Color3.FromHexString(value).toGammaSpace() });
+                                        }
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    )}
                 </div>
+
                 {this.props.linearhint && (
                     <div className="color-picker-warning">
-                        (Note: color is stored in linear mode and was converted to gamma to be displayed here (toGammaSpace() / toLinearSpace()))
+                        (Note: This color is stored in linear but converted to gamma to be displayed here. To set color in code, use the linear hex above or use
+                        gamma.toLinearSpace()
                     </div>
                 )}
             </div>


### PR DESCRIPTION
Today if a material stores color in linear mode (Ex: PBR) the color picker will do an auto conversion to gamma mode. This results in confusion when copying the hex value into code (user needs to know to convert it to linear when passing the hex)

This change adds the linear hex in the UX as well as a more informative message instructing how to use the hex values.