### PR TITLE
Make explicit the need for engine renderloop for end frame, and fix some small typos

### DIFF
--- a/packages/dev/core/src/Culling/ray.core.ts
+++ b/packages/dev/core/src/Culling/ray.core.ts
@@ -187,7 +187,7 @@ export class Ray {
 
     /**
      * Checks if the ray intersects a box
-     * This does not account for the ray lenght by design to improve perfs.
+     * This does not account for the ray length by design to improve perfs.
      * @param box the bounding box to check
      * @param intersectionTreshold extra extend to be added to the BoundingBox in all direction
      * @returns if the box was hit

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -1120,7 +1120,7 @@ export abstract class AbstractEngine {
     public onBeginFrameObservable = new Observable<AbstractEngine>();
 
     /**
-     * Observable raised when the engine ends the current frame
+     * Observable raised when the engine ends the current frame (requires a render loop, e.g. 'engine.runRenderLoop(...)')
      */
     public onEndFrameObservable = new Observable<AbstractEngine>();
 
@@ -1313,7 +1313,7 @@ export abstract class AbstractEngine {
     }
 
     /**
-     * Activates an effect, making it the current one (ie. the one used for rendering)
+     * Activates an effect, making it the current one (i.e. the one used for rendering)
      * @param effect defines the effect to activate
      */
     public abstract enableEffect(effect: Nullable<Effect | DrawWrapper>): void;

--- a/packages/dev/materials/src/water/readme.md
+++ b/packages/dev/materials/src/water/readme.md
@@ -45,5 +45,5 @@ waterMaterial.bumpHeight = 0.3; // According to the bump map, represents the per
 waterMaterial.windDirection = new BABYLON.Vector2(1.0, 1.0); // The wind direction on the water surface (on width and height)
 waterMaterial.waterColor = new BABYLON.Color3(0.1, 0.1, 0.6); // Represents the water color mixed with the reflected and refracted world
 waterMaterial.colorBlendFactor = 2.0; // Factor to determine how the water color is blended with the reflected and refracted world
-waterMaterial.waveLength = 0.1; // The lenght of waves. With smaller values, more waves are generated
+waterMaterial.waveLength = 0.1; // The length of waves. With smaller values, more waves are generated
 ```


### PR DESCRIPTION
Make explicit the need for `engine.runRenderLoop(...)` as part of `engine.onEndFrameObservable`. 

Drive by fix of some small typos.