### PR TITLE
bug fix - "moveWithCollisions" method parameter slideOnCollide==false now moves mesh to NEAR the collision point, instead of AT the collision point

### DIFF
--- a/packages/dev/core/src/Collisions/collider.ts
+++ b/packages/dev/core/src/Collisions/collider.ts
@@ -504,12 +504,16 @@ export class Collider {
         // Handle straight movement up to collision
 
         pos.addToRef(vel, this._destinationPoint);
-        vel.scaleInPlace(this._nearestDistance / vel.length());
-
-        this._basePoint.addToRef(vel, pos);
 
         if (!slideOnCollide) {
+            // Move to one "close distance" less than the collision point to
+            // prevent any collision penetration from floating point inaccuracy
+            vel.scaleInPlace((this._nearestDistance - this._epsilon) / vel.length());
+            this._basePoint.addToRef(vel, pos);
             return;
+        } else {
+            vel.scaleInPlace(this._nearestDistance / vel.length());
+            this._basePoint.addToRef(vel, pos);
         }
 
         // Handle slide movement past collision


### PR DESCRIPTION
Issue - "moveWithCollisions" with the parameter slideOnCollide == false used to move the mesh up to the point of collision.  Due to floating point inaccuracy, this sometimes meant just outside, and sometimes just inside penetration with the collided mesh.  When just inside, subsequent calls to "moveWithCollisions" would snag on the mesh previously collided with.

Solution - "moveWithCollisions" with the parameter slideOnCollide == false now moves the mesh NOT up to the point of collision, but up to a point just a small distance short of that collision.  The small distance is based on "AbstractEngine.CollisionsEpsilon", the same distance considered "close" by other aspects of the collision system.
