### PR TITLE
Removed hard coded value for cameraGizmo

### DIFF
--- a/packages/dev/core/src/Gizmos/cameraGizmo.ts
+++ b/packages/dev/core/src/Gizmos/cameraGizmo.ts
@@ -113,9 +113,9 @@ export class CameraGizmo extends Gizmo implements ICameraGizmo {
             if (
                 this.gizmoLayer.utilityLayerScene.activeCamera &&
                 this.gizmoLayer.utilityLayerScene.activeCamera != camera &&
-                this.gizmoLayer.utilityLayerScene.activeCamera.maxZ < camera.maxZ * 1.5
+                this.gizmoLayer.utilityLayerScene.activeCamera.maxZ < camera.maxZ
             ) {
-                this.gizmoLayer.utilityLayerScene.activeCamera.maxZ = camera.maxZ * 1.5;
+                this.gizmoLayer.utilityLayerScene.activeCamera.maxZ = camera.maxZ;
             }
 
             if (!this.attachedNode!.reservedDataStore) {


### PR DESCRIPTION
I browsed history but could not get the reason for that particular bug. Why the fix was valid in the first place or the meaning of the 1.5 value.
This PR removes it in the hope bug will re-surface and a proper fix will be done.

https://forum.babylonjs.com/t/cameragizmo-changes-maxz-every-time-it-shows/57966/6