### PR TITLE
Sandbox: fix pan speed when model was loaded via drag and drop

### DIFF
--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -189,7 +189,7 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
     }
 
     prepareCamera() {
-        let camera = this._scene.activeCamera! as ArcRotateCamera;
+        let camera = this._scene.activeCamera as ArcRotateCamera;
         // Attach camera to canvas inputs
         if (!camera) {
             this._scene.createDefaultCamera(true);

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -235,6 +235,8 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
         }
 
         this._scene.activeCamera!.attachControl();
+
+        return this._scene.activeCamera! as ArcRotateCamera;
     }
 
     handleErrors() {
@@ -301,7 +303,7 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
 
         this.props.globalState.onSceneLoaded.notifyObservers({ scene: this._scene, filename: filename });
 
-        this.prepareCamera();
+        const camera = this.prepareCamera();
         this.prepareLighting();
         this.handleErrors();
 
@@ -309,7 +311,6 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
             this.props.globalState.showDebugLayer();
         }
 
-        const camera = this._scene.activeCamera! as ArcRotateCamera;
         this._scene.executeWhenReady(() => {
             this._engine.runRenderLoop(() => {
                 // Adapt the camera sensibility based on the distance to the object

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -112,8 +112,6 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
             },
             null,
             () => {
-                // additionalRenderLoopLogicCallback
-                // TODO: make this more efficient, and share code if possible with the other codepath
                 const camera = this._scene?.activeCamera as ArcRotateCamera;
                 if (camera) {
                     // Adapt the camera sensibility based on the distance to the object

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -113,7 +113,7 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
             null,
             () => {
                 // additionalRenderLoopLogicCallback
-                // TODO: make this more efficient
+                // TODO: make this more efficient, and share code if possible with the other codepath
                 const camera = this._scene?.activeCamera as ArcRotateCamera;
                 if (camera) {
                     // Adapt the camera sensibility based on the distance to the object

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -189,11 +189,12 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
     }
 
     prepareCamera() {
+        let camera = this._scene.activeCamera! as ArcRotateCamera;
         // Attach camera to canvas inputs
-        if (!this._scene.activeCamera) {
+        if (!camera) {
             this._scene.createDefaultCamera(true);
 
-            const camera = this._scene.activeCamera! as ArcRotateCamera;
+            camera = this._scene.activeCamera! as ArcRotateCamera;
 
             if (this._currentPluginName === "gltf" || this._currentPluginName === "obj") {
                 // glTF assets use a +Z forward convention while the default camera faces +Z. Rotate the camera to look at the front of the asset.
@@ -234,9 +235,8 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
             }
         }
 
-        this._scene.activeCamera!.attachControl();
-
-        return this._scene.activeCamera! as ArcRotateCamera;
+        camera.attachControl();
+        return camera;
     }
 
     handleErrors() {

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -60,7 +60,6 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
     private _currentPluginName?: string;
     private _engine: AbstractEngine;
     private _scene: Scene;
-    //private _camera: Nullable<Camera>;
     private _canvas: HTMLCanvasElement;
 
     public constructor(props: IRenderingZoneProps) {
@@ -234,8 +233,6 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
                 camera.setPosition(this.props.globalState.cameraPosition);
                 camera.lowerRadiusLimit = camera.radius;
             }
-
-            //this._camera = camera;
         }
 
         this._scene.activeCamera!.attachControl();


### PR DESCRIPTION
There were previously 2 possible render loops depending on if you loaded from a URL or drag & drop. The previous fix for camera pan speed only applied to one of them, so if you didn't use a URL and just dragged and dropped in, you wouldn't get the corrected behavior. This change consolidates down to one render loop for both scenarios, so the camera behavior only has to be defined in one place.  Specifically, FilesInput is no longer responsible for creating a render loop - it's now always done by renderingZone.tsx in either case.