### PR TITLE
Add WebAudio node and microphone input sound sources to AudioEngineV2

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -6,10 +6,7 @@ import type { _AbstractSoundInstance } from "./abstractSoundInstance";
 import { AbstractSoundSource, type ISoundSourceOptions } from "./abstractSoundSource";
 import type { PrimaryAudioBus } from "./audioBus";
 import type { AudioEngineV2 } from "./audioEngineV2";
-import type { _AbstractAudioSubGraph } from "./subNodes/abstractAudioSubGraph";
 import type { IVolumeAudioOptions } from "./subNodes/volumeAudioSubNode";
-import { _GetVolumeAudioProperty, _GetVolumeAudioSubNode } from "./subNodes/volumeAudioSubNode";
-import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
 
 /** @internal */
 export interface IAbstractSoundOptionsBase {

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -3,7 +3,7 @@ import type { Nullable } from "../../types";
 import { SoundState } from "../soundState";
 import { AudioNodeType } from "./abstractAudioNode";
 import type { _AbstractSoundInstance } from "./abstractSoundInstance";
-import { AbstractSoundSource, type IAbstractSoundSourceOptions } from "./abstractSoundSource";
+import { AbstractSoundSource, type ISoundSourceOptions } from "./abstractSoundSource";
 import type { PrimaryAudioBus } from "./audioBus";
 import type { AudioEngineV2 } from "./audioEngineV2";
 import type { _AbstractAudioSubGraph } from "./subNodes/abstractAudioSubGraph";
@@ -38,7 +38,7 @@ export interface IAbstractSoundPlayOptionsBase {
 /**
  * Options for creating a sound.
  */
-export interface IAbstractSoundOptions extends IAbstractSoundOptionsBase, IAbstractSoundPlayOptions, IAbstractSoundSourceOptions {
+export interface IAbstractSoundOptions extends IAbstractSoundOptionsBase, IAbstractSoundPlayOptions, ISoundSourceOptions {
     /**
      * The output bus for the sound. Defaults to `null`.
      * - If not set or `null`, the sound is automatically connected to the audio engine's default main bus.

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
@@ -4,9 +4,9 @@ import type { PrimaryAudioBus } from "./audioBus";
 import type { AudioEngineV2 } from "./audioEngineV2";
 import type { _AbstractAudioSubGraph } from "./subNodes/abstractAudioSubGraph";
 import { _GetVolumeAudioProperty, _GetVolumeAudioSubNode } from "./subNodes/volumeAudioSubNode";
-import type { AbstractStereoAudio, IStereoAudioOptions } from "./subProperties";
 import type { AbstractAudioAnalyzer, IAudioAnalyzerOptions } from "./subProperties/abstractAudioAnalyzer";
 import type { AbstractSpatialAudio, ISpatialAudioOptions } from "./subProperties/abstractSpatialAudio";
+import type { AbstractStereoAudio, IStereoAudioOptions } from "./subProperties/abstractStereoAudio";
 import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
 
 /**

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
@@ -12,7 +12,7 @@ import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
 /**
  * Options for creating a sound source.
  */
-export interface IAbstractSoundSourceOptions extends IAudioAnalyzerOptions, ISpatialAudioOptions, IStereoAudioOptions {
+export interface ISoundSourceOptions extends IAudioAnalyzerOptions, ISpatialAudioOptions, IStereoAudioOptions {
     /**
      * The output bus for the sound source. Defaults to `null`.
      * - If not set or `null`, the sound source is automatically connected to the audio engine's default main bus.

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
@@ -1,0 +1,117 @@
+import type { Nullable } from "../../types";
+import { AbstractNamedAudioNode, AudioNodeType } from "./abstractAudioNode";
+import type { PrimaryAudioBus } from "./audioBus";
+import type { AudioEngineV2 } from "./audioEngineV2";
+import type { _AbstractAudioSubGraph } from "./subNodes/abstractAudioSubGraph";
+import { _GetVolumeAudioProperty, _GetVolumeAudioSubNode } from "./subNodes/volumeAudioSubNode";
+import type { AbstractStereoAudio, IStereoAudioOptions } from "./subProperties";
+import type { AbstractAudioAnalyzer, IAudioAnalyzerOptions } from "./subProperties/abstractAudioAnalyzer";
+import type { AbstractSpatialAudio, ISpatialAudioOptions } from "./subProperties/abstractSpatialAudio";
+import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
+
+/**
+ * Options for creating a sound source.
+ */
+export interface IAbstractSoundSourceOptions extends IAudioAnalyzerOptions, ISpatialAudioOptions, IStereoAudioOptions {
+    /**
+     * The output bus for the sound source. Defaults to `null`.
+     * - If not set or `null`, the sound source is automatically connected to the audio engine's default main bus.
+     * @see {@link AudioEngineV2.defaultMainBus}
+     */
+    outBus: Nullable<PrimaryAudioBus>;
+}
+
+/**
+ * Abstract class representing a sound in the audio engine.
+ */
+export abstract class AbstractSoundSource extends AbstractNamedAudioNode {
+    private _analyzer: Nullable<AbstractAudioAnalyzer> = null;
+    private _outBus: Nullable<PrimaryAudioBus> = null;
+
+    protected abstract _subGraph: _AbstractAudioSubGraph;
+
+    protected constructor(name: string, engine: AudioEngineV2, nodeType: AudioNodeType = AudioNodeType.HAS_OUTPUTS) {
+        super(name, engine, nodeType);
+    }
+
+    /**
+     * The analyzer features of the sound.
+     */
+    public get analyzer(): AbstractAudioAnalyzer {
+        return this._analyzer ?? (this._analyzer = new _AudioAnalyzer(this._subGraph));
+    }
+
+    /**
+     * The output bus for the sound. Defaults to `null`.
+     * - If not set or `null`, the sound is automatically connected to the audio engine's default main bus.
+     * @see {@link AudioEngineV2.defaultMainBus}
+     */
+    public get outBus(): Nullable<PrimaryAudioBus> {
+        return this._outBus;
+    }
+
+    public set outBus(outBus: Nullable<PrimaryAudioBus>) {
+        if (this._outBus === outBus) {
+            return;
+        }
+
+        if (this._outBus) {
+            this._outBus.onDisposeObservable.removeCallback(this._onOutBusDisposed);
+            if (!this._disconnect(this._outBus)) {
+                throw new Error("Disconnect failed");
+            }
+        }
+
+        this._outBus = outBus;
+
+        if (this._outBus) {
+            this._outBus.onDisposeObservable.add(this._onOutBusDisposed);
+            if (!this._connect(this._outBus)) {
+                throw new Error("Connect failed");
+            }
+        }
+    }
+
+    /**
+     * The spatial features of the sound.
+     */
+    public abstract spatial: AbstractSpatialAudio;
+
+    /**
+     * The stereo features of the sound.
+     */
+    public abstract stereo: AbstractStereoAudio;
+
+    /**
+     * The output volume of the sound.
+     */
+    public get volume(): number {
+        return _GetVolumeAudioProperty(this._subGraph, "volume");
+    }
+
+    public set volume(value: number) {
+        // The volume subnode is created on initialization and should always exist.
+        const node = _GetVolumeAudioSubNode(this._subGraph);
+        if (!node) {
+            throw new Error("No volume subnode");
+        }
+
+        node.volume = value;
+    }
+
+    /**
+     * Releases associated resources.
+     */
+    public override dispose(): void {
+        super.dispose();
+
+        this._analyzer?.dispose();
+        this._analyzer = null;
+
+        this._outBus = null;
+    }
+
+    private _onOutBusDisposed = () => {
+        this._outBus = null;
+    };
+}

--- a/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
@@ -1,5 +1,6 @@
 import type { Nullable } from "../../types";
 import type { AbstractAudioNode, AbstractNamedAudioNode } from "./abstractAudioNode";
+import type { AbstractSoundSource, ISoundSourceOptions } from "./abstractSoundSource";
 import type { AudioBus, IAudioBusOptions } from "./audioBus";
 import type { IMainAudioBusOptions, MainAudioBus } from "./mainAudioBus";
 import type { IStaticSoundOptions, StaticSound } from "./staticSound";
@@ -168,6 +169,15 @@ export abstract class AudioEngineV2 {
     ): Promise<StaticSoundBuffer>;
 
     /**
+     * Creates a new sound source.
+     * @param name - The name of the sound.
+     * @param source - The source of the sound.
+     * @param options - The options for the sound source.
+     * @returns A promise that resolves to the created sound source.
+     */
+    public abstract createSoundSourceAsync(name: string, source: AudioNode, options?: Partial<ISoundSourceOptions>): Promise<AbstractSoundSource>;
+
+    /**
      * Creates a new streaming sound.
      * @param name - The name of the sound.
      * @param source - The source of the sound.
@@ -319,6 +329,24 @@ export async function CreateSoundBufferAsync(
 ): Promise<StaticSoundBuffer> {
     engine = _GetAudioEngine(engine);
     return engine.createSoundBufferAsync(source, options);
+}
+
+/**
+ * Creates a new sound source.
+ * @param name - The name of the sound.
+ * @param source - The source of the sound.
+ * @param options - The options for the sound source.
+ * @param engine - The audio engine.
+ * @returns A promise that resolves to the created sound source.
+ */
+export function CreateSoundSourceAsync(
+    name: string,
+    source: AudioNode,
+    options: Partial<ISoundSourceOptions> = {},
+    engine: Nullable<AudioEngineV2> = null
+): Promise<AbstractSoundSource> {
+    engine = _GetAudioEngine(engine);
+    return engine.createSoundSourceAsync(name, source, options);
 }
 
 /**

--- a/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
@@ -143,6 +143,15 @@ export abstract class AudioEngineV2 {
      * @returns A promise that resolves with the created main audio bus.
      */
     public abstract createMainBusAsync(name: string, options?: Partial<IMainAudioBusOptions>): Promise<MainAudioBus>;
+
+    /**
+     * Creates a new microphone sound source.
+     * @param name - The name of the sound.
+     * @param options - The options for the sound source.
+     * @returns A promise that resolves to the created sound source.
+     */
+    public abstract createMicrophoneSoundSourceAsync(name: string, options?: Partial<ISoundSourceOptions>): Promise<AbstractSoundSource>;
+
     /**
      * Creates a new static sound.
      * @param name - The name of the sound.
@@ -295,6 +304,18 @@ export function CreateAudioBusAsync(name: string, options: Partial<IAudioBusOpti
 export function CreateMainAudioBusAsync(name: string, options: Partial<IMainAudioBusOptions> = {}, engine: Nullable<AudioEngineV2> = null): Promise<MainAudioBus> {
     engine = _GetAudioEngine(engine);
     return engine.createMainBusAsync(name, options);
+}
+
+/**
+ * Creates a new microphone sound source.
+ * @param name - The name of the sound.
+ * @param options - The options for the sound source.
+ * @param engine - The audio engine.
+ * @returns A promise that resolves to the created sound source.
+ */
+export function CreateMicrophoneSoundSourceAsync(name: string, options: Partial<ISoundSourceOptions> = {}, engine: Nullable<AudioEngineV2> = null): Promise<AbstractSoundSource> {
+    engine = _GetAudioEngine(engine);
+    return engine.createMicrophoneSoundSourceAsync(name, options);
 }
 
 /**

--- a/packages/dev/core/src/AudioV2/webAudio/index.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/index.ts
@@ -1,5 +1,6 @@
 export * from "./webAudioBus";
 export * from "./webAudioEngine";
 export * from "./webAudioMainBus";
+export * from "./webAudioSoundSource";
 export * from "./webAudioStaticSound";
 export * from "./webAudioStreamingSound";

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -1,6 +1,7 @@
 import { Observable } from "../../Misc/observable";
 import type { Nullable } from "../../types";
 import type { AbstractNamedAudioNode } from "../abstractAudio/abstractAudioNode";
+import type { AbstractSoundSource, ISoundSourceOptions } from "../abstractAudio/abstractSoundSource";
 import type { AudioBus, IAudioBusOptions } from "../abstractAudio/audioBus";
 import type { AudioEngineV2State, IAudioEngineV2Options } from "../abstractAudio/audioEngineV2";
 import { AudioEngineV2 } from "../abstractAudio/audioEngineV2";
@@ -235,6 +236,16 @@ export class _WebAudioEngine extends AudioEngineV2 {
         await soundBuffer._initAsync(source, options);
 
         return soundBuffer;
+    }
+
+    /** @internal */
+    public async createSoundSourceAsync(name: string, source: AudioNode, options: Partial<ISoundSourceOptions> = {}): Promise<AbstractSoundSource> {
+        const module = await import("./webAudioSoundSource");
+
+        const soundSource = new module._WebAudioSoundSource(name, source, this);
+        await soundSource._initAsync(options);
+
+        return soundSource;
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -255,7 +255,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
     public async createSoundSourceAsync(name: string, source: AudioNode, options: Partial<ISoundSourceOptions> = {}): Promise<AbstractSoundSource> {
         const module = await import("./webAudioSoundSource");
 
-        const soundSource = new module._WebAudioSoundSource(name, source, this);
+        const soundSource = new module._WebAudioSoundSource(name, source, this, options);
         await soundSource._initAsync(options);
 
         return soundSource;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -212,6 +212,19 @@ export class _WebAudioEngine extends AudioEngineV2 {
     }
 
     /** @internal */
+    public async createMicrophoneSoundSourceAsync(name: string, options?: Partial<ISoundSourceOptions>): Promise<AbstractSoundSource> {
+        let mediaStream: MediaStream;
+
+        try {
+            mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (e) {
+            throw new Error("Unable to access microphone: " + e);
+        }
+
+        return this.createSoundSourceAsync(name, new MediaStreamAudioSourceNode(this._audioContext, { mediaStream }), options);
+    }
+
+    /** @internal */
     public async createSoundAsync(
         name: string,
         source: ArrayBuffer | AudioBuffer | StaticSoundBuffer | string | string[],

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -1,4 +1,4 @@
-import type { Nullable } from "core/types";
+import type { Nullable } from "../../types";
 import type { AbstractAudioNode } from "../abstractAudio";
 import type { ISoundSourceOptions } from "../abstractAudio/abstractSoundSource";
 import { AbstractSoundSource } from "../abstractAudio/abstractSoundSource";

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -101,7 +101,7 @@ export class _WebAudioSoundSource extends AbstractSoundSource {
 
     /** @internal */
     public getClassName(): string {
-        return "_WebAudioStaticSound";
+        return "_WebAudioSoundSource";
     }
 
     protected override _connect(node: IWebAudioInNode): boolean {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -1,0 +1,147 @@
+import type { Nullable } from "core/types";
+import type { AbstractAudioNode } from "../abstractAudio";
+import type { IAbstractSoundSourceOptions } from "../abstractAudio/abstractSoundSource";
+import { AbstractSoundSource } from "../abstractAudio/abstractSoundSource";
+import { _HasSpatialAudioOptions } from "../abstractAudio/subProperties/abstractSpatialAudio";
+import type { _SpatialAudio } from "../abstractAudio/subProperties/spatialAudio";
+import { _StereoAudio } from "../abstractAudio/subProperties/stereoAudio";
+import { _WebAudioBusAndSoundSubGraph } from "./subNodes/webAudioBusAndSoundSubGraph";
+import { _SpatialWebAudio } from "./subProperties/spatialWebAudio";
+import type { _WebAudioEngine } from "./webAudioEngine";
+import type { IWebAudioInNode } from "./webAudioNode";
+
+/** @internal */
+export class _WebAudioSoundSource extends AbstractSoundSource {
+    private _spatial: Nullable<_SpatialWebAudio> = null;
+    private readonly _spatialAutoUpdate: boolean = true;
+    private readonly _spatialMinUpdateTime: number = 0;
+    private _stereo: Nullable<_StereoAudio> = null;
+
+    protected _subGraph: _WebAudioBusAndSoundSubGraph;
+    protected _webAudioNode: AudioNode;
+
+    /** @internal */
+    public _audioContext: AudioContext | OfflineAudioContext;
+
+    /** @internal */
+    public override readonly engine: _WebAudioEngine;
+
+    /** @internal */
+    public constructor(name: string, webAudioNode: AudioNode, engine: _WebAudioEngine) {
+        super(name, engine);
+
+        this._audioContext = this.engine._audioContext;
+        this._webAudioNode = webAudioNode;
+
+        this._subGraph = new _WebAudioSoundSource._SubGraph(this);
+    }
+
+    /** @internal */
+    public async _initAsync(options: Partial<IAbstractSoundSourceOptions>): Promise<void> {
+        if (options.outBus) {
+            this.outBus = options.outBus;
+        } else {
+            await this.engine.isReadyPromise;
+            this.outBus = this.engine.defaultMainBus;
+        }
+
+        await this._subGraph.initAsync(options);
+
+        if (_HasSpatialAudioOptions(options)) {
+            this._initSpatialProperty();
+        }
+
+        this.engine._addNode(this);
+    }
+
+    /** @internal */
+    public get _inNode() {
+        return this._webAudioNode;
+    }
+
+    /** @internal */
+    public get _outNode() {
+        return this._subGraph._outNode;
+    }
+
+    /** @internal */
+    public override get spatial(): _SpatialAudio {
+        if (this._spatial) {
+            return this._spatial;
+        }
+        return this._initSpatialProperty();
+    }
+
+    /** @internal */
+    public override get stereo(): _StereoAudio {
+        return this._stereo ?? (this._stereo = new _StereoAudio(this._subGraph));
+    }
+
+    /** @internal */
+    public override dispose(): void {
+        super.dispose();
+
+        this._spatial?.dispose();
+        this._spatial = null;
+
+        this._stereo = null;
+
+        this._subGraph.dispose();
+
+        this.engine._removeNode(this);
+    }
+
+    /** @internal */
+    public getClassName(): string {
+        return "_WebAudioStaticSound";
+    }
+
+    protected override _connect(node: IWebAudioInNode): boolean {
+        const connected = super._connect(node);
+
+        if (!connected) {
+            return false;
+        }
+
+        // If the wrapped node is not available now, it will be connected later by the subgraph.
+        if (node._inNode) {
+            this._outNode?.connect(node._inNode);
+        }
+
+        return true;
+    }
+
+    protected override _disconnect(node: IWebAudioInNode): boolean {
+        const disconnected = super._disconnect(node);
+
+        if (!disconnected) {
+            return false;
+        }
+
+        if (node._inNode) {
+            this._outNode?.disconnect(node._inNode);
+        }
+
+        return true;
+    }
+
+    private _initSpatialProperty(): _SpatialAudio {
+        if (!this._spatial) {
+            this._spatial = new _SpatialWebAudio(this._subGraph, this._spatialAutoUpdate, this._spatialMinUpdateTime);
+        }
+
+        return this._spatial;
+    }
+
+    private static _SubGraph = class extends _WebAudioBusAndSoundSubGraph {
+        protected override _owner: _WebAudioSoundSource;
+
+        protected get _downstreamNodes(): Nullable<Set<AbstractAudioNode>> {
+            return this._owner._downstreamNodes ?? null;
+        }
+
+        protected get _upstreamNodes(): Nullable<Set<AbstractAudioNode>> {
+            return this._owner._upstreamNodes ?? null;
+        }
+    };
+}

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -27,8 +27,16 @@ export class _WebAudioSoundSource extends AbstractSoundSource {
     public override readonly engine: _WebAudioEngine;
 
     /** @internal */
-    public constructor(name: string, webAudioNode: AudioNode, engine: _WebAudioEngine) {
+    public constructor(name: string, webAudioNode: AudioNode, engine: _WebAudioEngine, options: Partial<ISoundSourceOptions>) {
         super(name, engine);
+
+        if (typeof options.spatialAutoUpdate === "boolean") {
+            this._spatialAutoUpdate = options.spatialAutoUpdate;
+        }
+
+        if (typeof options.spatialMinUpdateTime === "number") {
+            this._spatialMinUpdateTime = options.spatialMinUpdateTime;
+        }
 
         this._audioContext = this.engine._audioContext;
         this._webAudioNode = webAudioNode;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -143,5 +143,15 @@ export class _WebAudioSoundSource extends AbstractSoundSource {
         protected get _upstreamNodes(): Nullable<Set<AbstractAudioNode>> {
             return this._owner._upstreamNodes ?? null;
         }
+
+        protected override _onSubNodesChanged(): void {
+            super._onSubNodesChanged();
+
+            this._owner._inNode.disconnect();
+
+            if (this._owner._subGraph._inNode) {
+                this._owner._inNode.connect(this._owner._subGraph._inNode);
+            }
+        }
     };
 }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -1,6 +1,6 @@
 import type { Nullable } from "core/types";
 import type { AbstractAudioNode } from "../abstractAudio";
-import type { IAbstractSoundSourceOptions } from "../abstractAudio/abstractSoundSource";
+import type { ISoundSourceOptions } from "../abstractAudio/abstractSoundSource";
 import { AbstractSoundSource } from "../abstractAudio/abstractSoundSource";
 import { _HasSpatialAudioOptions } from "../abstractAudio/subProperties/abstractSpatialAudio";
 import type { _SpatialAudio } from "../abstractAudio/subProperties/spatialAudio";
@@ -37,7 +37,7 @@ export class _WebAudioSoundSource extends AbstractSoundSource {
     }
 
     /** @internal */
-    public async _initAsync(options: Partial<IAbstractSoundSourceOptions>): Promise<void> {
+    public async _initAsync(options: Partial<ISoundSourceOptions>): Promise<void> {
         if (options.outBus) {
             this.outBus = options.outBus;
         } else {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -257,7 +257,7 @@ export class _WebAudioStaticSoundBuffer extends StaticSoundBuffer {
                 if (format && this.engine.isFormatValid(format)) {
                     try {
                         await this._initFromUrlAsync(url);
-                    } catch (e) {
+                    } catch {
                         if (format && 0 < format.length) {
                             this.engine.flagInvalidFormat(format);
                         }

--- a/packages/tools/tests/test/audioV2/soundSource.spatial.test.ts
+++ b/packages/tools/tests/test/audioV2/soundSource.spatial.test.ts
@@ -1,0 +1,5 @@
+import { AddSharedAbstractAudioNodeSpatialTests } from "./shared/abstractAudioNode.spatial";
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+InitAudioV2Tests();
+AddSharedAbstractAudioNodeSpatialTests("SoundSource");

--- a/packages/tools/tests/test/audioV2/soundSource.stereo.test.ts
+++ b/packages/tools/tests/test/audioV2/soundSource.stereo.test.ts
@@ -1,0 +1,5 @@
+import { AddSharedAbstractAudioNodeStereoTests } from "./shared/abstractAudioNode.stereo";
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+InitAudioV2Tests();
+AddSharedAbstractAudioNodeStereoTests("SoundSource");

--- a/packages/tools/tests/test/audioV2/soundSource.volume.test.ts
+++ b/packages/tools/tests/test/audioV2/soundSource.volume.test.ts
@@ -1,0 +1,5 @@
+import { AddSharedAbstractAudioNodeVolumeTests } from "./shared/abstractAudioNode.volume";
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+InitAudioV2Tests();
+AddSharedAbstractAudioNodeVolumeTests("SoundSource");

--- a/packages/tools/tests/test/audioV2/utils/audioV2.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/audioV2.utils.ts
@@ -3,7 +3,7 @@ import { test, Page, TestInfo } from "@playwright/test";
 import { getGlobalConfig } from "@tools/test-tools";
 
 export type AudioContextType = "Realtime" | "Offline";
-export type AudioNodeType = "AudioBus" | "AudioEngineV2" | "MainAudioBus" | "StaticSound" | "StreamingSound";
+export type AudioNodeType = "AudioBus" | "AudioEngineV2" | "MainAudioBus" | "SoundSource" | "StaticSound" | "StreamingSound";
 export type SoundType = "StaticSound" | "StreamingSound";
 
 export const enum Channel {
@@ -52,7 +52,7 @@ declare global {
             audioNodeType: AudioNodeType,
             source: string | string[],
             options?: Partial<BABYLON.IStaticSoundOptions | BABYLON.IStreamingSoundOptions> | Partial<BABYLON.IAudioBusOptions>
-        ): Promise<{ sound: BABYLON.AbstractSound; outputNode: { spatial: BABYLON.AbstractSpatialAudio; stereo: BABYLON.AbstractStereoAudio; volume: number } }>;
+        ): Promise<{ sound: { play(): void; stop(): void }; outputNode: { spatial: BABYLON.AbstractSpatialAudio; stereo: BABYLON.AbstractStereoAudio; volume: number } }>;
         public static CreateAbstractSoundAsync(
             soundType: SoundType,
             source: string | string[],
@@ -64,6 +64,7 @@ declare global {
             options?: Partial<BABYLON.IWebAudioEngineOptions>
         ): Promise<BABYLON.AudioEngineV2>;
         public static CreateSoundAsync(source: string | string[] | BABYLON.StaticSoundBuffer, options?: Partial<BABYLON.IStaticSoundOptions>): Promise<BABYLON.StaticSound>;
+        public static CreateSoundSourceAsync(source: string, options?: Partial<BABYLON.ISoundSourceOptions>): Promise<BABYLON.AbstractSoundSource>;
         public static CreateStreamingSoundAsync(source: string | string[], options?: Partial<BABYLON.IStreamingSoundOptions>): Promise<BABYLON.StreamingSound>;
         public static GetPulseCountsAsync(): Promise<number[][]>;
         public static GetResultAsync(): Promise<AudioTestResult>;


### PR DESCRIPTION
This change enables using any WebAudio node as a sound source in AudioEngineV2, and uses this new feature to implement microphone input sound sources.