### PR TITLE
fix shaders uninitialized members

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
@@ -55,6 +55,10 @@ preLightingInfo computePointAndSpotPreLightingInfo(vec4 lightData, vec3 V, vec3 
     result.NdotLUnclamped = dot(N, result.L);
     result.NdotL = saturateEps(result.NdotLUnclamped);
 
+    result.LdotV = 0.;
+    result.roughness = 0.;
+    result.diffuseRoughness = 0.;
+    result.surfaceAlbedo = vec3(0.);
     return result;
 }
 
@@ -72,6 +76,11 @@ preLightingInfo computeDirectionalPreLightingInfo(vec4 lightData, vec3 V, vec3 N
     result.NdotLUnclamped = dot(N, result.L);
     result.NdotL = saturateEps(result.NdotLUnclamped);
     result.LdotV = dot(result.L, V);
+
+    result.LdotV = 0.;
+    result.roughness = 0.;
+    result.diffuseRoughness = 0.;
+    result.surfaceAlbedo = vec3(0.);
     return result;
 }
 
@@ -89,7 +98,10 @@ preLightingInfo computeHemisphericPreLightingInfo(vec4 lightData, vec3 V, vec3 N
         result.H = normalize(V + result.L);
         result.VdotH = saturate(dot(V, result.H));
     #endif
-
+    result.LdotV = 0.;
+    result.roughness = 0.;
+    result.diffuseRoughness = 0.;
+    result.surfaceAlbedo = vec3(0.);
     return result;
 }
 
@@ -114,6 +126,11 @@ preLightingInfo computeAreaPreLightingInfo(sampler2D ltc1, sampler2D ltc2, vec3 
     result.areaLightSpecular = data.Specular;
 #endif
 	result.areaLightDiffuse = data.Diffuse;
+
+    result.LdotV = 0.;
+    result.roughness = 0.;
+    result.diffuseRoughness = 0.;
+    result.surfaceAlbedo = vec3(0.);
 	return result;
 }
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
@@ -77,7 +77,6 @@ preLightingInfo computeDirectionalPreLightingInfo(vec4 lightData, vec3 V, vec3 N
     result.NdotL = saturateEps(result.NdotLUnclamped);
     result.LdotV = dot(result.L, V);
 
-    result.LdotV = 0.;
     result.roughness = 0.;
     result.diffuseRoughness = 0.;
     result.surfaceAlbedo = vec3(0.);


### PR DESCRIPTION
this commit https://github.com/BabylonJS/Babylon.js/commit/5366c302a1cd67d3528b67d06fabab4d70d82e3a#diff-8893fe3229ee62f0f24bbfb95ef900191b5b9b7e0eda83bb929f51da05c94eae introduced new struct members.
With D3D, uninitialized variables trigger an error with D3DCompile.
```
error X4000: variable 'result' used without having been completely initialized
```

Newer versions of spriv-cross have an option to fix that issue. But updating our fork will take time (like, a lot!).
Adding a traverser to visit Declarations need an update as well.

So, setting these new members to 0. BN Infrastructure update will catch these kind of issue.
