### PR TITLE
Adding handling of InstacedMesh inside of addAllAssetsToContainer that was missing.

### DIFF
--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -1265,6 +1265,8 @@ export class AssetContainer extends AbstractAssetContainer {
                     this.geometries.push(nodeToVisit.geometry);
                 }
                 this.meshes.push(nodeToVisit);
+            } else if (nodeToVisit instanceof InstancedMesh) {
+                this.meshes.push(nodeToVisit);
             } else if (nodeToVisit instanceof TransformNode) {
                 this.transformNodes.push(nodeToVisit);
             } else if (nodeToVisit instanceof Light) {


### PR DESCRIPTION
AssetContainer.addAllAssetsToContainer  was missing handling InstancedMeshes, so when one of those meshes existed in the node hierarchy, it was getting added to the transformNodes list instead of the meshes list.