### PR TITLE
Viewer: Fix ignored options bug & camera framing with multiple models

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -755,7 +755,7 @@ export class Viewer implements IDisposable {
 
     public constructor(
         private readonly _engine: AbstractEngine,
-        private readonly _options?: ViewerOptions
+        private readonly _options?: Readonly<ViewerOptions>
     ) {
         this._defaultHardwareScalingLevel = this._lastHardwareScalingLevel = this._engine.getHardwareScalingLevel();
         {
@@ -1101,7 +1101,7 @@ export class Viewer implements IDisposable {
             this._applyAnimationSpeed();
             this._selectAnimation(0, false);
             this.onSelectedMaterialVariantChanged.notifyObservers();
-            this._reframeCamera(true);
+            this._reframeCamera(true, model ? [model] : undefined);
             this.onModelChanged.notifyObservers(options?.source ?? null);
         }
     }

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1298,70 +1298,69 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
                     const detailsDeferred = new Deferred<ViewerDetails>();
                     // eslint-disable-next-line @typescript-eslint/no-this-alias
                     const viewerElement = this;
-                    const viewer = await this._createViewer(canvas, {
-                        get engine() {
-                            return viewerElement.engine ?? viewerElement._options.engine;
-                        },
-                        get autoSuspendRendering() {
-                            return !(viewerElement.hasAttribute("render-when-idle") || viewerElement._options.autoSuspendRendering === false);
-                        },
-                        get source() {
-                            return viewerElement.getAttribute("source") ?? viewerElement._options.source;
-                        },
-                        get environmentLighting() {
-                            return viewerElement.getAttribute("environment-lighting") ?? viewerElement.getAttribute("environment") ?? viewerElement._options.environmentLighting;
-                        },
-                        get environmentSkybox() {
-                            return viewerElement.getAttribute("environment-skybox") ?? viewerElement.getAttribute("environment") ?? viewerElement._options.environmentSkybox;
-                        },
-                        get environmentConfig() {
-                            return {
-                                intensity: coerceNumericAttribute(viewerElement.getAttribute("environment-intensity")) ?? viewerElement._options.environmentConfig?.intensity,
-                                blur: coerceNumericAttribute(viewerElement.getAttribute("skybox-blur")) ?? viewerElement._options.environmentConfig?.blur,
-                                rotation: coerceNumericAttribute(viewerElement.getAttribute("environment-rotation")) ?? viewerElement._options.environmentConfig?.rotation,
-                                visible: viewerElement.hasAttribute("environment-visible") || viewerElement._options.environmentConfig?.visible,
-                            };
-                        },
-                        get cameraOrbit() {
-                            return coerceCameraOrbitOrTarget(viewerElement.getAttribute("camera-orbit")) ?? viewerElement._options.cameraOrbit;
-                        },
-                        get cameraTarget() {
-                            return coerceCameraOrbitOrTarget(viewerElement.getAttribute("camera-target")) ?? viewerElement._options.cameraTarget;
-                        },
-                        get cameraAutoOrbit() {
-                            return {
-                                enabled: viewerElement.hasAttribute("camera-auto-orbit") || viewerElement._options.cameraAutoOrbit?.enabled,
-                                speed: coerceNumericAttribute(viewerElement.getAttribute("camera-auto-orbit-speed")) ?? viewerElement._options.cameraAutoOrbit?.speed,
-                                delay: coerceNumericAttribute(viewerElement.getAttribute("camera-auto-orbit-delay")) ?? viewerElement._options.cameraAutoOrbit?.delay,
-                            };
-                        },
-                        get animationAutoPlay() {
-                            return viewerElement.hasAttribute("animation-auto-play") || viewerElement._options.animationAutoPlay;
-                        },
-                        get animationSpeed() {
-                            return coerceNumericAttribute(viewerElement.getAttribute("animation-speed")) ?? viewerElement._options.animationSpeed;
-                        },
-                        get selectedAnimation() {
-                            return coerceNumericAttribute(viewerElement.getAttribute("selected-animation")) ?? viewerElement._options.selectedAnimation;
-                        },
-                        get postProcessing() {
-                            return {
-                                toneMapping: coerceToneMapping(viewerElement.getAttribute("tone-mapping")) ?? viewerElement._options.postProcessing?.toneMapping,
-                                contrast: coerceNumericAttribute(viewerElement.getAttribute("contrast")) ?? viewerElement._options.postProcessing?.contrast,
-                                exposure: coerceNumericAttribute(viewerElement.getAttribute("exposure")) ?? viewerElement._options.postProcessing?.exposure,
-                            };
-                        },
-                        get selectedMaterialVariant() {
-                            return viewerElement.getAttribute("material-variant") ?? viewerElement._options.selectedMaterialVariant;
-                        },
-                        onInitialized: (details) => {
-                            detailsDeferred.resolve(details);
-                        },
-                        onFaulted: () => {
-                            this._isFaultedBacking = true;
-                            this._tearDownViewer();
-                        },
-                    });
+                    const viewer = await this._createViewer(
+                        canvas,
+                        new Proxy(this._options, {
+                            get(target, prop: keyof CanvasViewerOptions) {
+                                switch (prop) {
+                                    case "engine":
+                                        return viewerElement.engine ?? target.engine;
+                                    case "autoSuspendRendering":
+                                        return !(viewerElement.hasAttribute("render-when-idle") || target.autoSuspendRendering === false);
+                                    case "source":
+                                        return viewerElement.getAttribute("source") ?? target.source;
+                                    case "environmentLighting":
+                                        return viewerElement.getAttribute("environment-lighting") ?? viewerElement.getAttribute("environment") ?? target.environmentLighting;
+                                    case "environmentSkybox":
+                                        return viewerElement.getAttribute("environment-skybox") ?? viewerElement.getAttribute("environment") ?? target.environmentSkybox;
+                                    case "environmentConfig":
+                                        return {
+                                            intensity: coerceNumericAttribute(viewerElement.getAttribute("environment-intensity")) ?? target.environmentConfig?.intensity,
+                                            blur: coerceNumericAttribute(viewerElement.getAttribute("skybox-blur")) ?? target.environmentConfig?.blur,
+                                            rotation: coerceNumericAttribute(viewerElement.getAttribute("environment-rotation")) ?? target.environmentConfig?.rotation,
+                                            visible: viewerElement.hasAttribute("environment-visible") || target.environmentConfig?.visible,
+                                        };
+                                    case "cameraOrbit":
+                                        return coerceCameraOrbitOrTarget(viewerElement.getAttribute("camera-orbit")) ?? target.cameraOrbit;
+                                    case "cameraTarget":
+                                        return coerceCameraOrbitOrTarget(viewerElement.getAttribute("camera-target")) ?? target.cameraTarget;
+                                    case "cameraAutoOrbit":
+                                        return {
+                                            enabled: viewerElement.hasAttribute("camera-auto-orbit") || target.cameraAutoOrbit?.enabled,
+                                            speed: coerceNumericAttribute(viewerElement.getAttribute("camera-auto-orbit-speed")) ?? target.cameraAutoOrbit?.speed,
+                                            delay: coerceNumericAttribute(viewerElement.getAttribute("camera-auto-orbit-delay")) ?? target.cameraAutoOrbit?.delay,
+                                        };
+                                    case "animationAutoPlay":
+                                        return viewerElement.hasAttribute("animation-auto-play") || target.animationAutoPlay;
+                                    case "animationSpeed":
+                                        return coerceNumericAttribute(viewerElement.getAttribute("animation-speed")) ?? target.animationSpeed;
+                                    case "selectedAnimation":
+                                        return coerceNumericAttribute(viewerElement.getAttribute("selected-animation")) ?? target.selectedAnimation;
+                                    case "postProcessing":
+                                        return {
+                                            toneMapping: coerceToneMapping(viewerElement.getAttribute("tone-mapping")) ?? target.postProcessing?.toneMapping,
+                                            contrast: coerceNumericAttribute(viewerElement.getAttribute("contrast")) ?? target.postProcessing?.contrast,
+                                            exposure: coerceNumericAttribute(viewerElement.getAttribute("exposure")) ?? target.postProcessing?.exposure,
+                                        };
+                                    case "selectedMaterialVariant":
+                                        return viewerElement.getAttribute("material-variant") ?? target.selectedMaterialVariant;
+                                    case "onInitialized":
+                                        return (details: Readonly<ViewerDetails>) => {
+                                            target.onInitialized?.(details);
+                                            detailsDeferred.resolve(details);
+                                        };
+                                    case "onFaulted":
+                                        return (error: Error) => {
+                                            viewerElement._isFaultedBacking = true;
+                                            target.onFaulted?.(error);
+                                            viewerElement._tearDownViewer();
+                                        };
+                                    default:
+                                        return target[prop];
+                                }
+                            },
+                        })
+                    );
                     const details = await detailsDeferred.promise;
 
                     this._viewerDetails = Object.assign(details, { viewer });
@@ -1514,7 +1513,7 @@ export class HTML3DElement extends ViewerElement {
      * Creates a new HTML3DElement.
      * @param options The options to use for the viewer. This is optional, and is only used when programmatically creating a viewer element.
      */
-    public constructor(options?: CanvasViewerOptions) {
+    public constructor(options?: Readonly<CanvasViewerOptions>) {
         super(Viewer, options);
     }
 }
@@ -1524,7 +1523,7 @@ export class HTML3DElement extends ViewerElement {
  * @param elementName The name of the custom element.
  * @param options The options to use for the viewer.
  */
-export function ConfigureCustomViewerElement(elementName: string, options: CanvasViewerOptions) {
+export function ConfigureCustomViewerElement(elementName: string, options: Readonly<CanvasViewerOptions>) {
     customElements.define(
         elementName,
         // eslint-disable-next-line jsdoc/require-jsdoc


### PR DESCRIPTION
This PR primarily is to address this forum issue: https://forum.babylonjs.com/t/babylon-viewer-v2/54317/82

The main problem is that a wrapper options object is constructed, but does not correctly handle options that are just pass-throughs (e.g. the ViewerElement doesn't do anything special with them, like map them to attributes, which is the case for `useRightHandedSystem` for example), and also does not correctly handle callback options (the callbacks passed in are overwritten by the ViewerElement's own callbacks). To fix this, I'm introducing an Options Proxy at the ViewerElement layer similar to what was done in the ViewerFactory layer. While Proxy may be slower for evaluating properties, this is not in the hot path (e.g. options are not evaluated on a per-frame basis), so this should be a fine usage of Proxy.

Once this change was in place, it exposed another issue, where the ViewerFactory layer was writing to one of the options, which calls the setter on the Proxy, which passes through to setting a property directly on the target object. This was not intentional, it was just leftover from how the options worked before the Proxy was introduced and got missed. To fix this, instead of overwriting the `onInitialized` options property in the ViewerFactory, it is handled in the options Proxy within the ViewerFactory. To make sure this kind of error doesn't happen again, I also made all the options readonly.

Finally this PR has one other unrelated but small fix, where in the case of multiple models, when one is made "active," the camera is reset to the bounds of that single model, not all loaded models.