### PR TITLE
Change return statements to continue in for loops

### DIFF
--- a/packages/dev/addons/src/htmlMesh/htmlMeshRenderer.ts
+++ b/packages/dev/addons/src/htmlMesh/htmlMeshRenderer.ts
@@ -626,7 +626,7 @@ export class HtmlMeshRenderer {
             const source = [this._inSceneElements?.container, this._overlayElements?.container];
             for (const container of source) {
                 if (!container) {
-                    return;
+                    continue;
                 }
                 // set the top and left of the css container to match the canvas
                 const containerParent = container.offsetParent as HTMLElement;

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlock.ts
@@ -484,7 +484,7 @@ export class NodeRenderGraphBlock {
             for (const port of serializedInputs) {
                 const input = this.inputs.find((i) => i.name === port.name);
                 if (!input) {
-                    return;
+                    continue;
                 }
                 if (port.displayName) {
                     input.displayName = port.displayName;

--- a/packages/dev/core/src/Physics/physicsHelper.ts
+++ b/packages/dev/core/src/Physics/physicsHelper.ts
@@ -782,7 +782,7 @@ class PhysicsUpdraftEvent {
             const impostors = (<PhysicsEngineV1>this._physicsEngine).getImpostors();
             for (const impostor of impostors) {
                 if (!this._getImpostorHitData(impostor, hitData)) {
-                    return;
+                    continue;
                 }
 
                 impostor.applyForce(hitData.force, hitData.contactPoint);
@@ -997,7 +997,7 @@ class PhysicsVortexEvent {
             const impostors = (<PhysicsEngineV1>this._physicsEngine).getImpostors();
             for (const impostor of impostors) {
                 if (!this._getImpostorHitData(impostor, hitData)) {
-                    return;
+                    continue;
                 }
 
                 impostor.applyForce(hitData.force, hitData.contactPoint);

--- a/packages/dev/core/src/Physics/v1/Plugins/oimoJSPlugin.ts
+++ b/packages/dev/core/src/Physics/v1/Plugins/oimoJSPlugin.ts
@@ -156,7 +156,7 @@ export class OimoJSPlugin implements IPhysicsEnginePlugin {
 
             for (const i of impostors) {
                 if (!i.object.rotationQuaternion) {
-                    return;
+                    continue;
                 }
                 //get the correct bounding box
                 const oldQuaternion = i.object.rotationQuaternion;

--- a/packages/dev/core/src/XR/features/WebXRHitTest.ts
+++ b/packages/dev/core/src/XR/features/WebXRHitTest.ts
@@ -242,7 +242,7 @@ export class WebXRHitTest extends WebXRAbstractFeature implements IWebXRHitTestF
         for (const hitTestResult of hitTestResults) {
             const pose = hitTestResult.getPose(this._xrSessionManager.referenceSpace);
             if (!pose) {
-                return;
+                continue;
             }
             const pos = pose.transform.position;
             const quat = pose.transform.orientation;

--- a/packages/dev/core/src/XR/motionController/webXRMicrosoftMixedRealityController.ts
+++ b/packages/dev/core/src/XR/motionController/webXRMicrosoftMixedRealityController.ts
@@ -121,20 +121,20 @@ export class WebXRMicrosoftMixedRealityController extends WebXRAbstractMotionCon
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i];
             if (this.disableAnimation) {
-                return;
+                continue;
             }
             if (id && this.rootMesh) {
                 const buttonMap = (<any>this._mapping.buttons)[id];
                 const buttonMeshName = buttonMap.rootNodeName;
                 if (!buttonMeshName) {
                     Logger.Log("Skipping unknown button at index: " + i + " with mapped name: " + id);
-                    return;
+                    continue;
                 }
 
                 const buttonMesh = this._getChildByName(this.rootMesh, buttonMeshName);
                 if (!buttonMesh) {
                     Logger.Warn("Missing button mesh with name: " + buttonMeshName);
-                    return;
+                    continue;
                 }
 
                 buttonMap.valueMesh = this._getImmediateChildByName(buttonMesh, this._mapping.defaultButton.valueNodeName);
@@ -163,21 +163,21 @@ export class WebXRMicrosoftMixedRealityController extends WebXRAbstractMotionCon
         for (const id of ids) {
             const comp = this.getComponent(id);
             if (!comp.isAxes()) {
-                return;
+                continue;
             }
 
             const axisArray = ["x-axis", "y-axis"];
 
             for (const axis of axisArray) {
                 if (!this.rootMesh) {
-                    return;
+                    continue;
                 }
                 const axisMap = (<any>this._mapping.axes)[id][axis];
 
                 const axisMesh = this._getChildByName(this.rootMesh, axisMap.rootNodeName);
                 if (!axisMesh) {
                     Logger.Warn("Missing axis mesh with name: " + axisMap.rootNodeName);
-                    return;
+                    continue;
                 }
 
                 axisMap.valueMesh = this._getImmediateChildByName(axisMesh, this._mapping.defaultAxis.valueNodeName);

--- a/packages/dev/core/src/XR/motionController/webXRProfiledMotionController.ts
+++ b/packages/dev/core/src/XR/motionController/webXRProfiledMotionController.ts
@@ -152,7 +152,7 @@ export class WebXRProfiledMotionController extends WebXRAbstractMotionController
         for (const id of ids) {
             const component = this.getComponent(id);
             if (!component.hasChanges) {
-                return;
+                continue;
             }
             const meshes = this._buttonMeshMapping[id];
             const componentInLayout = this.layout.components[id];

--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -729,89 +729,89 @@ export class AssetContainer extends AbstractAssetContainer {
         const addedNodes: Node[] = [];
         for (const o of this.cameras) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addCamera(o);
             addedNodes.push(o);
         }
         for (const o of this.lights) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addLight(o);
             addedNodes.push(o);
         }
         for (const o of this.meshes) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addMesh(o);
             addedNodes.push(o);
         }
         for (const o of this.skeletons) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addSkeleton(o);
         }
         for (const o of this.animations) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addAnimation(o);
         }
         for (const o of this.animationGroups) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addAnimationGroup(o);
         }
         for (const o of this.multiMaterials) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addMultiMaterial(o);
         }
         for (const o of this.materials) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addMaterial(o);
         }
         for (const o of this.morphTargetManagers) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addMorphTargetManager(o);
         }
         for (const o of this.geometries) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addGeometry(o);
         }
         for (const o of this.transformNodes) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addTransformNode(o);
             addedNodes.push(o);
         }
         for (const o of this.actionManagers) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addActionManager(o);
         }
         for (const o of this.textures) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addTexture(o);
         }
         for (const o of this.reflectionProbes) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.addReflectionProbe(o);
         }
@@ -857,85 +857,85 @@ export class AssetContainer extends AbstractAssetContainer {
     public removeFromScene(predicate: Nullable<(entity: any) => boolean> = null) {
         for (const o of this.cameras) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeCamera(o);
         }
         for (const o of this.lights) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeLight(o);
         }
         for (const o of this.meshes) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeMesh(o, true);
         }
         for (const o of this.skeletons) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeSkeleton(o);
         }
         for (const o of this.animations) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeAnimation(o);
         }
         for (const o of this.animationGroups) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeAnimationGroup(o);
         }
         for (const o of this.multiMaterials) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeMultiMaterial(o);
         }
         for (const o of this.materials) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeMaterial(o);
         }
         for (const o of this.morphTargetManagers) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeMorphTargetManager(o);
         }
         for (const o of this.geometries) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeGeometry(o);
         }
         for (const o of this.transformNodes) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeTransformNode(o);
         }
         for (const o of this.actionManagers) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeActionManager(o);
         }
         for (const o of this.textures) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeTexture(o);
         }
         for (const o of this.reflectionProbes) {
             if (predicate && !predicate(o)) {
-                return;
+                continue;
             }
             this.scene.removeReflectionProbe(o);
         }

--- a/packages/dev/gui/src/2D/controls/multiLine.ts
+++ b/packages/dev/gui/src/2D/controls/multiLine.ts
@@ -200,7 +200,7 @@ export class MultiLine extends Control {
 
         for (const point of this._points) {
             if (!point) {
-                return;
+                continue;
             }
 
             if (first) {
@@ -230,7 +230,7 @@ export class MultiLine extends Control {
 
         for (const point of this._points) {
             if (!point) {
-                return;
+                continue;
             }
 
             point.translate();

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/lights/commonShadowLightPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/lights/commonShadowLightPropertyGridComponent.tsx
@@ -41,7 +41,7 @@ export class CommonShadowLightPropertyGridComponent extends React.Component<ICom
 
         for (const m of scene.meshes) {
             if (m.infiniteDistance) {
-                return;
+                continue;
             }
             generator.addShadowCaster(m);
             if (!m.isAnInstance) {

--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/nodeMaterialPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/materials/nodeMaterialPropertyGridComponent.tsx
@@ -184,7 +184,7 @@ export class NodeMaterialPropertyGridComponent extends React.Component<INodeMate
         const namedGroups: string[] = [];
         for (const block of configurableInputBlocks) {
             if (!block.groupInInspector) {
-                return;
+                continue;
             }
 
             if (namedGroups.indexOf(block.groupInInspector) === -1) {

--- a/packages/dev/inspector/src/components/graph/canvasGraphService.ts
+++ b/packages/dev/inspector/src/components/graph/canvasGraphService.ts
@@ -441,7 +441,7 @@ export class CanvasGraphService {
         for (let idOffset = 0; idOffset < this.datasets.ids.length; idOffset++) {
             const id = this.datasets.ids[idOffset];
             if (this.metadata.get(id)?.hidden) {
-                return;
+                continue;
             }
 
             const valueMinMax = this._getMinMax(bounds, idOffset);
@@ -883,13 +883,13 @@ export class CanvasGraphService {
         for (let idOffset = 0; idOffset < this.datasets.ids.length; idOffset++) {
             const id = this.datasets.ids[idOffset];
             if (this.metadata.get(id)?.hidden) {
-                return;
+                continue;
             }
 
             const numPoints = this.datasets.data.at(this.datasets.startingIndices.at(closestIndex) + PerformanceViewerCollector.NumberOfPointsOffset);
 
             if (idOffset >= numPoints) {
-                return;
+                continue;
             }
 
             const valueAtClosestPointIndex = this.datasets.startingIndices.at(closestIndex) + PerformanceViewerCollector.SliceDataOffset + idOffset;
@@ -905,7 +905,7 @@ export class CanvasGraphService {
             }
 
             if (!valueMinMax) {
-                return;
+                continue;
             }
 
             actualTimestamp = this.datasets.data.at(this.datasets.startingIndices.at(closestIndex));
@@ -923,7 +923,7 @@ export class CanvasGraphService {
             numberOfTooltipItems++;
             // don't process rest if we aren't panned.
             if (!this._position) {
-                return;
+                continue;
             }
 
             // initially distance between closest data point and mouse point.

--- a/packages/dev/sharedUiComponents/src/tabs/propertyGrids/gui/linePropertyGridComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/tabs/propertyGrids/gui/linePropertyGridComponent.tsx
@@ -28,7 +28,7 @@ export class LinePropertyGridComponent extends React.Component<ILinePropertyGrid
             const int = parseInt(v);
 
             if (isNaN(int)) {
-                return;
+                continue;
             }
 
             line.dash.push(int);

--- a/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/linePropertyGridComponent.tsx
+++ b/packages/tools/guiEditor/src/components/propertyTab/propertyGrids/gui/linePropertyGridComponent.tsx
@@ -39,7 +39,7 @@ export class LinePropertyGridComponent extends React.Component<ILinePropertyGrid
                 const int = parseInt(v);
 
                 if (isNaN(int)) {
-                    return;
+                    continue;
                 }
 
                 line.dash.push(int);


### PR DESCRIPTION
Following up on PR #16513 that switched from forEach to for loops.

Replace return statements with continue in various loops to ensure that the iteration continues instead of exiting the function. 