### PR TITLE
Skip SVG processing if no window/document or SVG support.

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -625,10 +625,8 @@ export class Image extends Control {
      * @returns the svg
      */
     private _svgCheck(value: string): string {
-         // Skip SVG processing if no window/document or SVG support
-        if (typeof window === "undefined" || 
-            typeof document === "undefined" || 
-            !window.SVGSVGElement) {
+        // Skip SVG processing if no window/document or SVG support
+        if (typeof window === "undefined" || typeof document === "undefined" || !window.SVGSVGElement) {
             return value;
         }
 

--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -625,6 +625,13 @@ export class Image extends Control {
      * @returns the svg
      */
     private _svgCheck(value: string): string {
+         // Skip SVG processing if no window/document or SVG support
+        if (typeof window === "undefined" || 
+            typeof document === "undefined" || 
+            !window.SVGSVGElement) {
+            return value;
+        }
+
         if (window.SVGSVGElement && value.search(/(\.svg|\.svg?[?|#].*)$/gi) !== -1 && value.indexOf("#") === value.lastIndexOf("#")) {
             this._isSVG = true;
             const svgsrc = value.split("#")[0];


### PR DESCRIPTION
In edge cases where BabylonJS is being ran in a Windowless/DOM-less environment, creation of images fails due to the "Check SVG" requiring a DOM to work. Just added a catch to find if you don't have a window and return the same value. 