### PR TITLE
Flow graph Cancel delay fix

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.ts
@@ -27,7 +27,7 @@ export class FlowGraphCancelDelayBlock extends FlowGraphExecutionBlockWithOutSig
         if (delayIndex <= 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
             return this._reportError(context, "Invalid delay index");
         }
-        const timers = context._getExecutionVariable(this, "pendingDelays", [] as AdvancedTimer[]);
+        const timers = context._getGlobalContextVariable("pendingDelays", [] as AdvancedTimer[]);
         const timer = timers[delayIndex];
         if (timer) {
             timer.dispose();

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.ts
@@ -4,9 +4,11 @@ import type { IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
 import type { FlowGraphContext } from "../../../flowGraphContext";
 import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";
 import { FlowGraphExecutionBlockWithOutSignal } from "../../../flowGraphExecutionBlockWithOutSignal";
-import { RichTypeNumber } from "../../../flowGraphRichTypes";
+import { RichTypeFlowGraphInteger } from "../../../flowGraphRichTypes";
 import type { FlowGraphSignalConnection } from "../../../flowGraphSignalConnection";
 import { FlowGraphBlockNames } from "../../flowGraphBlockNames";
+import type { FlowGraphInteger } from "core/FlowGraph/CustomTypes/flowGraphInteger";
+import { getNumericValue } from "core/FlowGraph/utils";
 
 /**
  * This block cancels a delay that was previously scheduled.
@@ -15,15 +17,15 @@ export class FlowGraphCancelDelayBlock extends FlowGraphExecutionBlockWithOutSig
     /**
      * Input connection: The index value of the scheduled activation to be cancelled.
      */
-    public readonly delayIndex: FlowGraphDataConnection<number>;
+    public readonly delayIndex: FlowGraphDataConnection<FlowGraphInteger>;
 
     constructor(config?: IFlowGraphBlockConfiguration) {
         super(config);
-        this.delayIndex = this.registerDataInput("delayIndex", RichTypeNumber);
+        this.delayIndex = this.registerDataInput("delayIndex", RichTypeFlowGraphInteger);
     }
 
     public _execute(context: FlowGraphContext, _callingSignal: FlowGraphSignalConnection): void {
-        const delayIndex = this.delayIndex.getValue(context);
+        const delayIndex = getNumericValue(this.delayIndex.getValue(context));
         if (delayIndex <= 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
             return this._reportError(context, "Invalid delay index");
         }

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphSetDelayBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphSetDelayBlock.ts
@@ -2,12 +2,13 @@ import { FlowGraphAsyncExecutionBlock } from "../../../flowGraphAsyncExecutionBl
 import type { IFlowGraphBlockConfiguration } from "../../../flowGraphBlock";
 import type { FlowGraphContext } from "../../../flowGraphContext";
 import type { FlowGraphDataConnection } from "../../../flowGraphDataConnection";
-import { RichTypeNumber } from "../../../flowGraphRichTypes";
+import { RichTypeFlowGraphInteger, RichTypeNumber } from "../../../flowGraphRichTypes";
 import type { FlowGraphSignalConnection } from "../../../flowGraphSignalConnection";
 import { AdvancedTimer } from "../../../../Misc/timer";
 import { Logger } from "../../../../Misc/logger";
 import { FlowGraphBlockNames } from "../../flowGraphBlockNames";
 import { RegisterClass } from "core/Misc/typeStore";
+import { FlowGraphInteger } from "core/FlowGraph/CustomTypes/flowGraphInteger";
 
 /**
  * Block that sets a delay in seconds before activating the output signal.
@@ -30,13 +31,13 @@ export class FlowGraphSetDelayBlock extends FlowGraphAsyncExecutionBlock {
     /**
      * Output connection: The last delay index that was set.
      */
-    public readonly lastDelayIndex: FlowGraphDataConnection<number>;
+    public readonly lastDelayIndex: FlowGraphDataConnection<FlowGraphInteger>;
 
     constructor(config?: IFlowGraphBlockConfiguration) {
         super(config);
         this.cancel = this._registerSignalInput("cancel");
         this.duration = this.registerDataInput("duration", RichTypeNumber);
-        this.lastDelayIndex = this.registerDataOutput("lastDelayIndex", RichTypeNumber, -1);
+        this.lastDelayIndex = this.registerDataOutput("lastDelayIndex", RichTypeFlowGraphInteger, new FlowGraphInteger(-1));
     }
 
     public _preparePendingTasks(context: FlowGraphContext): void {
@@ -63,7 +64,7 @@ export class FlowGraphSetDelayBlock extends FlowGraphAsyncExecutionBlock {
         });
         timer.start();
         const newIndex = lastDelayIndex + 1;
-        this.lastDelayIndex.setValue(newIndex, context);
+        this.lastDelayIndex.setValue(new FlowGraphInteger(newIndex), context);
         context._setGlobalContextVariable("lastDelayIndex", newIndex);
 
         timers[newIndex] = timer;
@@ -77,7 +78,7 @@ export class FlowGraphSetDelayBlock extends FlowGraphAsyncExecutionBlock {
             timer?.dispose();
         }
         context._deleteExecutionVariable(this, "pendingDelays");
-        this.lastDelayIndex.setValue(-1, context);
+        this.lastDelayIndex.setValue(new FlowGraphInteger(-1), context);
         this._updateGlobalTimers(context);
     }
 

--- a/packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts
@@ -582,7 +582,7 @@ describe("Flow Nodes", () => {
         // wait for the delay to pass
         await new Promise((resolve) => setTimeout(resolve, duration * 1000 + 100));
         expect(log).toHaveBeenCalledTimes(1);
-        expect(log).toHaveBeenCalledWith(0);
+        expect(log).toHaveBeenCalledWith({ value: 0 });
     });
 
     // flowDelay with NaN as duration - should activate the error signal


### PR DESCRIPTION
1. Index endpoints should be integers
2. Pending delays are now a global array so that cancel delay could access all of them.