### PR TITLE
Let Mesh.bakeTransformIntoVertices use DeepImmutable<Matrix>

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -7,7 +7,7 @@ import { DeepCopier } from "../Misc/deepCopier";
 import { Tags } from "../Misc/tags";
 import type { Coroutine } from "../Misc/coroutine";
 import { runCoroutineSync, runCoroutineAsync, createYieldingScheduler } from "../Misc/coroutine";
-import type { Nullable, FloatArray, IndicesArray } from "../types";
+import type { Nullable, FloatArray, IndicesArray, DeepImmutable } from "../types";
 import { Camera } from "../Cameras/camera";
 import type { Scene } from "../scene";
 import { ScenePerformancePriority } from "../scene";
@@ -2972,7 +2972,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/mesh/transforms/center_origin/bakingTransforms
      * @returns the current mesh
      */
-    public bakeTransformIntoVertices(transform: Matrix): Mesh {
+    public bakeTransformIntoVertices(transform: DeepImmutable<Matrix>): Mesh {
         // Position
         if (!this.isVerticesDataPresent(VertexBuffer.PositionKind)) {
             return this;


### PR DESCRIPTION
I ran into a use case where I would like to transform a mesh by a `DeepImmutable<Matrix>`, but the type checker complains because it does not satisfy `Matrix`.

However, `Mesh.bakeTransformIntoVertices(transform)` does not need the Matrix to be mutable.

This PR simply allows a `DeepImmutable<Matrix>` to be passed to `Mesh.bakeTransformIntoVertices(transform)`