### PR TITLE
Dispose all entities of an AssetContainer

### DIFF
--- a/packages/dev/core/src/assetContainer.ts
+++ b/packages/dev/core/src/assetContainer.ts
@@ -945,79 +945,79 @@ export class AssetContainer extends AbstractAssetContainer {
      * Disposes all the assets in the container
      */
     public dispose() {
-        const cameras = this.cameras;
+        const cameras = this.cameras.slice(0);
         for (const camera of cameras) {
             camera.dispose();
         }
         this.cameras.length = 0;
 
-        const lights = this.lights;
+        const lights = this.lights.slice(0);
         for (const light of lights) {
             light.dispose();
         }
         this.lights.length = 0;
 
-        const meshes = this.meshes;
+        const meshes = this.meshes.slice(0);
         for (const mesh of meshes) {
             mesh.dispose();
         }
         this.meshes.length = 0;
 
-        const skeletons = this.skeletons;
+        const skeletons = this.skeletons.slice(0);
         for (const skeleton of skeletons) {
             skeleton.dispose();
         }
         this.skeletons.length = 0;
 
-        const animationGroups = this.animationGroups;
+        const animationGroups = this.animationGroups.slice(0);
         for (const animationGroup of animationGroups) {
             animationGroup.dispose();
         }
         this.animationGroups.length = 0;
 
-        const multiMaterials = this.multiMaterials;
+        const multiMaterials = this.multiMaterials.slice(0);
         for (const multiMaterial of multiMaterials) {
             multiMaterial.dispose();
         }
         this.multiMaterials.length = 0;
 
-        const materials = this.materials;
+        const materials = this.materials.slice(0);
         for (const material of materials) {
             material.dispose();
         }
         this.materials.length = 0;
 
-        const geometries = this.geometries;
+        const geometries = this.geometries.slice(0);
         for (const geometry of geometries) {
             geometry.dispose();
         }
         this.geometries.length = 0;
 
-        const transformNodes = this.transformNodes;
+        const transformNodes = this.transformNodes.slice(0);
         for (const transformNode of transformNodes) {
             transformNode.dispose();
         }
         this.transformNodes.length = 0;
 
-        const actionManagers = this.actionManagers;
+        const actionManagers = this.actionManagers.slice(0);
         for (const actionManager of actionManagers) {
             actionManager.dispose();
         }
         this.actionManagers.length = 0;
 
-        const textures = this.textures;
+        const textures = this.textures.slice(0);
         for (const texture of textures) {
             texture.dispose();
         }
         this.textures.length = 0;
 
-        const reflectionProbes = this.reflectionProbes;
+        const reflectionProbes = this.reflectionProbes.slice(0);
         for (const reflectionProbe of reflectionProbes) {
             reflectionProbe.dispose();
         }
         this.reflectionProbes.length = 0;
 
-        const morphTargetManagers = this.morphTargetManagers;
+        const morphTargetManagers = this.morphTargetManagers.slice(0);
         for (const morphTargetManager of morphTargetManagers) {
             morphTargetManager.dispose();
         }

--- a/packages/dev/core/test/unit/babylon.assetContainer.test.ts
+++ b/packages/dev/core/test/unit/babylon.assetContainer.test.ts
@@ -1,0 +1,51 @@
+import { Engine } from "core/Engines/engine";
+import { Scene } from "core/scene";
+import { TransformNode } from "core/Meshes/transformNode";
+import { Mesh } from "core/Meshes/mesh";
+import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
+import { AssetContainer } from "core/assetContainer";
+import { NullEngine } from "core/Engines/nullEngine";
+
+/**
+ * Describes the test suite.
+ */
+describe("Babylon AssetContainer", () => {
+    console.log("Babylon AssetContainer Tests");
+    let engine: Engine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+
+        scene = new Scene(engine);
+    });
+
+    it("dispose", () => {
+        // Arrange
+        const assetCount = 4;
+        const assetContainer = new AssetContainer(scene);
+        for (let i = 0; i < assetCount; i++) {
+            assetContainer.transformNodes.push(new TransformNode(`transformNode${i}`, scene));
+            assetContainer.transformNodes[i]._parentContainer = assetContainer;
+            assetContainer.meshes.push(new Mesh(`mesh${i}`, scene));
+            assetContainer.meshes[i]._parentContainer = assetContainer;
+            assetContainer.meshes[i].parent = assetContainer.transformNodes[i];
+            assetContainer.materials.push(new PBRMaterial(`material${i}`, scene));
+            assetContainer.materials[i]._parentContainer = assetContainer;
+        }
+
+        // Act
+        assetContainer.dispose();
+
+        // Assert
+        expect(scene.transformNodes.length).toBe(0);
+        expect(scene.meshes.length).toBe(0);
+        expect(scene.materials.length).toBe(0);
+    });
+});

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1418,9 +1418,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
                     this._dispatchCustomEvent("viewerrender", (type) => new Event(type));
                 });
 
-                this._updateModel();
-                this._updateEnv({ lighting: true, skybox: true });
-
                 this._propertyBindings.forEach((binding) => binding.onInitialized(details));
 
                 this._dispatchCustomEvent("viewerready", (type) => new Event(type));


### PR DESCRIPTION
There was a recent regression in `AssetContainer.dispose` where basically only half the assets actually get disposed and removed from the scene. I noticed this while testing some unrelated stuff in the Viewer. This change includes:

- Fixing the regression in AssetContainer.dispose by re-introducing the call to .slice(0) to copy the arrays.
- Adding a unit test for this AssetContainer scenario.
- Fixing the original Viewer bug I was looking at, where initial model and env load are doubled (once by the Viewer respecting the current options that includes the source and env, and once by an explicit call that should have been removed when I fleshed out the config/options). 😬