### PR TITLE
instancedMesh: fix getWorldMatrix in case billboardMode of source mesh enabled

### DIFF
--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -438,7 +438,12 @@ export class InstancedMesh extends AbstractMesh {
     }
 
     public override getWorldMatrix(): Matrix {
-        if (this._currentLOD && this._currentLOD.billboardMode !== TransformNode.BILLBOARDMODE_NONE && this._currentLOD._masterMesh !== this) {
+        if (
+            this._currentLOD &&
+            this._currentLOD !== this._sourceMesh &&
+            this._currentLOD.billboardMode !== TransformNode.BILLBOARDMODE_NONE &&
+            this._currentLOD._masterMesh !== this
+        ) {
             if (!this._billboardWorldMatrix) {
                 this._billboardWorldMatrix = new Matrix();
             }


### PR DESCRIPTION
The `_currentLOD` of InstancedMesh would be `_sourceMesh` if LOD of source mesh not enabled, but if billboardMode of source mesh enabled, `getWorldMatrix` would incorrectly use the billboardMode of the `sourceMesh` to compute world matrix. This commit would add a check in `getWorldMatrix` to skip this if `_currentLOD` is `_sourceMesh`.

Forum post: <https://forum.babylonjs.com/t/billboardmode-of-sourcemesh-changes-instance-rotation/58469>
Playground: <https://playground.babylonjs.com/#1RQ8OR>