### PR TITLE
Improved render quality of ADT with adjustToEngineHardwareScalingLevel

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -726,7 +726,7 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         const engine = scene.getEngine();
         if (this.adjustToEngineHardwareScalingLevel) {
             // force the renderScale to the engine's hardware scaling level
-            this._renderScale = engine.getHardwareScalingLevel();
+            this._renderScale = 1 / engine.getHardwareScalingLevel();
         }
         const textureSize = this.getSize();
         let renderWidth = engine.getRenderWidth() * this._renderScale;
@@ -743,6 +743,13 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         }
         if (textureSize.width !== renderWidth || textureSize.height !== renderHeight) {
             this.scaleTo(renderWidth, renderHeight);
+            if (this.adjustToEngineHardwareScalingLevel) {
+                const scale = this._renderScale * this._renderScale;
+                this._rootContainer.scaleX = scale;
+                this._rootContainer.scaleY = scale;
+                this._rootContainer.widthInPixels = renderWidth / scale;
+                this._rootContainer.heightInPixels = renderHeight / scale;
+            }
             this.markAsDirty();
             if (this._idealWidth || this._idealHeight) {
                 this._rootContainer._markAllAsDirty();


### PR DESCRIPTION
The solution, intoruced in #16393, was to downscale the ADT to fit the right scale, but the better handlign is to scale the texture up while adjusting the root container's scale and size as well. 

Before:

![image](https://github.com/user-attachments/assets/2ecd007c-15db-4d27-8168-77b2bcdbd90e)

After:
![image](https://github.com/user-attachments/assets/77251f1a-4093-417d-a960-ec6719020c82)

See https://forum.babylonjs.com/t/problem-with-adapttodeviceratio-and-adaptivescaling/57373?u=raananw
