### PR TITLE
instancedMesh: optimize initialization performance

### DIFF
--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -80,7 +80,13 @@ export class InstancedMesh extends AbstractMesh {
 
         this.setPivotMatrix(source.getPivotMatrix());
 
-        this.refreshBoundingInfo(true, true);
+        if (!source.skeleton && !source.morphTargetManager && source.hasBoundingInfo) {
+            // without skeleton or morphTargetManager, use bounding info of source mesh directly
+            const boundingInfo = source.getBoundingInfo();
+            this.buildBoundingInfo(boundingInfo.minimum, boundingInfo.maximum);
+        } else {
+            this.refreshBoundingInfo(true, true);
+        }
         this._syncSubMeshes();
     }
 


### PR DESCRIPTION
In the constructor of InstancedMesh, refreshBoundingInfo if called, but if the source mesh does not contain skeleton or morphTargetManager, we can use bounding info of source mesh directly, to avoid overheads introduced by refreshBoundingInfo.

Forum post: <https://forum.babylonjs.com/t/instancedmesh-why-fully-refreshboundinginfo-even-without-bones/58543>