### PR TITLE
PBR material: Fix an incorrect #if evaluation in vertex shader

### DIFF
--- a/packages/dev/core/src/Engines/Processors/Expressions/Operators/shaderDefineArithmeticOperator.ts
+++ b/packages/dev/core/src/Engines/Processors/Expressions/Operators/shaderDefineArithmeticOperator.ts
@@ -10,11 +10,27 @@ export class ShaderDefineArithmeticOperator extends ShaderDefineExpression {
         super();
     }
 
+    public override toString() {
+        return `${this.define} ${this.operand} ${this.testValue}`;
+    }
+
     public override isTrue(preprocessors: { [key: string]: string }) {
         let condition = false;
 
         const left = parseInt(preprocessors[this.define] != undefined ? preprocessors[this.define] : this.define);
         const right = parseInt(preprocessors[this.testValue] != undefined ? preprocessors[this.testValue] : this.testValue);
+
+        if (isNaN(left)) {
+            throw new Error(
+                `ShaderDefineArithmeticOperator: "${this.define}" could not be evaluated in expression "${this.toString()}". Make sure you have included all necessary files in your shader.`
+            );
+        }
+
+        if (isNaN(right)) {
+            throw new Error(
+                `ShaderDefineArithmeticOperator: "${this.testValue}" could not be evaluated in expression "${this.toString()}". Make sure you have included all necessary files in your shader.`
+            );
+        }
 
         switch (this.operand) {
             case ">":

--- a/packages/dev/core/src/Engines/Processors/Expressions/Operators/shaderDefineArithmeticOperator.ts
+++ b/packages/dev/core/src/Engines/Processors/Expressions/Operators/shaderDefineArithmeticOperator.ts
@@ -20,16 +20,10 @@ export class ShaderDefineArithmeticOperator extends ShaderDefineExpression {
         const left = parseInt(preprocessors[this.define] != undefined ? preprocessors[this.define] : this.define);
         const right = parseInt(preprocessors[this.testValue] != undefined ? preprocessors[this.testValue] : this.testValue);
 
-        if (isNaN(left)) {
-            throw new Error(
-                `ShaderDefineArithmeticOperator: "${this.define}" could not be evaluated in expression "${this.toString()}". Make sure you have included all necessary files in your shader.`
-            );
-        }
-
-        if (isNaN(right)) {
-            throw new Error(
-                `ShaderDefineArithmeticOperator: "${this.testValue}" could not be evaluated in expression "${this.toString()}". Make sure you have included all necessary files in your shader.`
-            );
+        if (isNaN(left) || isNaN(right)) {
+            // We can't evaluate the expression because we can't resolve the left and/or right side
+            // We should not throw an error here because the code might be using a define that is not defined in the material/shader!
+            return false;
         }
 
         switch (this.operand) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBRDFFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBRDFFunctions.fx
@@ -9,6 +9,8 @@
 #define CONDUCTOR_SPECULAR_MODEL_GLTF 0
 #define CONDUCTOR_SPECULAR_MODEL_OPENPBR 1
 
+#ifndef PBR_VERTEX_SHADER
+
 // ______________________________________________________________________
 //
 //                              BRDF LOOKUP
@@ -505,3 +507,5 @@ vec3 diffuseBRDF_EON(vec3 albedo, float roughness, float NdotL, float NdotV, flo
         return saturate((NdotL + w) * invt2);
     }
 #endif
+
+#endif // PBR_VERTEX_SHADER

--- a/packages/dev/core/src/Shaders/pbr.fragment.fx
+++ b/packages/dev/core/src/Shaders/pbr.fragment.fx
@@ -1,4 +1,6 @@
-﻿#define CUSTOM_FRAGMENT_EXTENSION
+﻿#define PBR_FRAGMENT_SHADER
+
+#define CUSTOM_FRAGMENT_EXTENSION
 
 #if defined(BUMP) || !defined(NORMAL) || defined(FORCENORMALFORWARD) || defined(SPECULARAA) || defined(CLEARCOAT_BUMP) || defined(ANISOTROPIC)
 #extension GL_OES_standard_derivatives : enable

--- a/packages/dev/core/src/Shaders/pbr.vertex.fx
+++ b/packages/dev/core/src/Shaders/pbr.vertex.fx
@@ -1,3 +1,5 @@
+#define PBR_VERTEX_SHADER
+
 #define CUSTOM_VERTEX_EXTENSION
 
 precision highp float;
@@ -24,6 +26,7 @@ attribute vec4 color;
 #endif
 
 #include<helperFunctions>
+#include<pbrBRDFFunctions>
 #include<bonesDeclaration>
 #include<bakedVertexAnimationDeclaration>
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBRDFFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBRDFFunctions.fx
@@ -9,6 +9,8 @@
 #define CONDUCTOR_SPECULAR_MODEL_GLTF 0
 #define CONDUCTOR_SPECULAR_MODEL_OPENPBR 1
 
+#ifndef PBR_VERTEX_SHADER
+
 // ______________________________________________________________________
 //
 //                              BRDF LOOKUP
@@ -513,3 +515,5 @@ fn diffuseBRDF_Burley(NdotL: f32, NdotV: f32, VdotH: f32, roughness: f32) -> f32
         return saturate((NdotL + w) * invt2);
     }
 #endif
+
+#endif // PBR_VERTEX_SHADER

--- a/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.fragment.fx
@@ -1,3 +1,5 @@
+#define PBR_FRAGMENT_SHADER
+
 #define CUSTOM_FRAGMENT_BEGIN
 
 #include<prePassDeclaration>[SCENE_MRT_COUNT]

--- a/packages/dev/core/src/ShadersWGSL/pbr.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/pbr.vertex.fx
@@ -1,3 +1,5 @@
+#define PBR_VERTEX_SHADER
+
 #include<pbrUboDeclaration>
 
 #define CUSTOM_VERTEX_BEGIN
@@ -20,6 +22,7 @@ attribute color: vec4f;
 #endif
 
 #include<helperFunctions>
+#include<pbrBRDFFunctions>
 #include<bonesDeclaration>
 #include<bakedVertexAnimationDeclaration>
 


### PR DESCRIPTION
`pbrBRDFFunctions` was not included in the PBR vertex shader, which means that `#if BASE_DIFFUSE_MODEL != BRDF_DIFFUSE_MODEL_LAMBERT && BASE_DIFFUSE_MODEL != BRDF_DIFFUSE_MODEL_LEGACY` was not evaluated correctly.

Note that `environmentBrdfSampler` is defined globally, but only in fragment shader code. That's why I added a check on **PBR_VERTEX_SHADER** to skip evaluating all `pbrBRDFFunctions`, except for the definitions at the top.