### PR TITLE
Fix the ignoreParentScaling situation for the camera

### DIFF
--- a/packages/dev/core/src/Cameras/targetCamera.ts
+++ b/packages/dev/core/src/Cameras/targetCamera.ts
@@ -25,9 +25,6 @@ export class TargetCamera extends Camera {
     private static _TargetTransformMatrix = new Matrix();
     private static _TargetFocalPoint = new Vector3();
 
-    private _tmpUpVector = Vector3.Zero();
-    private _tmpTargetVector = Vector3.Zero();
-
     /**
      * Define the current direction the camera is moving to
      */

--- a/packages/dev/core/src/Cameras/targetCamera.ts
+++ b/packages/dev/core/src/Cameras/targetCamera.ts
@@ -12,9 +12,6 @@ Node.AddNodeConstructor("TargetCamera", (name, scene) => {
     return () => new TargetCamera(name, Vector3.Zero(), scene);
 });
 
-const RootNodeCounterScaling = Matrix.Scaling(-1, 1, 1);
-const ScaledParentWorldMatrix = Matrix.Identity();
-
 /**
  * A target camera takes a mesh or position as a target and continues to look at it while it moves.
  * This is the base of the follow, arc rotate cameras and Free camera
@@ -33,12 +30,6 @@ export class TargetCamera extends Camera {
      * Define the current rotation the camera is rotating to
      */
     public cameraRotation = new Vector2(0, 0);
-
-    /**
-     * Boolean indicating that the root node handedness correction should be skipped when computing the camera's view matrix.
-     */
-    @serialize()
-    public skipRootNodeHandedness = false;
 
     /**
      * When set, the up vector of the camera will be updated by the rotation of the camera
@@ -509,12 +500,7 @@ export class TargetCamera extends Camera {
         if (this.parent) {
             const parentWorldMatrix = this.parent.getWorldMatrix();
             this._viewMatrix.invert();
-            if (this.skipRootNodeHandedness) {
-                RootNodeCounterScaling.multiplyToRef(parentWorldMatrix, ScaledParentWorldMatrix);
-                this._viewMatrix.multiplyToRef(ScaledParentWorldMatrix, this._viewMatrix);
-            } else {
-                this._viewMatrix.multiplyToRef(parentWorldMatrix, this._viewMatrix);
-            }
+            this._viewMatrix.multiplyToRef(parentWorldMatrix, this._viewMatrix);
             this._viewMatrix.getTranslationToRef(this._globalPosition);
             this._viewMatrix.invert();
 

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -848,6 +848,9 @@ export class GLTFLoader implements IGLTFLoader {
                 promises.push(
                     this.loadCameraAsync(`/cameras/${camera.index}`, camera, (babylonCamera) => {
                         babylonCamera.parent = babylonTransformNode;
+                        if (!this._babylonScene.useRightHandedSystem) {
+                            babylonTransformNode.scaling.x = -1; // Cancelling root node scaling for handedness so the view matrix does not end up flipped.
+                        }
                     })
                 );
             }
@@ -1564,9 +1567,6 @@ export class GLTFLoader implements IGLTFLoader {
         const babylonCamera = new FreeCamera(camera.name || `camera${camera.index}`, Vector3.Zero(), this._babylonScene, false);
         babylonCamera._parentContainer = this._assetContainer;
         this._babylonScene._blockEntityCollection = false;
-        if (!this._babylonScene.useRightHandedSystem) {
-            babylonCamera.skipRootNodeHandedness = true;
-        }
         camera._babylonCamera = babylonCamera;
 
         // Rotation by 180 as glTF has a different convention than Babylon.

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1564,7 +1564,9 @@ export class GLTFLoader implements IGLTFLoader {
         const babylonCamera = new FreeCamera(camera.name || `camera${camera.index}`, Vector3.Zero(), this._babylonScene, false);
         babylonCamera._parentContainer = this._assetContainer;
         this._babylonScene._blockEntityCollection = false;
-        babylonCamera.ignoreParentScaling = true;
+        if (!this._babylonScene.useRightHandedSystem) {
+            babylonCamera.skipRootNodeHandedness = true;
+        }
         camera._babylonCamera = babylonCamera;
 
         // Rotation by 180 as glTF has a different convention than Babylon.


### PR DESCRIPTION
The assumption here is that ignoreParentScaling was only used for glTF loading (and it was badly used)

If this happens to not be the case I'll reintroduce the property but for now I assume this is not really a breaking change