### PR TITLE
Fix the active camera rotation and position reference in glTF interactivity

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity.ts
@@ -102,7 +102,12 @@ export function _AddInteractivityObjectModel(scene: Scene) {
             if (!scene.activeCamera) {
                 return new Quaternion(NaN, NaN, NaN, NaN);
             }
-            return Quaternion.FromRotationMatrix(scene.activeCamera.getWorldMatrix()).normalize();
+            const quat = Quaternion.FromRotationMatrix(scene.activeCamera.getWorldMatrix()).normalize();
+            if (!scene.useRightHandedSystem) {
+                quat.w *= -1; // glTF uses right-handed system, while babylon uses left-handed
+                quat.x *= -1; // glTF uses right-handed system, while babylon uses left-handed
+            }
+            return quat;
         },
         type: "Quaternion",
         getTarget: () => scene.activeCamera,
@@ -113,7 +118,11 @@ export function _AddInteractivityObjectModel(scene: Scene) {
             if (!scene.activeCamera) {
                 return new Vector3(NaN, NaN, NaN);
             }
-            return scene.activeCamera.position; // not global position
+            const pos = scene.activeCamera.getWorldMatrix().getTranslation(); // not global position
+            if (!scene.useRightHandedSystem) {
+                pos.x *= -1; // glTF uses right-handed system, while babylon uses left-handed
+            }
+            return pos;
         },
         type: "Vector3",
         getTarget: () => scene.activeCamera,


### PR DESCRIPTION
Camera is not part of the glTF tree, so the RHS->LHS conversion applied to all other glTF nodes doesn't affect the its transformation.
We need to compensate that so that the coordinates are correct, relative to the glTF coordinates system.