### PR TITLE
PBR material: Fix wrong reflectivity color in legacy specular mode

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
@@ -129,7 +129,7 @@ reflectivityOutParams reflectivityBlock(
         // In glTF's material model, the F0 value is multiplied by the maximum component of the specular colour.
         #ifdef LEGACY_SPECULAR_ENERGY_CONSERVATION
             {
-                vec3 reflectivityColor = mix(surfaceReflectivityColor, baseColor.rgb, outParams.metallic);
+                vec3 reflectivityColor = mix(dielectricF0 * surfaceReflectivityColor, baseColor.rgb, outParams.metallic);
                 outParams.reflectanceF0 = max(reflectivityColor.r, max(reflectivityColor.g, reflectivityColor.b));
             }
         #else

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockReflectivity.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockReflectivity.fx
@@ -129,7 +129,7 @@ fn reflectivityBlock(
         // In glTF's material model, the F0 value is multiplied by the maximum component of the specular colour.
         #ifdef LEGACY_SPECULAR_ENERGY_CONSERVATION
             {
-                let reflectivityColor: vec3f = mix(surfaceReflectivityColor, baseColor.rgb, outParams.metallic);
+                let reflectivityColor: vec3f = mix(dielectricF0 * surfaceReflectivityColor, baseColor.rgb, outParams.metallic);
                 outParams.reflectanceF0 = max(reflectivityColor.r, max(reflectivityColor.g, reflectivityColor.b));
             }
         #else


### PR DESCRIPTION
See https://forum.babylonjs.com/t/pbr-material-sheen-has-changed-in-latest-babylon-8-9-0-version/58608