### PR TITLE
Viewer fixes for IBL Shadows (Draft)

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -594,6 +594,13 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
     }
 
     /**
+     * Clear the list of shadow-casting meshes. This will remove all meshes from the list
+     */
+    public clearShadowCastingMeshes(): void {
+        this._shadowCastingMeshes.length = 0;
+    }
+
+    /**
      * The exponent of the resolution of the voxel shadow grid. Higher resolutions will result in sharper
      * shadows but are more expensive to compute and require more memory.
      * The resolution is calculated as 2 to the power of this number.
@@ -881,6 +888,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             },
         };
         this._gbufferDebugPass = new PostProcess("iblShadowGBufferDebug", "iblShadowGBufferDebug", options);
+        this._gbufferDebugPass.samples = (this.engine as any).currentSampleCount || 1;
         this._gbufferDebugPass.autoClear = false;
         this._gbufferDebugPass.onApplyObservable.add((effect) => {
             const depthIndex = this._geometryBufferRenderer.getTextureIndex(GeometryBufferRenderer.SCREENSPACE_DEPTH_TEXTURE_TYPE);
@@ -1089,6 +1097,19 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
                 plugin.isEnabled = false;
             }
         }
+    }
+
+    /**
+     * Clear the list of materials that receive shadows. This will remove all materials from the list
+     */
+    public clearShadowReceivingMaterials() {
+        for (const mat of this._materialsWithRenderPlugin) {
+            const plugin = mat.pluginManager?.getPlugin<IBLShadowsPluginMaterial>(IBLShadowsPluginMaterial.Name);
+            if (plugin) {
+                plugin.isEnabled = false;
+            }
+        }
+        this._materialsWithRenderPlugin.length = 0;
     }
 
     protected _addShadowSupportToMaterial(material: Material) {

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
@@ -88,7 +88,7 @@ export class _IblShadowsSpatialBlurPass {
             const debugOptions: PostProcessOptions = {
                 width: this._engine.getRenderWidth(),
                 height: this._engine.getRenderHeight(),
-                textureFormat: Constants.TEXTUREFORMAT_R,
+                textureFormat: Constants.TEXTUREFORMAT_RGBA,
                 textureType: Constants.TEXTURETYPE_UNSIGNED_BYTE,
                 samplingMode: Constants.TEXTURE_NEAREST_SAMPLINGMODE,
                 uniforms: ["sizeParams"],

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/bonesDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/bonesDeclaration.fx
@@ -12,9 +12,10 @@
             uniform boneTextureWidth : f32;
         #else
             uniform mBones : array<mat4x4f, BonesPerMesh>;
-            #ifdef BONES_VELOCITY_ENABLED
-                uniform mPreviousBones : array<mat4x4f, BonesPerMesh>;
-            #endif
+        #endif
+
+        #ifdef BONES_VELOCITY_ENABLED
+            uniform mPreviousBones : array<mat4x4f, BonesPerMesh>;
         #endif
 
         #ifdef BONETEXTURE

--- a/packages/dev/core/src/ShadersWGSL/iblShadowGBufferDebug.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/iblShadowGBufferDebug.fragment.fx
@@ -1,39 +1,39 @@
-varying vUV: vec2f;
+varying vUV : vec2f;
 
-var textureSamplerSampler: sampler;
-var textureSampler: texture_2d<f32>;
-var depthSampler: sampler;
-var depthTexture: texture_2d<f32>;
-var normalSampler: sampler;
-var normalTexture: texture_2d<f32>;
-var positionSampler: sampler;
-var positionTexture: texture_2d<f32>;
-var velocitySampler: sampler;
-var velocityTexture: texture_2d<f32>;
-uniform sizeParams: vec4f;
-uniform maxDepth: f32;
+var textureSamplerSampler : sampler;
+var textureSampler : texture_2d<f32>;
+var depthSamplerSampler : sampler;
+var depthSampler : texture_2d<f32>;
+var normalSamplerSampler : sampler;
+var normalSampler : texture_2d<f32>;
+var positionSamplerSampler : sampler;
+var positionSampler : texture_2d<f32>;
+var velocitySamplerSampler : sampler;
+var velocitySampler : texture_2d<f32>;
+uniform sizeParams : vec4f;
 
 #define offsetX uniforms.sizeParams.x
 #define offsetY uniforms.sizeParams.y
 #define widthScale uniforms.sizeParams.z
 #define heightScale uniforms.sizeParams.w
 
-@fragment
-fn main(input: FragmentInputs) -> FragmentOutputs {
-  var uv: vec2f =
-       vec2f((offsetX + input.vUV.x) * widthScale, (offsetY + input.vUV.y) * heightScale);
+@fragment fn main(input : FragmentInputs)->FragmentOutputs {
+  var uv : vec2f = 
+        vec2f((offsetX + input.vUV.x) * widthScale, (offsetY + input.vUV.y) * heightScale);
   var backgroundColour: vec4f = textureSample(textureSampler, textureSamplerSampler, input.vUV).rgba;
-  var depth: vec4f = textureSample(depthTexture, depthSampler, input.vUV);
-  var worldNormal: vec4f = textureSample(normalTexture, normalSampler, input.vUV);
-  var worldPosition: vec4f = textureSample(positionTexture, positionSampler, input.vUV);
-  var velocityLinear: vec4f = textureSample(velocityTexture, velocitySampler, input.vUV);
+  var depth : vec4f = textureSample(depthSampler, depthSamplerSampler, input.vUV);
+  var worldNormal: vec4f = textureSample(normalSampler, normalSamplerSampler, input.vUV);
+  var worldPosition : vec4f = textureSample(positionSampler, positionSamplerSampler, input.vUV);
+  var velocityLinear : vec4f = textureSample(velocitySampler, velocitySamplerSampler, input.vUV);
   if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
     fragmentOutputs.color = backgroundColour;
   } else {
     if (uv.x <= 0.25) {
       fragmentOutputs.color = vec4f(depth.rgb, 1.0);
     } else if (uv.x <= 0.5) {
-      velocityLinear = vec4f(velocityLinear.r * 0.5 + 0.5, velocityLinear.g * 0.5 + 0.5, velocityLinear.b, velocityLinear.a);
+      velocityLinear =
+          vec4f(velocityLinear.r * 0.5 + 0.5, velocityLinear.g * 0.5 + 0.5,
+                velocityLinear.b, velocityLinear.a);
       fragmentOutputs.color = vec4f(velocityLinear.rgb, 1.0);
     } else if (uv.x <= 0.75) {
       fragmentOutputs.color = vec4f(worldPosition.rgb, 1.0);

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1551,12 +1551,6 @@ export class Viewer implements IDisposable {
                 if (this._shadowQuality === "normal") {
                     await this._updateShadowMap(abortController.signal);
                 } else if (this._shadowQuality === "high") {
-                    const isWebGPU = this._scene.getEngine().isWebGPU;
-                    // there is some issue with meshes with indices, so disable environment shadows for now
-                    const hasAnyAnimationOrIndices = this._loadedModelsBacking.some(
-                        (model) => model.assetContainer.animationGroups.length > 0 && model.assetContainer.meshes.some((mesh) => mesh.getIndices() !== null)
-                    );
-
                     if (this._loadedModelsBacking.length > 0) {
                         await this._updateEnvShadow(abortController.signal);
                     }

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1557,10 +1557,8 @@ export class Viewer implements IDisposable {
                         (model) => model.assetContainer.animationGroups.length > 0 && model.assetContainer.meshes.some((mesh) => mesh.getIndices() !== null)
                     );
 
-                    if (this._loadedModelsBacking.length > 0 && !(isWebGPU && hasAnyAnimationOrIndices)) {
+                    if (this._loadedModelsBacking.length > 0) {
                         await this._updateEnvShadow(abortController.signal);
-                    } else {
-                        this._log("Environment shadows are not supported in WebGPU with animated meshes.");
                     }
                 }
             }


### PR DESCRIPTION
When using the geometry buffer with animated meshes, we're hitting this compile error about `uniforms.mPreviousBones` not being defined. Turns out there was a slight difference in the WebGPU shader that was preventing compilation when BONETEXTURE was also defined. Now, the behaviour matches WebGL.