### PR TITLE
Prevent microphone feedback loop

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -4,7 +4,6 @@ import { SoundState } from "../soundState";
 import { AudioNodeType } from "./abstractAudioNode";
 import type { _AbstractSoundInstance } from "./abstractSoundInstance";
 import { AbstractSoundSource, type ISoundSourceOptions } from "./abstractSoundSource";
-import type { PrimaryAudioBus } from "./audioBus";
 import type { AudioEngineV2 } from "./audioEngineV2";
 import type { IVolumeAudioOptions } from "./subNodes/volumeAudioSubNode";
 
@@ -35,14 +34,7 @@ export interface IAbstractSoundPlayOptionsBase {
 /**
  * Options for creating a sound.
  */
-export interface IAbstractSoundOptions extends IAbstractSoundOptionsBase, IAbstractSoundPlayOptions, ISoundSourceOptions {
-    /**
-     * The output bus for the sound. Defaults to `null`.
-     * - If not set or `null`, the sound is automatically connected to the audio engine's default main bus.
-     * @see {@link AudioEngineV2.defaultMainBus}
-     */
-    outBus: Nullable<PrimaryAudioBus>;
-}
+export interface IAbstractSoundOptions extends IAbstractSoundOptionsBase, IAbstractSoundPlayOptions, ISoundSourceOptions {}
 
 /**
  * Options for playing a sound.

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
@@ -14,8 +14,13 @@ import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
  */
 export interface ISoundSourceOptions extends IAudioAnalyzerOptions, ISpatialAudioOptions, IStereoAudioOptions {
     /**
+     * Whether the sound's `outBus` should be set to the audio engine's main bus by default. Defaults to `true` for all sound sources except microphones.
+     */
+    defaultToMainBus: boolean;
+
+    /**
      * The output bus for the sound source. Defaults to `null`.
-     * - If not set or `null`, the sound source is automatically connected to the audio engine's default main bus.
+     * - If not set or `null`, and `defaultToMainBus` is `true`, then the sound source is automatically connected to the audio engine's default main bus.
      * @see {@link AudioEngineV2.defaultMainBus}
      */
     outBus: Nullable<PrimaryAudioBus>;
@@ -42,8 +47,7 @@ export abstract class AbstractSoundSource extends AbstractNamedAudioNode {
     }
 
     /**
-     * The output bus for the sound. Defaults to `null`.
-     * - If not set or `null`, the sound is automatically connected to the audio engine's default main bus.
+     * The output bus for the sound.
      * @see {@link AudioEngineV2.defaultMainBus}
      */
     public get outBus(): Nullable<PrimaryAudioBus> {

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundSource.ts
@@ -14,16 +14,16 @@ import { _AudioAnalyzer } from "./subProperties/audioAnalyzer";
  */
 export interface ISoundSourceOptions extends IAudioAnalyzerOptions, ISpatialAudioOptions, IStereoAudioOptions {
     /**
-     * Whether the sound's `outBus` should be set to the audio engine's main bus by default. Defaults to `true` for all sound sources except microphones.
-     */
-    defaultToMainBus: boolean;
-
-    /**
      * The output bus for the sound source. Defaults to `null`.
-     * - If not set or `null`, and `defaultToMainBus` is `true`, then the sound source is automatically connected to the audio engine's default main bus.
+     * - If not set or `null`, and `outBusAutoDefault` is `true`, then the sound source is automatically connected to the audio engine's default main bus.
      * @see {@link AudioEngineV2.defaultMainBus}
      */
     outBus: Nullable<PrimaryAudioBus>;
+
+    /**
+     * Whether the sound's `outBus` should default to the audio engine's main bus. Defaults to `true` for all sound sources except microphones.
+     */
+    outBusAutoDefault: boolean;
 }
 
 /**

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -222,7 +222,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
         }
 
         return await this.createSoundSourceAsync(name, new MediaStreamAudioSourceNode(this._audioContext, { mediaStream }), {
-            defaultToMainBus: false,
+            outBusAutoDefault: false,
             ...options,
         });
     }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -221,6 +221,11 @@ export class _WebAudioEngine extends AudioEngineV2 {
             throw new Error("Unable to access microphone: " + e);
         }
 
+        options = {
+            defaultToMainBus: false,
+            ...options,
+        };
+
         return await this.createSoundSourceAsync(name, new MediaStreamAudioSourceNode(this._audioContext, { mediaStream }), options);
     }
 

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -221,12 +221,10 @@ export class _WebAudioEngine extends AudioEngineV2 {
             throw new Error("Unable to access microphone: " + e);
         }
 
-        options = {
+        return await this.createSoundSourceAsync(name, new MediaStreamAudioSourceNode(this._audioContext, { mediaStream }), {
             defaultToMainBus: false,
             ...options,
-        };
-
-        return await this.createSoundSourceAsync(name, new MediaStreamAudioSourceNode(this._audioContext, { mediaStream }), options);
+        });
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -48,7 +48,7 @@ export class _WebAudioSoundSource extends AbstractSoundSource {
     public async _initAsync(options: Partial<ISoundSourceOptions>): Promise<void> {
         if (options.outBus) {
             this.outBus = options.outBus;
-        } else if (options.defaultToMainBus !== false) {
+        } else if (options.outBusAutoDefault !== false) {
             await this.engine.isReadyPromise;
             this.outBus = this.engine.defaultMainBus;
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioSoundSource.ts
@@ -48,7 +48,7 @@ export class _WebAudioSoundSource extends AbstractSoundSource {
     public async _initAsync(options: Partial<ISoundSourceOptions>): Promise<void> {
         if (options.outBus) {
             this.outBus = options.outBus;
-        } else {
+        } else if (options.defaultToMainBus !== false) {
             await this.engine.isReadyPromise;
             this.outBus = this.engine.defaultMainBus;
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -74,7 +74,7 @@ export class _WebAudioStaticSound extends StaticSound implements IWebAudioSuperN
 
         if (options.outBus) {
             this.outBus = options.outBus;
-        } else {
+        } else if (options.defaultToMainBus !== false) {
             await this.engine.isReadyPromise;
             this.outBus = this.engine.defaultMainBus;
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -74,7 +74,7 @@ export class _WebAudioStaticSound extends StaticSound implements IWebAudioSuperN
 
         if (options.outBus) {
             this.outBus = options.outBus;
-        } else if (options.defaultToMainBus !== false) {
+        } else if (options.outBusAutoDefault !== false) {
             await this.engine.isReadyPromise;
             this.outBus = this.engine.defaultMainBus;
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -73,7 +73,7 @@ export class _WebAudioStreamingSound extends StreamingSound implements IWebAudio
 
         if (options.outBus) {
             this.outBus = options.outBus;
-        } else {
+        } else if (options.defaultToMainBus !== false) {
             await this.engine.isReadyPromise;
             this.outBus = this.engine.defaultMainBus;
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -73,7 +73,7 @@ export class _WebAudioStreamingSound extends StreamingSound implements IWebAudio
 
         if (options.outBus) {
             this.outBus = options.outBus;
-        } else if (options.defaultToMainBus !== false) {
+        } else if (options.outBusAutoDefault !== false) {
             await this.engine.isReadyPromise;
             this.outBus = this.engine.defaultMainBus;
         }

--- a/packages/tools/tests/test/audioV2/shared/abstractSoundSource.outBus.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSoundSource.outBus.ts
@@ -6,10 +6,10 @@ import { expect, test } from "@playwright/test";
 
 export const AddSharedAbstractSoundSourceOutBusTests = (audioNodeType: AudioNodeType) => {
     test.describe(`${audioNodeType} outBus`, () => {
-        test("Setting `defaultToMainBus` to false should play sound at 0 volume", async ({ page }) => {
+        test("Setting `outBusAutoDefault` to false should play sound at 0 volume", async ({ page }) => {
             await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                 await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
-                const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { defaultToMainBus: false });
+                const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { outBusAutoDefault: false });
 
                 sound.play();
                 await AudioV2Test.WaitAsync(1, () => {
@@ -23,10 +23,10 @@ export const AddSharedAbstractSoundSourceOutBusTests = (audioNodeType: AudioNode
             expect(volumes[Channel.R]).toBeCloseTo(0, 0);
         });
 
-        test("Setting `defaultToMainBus` to true should play sound at 1x volume", async ({ page }) => {
+        test("Setting `outBusAutoDefault` to true should play sound at 1x volume", async ({ page }) => {
             await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                 await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
-                const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { defaultToMainBus: true });
+                const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { outBusAutoDefault: true });
 
                 sound.play();
                 await AudioV2Test.WaitAsync(1, () => {

--- a/packages/tools/tests/test/audioV2/shared/abstractSoundSource.outBus.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSoundSource.outBus.ts
@@ -1,0 +1,43 @@
+import { EvaluateAbstractAudioNodeTestAsync } from "../utils/abstractAudioNode.utils";
+import type { AudioNodeType } from "../utils/audioV2.utils";
+import { Channel, EvaluateVolumesAtTimeAsync, VolumePrecision } from "../utils/audioV2.utils";
+
+import { expect, test } from "@playwright/test";
+
+export const AddSharedAbstractSoundSourceOutBusTests = (audioNodeType: AudioNodeType) => {
+    test.describe(`${audioNodeType} outBus`, () => {
+        test("Setting `defaultToMainBus` to false should play sound at 0 volume", async ({ page }) => {
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
+                const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { defaultToMainBus: false });
+
+                sound.play();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
+            });
+
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
+
+            expect(volumes[Channel.L]).toBeCloseTo(0, 0);
+            expect(volumes[Channel.R]).toBeCloseTo(0, 0);
+        });
+
+        test("Setting `defaultToMainBus` to true should play sound at 1x volume", async ({ page }) => {
+            await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
+                await AudioV2Test.CreateAudioEngineAsync(audioNodeType);
+                const { sound } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, { defaultToMainBus: true });
+
+                sound.play();
+                await AudioV2Test.WaitAsync(1, () => {
+                    sound.stop();
+                });
+            });
+
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
+
+            expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
+            expect(volumes[Channel.R]).toBeCloseTo(1, VolumePrecision);
+        });
+    });
+};

--- a/packages/tools/tests/test/audioV2/soundSource.outBus.test.ts
+++ b/packages/tools/tests/test/audioV2/soundSource.outBus.test.ts
@@ -1,0 +1,5 @@
+import { AddSharedAbstractSoundSourceOutBusTests } from "./shared/abstractSoundSource.outBus";
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+InitAudioV2Tests();
+AddSharedAbstractSoundSourceOutBusTests("SoundSource");

--- a/packages/tools/tests/test/audioV2/staticSound.outBus.test.ts
+++ b/packages/tools/tests/test/audioV2/staticSound.outBus.test.ts
@@ -1,0 +1,5 @@
+import { AddSharedAbstractSoundSourceOutBusTests } from "./shared/abstractSoundSource.outBus";
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+InitAudioV2Tests();
+AddSharedAbstractSoundSourceOutBusTests("StaticSound");

--- a/packages/tools/tests/test/audioV2/streamingSound.outBus.test.ts
+++ b/packages/tools/tests/test/audioV2/streamingSound.outBus.test.ts
@@ -1,0 +1,5 @@
+import { AddSharedAbstractSoundSourceOutBusTests } from "./shared/abstractSoundSource.outBus";
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+InitAudioV2Tests();
+AddSharedAbstractSoundSourceOutBusTests("StreamingSound");


### PR DESCRIPTION
Microphone sound sources are connected to the main audio bus by default, and get output to the speakers. This causes an extremely loud feedback loop that should be avoided.

This change adds an `outBusAutoDefault` option to the sound source, defaulted to `true`, except for the microphone sound sources which default to `false` so they don't automatically output to the speakers.