### PR TITLE
Allow Image source to be set without Canvas

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -566,8 +566,9 @@ export class Image extends Control {
 
         // Should abstract platform instead of using LastCreatedEngine
         const engine = this._host?.getScene()?.getEngine() || EngineStore.LastCreatedEngine;
+        // If no engine, skip all other DOM operations. 
         if (!engine) {
-            throw new Error("Invalid engine. Unable to create a canvas.");
+            return;
         }
         if (value && Image.SourceImgCache.has(value)) {
             const cachedData = Image.SourceImgCache.get(value)!;


### PR DESCRIPTION
Instead of throwing an error, now just skips DOM image operations and the image source will just be the passed in value. Needed for Domless environments. 