### PR TITLE
Fix rotation gizmo fragment shader angle when using right handed system

### DIFF
--- a/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
+++ b/packages/dev/core/src/Gizmos/planeRotationGizmo.ts
@@ -399,7 +399,7 @@ export class PlaneRotationGizmo extends Gizmo implements IPlaneRotationGizmo {
                     tmpSnapEvent.snapDistance = angle;
                     this.onSnapObservable.notifyObservers(tmpSnapEvent);
                 }
-                this._angles.y += angle;
+                this._angles.y += gizmoLayer.utilityLayerScene.useRightHandedSystem ? -angle : angle;
                 this.angle += cameraFlipped ? -angle : angle;
                 this._rotationShaderMaterial.setVector3("angles", this._angles);
                 this._matrixChanged();


### PR DESCRIPTION
I am working on a project that uses a right-handed coordinate system and rotation gizmos. However, when using the rotation gizmo in a right-handed coordinate system, the shaded region of the rotation gizmo appears on the wrong side of the gizmo drag point.

This PR inverts the rotation angle sign if the scene uses a right-handed coordinate system, so the rotation gizmo shaded region always appears on the correct side of the drag point.

Here is a demo using this playground from the docs: https://playground.babylonjs.com/#31M2AP#11 

**Before:**

https://github.com/user-attachments/assets/2bd0bad9-2cdc-4c21-a542-6a821db67789

**After:**

https://github.com/user-attachments/assets/80c15e49-d5c5-4ce6-b909-6c7e74cb8d9d

