### PR TITLE
WebGL: Fix flicker on MacOS

### DIFF
--- a/packages/dev/core/src/Shaders/pbr.vertex.fx
+++ b/packages/dev/core/src/Shaders/pbr.vertex.fx
@@ -182,6 +182,13 @@ void main(void) {
         #if BASE_DIFFUSE_MODEL != BRDF_DIFFUSE_MODEL_LAMBERT && BASE_DIFFUSE_MODEL != BRDF_DIFFUSE_MODEL_LEGACY
             // Bend the normal towards the viewer based on the diffuse roughness
             vec3 viewDirectionW = normalize(vEyePosition.xyz - vPositionW);
+
+            // Next two lines fixes a flickering that occurs on some specific circumstances on MacOS/iOS
+            // See https://forum.babylonjs.com/t/needdepthprepass-creates-flickering-in-8-6-2/58421/12
+            // Note that the variable passed to isnan doesn't matter...
+            bool bbb = any(isnan(position));
+            if (bbb) { }
+
             float NdotV = max(dot(vNormalW, viewDirectionW), 0.0);
             vec3 roughNormal = mix(vNormalW, viewDirectionW, (0.5 * (1.0 - NdotV)) * baseDiffuseRoughness);
             vec3 reflectionVector = vec3(reflectionMatrix * vec4(roughNormal, 0)).xyz;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/needdepthprepass-creates-flickering-in-8-6-2/58421/12