### PR TITLE
Texture max size - Some devices enforce a max texture size of 4096

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -727,8 +727,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         if (this.adjustToEngineHardwareScalingLevel) {
             // force the renderScale to the engine's hardware scaling level
             this._renderScale = engine.getHardwareScalingLevel();
-            // calculate the max renderScale, based on the max texture size of 4096 (enforced by some mobile devices)
-            this._renderScale = 1 / Math.max(this._renderScale, engine.getRenderWidth() / 4096, engine.getRenderHeight() / 4096);
+            // calculate the max renderScale, based on the max texture size of engine.getCaps().maxTextureSize (enforced by some mobile devices)
+            this._renderScale =
+                1 / Math.max(this._renderScale, engine.getRenderWidth() / engine.getCaps().maxTextureSize, engine.getRenderHeight() / engine.getCaps().maxTextureSize);
         }
         const textureSize = this.getSize();
         let renderWidth = engine.getRenderWidth() * this._renderScale;


### PR DESCRIPTION
See - https://forum.babylonjs.com/t/problem-with-adapttodeviceratio-and-adaptivescaling/57373/11?u=raananw

Android devices (tested on 2 different samsung devices) enfore a max texture size fot the ADT. It is set at 4096. This sets the max render scale at the ratio that gets us to 4096 (or, if it doesn[t get to 4096, the hardware scaling level)