### PR TITLE
Viewer: add @babylonjs/materials as peerDependency

### DIFF
--- a/packages/public/@babylonjs/materials/package.json
+++ b/packages/public/@babylonjs/materials/package.json
@@ -23,7 +23,7 @@
         "@lts/materials": "^1.0.0"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^8.0.0"
+        "@babylonjs/core": "^8.6.0"
     },
     "keywords": [
         "3D",

--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -31,9 +31,9 @@
         "lit": "^3.2.0"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^8.6.0",
-        "@babylonjs/loaders": "^8.6.0",
-        "@babylonjs/materials": "^8.6.0"
+        "@babylonjs/core": "^8.0.0",
+        "@babylonjs/loaders": "^8.0.0",
+        "@babylonjs/materials": "^8.0.0"
     },
     "devDependencies": {
         "@babylonjs/core": "^8.9.0",

--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -31,8 +31,9 @@
         "lit": "^3.2.0"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^8.0.0",
-        "@babylonjs/loaders": "^8.0.0"
+        "@babylonjs/core": "^8.6.0",
+        "@babylonjs/loaders": "^8.6.0",
+        "@babylonjs/materials": "^8.6.0"
     },
     "devDependencies": {
         "@babylonjs/core": "^8.9.0",


### PR DESCRIPTION
With the introduction of shadows in the Viewer, we took a dependency on `ShadowOnlyMaterial` from `@babylonjs/materials`, but missed adding it as a `peerDependency`. This PR adds it, and addresses https://forum.babylonjs.com/t/babylon-viewer-v2/54317/90.

However, while testing I noticed that what happens for existing projects is that they may have `@babylonjs/core` <8.6.0, and then `@babylonjs/materials` >=8.6.0 gets installed, and these two versions are incompatible because of internal API breaking changes (casing on function names). I expect hitting this issue would be common. We can deal with it in the Viewer by making all @babylonjs/* dependencies be ^8.6.0, but it seems like the correct fix is to update `@babylonjs/materials`'s dependency on `@babylonjs/core` to ^8.6.0. @RaananW thoughts?