### PR TITLE
PBRBlockReflectivity: Remove `f` suffix

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflectivity.fx
@@ -143,7 +143,7 @@ reflectivityOutParams reflectivityBlock(
 
         #ifdef LEGACY_SPECULAR_ENERGY_CONSERVATION
             outParams.reflectanceF90 = vec3(outParams.specularWeight);
-            float f90Scale = 1.0f;
+            float f90Scale = 1.0;
         #else
             // Scale the reflectanceF90 by the IOR for values less than 1.5.
             // This is an empirical hack to account for the fact that Schlick is tuned for IOR = 1.5

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockReflectivity.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrBlockReflectivity.fx
@@ -143,7 +143,7 @@ fn reflectivityBlock(
 
         #ifdef LEGACY_SPECULAR_ENERGY_CONSERVATION
             outParams.reflectanceF90 = vec3(outParams.specularWeight);
-            var f90Scale: f32 = 1.0f;
+            var f90Scale: f32 = 1.0;
         #else
             // Scale the reflectanceF90 by the IOR for values less than 1.5.
             // This is an empirical hack to account for the fact that Schlick is tuned for IOR = 1.5


### PR DESCRIPTION
... to avoid in WebGL1
Error: FRAGMENT SHADER ERROR: 0:552: '1.0f' : Floating-point suffix unsupported prior to GLSL ES 3.00
ERROR: 0:552: '1.0f' : syntax error