### PR TITLE
Viewer: small fixes to test apps

### DIFF
--- a/packages/public/@babylonjs/viewer/test/apps/web/index.html
+++ b/packages/public/@babylonjs/viewer/test/apps/web/index.html
@@ -12,6 +12,6 @@
     </style>
     <body>
         <script type="module" src="../../../dist/babylon-viewer.esm.min.js"></script>
-        <babylon-viewer source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb" environment="../../../assets/photoStudio.env"> </babylon-viewer>
+        <babylon-viewer source="https://raw.githubusercontent.com/BabylonJS/Assets/master/meshes/ufo.glb"></babylon-viewer>
     </body>
 </html>

--- a/packages/public/@babylonjs/viewer/test/apps/web/published.html
+++ b/packages/public/@babylonjs/viewer/test/apps/web/published.html
@@ -3,7 +3,7 @@
     <head>
         <title>Babylon Viewer Demo</title>
         <meta charset="UTF-8" />
-        <script type="module" src="https://cdn.jsdelivr.net/npm/@babylonjs/viewer@preview/dist/babylon-viewer.esm.min.js"></script>
+        <script type="module" src="https://cdn.jsdelivr.net/npm/@babylonjs/viewer/dist/babylon-viewer.esm.min.js"></script>
         <style>
             html,
             body {

--- a/packages/tools/viewer/vite.config.mjs
+++ b/packages/tools/viewer/vite.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig(({ mode }) => {
         ],
         resolve: {
             alias: {
+                addons: `@${source}/addons/dist`,
                 core: `@${source}/core/dist`,
                 loaders: `@${source}/loaders/dist`,
                 inspector: `@${source}/inspector/dist`,


### PR DESCRIPTION
This PR has a few small fixes to the Viewer test apps:
1. Add the addons package to the vite config (needed for inspector)
2. Remove @preview in the public package test html
3. Remove the `environment` attribute (use the default embedded one instead)