### PR TITLE
Fix compile error for WebGPU and animated meshes

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/bonesDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/bonesDeclaration.fx
@@ -12,9 +12,10 @@
             uniform boneTextureWidth : f32;
         #else
             uniform mBones : array<mat4x4f, BonesPerMesh>;
-            #ifdef BONES_VELOCITY_ENABLED
-                uniform mPreviousBones : array<mat4x4f, BonesPerMesh>;
-            #endif
+        #endif
+
+        #ifdef BONES_VELOCITY_ENABLED
+            uniform mPreviousBones : array<mat4x4f, BonesPerMesh>;
         #endif
 
         #ifdef BONETEXTURE

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1551,12 +1551,6 @@ export class Viewer implements IDisposable {
                 if (this._shadowQuality === "normal") {
                     await this._updateShadowMap(abortController.signal);
                 } else if (this._shadowQuality === "high") {
-                    const isWebGPU = this._scene.getEngine().isWebGPU;
-                    // there is some issue with meshes with indices, so disable environment shadows for now
-                    const hasAnyAnimationOrIndices = this._loadedModelsBacking.some(
-                        (model) => model.assetContainer.animationGroups.length > 0 && model.assetContainer.meshes.some((mesh) => mesh.getIndices() !== null)
-                    );
-
                     if (this._loadedModelsBacking.length > 0) {
                         await this._updateEnvShadow(abortController.signal);
                     }

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1557,10 +1557,8 @@ export class Viewer implements IDisposable {
                         (model) => model.assetContainer.animationGroups.length > 0 && model.assetContainer.meshes.some((mesh) => mesh.getIndices() !== null)
                     );
 
-                    if (this._loadedModelsBacking.length > 0 && !(isWebGPU && hasAnyAnimationOrIndices)) {
+                    if (this._loadedModelsBacking.length > 0) {
                         await this._updateEnvShadow(abortController.signal);
-                    } else {
-                        this._log("Environment shadows are not supported in WebGPU with animated meshes.");
                     }
                 }
             }


### PR DESCRIPTION
Animated meshes with WebGPU previously caused a shader compile error in the GeometryBufferRenderer. This PR fixes the issue.