### PR TITLE
NME: Consolidate SFE mode logic into SmartFilterTextureBlock

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
@@ -1,7 +1,6 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
-import { SfeModeDefine } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
@@ -19,11 +18,18 @@ import { Constants } from "core/Engines/constants";
  * Base block used as input for post process
  */
 export class CurrentScreenBlock extends NodeMaterialBlock {
-    private _samplerName = "textureSampler";
-    private _linearDefineName: string;
-    private _gammaDefineName: string;
-    private _mainUVName: string;
-    private _tempTextureRead: string;
+    protected _samplerName = "textureSampler";
+    protected _linearDefineName: string;
+    protected _gammaDefineName: string;
+    protected _mainUVName: string;
+    protected _tempTextureRead: string;
+
+    /**
+     * The name of the sampler to read the screen texture from.
+     */
+    public get samplerName(): string {
+        return this._samplerName;
+    }
 
     /**
      * Gets or sets the texture associated with the node
@@ -155,7 +161,11 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         return true;
     }
 
-    private _injectVertexCode(state: NodeMaterialBuildState) {
+    protected _getMainUvName(state: NodeMaterialBuildState): string {
+        return "vMain" + this.uv.associatedVariableName;
+    }
+
+    protected _injectVertexCode(state: NodeMaterialBuildState) {
         const uvInput = this.uv;
 
         if (uvInput.connectedPoint!.ownerBlock.isInput) {
@@ -181,7 +191,7 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         }
     }
 
-    private _writeTextureRead(state: NodeMaterialBuildState, vertexMode = false) {
+    protected _writeTextureRead(state: NodeMaterialBuildState, vertexMode = false) {
         const uvInput = this.uv;
 
         if (vertexMode) {
@@ -212,7 +222,7 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         state.compilationString += `${state._declareLocalVar(this._tempTextureRead, NodeMaterialBlockConnectionPointTypes.Vector4)} = ${textureReadFunc} ${this._mainUVName});\n`;
     }
 
-    private _writeOutput(state: NodeMaterialBuildState, output: NodeMaterialConnectionPoint, swizzle: string, vertexMode = false) {
+    protected _writeOutput(state: NodeMaterialBuildState, output: NodeMaterialConnectionPoint, swizzle: string, vertexMode = false) {
         if (vertexMode) {
             if (state.target === NodeMaterialBlockTargets.Fragment) {
                 return;
@@ -239,6 +249,11 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         state.compilationString += `#endif\n`;
     }
 
+    protected _emitUvAndSampler(state: NodeMaterialBuildState) {
+        state._emitVaryingFromString(this._mainUVName, NodeMaterialBlockConnectionPointTypes.Vector2);
+        state._emit2DSampler(this._samplerName);
+    }
+
     protected override _buildBlock(state: NodeMaterialBuildState) {
         super._buildBlock(state);
 
@@ -253,17 +268,12 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         if (state.sharedData.blocksWithDefines.indexOf(this) < 0) {
             state.sharedData.blocksWithDefines.push(this);
         }
+        this._mainUVName = this._getMainUvName(state);
 
-        // SFE: We rely on the default postprocess.vertex shader to supply our varying, which is named vUV.
-        this._mainUVName = state.isSFEMode ? "vUV" : "vMain" + this.uv.associatedVariableName;
-
-        // SFE: Wrap the varying in a define, as it won't be needed there.
-        const define = state.isSFEMode ? SfeModeDefine : undefined;
-        state._emitVaryingFromString(this._mainUVName, NodeMaterialBlockConnectionPointTypes.Vector2, define, true);
+        this._emitUvAndSampler(state);
 
         if (state.target !== NodeMaterialBlockTargets.Fragment) {
             // Vertex
-            state._emit2DSampler(this._samplerName);
             this._injectVertexCode(state);
             return;
         }
@@ -272,10 +282,6 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         if (!this._outputs.some((o) => o.isConnectedInFragmentShader)) {
             return;
         }
-
-        // SFE: Append `// main` to denote this as the main input texture to composite.
-        const annotation = state.isSFEMode ? "// main" : undefined;
-        state._emit2DSampler(this._samplerName, undefined, undefined, annotation);
 
         this._linearDefineName = state._getFreeDefineName("ISLINEAR");
         this._gammaDefineName = state._getFreeDefineName("ISGAMMA");

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/index.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/index.ts
@@ -7,6 +7,7 @@ export * from "./currentScreenBlock";
 export * from "./sceneDepthBlock";
 export * from "./imageSourceBlock";
 export * from "./clipPlanesBlock";
+export * from "./smartFilterTextureBlock";
 
 // async-loaded shaders
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -1,0 +1,116 @@
+import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
+import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
+import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
+import { NodeMaterialModes } from "../../Enums/nodeMaterialModes";
+import { CurrentScreenBlock } from "./currentScreenBlock";
+import { RegisterClass } from "core/Misc/typeStore";
+import { InputBlock } from "../Input/inputBlock";
+import type { NodeMaterialBlock } from "../../nodeMaterialBlock";
+import type { NodeMaterial } from "../../nodeMaterial";
+
+/** @internal */
+export const SfeModeDefine = "USE_SFE_FRAMEWORK";
+
+/**
+ * Base block used for compositing an input SFE texture.
+ * This block extends the functionality of CurrentScreenBlock
+ * so that it can be used in the SFE framework.
+ */
+export class SmartFilterTextureBlock extends CurrentScreenBlock {
+    /**
+     * Create a new SmartFilterTextureBlock
+     * @param name defines the block name
+     */
+    public constructor(name: string) {
+        super(name);
+        this._samplerName = "sfeInput";
+    }
+
+    /**
+     * Gets the current class name
+     * @returns the class name
+     */
+    public override getClassName() {
+        return "SmartFilterTextureBlock";
+    }
+    /**
+     * Initialize the block and prepare the context for build
+     * @param state defines the state that will be used for the build
+     */
+    public override initialize(state: NodeMaterialBuildState) {
+        super.initialize(state);
+
+        if (state.sharedData.nodeMaterial.mode !== NodeMaterialModes.SFE) {
+            throw new Error("SmartFilterTextureBlock: Can only be used in SFE mode.");
+        }
+
+        // Tell FragmentOutputBlock ahead of time to store the final color in a temp variable
+        if (state.target === NodeMaterialBlockTargets.Fragment) {
+            state._customOutputName = "outColor";
+        }
+    }
+
+    protected override _getMainUvName(state: NodeMaterialBuildState): string {
+        // Get the ScreenUVBlock's name, which is required for SFE and should be vUV.
+        // NOTE: In the future, when we move to vertex shaders, update this to check for the nearest vec2 varying output.
+        const screenUv = state.sharedData.nodeMaterial.getInputBlockByPredicate((b) => b.isAttribute && b.name === "postprocess_uv");
+        if (!screenUv || !screenUv.isAnAncestorOf(this)) {
+            throw new Error("SmartFilterTextureBlock: 'postprocess_uv' attribute from ScreenUVBlock is required.");
+        }
+        return screenUv.associatedVariableName;
+    }
+
+    protected override _emitUvAndSampler(state: NodeMaterialBuildState): void {
+        if (state.target === NodeMaterialBlockTargets.Fragment) {
+            // Wrap the varying in a define, as it won't be needed in SFE.
+            state._emitVaryingFromString(this._mainUVName, NodeMaterialBlockConnectionPointTypes.Vector2, SfeModeDefine, true);
+            // Append `// main` to denote this as the main input texture to composite
+            state._emit2DSampler(this._samplerName, undefined, undefined, "// main");
+        }
+    }
+
+    public override autoConfigure(material: NodeMaterial, additionalFilteringInfo: (node: NodeMaterialBlock) => boolean = () => true) {
+        if (!this.uv.isConnected) {
+            let uvInput = material.getInputBlockByPredicate((b) => b.isAttribute && b.name === "postprocess_uv" && additionalFilteringInfo(b));
+
+            if (!uvInput) {
+                uvInput = new InputBlock("uv");
+                uvInput.setAsAttribute("postprocess_uv");
+            }
+            uvInput.output.connectTo(this.uv);
+        }
+    }
+
+    protected override _buildBlock(state: NodeMaterialBuildState) {
+        super._buildBlock(state);
+
+        if (state.target === NodeMaterialBlockTargets.Fragment) {
+            // Add the header JSON for the SFE block
+            if (!state._injectAtTop) {
+                state._injectAtTop = `// { "smartFilterBlockType": "${state.sharedData.nodeMaterial.name}", "namespace": "Babylon.NME.Test" }`;
+            }
+
+            // Convert the main fragment function into a helper function, to later be inserted in an SFE pipeline.
+            if (!state._customEntryHeader) {
+                state._customEntryHeader += `#ifdef ${SfeModeDefine}\n`;
+                state._customEntryHeader += `vec4 nmeMain(vec2 ${this._mainUVName}) { // main\n`;
+                state._customEntryHeader += `#else\n`;
+                state._customEntryHeader += `void main(void) {\n`;
+                state._customEntryHeader += `#endif\n`;
+                state._customEntryHeader += `vec4 outColor = vec4(0.0);\n`;
+            }
+
+            if (!state._injectAtEnd) {
+                state._injectAtEnd += `\n#ifndef ${SfeModeDefine}\n`;
+                state._injectAtEnd += `gl_FragColor = outColor;\n`;
+                state._injectAtEnd += `#else\n`;
+                state._injectAtEnd += `return outColor;\n`;
+                state._injectAtEnd += `#endif\n`;
+            }
+        }
+
+        return this;
+    }
+}
+
+RegisterClass("BABYLON.SmartFilterTextureBlock", SmartFilterTextureBlock);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -1,7 +1,6 @@
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
-import { SfeModeDefine } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { RegisterClass } from "../../../../Misc/typeStore";
@@ -178,18 +177,11 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
         state._emitFunctionFromInclude("helperFunctions", comments);
 
         let outputString = "gl_FragColor";
-        if (state.shaderLanguage === ShaderLanguage.WGSL) {
+        if (state._customOutputName) {
+            outputString = state._customOutputName;
+        } else if (state.shaderLanguage === ShaderLanguage.WGSL) {
             state.compilationString += `var fragmentOutputsColor : vec4<f32>;\r\n`;
             outputString = "fragmentOutputsColor";
-        } else if (state.isSFEMode) {
-            // SFE: Use an intermediate variable to control whether to use gl_FragColor or return the color
-            state.compilationString += `vec4 outColor = vec4(0.0);`;
-            outputString = "outColor";
-            state._injectAtEnd += `\n#ifndef ${SfeModeDefine}\n`;
-            state._injectAtEnd += `gl_FragColor = outColor;\n`;
-            state._injectAtEnd += `#else\n`;
-            state._injectAtEnd += `return outColor;\n`;
-            state._injectAtEnd += `#endif\n`;
         }
 
         const vec4 = state._getShaderType(NodeMaterialBlockConnectionPointTypes.Vector4);

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -533,9 +533,7 @@ export class InputBlock extends NodeMaterialBlock {
                 return;
             }
 
-            // SFE: Mark the current value of the uniform as its default value.
-            const annotation = state.isSFEMode ? `// { "default": ${JSON.stringify(this.valueCallback?.() ?? this.value)} }` : undefined;
-            state._emitUniformFromString(this._associatedVariableName, this.type, undefined, undefined, annotation);
+            state._emitUniformFromString(this._associatedVariableName, this.type, undefined, undefined, JSON.stringify(this.valueCallback?.() ?? this.value));
 
             if (state.shaderLanguage === ShaderLanguage.WGSL) {
                 this._prefix = "uniforms.";

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -533,7 +533,7 @@ export class InputBlock extends NodeMaterialBlock {
                 return;
             }
 
-            state._emitUniformFromString(this._associatedVariableName, this.type, undefined, undefined, JSON.stringify(this.valueCallback?.() ?? this.value));
+            state._emitUniformFromString(this._associatedVariableName, this.type);
 
             if (state.shaderLanguage === ShaderLanguage.WGSL) {
                 this._prefix = "uniforms.";

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1277,9 +1277,6 @@ export class NodeMaterial extends PushMaterial {
         const defines = new NodeMaterialDefines();
 
         const dummyMesh = new Mesh(tempName + "PostProcess", this.getScene());
-        dummyMesh.reservedDataStore = {
-            hidden: true,
-        };
 
         let buildId = this._buildId;
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1850,11 +1850,7 @@ export class NodeMaterial extends PushMaterial {
             this.build();
         }
 
-        const nmeDefines = new NodeMaterialDefines();
-        const dummyMesh = new Mesh("Dummy", this.getScene());
-        this._processDefines(dummyMesh, nmeDefines);
-
-        let processingDefines = nmeDefines.toString();
+        let processingDefines = "";
         if (this.mode === NodeMaterialModes.SFE) {
             processingDefines += `#define ${SfeModeDefine}\n`;
         }

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -9,7 +9,6 @@ import type { NodeMaterialBlock } from "./nodeMaterialBlock";
 import { Process } from "core/Engines/Processors/shaderProcessor";
 import type { _IProcessingOptions } from "core/Engines/Processors/shaderProcessingOptions";
 import { WebGLShaderProcessor } from "core/Engines/WebGL/webGLShaderProcessors";
-// import type { Nullable } from "core/types";
 
 /**
  * Class used to store node based material build state
@@ -614,7 +613,7 @@ export class NodeMaterialBuildState {
     /**
      * @internal
      */
-    public _emitUniformFromString(name: string, type: NodeMaterialBlockConnectionPointTypes, define: string = "", notDefine = false, currentValue?: string) {
+    public _emitUniformFromString(name: string, type: NodeMaterialBlockConnectionPointTypes, define: string = "", notDefine = false) {
         if (this.uniforms.indexOf(name) !== -1) {
             return;
         }

--- a/packages/dev/core/src/Materials/Node/nodeMaterialDefault.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialDefault.ts
@@ -11,7 +11,7 @@ import type { NodeMaterial } from "./nodeMaterial";
 import { MultiplyBlock } from "./Blocks/multiplyBlock";
 import { Texture } from "../Textures/texture";
 import { Tools } from "core/Misc/tools";
-import { CurrentScreenBlock } from "./Blocks/Dual/currentScreenBlock";
+import { SmartFilterTextureBlock } from "./Blocks/Dual/smartFilterTextureBlock";
 import { Color4 } from "core/Maths/math.color";
 
 /**
@@ -85,8 +85,10 @@ export function SetToDefaultSFE(nodeMaterial: NodeMaterial): void {
 
     const uv = new InputBlock("uv");
     uv.setAsAttribute("postprocess_uv");
+    uv.comments = "Normalized screen position to sample our texture with.";
 
-    const currentScreen = new CurrentScreenBlock("Main Input Texture");
+    const currentScreen = new SmartFilterTextureBlock("Input Texture");
+    currentScreen.comments = "A placeholder that represents the input texture to compose.";
     uv.connectTo(currentScreen);
     const textureUrl = Tools.GetAssetUrl("https://assets.babylonjs.com/core/nme/currentScreenPostProcess.png");
     currentScreen.texture = new Texture(textureUrl, nodeMaterial.getScene());

--- a/packages/tools/nodeEditor/src/blockTools.ts
+++ b/packages/tools/nodeEditor/src/blockTools.ts
@@ -111,6 +111,7 @@ import { StorageWriteBlock } from "core/Materials/Node/Blocks/storageWriteBlock"
 import { MatrixSplitterBlock } from "core/Materials/Node/Blocks/matrixSplitterBlock";
 import { NodeMaterialDebugBlock } from "core/Materials/Node/Blocks/debugBlock";
 import { IridescenceBlock } from "core/Materials/Node/Blocks/PBR/iridescenceBlock";
+import { SmartFilterTextureBlock } from "core/Materials/Node/Blocks/Dual/smartFilterTextureBlock";
 
 export class BlockTools {
     public static GetBlockFromString(data: string, scene: Scene, nodeMaterial: NodeMaterial) {
@@ -700,6 +701,8 @@ export class BlockTools {
                 return new GaussianBlock("Gaussian");
             case "SplatReaderBlock":
                 return new SplatReaderBlock("SplatReader");
+            case "SmartFilterTextureBlock":
+                return new SmartFilterTextureBlock("SmartFilterTexture");
         }
 
         return null;

--- a/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -198,6 +198,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
         StorageWriteBlock: "Block used to write to a loop storage variable",
         MatrixSplitterBlock: "Block used to split a matrix into Vector4",
         DebugBlock: "Block used to render intermediate debug values",
+        SmartFilterTextureBlock: "Block used to add a Smart Filter Effect (SFE) shader interface",
     };
 
     private _customFrameList: { [key: string]: string };
@@ -464,7 +465,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 "ParticleTextureMaskBlock",
                 "ParticleUVBlock",
             ],
-            SFE: ["ScreenUVBlock"],
+            SFE: ["ScreenUVBlock", "SmartFilterTextureBlock"],
             GaussianSplatting: ["GaussianSplattingBlock", "SplatIndexBlock", "SplatReaderBlock", "GaussianBlock"],
             PBR: ["PBRMetallicRoughnessBlock", "AnisotropyBlock", "ClearCoatBlock", "IridescenceBlock", "ReflectionBlock", "RefractionBlock", "SheenBlock", "SubSurfaceBlock"],
             PostProcess: ["ScreenPositionBlock", "CurrentScreenBlock", "PrePassTextureBlock"],
@@ -500,6 +501,7 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 delete allBlocks["Procedural__Texture"];
                 delete allBlocks["PBR"];
                 delete allBlocks["GaussianSplatting"];
+                allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassTextureBlock"), 1);
                 allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassOutputBlock"), 1);
                 break;
             case NodeMaterialModes.PostProcess:

--- a/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/nodeList/nodeListComponent.tsx
@@ -501,7 +501,6 @@ export class NodeListComponent extends React.Component<INodeListComponentProps, 
                 delete allBlocks["Procedural__Texture"];
                 delete allBlocks["PBR"];
                 delete allBlocks["GaussianSplatting"];
-                allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassTextureBlock"), 1);
                 allBlocks.Output_Nodes.splice(allBlocks.Output_Nodes.indexOf("PrePassOutputBlock"), 1);
                 break;
             case NodeMaterialModes.PostProcess:

--- a/packages/tools/nodeEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeEditor/src/components/preview/previewManager.ts
@@ -681,11 +681,11 @@ export class PreviewManager {
 
                     this._postprocess = tempMaterial.createPostProcess(this._camera, 1.0, Constants.TEXTURE_NEAREST_SAMPLINGMODE, this._engine);
 
-                    const currentScreen = tempMaterial.getBlockByPredicate((block) => block instanceof CurrentScreenBlock);
+                    const currentScreen = tempMaterial.getBlockByPredicate((block) => block instanceof CurrentScreenBlock) as Nullable<CurrentScreenBlock>;
                     if (currentScreen && this._postprocess) {
                         this._postprocess.externalTextureSamplerBinding = true;
                         this._postprocess.onApplyObservable.add((effect) => {
-                            effect.setTexture("textureSampler", (currentScreen as CurrentScreenBlock).texture);
+                            effect.setTexture(currentScreen.samplerName, currentScreen.texture);
                         });
                     }
 

--- a/packages/tools/nodeEditor/src/graphSystem/registerToDisplayLedger.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/registerToDisplayLedger.ts
@@ -34,6 +34,7 @@ export const RegisterToDisplayManagers = () => {
     DisplayLedger.RegisteredControls["ReflectionBlock"] = TextureDisplayManager;
     DisplayLedger.RegisteredControls["RefractionBlock"] = TextureDisplayManager;
     DisplayLedger.RegisteredControls["CurrentScreenBlock"] = TextureDisplayManager;
+    DisplayLedger.RegisteredControls["SmartFilterTextureBlock"] = TextureDisplayManager;
     DisplayLedger.RegisteredControls["ParticleTextureBlock"] = TextureDisplayManager;
     DisplayLedger.RegisteredControls["TriPlanarBlock"] = TextureDisplayManager;
     DisplayLedger.RegisteredControls["BiPlanarBlock"] = TextureDisplayManager;

--- a/packages/tools/nodeEditor/src/graphSystem/registerToPropertyLedger.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/registerToPropertyLedger.ts
@@ -21,6 +21,7 @@ export const RegisterToPropertyTabManagers = () => {
     PropertyLedger.RegisteredControls["ReflectionBlock"] = TexturePropertyTabComponent;
     PropertyLedger.RegisteredControls["RefractionBlock"] = TexturePropertyTabComponent;
     PropertyLedger.RegisteredControls["CurrentScreenBlock"] = TexturePropertyTabComponent;
+    PropertyLedger.RegisteredControls["SmartFilterTextureBlock"] = TexturePropertyTabComponent;
     PropertyLedger.RegisteredControls["ParticleTextureBlock"] = TexturePropertyTabComponent;
     PropertyLedger.RegisteredControls["TriPlanarBlock"] = TexturePropertyTabComponent;
     PropertyLedger.RegisteredControls["BiPlanarBlock"] = TexturePropertyTabComponent;


### PR DESCRIPTION
This is an attempt to keep the SFE logic all in one place, as much as possible, to help with maintainability and extending the SFE mode logic. In practice, this block would be mandatory for exporting an SFE block.