### PR TITLE
Fix inspector bugs where animation target name gets cut off and clicking on it does not link to target

### DIFF
--- a/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/targetedAnimationPropertyGridComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/propertyGrids/animations/targetedAnimationPropertyGridComponent.tsx
@@ -107,7 +107,7 @@ export class TargetedAnimationGridComponent extends React.Component<ITargetedAni
                         <TextLineComponent
                             label="Target"
                             value={targetedAnimation.target.name}
-                            onLink={() => this.props.globalState.onSelectionChangedObservable.notifyObservers(targetedAnimation)}
+                            onLink={() => this.props.globalState.onSelectionChangedObservable.notifyObservers(targetedAnimation.target)}
                         />
                     )}
                     {this._animationCurveEditorContext && <AnimationCurveEditorComponent globalState={this.props.globalState} context={this._animationCurveEditorContext} />}

--- a/packages/dev/sharedUiComponents/src/lines/textLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/textLineComponent.tsx
@@ -39,16 +39,17 @@ export class TextLineComponent extends React.Component<ITextLineComponentProps> 
         if (this.props.ignoreValue) {
             return null;
         }
+        const title = this.props.tooltip ?? this.props.value ?? this.props.label ?? "";
 
         if (this.props.onLink || this.props.url) {
             return (
-                <div className="link-value" title={this.props.tooltip ?? this.props.label ?? ""} onClick={() => this.onLink()}>
+                <div className="link-value" title={title} onClick={() => this.onLink()}>
                     {this.props.url ? "doc" : this.props.value || "no name"}
                 </div>
             );
         }
         return (
-            <div className="value" title={this.props.tooltip ?? this.props.label ?? ""} style={{ color: this.props.color ? this.props.color : "" }}>
+            <div className="value" title={title} style={{ color: this.props.color ? this.props.color : "" }}>
                 {this.props.value || "no name"}
             </div>
         );


### PR DESCRIPTION
Added the tooltip on hover
![image](https://github.com/user-attachments/assets/39eedd11-60ab-4e7e-91ad-62653fbeacb9)

And clicking on the target now updates scene explorer with target as selected node
![image](https://github.com/user-attachments/assets/abbc6e6e-1628-4b74-8694-e7cfb4e35d25)
