### PR TITLE
glTF interactivity extension updates

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVectorMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphVectorMathBlocks.ts
@@ -1,11 +1,19 @@
 import type { IFlowGraphBlockConfiguration } from "core/FlowGraph/flowGraphBlock";
-import { RichTypeVector3, FlowGraphTypes, RichTypeNumber, RichTypeAny, RichTypeVector2, RichTypeMatrix, getRichTypeByFlowGraphType } from "core/FlowGraph/flowGraphRichTypes";
+import {
+    RichTypeVector3,
+    FlowGraphTypes,
+    RichTypeNumber,
+    RichTypeAny,
+    RichTypeVector2,
+    RichTypeMatrix,
+    getRichTypeByFlowGraphType,
+    RichTypeQuaternion,
+} from "core/FlowGraph/flowGraphRichTypes";
 import { RegisterClass } from "core/Misc/typeStore";
 import { FlowGraphBlockNames } from "../../flowGraphBlockNames";
 import { FlowGraphBinaryOperationBlock } from "../flowGraphBinaryOperationBlock";
 import { FlowGraphUnaryOperationBlock } from "../flowGraphUnaryOperationBlock";
-import { Matrix, Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
-import { FlowGraphTernaryOperationBlock } from "../flowGraphTernaryOperationBlock";
+import { Matrix, Quaternion, Vector2, Vector3, Vector4 } from "core/Maths/math.vector";
 import type { FlowGraphMatrix2D, FlowGraphMatrix3D } from "core/FlowGraph/CustomTypes";
 import type { FlowGraphMatrix, FlowGraphVector } from "core/FlowGraph/utils";
 import { _GetClassNameOf } from "core/FlowGraph/utils";
@@ -114,7 +122,7 @@ RegisterClass(FlowGraphBlockNames.Cross, FlowGraphCrossBlock);
  */
 export class FlowGraphRotate2DBlock extends FlowGraphBinaryOperationBlock<Vector2, number, Vector2> {
     constructor(config?: IFlowGraphBlockConfiguration) {
-        super(RichTypeVector2, RichTypeNumber, RichTypeVector2, (a, b) => Vector2.Transform(a, Matrix.RotationZ(b)), FlowGraphBlockNames.Rotate2D, config);
+        super(RichTypeVector2, RichTypeNumber, RichTypeVector2, (a, b) => a.rotate(b), FlowGraphBlockNames.Rotate2D, config);
     }
 }
 RegisterClass(FlowGraphBlockNames.Rotate2D, FlowGraphRotate2DBlock);
@@ -122,17 +130,9 @@ RegisterClass(FlowGraphBlockNames.Rotate2D, FlowGraphRotate2DBlock);
 /**
  * 3D rotation block.
  */
-export class FlowGraphRotate3DBlock extends FlowGraphTernaryOperationBlock<Vector3, Vector3, number, Vector3> {
+export class FlowGraphRotate3DBlock extends FlowGraphBinaryOperationBlock<Vector3, Quaternion, Vector3> {
     constructor(config?: IFlowGraphBlockConfiguration) {
-        super(
-            RichTypeVector3,
-            RichTypeVector3,
-            RichTypeNumber,
-            RichTypeVector3,
-            (a, b, c) => Vector3.TransformCoordinates(a, Matrix.RotationAxis(b, c)),
-            FlowGraphBlockNames.Rotate3D,
-            config
-        );
+        super(RichTypeVector3, RichTypeQuaternion, RichTypeVector3, (a, b) => a.applyRotationQuaternion(b), FlowGraphBlockNames.Rotate3D, config);
     }
 }
 RegisterClass(FlowGraphBlockNames.Rotate3D, FlowGraphRotate3DBlock);

--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -636,6 +636,17 @@ export class Vector2 implements Vector<Tuple<number, 2>, IVector2Like>, IVector2
     }
 
     /**
+     * Gets a new Vector2 rotated by the given angle
+     * @param angle defines the rotation angle
+     * @returns a new Vector2
+     */
+    public rotate(angle: number): Vector2 {
+        const result = new Vector2();
+        this.rotateToRef(angle, result);
+        return result;
+    }
+
+    /**
      * Rotate the current vector into a given result vector
      * Example Playground https://playground.babylonjs.com/#QYBWV4#49
      * @param angle defines the rotation angle
@@ -645,10 +656,8 @@ export class Vector2 implements Vector<Tuple<number, 2>, IVector2Like>, IVector2
     public rotateToRef<T extends IVector2Like>(angle: number, result: T): T {
         const cos = Math.cos(angle);
         const sin = Math.sin(angle);
-        const x = cos * this.x - sin * this.y;
-        const y = sin * this.x + cos * this.y;
-        result.x = x;
-        result.y = y;
+        result.x = cos * this.x - sin * this.y;
+        result.y = sin * this.x + cos * this.y;
         return result;
     }
 

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity.ts
@@ -79,7 +79,7 @@ export class KHR_interactivity implements IGLTFLoaderExtension {
         const coordinator = new FlowGraphCoordinator({ scene });
         coordinator.dispatchEventsSynchronously = false; // glTF interactivity dispatches events asynchronously
         const graphs = interactivityDefinition.graphs.map((graph) => {
-            const parser = new InteractivityGraphToFlowGraphParser(graph, this._loader.gltf, this._loader);
+            const parser = new InteractivityGraphToFlowGraphParser(graph, this._loader.gltf, this._loader.parent.targetFps);
             return parser.serializeToFlowGraph();
         });
         // parse each graph async

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -457,8 +457,8 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
     "math/normalize": getSimpleInputMapping(FlowGraphBlockNames.Normalize),
     "math/dot": getSimpleInputMapping(FlowGraphBlockNames.Dot, ["a", "b"]),
     "math/cross": getSimpleInputMapping(FlowGraphBlockNames.Cross, ["a", "b"]),
-    "math/rotate2d": getSimpleInputMapping(FlowGraphBlockNames.Rotate2D, ["a", "b"]),
-    "math/rotate3d": getSimpleInputMapping(FlowGraphBlockNames.Rotate3D, ["a", "b", "c"]),
+    "math/rotate2D": getSimpleInputMapping(FlowGraphBlockNames.Rotate2D, ["a", "b"]),
+    "math/rotate3D": getSimpleInputMapping(FlowGraphBlockNames.Rotate3D, ["a", "b"]),
     "math/transform": {
         // glTF transform is vectorN with matrixN
         blocks: [FlowGraphBlockNames.TransformVector],
@@ -1431,9 +1431,8 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
             values: {
                 animation: { name: "index", gltfType: "number", toBlock: FlowGraphBlockNames.ArrayIndex },
                 speed: { name: "speed", gltfType: "number" },
-                // 60 is a const from the glTF loader
-                startTime: { name: "from", gltfType: "number", dataTransformer: (time: number[], parser) => [time[0] * parser._loader.parent.targetFps] },
-                endTime: { name: "to", gltfType: "number", dataTransformer: (time: number[], parser) => [time[0] * parser._loader.parent.targetFps] },
+                startTime: { name: "from", gltfType: "number", dataTransformer: (time: number[], parser) => [time[0] * parser._animationTargetFps] },
+                endTime: { name: "to", gltfType: "number", dataTransformer: (time: number[], parser) => [time[0] * parser._animationTargetFps] },
             },
         },
         outputs: {
@@ -1507,7 +1506,7 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         inputs: {
             values: {
                 animation: { name: "index", gltfType: "number", toBlock: FlowGraphBlockNames.ArrayIndex },
-                stopTime: { name: "stopAtFrame", gltfType: "number", dataTransformer: (time: number[], parser) => [time[0] * parser._loader.parent.targetFps] },
+                stopTime: { name: "stopAtFrame", gltfType: "number", dataTransformer: (time: number[], parser) => [time[0] * parser._animationTargetFps] },
             },
         },
         outputs: {
@@ -1722,8 +1721,8 @@ export function getAllSupportedNativeNodeTypes(): string[] {
    - Normalize (`math/normalize`) FlowGraphBlockNames.Normalize
    - Dot Product (`math/dot`) FlowGraphBlockNames.Dot
    - Cross Product (`math/cross`) FlowGraphBlockNames.Cross
-   - Rotate 2D (`math/rotate2d`) FlowGraphBlockNames.Rotate2D
-   - Rotate 3D (`math/rotate3d`) FlowGraphBlockNames.Rotate3D
+   - Rotate 2D (`math/rotate2D`) FlowGraphBlockNames.Rotate2D
+   - Rotate 3D (`math/rotate3D`) FlowGraphBlockNames.Rotate3D
    - Transform (`math/transform`) FlowGraphBlockNames.TransformVector
 9. **Matrix Nodes**
    - Transpose (`math/transpose`) FlowGraphBlockNames.Transpose

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/interactivityGraphParser.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/interactivityGraphParser.ts
@@ -9,7 +9,6 @@ import type { IFlowGraphBlockConfiguration } from "core/FlowGraph/flowGraphBlock
 import type { FlowGraphBlockNames } from "core/FlowGraph/Blocks/flowGraphBlockNames";
 import { FlowGraphConnectionType } from "core/FlowGraph/flowGraphConnection";
 import { FlowGraphTypes } from "core/FlowGraph/flowGraphRichTypes";
-import type { GLTFLoader } from "../../glTFLoader";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface InteractivityEvent {
@@ -51,7 +50,7 @@ export class InteractivityGraphToFlowGraphParser {
     constructor(
         private _interactivityGraph: IKHRInteractivity_Graph,
         private _gltf: IGLTF,
-        public _loader: GLTFLoader
+        public _animationTargetFps: number = 60
     ) {
         // start with types
         this._parseTypes();

--- a/packages/dev/loaders/test/unit/Interactivity/animation nodes.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/animation nodes.test.ts
@@ -47,11 +47,7 @@ describe("Interactivity/animation nodes", () => {
         };
 
         const pathConverter = GetPathToObjectConverter(mockGltf);
-        const i2fg = new InteractivityGraphToFlowGraphParser(ig, mockGltf, {
-            parent: {
-                targetFps: 60,
-            },
-        } as unknown as any);
+        const i2fg = new InteractivityGraphToFlowGraphParser(ig, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         const graph = await ParseFlowGraphAsync(json, { coordinator, pathConverter });

--- a/packages/dev/loaders/test/unit/Interactivity/babylon.interactivity.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/babylon.interactivity.test.ts
@@ -17,11 +17,6 @@ describe("Babylon Interactivity", () => {
     const log: jest.SpyInstance = jest.spyOn(Logger, "Log");
     let mockGltf: any;
     const pathConverter = GetPathToObjectConverter(mockGltf);
-    const mockLoader = {
-        parent: {
-            targetFps: 60,
-        },
-    } as unknown as any;
 
     beforeEach(() => {
         engine = new NullEngine();
@@ -31,7 +26,7 @@ describe("Babylon Interactivity", () => {
     });
 
     it("should load a basic graph", async () => {
-        const i2fg = new InteractivityGraphToFlowGraphParser(loggerExample, mockGltf, mockLoader);
+        const i2fg = new InteractivityGraphToFlowGraphParser(loggerExample, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         await ParseFlowGraphAsync(json, { coordinator, pathConverter });
@@ -42,7 +37,7 @@ describe("Babylon Interactivity", () => {
     });
 
     it("should load a math graph", async () => {
-        const i2fg = new InteractivityGraphToFlowGraphParser(mathExample, mockGltf, mockLoader);
+        const i2fg = new InteractivityGraphToFlowGraphParser(mathExample, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         await ParseFlowGraphAsync(json, { coordinator, pathConverter });
@@ -53,7 +48,7 @@ describe("Babylon Interactivity", () => {
     });
 
     it("should do integer math operations", async () => {
-        const i2fg = new InteractivityGraphToFlowGraphParser(intMathExample, mockGltf, mockLoader);
+        const i2fg = new InteractivityGraphToFlowGraphParser(intMathExample, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         await ParseFlowGraphAsync(json, { coordinator, pathConverter });
@@ -72,7 +67,7 @@ describe("Babylon Interactivity", () => {
                 },
             ],
         };
-        const i2fg = new InteractivityGraphToFlowGraphParser(worldPointerExample, mockGltf, mockLoader);
+        const i2fg = new InteractivityGraphToFlowGraphParser(worldPointerExample, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         const pathConverter = GetPathToObjectConverter(gltf);
@@ -85,7 +80,7 @@ describe("Babylon Interactivity", () => {
     });
 
     it("should execute an event N times with doN", async () => {
-        const i2fg = new InteractivityGraphToFlowGraphParser(doNExample, mockGltf, mockLoader);
+        const i2fg = new InteractivityGraphToFlowGraphParser(doNExample, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         await ParseFlowGraphAsync(json, { coordinator, pathConverter });

--- a/packages/dev/loaders/test/unit/Interactivity/event nodes.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/event nodes.test.ts
@@ -53,20 +53,12 @@ describe("Interactivity event nodes", () => {
         };
 
         const pathConverter = GetPathToObjectConverter(mockGltf);
-        const i2fg = new InteractivityGraphToFlowGraphParser(
-            ig,
-            {
-                ...mockGltf,
-                extensions: {
-                    KHR_interactivity: ig,
-                },
+        const i2fg = new InteractivityGraphToFlowGraphParser(ig, {
+            ...mockGltf,
+            extensions: {
+                KHR_interactivity: ig,
             },
-            {
-                parent: {
-                    targetFps: 60,
-                },
-            } as unknown as any
-        );
+        });
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         const graph = await ParseFlowGraphAsync(json, { coordinator, pathConverter });

--- a/packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts
@@ -43,11 +43,7 @@ describe("Flow Nodes", () => {
             variables,
         };
 
-        const i2fg = new InteractivityGraphToFlowGraphParser(ig, mockGltf, {
-            parent: {
-                targetFps: 60,
-            },
-        } as unknown as any);
+        const i2fg = new InteractivityGraphToFlowGraphParser(ig, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         const graph = await ParseFlowGraphAsync(json, { coordinator, pathConverter });

--- a/packages/dev/loaders/test/unit/Interactivity/objectModel.test.ts
+++ b/packages/dev/loaders/test/unit/Interactivity/objectModel.test.ts
@@ -51,11 +51,7 @@ describe("glTF interactivity Object Model", () => {
         };
 
         const pathConverter = GetPathToObjectConverter(mockGltf);
-        const i2fg = new InteractivityGraphToFlowGraphParser(ig, mockGltf, {
-            parent: {
-                targetFps: 60,
-            },
-        } as unknown as any);
+        const i2fg = new InteractivityGraphToFlowGraphParser(ig, mockGltf);
         const json = i2fg.serializeToFlowGraph();
         const coordinator = new FlowGraphCoordinator({ scene });
         const graph = await ParseFlowGraphAsync(json, { coordinator, pathConverter });


### PR DESCRIPTION
- Changed casing (spec update)
  - rotate2d -> rotate2D
  - rotate3d -> rotate3D
- Updated rotate2D to use explicit function instead of matrix (to match new spec language exactly)
- Updated rotate3D to use quaternion instead of axis/angle (spec update)
- Pass targetFps directly into gltf interactivity parser
- Factor out rounding function in math nodes unit test