### PR TITLE
Viewer: Switch from ShadowOnlyMaterial to BackgroundMaterial

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/background.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/background.fragment.fx
@@ -203,7 +203,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 
             #ifdef TEXTURELODSUPPORT
                 // Apply environment convolution scale/offset filter tuning parameters to the mipmap LOD selection
-                reflectionLOD = reflectionLOD * log2(vReflectionMicrosurfaceInfos.x) * vReflectionMicrosurfaceInfos.y + vReflectionMicrosurfaceInfos.z;
+                reflectionLOD = reflectionLOD * log2(uniforms.vReflectionMicrosurfaceInfos.x) * uniforms.vReflectionMicrosurfaceInfos.y + uniforms.vReflectionMicrosurfaceInfos.z;
                 reflectionColor = textureSampleLevel(reflectionSampler, reflectionSamplerSampler, reflectionCoords, reflectionLOD);
             #else
                 var lodReflectionNormalized: f32 = saturate(reflectionLOD);

--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -32,8 +32,7 @@
     },
     "peerDependencies": {
         "@babylonjs/core": "^8.0.0",
-        "@babylonjs/loaders": "^8.0.0",
-        "@babylonjs/materials": "^8.0.0"
+        "@babylonjs/loaders": "^8.0.0"
     },
     "devDependencies": {
         "@babylonjs/core": "^8.10.0",

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1789,6 +1789,8 @@ export class Viewer implements IDisposable {
             generator.setTransparencyShadow(true);
             generator.filteringQuality = ShadowGenerator.QUALITY_HIGH;
             generator.useBlurExponentialShadowMap = true;
+            generator.enableSoftTransparentShadow = true;
+            generator.bias = radius / 1000;
             generator.useKernelBlur = true;
             generator.blurKernel = 32;
 

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1801,7 +1801,7 @@ export class Viewer implements IDisposable {
 
             const shadowMaterial = new BackgroundMaterial("shadowMapGroundMaterial", this._scene);
             shadowMaterial.shadowOnly = true;
-            shadowMaterial.primaryColor = new Color3(0, 0, 0);
+            shadowMaterial.primaryColor = Color3.Black();
 
             const ground = CreateDisc("shadowMapGround", { radius: groundSize, tessellation: 64 }, this._scene);
             ground.rotation.x = Math.PI / 2;


### PR DESCRIPTION
`ShadowOnlyMaterial` does not currently have a native wgsl implementation, which means it has to be converted to glsl at runtime, which is not ideal. Switching to `BackgroundMaterial` solves this, plus it removes the dependency on `@babylonjs/materials`.

I also switched the skybox material over to `BackgroundMaterial` since it can do what we need in a lighter weight way (unlit + reflection blur). In doing so, it revealed a bug in `BackgroundMaterial`'s wgls fragment shader implementation, where it was simply missing `uniforms.` when referencing the `vReflectionMicrosurfaceInfos` uniform.

This PR also includes a few other small Viewer changes related to shadows:
- Store the shadow light as type `ShadowLight` instead of `Spotlight`. This is really just in preparation to switch to `DirectionalLight`, which will be a different PR.
- Set `ShadowGenerator.enableSoftTransparentShadow = true;` (feedback from @Popov72).
- Set `ShadowGenerator.bias = radius / 1000;` (feedback from @Popov72, and we'll see if we need to also allow the user to explicitly override the `bias`).