### PR TITLE
SmartFilterTextureBlock: Uniform metadata and multiple block instance handling

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -13,9 +13,9 @@ import { ScreenSizeBlock } from "../Fragment/screenSizeBlock";
 export const SfeModeDefine = "USE_SFE_FRAMEWORK";
 
 /**
- * Base block used for compositing an input SFE texture.
- * This block extends the functionality of CurrentScreenBlock
- * so that it can be used in the SFE framework.
+ * Base block used for creating Smart Filter shader blocks for the SFE framework.
+ * This block extends the functionality of CurrentScreenBlock, as both are used
+ * to represent composition against an arbitrary texture and work similarly.
  */
 export class SmartFilterTextureBlock extends CurrentScreenBlock {
     /**
@@ -111,7 +111,7 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
         if (state.target === NodeMaterialBlockTargets.Fragment) {
             // Add the header JSON for the SFE block
             if (!state._injectAtTop) {
-                state._injectAtTop = `// { "smartFilterBlockType": "${state.sharedData.nodeMaterial.name}", "namespace": "Babylon.NME.Test" }`;
+                state._injectAtTop = `// { "smartFilterBlockType": "${state.sharedData.nodeMaterial.name}", "namespace": "Babylon.NME.Exports" }`;
             }
 
             // Convert the main fragment function into a helper function, to later be inserted in an SFE pipeline.

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -8,6 +8,7 @@ import { InputBlock } from "../Input/inputBlock";
 import type { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import type { NodeMaterial } from "../../nodeMaterial";
 import { ScreenSizeBlock } from "../Fragment/screenSizeBlock";
+import { Logger } from "core/Misc/logger";
 
 /** @internal */
 export const SfeModeDefine = "USE_SFE_FRAMEWORK";
@@ -43,7 +44,7 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
         super.initialize(state);
 
         if (state.sharedData.nodeMaterial.mode !== NodeMaterialModes.SFE) {
-            throw new Error("SmartFilterTextureBlock: Can only be used in SFE mode.");
+            Logger.Error("SmartFilterTextureBlock: Should not be used outside of SFE mode.");
         }
 
         // Tell FragmentOutputBlock ahead of time to store the final color in a temp variable
@@ -79,7 +80,8 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
         // NOTE: In the future, when we move to vertex shaders, update this to check for the nearest vec2 varying output.
         const screenUv = state.sharedData.nodeMaterial.getInputBlockByPredicate((b) => b.isAttribute && b.name === "postprocess_uv");
         if (!screenUv || !screenUv.isAnAncestorOf(this)) {
-            throw new Error("SmartFilterTextureBlock: 'postprocess_uv' attribute from ScreenUVBlock is required.");
+            Logger.Error("SmartFilterTextureBlock: 'postprocess_uv' attribute from ScreenUVBlock is required.");
+            return "";
         }
         return screenUv.associatedVariableName;
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -9,6 +9,7 @@ import type { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import type { NodeMaterial } from "../../nodeMaterial";
 import { ScreenSizeBlock } from "../Fragment/screenSizeBlock";
 import { Logger } from "core/Misc/logger";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
 /** @internal */
 export const SfeModeDefine = "USE_SFE_FRAMEWORK";
@@ -45,6 +46,10 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
 
         if (state.sharedData.nodeMaterial.mode !== NodeMaterialModes.SFE) {
             Logger.Error("SmartFilterTextureBlock: Should not be used outside of SFE mode.");
+        }
+
+        if (state.sharedData.nodeMaterial.shaderLanguage !== ShaderLanguage.GLSL) {
+            Logger.Error("SmartFilterTextureBlock: WebGPU is not supported by SFE mode.");
         }
 
         // Tell FragmentOutputBlock ahead of time to store the final color in a temp variable

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -68,8 +68,8 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
         }
 
         // Annotate uniforms of InputBlocks and bindable blocks with their current values
-        if (!state.sharedData.getUniformAnnotation) {
-            state.sharedData.getUniformAnnotation = (name: string) => {
+        if (!state.sharedData.formatConfig.getUniformAnnotation) {
+            state.sharedData.formatConfig.getUniformAnnotation = (name: string) => {
                 for (const block of state.sharedData.nodeMaterial.attachedBlocks) {
                     if (block instanceof InputBlock && block.isUniform && block.associatedVariableName === name) {
                         return this._generateInputBlockAnnotation(block);
@@ -81,6 +81,18 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
                 return "";
             };
         }
+
+        // Do our best to clean up variable names, as they will be used as display names.
+        state.sharedData.formatConfig.formatVariablename = (n: string) => {
+            let name = n;
+
+            const hasUnderscoredPrefix = name.length > 1 && name[1] === "_";
+            if (hasUnderscoredPrefix) {
+                name = name.substring(2);
+            }
+
+            return name.replace(/[^a-zA-Z]+/g, "");
+        };
     }
 
     private _generateInputBlockAnnotation(inputBlock: InputBlock): string {

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSizeBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/screenSizeBlock.ts
@@ -16,6 +16,13 @@ export class ScreenSizeBlock extends NodeMaterialBlock {
     private _scene: Scene;
 
     /**
+     * Name of the variable in the shader that holds the screen size
+     */
+    public get associatedVariableName(): string {
+        return this._varName;
+    }
+
+    /**
      * Creates a new ScreenSizeBlock
      * @param name defines the block name
      */

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -517,7 +517,7 @@ export class InputBlock extends NodeMaterialBlock {
         // Uniforms
         if (this.isUniform) {
             if (!this._associatedVariableName) {
-                this._associatedVariableName = state._getFreeVariableName("u_" + this.name);
+                this._associatedVariableName = state._getFreeVariableName(this.name);
             }
 
             if (this.isConstant) {

--- a/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Input/inputBlock.ts
@@ -517,7 +517,7 @@ export class InputBlock extends NodeMaterialBlock {
         // Uniforms
         if (this.isUniform) {
             if (!this._associatedVariableName) {
-                this._associatedVariableName = state._getFreeVariableName(this.name);
+                this._associatedVariableName = state._getFreeVariableName("u_" + this.name);
             }
 
             if (this.isConstant) {

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -630,6 +630,9 @@ export class NodeMaterialBuildState {
                 this._uniformDeclaration += `${notDefine ? "#ifndef" : "#ifdef"} ${define}\n`;
             }
         }
+        if (this.sharedData.getUniformAnnotation) {
+            this._uniformDeclaration += this.sharedData.getUniformAnnotation(name);
+        }
         const shaderType = this._getShaderType(type);
         if (this.shaderLanguage === ShaderLanguage.WGSL) {
             this._uniformDeclaration += `uniform ${name}: ${shaderType};\n`;

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildState.ts
@@ -240,7 +240,7 @@ export class NodeMaterialBuildState {
      * @internal
      */
     public _getFreeVariableName(prefix: string): string {
-        prefix = prefix.replace(/[^a-zA-Z_]+/g, "");
+        prefix = this.sharedData.formatConfig.formatVariablename(prefix);
 
         if (this.sharedData.variableNames[prefix] === undefined) {
             this.sharedData.variableNames[prefix] = 0;
@@ -630,8 +630,8 @@ export class NodeMaterialBuildState {
                 this._uniformDeclaration += `${notDefine ? "#ifndef" : "#ifdef"} ${define}\n`;
             }
         }
-        if (this.sharedData.getUniformAnnotation) {
-            this._uniformDeclaration += this.sharedData.getUniformAnnotation(name);
+        if (this.sharedData.formatConfig.getUniformAnnotation) {
+            this._uniformDeclaration += this.sharedData.formatConfig.getUniformAnnotation(name);
         }
         const shaderType = this._getShaderType(type);
         if (this.shaderLanguage === ShaderLanguage.WGSL) {

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
@@ -99,6 +99,11 @@ export class NodeMaterialBuildStateSharedData {
     public animatedInputs: InputBlock[] = [];
 
     /**
+     * Callback to add comments to uniform declarations
+     */
+    public getUniformAnnotation: Nullable<(name: string) => string> = null;
+
+    /**
      * Build Id used to avoid multiple recompilations
      */
     public buildId: number;

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBuildStateSharedData.ts
@@ -99,9 +99,12 @@ export class NodeMaterialBuildStateSharedData {
     public animatedInputs: InputBlock[] = [];
 
     /**
-     * Callback to add comments to uniform declarations
+     * Configurations used to format the generated code
      */
-    public getUniformAnnotation: Nullable<(name: string) => string> = null;
+    public formatConfig = {
+        getUniformAnnotation: null as Nullable<(name: string) => string>,
+        formatVariablename: (name: string) => name.replace(/[^a-zA-Z_]+/g, ""),
+    };
 
     /**
      * Build Id used to avoid multiple recompilations

--- a/packages/tools/nodeEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeEditor/src/components/preview/previewManager.ts
@@ -680,13 +680,16 @@ export class PreviewManager {
                     this._globalState.onIsLoadingChanged.notifyObservers(false);
 
                     this._postprocess = tempMaterial.createPostProcess(this._camera, 1.0, Constants.TEXTURE_NEAREST_SAMPLINGMODE, this._engine);
-
-                    const currentScreen = tempMaterial.getBlockByPredicate((block) => block instanceof CurrentScreenBlock) as Nullable<CurrentScreenBlock>;
-                    if (currentScreen && this._postprocess) {
-                        this._postprocess.externalTextureSamplerBinding = true;
-                        this._postprocess.onApplyObservable.add((effect) => {
-                            effect.setTexture(currentScreen.samplerName, currentScreen.texture);
-                        });
+                    if (this._postprocess) {
+                        for (const block of tempMaterial.getTextureBlocks()) {
+                            if (!(block instanceof CurrentScreenBlock)) {
+                                return;
+                            }
+                            this._postprocess.externalTextureSamplerBinding = true;
+                            this._postprocess.onApplyObservable.add((effect) => {
+                                effect.setTexture(block.samplerName, block.texture);
+                            });
+                        }
                     }
 
                     if (this._material) {


### PR DESCRIPTION
This PR extends the SmartFilterTextureBlock's functionality to permit
- Multiple instances of the block, used for sampling several textures
- Designating a block as the "main input", which is used for auto-disabling in SFE
- Annotations for input block and bindable block uniforms, used for specifying default values
- Cleaning up of uniform names, used as display names for connection points in SFE

Some misc changes include
- Use Logger for errors instead of throwing and breaking the build :)
- Extra WebGPU check for good measure
- Expose ScreenSizeBlock uniform name 