### PR TITLE
Fixed area light specular calculation

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -101,7 +101,7 @@
             // Specular contribution
             #ifdef SPECULARTERM
                 #if AREALIGHT{X}
-                    info.specular = computeAreaSpecularLighting(preInfo, light{X}.vLightSpecular.rgb);
+                    info.specular = computeAreaSpecularLighting(preInfo, light{X}.vLightSpecular.rgb, clearcoatOut.specularEnvironmentR0, reflectivityOut.colorReflectanceF90);
                 #else
                     // For OpenPBR, we use the F82 specular model for metallic materials and mix with the
                     // usual Schlick lobe.

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingFunctions.fx
@@ -120,8 +120,8 @@ vec3 computeProjectionTextureDiffuseLighting(sampler2D projectionLightSampler, m
     }
 
     #if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
-        vec3 computeAreaSpecularLighting(preLightingInfo info, vec3 specularColor) {
-            vec3 fresnel = ( specularColor * info.areaLightFresnel.x + ( vec3( 1.0 ) - specularColor ) * info.areaLightFresnel.y );
+        vec3 computeAreaSpecularLighting(preLightingInfo info, vec3 specularColor, vec3 reflectance0, vec3 reflectance90) {
+            vec3 fresnel = specularColor * info.areaLightFresnel.x * reflectance0 + ( vec3( 1.0 ) - specularColor ) * info.areaLightFresnel.y * reflectance90;
 	        return specularColor * fresnel * info.areaLightSpecular;
         }
     #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -101,7 +101,7 @@
             // Specular contribution
             #ifdef SPECULARTERM
                 #if AREALIGHT{X}
-                    info.specular = computeAreaSpecularLighting(preInfo, light{X}.vLightSpecular.rgb);
+                    info.specular = computeAreaSpecularLighting(preInfo, light{X}.vLightSpecular.rgb, clearcoatOut.specularEnvironmentR0, reflectivityOut.colorReflectanceF90);
                 #else
                     // For OpenPBR, we use the F82 specular model for metallic materials and mix with the
                     // usual Schlick lobe.

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions.fx
@@ -123,8 +123,8 @@ fn computeProjectionTextureDiffuseLighting(projectionLightTexture: texture_2d<f3
     }
 
     #if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
-        fn computeAreaSpecularLighting(info: preLightingInfo, specularColor: vec3f) -> vec3f {
-            var fresnel:vec3f  = ( specularColor * info.areaLightFresnel.x + ( vec3f( 1.0 ) - specularColor ) * info.areaLightFresnel.y );
+        fn computeAreaSpecularLighting(info: preLightingInfo, specularColor: vec3f, reflectance0: vec3f, reflectance90: vec3f) -> vec3f {
+            var fresnel:vec3f  = reflectance0 * specularColor * info.areaLightFresnel.x + ( vec3f( 1.0 ) - specularColor ) * info.areaLightFresnel.y * reflectance90;
             return specularColor * fresnel * info.areaLightSpecular;
         }
     #endif


### PR DESCRIPTION
Area lights were not correctly considering the contributions of object's albedo and metallic channel when rendering. We now have those contributions been properly considered and making it render the same way as other light sources. 