### PR TITLE
NodeMaterial: Gather defines without mesh

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/clipPlanesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/clipPlanesBlock.ts
@@ -90,7 +90,11 @@ export class ClipPlanesBlock extends NodeMaterialBlock {
 
     public override set target(value: NodeMaterialBlockTargets) {}
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         const scene = mesh.getScene();
 
         const useClipPlane1 = (nodeMaterial.clipPlane ?? scene.clipPlane) ? true : false;

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/currentScreenBlock.ts
@@ -3,8 +3,7 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
-import type { NodeMaterialDefines, NodeMaterial } from "../../nodeMaterial";
+import type { NodeMaterialDefines } from "../../nodeMaterial";
 import type { BaseTexture } from "../../../Textures/baseTexture";
 import type { Nullable } from "../../../../types";
 import { RegisterClass } from "../../../../Misc/typeStore";
@@ -148,7 +147,7 @@ export class CurrentScreenBlock extends NodeMaterialBlock {
         return NodeMaterialBlockTargets.Fragment;
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines) {
         defines.setValue(this._linearDefineName, this.convertToGammaSpace, true);
         defines.setValue(this._gammaDefineName, this.convertToLinearSpace, true);
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/fogBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/fogBlock.ts
@@ -128,7 +128,11 @@ export class FogBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         const scene = mesh.getScene();
         defines.setValue("FOG", nodeMaterial.fogEnabled && GetFogState(mesh, scene));
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -211,8 +211,8 @@ export class LightBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        if (!defines._areLightsDirty) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh || !defines._areLightsDirty) {
             return;
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.ts
@@ -3,7 +3,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import type { BaseTexture } from "../../../Textures/baseTexture";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines } from "../../nodeMaterial";
 import { NodeMaterial } from "../../nodeMaterial";
 import type { Effect } from "../../../effect";
@@ -225,7 +224,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines) {
         if (!defines._areTexturesDirty) {
             return;
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -350,7 +350,7 @@ export class TextureBlock extends NodeMaterialBlock {
         }
     }
 
-    public override initializeDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override initializeDefines(defines: NodeMaterialDefines) {
         if (!defines._areTexturesDirty) {
             return;
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines } from "../../nodeMaterial";
 import { NodeMaterial } from "../../nodeMaterial";
 import { InputBlock } from "../Input/inputBlock";
@@ -360,7 +359,7 @@ export class TextureBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines) {
         if (!defines._areTexturesDirty) {
             return;
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/TBNBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/TBNBlock.ts
@@ -152,7 +152,11 @@ export class TBNBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         const normal = this.normal;
         const tangent = this.tangent;
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -5,7 +5,6 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { Scene } from "../../../../scene";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines, NodeMaterial } from "../../nodeMaterial";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import type { Effect } from "../../../effect";
@@ -134,7 +133,7 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
         return this._inputs[3];
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial) {
         defines.setValue(this._linearDefineName, this.convertToLinearSpace, true);
         defines.setValue(this._gammaDefineName, this.convertToGammaSpace, true);
         defines.setValue(this._additionalColorDefineName, this.additionalColor.connectedPoint && nodeMaterial._useAdditionalColor, true);

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
@@ -121,7 +121,7 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
         return true;
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial) {
         if (defines._areImageProcessingDirty && nodeMaterial.imageProcessingConfiguration) {
             nodeMaterial.imageProcessingConfiguration.prepareDefines(defines);
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/perturbNormalBlock.ts
@@ -6,7 +6,6 @@ import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnect
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { Mesh } from "../../../../Meshes/mesh";
 import { InputBlock } from "../Input/inputBlock";
 import type { Effect } from "../../../effect";
@@ -199,7 +198,7 @@ export class PerturbNormalBlock extends NodeMaterialBlock {
         this.onCodeIsReadyObservable.notifyObservers(this);
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial) {
         const normalSamplerName = (this.normalMapColor.connectedPoint!._ownerBlock as TextureBlock).samplerName;
         const useParallax = this.viewDirection.isConnected && ((this.useParallaxOcclusion && normalSamplerName) || (!this.useParallaxOcclusion && this.parallaxHeight.isConnected));
 

--- a/packages/dev/core/src/Materials/Node/Blocks/GaussianSplatting/gaussianSplattingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/GaussianSplatting/gaussianSplattingBlock.ts
@@ -106,7 +106,11 @@ export class GaussianSplattingBlock extends NodeMaterialBlock {
      * @param nodeMaterial defines the node material requesting the update
      * @param defines defines the material defines to update
      */
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         if (mesh.getClassName() == "GaussianSplattingMesh") {
             defines.setValue("SH_DEGREE", (<GaussianSplattingMesh>mesh).shDegree, true);
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/anisotropyBlock.ts
@@ -5,7 +5,6 @@ import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnect
 import { NodeMaterialConnectionPointDirection } from "../../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import { TBNBlock } from "../Fragment/TBNBlock";
 import type { Mesh } from "../../../../Meshes/mesh";
@@ -212,9 +211,7 @@ export class AnisotropyBlock extends NodeMaterialBlock {
         return code;
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
-
+    public override prepareDefines(defines: NodeMaterialDefines) {
         defines.setValue("ANISOTROPIC", true);
         defines.setValue("ANISOTROPIC_TEXTURE", false, true);
         defines.setValue("ANISOTROPIC_LEGACY", !this.roughness.isConnected);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/clearCoatBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/clearCoatBlock.ts
@@ -8,7 +8,6 @@ import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { ReflectionBlock } from "./reflectionBlock";
 import type { Scene } from "../../../../scene";
 import type { Nullable } from "../../../../types";
@@ -186,9 +185,7 @@ export class ClearCoatBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
-
+    public override prepareDefines(defines: NodeMaterialDefines) {
         defines.setValue("CLEARCOAT", true);
         defines.setValue("CLEARCOAT_TEXTURE", false, true);
         defines.setValue("CLEARCOAT_USE_ROUGHNESS_FROM_MAINTEXTURE", true, true);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/iridescenceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/iridescenceBlock.ts
@@ -7,8 +7,7 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
-import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
+import type { NodeMaterialDefines } from "../../nodeMaterial";
 import type { Scene } from "../../../../scene";
 import type { Nullable } from "../../../../types";
 import { PBRIridescenceConfiguration } from "../../../../Materials/PBR/pbrIridescenceConfiguration";
@@ -100,9 +99,7 @@ export class IridescenceBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
-
+    public override prepareDefines(defines: NodeMaterialDefines) {
         defines.setValue("IRIDESCENCE", true, true);
         defines.setValue("IRIDESCENCE_TEXTURE", false, true);
         defines.setValue("IRIDESCENCE_THICKNESS_TEXTURE", false, true);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -717,7 +717,11 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         // General
         defines.setValue("PBR", true);
         defines.setValue("METALLICWORKFLOW", true);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/reflectionBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/reflectionBlock.ts
@@ -7,7 +7,6 @@ import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
 import { ReflectionTextureBaseBlock } from "../Dual/reflectionTextureBaseBlock";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { Nullable } from "../../../../types";
 import { Texture } from "../../../Textures/texture";
 import type { BaseTexture } from "../../../Textures/baseTexture";
@@ -195,8 +194,8 @@ export class ReflectionBlock extends ReflectionTextureBaseBlock {
         return this._scene.environmentTexture;
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
+    public override prepareDefines(defines: NodeMaterialDefines) {
+        super.prepareDefines(defines);
 
         const reflectionTexture = this._getTexture();
         const reflection = reflectionTexture && reflectionTexture.getTextureMatrix;

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.ts
@@ -7,7 +7,6 @@ import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { Nullable } from "../../../../types";
 import type { BaseTexture } from "../../../Textures/baseTexture";
 import type { Mesh } from "../../../../Meshes/mesh";
@@ -189,9 +188,7 @@ export class RefractionBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
-
+    public override prepareDefines(defines: NodeMaterialDefines) {
         const refractionTexture = this._getTexture();
         const refraction = refractionTexture && refractionTexture.getTextureMatrix;
 

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/sheenBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/sheenBlock.ts
@@ -7,8 +7,7 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
-import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
+import type { NodeMaterialDefines } from "../../nodeMaterial";
 import type { ReflectionBlock } from "./reflectionBlock";
 import type { Scene } from "../../../../scene";
 import type { Nullable } from "../../../../types";
@@ -100,9 +99,7 @@ export class SheenBlock extends NodeMaterialBlock {
         return this._outputs[0];
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
-
+    public override prepareDefines(defines: NodeMaterialDefines) {
         defines.setValue("SHEEN", true);
         defines.setValue("SHEEN_USE_ROUGHNESS_FROM_MAINTEXTURE", true, true);
         defines.setValue("SHEEN_LINKWITHALBEDO", this.linkSheenWithAlbedo, true);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/subSurfaceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/subSurfaceBlock.ts
@@ -7,8 +7,7 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
-import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
+import type { NodeMaterialDefines } from "../../nodeMaterial";
 import type { ReflectionBlock } from "./reflectionBlock";
 import type { Nullable } from "../../../../types";
 import { RefractionBlock } from "./refractionBlock";
@@ -134,9 +133,7 @@ export class SubSurfaceBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        super.prepareDefines(mesh, nodeMaterial, defines);
-
+    public override prepareDefines(defines: NodeMaterialDefines) {
         const translucencyEnabled = this.translucencyDiffusionDist.isConnected || this.translucencyIntensity.isConnected;
 
         defines.setValue("SUBSURFACE", translucencyEnabled || this.refraction.isConnected, true);

--- a/packages/dev/core/src/Materials/Node/Blocks/Particle/particleTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Particle/particleTextureBlock.ts
@@ -3,7 +3,6 @@ import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialB
 import type { NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines, NodeMaterial } from "../../nodeMaterial";
 import { InputBlock } from "../Input/inputBlock";
 import type { BaseTexture } from "../../../Textures/baseTexture";
@@ -136,7 +135,7 @@ export class ParticleTextureBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines) {
         defines.setValue(this._linearDefineName, this.convertToGammaSpace, true);
         defines.setValue(this._gammaDefineName, this.convertToLinearSpace, true);
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/bonesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/bonesBlock.ts
@@ -141,7 +141,7 @@ export class BonesBlock extends NodeMaterialBlock {
         }
     }
 
-    public override provideFallbacks(mesh: AbstractMesh, fallbacks: EffectFallbacks) {
+    public override provideFallbacks(fallbacks: EffectFallbacks, mesh?: AbstractMesh) {
         if (mesh && mesh.useBones && mesh.computeBonesUsingShaders && mesh.skeleton) {
             fallbacks.addCPUSkinningFallback(0, mesh);
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/bonesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/bonesBlock.ts
@@ -151,8 +151,8 @@ export class BonesBlock extends NodeMaterialBlock {
         BindBonesParameters(mesh, effect);
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        if (!defines._areAttributesDirty) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!defines._areAttributesDirty || !mesh) {
             return;
         }
         PrepareDefinesForBones(mesh, defines);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/instancesBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/instancesBlock.ts
@@ -141,7 +141,7 @@ export class InstancesBlock extends NodeMaterialBlock {
         this.world.define = "!INSTANCES || THIN_INSTANCES";
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines, useInstances: boolean = false, subMesh?: SubMesh) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh, useInstances: boolean = false, subMesh?: SubMesh) {
         let changed = false;
         if (defines["INSTANCES"] !== useInstances) {
             defines.setValue("INSTANCES", useInstances);

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/lightInformationBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/lightInformationBlock.ts
@@ -11,7 +11,6 @@ import type { NodeMaterial, NodeMaterialDefines } from "../../nodeMaterial";
 import type { Mesh } from "../../../../Meshes/mesh";
 import type { Light } from "../../../../Lights/light";
 import { PointLight } from "../../../../Lights/pointLight";
-import type { AbstractMesh } from "../../../../Meshes/abstractMesh";
 import type { ShadowGenerator } from "../../../../Lights/Shadows/shadowGenerator";
 import type { ShadowLight } from "../../../../Lights";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -163,7 +162,7 @@ export class LightInformationBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines) {
         if (!defines._areLightsDirty && !this._forcePrepareDefines) {
             return;
         }

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -253,12 +253,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         }
     }
 
-    public override replaceRepeatableContent(
-        vertexShaderState: NodeMaterialBuildState,
-        fragmentShaderState: NodeMaterialBuildState,
-        mesh: AbstractMesh,
-        defines: NodeMaterialDefines
-    ) {
+    public override replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, mesh: AbstractMesh, defines: NodeMaterialDefines) {
         const position = this.position;
         const normal = this.normal;
         const tangent = this.tangent;

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -253,7 +253,11 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         }
     }
 
-    public override replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, mesh: AbstractMesh, defines: NodeMaterialDefines) {
+    public override replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, defines: NodeMaterialDefines, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         const position = this.position;
         const normal = this.normal;
         const tangent = this.tangent;

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -223,7 +223,11 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         }
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (!mesh) {
+            return;
+        }
+
         if ((<Mesh>mesh).morphTargetManager) {
             const morphTargetManager = (<Mesh>mesh).morphTargetManager;
 

--- a/packages/dev/core/src/Materials/Node/Blocks/transformBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/transformBlock.ts
@@ -169,13 +169,12 @@ export class TransformBlock extends NodeMaterialBlock {
 
     /**
      * Update defines for shader compilation
-     * @param mesh defines the mesh to be rendered
-     * @param nodeMaterial defines the node material requesting the update
      * @param defines defines the material defines to update
+     * @param nodeMaterial defines the node material requesting the update
+     * @param mesh defines the mesh to be rendered
      */
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
-        // Do nothing
-        if (mesh.nonUniformScaling) {
+    public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh) {
+        if (mesh && mesh.nonUniformScaling) {
             defines.setValue("NONUNIFORMSCALING", true);
         }
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.ts
@@ -4,7 +4,6 @@ import type { NodeMaterialBuildState } from "../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../Enums/nodeMaterialBlockTargets";
 import type { NodeMaterialConnectionPoint } from "../nodeMaterialBlockConnectionPoint";
 import { NodeMaterialConnectionPointDirection } from "../nodeMaterialBlockConnectionPoint";
-import type { AbstractMesh } from "../../../Meshes/abstractMesh";
 import type { NodeMaterialDefines } from "../nodeMaterial";
 import { NodeMaterial } from "../nodeMaterial";
 import type { Effect } from "../../effect";
@@ -324,7 +323,7 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         return this._outputs[6];
     }
 
-    public override prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+    public override prepareDefines(defines: NodeMaterialDefines) {
         if (!defines._areTexturesDirty) {
             return;
         }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1276,11 +1276,9 @@ export class NodeMaterial extends PushMaterial {
 
         const defines = new NodeMaterialDefines();
 
-        const dummyMesh = new Mesh(tempName + "PostProcess", this.getScene());
-
         let buildId = this._buildId;
 
-        this._processDefines(dummyMesh, defines);
+        this._processDefines(defines);
 
         // If no vertex shader emitted, fallback to default postprocess vertex shader
         const vertexCode = this._sharedData.checks.emitVertex ? this._vertexCompilationState._builtCompilationString : undefined;
@@ -1320,9 +1318,6 @@ export class NodeMaterial extends PushMaterial {
         }
 
         postProcess.nodeMaterialSource = this;
-        postProcess.onDisposeObservable.add(() => {
-            dummyMesh.dispose();
-        });
 
         postProcess.onApplyObservable.add((effect) => {
             if (buildId !== this._buildId) {
@@ -1336,7 +1331,7 @@ export class NodeMaterial extends PushMaterial {
                 buildId = this._buildId;
             }
 
-            const result = this._processDefines(dummyMesh, defines);
+            const result = this._processDefines(defines);
 
             if (result) {
                 Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString);
@@ -1377,13 +1372,8 @@ export class NodeMaterial extends PushMaterial {
 
         const proceduralTexture = new ProceduralTexture(tempName, size, null, scene);
 
-        const dummyMesh = new Mesh(tempName + "Procedural", this.getScene());
-        dummyMesh.reservedDataStore = {
-            hidden: true,
-        };
-
         const defines = new NodeMaterialDefines();
-        const result = this._processDefines(dummyMesh, defines);
+        const result = this._processDefines(defines);
         Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString, this.shaderLanguage);
 
         let effect = this.getScene().getEngine().createEffect(
@@ -1418,7 +1408,7 @@ export class NodeMaterial extends PushMaterial {
                 buildId = this._buildId;
             }
 
-            const result = this._processDefines(dummyMesh, defines);
+            const result = this._processDefines(defines);
 
             if (result) {
                 Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString, this.shaderLanguage);
@@ -1463,7 +1453,6 @@ export class NodeMaterial extends PushMaterial {
         onError?: (effect: Effect, errors: string) => void,
         effect?: Effect,
         defines?: NodeMaterialDefines,
-        dummyMesh?: Nullable<AbstractMesh>,
         particleSystemDefinesJoined = ""
     ) {
         let tempName = this.name + this._buildId + "_" + blendMode;
@@ -1472,23 +1461,13 @@ export class NodeMaterial extends PushMaterial {
             defines = new NodeMaterialDefines();
         }
 
-        if (!dummyMesh) {
-            dummyMesh = this.getScene().getMeshByName(this.name + "Particle");
-            if (!dummyMesh) {
-                dummyMesh = new Mesh(this.name + "Particle", this.getScene());
-                dummyMesh.reservedDataStore = {
-                    hidden: true,
-                };
-            }
-        }
-
         let buildId = this._buildId;
 
         const particleSystemDefines: Array<string> = [];
         let join = particleSystemDefinesJoined;
 
         if (!effect) {
-            const result = this._processDefines(dummyMesh, defines);
+            const result = this._processDefines(defines);
 
             Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, undefined, this.shaderLanguage);
 
@@ -1535,7 +1514,7 @@ export class NodeMaterial extends PushMaterial {
                 join = particleSystemDefinesJoinedCurrent;
             }
 
-            const result = this._processDefines(dummyMesh, defines);
+            const result = this._processDefines(defines);
 
             if (result) {
                 Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, undefined, this.shaderLanguage);
@@ -1553,7 +1532,7 @@ export class NodeMaterial extends PushMaterial {
                         particleSystem
                     );
                 particleSystem.setCustomEffect(effect, blendMode);
-                this._createEffectForParticles(particleSystem, blendMode, onCompiled, onError, effect, defines, dummyMesh, particleSystemDefinesJoined); // add the effect.onBindObservable observer
+                this._createEffectForParticles(particleSystem, blendMode, onCompiled, onError, effect, defines, particleSystemDefinesJoined); // add the effect.onBindObservable observer
                 return;
             }
 
@@ -1618,8 +1597,8 @@ export class NodeMaterial extends PushMaterial {
     }
 
     private _processDefines(
-        mesh: AbstractMesh,
         defines: NodeMaterialDefines,
+        mesh?: AbstractMesh,
         useInstances = false,
         subMesh?: SubMesh
     ): Nullable<{
@@ -1756,7 +1735,7 @@ export class NodeMaterial extends PushMaterial {
             return false;
         }
 
-        const result = this._processDefines(mesh, defines, useInstances, subMesh);
+        const result = this._processDefines(defines, mesh, useInstances, subMesh);
 
         if (result) {
             const previousEffect = subMesh.effect;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1643,7 +1643,7 @@ export class NodeMaterial extends PushMaterial {
         }
 
         for (const b of this._sharedData.blocksWithDefines) {
-            b.prepareDefines(mesh, this, defines, useInstances, subMesh);
+            b.prepareDefines(defines, this, mesh, useInstances, subMesh);
         }
 
         // Need to recompile?

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1829,7 +1829,10 @@ export class NodeMaterial extends PushMaterial {
             this.build();
         }
 
-        let processingDefines = "";
+        const defines = new NodeMaterialDefines();
+        this._processDefines(defines);
+
+        let processingDefines = defines.toString();
         if (this.mode === NodeMaterialModes.SFE) {
             processingDefines += `#define ${SfeModeDefine}\n`;
         }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1656,7 +1656,7 @@ export class NodeMaterial extends PushMaterial {
             this._fragmentCompilationState.compilationString = this._fragmentCompilationState._builtCompilationString;
 
             for (const b of this._sharedData.repeatableContentBlocks) {
-                b.replaceRepeatableContent(this._vertexCompilationState, mesh, defines);
+                b.replaceRepeatableContent(this._vertexCompilationState, defines, mesh);
             }
 
             // Uniforms

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1689,7 +1689,7 @@ export class NodeMaterial extends PushMaterial {
             const fallbacks = new EffectFallbacks();
 
             for (const b of this._sharedData.blocksWithFallbacks) {
-                b.provideFallbacks(mesh, fallbacks);
+                b.provideFallbacks(fallbacks, mesh);
             }
 
             result = {

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1639,7 +1639,7 @@ export class NodeMaterial extends PushMaterial {
 
         // Shared defines
         for (const b of this._sharedData.blocksWithDefines) {
-            b.initializeDefines(mesh, this, defines, useInstances);
+            b.initializeDefines(defines);
         }
 
         for (const b of this._sharedData.blocksWithDefines) {

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1656,7 +1656,7 @@ export class NodeMaterial extends PushMaterial {
             this._fragmentCompilationState.compilationString = this._fragmentCompilationState._builtCompilationString;
 
             for (const b of this._sharedData.repeatableContentBlocks) {
-                b.replaceRepeatableContent(this._vertexCompilationState, this._fragmentCompilationState, mesh, defines);
+                b.replaceRepeatableContent(this._vertexCompilationState, mesh, defines);
             }
 
             // Uniforms

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -520,9 +520,9 @@ export class NodeMaterialBlock {
 
     /**
      * Update defines for shader compilation
-     * @param mesh defines the mesh to be rendered
-     * @param nodeMaterial defines the node material requesting the update
      * @param defines defines the material defines to update
+     * @param nodeMaterial defines the node material requesting the update
+     * @param mesh defines the mesh to be rendered
      * @param useInstances specifies that instances should be used
      * @param subMesh defines which submesh to render
      */

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -501,11 +501,11 @@ export class NodeMaterialBlock {
 
     /**
      * Add potential fallbacks if shader compilation fails
-     * @param mesh defines the mesh to be rendered
      * @param fallbacks defines the current prioritized list of fallbacks
+     * @param mesh defines the mesh to be rendered
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public provideFallbacks(mesh: AbstractMesh, fallbacks: EffectFallbacks) {
+    public provideFallbacks(fallbacks: EffectFallbacks, mesh?: AbstractMesh) {
         // Do nothing
     }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -549,7 +549,7 @@ export class NodeMaterialBlock {
      * @param defines defines the material defines to update
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, fragmentShaderState: NodeMaterialBuildState, mesh: AbstractMesh, defines: NodeMaterialDefines) {
+    public replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, mesh: AbstractMesh, defines: NodeMaterialDefines) {
         // Do nothing
     }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -527,7 +527,7 @@ export class NodeMaterialBlock {
      * @param subMesh defines which submesh to render
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public prepareDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines, useInstances: boolean = false, subMesh?: SubMesh) {
+    public prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial, mesh?: AbstractMesh, useInstances: boolean = false, subMesh?: SubMesh) {
         // Do nothing
     }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -511,13 +511,12 @@ export class NodeMaterialBlock {
 
     /**
      * Initialize defines for shader compilation
-     * @param mesh defines the mesh to be rendered
-     * @param nodeMaterial defines the node material requesting the update
      * @param defines defines the material defines to update
-     * @param useInstances specifies that instances should be used
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public initializeDefines(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines, useInstances: boolean = false) {}
+    public initializeDefines(defines: NodeMaterialDefines) {
+        // Do nothing
+    }
 
     /**
      * Update defines for shader compilation

--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlock.ts
@@ -544,12 +544,11 @@ export class NodeMaterialBlock {
     /**
      * Function called when a block is declared as repeatable content generator
      * @param vertexShaderState defines the current compilation state for the vertex shader
-     * @param fragmentShaderState defines the current compilation state for the fragment shader
-     * @param mesh defines the mesh to be rendered
      * @param defines defines the material defines to update
+     * @param mesh defines the mesh to be rendered
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, mesh: AbstractMesh, defines: NodeMaterialDefines) {
+    public replaceRepeatableContent(vertexShaderState: NodeMaterialBuildState, defines: NodeMaterialDefines, mesh?: AbstractMesh) {
         // Do nothing
     }
 


### PR DESCRIPTION
Allow mesh to be optional when preparing defines for blocks in a graph. This avoids the need for a dummy mesh when gathering defines for modes like postprocess, procedural texture, particle, and smart filters.