### PR TITLE
Fix adding dominant direction to env

### DIFF
--- a/packages/dev/core/src/Misc/environmentTextureTools.ts
+++ b/packages/dev/core/src/Misc/environmentTextureTools.ts
@@ -365,7 +365,7 @@ export async function CreateEnvTextureAsync(texture: BaseTexture, options: Creat
         info.irradiance.irradianceTexture = {
             size: irradianceTexture.getSize().width,
             faces: [],
-            dominantDirection: texture._dominantDirection?.asArray(),
+            dominantDirection: irradianceTexture._dominantDirection?.asArray(),
         };
 
         for (let face = 0; face < 6; face++) {


### PR DESCRIPTION
Looks like the dominant direction wasn't actually getting added to the .env file because the wrong texture was being referenced.