### PR TITLE
Add support for zoomOn with ArcRotateCamera in Orthographic mode

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1452,6 +1452,15 @@ export class ArcRotateCamera extends TargetCamera {
         distance = Math.max(Math.min(distance, this.upperRadiusLimit || Number.MAX_VALUE), this.lowerRadiusLimit || 0);
         this.radius = distance * this.zoomOnFactor;
 
+        if (this.mode === Camera.ORTHOGRAPHIC_CAMERA) {
+            const aspectRatio = this.getScene().getEngine().getAspectRatio(this);
+            const orthoExtent = (distance * this.zoomOnFactor) / 2;
+            this.orthoLeft = -orthoExtent * aspectRatio;
+            this.orthoRight = orthoExtent * aspectRatio;
+            this.orthoBottom = -orthoExtent;
+            this.orthoTop = orthoExtent;
+        }
+
         this.focusOn({ min: minMaxVector.min, max: minMaxVector.max, distance: distance }, doNotUpdateMaxZ);
     }
 


### PR DESCRIPTION
I am working on a project that uses the ArcRotateCamera in Orthographic mode. I want to use the `ArcRotateCamera.zoomOn` function to zoom to a set of meshes. Unfortunately, the zoomOn function updates only the radius, not the orthographic extents.

This PR updates the orthographic extents along with the radius when zooming onto mesh(es) in orthographic mode.

Here is a demo playground: https://playground.babylonjs.com/#545IZ4

**Before:**

https://github.com/user-attachments/assets/77b8516e-4ec8-40e0-a4d5-4f9ae0d4104d

**After:**

https://github.com/user-attachments/assets/876c3b68-3638-48a2-9b71-c909a4ae55ef
