### PR TITLE
fix missing morphtarget color attribute

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -19,6 +19,10 @@
 		#ifdef MORPHTARGETS_UV2
 		attribute vec2 uv2_{X};
 		#endif
+
+		#ifdef MORPHTARGETS_COLOR
+		attribute vec4 color{X};
+		#endif
 	#elif {X} == 0
 		uniform int morphTargetCount;
 	#endif


### PR DESCRIPTION
There's one color attribute declaration that is missing and will cause an error.