### PR TITLE
Add option for HalfFloat in vertexAnimationBaker's textureFromBakedVertexData

### DIFF
--- a/packages/dev/core/src/BakedVertexAnimation/vertexAnimationBaker.ts
+++ b/packages/dev/core/src/BakedVertexAnimation/vertexAnimationBaker.ts
@@ -142,7 +142,7 @@ export class VertexAnimationBaker {
     /**
      * Builds a vertex animation texture given the vertexData in an array.
      * @param vertexData The vertex animation data. You can generate it with bakeVertexData(). You can pass in a Float32Array to return a full precision texture, or a Uint16Array to return a half-float texture.
-     * If you pass in a Uint16Array, make sure your device supports half-float textures.
+     * If you pass in a Uint16Array, make sure your device supports half-float textures
      * @returns The vertex animation texture to be used with BakedVertexAnimationManager.
      */
     public textureFromBakedVertexData(vertexData: Float32Array | Uint16Array): RawTexture {


### PR DESCRIPTION
For devices that support it and animations whose precision is not affected by the precision of float16, using HalfFloat can cut down memory usage by 50%. Currently have a warning when the engine caps don't include HalfFloat - don't know if might make sense to return null instead since whatever happens down the line will not be supported, likely crazy polygon soup from the VAT shader.