### PR TITLE
Viewer Configurator: Add support for shadow quality "high" (IBL)

### DIFF
--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
@@ -61,6 +61,7 @@ const OutputOptions = [
 const ShadowQualityOptions = [
     { label: "None", value: "none" },
     { label: "Normal", value: "normal" },
+    { label: "High", value: "high" },
 ] as const satisfies IInspectableOptions[] & { label: string; value: ShadowQuality }[];
 
 const ToneMappingOptions = [


### PR DESCRIPTION
Now that IBL shadows (quality "high") are in the Viewer and stable, enabling this option in the configurator.

![image](https://github.com/user-attachments/assets/4376829a-0d7d-4c19-bb7d-9dde4a8dbc32)
