### PR TITLE
Inspector v2: Playground integration fixes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -255,7 +255,7 @@
             "label": "Playground Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": "CDN Serve and watch (Dev)",
+            "dependsOn": ["CDN Serve and watch (Dev)", "Watch Inspector v2"],
             "runOptions": {
                 "instanceLimit": 1
             },

--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -25,9 +25,24 @@ module.exports = (env) => {
                 loaders: path.resolve("../../dev/loaders/dist"),
             },
         },
-        externals: {
-            "@dev/core": "BABYLON",
-        },
+        externals: [
+            function ({ context, request }, callback) {
+                if (/^@dev\/core$/.test(request)) {
+                    return callback(null, "BABYLON");
+                }
+
+                if (context.includes("inspector-v2")) {
+                    if (/^core\//.test(request)) {
+                        return callback(null, "BABYLON");
+                    } else if (/^loaders\//.test(request)) {
+                        return callback(null, "BABYLON");
+                    }
+                }
+
+                // Continue without externalizing the import
+                callback();
+            },
+        ],
         module: {
             rules: webpackTools.getRules({
                 sideEffects: true,


### PR DESCRIPTION
From what I can tell, Playground is setup such that the site itself is bundled, and separately it uses the babylonjs umd bundle for running the actual user code in the Playground. Some the Playground website features themselves seem to use @dev/core, and from what I can tell this is a different copy of the code from core. For the inspector-v2 integration, it was effectively also getting a copy of code from core, so the actual classes inspector v2 was looking at were not the same as the ones coming from the Playground user code (e.g. the objects had different prototype chains). I updated the Playground webpack config to externalize any `import { blah } from "core/blah"` to BABYLON for the inspector-v2 and this fixes the problem. That said, it's unclear to me why we don't do this for other features. Why does the Playground site ever need a separate copy of things from core rather than just getting them through the UMD bundle (e.g. BABYLON)? I tried to change it so that all @dev/core and core imports are externalized to BABYLON, but this broke all kinds of things. I don't really understand why, so for now I'm just limiting the externalization to inspector-v2 (e.g. don't change anything was already being packed before adding inspector-v2 to the mix). I'll discuss more with Raanan when he's back.

Also added a VSCode task dependency on inspector-v2 watch to make sure inspector v2 code changes are reflected in Playground.