### PR TITLE
Inspector v2: Stub out stats pane

### DIFF
--- a/packages/dev/inspector-v2/src/components/accordionPane.tsx
+++ b/packages/dev/inspector-v2/src/components/accordionPane.tsx
@@ -1,0 +1,149 @@
+// eslint-disable-next-line import/no-internal-modules
+
+import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, makeStyles, Subtitle1, tokens } from "@fluentui/react-components";
+import { useMemo, useState, type ComponentType } from "react";
+
+export type AccordionSection = Readonly<{
+    /**
+     * A unique identity for the section, which can be referenced by section content.
+     */
+    identity: symbol;
+
+    /**
+     * An optional order for the section, relative to other sections.
+     * Defaults to 0.
+     */
+    order?: number;
+
+    /**
+     * An optional flag indicating whether the section should be collapsed by default.
+     * Defaults to false.
+     */
+    collapseByDefault?: boolean;
+}>;
+
+export type AccordionSectionContent<ContextT> = Readonly<{
+    /**
+     * A unique key for the the content.
+     */
+    key: string;
+
+    /**
+     * The content that is added to individual sections.
+     */
+    content: readonly Readonly<{
+        /**
+         * The section this content belongs to.
+         */
+        section: symbol;
+
+        /**
+         * An optional order for the content within the section.
+         * Defaults to 0.
+         */
+        order?: number;
+
+        /**
+         * The React component that will be rendered for this content.
+         */
+        component: ComponentType<{ context: ContextT }>;
+    }>[];
+}>;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const useStyles = makeStyles({
+    rootDiv: {
+        flex: 1,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+    },
+    placeholderDiv: {
+        padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,
+    },
+    accordion: {
+        overflowY: "auto",
+        paddingBottom: tokens.spacingVerticalM,
+    },
+    panelDiv: {
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+    },
+});
+
+export function AccordionPane<ContextT = unknown>(props: {
+    sections: readonly AccordionSection[];
+    sectionContent: readonly AccordionSectionContent<ContextT>[];
+    context: ContextT;
+}) {
+    const classes = useStyles();
+
+    const { sections, sectionContent, context } = props;
+
+    const [version, setVersion] = useState(0);
+
+    const visibleSections = useMemo(() => {
+        // When any of this state changes, we should re-render the Accordion so the defaultOpenItems are re-evaluated.
+        setVersion((prev) => prev + 1);
+
+        if (!context) {
+            return [];
+        }
+
+        return sections
+            .map((section) => {
+                // Get a flat list of the section content, preserving the key so it can be used when each component for each section is rendered.
+                const contentForSection = sectionContent
+                    .flatMap((entry) => entry.content.map((content) => ({ key: entry.key, ...content })))
+                    .filter((content) => content.section === section.identity);
+
+                // If there is no content for this section, we skip it.
+                if (contentForSection.length === 0) {
+                    return null; // No content for this section
+                }
+
+                // Sort the content for this section by order, defaulting to 0 if not specified.
+                contentForSection.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+
+                // Return the section with its identity, collapseByDefault flag, and the content components to render.
+                return {
+                    identity: section.identity,
+                    collapseByDefault: section.collapseByDefault ?? false,
+                    components: contentForSection.map((content) => ({ key: content.key, component: content.component })),
+                };
+            })
+            .filter((section) => section !== null);
+    }, [sections, sectionContent, context]);
+
+    return (
+        <div className={classes.rootDiv}>
+            {visibleSections.length > 0 && (
+                <Accordion
+                    key={version}
+                    className={classes.accordion}
+                    collapsible
+                    multiple
+                    defaultOpenItems={visibleSections.filter((section) => !section.collapseByDefault).map((section) => section.identity.description)}
+                >
+                    {visibleSections.map((section) => {
+                        return (
+                            <AccordionItem key={section.identity.description} value={section.identity.description}>
+                                <AccordionHeader expandIconPosition="end">
+                                    <Subtitle1>{section.identity.description}</Subtitle1>
+                                </AccordionHeader>
+                                <AccordionPanel>
+                                    <div className={classes.panelDiv}>
+                                        {section.components.map((component) => {
+                                            return <component.component key={component.key} context={context} />;
+                                        })}
+                                    </div>
+                                </AccordionPanel>
+                            </AccordionItem>
+                        );
+                    })}
+                </Accordion>
+            )}
+        </div>
+    );
+}

--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -7,7 +7,7 @@ type CommonEntity = {
     getClassName?: () => string;
 };
 
-export const CommonGeneralProperties: FunctionComponent<{ entity: CommonEntity }> = ({ entity: commonEntity }) => {
+export const CommonGeneralProperties: FunctionComponent<{ context: CommonEntity }> = ({ context: commonEntity }) => {
     return (
         // TODO: Use the new Fluent property line shared components.
         <>

--- a/packages/dev/inspector-v2/src/components/properties/meshAdvancedProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshAdvancedProperties.tsx
@@ -6,7 +6,7 @@ import type { FunctionComponent } from "react";
 import { useInterceptObservable } from "../../hooks/instrumentationHooks";
 import { useObservableState } from "../../hooks/observableHooks";
 
-export const MeshAdvancedProperties: FunctionComponent<{ entity: AbstractMesh }> = ({ entity: mesh }) => {
+export const MeshAdvancedProperties: FunctionComponent<{ context: AbstractMesh }> = ({ context: mesh }) => {
     // There is no observable for computeBonesUsingShaders, so we use an interceptor to listen for changes.
     const computeBonesUsingShaders = useObservableState(() => mesh.computeBonesUsingShaders, useInterceptObservable("property", mesh, "computeBonesUsingShaders"));
 

--- a/packages/dev/inspector-v2/src/components/properties/meshGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshGeneralProperties.tsx
@@ -5,7 +5,7 @@ import type { FunctionComponent } from "react";
 
 import { useObservableState } from "../../hooks/observableHooks";
 
-export const MeshGeneralProperties: FunctionComponent<{ entity: AbstractMesh }> = ({ entity: mesh }) => {
+export const MeshGeneralProperties: FunctionComponent<{ context: AbstractMesh }> = ({ context: mesh }) => {
     // Use the observable to keep keep state up-to-date and re-render the component when it changes.
     const material = useObservableState(() => mesh.material, mesh.onMaterialChangedObservable);
 

--- a/packages/dev/inspector-v2/src/components/properties/meshTransformProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshTransformProperties.tsx
@@ -3,7 +3,7 @@ import type { AbstractMesh } from "core/index";
 
 import type { FunctionComponent } from "react";
 
-export const MeshTransformProperties: FunctionComponent<{ entity: AbstractMesh }> = ({ entity: mesh }) => {
+export const MeshTransformProperties: FunctionComponent<{ context: AbstractMesh }> = ({ context: mesh }) => {
     return (
         // TODO: Use the new Fluent property line shared components.
         <>

--- a/packages/dev/inspector-v2/src/components/properties/propertiesPane.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/propertiesPane.tsx
@@ -1,161 +1,26 @@
 // eslint-disable-next-line import/no-internal-modules
 
-import type { FunctionComponent } from "react";
+import { Body1Strong, makeStyles, tokens } from "@fluentui/react-components";
 
-import { Accordion, AccordionHeader, AccordionItem, AccordionPanel, Body1Strong, makeStyles, Subtitle1, tokens } from "@fluentui/react-components";
-import { useMemo, useState, type ComponentType } from "react";
-
-export type PropertiesServiceSection = Readonly<{
-    /**
-     * A unique identity for the section, which can be referenced by section content.
-     */
-    identity: symbol;
-
-    /**
-     * An optional order for the section, relative to other sections.
-     * Defaults to 0.
-     */
-    order?: number;
-
-    /**
-     * An optional flag indicating whether the section should be collapsed by default.
-     * Defaults to false.
-     */
-    collapseByDefault?: boolean;
-}>;
-
-export type PropertiesServiceSectionContent<EntityT> = Readonly<{
-    /**
-     * A unique key for the the content.
-     */
-    key: string;
-
-    /**
-     * A predicate function that determines if the content is applicable to the given entity.
-     */
-    predicate: (entity: unknown) => entity is EntityT;
-
-    /**
-     * The content that is added to individual sections.
-     */
-    content: readonly Readonly<{
-        /**
-         * The section this content belongs to.
-         */
-        section: symbol;
-
-        /**
-         * An optional order for the content within the section.
-         * Defaults to 0.
-         */
-        order?: number;
-
-        /**
-         * The React component that will be rendered for this content.
-         */
-        component: ComponentType<{ entity: EntityT }>;
-    }>[];
-}>;
+import { AccordionPane } from "../accordionPane";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
-    rootDiv: {
-        flex: 1,
-        overflow: "hidden",
-        display: "flex",
-        flexDirection: "column",
-    },
     placeholderDiv: {
         padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,
     },
-    accordion: {
-        overflowY: "auto",
-        paddingBottom: tokens.spacingVerticalM,
-    },
-    panelDiv: {
-        display: "flex",
-        flexDirection: "column",
-        overflow: "hidden",
-    },
 });
 
-export const PropertiesPane: FunctionComponent<{
-    sections: readonly PropertiesServiceSection[];
-    sectionContent: readonly PropertiesServiceSectionContent<unknown>[];
-    entity: unknown;
-}> = (props) => {
+export const PropertiesPane: typeof AccordionPane<unknown> = (props) => {
     const classes = useStyles();
 
-    const { sections, sectionContent, entity } = props;
+    const entity = props.context;
 
-    const [version, setVersion] = useState(0);
-
-    const visibleSections = useMemo(() => {
-        // When any of this state changes, we should re-render the Accordion so the defaultOpenItems are re-evaluated.
-        setVersion((prev) => prev + 1);
-
-        if (!entity) {
-            return [];
-        }
-
-        const applicableContent = sectionContent.filter((content) => content.predicate(entity));
-        return sections
-            .map((section) => {
-                // Get a flat list of the section content, preserving the key so it can be used when each component for each section is rendered.
-                const contentForSection = applicableContent
-                    .flatMap((entry) => entry.content.map((content) => ({ key: entry.key, ...content })))
-                    .filter((content) => content.section === section.identity);
-
-                // If there is no content for this section, we skip it.
-                if (contentForSection.length === 0) {
-                    return null; // No content for this section
-                }
-
-                // Sort the content for this section by order, defaulting to 0 if not specified.
-                contentForSection.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-
-                // Return the section with its identity, collapseByDefault flag, and the content components to render.
-                return {
-                    identity: section.identity,
-                    collapseByDefault: section.collapseByDefault ?? false,
-                    components: contentForSection.map((content) => ({ key: content.key, component: content.component })),
-                };
-            })
-            .filter((section) => section !== null);
-    }, [sections, sectionContent, entity]);
-
-    return (
-        <div className={classes.rootDiv}>
-            {visibleSections.length > 0 ? (
-                <Accordion
-                    key={version}
-                    className={classes.accordion}
-                    collapsible
-                    multiple
-                    defaultOpenItems={visibleSections.filter((section) => !section.collapseByDefault).map((section) => section.identity.description)}
-                >
-                    {visibleSections.map((section) => {
-                        return (
-                            <AccordionItem key={section.identity.description} value={section.identity.description}>
-                                <AccordionHeader expandIconPosition="end">
-                                    <Subtitle1>{section.identity.description}</Subtitle1>
-                                </AccordionHeader>
-                                <AccordionPanel>
-                                    <div className={classes.panelDiv}>
-                                        {section.components.map((component) => {
-                                            return <component.component key={component.key} entity={entity} />;
-                                        })}
-                                    </div>
-                                </AccordionPanel>
-                            </AccordionItem>
-                        );
-                    })}
-                </Accordion>
-            ) : (
-                <div className={classes.placeholderDiv}>
-                    <Body1Strong italic>{entity ? `Can't show properties for the selected entity type (${entity.toString()})` : "No entity selected."}</Body1Strong>
-                </div>
-            )}
+    return entity != null ? (
+        <AccordionPane {...props} />
+    ) : (
+        <div className={classes.placeholderDiv}>
+            <Body1Strong italic>No entity selected.</Body1Strong>
         </div>
     );
 };

--- a/packages/dev/inspector-v2/src/components/stats/countStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/countStats.tsx
@@ -1,0 +1,17 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { Scene } from "core/index";
+
+import type { FunctionComponent } from "react";
+
+import { useObservableState } from "../../hooks/observableHooks";
+
+export const CountStats: FunctionComponent<{ context: Scene }> = ({ context: scene }) => {
+    const totalMeshes = useObservableState(() => scene.meshes.length, scene.onNewMeshAddedObservable, scene.onMeshRemovedObservable);
+
+    return (
+        // TODO: Use the new Fluent property line shared components.
+        <>
+            <div key="TotalMeshes">TotalMeshes: {totalMeshes}</div>
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
@@ -1,0 +1,57 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { Scene } from "core/index";
+
+import { useEffect, useMemo, type FunctionComponent } from "react";
+
+import { EngineInstrumentation } from "core/Instrumentation/engineInstrumentation";
+import { SceneInstrumentation } from "core/Instrumentation/sceneInstrumentation";
+import "core/Engines/AbstractEngine/abstractEngine.timeQuery";
+
+import { useObservableState } from "../../hooks/observableHooks";
+import { usePollingObservable } from "../../hooks/pollingHooks";
+
+export const FrameStepsStats: FunctionComponent<{ context: Scene }> = ({ context: scene }) => {
+    const engine = scene.getEngine();
+
+    const pollingObservable = usePollingObservable(500);
+
+    const sceneInstrumentation = useMemo(() => {
+        const sceneInstrumentation = new SceneInstrumentation(scene);
+        sceneInstrumentation.captureActiveMeshesEvaluationTime = true;
+        sceneInstrumentation.captureRenderTargetsRenderTime = true;
+        sceneInstrumentation.captureFrameTime = true;
+        sceneInstrumentation.captureRenderTime = true;
+        sceneInstrumentation.captureInterFrameTime = true;
+        sceneInstrumentation.captureParticlesRenderTime = true;
+        sceneInstrumentation.captureSpritesRenderTime = true;
+        sceneInstrumentation.capturePhysicsTime = true;
+        sceneInstrumentation.captureAnimationsTime = true;
+        return sceneInstrumentation;
+    }, [scene]);
+
+    useEffect(() => {
+        return () => sceneInstrumentation.dispose();
+    }, [sceneInstrumentation]);
+
+    const engineInstrumentation = useMemo(() => {
+        const engineInstrumentation = new EngineInstrumentation(engine);
+        engineInstrumentation.captureGPUFrameTime = true;
+        return engineInstrumentation;
+    }, [engine]);
+
+    useEffect(() => {
+        return () => engineInstrumentation.dispose();
+    }, [engineInstrumentation]);
+
+    const absoluteFPS = useObservableState(() => (1000.0 / sceneInstrumentation.frameTimeCounter.lastSecAverage).toFixed(0), pollingObservable);
+    // TODO: Dynamically import the right engine.query module based on the type of engine?
+    const gpuFrameTime = useObservableState(() => (engineInstrumentation.gpuFrameTimeCounter!.lastSecAverage * 0.000001).toFixed(2), pollingObservable);
+
+    return (
+        // TODO: Use the new Fluent property line shared components.
+        <>
+            <div key="AbsoluteFPS">AbsoluteFPS: {absoluteFPS}</div>
+            <div key="GPUFrameTime">GPU Frame Time: {gpuFrameTime}ms</div>
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
@@ -1,0 +1,33 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { Scene } from "core/index";
+
+import { makeStyles, tokens } from "@fluentui/react-components";
+
+import { AbstractEngine } from "core/Engines/abstractEngine";
+
+import { AccordionPane } from "../accordionPane";
+import { useObservableState } from "../../hooks/observableHooks";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const useStyles = makeStyles({
+    fixedStatsDiv: {
+        padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM} 0 ${tokens.spacingHorizontalM}`,
+    },
+});
+
+export const StatsPane: typeof AccordionPane<Scene> = (props) => {
+    const classes = useStyles();
+
+    const scene = props.context;
+    const engine = scene.getEngine();
+    const fps = useObservableState(() => Math.round(engine.getFps()), engine.onBeginFrameObservable);
+
+    return (
+        // TODO: Use the new Fluent property line shared components.
+        <>
+            <div className={classes.fixedStatsDiv}>Version: {AbstractEngine.Version}</div>
+            <div className={classes.fixedStatsDiv}>FPS: {fps}</div>
+            <AccordionPane {...props} />
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/hooks/pollingHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/pollingHooks.ts
@@ -1,0 +1,27 @@
+// eslint-disable-next-line import/no-internal-modules
+import type { IReadonlyObservable } from "core/index";
+
+import { Observable } from "core/Misc";
+import { useEffect, useMemo } from "react";
+
+/**
+ * Creates a polling observable that notifies its observers at a specified interval.
+ * @param delay The polling interval in milliseconds.
+ * @returns A readonly observable that can be used to subscribe to polling notifications.
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function usePollingObservable(delay: number): IReadonlyObservable<void> {
+    const observable = useMemo(() => new Observable<void>(), []);
+
+    useEffect(() => {
+        const intervalId = setInterval(() => {
+            observable.notifyObservers();
+        }, delay);
+
+        return () => {
+            clearInterval(intervalId);
+        };
+    }, [delay, observable]);
+
+    return observable;
+}

--- a/packages/dev/inspector-v2/src/services/panes/statsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/statsService.tsx
@@ -1,14 +1,51 @@
-import type { ServiceDefinition } from "../../modularity/serviceDefinition";
+// eslint-disable-next-line import/no-internal-modules
+import type { IDisposable, Scene } from "core/index";
+
+import type { AccordionSection, AccordionSectionContent } from "../../components/accordionPane";
+import type { IService, ServiceDefinition } from "../../modularity/serviceDefinition";
+import type { ISceneContext } from "../sceneContext";
 import type { IShellService } from "../shellService";
 
 import { DataBarHorizontalRegular } from "@fluentui/react-icons";
 
+import { CountStats } from "../../components/stats/countStats";
+import { StatsPane } from "../../components/stats/statsPane";
+import { useObservableCollection, useObservableState, useOrderedObservableCollection } from "../../hooks/observableHooks";
+import { ObservableCollection } from "../../misc/observableCollection";
+import { SceneContextIdentity } from "../sceneContext";
 import { ShellServiceIdentity } from "../shellService";
 
-export const StatsServiceDefinition: ServiceDefinition<[], [IShellService]> = {
+export const StatsServiceIdentity = Symbol("StatsService");
+export const StatsPerformanceSectionIdentity = Symbol("Performance");
+export const StatsCountSectionIdentity = Symbol("Count");
+export const StatsFrameStepsSectionIdentity = Symbol("Frame Steps Duration");
+export const StatsSystemInfoSectionIdentity = Symbol("System Info");
+
+/**
+ * Provides a scene stats pane.
+ */
+export interface IStatsService extends IService<typeof StatsServiceIdentity> {
+    /**
+     * Adds a new section (e.g. "Count", "Frame Steps Duration", etc.).
+     * @param section A description of the section to add.
+     */
+    addSection(section: AccordionSection): IDisposable;
+
+    /**
+     * Adds content to one or more sections.
+     * @param content A description of the content to add.
+     */
+    addSectionContent(content: AccordionSectionContent<Scene>): IDisposable;
+}
+
+export const StatsServiceDefinition: ServiceDefinition<[IStatsService], [IShellService, ISceneContext]> = {
     friendlyName: "Stats",
-    consumes: [ShellServiceIdentity],
-    factory: (shellService) => {
+    produces: [StatsServiceIdentity],
+    consumes: [ShellServiceIdentity, SceneContextIdentity],
+    factory: (shellService, sceneContext) => {
+        const sectionsCollection = new ObservableCollection<AccordionSection>();
+        const sectionContentCollection = new ObservableCollection<AccordionSectionContent<Scene>>();
+
         const registration = shellService.addSidePane({
             key: "Stats",
             title: "Stats",
@@ -16,11 +53,50 @@ export const StatsServiceDefinition: ServiceDefinition<[], [IShellService]> = {
             horizontalLocation: "right",
             suppressTeachingMoment: true,
             content: () => {
-                return <>Not yet implemented.</>;
+                const sections = useOrderedObservableCollection(sectionsCollection);
+                const sectionContent = useObservableCollection(sectionContentCollection);
+                const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
+
+                return <>{scene && <StatsPane sections={sections} sectionContent={sectionContent} context={scene} />}</>;
             },
         });
 
+        // Default/built-in sections.
+        sectionsCollection.add({
+            identity: StatsPerformanceSectionIdentity,
+            order: 0,
+        });
+
+        sectionsCollection.add({
+            identity: StatsCountSectionIdentity,
+            order: 1,
+        });
+
+        sectionsCollection.add({
+            identity: StatsFrameStepsSectionIdentity,
+            order: 2,
+        });
+
+        sectionsCollection.add({
+            identity: StatsSystemInfoSectionIdentity,
+            order: 3,
+        });
+
+        // Default/built-in content.
+        sectionContentCollection.add({
+            key: "DefaultStats",
+            content: [
+                {
+                    section: StatsCountSectionIdentity,
+                    order: 0,
+                    component: CountStats,
+                },
+            ],
+        });
+
         return {
+            addSection: (section) => sectionsCollection.add(section),
+            addSectionContent: (content) => sectionContentCollection.add(content as AccordionSectionContent<Scene>),
             dispose: () => registration.dispose(),
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/statsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/statsService.tsx
@@ -9,6 +9,7 @@ import type { IShellService } from "../shellService";
 import { DataBarHorizontalRegular } from "@fluentui/react-icons";
 
 import { CountStats } from "../../components/stats/countStats";
+import { FrameStepsStats } from "../../components/stats/frameStepStats";
 import { StatsPane } from "../../components/stats/statsPane";
 import { useObservableCollection, useObservableState, useOrderedObservableCollection } from "../../hooks/observableHooks";
 import { ObservableCollection } from "../../misc/observableCollection";
@@ -90,6 +91,11 @@ export const StatsServiceDefinition: ServiceDefinition<[IStatsService], [IShellS
                     section: StatsCountSectionIdentity,
                     order: 0,
                     component: CountStats,
+                },
+                {
+                    section: StatsFrameStepsSectionIdentity,
+                    order: 0,
+                    component: FrameStepsStats,
                 },
             ],
         });


### PR DESCRIPTION
In this PR, I'm stubbing out a new stats pane, which includes:
1. Factoring out an `AccordionPane` react component from the `PropertiesPane` component. The idea is that we will have several panes that will have the same basic accordion UI, and each can support the same type of extensibility as properties.
2. `PropertiesPane`/`PropertiesService` are slightly more complicated that the other panes in that the "context" of the pane can have different types (e.g. a Mesh or a Light). Given this, I kept the predicate stuff specific to Properties. Other panes like Stats can have a single type that is always the same (like Scene) and be a little simpler.
3. Added a new `StatsPane`/`StatsService` that otherwise follow the same model as properties.

One other difference that I am trying with `StatsService` is to not bother having separate service definitions for the default/built-in content of the status pane. Instead it is defined directly in the `StatsService`, but new service definitions could be defined to extend the default content of the stats pane. This was based off a suggestion @deltakosh had in the original inspector v2 PR.

![image](https://github.com/user-attachments/assets/4c177ec7-e988-4eb5-8875-b423d93926c1)