### PR TITLE
Load dominant direction from .env

### DIFF
--- a/packages/dev/core/src/Misc/environmentTextureTools.ts
+++ b/packages/dev/core/src/Misc/environmentTextureTools.ts
@@ -580,7 +580,11 @@ export function UploadEnvLevelsAsync(texture: InternalTexture, data: ArrayBuffer
     const irradianceTexture = info.irradiance?.irradianceTexture;
     if (irradianceTexture) {
         const irradianceImageData = CreateIrradianceImageDataArrayBufferViews(data, info);
-        promises.push(UploadIrradianceLevelsAsync(texture, irradianceImageData, irradianceTexture.size, info.imageType));
+        let dominantDirection = null;
+        if (info.irradiance?.irradianceTexture?.dominantDirection) {
+            dominantDirection = Vector3.FromArray(info.irradiance.irradianceTexture.dominantDirection);
+        }
+        promises.push(UploadIrradianceLevelsAsync(texture, irradianceImageData, irradianceTexture.size, info.imageType, dominantDirection));
     }
 
     return Promise.all(promises);
@@ -679,20 +683,22 @@ export async function UploadRadianceLevelsAsync(texture: InternalTexture, imageD
  * @param imageData defines the array buffer views of image data [mipmap][face]
  * @param size defines the size of the texture faces
  * @param imageType the mime type of the image data
+ * @param dominantDirection the dominant direction of light in the environment texture, if available
  * @returns a promise
  */
 export async function UploadIrradianceLevelsAsync(
     mainTexture: InternalTexture,
     imageData: ArrayBufferView[],
     size: number,
-    imageType: string = DefaultEnvironmentTextureImageType
+    imageType: string = DefaultEnvironmentTextureImageType,
+    dominantDirection: Nullable<Vector3> = null
 ): Promise<void> {
     // Gets everything ready.
     const engine = mainTexture.getEngine() as Engine;
     const texture = new InternalTexture(engine, InternalTextureSource.RenderTarget);
     const baseTexture = new BaseTexture(engine, texture);
     mainTexture._irradianceTexture = baseTexture;
-
+    baseTexture._dominantDirection = dominantDirection;
     texture.isCube = true;
     texture.format = Constants.TEXTUREFORMAT_RGBA;
     texture.type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
@@ -1076,6 +1082,7 @@ export const EnvironmentTextureTools = {
      * @param texture defines the internal texture to upload to
      * @param imageData defines the array buffer views of image data [mipmap][face]
      * @param imageType the mime type of the image data
+     * @param dominantDirection the dominant direction of light in the environment texture, if available
      * @returns a promise
      */
     UploadIrradianceLevelsAsync,


### PR DESCRIPTION
This adds logic to read the dominant direction of an IBL from the .env file, if it exists.