### PR TITLE
Various fixes for glTF interactivity

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/Math/flowGraphMathBlocks.ts
@@ -15,7 +15,7 @@ import type { FlowGraphMathOperationType, FlowGraphNumber } from "core/FlowGraph
 import { _AreSameIntegerClass, _AreSameMatrixClass, _AreSameVectorOrQuaternionClass, _GetClassNameOf, getNumericValue, isNumeric } from "core/FlowGraph/utils";
 
 /**
- * A configuration interface  for math blocks
+ * A configuration interface for math blocks
  */
 export interface IFlowGraphMathBlockConfiguration extends IFlowGraphBlockConfiguration {
     /**
@@ -61,6 +61,10 @@ export class FlowGraphAddBlock extends FlowGraphBinaryOperationBlock<FlowGraphMa
         if (_AreSameVectorOrQuaternionClass(aClassName, bClassName) || _AreSameMatrixClass(aClassName, bClassName) || _AreSameIntegerClass(aClassName, bClassName)) {
             // cast to vector3, but any other cast will be fine
             return (a as Vector3).add(b as Vector3);
+        } else if (aClassName === FlowGraphTypes.Quaternion || bClassName === FlowGraphTypes.Vector4) {
+            return new Vector4((a as Quaternion).x, (a as Quaternion).y, (a as Quaternion).z, (a as Quaternion).w).addInPlace(b as Vector4);
+        } else if (aClassName === FlowGraphTypes.Vector4 || bClassName === FlowGraphTypes.Quaternion) {
+            return (a as Vector4).add(b as Quaternion);
         } else {
             // at this point at least one of the variables is a number.
             if (this.config?.preventIntegerFloatArithmetic && typeof a !== typeof b) {
@@ -97,6 +101,10 @@ export class FlowGraphSubtractBlock extends FlowGraphBinaryOperationBlock<FlowGr
         if (_AreSameVectorOrQuaternionClass(aClassName, bClassName) || _AreSameIntegerClass(aClassName, bClassName) || _AreSameMatrixClass(aClassName, bClassName)) {
             // cast to vector3, but it can be casted to any vector type
             return (a as Vector3).subtract(b as Vector3);
+        } else if (aClassName === FlowGraphTypes.Quaternion || bClassName === FlowGraphTypes.Vector4) {
+            return new Vector4((a as Quaternion).x, (a as Quaternion).y, (a as Quaternion).z, (a as Quaternion).w).subtractInPlace(b as Vector4);
+        } else if (aClassName === FlowGraphTypes.Vector4 || bClassName === FlowGraphTypes.Quaternion) {
+            return (a as Vector4).subtract(b as Quaternion);
         } else {
             // at this point at least one of the variables is a number.
             if (this.config?.preventIntegerFloatArithmetic && typeof a !== typeof b) {
@@ -130,6 +138,10 @@ export class FlowGraphMultiplyBlock extends FlowGraphBinaryOperationBlock<FlowGr
         if (_AreSameVectorOrQuaternionClass(aClassName, bClassName) || _AreSameIntegerClass(aClassName, bClassName)) {
             // cast to vector3, but it can be casted to any vector type
             return (a as Vector3).multiply(b as Vector3);
+        } else if (aClassName === FlowGraphTypes.Quaternion || bClassName === FlowGraphTypes.Vector4) {
+            return new Vector4((a as Quaternion).x, (a as Quaternion).y, (a as Quaternion).z, (a as Quaternion).w).multiplyInPlace(b as Vector4);
+        } else if (aClassName === FlowGraphTypes.Vector4 || bClassName === FlowGraphTypes.Quaternion) {
+            return (a as Vector4).multiply(b as Quaternion);
         } else if (_AreSameMatrixClass(aClassName, bClassName)) {
             if (this.config?.useMatrixPerComponent) {
                 // this is the definition of multiplication of glTF interactivity
@@ -194,6 +206,10 @@ export class FlowGraphDivideBlock extends FlowGraphBinaryOperationBlock<FlowGrap
             aClone.z /= (b as Quaternion).z;
             aClone.w /= (b as Quaternion).w;
             return aClone;
+        } else if (aClassName === FlowGraphTypes.Quaternion || bClassName === FlowGraphTypes.Vector4) {
+            return new Vector4((a as Quaternion).x, (a as Quaternion).y, (a as Quaternion).z, (a as Quaternion).w).divideInPlace(b as Vector4);
+        } else if (aClassName === FlowGraphTypes.Vector4 || bClassName === FlowGraphTypes.Quaternion) {
+            return (a as Vector4).divide(b as Quaternion);
         } else if (_AreSameMatrixClass(aClassName, bClassName)) {
             if (this.config?.useMatrixPerComponent) {
                 // get a's m as array, and divide each component with b's m

--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
@@ -113,14 +113,14 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
     /**
      * @internal
      */
-    public _preparePendingTasks(_context: FlowGraphContext): void {
+    public override _preparePendingTasks(_context: FlowGraphContext): void {
         // no-op
     }
 
     /**
      * @internal
      */
-    public _cancelPendingTasks(_context: FlowGraphContext): void {
+    public override _cancelPendingTasks(_context: FlowGraphContext): void {
         // no-op
     }
 

--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphReceiveCustomEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphReceiveCustomEventBlock.ts
@@ -45,7 +45,7 @@ export class FlowGraphReceiveCustomEventBlock extends FlowGraphEventBlock {
         }
     }
 
-    public _preparePendingTasks(context: FlowGraphContext): void {
+    public override _preparePendingTasks(context: FlowGraphContext): void {
         const observable = context.configuration.coordinator.getCustomEventObservable(this.config.eventId);
         // check if we are not exceeding the max number of events
         if (observable && observable.hasObservers() && observable.observers.length > FlowGraphCoordinator.MaxEventsPerType) {
@@ -62,7 +62,7 @@ export class FlowGraphReceiveCustomEventBlock extends FlowGraphEventBlock {
         });
         context._setExecutionVariable(this, "_eventObserver", eventObserver);
     }
-    public _cancelPendingTasks(context: FlowGraphContext): void {
+    public override _cancelPendingTasks(context: FlowGraphContext): void {
         const observable = context.configuration.coordinator.getCustomEventObservable(this.config.eventId);
         if (observable) {
             const eventObserver = context._getExecutionVariable<Nullable<Observer<any[]>>>(this, "_eventObserver", null);

--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphSceneTickEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphSceneTickEventBlock.ts
@@ -62,7 +62,7 @@ export class FlowGraphSceneTickEventBlock extends FlowGraphEventBlock {
     /**
      * @internal
      */
-    public _cancelPendingTasks(_context: FlowGraphContext) {
+    public override _cancelPendingTasks(_context: FlowGraphContext) {
         // no-op
     }
 

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/Animation/flowGraphPlayAnimationBlock.ts
@@ -87,7 +87,7 @@ export class FlowGraphPlayAnimationBlock extends FlowGraphAsyncExecutionBlock {
      * @internal
      * @param context
      */
-    public _preparePendingTasks(context: FlowGraphContext): void {
+    public override _preparePendingTasks(context: FlowGraphContext): void {
         const ag = this.animationGroup.getValue(context);
         const animation = this.animation.getValue(context);
         if (!ag && !animation) {
@@ -217,7 +217,7 @@ export class FlowGraphPlayAnimationBlock extends FlowGraphAsyncExecutionBlock {
      * @internal
      * Stop any currently running animations.
      */
-    public _cancelPendingTasks(context: FlowGraphContext): void {
+    public override _cancelPendingTasks(context: FlowGraphContext): void {
         const ag = this.currentAnimationGroup.getValue(context);
         if (ag) {
             this._stopAnimationGroup(context, ag);

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphSetDelayBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphSetDelayBlock.ts
@@ -40,7 +40,7 @@ export class FlowGraphSetDelayBlock extends FlowGraphAsyncExecutionBlock {
         this.lastDelayIndex = this.registerDataOutput("lastDelayIndex", RichTypeFlowGraphInteger, new FlowGraphInteger(-1));
     }
 
-    public _preparePendingTasks(context: FlowGraphContext): void {
+    public override _preparePendingTasks(context: FlowGraphContext): void {
         const duration = this.duration.getValue(context);
         if (duration < 0 || isNaN(duration) || !isFinite(duration)) {
             return this._reportError(context, "Invalid duration in SetDelay block");
@@ -72,7 +72,7 @@ export class FlowGraphSetDelayBlock extends FlowGraphAsyncExecutionBlock {
         this._updateGlobalTimers(context);
     }
 
-    public _cancelPendingTasks(context: FlowGraphContext): void {
+    public override _cancelPendingTasks(context: FlowGraphContext): void {
         const timers = context._getExecutionVariable(this, "pendingDelays", [] as AdvancedTimer[]);
         for (const timer of timers) {
             timer?.dispose();

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetVariableBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/flowGraphSetVariableBlock.ts
@@ -60,16 +60,16 @@ export class FlowGraphSetVariableBlock<T> extends FlowGraphExecutionBlockWithOut
         // check if there is an animation(group) running on this variable. If there is, stop the animation - a value was force-set.
         const currentlyRunningAnimationGroups = context._getGlobalContextVariable("currentlyRunningAnimationGroups", []) as number[];
         for (const animationUniqueId of currentlyRunningAnimationGroups) {
-            const animation = context.assetsContext.animationGroups[animationUniqueId];
-            // check if there is a target animation that has the target set to be the context
-            for (const targetAnimation of animation.targetedAnimations) {
-                if (targetAnimation.target === context) {
+            const animationGroup = context.assetsContext.animationGroups.find((animationGroup) => animationGroup.uniqueId == animationUniqueId);
+            if (animationGroup) {
+                // check if there is a target animation that has the target set to be the context
+                for (const targetAnimation of animationGroup.targetedAnimations) {
                     // check if the target property is the variable we are setting
                     if (targetAnimation.target === context) {
                         // check the variable name
                         if (targetAnimation.animation.targetProperty === variableName) {
                             // stop the animation
-                            animation.stop();
+                            animationGroup.stop();
                             // remove the animation from the currently running animations
                             const index = currentlyRunningAnimationGroups.indexOf(animationUniqueId);
                             if (index > -1) {

--- a/packages/dev/core/src/FlowGraph/flowGraphRichTypes.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphRichTypes.ts
@@ -88,12 +88,14 @@ export const RichTypeColor4: RichType<Color4> = new RichType(FlowGraphTypes.Colo
 
 export const RichTypeQuaternion: RichType<Quaternion> = new RichType(FlowGraphTypes.Quaternion, Quaternion.Identity(), Constants.ANIMATIONTYPE_QUATERNION);
 RichTypeQuaternion.typeTransformer = (value: any) => {
-    if (value.getClassName && value.getClassName() === FlowGraphTypes.Vector4) {
-        return Quaternion.FromArray(value.asArray());
-    } else if (value.getClassName && value.getClassName() === FlowGraphTypes.Vector3) {
-        return Quaternion.FromEulerVector(value);
-    } else if (value.getClassName && value.getClassName() === FlowGraphTypes.Matrix) {
-        return Quaternion.FromRotationMatrix(value);
+    if (value.getClassName) {
+        if (value.getClassName() === FlowGraphTypes.Vector4) {
+            return Quaternion.FromArray(value.asArray());
+        } else if (value.getClassName() === FlowGraphTypes.Vector3) {
+            return Quaternion.FromEulerVector(value);
+        } else if (value.getClassName() === FlowGraphTypes.Matrix) {
+            return Quaternion.FromRotationMatrix(value);
+        }
     }
     return value;
 };

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_interactivity/declarationMapper.ts
@@ -796,38 +796,6 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
             },
         },
     },
-    "math/compose": {
-        blocks: [FlowGraphBlockNames.MatrixCompose],
-        configuration: {},
-        inputs: {
-            values: {
-                translation: { name: "position", gltfType: "float3" },
-                rotation: { name: "rotationQuaternion", gltfType: "float4" },
-                scale: { name: "scaling", gltfType: "float3" },
-            },
-        },
-        outputs: {
-            values: {
-                value: { name: "output" },
-            },
-        },
-    },
-    "math/decompose": {
-        blocks: [FlowGraphBlockNames.MatrixDecompose],
-        configuration: {},
-        inputs: {
-            values: {
-                a: { name: "input" },
-            },
-        },
-        outputs: {
-            values: {
-                translation: { name: "position" },
-                rotation: { name: "rotationQuaternion" },
-                scale: { name: "scaling" },
-            },
-        },
-    },
     "math/not": {
         blocks: [FlowGraphBlockNames.BitwiseNot],
         inputs: {
@@ -1621,6 +1589,10 @@ const gltfToFlowGraphMapping: { [key: string]: IGLTFToFlowGraphMapping } = {
         },
     },
 };
+
+// aliases for backwards compatibility
+gltfToFlowGraphMapping["math/compose"] = gltfToFlowGraphMapping["math/matCompose"];
+gltfToFlowGraphMapping["math/decompose"] = gltfToFlowGraphMapping["math/matDecompose"];
 
 function getSimpleInputMapping(type: FlowGraphBlockNames, inputs: string[] = ["a"], inferType?: boolean): IGLTFToFlowGraphMapping {
     return {


### PR DESCRIPTION
* Added support for operations involving `Quaternion` and `Vector4` types in `FlowGraphAddBlock`, `FlowGraphSubtractBlock`, `FlowGraphMultiplyBlock`, and `FlowGraphDivideBlock`. Returns `Vector4` when the inputs are mixed types.
* Added logic to stop running animations when setting properties in `FlowGraphSetPropertyBlock`, preventing conflicts with ongoing animations. This is buried in [the spec](https://github.com/KhronosGroup/glTF/blob/interactivity/extensions/2.0/Khronos/KHR_interactivity/Specification.adoc) `4.1.4.2.4, step 5` and `4.1.4.2.5, step 8`.
* Fixed incorrect code that causes a script error in `FlowGraphSetVariableBlock` that stop animations targeting the same variable.