### PR TITLE
[Fluent] Various minor style cleanups

### DIFF
--- a/packages/dev/inspector-v2/src/components/accordionPane.tsx
+++ b/packages/dev/inspector-v2/src/components/accordionPane.tsx
@@ -64,6 +64,9 @@ const useStyles = makeStyles({
     accordion: {
         overflowY: "auto",
         paddingBottom: tokens.spacingVerticalM,
+        display: "flex",
+        flexDirection: "column",
+        rowGap: tokens.spacingVerticalM,
     },
     panelDiv: {
         display: "flex",

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
@@ -43,6 +43,7 @@ const usePropertyLineStyles = makeStyles({
         margin: 0,
         padding: 0,
         border: 0,
+        minWidth: 0,
     },
     fillRestOfRightContentWidth: {
         flex: 1,

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
@@ -1,5 +1,6 @@
-import { Body1Strong, Button, InfoLabel, makeStyles, tokens } from "@fluentui/react-components";
-import { Add24Filled, Copy24Regular, Subtract24Filled } from "@fluentui/react-icons";
+import { Body1Strong, Button, InfoLabel, ToggleButton, makeStyles, tokens } from "@fluentui/react-components";
+import { Collapse } from "@fluentui/react-motion-components-preview";
+import { AddFilled, CopyRegular, SubtractFilled } from "@fluentui/react-icons";
 import type { FunctionComponent, PropsWithChildren } from "react";
 import { useContext, useState } from "react";
 import { copyCommandToClipboard } from "../../copyCommandToClipboard";
@@ -28,16 +29,22 @@ const usePropertyLineStyles = makeStyles({
         display: "flex",
         alignItems: "center",
         justifyContent: "flex-end",
+        gap: tokens.spacingHorizontalS,
     },
     button: {
         marginLeft: tokens.spacingHorizontalXXS,
-        width: "100px",
+        margin: 0,
+        padding: 0,
+        border: 0,
     },
     fillRestOfRightContentWidth: {
         flex: 1,
         display: "flex",
         justifyContent: "flex-end",
         alignItems: "center",
+    },
+    expandButton: {
+        margin: 0,
     },
     expandedContent: {
         backgroundColor: tokens.colorNeutralBackground1,
@@ -93,10 +100,11 @@ export const PropertyLine: FunctionComponent<PropsWithChildren<PropertyLineProps
                     <div className={classes.fillRestOfRightContentWidth}>{children}</div>
 
                     {expandedContent && (
-                        <Button
-                            appearance="subtle"
-                            icon={expanded ? <Subtract24Filled /> : <Add24Filled />}
+                        <ToggleButton
+                            appearance="transparent"
+                            icon={expanded ? <SubtractFilled /> : <AddFilled />}
                             className={classes.button}
+                            checked={expanded}
                             onClick={(e) => {
                                 e.stopPropagation();
                                 setExpanded((expanded) => !expanded);
@@ -105,11 +113,13 @@ export const PropertyLine: FunctionComponent<PropsWithChildren<PropertyLineProps
                     )}
 
                     {onCopy && !disableCopy && (
-                        <Button className={classes.button} id="copyProperty" icon={<Copy24Regular />} onClick={() => copyCommandToClipboard(onCopy())} title="Copy to clipboard" />
+                        <Button className={classes.button} id="copyProperty" icon={<CopyRegular />} onClick={() => copyCommandToClipboard(onCopy())} title="Copy to clipboard" />
                     )}
                 </div>
             </div>
-            {expanded && expandedContent && <div className={classes.expandedContent}>{expandedContent}</div>}
+            <Collapse visible={expanded && !!expandedContent}>
+                <div className={classes.expandedContent}>{expandedContent}</div>
+            </Collapse>
         </LineContainer>
     );
 };

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
@@ -53,9 +53,7 @@ const usePropertyLineStyles = makeStyles({
     expandButton: {
         margin: 0,
     },
-    expandedContent: {
-        backgroundColor: tokens.colorNeutralBackground1,
-    },
+    expandedContent: {},
 });
 
 export type PropertyLineProps = {

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLine.tsx
@@ -21,11 +21,18 @@ const usePropertyLineStyles = makeStyles({
         width: "100%",
     },
     label: {
-        width: "33%",
+        flex: "1 1 0",
+        minWidth: "50px",
         textAlign: "left",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+    },
+    labelText: {
+        whiteSpace: "nowrap",
     },
     rightContent: {
-        width: "67%",
+        flex: "0 1 auto",
         display: "flex",
         alignItems: "center",
         justifyContent: "flex-end",
@@ -94,7 +101,7 @@ export const PropertyLine: FunctionComponent<PropsWithChildren<PropertyLineProps
         <LineContainer>
             <div className={classes.line}>
                 <InfoLabel className={classes.label} info={description}>
-                    <Body1Strong>{label}</Body1Strong>
+                    <Body1Strong className={classes.labelText}>{label}</Body1Strong>
                 </InfoLabel>
                 <div className={classes.rightContent}>
                     <div className={classes.fillRestOfRightContentWidth}>{children}</div>

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/vectorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/vectorPropertyLine.tsx
@@ -37,7 +37,7 @@ const VectorSliders: FunctionComponent<VectorSliderProps> = (props) => {
 export const VectorPropertyLine: FunctionComponent<VectorSliderProps & PropertyLineProps> = (props) => {
     return (
         <PropertyLine {...props} expandedContent={<VectorSliders {...props} />}>
-            <Body1>{props.vector.toString()}</Body1>
+            <Body1>{`X: ${props.vector.x.toFixed(2)} | Y: ${props.vector.y.toFixed(2)} | Z: ${props.vector.z.toFixed(2)}${props.vector instanceof Vector4 ? ` | W: ${props.vector.w.toFixed(2)}` : ""}`}</Body1>
         </PropertyLine>
     );
 };

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/switch.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/switch.tsx
@@ -11,7 +11,7 @@ const useSwitchStyles = makeStyles({
         marginLeft: "auto",
     },
     indicator: {
-        marginRight: 0, // Remove the default right margin so the switch aligns well on the right side inside panels like the properties pane.
+        margin: 0, // Remove the default right margin so the switch aligns well on the right side inside panels like the properties pane.
     },
 });
 

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/syncedSlider.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/syncedSlider.tsx
@@ -38,12 +38,13 @@ export type SyncedSliderProps = Omit<InputProps & SliderProps, "onChange" | "val
  * @returns SyncedSlider component
  */
 export const SyncedSliderInput: FunctionComponent<SyncedSliderProps> = (props) => {
+    const { value: valueProp, ...otherProps } = props;
     const classes = useSyncedSliderStyles();
-    const [value, setValue] = useState<number>(props.value);
+    const [value, setValue] = useState<number>(valueProp);
 
     useEffect(() => {
-        setValue(props.value ?? ""); // Update local state when props.value changes
-    }, [props.value]);
+        setValue(valueProp ?? ""); // Update local state when props.value changes
+    }, [valueProp]);
 
     const handleSliderChange = (_: ChangeEvent<HTMLInputElement>, data: SliderOnChangeData) => {
         setValue(data.value);
@@ -60,8 +61,8 @@ export const SyncedSliderInput: FunctionComponent<SyncedSliderProps> = (props) =
 
     return (
         <div className={classes.syncedSlider}>
-            <Slider {...props} className={classes.slider} value={value} onChange={handleSliderChange} />
-            <Input {...props} type="number" value={value.toString()} onChange={handleInputChange} />
+            {props.min != undefined && props.max != undefined && <Slider {...props} className={classes.slider} value={value} onChange={handleSliderChange} step={undefined} />}
+            <Input {...otherProps} className={classes.input} type="number" appearance="filled-lighter" value={value.toFixed(2)} onChange={handleInputChange} />
         </div>
     );
 };


### PR DESCRIPTION
- Remove default vertical margin from Switch so PropertyLines have uniform heights
- Allow PropertyLine label to use extra space unused by the main content
- Disallow PropertyLine label from wrapping (truncate instead)
- Improve horizontal alignment of the expand button for the "expandedContent" of a PropertyLine
- Use the Fluent Collapse component to animate the expand/collapse of the "expandedContent" of a PropertyLine
- Use ToggleButton for the expand/collapse button for the "expandedContent" of a PropertyLine
- Use fixed precision of 2 for VectorPropertyLine
- Hide sliders in VectorPropertyLine when no min/max is specified
- Use a more subtle appearance for the text input part of the VectorPropertyLine

![image](https://github.com/user-attachments/assets/47b6d025-4e90-49dd-9776-f308365de05f)
