### PR TITLE
Increase node memory limit to 8gb when running any commands via npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options=--max-old-space-size=8192


### PR DESCRIPTION
By putting this in a `.npmrc` file, it sets the node memory limit to 8gb for *any* command run via npm (e.g. `npm run lint`, `npm run watch:dev`, etc.).