### PR TITLE
Allow secondary mouse button clicks when using PointerDragBehavior

### DIFF
--- a/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Meshes/pointerDragBehavior.ts
@@ -264,19 +264,6 @@ export class PointerDragBehavior implements Behavior<AbstractMesh> {
                 return;
             }
 
-            // If we are dragging and the user presses another button on the same pointer, end the drag. Otherwise,
-            // tracking when the drag should end becomes very complex.
-            // gizmo.ts has similar behavior.
-            if (
-                this.dragging &&
-                this.currentDraggingPointerId == (<IPointerEvent>pointerInfo.event).pointerId &&
-                pointerInfo.event.button !== -1 &&
-                pointerInfo.event.button !== this._activeDragButton
-            ) {
-                this.releaseDrag();
-                return;
-            }
-
             if (pointerInfo.type == PointerEventTypes.POINTERDOWN) {
                 if (
                     this.startAndReleaseDragOnPointerEvents &&

--- a/packages/dev/core/src/Gizmos/gizmo.ts
+++ b/packages/dev/core/src/Gizmos/gizmo.ts
@@ -614,7 +614,6 @@ export class Gizmo implements IGizmo {
             if (pointerInfo.pickInfo) {
                 // If we are dragging and the user presses another button, end the drag.
                 // Otherwise, tracking when the drag should end becomes very complex.
-                // pointerDragBehavior.ts has similar logic.
                 forcePointerUp = dragging && pointerInfo.event.button !== -1 && pointerInfo.event.button !== activeDragButton;
 
                 if (forcePointerUp || pointerInfo.type === PointerEventTypes.POINTERUP) {


### PR DESCRIPTION
Previously, a change was made to cancel the drag operation when a second button on the same pointer was pressed, for parity with the gizmo, which needed this change to fix a bug.  Since some users relied on this behavior for PointerDragBehavior, this change allows that second button just for PointerDragBehavior.