### PR TITLE
Inspector v2: Handle extension install errors

### DIFF
--- a/packages/dev/inspector-v2/src/extensibility/extensionManager.ts
+++ b/packages/dev/inspector-v2/src/extensibility/extensionManager.ts
@@ -5,8 +5,6 @@ import type { IExtensionFeed, ExtensionMetadata, ExtensionModule } from "./exten
 
 import { Logger } from "core/Misc/logger";
 
-import { Assert } from "../misc/assert";
-
 /**
  * Represents a loaded extension.
  */

--- a/packages/dev/inspector-v2/src/modularTool.tsx
+++ b/packages/dev/inspector-v2/src/modularTool.tsx
@@ -3,11 +3,25 @@ import type { IDisposable } from "core/index";
 
 import type { ComponentType, FunctionComponent } from "react";
 import type { IExtensionFeed } from "./extensibility/extensionFeed";
-import type { IExtension } from "./extensibility/extensionManager";
+import type { IExtension, InstallFailedInfo } from "./extensibility/extensionManager";
 import type { WeaklyTypedServiceDefinition } from "./modularity/serviceContainer";
 import type { IRootComponentService, ShellServiceOptions } from "./services/shellService";
 
-import { Button, Dialog, DialogActions, DialogBody, DialogContent, DialogSurface, DialogTitle, FluentProvider, makeStyles, Spinner } from "@fluentui/react-components";
+import {
+    Body1,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogBody,
+    DialogContent,
+    DialogSurface,
+    DialogTitle,
+    FluentProvider,
+    List,
+    ListItem,
+    makeStyles,
+    Spinner,
+} from "@fluentui/react-components";
 import { createElement, Suspense, useCallback, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { useTernaryDarkMode } from "usehooks-ts";
@@ -22,7 +36,8 @@ import { ExtensionListServiceDefinition } from "./services/extensionsListService
 import { MakeShellServiceDefinition, RootComponentServiceIdentity } from "./services/shellService";
 import { ThemeSelectorServiceDefinition } from "./services/themeSelectorService";
 //import { DarkTheme, LightTheme } from "./themes/babylonTheme";
-import { webDarkTheme as DarkTheme, webLightTheme as LightTheme } from "@fluentui/react-components";
+import { webDarkTheme as DarkTheme, webLightTheme as LightTheme, tokens } from "@fluentui/react-components";
+import { ErrorCircleRegular } from "@fluentui/react-icons";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
@@ -39,6 +54,15 @@ const useStyles = makeStyles({
             from: { opacity: 0 },
             to: { opacity: 1 },
         },
+    },
+    extensionErrorTitleDiv: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: tokens.spacingHorizontalS,
+    },
+    extensionErrorIcon: {
+        color: tokens.colorPaletteRedForeground1,
     },
 });
 
@@ -78,6 +102,7 @@ export function MakeModularTool(options: ModularToolOptions): IDisposable {
         const { isDarkMode } = useTernaryDarkMode();
         const [requiredExtensions, setRequiredExtensions] = useState<string[]>();
         const [requiredExtensionsDeferred, setRequiredExtensionsDeferred] = useState<Deferred<boolean>>();
+        const [extensionInstallError, setExtensionInstallError] = useState<InstallFailedInfo>();
 
         const [rootComponent, setRootComponent] = useState<ComponentType>();
 
@@ -116,7 +141,7 @@ export function MakeModularTool(options: ModularToolOptions): IDisposable {
                 await serviceContainer.addServicesAsync(...serviceDefinitions);
 
                 // Create the extension manager, passing along the registry for runtime changes to the registered services.
-                const extensionManager = await ExtensionManager.CreateAsync(serviceContainer, extensionFeeds);
+                const extensionManager = await ExtensionManager.CreateAsync(serviceContainer, extensionFeeds, setExtensionInstallError);
 
                 // Check query params for required extensions. This lets users share links with sets of extensions.
                 const queryParams = new URLSearchParams(window.location.search);
@@ -182,6 +207,10 @@ export function MakeModularTool(options: ModularToolOptions): IDisposable {
             requiredExtensionsDeferred?.resolve(false);
         }, [setRequiredExtensions, requiredExtensionsDeferred]);
 
+        const onAcknowledgedExtensionInstallError = useCallback(() => {
+            setExtensionInstallError(undefined);
+        }, [setExtensionInstallError]);
+
         // Show a spinner until a main view has been set.
         // eslint-disable-next-line @typescript-eslint/naming-convention
         const Content: ComponentType = rootComponent ?? (() => <Spinner className={classes.spinner} />);
@@ -204,6 +233,33 @@ export function MakeModularTool(options: ModularToolOptions): IDisposable {
                                         </Button>
                                         <Button appearance="secondary" onClick={onRejectRequiredExtensions}>
                                             No Thanks
+                                        </Button>
+                                    </DialogActions>
+                                </DialogBody>
+                            </DialogSurface>
+                        </Dialog>
+                        <Dialog open={!!extensionInstallError} modalType="alert">
+                            <DialogSurface>
+                                <DialogBody>
+                                    <DialogTitle>
+                                        <div className={classes.extensionErrorTitleDiv}>
+                                            Extension Install Error
+                                            <ErrorCircleRegular className={classes.extensionErrorIcon} />
+                                        </div>
+                                    </DialogTitle>
+                                    <DialogContent>
+                                        <List>
+                                            <ListItem>
+                                                <Body1>{`Extension "${extensionInstallError?.extension.name}" failed to install and was removed.`}</Body1>
+                                            </ListItem>
+                                            <ListItem>
+                                                <Body1>{`${extensionInstallError?.error}`}</Body1>
+                                            </ListItem>
+                                        </List>
+                                    </DialogContent>
+                                    <DialogActions>
+                                        <Button appearance="primary" onClick={onAcknowledgedExtensionInstallError}>
+                                            Close
                                         </Button>
                                     </DialogActions>
                                 </DialogBody>

--- a/packages/dev/inspector-v2/src/modularTool.tsx
+++ b/packages/dev/inspector-v2/src/modularTool.tsx
@@ -21,7 +21,9 @@ import {
     ListItem,
     makeStyles,
     Spinner,
+    tokens,
 } from "@fluentui/react-components";
+import { ErrorCircleRegular } from "@fluentui/react-icons";
 import { createElement, Suspense, useCallback, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { useTernaryDarkMode } from "usehooks-ts";
@@ -35,9 +37,7 @@ import { ServiceContainer } from "./modularity/serviceContainer";
 import { ExtensionListServiceDefinition } from "./services/extensionsListService";
 import { MakeShellServiceDefinition, RootComponentServiceIdentity } from "./services/shellService";
 import { ThemeSelectorServiceDefinition } from "./services/themeSelectorService";
-//import { DarkTheme, LightTheme } from "./themes/babylonTheme";
-import { webDarkTheme as DarkTheme, webLightTheme as LightTheme, tokens } from "@fluentui/react-components";
-import { ErrorCircleRegular } from "@fluentui/react-icons";
+import { DarkTheme, LightTheme } from "./themes/babylonTheme";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({

--- a/packages/dev/inspector-v2/src/services/extensionsListService.tsx
+++ b/packages/dev/inspector-v2/src/services/extensionsListService.tsx
@@ -103,8 +103,21 @@ const ExtensionDetails: FunctionComponent<{ extension: IExtension }> = memo((pro
         return stateChangedHandlerRegistration.dispose;
     }, [props.extension]);
 
-    const install = useCallback(async () => await props.extension.installAsync(), [props.extension]);
-    const uninstall = useCallback(async () => await props.extension.uninstallAsync(), [props.extension]);
+    const install = useCallback(async () => {
+        try {
+            await props.extension.installAsync();
+        } catch {
+            // Ignore errors. Other parts of the infrastructure handle them and communicate them to the user.
+        }
+    }, [props.extension]);
+
+    const uninstall = useCallback(async () => {
+        try {
+            await props.extension.uninstallAsync();
+        } catch {
+            // Ignore errors. Other parts of the infrastructure handle them and communicate them to the user.
+        }
+    }, [props.extension]);
 
     return (
         <>

--- a/packages/dev/inspector-v2/src/themes/babylonTheme.ts
+++ b/packages/dev/inspector-v2/src/themes/babylonTheme.ts
@@ -4,37 +4,31 @@ import type { BrandVariants, Theme } from "@fluentui/react-components";
 
 import { createDarkTheme, createLightTheme } from "@fluentui/react-components";
 
-const babylonBrand: BrandVariants = {
-    10: "#000000",
-    20: "#1E0F11",
-    30: "#34181B",
-    40: "#4B1F24",
-    50: "#63272D",
-    60: "#7C2F36",
-    70: "#96373E",
-    80: "#AF4046",
-    90: "#C44F51",
-    100: "#D5625F",
-    110: "#E4766E",
-    120: "#F18A7F",
-    130: "#FBA092",
-    140: "#FFB8AA",
-    150: "#FFD1C6",
-    160: "#FFE8E2",
+// Generated from https://react.fluentui.dev/?path=/docs/theme-theme-designer--docs
+// Key color: #3A94FC
+const babylonRamp: BrandVariants = {
+    10: "#020305",
+    20: "#121721",
+    30: "#1A263A",
+    40: "#1F314F",
+    50: "#243E64",
+    60: "#294B7B",
+    70: "#2D5892",
+    80: "#3166AA",
+    90: "#3473C3",
+    100: "#3782DC",
+    110: "#3990F6",
+    120: "#5A9EFD",
+    130: "#7BACFE",
+    140: "#96BAFF",
+    150: "#AFC9FF",
+    160: "#C6D8FF",
 };
 
 export const LightTheme: Theme = {
-    ...createLightTheme(babylonBrand),
+    ...createLightTheme(babylonRamp),
 };
 
 export const DarkTheme: Theme = {
-    ...createDarkTheme(babylonBrand),
-    colorBrandForeground1: babylonBrand[110],
-    colorBrandForegroundLink: babylonBrand[110],
-    colorBrandForegroundLinkPressed: babylonBrand[110],
-    colorBrandForegroundLinkSelected: babylonBrand[110],
-    colorCompoundBrandBackgroundHover: babylonBrand[100],
-    colorCompoundBrandForeground1Pressed: babylonBrand[100],
-    colorCompoundBrandStrokePressed: babylonBrand[100],
-    colorNeutralForeground2BrandPressed: babylonBrand[100],
+    ...createDarkTheme(babylonRamp),
 };


### PR DESCRIPTION
A few people recently got hung up on extension install errors not currently being handled, particularly in the case where a previously installed extension can no longer be installed (such as the name changing). This PR adds error handling for these scenarios that works for our dev workflow as well as users.

Also unrelated, but I updated the theme with a color ramp generated from the color used for icons in inspector v1. We can continue to tune of course, I just wanted to put something in place that is slightly closer to the Babylon colors.

![image](https://github.com/user-attachments/assets/e3d66afd-c4f0-472d-82d6-92cf5cb56caa)
