### PR TITLE
[Fluent] Move useDegrees into RotationVectorPropertyLine; update how dropdown accepts undefined; rename BoundProperty

### DIFF
--- a/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
+++ b/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
@@ -16,7 +16,7 @@ import { Texture } from "core/Materials/Textures/texture";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import type { Scene } from "core/scene";
 import { MaterialFlags } from "core/Materials/materialFlags";
-import { BoundPropertyLine } from "../properties/boundPropertyLine";
+import { BoundProperty } from "../properties/boundProperty";
 import { Accordion, AccordionSection } from "shared-ui-components/fluent/primitives/accordion";
 
 const SwitchGrid = function (renderScene: Scene) {
@@ -180,41 +180,35 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
                     />
                 </AccordionSection>
                 <AccordionSection title="Core texture channels">
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Diffuse" label="Diffuse" target={StandardMaterial} propertyKey="DiffuseTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Ambient" label="Ambient" target={StandardMaterial} propertyKey="AmbientTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Specular" label="Specular" target={StandardMaterial} propertyKey="SpecularTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Emissive" label="Emissive" target={StandardMaterial} propertyKey="EmissiveTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Bump" label="Bump" target={StandardMaterial} propertyKey="BumpTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Opacity" label="Opacity" target={StandardMaterial} propertyKey="OpacityTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Reflection" label="Reflection" target={StandardMaterial} propertyKey="ReflectionTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="ColorGrading" label="Color Grading" target={StandardMaterial} propertyKey="ColorGradingTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Lightmap" label="Lightmap" target={StandardMaterial} propertyKey="LightmapTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Fresnel" label="Fresnel" target={StandardMaterial} propertyKey="FresnelEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Detail" label="Detail" target={MaterialFlags} propertyKey="DetailTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Decal" label="Decal" target={MaterialFlags} propertyKey="DecalMapEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Diffuse" label="Diffuse" target={StandardMaterial} propertyKey="DiffuseTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Ambient" label="Ambient" target={StandardMaterial} propertyKey="AmbientTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Specular" label="Specular" target={StandardMaterial} propertyKey="SpecularTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Emissive" label="Emissive" target={StandardMaterial} propertyKey="EmissiveTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Bump" label="Bump" target={StandardMaterial} propertyKey="BumpTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Opacity" label="Opacity" target={StandardMaterial} propertyKey="OpacityTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Reflection" label="Reflection" target={StandardMaterial} propertyKey="ReflectionTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="ColorGrading" label="Color Grading" target={StandardMaterial} propertyKey="ColorGradingTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Lightmap" label="Lightmap" target={StandardMaterial} propertyKey="LightmapTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Fresnel" label="Fresnel" target={StandardMaterial} propertyKey="FresnelEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Detail" label="Detail" target={MaterialFlags} propertyKey="DetailTextureEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Decal" label="Decal" target={MaterialFlags} propertyKey="DecalMapEnabled" />
                 </AccordionSection>
                 <AccordionSection title="Features">
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Animations" label="Animations" target={scene} propertyKey="animationsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Physics" label="Physics" target={scene} propertyKey="physicsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Collisions" label="Collisions" target={scene} propertyKey="collisionsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Fog" label="Fog" target={scene} propertyKey="fogEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Lens flares" label="Lens flares" target={scene} propertyKey="lensFlaresEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Lights" label="Lights" target={scene} propertyKey="lightsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Particles" label="Particles" target={scene} propertyKey="particlesEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Post-processes" label="Post-processes" target={scene} propertyKey="postProcessesEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Probes" label="Probes" target={scene} propertyKey="probesEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Textures" label="Textures" target={scene} propertyKey="texturesEnabled" />
-                    <BoundPropertyLine
-                        component={SwitchPropertyLine}
-                        key="Procedural textures"
-                        label="Procedural textures"
-                        target={scene}
-                        propertyKey="proceduralTexturesEnabled"
-                    />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Render targets" label="Render targets" target={scene} propertyKey="renderTargetsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Shadows" label="Shadows" target={scene} propertyKey="shadowsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Animations" label="Animations" target={scene} propertyKey="animationsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Physics" label="Physics" target={scene} propertyKey="physicsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Collisions" label="Collisions" target={scene} propertyKey="collisionsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Fog" label="Fog" target={scene} propertyKey="fogEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Lens flares" label="Lens flares" target={scene} propertyKey="lensFlaresEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Lights" label="Lights" target={scene} propertyKey="lightsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Particles" label="Particles" target={scene} propertyKey="particlesEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Post-processes" label="Post-processes" target={scene} propertyKey="postProcessesEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Probes" label="Probes" target={scene} propertyKey="probesEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Textures" label="Textures" target={scene} propertyKey="texturesEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Procedural textures" label="Procedural textures" target={scene} propertyKey="proceduralTexturesEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Render targets" label="Render targets" target={scene} propertyKey="renderTargetsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Shadows" label="Shadows" target={scene} propertyKey="shadowsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
+                    <BoundProperty component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />
                 </AccordionSection>
             </Accordion>
             <AccordionPane {...props} />

--- a/packages/dev/inspector-v2/src/components/properties/boundProperty.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/boundProperty.tsx
@@ -9,7 +9,13 @@ export type BoundPropertyProps<T, P extends object> = Omit<P, "value" | "onChang
     propertyKey: PropertyKey;
 };
 
-export function BoundPropertyLine<T, P extends object>(props: BoundPropertyProps<T, P>) {
+/**
+ * Intercepts the passed in component's target[propertyKey] with useInterceptObservable and sets component state using useObservableState.
+ * Renders the passed in component with value as the new observableState value and onChange as a callback to set the target[propertyKey] value.
+ * @param props
+ * @returns
+ */
+export function BoundProperty<T, P extends object>(props: BoundPropertyProps<T, P>) {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { target, propertyKey, component: Component, ...rest } = props;
     const value = useObservableState(() => target[propertyKey], useInterceptObservable("property", target, propertyKey));

--- a/packages/dev/inspector-v2/src/components/properties/materialTransparencyProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materialTransparencyProperties.tsx
@@ -6,8 +6,9 @@ import type { FunctionComponent } from "react";
 
 import { DropdownPropertyLine } from "shared-ui-components/fluent/hoc/dropdownPropertyLine";
 import { BoundProperty } from "./boundProperty";
+import type { DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";
 
-const TransparencyModeOptions = [
+const TransparencyModeOptions: DropdownOption[] = [
     { label: "Opaque", value: PBRMaterial.PBRMATERIAL_OPAQUE },
     { label: "Alpha test", value: PBRMaterial.PBRMATERIAL_ALPHATEST },
     { label: "Alpha blend", value: PBRMaterial.PBRMATERIAL_ALPHABLEND },

--- a/packages/dev/inspector-v2/src/components/properties/materialTransparencyProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materialTransparencyProperties.tsx
@@ -1,0 +1,33 @@
+// eslint-disable-next-line import/no-internal-modules
+import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
+import type { Material } from "core/Materials/material";
+
+import type { FunctionComponent } from "react";
+
+import { DropdownPropertyLine } from "shared-ui-components/fluent/hoc/dropdownPropertyLine";
+import { BoundProperty } from "./boundProperty";
+
+const TransparencyModeOptions = [
+    { label: "Opaque", value: PBRMaterial.PBRMATERIAL_OPAQUE },
+    { label: "Alpha test", value: PBRMaterial.PBRMATERIAL_ALPHATEST },
+    { label: "Alpha blend", value: PBRMaterial.PBRMATERIAL_ALPHABLEND },
+    { label: "Alpha blend and test", value: PBRMaterial.PBRMATERIAL_ALPHATESTANDBLEND },
+];
+
+export const MaterialTransparencyProperties: FunctionComponent<{ material: Material }> = (props) => {
+    const { material } = props;
+
+    return (
+        <>
+            <BoundProperty
+                component={DropdownPropertyLine}
+                key="Transparency mode"
+                label="Transparency mode"
+                target={material}
+                propertyKey="transparencyMode"
+                options={TransparencyModeOptions}
+                includeUndefined={true}
+            />
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/properties/meshOutlineOverlayProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshOutlineOverlayProperties.tsx
@@ -10,6 +10,9 @@ import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/switchProper
 import { useInterceptObservable } from "../../hooks/instrumentationHooks";
 import { useObservableState } from "../../hooks/observableHooks";
 
+// Ensures that the outlineRenderer properties exist on the prototype of the Mesh
+import "core/Rendering/outlineRenderer";
+
 type Color3Keys<T> = { [P in keyof T]: T[P] extends Color3 ? P : never }[keyof T];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/dev/inspector-v2/src/components/properties/transformNodeTransformProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/transformNodeTransformProperties.tsx
@@ -3,7 +3,7 @@ import type { TransformNode, Vector3 } from "core/index";
 
 import type { FunctionComponent } from "react";
 
-import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/vectorPropertyLine";
+import { RotationVectorPropertyLine, Vector3PropertyLine } from "shared-ui-components/fluent/hoc/vectorPropertyLine";
 
 import { useInterceptObservable } from "../../hooks/instrumentationHooks";
 import { useObservableState } from "../../hooks/observableHooks";
@@ -34,7 +34,7 @@ export const TransformNodeTransformProperties: FunctionComponent<{ node: Transfo
     return (
         <>
             <Vector3PropertyLine key="PositionTransform" label="Position" value={position} onChange={(val) => (node.position = val)} />
-            <Vector3PropertyLine key="RotationTransform" label="Rotation" value={rotation} onChange={(val) => (node.rotation = val)} useDegrees={useDegrees} />
+            <RotationVectorPropertyLine key="RotationTransform" label="Rotation" value={rotation} onChange={(val) => (node.rotation = val)} useDegrees={useDegrees} />
             <Vector3PropertyLine key="ScalingTransform" label="Scaling" value={scaling} onChange={(val) => (node.scaling = val)} />
         </>
     );

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -27,6 +27,7 @@ import { ToolsServiceDefinition } from "./services/panes/toolsService";
 import { SceneContextIdentity } from "./services/sceneContext";
 import { SelectionServiceDefinition } from "./services/selectionService";
 import { ShellServiceIdentity } from "./services/shellService";
+import { MaterialPropertiesServiceDefinition } from "./services/panes/properties/materialPropertiesService";
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
@@ -177,6 +178,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             NodePropertiesServiceDefinition,
             MeshPropertiesServiceDefinition,
             TransformNodePropertiesServiceDefinition,
+            MaterialPropertiesServiceDefinition,
 
             // Debug pane tab and related services.
             DebugServiceDefinition,

--- a/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
@@ -1,0 +1,44 @@
+import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { IPropertiesService } from "./propertiesService";
+import type { ISelectionService } from "../../selectionService";
+
+import { PropertiesServiceIdentity } from "./propertiesService";
+import { SelectionServiceIdentity } from "../../selectionService";
+
+import { Material } from "core/Materials";
+import { MaterialTransparencyProperties } from "../../../components/properties/materialTransparencyProperties";
+
+export const TransparencyPropertiesSectionIdentity = Symbol("Transparency");
+export const StencilPropertiesSectionItentity = Symbol("Stencil");
+
+export const MaterialPropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISelectionService]> = {
+    friendlyName: "Material Properties",
+    consumes: [PropertiesServiceIdentity, SelectionServiceIdentity],
+    factory: (propertiesService) => {
+        // Transparency
+        const transparencySectionRegistration = propertiesService.addSection({
+            order: 1,
+            identity: TransparencyPropertiesSectionIdentity,
+        });
+
+        const materialContentRegistration = propertiesService.addSectionContent({
+            key: "Material Properties",
+            predicate: (entity: unknown): entity is Material => entity instanceof Material,
+            content: [
+                // "Transparency" section.
+                {
+                    section: TransparencyPropertiesSectionIdentity,
+                    order: 0,
+                    component: ({ context }) => <MaterialTransparencyProperties material={context} />,
+                },
+            ],
+        });
+
+        return {
+            dispose: () => {
+                materialContentRegistration.dispose();
+                transparencySectionRegistration.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/test/app/index.ts
+++ b/packages/dev/inspector-v2/test/app/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-internal-modules
-import type { ArcRotateCamera, Nullable } from "core/index";
+import { type ArcRotateCamera, type Nullable } from "core/index";
 
 import { Engine } from "core/Engines/engine";
 import { LoadAssetContainerAsync } from "core/Loading/sceneLoader";
@@ -9,8 +9,6 @@ import { registerBuiltInLoaders } from "loaders/dynamic";
 import { ShowInspector } from "../../src/inspector";
 
 import "core/Helpers/sceneHelpers";
-// For testing the Outline & Overlay section
-import "core/Rendering/outlineRenderer";
 
 // Register scene loader plugins.
 registerBuiltInLoaders();

--- a/packages/dev/inspector-v2/test/app/index.ts
+++ b/packages/dev/inspector-v2/test/app/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-internal-modules
-import { type ArcRotateCamera, type Nullable } from "core/index";
+import type { ArcRotateCamera, Nullable } from "core/index";
 
 import { Engine } from "core/Engines/engine";
 import { LoadAssetContainerAsync } from "core/Loading/sceneLoader";

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/colorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/colorPropertyLine.tsx
@@ -1,7 +1,7 @@
 import type { FunctionComponent } from "react";
 import { forwardRef, useState } from "react";
 
-import type { BaseComponentProps, PropertyLineProps } from "./propertyLine";
+import type { PropertyLineProps } from "./propertyLine";
 import { PropertyLine } from "./propertyLine";
 import { SyncedSliderLine } from "./syncedSliderLine";
 
@@ -16,23 +16,11 @@ export type ColorPropertyLineProps = ColorPickerProps<Color3 | Color4> & Propert
  * Reusable component which renders a color property line containing a label, colorPicker popout, and expandable RGBA values
  * The expandable RGBA values are synced sliders that allow the user to modify the color's RGBA values directly
  * @param props - PropertyLine props, replacing children with a color object so that we can properly display the color
- * @returns Component wrapping a colorPicker component (coming soon) with a property line
+ * @returns Component wrapping a colorPicker component with a property line
  */
 const ColorPropertyLine = forwardRef<HTMLDivElement, ColorPropertyLineProps>((props, ref) => {
     const [color, setColor] = useState(props.value);
-    const onChange = (value: Color3 | Color4) => {
-        setColor(value);
-        props.onChange(value);
-    };
-    return (
-        <PropertyLine ref={ref} {...props} expandedContent={<ColorSliders {...props} value={color} onChange={onChange} />}>
-            <ColorPickerPopup {...props} value={color} />
-        </PropertyLine>
-    );
-});
 
-const ColorSliders: FunctionComponent<BaseComponentProps<Color3 | Color4>> = (props) => {
-    const [color, setColor] = useState(props.value);
     const onChange = (value: number, key: "r" | "g" | "b" | "a") => {
         let newColor;
         if (key === "a") {
@@ -46,15 +34,28 @@ const ColorSliders: FunctionComponent<BaseComponentProps<Color3 | Color4>> = (pr
         props.onChange(newColor);
     };
 
+    const onColorPickerChange = (newColor: Color3 | Color4) => {
+        setColor(newColor);
+        props.onChange(newColor);
+    };
+
     return (
-        <>
-            <SyncedSliderLine label="R" value={color.r * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "r")} />
-            <SyncedSliderLine label="G" value={color.g * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "g")} />
-            <SyncedSliderLine label="B" value={color.b * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "b")} />
-            {color instanceof Color4 && <SyncedSliderLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onChange(value, "a")} />}
-        </>
+        <PropertyLine
+            ref={ref}
+            {...props}
+            expandedContent={
+                <>
+                    <SyncedSliderLine label="R" value={color.r * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "r")} />
+                    <SyncedSliderLine label="G" value={color.g * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "g")} />
+                    <SyncedSliderLine label="B" value={color.b * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "b")} />
+                    {color instanceof Color4 && <SyncedSliderLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onChange(value, "a")} />}
+                </>
+            }
+        >
+            <ColorPickerPopup {...props} onChange={onColorPickerChange} value={color} />
+        </PropertyLine>
     );
-};
+});
 
 export const Color3PropertyLine = ColorPropertyLine as FunctionComponent<ColorPickerProps<Color3> & PropertyLineProps>;
 export const Color4PropertyLine = ColorPropertyLine as FunctionComponent<ColorPickerProps<Color4> & PropertyLineProps>;

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/colorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/colorPropertyLine.tsx
@@ -21,7 +21,7 @@ export type ColorPropertyLineProps = ColorPickerProps<Color3 | Color4> & Propert
 const ColorPropertyLine = forwardRef<HTMLDivElement, ColorPropertyLineProps>((props, ref) => {
     const [color, setColor] = useState(props.value);
 
-    const onChange = (value: number, key: "r" | "g" | "b" | "a") => {
+    const onSliderChange = (value: number, key: "r" | "g" | "b" | "a") => {
         let newColor;
         if (key === "a") {
             newColor = Color4.FromColor3(color, value);
@@ -45,10 +45,10 @@ const ColorPropertyLine = forwardRef<HTMLDivElement, ColorPropertyLineProps>((pr
             {...props}
             expandedContent={
                 <>
-                    <SyncedSliderLine label="R" value={color.r * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "r")} />
-                    <SyncedSliderLine label="G" value={color.g * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "g")} />
-                    <SyncedSliderLine label="B" value={color.b * 255.0} min={0} max={255} step={1} onChange={(value) => onChange(value, "b")} />
-                    {color instanceof Color4 && <SyncedSliderLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onChange(value, "a")} />}
+                    <SyncedSliderLine label="R" value={color.r * 255.0} min={0} max={255} step={1} onChange={(value) => onSliderChange(value, "r")} />
+                    <SyncedSliderLine label="G" value={color.g * 255.0} min={0} max={255} step={1} onChange={(value) => onSliderChange(value, "g")} />
+                    <SyncedSliderLine label="B" value={color.b * 255.0} min={0} max={255} step={1} onChange={(value) => onSliderChange(value, "b")} />
+                    {color instanceof Color4 && <SyncedSliderLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onSliderChange(value, "a")} />}
                 </>
             }
         >

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/vectorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/vectorPropertyLine.tsx
@@ -1,4 +1,5 @@
-import { useState, type FunctionComponent } from "react";
+import { useState } from "react";
+import type { FunctionComponent } from "react";
 
 import { Body1 } from "@fluentui/react-components";
 import { PropertyLine } from "./propertyLine";
@@ -23,7 +24,7 @@ export type VectorPropertyLineProps<V extends Vector3 | Vector4> = BaseComponent
         /**
          * If passed, the UX will use the conversion functions to display/update values
          */
-        valConverter?: {
+        valueConverter?: {
             /**
              * Will call from(val) before displaying in the UX
              */
@@ -42,14 +43,14 @@ export type VectorPropertyLineProps<V extends Vector3 | Vector4> = BaseComponent
  * @returns
  */
 const VectorPropertyLine: FunctionComponent<VectorPropertyLineProps<Vector3 | Vector4>> = (props) => {
-    const converted = (val: number) => (props.valConverter ? props.valConverter.from(val) : val);
+    const converted = (val: number) => (props.valueConverter ? props.valueConverter.from(val) : val);
     const formatted = (val: number) => converted(val).toFixed(2);
 
     const [vector, setVector] = useState(props.value);
     const { min, max } = props;
 
     const onChange = (val: number, key: "x" | "y" | "z" | "w") => {
-        const value = props.valConverter ? props.valConverter.to(val) : val;
+        const value = props.valueConverter ? props.valueConverter.to(val) : val;
         const newVector = vector.clone();
         (newVector as Vector4)[key] = value; // The syncedSlider for 'w' is only rendered when vector is a Vector4, so this is safe
 
@@ -85,7 +86,7 @@ const ToDegreesConverter = { from: Tools.ToDegrees, to: Tools.ToRadians };
 export const RotationVectorPropertyLine: FunctionComponent<RotationVectorPropertyLineProps> = (props) => {
     const min = props.useDegrees ? 0 : undefined;
     const max = props.useDegrees ? 360 : undefined;
-    return <Vector3PropertyLine {...props} valConverter={props.useDegrees ? ToDegreesConverter : undefined} min={min} max={max} />;
+    return <Vector3PropertyLine {...props} valueConverter={props.useDegrees ? ToDegreesConverter : undefined} min={min} max={max} />;
 };
 
 export const Vector3PropertyLine = VectorPropertyLine as FunctionComponent<VectorPropertyLineProps<Vector3>>;

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/dropdown.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/dropdown.tsx
@@ -36,10 +36,10 @@ export type DropdownProps = BaseComponentProps<AcceptedDropdownValue | undefined
  */
 export const Dropdown: FunctionComponent<DropdownProps> = (props) => {
     const classes = useDropdownStyles();
-    const [options] = useState<DropdownOption[]>(props.includeUndefined ? [{ label: "<Not defined>", value: Number.MAX_SAFE_INTEGER }, ...props.options] : props.options);
-    const [defaultVal, setDefaultVal] = useState(props.includeUndefined && props.value === undefined ? Number.MAX_SAFE_INTEGER : props.value);
+    const [options] = useState<DropdownOption[]>(props.includeUndefined ? [{ label: "<Not defined>", value: Number.NaN }, ...props.options] : props.options);
+    const [defaultVal, setDefaultVal] = useState(props.includeUndefined && props.value === undefined ? Number.NaN : props.value);
     useEffect(() => {
-        setDefaultVal(props.includeUndefined && props.value === undefined ? Number.MAX_SAFE_INTEGER : props.value);
+        setDefaultVal(props.includeUndefined && props.value === undefined ? Number.NaN : props.value);
     }, [props.value]);
 
     return (
@@ -49,7 +49,7 @@ export const Dropdown: FunctionComponent<DropdownProps> = (props) => {
             onOptionSelect={(evt, data) => {
                 let value = typeof props.value === "number" ? Number(data.optionValue) : data.optionValue;
                 setDefaultVal(value);
-                if (props.includeUndefined && value === Number.MAX_SAFE_INTEGER.toString()) {
+                if (props.includeUndefined && value === Number.NaN.toString()) {
                     value = undefined;
                 }
                 props.onChange(value);

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/syncedSlider.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/syncedSlider.tsx
@@ -4,7 +4,6 @@ import { Input } from "./input";
 import type { ChangeEvent, FunctionComponent } from "react";
 import { useEffect, useState } from "react";
 import type { BaseComponentProps } from "../hoc/propertyLine";
-import { Tools } from "core/Misc/tools";
 
 const useSyncedSliderStyles = makeStyles({
     syncedSlider: {
@@ -27,7 +26,6 @@ export type SyncedSliderProps = BaseComponentProps<number> & {
     min?: number;
     max?: number;
     step?: number;
-    useDegrees?: boolean; // Optional prop to use degrees instead of radians
 };
 
 /**
@@ -44,39 +42,23 @@ export const SyncedSliderInput: FunctionComponent<SyncedSliderProps> = (props) =
     }, [props.value]);
 
     const handleSliderChange = (_: ChangeEvent<HTMLInputElement>, data: SliderOnChangeData) => {
-        let value = data.value;
-        if (props.useDegrees) {
-            // Convert degrees to radians if necessary
-            value = Tools.ToRadians(value);
-        }
+        const value = data.value;
         setValue(value);
         props.onChange(value); // Notify parent
     };
 
     const handleInputChange = (value: string | number) => {
-        let newValue = Number(value);
+        const newValue = Number(value);
         if (!isNaN(newValue)) {
-            if (props.useDegrees) {
-                // Convert degrees to radians if necessary
-                newValue = Tools.ToRadians(newValue);
-            }
-
             setValue(newValue);
             props.onChange(newValue); // Notify parent
         }
     };
 
-    const min = props.min ?? (props.useDegrees ? 0 : undefined);
-    const max = props.max ?? (props.useDegrees ? 360 : undefined);
-
-    const convertedValue = props.useDegrees ? Tools.ToDegrees(value) : value;
-
     return (
         <div className={classes.syncedSlider}>
-            {min !== undefined && max !== undefined && (
-                <Slider {...props} min={min} max={max} size="small" className={classes.slider} value={convertedValue} onChange={handleSliderChange} />
-            )}
-            <Input {...props} className={classes.input} value={convertedValue} onChange={handleInputChange} step={props.step} />
+            {props.min !== undefined && props.max !== undefined && <Slider {...props} size="small" className={classes.slider} value={value} onChange={handleSliderChange} />}
+            <Input {...props} className={classes.input} value={value} onChange={handleInputChange} step={props.step} />
         </div>
     );
 };

--- a/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
+++ b/packages/dev/sharedUiComponents/src/lines/optionsLineComponent.tsx
@@ -6,7 +6,7 @@ import type { IInspectableOptions } from "core/Misc/iInspectable";
 import copyIcon from "../imgs/copy.svg";
 import { PropertyLine } from "../fluent/hoc/propertyLine";
 import { Dropdown } from "../fluent/primitives/dropdown";
-import type { DropdownOption } from "../fluent/primitives/dropdown";
+import type { AcceptedDropdownValue } from "../fluent/primitives/dropdown";
 import { ToolContext } from "../fluent/hoc/fluentToolWrapper";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -125,14 +125,10 @@ export class OptionsLine extends React.Component<IOptionsLineProps, { value: num
             <PropertyLine label={this.props.label} onCopy={() => this.onCopyClickStr()}>
                 <Dropdown
                     options={this.props.options}
-                    onChange={(val: DropdownOption) => {
-                        if (val.value === null || val.value === undefined) {
-                            this.updateValue(Null_Value.toString());
-                        } else {
-                            this.updateValue(val.value.toString());
-                        }
+                    onChange={(val: AcceptedDropdownValue | undefined) => {
+                        val !== undefined && this.updateValue(val.toString());
                     }}
-                    value={this.props.options.find((o) => o.value === this.state.value || o.selected) || ({ label: "Default", value: null } as DropdownOption)}
+                    value={this.state.value}
                 />
             </PropertyLine>
         );


### PR DESCRIPTION
- Rename BoundPropertyLine to BoundProperty
- Move the useDegrees concept outside of syncedslider/vectorpropertyline and keep it only within RotationVectorPropertyLine
- Change how dropdown accepts undefined values -- the component will supply the 'undefined' value directly
- Add stub for transparentmaterial in iv2 to test the above dropdown logic
- Remove the colorsliders/vectorsliders components and just render the fragment directly within the propertylines to reduce complexity 