### PR TITLE
Inspector v2: Allow AccordionPane to have default content and use it in DebugService and SettingsService

### DIFF
--- a/packages/dev/inspector-v2/src/components/accordionPane.tsx
+++ b/packages/dev/inspector-v2/src/components/accordionPane.tsx
@@ -1,9 +1,11 @@
 // eslint-disable-next-line import/no-internal-modules
 
-import type { ComponentType } from "react";
+import type { ComponentType, FunctionComponent, PropsWithChildren } from "react";
+
+import type { AccordionSectionProps } from "shared-ui-components/fluent/primitives/accordion";
 
 import { makeStyles } from "@fluentui/react-components";
-import { useMemo, useState } from "react";
+import { Children, isValidElement, useMemo, useState } from "react";
 
 import { Accordion, AccordionSection } from "shared-ui-components/fluent/primitives/accordion";
 
@@ -69,14 +71,67 @@ const useStyles = makeStyles({
     },
 });
 
-export function AccordionPane<ContextT = unknown>(props: {
-    sections: readonly AccordionSection[];
-    sectionContent: readonly AccordionSectionContent<ContextT>[];
-    context: ContextT;
-}) {
+export type AccordionPaneSectionProps = {
+    identity: symbol;
+    collapseByDefault?: boolean;
+};
+
+export const AccordionPaneSection: FunctionComponent<PropsWithChildren<AccordionSectionProps | AccordionPaneSectionProps>> = (props) => {
+    const { title, identity, children } = props as PropsWithChildren<Partial<AccordionSectionProps> & Partial<AccordionPaneSectionProps>>;
+
+    return <AccordionSection title={title ?? identity?.description ?? ""}>{children}</AccordionSection>;
+};
+
+export function AccordionPane<ContextT = unknown>(
+    props: PropsWithChildren<{
+        sections: readonly AccordionSection[];
+        sectionContent: readonly AccordionSectionContent<ContextT>[];
+        context: ContextT;
+    }>
+) {
     const classes = useStyles();
 
-    const { sections, sectionContent, context } = props;
+    const { children, sections, sectionContent, context } = props;
+
+    const defaultSections = useMemo(() => {
+        const defaultSections: AccordionSection[] = [];
+        if (children) {
+            Children.forEach(children, (child, index) => {
+                if (isValidElement(child)) {
+                    const childProps = child.props as Partial<AccordionSectionProps> & Partial<AccordionPaneSectionProps>;
+                    defaultSections.push({
+                        identity: childProps.identity ?? Symbol(childProps.title),
+                        collapseByDefault: childProps.collapseByDefault,
+                    });
+                }
+            });
+        }
+        return defaultSections;
+    }, [children]);
+
+    const defaultSectionContent = useMemo(() => {
+        const defaultSectionContent: AccordionSectionContent<ContextT>[] = [];
+        if (children) {
+            Children.forEach(children, (child, index) => {
+                if (isValidElement(child)) {
+                    const childProps = child.props as AccordionSectionProps;
+                    defaultSectionContent.push({
+                        key: child.key ?? childProps.title,
+                        content: [
+                            {
+                                section: defaultSections[index].identity,
+                                component: () => child,
+                            },
+                        ],
+                    });
+                }
+            });
+        }
+        return defaultSectionContent;
+    }, [children, defaultSections]);
+
+    const mergedSections = useMemo(() => [...defaultSections, ...sections], [defaultSections, sections]);
+    const mergedSectionContent = useMemo(() => [...defaultSectionContent, ...sectionContent], [defaultSectionContent, sectionContent]);
 
     const [version, setVersion] = useState(0);
 
@@ -88,10 +143,10 @@ export function AccordionPane<ContextT = unknown>(props: {
             return [];
         }
 
-        return sections
+        return mergedSections
             .map((section) => {
                 // Get a flat list of the section content, preserving the key so it can be used when each component for each section is rendered.
-                const contentForSection = sectionContent
+                const contentForSection = mergedSectionContent
                     .flatMap((entry) => entry.content.map((content) => ({ key: entry.key, ...content })))
                     .filter((content) => content.section === section.identity);
 
@@ -107,22 +162,20 @@ export function AccordionPane<ContextT = unknown>(props: {
                 return {
                     identity: section.identity,
                     collapseByDefault: section.collapseByDefault ?? false,
-                    components: contentForSection.map((content) => ({ key: content.key, component: content.component })),
+                    components: contentForSection.map((content) => <content.component key={content.key} context={context} />),
                 };
             })
             .filter((section) => section !== null);
-    }, [sections, sectionContent, context]);
+    }, [mergedSections, mergedSectionContent, context]);
 
     return (
         <div className={classes.rootDiv}>
-            {visibleSections.length > 0 && (
+            {visibleSections.length > -1 && (
                 <Accordion key={version}>
-                    {visibleSections.map((section) => {
+                    {...visibleSections.map((section) => {
                         return (
-                            <AccordionSection key={section.identity.description} title={section.identity.description!}>
-                                {section.components.map((component) => {
-                                    return <component.component key={component.key} context={context} />;
-                                })}
+                            <AccordionSection key={section.identity.description} title={section.identity.description ?? section.identity.toString()}>
+                                {section.components}
                             </AccordionSection>
                         );
                     })}

--- a/packages/dev/inspector-v2/src/components/accordionPane.tsx
+++ b/packages/dev/inspector-v2/src/components/accordionPane.tsx
@@ -73,13 +73,16 @@ const useStyles = makeStyles({
 
 export type AccordionPaneSectionProps = {
     identity: symbol;
-    collapseByDefault?: boolean;
 };
 
 export const AccordionPaneSection: FunctionComponent<PropsWithChildren<AccordionSectionProps | AccordionPaneSectionProps>> = (props) => {
-    const { title, identity, children } = props as PropsWithChildren<Partial<AccordionSectionProps> & Partial<AccordionPaneSectionProps>>;
+    const { title, identity, collapseByDefault, children } = props as PropsWithChildren<Partial<AccordionSectionProps> & Partial<AccordionPaneSectionProps>>;
 
-    return <AccordionSection title={title ?? identity?.description ?? ""}>{children}</AccordionSection>;
+    return (
+        <AccordionSection title={title ?? identity?.description ?? ""} collapseByDefault={collapseByDefault}>
+            {children}
+        </AccordionSection>
+    );
 };
 
 export function AccordionPane<ContextT = unknown>(
@@ -96,7 +99,7 @@ export function AccordionPane<ContextT = unknown>(
     const defaultSections = useMemo(() => {
         const defaultSections: AccordionSection[] = [];
         if (children) {
-            Children.forEach(children, (child, index) => {
+            Children.forEach(children, (child) => {
                 if (isValidElement(child)) {
                     const childProps = child.props as Partial<AccordionSectionProps> & Partial<AccordionPaneSectionProps>;
                     defaultSections.push({
@@ -174,7 +177,11 @@ export function AccordionPane<ContextT = unknown>(
                 <Accordion key={version}>
                     {...visibleSections.map((section) => {
                         return (
-                            <AccordionSection key={section.identity.description} title={section.identity.description ?? section.identity.toString()}>
+                            <AccordionSection
+                                key={section.identity.description}
+                                title={section.identity.description ?? section.identity.toString()}
+                                collapseByDefault={section.collapseByDefault}
+                            >
                                 {section.components}
                             </AccordionSection>
                         );

--- a/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
+++ b/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
@@ -1,22 +1,26 @@
-import { AccordionPane, AccordionPaneSection } from "../accordionPane";
-import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/switchPropertyLine";
+// eslint-disable-next-line import/no-internal-modules
+import type { AbstractMesh, Mesh, Scene } from "core/index";
+
 import { FontAsset } from "addons/msdfText/fontAsset";
 import { TextRenderer } from "addons/msdfText/textRenderer";
-import { Matrix } from "core/Maths/math.vector";
 import { PhysicsViewer } from "core/Debug/physicsViewer";
-import type { Mesh } from "core/Meshes/mesh";
-import type { AbstractMesh } from "core/Meshes/abstractMesh";
-import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";
-import { CreateGround } from "core/Meshes/Builders/groundBuilder";
-import { GridMaterial } from "materials/grid/gridMaterial";
-import { Tools } from "core/Misc/tools";
-import { Color3 } from "core/Maths/math.color";
 import { Texture } from "core/Materials/Textures/texture";
-import { StandardMaterial } from "core/Materials/standardMaterial";
-import type { Scene } from "core/scene";
 import { MaterialFlags } from "core/Materials/materialFlags";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Color3 } from "core/Maths/math.color";
+import { Matrix } from "core/Maths/math.vector";
+import { CreateGround } from "core/Meshes/Builders/groundBuilder";
+import { Tools } from "core/Misc/tools";
+import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";
+import { GridMaterial } from "materials/grid/gridMaterial";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/switchPropertyLine";
+
+import { AccordionPane, AccordionPaneSection } from "../accordionPane";
 import { BoundPropertyLine } from "../properties/boundPropertyLine";
-import { Accordion, AccordionSection } from "shared-ui-components/fluent/primitives/accordion";
+
+export const HelpersDebugSectionIdentity = Symbol("Helpers");
+export const TextureChannelsDebugSectionIdentity = Symbol("Texture Channels");
+export const FeaturesDebugSectionIdentity = Symbol("Features");
 
 const SwitchGrid = function (renderScene: Scene) {
     const scene = UtilityLayerRenderer.DefaultKeepDepthUtilityLayer.utilityLayerScene;
@@ -163,7 +167,7 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
     return (
         <>
             <AccordionPane {...props}>
-                <AccordionPaneSection title="Helpers">
+                <AccordionPaneSection identity={HelpersDebugSectionIdentity}>
                     <SwitchPropertyLine label="Grid" description="Display a ground grid." value={!!scene.reservedDataStore.gridMesh} onChange={() => SwitchGrid(scene)} />
                     <SwitchPropertyLine
                         label="Physics"
@@ -178,7 +182,7 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
                         onChange={() => void SwitchNameViewerAsync(scene)}
                     />
                 </AccordionPaneSection>
-                <AccordionSection title="Core texture channels">
+                <AccordionPaneSection identity={TextureChannelsDebugSectionIdentity}>
                     <BoundPropertyLine component={SwitchPropertyLine} key="Diffuse" label="Diffuse" target={StandardMaterial} propertyKey="DiffuseTextureEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Ambient" label="Ambient" target={StandardMaterial} propertyKey="AmbientTextureEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Specular" label="Specular" target={StandardMaterial} propertyKey="SpecularTextureEnabled" />
@@ -191,8 +195,8 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
                     <BoundPropertyLine component={SwitchPropertyLine} key="Fresnel" label="Fresnel" target={StandardMaterial} propertyKey="FresnelEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Detail" label="Detail" target={MaterialFlags} propertyKey="DetailTextureEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Decal" label="Decal" target={MaterialFlags} propertyKey="DecalMapEnabled" />
-                </AccordionSection>
-                <AccordionSection title="Features">
+                </AccordionPaneSection>
+                <AccordionPaneSection identity={FeaturesDebugSectionIdentity}>
                     <BoundPropertyLine component={SwitchPropertyLine} key="Animations" label="Animations" target={scene} propertyKey="animationsEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Physics" label="Physics" target={scene} propertyKey="physicsEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Collisions" label="Collisions" target={scene} propertyKey="collisionsEnabled" />
@@ -214,7 +218,7 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
                     <BoundPropertyLine component={SwitchPropertyLine} key="Shadows" label="Shadows" target={scene} propertyKey="shadowsEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />
-                </AccordionSection>
+                </AccordionPaneSection>
             </AccordionPane>
         </>
     );

--- a/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
+++ b/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-internal-modules
-import { AccordionPane } from "../accordionPane";
+import { AccordionPane, AccordionPaneSection } from "../accordionPane";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/switchPropertyLine";
 import { FontAsset } from "addons/msdfText/fontAsset";
 import { TextRenderer } from "addons/msdfText/textRenderer";
@@ -163,8 +162,8 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
 
     return (
         <>
-            <Accordion>
-                <AccordionSection title="Helpers">
+            <AccordionPane {...props}>
+                <AccordionPaneSection title="Helpers">
                     <SwitchPropertyLine label="Grid" description="Display a ground grid." value={!!scene.reservedDataStore.gridMesh} onChange={() => SwitchGrid(scene)} />
                     <SwitchPropertyLine
                         label="Physics"
@@ -178,7 +177,7 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
                         value={!!scene.reservedDataStore.textRenderersHook}
                         onChange={() => void SwitchNameViewerAsync(scene)}
                     />
-                </AccordionSection>
+                </AccordionPaneSection>
                 <AccordionSection title="Core texture channels">
                     <BoundPropertyLine component={SwitchPropertyLine} key="Diffuse" label="Diffuse" target={StandardMaterial} propertyKey="DiffuseTextureEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Ambient" label="Ambient" target={StandardMaterial} propertyKey="AmbientTextureEnabled" />
@@ -216,8 +215,7 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
                     <BoundPropertyLine component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
                     <BoundPropertyLine component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />
                 </AccordionSection>
-            </Accordion>
-            <AccordionPane {...props} />
+            </AccordionPane>
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
+++ b/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
@@ -165,61 +165,53 @@ export const DebugPane: typeof AccordionPane<Scene> = (props) => {
     });
 
     return (
-        <>
-            <AccordionPane {...props}>
-                <AccordionPaneSection identity={HelpersDebugSectionIdentity}>
-                    <SwitchPropertyLine label="Grid" description="Display a ground grid." value={!!scene.reservedDataStore.gridMesh} onChange={() => SwitchGrid(scene)} />
-                    <SwitchPropertyLine
-                        label="Physics"
-                        description="Display physic debug info."
-                        value={!!scene.reservedDataStore.physicsViewer}
-                        onChange={() => SwitchPhysicsViewers(scene)}
-                    />
-                    <SwitchPropertyLine
-                        label="Names"
-                        description="Display mesh names."
-                        value={!!scene.reservedDataStore.textRenderersHook}
-                        onChange={() => void SwitchNameViewerAsync(scene)}
-                    />
-                </AccordionPaneSection>
-                <AccordionPaneSection identity={TextureChannelsDebugSectionIdentity}>
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Diffuse" label="Diffuse" target={StandardMaterial} propertyKey="DiffuseTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Ambient" label="Ambient" target={StandardMaterial} propertyKey="AmbientTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Specular" label="Specular" target={StandardMaterial} propertyKey="SpecularTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Emissive" label="Emissive" target={StandardMaterial} propertyKey="EmissiveTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Bump" label="Bump" target={StandardMaterial} propertyKey="BumpTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Opacity" label="Opacity" target={StandardMaterial} propertyKey="OpacityTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Reflection" label="Reflection" target={StandardMaterial} propertyKey="ReflectionTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="ColorGrading" label="Color Grading" target={StandardMaterial} propertyKey="ColorGradingTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Lightmap" label="Lightmap" target={StandardMaterial} propertyKey="LightmapTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Fresnel" label="Fresnel" target={StandardMaterial} propertyKey="FresnelEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Detail" label="Detail" target={MaterialFlags} propertyKey="DetailTextureEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Decal" label="Decal" target={MaterialFlags} propertyKey="DecalMapEnabled" />
-                </AccordionPaneSection>
-                <AccordionPaneSection identity={FeaturesDebugSectionIdentity}>
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Animations" label="Animations" target={scene} propertyKey="animationsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Physics" label="Physics" target={scene} propertyKey="physicsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Collisions" label="Collisions" target={scene} propertyKey="collisionsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Fog" label="Fog" target={scene} propertyKey="fogEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Lens flares" label="Lens flares" target={scene} propertyKey="lensFlaresEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Lights" label="Lights" target={scene} propertyKey="lightsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Particles" label="Particles" target={scene} propertyKey="particlesEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Post-processes" label="Post-processes" target={scene} propertyKey="postProcessesEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Probes" label="Probes" target={scene} propertyKey="probesEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Textures" label="Textures" target={scene} propertyKey="texturesEnabled" />
-                    <BoundPropertyLine
-                        component={SwitchPropertyLine}
-                        key="Procedural textures"
-                        label="Procedural textures"
-                        target={scene}
-                        propertyKey="proceduralTexturesEnabled"
-                    />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Render targets" label="Render targets" target={scene} propertyKey="renderTargetsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Shadows" label="Shadows" target={scene} propertyKey="shadowsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
-                    <BoundPropertyLine component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />
-                </AccordionPaneSection>
-            </AccordionPane>
-        </>
+        <AccordionPane {...props}>
+            <AccordionPaneSection identity={HelpersDebugSectionIdentity}>
+                <SwitchPropertyLine label="Grid" description="Display a ground grid." value={!!scene.reservedDataStore.gridMesh} onChange={() => SwitchGrid(scene)} />
+                <SwitchPropertyLine
+                    label="Physics"
+                    description="Display physic debug info."
+                    value={!!scene.reservedDataStore.physicsViewer}
+                    onChange={() => SwitchPhysicsViewers(scene)}
+                />
+                <SwitchPropertyLine
+                    label="Names"
+                    description="Display mesh names."
+                    value={!!scene.reservedDataStore.textRenderersHook}
+                    onChange={() => void SwitchNameViewerAsync(scene)}
+                />
+            </AccordionPaneSection>
+            <AccordionPaneSection identity={TextureChannelsDebugSectionIdentity}>
+                <BoundPropertyLine component={SwitchPropertyLine} key="Diffuse" label="Diffuse" target={StandardMaterial} propertyKey="DiffuseTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Ambient" label="Ambient" target={StandardMaterial} propertyKey="AmbientTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Specular" label="Specular" target={StandardMaterial} propertyKey="SpecularTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Emissive" label="Emissive" target={StandardMaterial} propertyKey="EmissiveTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Bump" label="Bump" target={StandardMaterial} propertyKey="BumpTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Opacity" label="Opacity" target={StandardMaterial} propertyKey="OpacityTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Reflection" label="Reflection" target={StandardMaterial} propertyKey="ReflectionTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="ColorGrading" label="Color Grading" target={StandardMaterial} propertyKey="ColorGradingTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Lightmap" label="Lightmap" target={StandardMaterial} propertyKey="LightmapTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Fresnel" label="Fresnel" target={StandardMaterial} propertyKey="FresnelEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Detail" label="Detail" target={MaterialFlags} propertyKey="DetailTextureEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Decal" label="Decal" target={MaterialFlags} propertyKey="DecalMapEnabled" />
+            </AccordionPaneSection>
+            <AccordionPaneSection identity={FeaturesDebugSectionIdentity}>
+                <BoundPropertyLine component={SwitchPropertyLine} key="Animations" label="Animations" target={scene} propertyKey="animationsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Physics" label="Physics" target={scene} propertyKey="physicsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Collisions" label="Collisions" target={scene} propertyKey="collisionsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Fog" label="Fog" target={scene} propertyKey="fogEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Lens flares" label="Lens flares" target={scene} propertyKey="lensFlaresEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Lights" label="Lights" target={scene} propertyKey="lightsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Particles" label="Particles" target={scene} propertyKey="particlesEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Post-processes" label="Post-processes" target={scene} propertyKey="postProcessesEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Probes" label="Probes" target={scene} propertyKey="probesEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Textures" label="Textures" target={scene} propertyKey="texturesEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Procedural textures" label="Procedural textures" target={scene} propertyKey="proceduralTexturesEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Render targets" label="Render targets" target={scene} propertyKey="renderTargetsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Shadows" label="Shadows" target={scene} propertyKey="shadowsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
+                <BoundPropertyLine component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />
+            </AccordionPaneSection>
+        </AccordionPane>
     );
 };

--- a/packages/dev/inspector-v2/src/services/panes/debugService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/debugService.tsx
@@ -1,21 +1,41 @@
-import type { ServiceDefinition } from "../../modularity/serviceDefinition";
+// eslint-disable-next-line import/no-internal-modules
+import type { IDisposable, Scene } from "core/index";
+
+import type { AccordionSection, AccordionSectionContent } from "../../components/accordionPane";
+import type { IService, ServiceDefinition } from "../../modularity/serviceDefinition";
+import type { ISceneContext } from "../sceneContext";
 import type { IShellService } from "../shellService";
 
 import { BugRegular } from "@fluentui/react-icons";
 
-import { ShellServiceIdentity } from "../shellService";
 import { DebugPane } from "../../components/debug/debugPane";
 import { useObservableCollection, useObservableState, useOrderedObservableCollection } from "../../hooks/observableHooks";
-import { SceneContextIdentity, type ISceneContext } from "../sceneContext";
 import { ObservableCollection } from "../../misc/observableCollection";
-import { type AccordionSection, type AccordionSectionContent } from "../../components/accordionPane";
-import type { Scene } from "core/scene";
+import { SceneContextIdentity } from "../sceneContext";
+import { ShellServiceIdentity } from "../shellService";
 
-export const HelpersServiceIdentity = Symbol("Helpers");
-export const CoreTextureSectionIdentity = Symbol("CoreTextureChannels");
+export const DebugServiceIdentity = Symbol("DebugService");
 
-export const DebugServiceDefinition: ServiceDefinition<[], [IShellService, ISceneContext]> = {
+/**
+ * Allows new sections or content to be added to the debug pane.
+ */
+export interface IDebugService extends IService<typeof DebugServiceIdentity> {
+    /**
+     * Adds a new section.
+     * @param section A description of the section to add.
+     */
+    addSection(section: AccordionSection): IDisposable;
+
+    /**
+     * Adds content to one or more sections.
+     * @param content A description of the content to add.
+     */
+    addSectionContent(content: AccordionSectionContent<Scene>): IDisposable;
+}
+
+export const DebugServiceDefinition: ServiceDefinition<[IDebugService], [IShellService, ISceneContext]> = {
     friendlyName: "Debug",
+    produces: [DebugServiceIdentity],
     consumes: [ShellServiceIdentity, SceneContextIdentity],
     factory: (shellService, sceneContext) => {
         const sectionsCollection = new ObservableCollection<AccordionSection>();
@@ -37,6 +57,8 @@ export const DebugServiceDefinition: ServiceDefinition<[], [IShellService, IScen
         });
 
         return {
+            addSection: (section) => sectionsCollection.add(section),
+            addSectionContent: (content) => sectionContentCollection.add(content),
             dispose: () => registration.dispose(),
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/debugService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/debugService.tsx
@@ -26,6 +26,7 @@ export const DebugServiceDefinition: ServiceDefinition<[], [IShellService, IScen
             title: "Debug",
             icon: BugRegular,
             horizontalLocation: "right",
+            order: 200,
             suppressTeachingMoment: true,
             content: () => {
                 const sections = useOrderedObservableCollection(sectionsCollection);
@@ -33,6 +34,25 @@ export const DebugServiceDefinition: ServiceDefinition<[], [IShellService, IScen
                 const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
                 return <>{scene && <DebugPane sections={sections} sectionContent={sectionContent} context={scene} />}</>;
             },
+        });
+
+        sectionsCollection.add({
+            identity: CoreTextureSectionIdentity,
+        });
+
+        sectionContentCollection.add({
+            key: "Stuff stuff",
+            content: [
+                {
+                    section: CoreTextureSectionIdentity,
+                    component: () => (
+                        <div>
+                            <h3>Core Texture Channels</h3>
+                            <p>This section is for testing purposes.</p>
+                        </div>
+                    ),
+                },
+            ],
         });
 
         return {

--- a/packages/dev/inspector-v2/src/services/panes/debugService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/debugService.tsx
@@ -36,25 +36,6 @@ export const DebugServiceDefinition: ServiceDefinition<[], [IShellService, IScen
             },
         });
 
-        sectionsCollection.add({
-            identity: CoreTextureSectionIdentity,
-        });
-
-        sectionContentCollection.add({
-            key: "Stuff stuff",
-            content: [
-                {
-                    section: CoreTextureSectionIdentity,
-                    component: () => (
-                        <div>
-                            <h3>Core Texture Channels</h3>
-                            <p>This section is for testing purposes.</p>
-                        </div>
-                    ),
-                },
-            ],
-        });
-
         return {
             dispose: () => registration.dispose(),
         };

--- a/packages/dev/inspector-v2/src/services/panes/properties/propertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/propertiesService.tsx
@@ -56,6 +56,7 @@ export const PropertiesServiceDefinition: ServiceDefinition<[IPropertiesService]
             title: "Properties",
             icon: DocumentTextRegular,
             horizontalLocation: "right",
+            order: 100,
             suppressTeachingMoment: true,
             content: () => {
                 const sections = useOrderedObservableCollection(sectionsCollection);

--- a/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
@@ -1,20 +1,50 @@
-import type { ServiceDefinition } from "../../modularity/serviceDefinition";
+// eslint-disable-next-line import/no-internal-modules
+import type { IDisposable, Scene } from "core/index";
+
+import type { AccordionSection, AccordionSectionContent } from "../../components/accordionPane";
+import type { IService, ServiceDefinition } from "../../modularity/serviceDefinition";
+import type { ISceneContext } from "../sceneContext";
 import type { IShellService } from "../shellService";
 
 import { SettingsRegular } from "@fluentui/react-icons";
 
-import { ShellServiceIdentity } from "../shellService";
-import { SettingsContextIdentity, type ISettingsContext } from "../settingsContext";
+import { DataStorage } from "core/Misc/dataStorage";
 import { Observable } from "core/Misc/observable";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/switchPropertyLine";
-import { DataStorage } from "core/Misc/dataStorage";
-import { Pane } from "../../components/pane";
+import { AccordionPane, AccordionPaneSection } from "../../components/accordionPane";
+import { useObservableCollection, useObservableState, useOrderedObservableCollection } from "../../hooks/observableHooks";
+import { ObservableCollection } from "../../misc/observableCollection";
+import { SceneContextIdentity } from "../sceneContext";
+import { SettingsContextIdentity, type ISettingsContext } from "../settingsContext";
+import { ShellServiceIdentity } from "../shellService";
 
-export const SettingsServiceDefinition: ServiceDefinition<[ISettingsContext], [IShellService]> = {
+export const SettingsServiceIdentity = Symbol("SettingsService");
+
+/**
+ * Allows new sections or content to be added to the Settings pane.
+ */
+export interface ISettingsService extends IService<typeof SettingsServiceIdentity> {
+    /**
+     * Adds a new section.
+     * @param section A description of the section to add.
+     */
+    addSection(section: AccordionSection): IDisposable;
+
+    /**
+     * Adds content to one or more sections.
+     * @param content A description of the content to add.
+     */
+    addSectionContent(content: AccordionSectionContent<Scene>): IDisposable;
+}
+
+export const SettingsServiceDefinition: ServiceDefinition<[ISettingsContext, ISettingsService], [IShellService, ISceneContext]> = {
     friendlyName: "Settings",
-    consumes: [ShellServiceIdentity],
-    produces: [SettingsContextIdentity],
-    factory: (shellService) => {
+    consumes: [ShellServiceIdentity, SceneContextIdentity],
+    produces: [SettingsContextIdentity, SettingsServiceIdentity],
+    factory: (shellService, sceneContext) => {
+        const sectionsCollection = new ObservableCollection<AccordionSection>();
+        const sectionContentCollection = new ObservableCollection<AccordionSectionContent<Scene>>();
+
         let useDegrees = DataStorage.ReadBoolean("settings_useDegrees", false);
         let ignoreBackfacesForPicking = DataStorage.ReadBoolean("settings_ignoreBackfacesForPicking", false);
         const settings = {
@@ -44,6 +74,8 @@ export const SettingsServiceDefinition: ServiceDefinition<[ISettingsContext], [I
                 this.settingsChangedObservable.notifyObservers(this);
             },
             settingsChangedObservable: new Observable<ISettingsContext>(),
+            addSection: (section: AccordionSection) => sectionsCollection.add(section),
+            addSectionContent: (content: AccordionSectionContent<Scene>) => sectionContentCollection.add(content),
             dispose: () => {},
         };
 
@@ -55,25 +87,35 @@ export const SettingsServiceDefinition: ServiceDefinition<[ISettingsContext], [I
             order: 500,
             suppressTeachingMoment: true,
             content: () => {
+                const sections = useOrderedObservableCollection(sectionsCollection);
+                const sectionContent = useObservableCollection(sectionContentCollection);
+                const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
+
                 return (
-                    <Pane>
-                        <SwitchPropertyLine
-                            label="Use Degrees"
-                            description="Using degrees instead of radians."
-                            value={settings.useDegrees}
-                            onChange={(checked) => {
-                                settings.useDegrees = checked;
-                            }}
-                        />
-                        <SwitchPropertyLine
-                            label="Ignore backfaces for picking"
-                            description="Ignore backfaces when picking."
-                            value={settings.ignoreBackfacesForPicking}
-                            onChange={(checked) => {
-                                settings.ignoreBackfacesForPicking = checked;
-                            }}
-                        />
-                    </Pane>
+                    <>
+                        {scene && (
+                            <AccordionPane sections={sections} sectionContent={sectionContent} context={scene}>
+                                <AccordionPaneSection title="UI">
+                                    <SwitchPropertyLine
+                                        label="Use Degrees"
+                                        description="Using degrees instead of radians."
+                                        value={settings.useDegrees}
+                                        onChange={(checked) => {
+                                            settings.useDegrees = checked;
+                                        }}
+                                    />
+                                    <SwitchPropertyLine
+                                        label="Ignore backfaces for picking"
+                                        description="Ignore backfaces when picking."
+                                        value={settings.ignoreBackfacesForPicking}
+                                        onChange={(checked) => {
+                                            settings.ignoreBackfacesForPicking = checked;
+                                        }}
+                                    />
+                                </AccordionPaneSection>
+                            </AccordionPane>
+                        )}
+                    </>
                 );
             },
         });

--- a/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
@@ -52,6 +52,7 @@ export const SettingsServiceDefinition: ServiceDefinition<[ISettingsContext], [I
             title: "Settings",
             icon: SettingsRegular,
             horizontalLocation: "right",
+            order: 500,
             suppressTeachingMoment: true,
             content: () => {
                 return (

--- a/packages/dev/inspector-v2/src/services/panes/statsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/statsService.tsx
@@ -55,6 +55,7 @@ export const StatsServiceDefinition: ServiceDefinition<[IStatsService], [IShellS
             title: "Stats",
             icon: DataBarHorizontalRegular,
             horizontalLocation: "right",
+            order: 300,
             suppressTeachingMoment: true,
             content: () => {
                 const sections = useOrderedObservableCollection(sectionsCollection);

--- a/packages/dev/inspector-v2/src/services/panes/toolsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/toolsService.tsx
@@ -14,6 +14,7 @@ export const ToolsServiceDefinition: ServiceDefinition<[], [IShellService]> = {
             title: "Tools",
             icon: WrenchRegular,
             horizontalLocation: "right",
+            order: 400,
             suppressTeachingMoment: true,
             content: () => {
                 return <>Not yet implemented.</>;

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent, PropsWithChildren } from "react";
 
-import { Children, isValidElement } from "react";
+import { Children, isValidElement, useMemo } from "react";
 
 import { Accordion as FluentAccordion, AccordionItem, AccordionHeader, AccordionPanel, Subtitle1, makeStyles, tokens } from "@fluentui/react-components";
 
@@ -21,6 +21,7 @@ const useStyles = makeStyles({
 
 export type AccordionSectionProps = {
     title: string;
+    collapseByDefault?: boolean;
 };
 
 export const AccordionSection: FunctionComponent<PropsWithChildren<AccordionSectionProps>> = (props) => {
@@ -33,23 +34,43 @@ export const Accordion: FunctionComponent<PropsWithChildren> = (props) => {
     const classes = useStyles();
 
     const { children, ...rest } = props;
-
-    return (
-        <FluentAccordion className={classes.accordion} collapsible multiple defaultOpenItems={Array.from({ length: Children.count(children) }, (_, index) => index)} {...rest}>
-            {Children.map(children, (child, index) => {
+    const validChildren = useMemo(() => {
+        return (
+            Children.map(children, (child) => {
                 if (isValidElement(child)) {
-                    return (
-                        <AccordionItem key={child.props.title} value={index}>
-                            <AccordionHeader expandIconPosition="end">
-                                <Subtitle1>{child.props.title}</Subtitle1>
-                            </AccordionHeader>
-                            <AccordionPanel>
-                                <div className={classes.panelDiv}>{child}</div>
-                            </AccordionPanel>
-                        </AccordionItem>
-                    );
+                    const childProps = child.props as Partial<AccordionSectionProps>;
+                    if (childProps.title) {
+                        return {
+                            title: childProps.title,
+                            collapseByDefault: childProps.collapseByDefault,
+                            content: child,
+                        };
+                    }
                 }
                 return null;
+            })?.filter(Boolean) ?? []
+        );
+    }, [children]);
+
+    return (
+        <FluentAccordion
+            className={classes.accordion}
+            collapsible
+            multiple
+            defaultOpenItems={validChildren.filter((child) => !child.collapseByDefault).map((child) => child.title)}
+            {...rest}
+        >
+            {validChildren.map((child) => {
+                return (
+                    <AccordionItem key={child.title} value={child.title}>
+                        <AccordionHeader expandIconPosition="end">
+                            <Subtitle1>{child.title}</Subtitle1>
+                        </AccordionHeader>
+                        <AccordionPanel>
+                            <div className={classes.panelDiv}>{child.content}</div>
+                        </AccordionPanel>
+                    </AccordionItem>
+                );
             })}
         </FluentAccordion>
     );


### PR DESCRIPTION
This change makes it so that `AccordionPane` can have default sections with default content, which is merged with the "add on" sections and content. The default sections can optionally specify an identity which allows them to be extended (e.g. more content added to the default sections). This is trying to make it really easy to define all the default UI, but still have it be extensible. Later I will probably change section identities to just be strings rather than symbols and remove the `identity` prop (the `title` will be the identity), but I don't want to make a breaking change right now since there are a bunch of active PRs using it as is.