### PR TITLE
Fix volume fade ramps

### DIFF
--- a/packages/dev/core/src/AudioV2/audioUtils.ts
+++ b/packages/dev/core/src/AudioV2/audioUtils.ts
@@ -67,7 +67,7 @@ export function _GetAudioParamCurveValues(shape: AudioParameterRampShape, from: 
         throw new Error(`Unknown ramp shape: ${shape}`);
     }
 
-    const direction = to - from < 0 ? -1 : 1;
+    const direction = Math.sign(to - from);
     const range = Math.abs(to - from);
 
     if (direction === 1) {

--- a/packages/dev/core/src/AudioV2/audioUtils.ts
+++ b/packages/dev/core/src/AudioV2/audioUtils.ts
@@ -67,9 +67,18 @@ export function _GetAudioParamCurveValues(shape: AudioParameterRampShape, from: 
         throw new Error(`Unknown ramp shape: ${shape}`);
     }
 
-    const range = to - from;
-    for (let i = 0; i < normalizedCurve.length; i++) {
-        TmpCurveValues[i] = from + range * normalizedCurve[i];
+    const direction = to - from < 0 ? -1 : 1;
+    const range = Math.abs(to - from);
+
+    if (direction === 1) {
+        for (let i = 0; i < normalizedCurve.length; i++) {
+            TmpCurveValues[i] = from + range * normalizedCurve[i];
+        }
+    } else {
+        let j = CurveLength - 1;
+        for (let i = 0; i < normalizedCurve.length; i++, j--) {
+            TmpCurveValues[i] = from - range * (1 - normalizedCurve[j]);
+        }
     }
 
     return TmpCurveValues;

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -386,7 +386,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
                 expect(volumes[Channel.L]).toBeCloseTo(0.3, VolumePrecision);
             });
 
-            test("Ramping volume from 1 to 0 over 1 second should play sound at 1x volume at 0.1 seconds with shape set to exponential", async ({ page }) => {
+            test("Ramping volume from 1 to 0 over 1 second should play sound at 0.3x volume at 0.1 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -402,10 +402,16 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.1);
 
-                expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
+                if ((await EvaluateAudioContextType(page)) === "Offline") {
+                    expect(volumes[Channel.L]).toBeCloseTo(0.3, VolumePrecision);
+                } else {
+                    // Expect larger range due to timing variations.
+                    expect(volumes[Channel.L]).toBeGreaterThan(0.25);
+                    expect(volumes[Channel.L]).toBeLessThan(0.36);
+                }
             });
 
-            test("Ramping volume from 1 to 0 over 1 second should play sound at 1x volume at 0.5 seconds with shape set to exponential", async ({ page }) => {
+            test("Ramping volume from 1 to 0 over 1 second should play sound at close to 0 volume at 0.5 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -421,10 +427,10 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
-                expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
+                expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
             });
 
-            test("Ramping volume from 1 to 0 over 1 second should play sound at 0.7x volume at 0.9 seconds with shape set to exponential", async ({ page }) => {
+            test("Ramping volume from 1 to 0 over 1 second should play sound at close to 0 volume at 0.9 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -440,13 +446,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.9);
 
-                if ((await EvaluateAudioContextType(page)) === "Offline") {
-                    expect(volumes[Channel.L]).toBeCloseTo(0.7, VolumePrecision);
-                } else {
-                    // Expect larger range due to timing variations.
-                    expect(volumes[Channel.L]).toBeGreaterThan(0.65);
-                    expect(volumes[Channel.L]).toBeLessThan(0.76);
-                }
+                expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
             });
         });
 
@@ -524,10 +524,10 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.1);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
+                expect(volumes[Channel.L]).toBeCloseTo(1, VolumePrecision);
             });
 
-            test("Ramping volume from 1 to 0 over 1 second should play sound at 1x volume at 0.5 seconds with shape set to logarithmic", async ({ page }) => {
+            test("Ramping volume from 1 to 0 over 1 second should play sound at 0.85x volume at 0.5 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -543,10 +543,10 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.5);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0.15, VolumePrecision);
+                expect(volumes[Channel.L]).toBeCloseTo(0.85, VolumePrecision);
             });
 
-            test("Ramping volume from 1 to 0 over 1 second should play sound at 0.7x volume at 0.9 seconds with shape set to logarithmic", async ({ page }) => {
+            test("Ramping volume from 1 to 0 over 1 second should play sound at 0.5x volume at 0.9 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -562,7 +562,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.9);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
+                expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
             });
         });
 

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -284,9 +284,9 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
                     });
                 });
 
-                const volumes = await EvaluateVolumesAtTimeAsync(page, 0.25);
+                const volumes = await EvaluateVolumesAtTimeAsync(page, 0.1);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0.75, VolumePrecision);
+                expect(volumes[Channel.L]).toBeCloseTo(0.9, VolumePrecision);
             });
 
             test("Ramping volume from 1 to 0 over 1 second should play sound at 0.5x volume at 0.5 seconds with shape set to linear", async ({ page }) => {
@@ -345,7 +345,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.1);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0.0, VolumePrecision);
+                expect(volumes[Channel.L]).toBeCloseTo(0, VolumePrecision);
             });
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.5 seconds with shape set to exponential", async ({ page }) => {
@@ -451,7 +451,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         });
 
         test.describe("Logarithmic ramp", () => {
-            test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.1 seconds shape set to logarithmic", async ({ page }) => {
+            test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.1 seconds shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -470,7 +470,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
                 expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
             });
 
-            test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.5 seconds with shape set to logarithmic", async ({ page }) => {
+            test("Ramping volume from 0 to 1 over 1 second should play sound at 0.85x volume at 0.5 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
@@ -489,7 +489,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
                 expect(volumes[Channel.L]).toBeCloseTo(0.85, VolumePrecision);
             });
 
-            test("Ramping volume from 0 to 1 over 1 second should play sound at 0.3x volume at 0.9 seconds with shape set to logarithmic", async ({ page }) => {
+            test("Ramping volume from 0 to 1 over 1 second should play sound at 1x volume at 0.9 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
                     await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {


### PR DESCRIPTION
The logarithmic and exponential fade ramps are swapped, so fading out with a logarithmic shape actually results in an exponential fade out, and vice-versa.

This change fixes the issue by stepping through the curve backwards for fade outs.

Tested with playground https://playground.babylonjs.com/#HDPCXJ#1.