### PR TITLE
[Fluent] Scale slider min/max to avoid tick marks

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/hoc/colorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/colorPropertyLine.tsx
@@ -45,9 +45,9 @@ const ColorPropertyLine = forwardRef<HTMLDivElement, ColorPropertyLineProps>((pr
             {...props}
             expandedContent={
                 <>
-                    <SyncedSliderLine label="R" value={Math.round(color.r * 255)} min={0} max={255} onChange={(value) => onSliderChange(value, "r")} />
-                    <SyncedSliderLine label="G" value={Math.round(color.g * 255)} min={0} max={255} onChange={(value) => onSliderChange(value, "g")} />
-                    <SyncedSliderLine label="B" value={Math.round(color.b * 255)} min={0} max={255} onChange={(value) => onSliderChange(value, "b")} />
+                    <SyncedSliderLine label="R" value={color.r * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "r")} />
+                    <SyncedSliderLine label="G" value={color.g * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "g")} />
+                    <SyncedSliderLine label="B" value={color.b * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "b")} />
                     {color instanceof Color4 && <SyncedSliderLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onSliderChange(value, "a")} />}
                 </>
             }

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/syncedSlider.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/syncedSlider.tsx
@@ -37,12 +37,19 @@ export const SyncedSliderInput: FunctionComponent<SyncedSliderProps> = (props) =
     const classes = useSyncedSliderStyles();
     const [value, setValue] = useState<number>(props.value);
 
+    // NOTE: The Fluent slider will add tick marks if the step prop is anything other than undefined.
+    // To avoid this, we scale the min/max based on the step so we can always make step undefined.
+    // The actual step size in the Fluent slider is 1 when it is ste to undefined.
+    const min = props.min ?? 0;
+    const max = props.max ?? 100;
+    const step = props.step ?? 1;
+
     useEffect(() => {
         setValue(props.value ?? ""); // Update local state when props.value changes
     }, [props.value]);
 
     const handleSliderChange = (_: ChangeEvent<HTMLInputElement>, data: SliderOnChangeData) => {
-        const value = data.value;
+        const value = data.value * step;
         setValue(value);
         props.onChange(value); // Notify parent
     };
@@ -57,8 +64,10 @@ export const SyncedSliderInput: FunctionComponent<SyncedSliderProps> = (props) =
 
     return (
         <div className={classes.syncedSlider}>
-            {props.min !== undefined && props.max !== undefined && <Slider {...props} size="small" className={classes.slider} value={value} onChange={handleSliderChange} />}
-            <Input {...props} className={classes.input} value={value} onChange={handleInputChange} step={props.step} />
+            {props.min !== undefined && props.max !== undefined && (
+                <Slider {...props} size="small" className={classes.slider} min={min / step} max={max / step} step={undefined} value={value / step} onChange={handleSliderChange} />
+            )}
+            <Input {...props} className={classes.input} value={Math.round(value / step) * step} onChange={handleInputChange} step={step} />
         </div>
     );
 };


### PR DESCRIPTION
The Fluent slider uses a step size of 1 by default, but if the `step` prop is set to anything other than `undefined`, it adds tick marks. This is especially bad when you have something like min=0 max=1 step=0.01, as it will render 100 tick marks, which basically makes the slider look like garbage. This change just scales the min/max such that step can always be undefined (the default value of 1) and never draw tick marks.

It also rounds the Input box numeric value to the closes step for consistency.

![image](https://github.com/user-attachments/assets/520cc113-624d-413c-a3c0-45f4fa2abcce)
