### PR TITLE
ESLint: Allow react hook function naming and allow type only imports from index.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -232,6 +232,25 @@ const rules = {
                         message: "Async function name must end in 'Async'",
                     },
                 ],
+                // For typescript files, allow type only imports from index files as these are compile time only and cause no issues with runtime side effects.
+                "@typescript-eslint/no-restricted-imports": [
+                    "error",
+                    {
+                        patterns: [
+                            {
+                                group: ["**/index"],
+                                message: "Do not import from index files",
+                                allowTypeImports: true,
+                            },
+                        ],
+                    },
+                ],
+                "import/no-internal-modules": [
+                    "error",
+                    {
+                        forbid: ["**/"],
+                    },
+                ],
                 "@typescript-eslint/naming-convention": [
                     "error",
                     {
@@ -427,6 +446,16 @@ const rules = {
                         },
                     },
                     {
+                        // Exception for hooks which start with 'use'
+                        selector: "function",
+                        format: ["strictCamelCase"],
+                        modifiers: ["global"],
+                        filter: {
+                            regex: "^use",
+                            match: true,
+                        },
+                    },
+                    {
                         selector: "variable",
                         format: ["PascalCase"],
                         modifiers: ["global"],
@@ -520,7 +549,6 @@ const rules = {
         "import/no-internal-modules": [
             "error",
             {
-                // {   "allow": ["**/*.ts", "**/*.tsx"]
                 forbid: ["**/index", "**/"],
             },
         ],

--- a/packages/dev/addons/src/index.ts
+++ b/packages/dev/addons/src/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./htmlMesh/index";
 export * from "./msdfText/index";

--- a/packages/dev/addons/src/msdfText/index.ts
+++ b/packages/dev/addons/src/msdfText/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./fontAsset";
 export * from "./paragraphOptions";
 export * from "./textRenderer";

--- a/packages/dev/core/src/AudioV2/abstractAudio/index.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./abstractAudioBus";
 export * from "./abstractAudioNode";
 export * from "./abstractAudioOutNode";

--- a/packages/dev/core/src/AudioV2/index.ts
+++ b/packages/dev/core/src/AudioV2/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./abstractAudio/index";
 export * from "./audioParameter";
 export * from "./soundState";

--- a/packages/dev/core/src/Behaviors/index.ts
+++ b/packages/dev/core/src/Behaviors/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./behavior";
 export * from "./Cameras/index";
 export * from "./Meshes/index";

--- a/packages/dev/core/src/Cameras/index.ts
+++ b/packages/dev/core/src/Cameras/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Inputs/index";
 export * from "./cameraInputsManager";
 export * from "./camera";

--- a/packages/dev/core/src/Culling/index.ts
+++ b/packages/dev/core/src/Culling/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./boundingBox";
 export * from "./boundingInfo";
 export * from "./Helper/boundingInfoHelper";

--- a/packages/dev/core/src/Engines/Processors/Expressions/index.ts
+++ b/packages/dev/core/src/Engines/Processors/Expressions/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./shaderDefineExpression";
 export * from "./Operators/index";

--- a/packages/dev/core/src/Engines/Processors/index.ts
+++ b/packages/dev/core/src/Engines/Processors/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./iShaderProcessor";
 export * from "./Expressions/index";
 export * from "./shaderCodeConditionNode";

--- a/packages/dev/core/src/Engines/index.ts
+++ b/packages/dev/core/src/Engines/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./constants";
 export * from "./engineCapabilities";
 export * from "./instancingAttributeInfo";

--- a/packages/dev/core/src/FlowGraph/Blocks/Data/index.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Data/index.ts
@@ -7,9 +7,9 @@ export * from "../Execution/flowGraphSetPropertyBlock";
 export * from "./flowGraphConstantBlock";
 export * from "./flowGraphGetAssetBlock";
 export * from "./flowGraphDataSwitchBlock";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./Math/index";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./Transformers/index";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./Utils/index";

--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/index.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/index.ts
@@ -1,5 +1,5 @@
 export * from "./flowGraphConsoleLogBlock";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./ControlFlow/index";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./Animation/index";

--- a/packages/dev/core/src/FlowGraph/Blocks/index.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Execution/index";
 export * from "./Data/index";
 export * from "./Event/index";

--- a/packages/dev/core/src/FlowGraph/index.ts
+++ b/packages/dev/core/src/FlowGraph/index.ts
@@ -14,7 +14,7 @@ export * from "./flowGraphParser";
 export * from "./flowGraphPathConverter";
 export * from "./flowGraphPathConverterComponent";
 export * from "./flowGraphLogger";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./Blocks/index";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./CustomTypes/index";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Layers/glowLayerBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Layers/glowLayerBlock.ts
@@ -1,12 +1,4 @@
-import type {
-    Scene,
-    NodeRenderGraphBuildState,
-    FrameGraph,
-    FrameGraphTextureHandle,
-    NodeRenderGraphConnectionPoint,
-    FrameGraphObjectRendererTask,
-    // eslint-disable-next-line import/no-internal-modules
-} from "core/index";
+import type { Scene, NodeRenderGraphBuildState, FrameGraph, FrameGraphTextureHandle, NodeRenderGraphConnectionPoint, FrameGraphObjectRendererTask } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes, NodeRenderGraphConnectionPointDirection } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Layers/highlightLayerBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Layers/highlightLayerBlock.ts
@@ -1,12 +1,4 @@
-import type {
-    Scene,
-    NodeRenderGraphBuildState,
-    FrameGraph,
-    FrameGraphTextureHandle,
-    NodeRenderGraphConnectionPoint,
-    FrameGraphObjectRendererTask,
-    // eslint-disable-next-line import/no-internal-modules
-} from "core/index";
+import type { Scene, NodeRenderGraphBuildState, FrameGraph, FrameGraphTextureHandle, NodeRenderGraphConnectionPoint, FrameGraphObjectRendererTask } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes, NodeRenderGraphConnectionPointDirection } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/anaglyphPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/anaglyphPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraphTextureHandle, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/basePostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/basePostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraphTextureHandle, FrameGraph, FrameGraphTask } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/blackAndWhitePostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/blackAndWhitePostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/bloomPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/bloomPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/blurPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/blurPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/chromaticAberrationPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/chromaticAberrationPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { Vector2 } from "core/Maths/math.vector";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/circleOfConfusionPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/circleOfConfusionPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraphTextureHandle, FrameGraph, Camera } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/depthOfFieldPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/depthOfFieldPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraphTextureHandle, FrameGraph, Camera } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/extractHighlightsPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/extractHighlightsPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/fxaaPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/fxaaPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { FrameGraphFXAATask } from "core/FrameGraph/Tasks/PostProcesses/fxaaTask";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/grainPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/grainPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/imageProcessingPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/imageProcessingPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/motionBlurPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/motionBlurPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraphTextureHandle, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/passPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/passPostProcessBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { FrameGraphPassCubeTask, FrameGraphPassTask } from "core/FrameGraph/Tasks/PostProcesses/passTask";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/ssrPostProcessBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/PostProcesses/ssrPostProcessBlock.ts
@@ -6,7 +6,6 @@ import type {
     FrameGraphTextureHandle,
     Camera,
     NodeRenderGraphGeometryRendererBlock,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseObjectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseObjectRendererBlock.ts
@@ -8,7 +8,6 @@ import type {
     FrameGraphObjectRendererTask,
     NodeRenderGraphResourceContainerBlock,
     FrameGraphShadowGeneratorTask,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { NodeRenderGraphBlockConnectionPointTypes, NodeRenderGraphConnectionPointDirection } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseShadowGeneratorBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/baseShadowGeneratorBlock.ts
@@ -7,7 +7,6 @@ import type {
     FrameGraphObjectList,
     FrameGraphShadowGeneratorTask,
     Camera,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/csmShadowGeneratorBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/csmShadowGeneratorBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph, NodeRenderGraphConnectionPoint, FrameGraphTextureHandle, NodeRenderGraphBuildState } from "core/index";
 import { NodeRenderGraphBaseShadowGeneratorBlock } from "./baseShadowGeneratorBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/geometryRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/geometryRendererBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraph, FrameGraphTextureHandle, FrameGraphObjectList, Camera } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/objectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/objectRendererBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/shadowGeneratorBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/shadowGeneratorBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { NodeRenderGraphBaseShadowGeneratorBlock } from "./baseShadowGeneratorBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/taaObjectRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/taaObjectRendererBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/utilityLayerRendererBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Rendering/utilityLayerRendererBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraph, NodeRenderGraphBuildState, FrameGraphTextureHandle, Camera } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Teleport/teleportInBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Teleport/teleportInBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, Nullable, FrameGraph, NodeRenderGraphTeleportOutBlock } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Teleport/teleportOutBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Teleport/teleportOutBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, Nullable, FrameGraph, NodeRenderGraphTeleportInBlock, NodeRenderGraphBuildState } from "core/index";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/clearBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/clearBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraphTextureHandle, FrameGraph, NodeRenderGraphBuildState } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/copyTextureBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/copyTextureBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraphTextureHandle, FrameGraph, NodeRenderGraphBuildState } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/generateMipmapsBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/generateMipmapsBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraphTextureHandle, FrameGraph, NodeRenderGraphBuildState } from "core/index";
 import { NodeRenderGraphBlock } from "../../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/cullObjectsBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/cullObjectsBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, NodeRenderGraphBuildState, FrameGraph } from "core/index";
 import { NodeRenderGraphBlock } from "../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/elbowBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/elbowBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraph, NodeRenderGraphBuildState } from "core/index";
 import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/executeBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/executeBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/inputBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/inputBlock.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-internal-modules */
 import type {
     NodeRenderGraphConnectionPoint,
     Scene,

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/outputBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/outputBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraph, NodeRenderGraphBuildState, FrameGraphTextureHandle } from "core/index";
 import { NodeRenderGraphBlock } from "../nodeRenderGraphBlock";
 import { RegisterClass } from "../../../Misc/typeStore";

--- a/packages/dev/core/src/FrameGraph/Node/Blocks/resourceContainerBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/resourceContainerBlock.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPoint, Scene, FrameGraph } from "core/index";
 import { RegisterClass } from "../../../Misc/typeStore";
 import { NodeRenderGraphBlockConnectionPointTypes } from "../Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/Types/nodeRenderGraphTypes.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Types/nodeRenderGraphTypes.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Color4, Scene, FrameGraphTextureHandle, Camera, FrameGraphObjectList, IShadowLight, FrameGraphShadowGeneratorTask, FrameGraphObjectRendererTask } from "core/index";
 
 /**

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-internal-modules */
 import type {
     Observer,
     Nullable,

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlock.ts
@@ -8,7 +8,6 @@ import type {
     FrameGraph,
     NodeRenderGraphResourceContainerBlock,
     FrameGraphTextureHandle,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { GetClass } from "../../Misc/typeStore";
 import { serialize } from "../../Misc/decorators";

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlockConnectionPoint.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBlockConnectionPoint.ts
@@ -5,7 +5,6 @@ import type {
     NodeRenderGraphInputBlock,
     IShadowLight,
     FrameGraphShadowGeneratorTask,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { Observable } from "../../Misc/observable";
 import { NodeRenderGraphBlockConnectionPointTypes, NodeRenderGraphConnectionPointCompatibilityStates, NodeRenderGraphConnectionPointDirection } from "./Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBuildState.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphBuildState.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, NodeRenderGraphConnectionPoint, Observable } from "core/index";
 import { Logger } from "../../Misc/logger";
 

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphConnectionPointCustomObject.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraphConnectionPointCustomObject.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { NodeRenderGraphConnectionPointDirection, NodeRenderGraphBlock, Nullable } from "core/index";
 import { NodeRenderGraphConnectionPoint } from "./nodeRenderGraphBlockConnectionPoint";
 import { NodeRenderGraphConnectionPointCompatibilityStates } from "./Types/nodeRenderGraphTypes";

--- a/packages/dev/core/src/FrameGraph/Passes/cullPass.ts
+++ b/packages/dev/core/src/FrameGraph/Passes/cullPass.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, IFrameGraphPass, FrameGraphContext, FrameGraphObjectList, FrameGraphTask } from "core/index";
 import { FrameGraphPass } from "./pass";
 

--- a/packages/dev/core/src/FrameGraph/Passes/pass.ts
+++ b/packages/dev/core/src/FrameGraph/Passes/pass.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, FrameGraphContext, IFrameGraphPass, FrameGraphTask } from "core/index";
 
 /**

--- a/packages/dev/core/src/FrameGraph/Passes/renderPass.ts
+++ b/packages/dev/core/src/FrameGraph/Passes/renderPass.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, FrameGraphRenderContext, AbstractEngine, IFrameGraphPass, FrameGraphTextureHandle, FrameGraphTask, FrameGraphRenderTarget } from "core/index";
 import { FrameGraphPass } from "./pass";
 

--- a/packages/dev/core/src/FrameGraph/Tasks/Layers/baseLayerTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Layers/baseLayerTask.ts
@@ -12,7 +12,6 @@ import type {
     ThinEffectLayer,
     FrameGraphRenderPass,
     FrameGraphRenderContext,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 import { FrameGraphObjectRendererTask } from "../Rendering/objectRendererTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Layers/glowLayerTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Layers/glowLayerTask.ts
@@ -1,9 +1,4 @@
-import type {
-    FrameGraph,
-    Scene,
-    IThinGlowLayerOptions,
-    // eslint-disable-next-line import/no-internal-modules
-} from "core/index";
+import type { FrameGraph, Scene, IThinGlowLayerOptions } from "core/index";
 import { ThinGlowLayer } from "core/Layers/thinGlowLayer";
 import { FrameGraphBaseLayerTask } from "./baseLayerTask";
 

--- a/packages/dev/core/src/FrameGraph/Tasks/Layers/highlightLayerTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Layers/highlightLayerTask.ts
@@ -1,9 +1,4 @@
-import type {
-    FrameGraph,
-    Scene,
-    IThinHighlightLayerOptions,
-    // eslint-disable-next-line import/no-internal-modules
-} from "core/index";
+import type { FrameGraph, Scene, IThinHighlightLayerOptions } from "core/index";
 import { ThinHighlightLayer } from "core/Layers/thinHighlightLayer";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphBaseLayerTask } from "./baseLayerTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Misc/cullObjectsTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Misc/cullObjectsTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, Camera, FrameGraph, FrameGraphObjectList } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 

--- a/packages/dev/core/src/FrameGraph/Tasks/Misc/executeTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Misc/executeTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphContext, FrameGraphPass } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/anaglyphTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/anaglyphTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderPass, FrameGraphTextureHandle } from "core/index";
 import { ThinAnaglyphPostProcess } from "core/PostProcesses/thinAnaglyphPostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/bloomMergeTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/bloomMergeTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass } from "core/index";
 import { ThinBloomMergePostProcess } from "core/PostProcesses/thinBloomMergePostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/bloomTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/bloomTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureCreationOptions, FrameGraphTextureHandle } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphBloomMergeTask } from "./bloomMergeTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/blurTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/blurTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderContext, FrameGraphRenderPass } from "core/index";
 import { ThinBlurPostProcess } from "core/PostProcesses/thinBlurPostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/chromaticAberrationTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/chromaticAberrationTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderContext, FrameGraphRenderPass } from "core/index";
 import { ThinChromaticAberrationPostProcess } from "core/PostProcesses/thinChromaticAberrationPostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/circleOfConfusionTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/circleOfConfusionTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass, Camera } from "core/index";
 import { FrameGraphPostProcessTask } from "./postProcessTask";
 import { Constants } from "core/Engines/constants";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/depthOfFieldBlurTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/depthOfFieldBlurTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphBlurTask } from "./blurTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/depthOfFieldMergeTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/depthOfFieldMergeTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass } from "core/index";
 import { ThinDepthOfFieldMergePostProcess } from "core/PostProcesses/thinDepthOfFieldMergePostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/depthOfFieldTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/depthOfFieldTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureCreationOptions, FrameGraphTextureHandle, AbstractEngine, Camera } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphTask } from "../../frameGraphTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/extractHighlightsTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/extractHighlightsTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph } from "core/index";
 import { ThinExtractHighlightsPostProcess } from "core/PostProcesses/thinExtractHighlightsPostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/fxaaTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/fxaaTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderContext, FrameGraphRenderPass } from "core/index";
 import { ThinFXAAPostProcess } from "core/PostProcesses/thinFXAAPostProcess";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/imageProcessingTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/imageProcessingTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderPass, FrameGraphRenderContext } from "core/index";
 import { FrameGraphPostProcessTask } from "./postProcessTask";
 import { ThinImageProcessingPostProcess } from "core/PostProcesses/thinImageProcessingPostProcess";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/motionBlurTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/motionBlurTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass } from "core/index";
 import { FrameGraphPostProcessTask } from "./postProcessTask";
 import { ThinMotionBlurPostProcess } from "core/PostProcesses/thinMotionBlurPostProcess";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/postProcessTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/postProcessTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, DrawWrapper, FrameGraphRenderPass, FrameGraphRenderContext, EffectWrapper } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphTask } from "../../frameGraphTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/ssrBlurTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/ssrBlurTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderPass, FrameGraphRenderContext } from "core/index";
 import { FrameGraphPostProcessTask } from "./postProcessTask";
 import { ThinSSRBlurPostProcess } from "core/PostProcesses/thinSSRBlurPostProcess";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/ssrRenderingPipelineTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/ssrRenderingPipelineTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, Camera, FrameGraphTextureCreationOptions } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphTask } from "../../frameGraphTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/ssrTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/ssrTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphRenderPass, Camera, FrameGraphTextureHandle } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { FrameGraphPostProcessTask } from "./postProcessTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/csmShadowGeneratorTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/csmShadowGeneratorTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraphTextureHandle, FrameGraph, Scene } from "core/index";
 import { CascadedShadowGenerator } from "../../../Lights/Shadows/cascadedShadowGenerator";
 import { FrameGraphShadowGeneratorTask } from "./shadowGeneratorTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/geometryRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/geometryRendererTask.ts
@@ -8,7 +8,6 @@ import type {
     FrameGraphObjectList,
     AbstractMesh,
     ObjectRendererOptions,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { backbufferDepthStencilTextureHandle } from "../../frameGraphTypes";
 import { Color4 } from "core/Maths/math.color";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/objectRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/objectRendererTask.ts
@@ -11,7 +11,6 @@ import type {
     Observer,
     FrameGraphShadowGeneratorTask,
     FrameGraphRenderPass,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { backbufferColorTextureHandle, backbufferDepthStencilTextureHandle } from "../../frameGraphTypes";
 import { FrameGraphTask } from "../../frameGraphTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/shadowGeneratorTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/shadowGeneratorTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene, FrameGraph, FrameGraphObjectList, IShadowLight, WritableObject, FrameGraphTextureHandle, Camera } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 import { ShadowGenerator } from "../../../Lights/Shadows/shadowGenerator";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/taaObjectRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/taaObjectRendererTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, Scene, DrawWrapper, FrameGraphTextureCreationOptions, ObjectRendererOptions, FrameGraphRenderTarget, FrameGraphRenderPass } from "core/index";
 import { backbufferColorTextureHandle, backbufferDepthStencilTextureHandle } from "../../frameGraphTypes";
 import { FrameGraphObjectRendererTask } from "./objectRendererTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/utilityLayerRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/utilityLayerRendererTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Camera, FrameGraph, FrameGraphTextureHandle, Scene } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";

--- a/packages/dev/core/src/FrameGraph/Tasks/Texture/clearTextureTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Texture/clearTextureTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass } from "core/index";
 import { Color4, TmpColors } from "../../../Maths/math.color";
 import { FrameGraphTask } from "../../frameGraphTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Texture/copyToBackbufferColorTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Texture/copyToBackbufferColorTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraphTextureHandle } from "core/index";
 import { backbufferColorTextureHandle } from "../../frameGraphTypes";
 import { FrameGraphTask } from "../../frameGraphTask";

--- a/packages/dev/core/src/FrameGraph/Tasks/Texture/copyToTextureTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Texture/copyToTextureTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 

--- a/packages/dev/core/src/FrameGraph/Tasks/Texture/generateMipMapsTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Texture/generateMipMapsTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphTextureHandle } from "core/index";
 import { FrameGraphTask } from "../../frameGraphTask";
 

--- a/packages/dev/core/src/FrameGraph/frameGraph.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraph.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-internal-modules */
 import type { Scene, AbstractEngine, FrameGraphTask, Nullable, NodeRenderGraph } from "core/index";
 import { FrameGraphPass } from "./Passes/pass";
 import { FrameGraphRenderPass } from "./Passes/renderPass";

--- a/packages/dev/core/src/FrameGraph/frameGraphContext.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphContext.ts
@@ -1,12 +1,4 @@
-import type {
-    AbstractEngine,
-    FrameGraphTextureManager,
-    Scene,
-    FrameGraphTextureHandle,
-    Nullable,
-    InternalTexture,
-    // eslint-disable-next-line import/no-internal-modules
-} from "core/index";
+import type { AbstractEngine, FrameGraphTextureManager, Scene, FrameGraphTextureHandle, Nullable, InternalTexture } from "core/index";
 
 /**
  * Base class for frame graph context.

--- a/packages/dev/core/src/FrameGraph/frameGraphObjectList.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphObjectList.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractMesh, IParticleSystem } from "core/index";
 
 /**

--- a/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphRenderContext.ts
@@ -12,7 +12,6 @@ import type {
     FrameGraphRenderTarget,
     InternalTexture,
     UtilityLayerRenderer,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { Constants } from "../Engines/constants";
 import { EffectRenderer } from "../Materials/effectRenderer";

--- a/packages/dev/core/src/FrameGraph/frameGraphRenderTarget.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphRenderTarget.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraphTextureHandle, FrameGraphTextureManager, IMultiRenderTargetOptions, RenderTargetWrapper } from "core/index";
 
 /**

--- a/packages/dev/core/src/FrameGraph/frameGraphTask.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraph, FrameGraphObjectList, IFrameGraphPass, Nullable, FrameGraphTextureHandle, InternalTexture, FrameGraphRenderContext } from "core/index";
 import { FrameGraphCullPass } from "./Passes/cullPass";
 import { FrameGraphRenderPass } from "./Passes/renderPass";

--- a/packages/dev/core/src/FrameGraph/frameGraphTextureManager.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphTextureManager.ts
@@ -12,7 +12,6 @@ import type {
     RenderTargetWrapper,
     FrameGraphTask,
     IFrameGraphPass,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 import { getDimensionsFromTextureSize, textureSizeIsObject } from "../Materials/Textures/textureCreationOptions";
 import { Texture } from "../Materials/Textures/texture";

--- a/packages/dev/core/src/FrameGraph/frameGraphTypes.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphTypes.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, TextureSize, FrameGraphContext } from "core/index";
 
 /**

--- a/packages/dev/core/src/FrameGraph/index.ts
+++ b/packages/dev/core/src/FrameGraph/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Node/nodeRenderGraph";
 export * from "./Node/nodeRenderGraphBlock";
 export * from "./Node/nodeRenderGraphBlockConnectionPoint";

--- a/packages/dev/core/src/Layers/thinHighlightLayer.ts
+++ b/packages/dev/core/src/Layers/thinHighlightLayer.ts
@@ -1,16 +1,4 @@
-import type {
-    Observer,
-    Nullable,
-    Scene,
-    SubMesh,
-    AbstractMesh,
-    Mesh,
-    Effect,
-    IThinEffectLayerOptions,
-    Color3,
-    EffectWrapper,
-    // eslint-disable-next-line import/no-internal-modules
-} from "core/index";
+import type { Observer, Nullable, Scene, SubMesh, AbstractMesh, Mesh, Effect, IThinEffectLayerOptions, Color3, EffectWrapper } from "core/index";
 import { Vector2 } from "../Maths/math.vector";
 import { VertexBuffer } from "../Buffers/buffer";
 import { Material } from "../Materials/material";

--- a/packages/dev/core/src/Lights/index.ts
+++ b/packages/dev/core/src/Lights/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./light";
 export * from "./shadowLight";
 export * from "./Shadows/index";

--- a/packages/dev/core/src/Loading/index.ts
+++ b/packages/dev/core/src/Loading/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./loadingScreen";
 export * from "./Plugins/index";
 export * from "./sceneLoader";

--- a/packages/dev/core/src/Materials/Node/Blocks/index.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Vertex/index";
 export * from "./Fragment/index";
 export * from "./Dual/index";

--- a/packages/dev/core/src/Materials/Node/index.ts
+++ b/packages/dev/core/src/Materials/Node/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Enums/index";
 export * from "./nodeMaterialConnectionPointCustomObject";
 export * from "./nodeMaterialBlockConnectionPoint";

--- a/packages/dev/core/src/Materials/Textures/Loaders/index.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/index.ts
@@ -8,5 +8,4 @@ export * from "./basisTextureLoader";
 export * from "./exrTextureLoader";
 export * from "./iesTextureLoader";
 export * from "./textureLoaderManager";
-// eslint-disable-next-line import/no-internal-modules
 export * from "./EXR/index";

--- a/packages/dev/core/src/Materials/Textures/Loaders/index.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./internalTextureLoader";
 export * from "./ddsTextureLoader";
 export * from "./envTextureLoader";

--- a/packages/dev/core/src/Materials/Textures/index.ts
+++ b/packages/dev/core/src/Materials/Textures/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./baseTexture";
 // eslint-disable-next-line import/export
 export * from "./baseTexture.polynomial";

--- a/packages/dev/core/src/Materials/index.ts
+++ b/packages/dev/core/src/Materials/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Background/index";
 export * from "./colorCurves";
 export * from "./iEffectFallbacks";

--- a/packages/dev/core/src/Materials/materialHelper.geometryrendering.ts
+++ b/packages/dev/core/src/Materials/materialHelper.geometryrendering.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { MaterialDefines, Effect, Mesh, AbstractMesh, Material } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { Matrix } from "core/Maths/math.vector";

--- a/packages/dev/core/src/Maths/index.ts
+++ b/packages/dev/core/src/Maths/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./math.scalar";
 export * from "./math.functions";
 export * from "./math.polar";

--- a/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.hotSpot.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { AbstractMesh, PickingInfo } from "core/index";
 import { Vector3, TmpVectors, Matrix } from "../Maths/math.vector";
 import { VertexBuffer } from "../Buffers/buffer";

--- a/packages/dev/core/src/Meshes/index.ts
+++ b/packages/dev/core/src/Meshes/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./abstractMesh";
 import "./abstractMesh.decalMap";
 export * from "./abstractMesh.hotSpot";

--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./andOrNotEvaluator";
 export * from "./assetsManager";
 export * from "./basis";

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -10,7 +10,6 @@ import type {
     WebGPUShaderProcessor,
     WebGPUPipelineContext,
     GaussianSplattingMesh,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 
 import { Constants } from "core/Engines/constants";

--- a/packages/dev/core/src/Misc/thinMinMaxReducer.ts
+++ b/packages/dev/core/src/Misc/thinMinMaxReducer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-internal-modules */
 import type { Nullable, EffectWrapperCreationOptions, AbstractEngine, InternalTexture, Scene } from "core/index";
 import { Observable } from "./observable";
 import { EffectWrapper } from "../Materials/effectRenderer";

--- a/packages/dev/core/src/Navigation/index.ts
+++ b/packages/dev/core/src/Navigation/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./INavigationEngine";
 export * from "./Plugins/index";

--- a/packages/dev/core/src/Particles/IParticleSystem.ts
+++ b/packages/dev/core/src/Particles/IParticleSystem.ts
@@ -13,7 +13,6 @@ import type {
     CylinderDirectedParticleEmitter,
     ConeParticleEmitter,
     ConeDirectedParticleEmitter,
-    // eslint-disable-next-line import/no-internal-modules
 } from "../Particles/EmitterTypes/index";
 import type { Scene } from "../scene";
 import type { ColorGradient, FactorGradient, Color3Gradient } from "../Misc/gradients";

--- a/packages/dev/core/src/Particles/Node/Blocks/index.ts
+++ b/packages/dev/core/src/Particles/Node/Blocks/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./systemBlock";
 export * from "./particleInputBlock";
 export * from "./particleSourceTextureBlock";

--- a/packages/dev/core/src/Particles/Node/index.ts
+++ b/packages/dev/core/src/Particles/Node/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./nodeParticleBlock";
 export * from "./nodeParticleSystemSet";
 export * from "./nodeParticleBlockConnectionPoint";

--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-internal-modules */
 import type { Nullable } from "../types";
 import { Vector2, Vector3 } from "../Maths/math.vector";
 import type { AbstractMesh } from "../Meshes/abstractMesh";

--- a/packages/dev/core/src/Particles/index.ts
+++ b/packages/dev/core/src/Particles/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./baseParticleSystem";
 export * from "./EmitterTypes/index";
 export * from "./webgl2ParticleSystem";

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-internal-modules */
 import type { Immutable, Nullable } from "../types";
 import { FactorGradient, ColorGradient, Color3Gradient, GradientHelper } from "../Misc/gradients";
 import type { Observer } from "../Misc/observable";

--- a/packages/dev/core/src/Physics/index.ts
+++ b/packages/dev/core/src/Physics/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./v1/index";
 export * from "./v2/index";
 export * from "./physicsEngineComponent";

--- a/packages/dev/core/src/Physics/v1/index.ts
+++ b/packages/dev/core/src/Physics/v1/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./IPhysicsEnginePlugin";
 export * from "./physicsEngine";
 export * from "./physicsEngineComponent";

--- a/packages/dev/core/src/Physics/v2/index.ts
+++ b/packages/dev/core/src/Physics/v2/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export { PhysicsEngine as PhysicsEngineV2 } from "./physicsEngine";
 export * from "./physicsBody";
 export * from "./physicsShape";
@@ -8,5 +8,5 @@ export * from "./physicsAggregate";
 export * from "./ragdoll";
 export * from "./IPhysicsEnginePlugin";
 export * from "./characterController";
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Plugins/index";

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/thinSSRRenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/thinSSRRenderingPipeline.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, CubeTexture, Scene, Camera } from "core/index";
 import { Vector2 } from "core/Maths/math.vector";
 import { ThinSSRPostProcess } from "core/PostProcesses/thinSSRPostProcess";

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/index.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Pipelines/index";
 export * from "./postProcessRenderEffect";
 export * from "./postProcessRenderPipeline";

--- a/packages/dev/core/src/PostProcesses/index.ts
+++ b/packages/dev/core/src/PostProcesses/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./anaglyphPostProcess";
 export * from "./blackAndWhitePostProcess";
 export * from "./bloomEffect";

--- a/packages/dev/core/src/PostProcesses/thinAnaglyphPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinAnaglyphPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinBlackAndWhitePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBlackAndWhitePostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinBloomEffect.ts
+++ b/packages/dev/core/src/PostProcesses/thinBloomEffect.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine } from "core/index";
 import { ThinBloomMergePostProcess } from "./thinBloomMergePostProcess";
 import { Vector2 } from "core/Maths/math.vector";

--- a/packages/dev/core/src/PostProcesses/thinBloomMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBloomMergePostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBlurPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Vector2, Effect } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { ShaderLanguage } from "../Materials/shaderLanguage";

--- a/packages/dev/core/src/PostProcesses/thinChromaticAberrationPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinChromaticAberrationPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinCircleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinCircleOfConfusionPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import type { Camera } from "core/Cameras/camera";

--- a/packages/dev/core/src/PostProcesses/thinDepthOfFieldBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinDepthOfFieldBlurPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Vector2 } from "core/index";
 import { ThinBlurPostProcess } from "./thinBlurPostProcess";
 

--- a/packages/dev/core/src/PostProcesses/thinDepthOfFieldMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinDepthOfFieldMergePostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinExtractHighlightsPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinExtractHighlightsPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { ToGammaSpace } from "../Maths/math.constants";

--- a/packages/dev/core/src/PostProcesses/thinFXAAPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinFXAAPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinGrainPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinGrainPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinImageProcessingPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinImageProcessingPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Observer, NonNullableFields, Scene, ColorCurves, BaseTexture, Color4 } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinMotionBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinMotionBlurPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { EffectWrapperCreationOptions, Scene } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Matrix, TmpVectors } from "../Maths/math.vector";

--- a/packages/dev/core/src/PostProcesses/thinPassPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinPassPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, EffectWrapperCreationOptions, AbstractEngine } from "core/index";
 import { EffectWrapper } from "core/Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinSSRBlurCombinerPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRBlurCombinerPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Camera } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinSSRBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRBlurPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { Engine } from "../Engines/engine";

--- a/packages/dev/core/src/PostProcesses/thinSSRPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, Scene, CubeTexture, Camera, EffectWrapperCreationOptions } from "core/index";
 import { Constants } from "core/Engines/constants";
 import { EffectWrapper } from "core/Materials/effectRenderer";

--- a/packages/dev/core/src/PostProcesses/thinTAAPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinTAAPostProcess.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { Camera } from "../Cameras/camera";
 import { Halton2DSequence } from "core/Maths/halton2DSequence";

--- a/packages/dev/core/src/Rendering/index.ts
+++ b/packages/dev/core/src/Rendering/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./boundingBoxRenderer";
 export * from "./depthRenderer";
 export * from "./depthRendererSceneComponent";

--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { SmartArray, Nullable, Immutable, Camera, Scene, AbstractMesh, SubMesh, Material, IParticleSystem, InstancedMesh } from "core/index";
 import { Observable } from "../Misc/observable";
 import { RenderingManager } from "../Rendering/renderingManager";

--- a/packages/dev/core/src/XR/index.ts
+++ b/packages/dev/core/src/XR/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./webXRCamera";
 export * from "./webXREnterExitUI";
 export * from "./webXRExperienceHelper";

--- a/packages/dev/core/src/index.ts
+++ b/packages/dev/core/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./Actions/index";
 export * from "./Animations/index";
 export * from "./assetContainer";

--- a/packages/dev/core/test/unit/XR/webXRFeaturesManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRFeaturesManager.test.ts
@@ -5,7 +5,6 @@
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRFeaturesManager, WebXRSessionManager, WebXRMotionControllerTeleportation, WebXRControllerMovement } from "core/XR";
-// eslint-disable-next-line import/no-internal-modules
 import "core/Animations/index";
 /**
  * WebXR Features Manager test suite.

--- a/packages/dev/gui/src/2D/FrameGraph/guiTask.ts
+++ b/packages/dev/gui/src/2D/FrameGraph/guiTask.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { FrameGraphTextureHandle, FrameGraph } from "core/index";
 import { AdvancedDynamicTexture } from "../advancedDynamicTexture";
 import { FrameGraphTask } from "core/FrameGraph/frameGraphTask";

--- a/packages/dev/gui/src/2D/index.ts
+++ b/packages/dev/gui/src/2D/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./controls/index";
 
 export * from "./advancedDynamicTexture";

--- a/packages/dev/gui/src/3D/index.ts
+++ b/packages/dev/gui/src/3D/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./controls/index";
 export * from "./materials/index";
 export * from "./gizmos/index";

--- a/packages/dev/gui/src/3D/materials/index.ts
+++ b/packages/dev/gui/src/3D/materials/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./fluent/index";
 export * from "./fluentButton/index";
 export * from "./fluentBackplate/index";

--- a/packages/dev/gui/src/index.ts
+++ b/packages/dev/gui/src/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./2D/index";
 export * from "./3D/index";

--- a/packages/dev/inspector-v2/src/components/accordionPane.tsx
+++ b/packages/dev/inspector-v2/src/components/accordionPane.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
-
 import type { ComponentType, FunctionComponent, PropsWithChildren } from "react";
 
 import type { AccordionSectionProps } from "shared-ui-components/fluent/primitives/accordion";

--- a/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
+++ b/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { AbstractMesh, Mesh, Scene } from "core/index";
 
 import { FontAsset } from "addons/msdfText/fontAsset";

--- a/packages/dev/inspector-v2/src/components/properties/lights/areaLightSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/areaLightSetupProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { RectAreaLight } from "core/index";
 import type { FunctionComponent } from "react";
 

--- a/packages/dev/inspector-v2/src/components/properties/lights/directionalLightSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/directionalLightSetupProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { DirectionalLight } from "core/index";
 import type { FunctionComponent } from "react";
 

--- a/packages/dev/inspector-v2/src/components/properties/lights/hemisphericLightSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/hemisphericLightSetupProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { HemisphericLight } from "core/index";
 import type { FunctionComponent } from "react";
 

--- a/packages/dev/inspector-v2/src/components/properties/lights/pointLightSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/pointLightSetupProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { PointLight } from "core/index";
 import type { FunctionComponent } from "react";
 

--- a/packages/dev/inspector-v2/src/components/properties/lights/shadowGeneratorSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/shadowGeneratorSetupProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Camera, IShadowGenerator, Nullable, ShadowLight } from "core/index";
 
 import type { DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";

--- a/packages/dev/inspector-v2/src/components/properties/lights/shadowsSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/shadowsSetupProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ShadowLight } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/properties/lights/spotLightSetupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/spotLightSetupProperties.tsx
@@ -1,7 +1,7 @@
-// eslint-disable-next-line import/no-internal-modules
-import { type SpotLight, Tools } from "core/index";
+import type { SpotLight } from "core/index";
 import type { FunctionComponent } from "react";
 
+import { Tools } from "core/Misc/tools";
 import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/colorPropertyLine";
 import { FloatInputPropertyLine } from "shared-ui-components/fluent/hoc/inputPropertyLine";
 import { SyncedSliderLine } from "shared-ui-components/fluent/hoc/syncedSliderLine";

--- a/packages/dev/inspector-v2/src/components/properties/materialTransparencyProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materialTransparencyProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import type { Material } from "core/Materials/material";
 

--- a/packages/dev/inspector-v2/src/components/properties/meshAdvancedProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshAdvancedProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { AbstractMesh } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/properties/meshGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshGeneralProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { AbstractMesh } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/properties/meshOutlineOverlayProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshOutlineOverlayProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Color3, Mesh } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/properties/meshOutlineOverlayProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/meshOutlineOverlayProperties.tsx
@@ -1,4 +1,4 @@
-import type { Color3, Mesh } from "core/index";
+import type { Mesh } from "core/index";
 
 import type { FunctionComponent } from "react";
 
@@ -6,22 +6,12 @@ import { Collapse } from "@fluentui/react-motion-components-preview";
 
 import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/colorPropertyLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/switchPropertyLine";
+import { useColor3Property } from "../../hooks/compoundPropertyHooks";
 import { useInterceptObservable } from "../../hooks/instrumentationHooks";
 import { useObservableState } from "../../hooks/observableHooks";
 
 // Ensures that the outlineRenderer properties exist on the prototype of the Mesh
 import "core/Rendering/outlineRenderer";
-
-type Color3Keys<T> = { [P in keyof T]: T[P] extends Color3 ? P : never }[keyof T];
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T, propertyKey: K): Color3 {
-    const color = useObservableState(() => target[propertyKey] as Color3, useInterceptObservable("property", target, propertyKey));
-    useObservableState(() => color.r, useInterceptObservable("property", color, "r"));
-    useObservableState(() => color.g, useInterceptObservable("property", color, "g"));
-    useObservableState(() => color.b, useInterceptObservable("property", color, "b"));
-    return color;
-}
 
 export const MeshOutlineOverlayProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {
     const { mesh } = props;

--- a/packages/dev/inspector-v2/src/components/properties/nodeGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodeGeneralProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Node } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/properties/propertiesPane.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/propertiesPane.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
-
 import { Body1Strong, makeStyles, tokens } from "@fluentui/react-components";
 
 import { AccordionPane } from "../accordionPane";

--- a/packages/dev/inspector-v2/src/components/properties/transformNodeTransformProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/transformNodeTransformProperties.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { TransformNode } from "core/index";
 
 import type { FunctionComponent } from "react";
@@ -22,7 +21,7 @@ export const TransformNodeTransformProperties: FunctionComponent<{ node: Transfo
     return (
         <>
             <Vector3PropertyLine key="PositionTransform" label="Position" value={position} onChange={(val) => (node.position = val)} />
-            {node.rotationQuaternion ? (
+            {quatRotation ? (
                 <QuaternionPropertyLine
                     key="QuaternionRotationTransform"
                     label="Rotation (Quaternion)"

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IReadonlyObservable, Nullable, Scene } from "core/index";
 
 import type { TreeItemValue, TreeOpenChangeData, TreeOpenChangeEvent } from "@fluentui/react-components";

--- a/packages/dev/inspector-v2/src/components/stats/countStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/countStats.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/stats/performanceStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/performanceStats.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { PerformanceViewerCollector, Scene } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene } from "core/index";
 
 import { AbstractEngine } from "core/Engines/abstractEngine";

--- a/packages/dev/inspector-v2/src/components/stats/systemStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/systemStats.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Scene } from "core/index";
 
 import type { FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/contexts/extensionManagerContext.ts
+++ b/packages/dev/inspector-v2/src/contexts/extensionManagerContext.ts
@@ -8,7 +8,6 @@ export type ExtensionManagerContext = {
 
 export const ExtensionManagerContext = createContext<ExtensionManagerContext | undefined>(undefined);
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useExtensionManager() {
     return useContext(ExtensionManagerContext)?.extensionManager;
 }

--- a/packages/dev/inspector-v2/src/extensibility/extensionManager.ts
+++ b/packages/dev/inspector-v2/src/extensibility/extensionManager.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, Nullable } from "core/index";
 import type { ServiceContainer } from "../modularity/serviceContainer";
 import type { IExtensionFeed, ExtensionMetadata, ExtensionModule } from "./extensionFeed";

--- a/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
@@ -1,51 +1,72 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Vector3, Color3, Nullable, Quaternion } from "core/index";
 
 import { useInterceptObservable } from "./instrumentationHooks";
 import { useObservableState } from "./observableHooks";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useProperty<T extends object, K extends keyof T>(target: T, propertyKey: K): T[K] {
-    return useObservableState(() => target[propertyKey], useInterceptObservable("property", target, propertyKey));
+export function useProperty<T extends object, K extends keyof T>(target: T, propertyKey: K): T[K];
+export function useProperty<T extends object, K extends keyof T>(target: T | null | undefined, propertyKey: K): T[K] | null;
+/**
+ * Translates a property value to react state, updating the state whenever the property changes.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useProperty<T extends object, K extends keyof T>(target: T | null | undefined, propertyKey: K) {
+    return useObservableState(() => (target ? target[propertyKey] : null), useInterceptObservable("property", target, propertyKey));
 }
 
-type Vector3Keys<T> = { [P in keyof T]: T[P] extends Vector3 ? P : never }[keyof T];
+type Vector3Keys<T> = { [K in keyof T]: T[K] extends Nullable<Vector3> ? K : never }[keyof T];
 
-// This helper hook gets the value of a Vector3 property from a target object and causes the component
-// to re-render when the property changes or when the x/y/z components of the Vector3 change.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T, propertyKey: K): Vector3 {
-    const vector = useProperty(target, propertyKey) as Vector3;
-    useProperty(vector, "x");
-    useProperty(vector, "y");
-    useProperty(vector, "z");
+export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T, propertyKey: K): T[K];
+export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T | null | undefined, propertyKey: K): T[K] | null;
+/**
+ * Translates a Vector3 property value to react state, updating the state whenever the property changes or when the x/y/z components of the Vector3 change.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T | null | undefined, propertyKey: K) {
+    const vector = useProperty(target, propertyKey);
+    useProperty(vector as Vector3 | null | undefined, "x");
+    useProperty(vector as Vector3 | null | undefined, "y");
+    useProperty(vector as Vector3 | null | undefined, "z");
     return vector;
 }
 
-type Color3Keys<T> = { [P in keyof T]: T[P] extends Color3 ? P : never }[keyof T];
+type Color3Keys<T> = { [P in keyof T]: T[P] extends Nullable<Color3> ? P : never }[keyof T];
 
-// This helper hook gets the value of a Color3 property from a target object and causes the component
-// to re-render when the property changes or when the r/g/b components of the Color3 change.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T, propertyKey: K): Color3 {
-    const color = useProperty(target, propertyKey) as Color3;
-    useProperty(color, "r");
-    useProperty(color, "g");
-    useProperty(color, "b");
+export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T, propertyKey: K): T[K];
+export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T | null | undefined, propertyKey: K): T[K] | null;
+/**
+ * Translates a Color3 property value to react state, updating the state whenever the property changes or when the r/g/b components of the Color3 change.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T | null | undefined, propertyKey: K) {
+    const color = useProperty(target, propertyKey);
+    useProperty(color as Color3 | null | undefined, "r");
+    useProperty(color as Color3 | null | undefined, "g");
+    useProperty(color as Color3 | null | undefined, "b");
     return color;
 }
 
 type QuaternionKeys<T> = { [P in keyof T]: T[P] extends Nullable<Quaternion> ? P : never }[keyof T];
 
-// This helper hook gets the value of a Quaternion property from a target object and causes the component
-// to re-render when the property changes or when the x/y/z components of the Quaternion change.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T, propertyKey: K): Quaternion {
-    const quaternion = useProperty(target, propertyKey) as Quaternion;
-    useProperty(quaternion, "x");
-    useProperty(quaternion, "y");
-    useProperty(quaternion, "z");
-    useProperty(quaternion, "w");
+export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T, propertyKey: K): T[K];
+export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T | null | undefined, propertyKey: K): T[K] | null;
+/**
+ * Translates a Quaternion property value to react state, updating the state whenever the property changes or when the x/y/z/w components of the Quaternion change.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T | null | undefined, propertyKey: K) {
+    const quaternion = useProperty(target, propertyKey);
+    useProperty(quaternion as Quaternion | null | undefined, "x");
+    useProperty(quaternion as Quaternion | null | undefined, "y");
+    useProperty(quaternion as Quaternion | null | undefined, "z");
+    useProperty(quaternion as Quaternion | null | undefined, "w");
 
     return quaternion;
 }

--- a/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
@@ -3,29 +3,35 @@ import type { Vector3, Color3, Nullable, Quaternion } from "core/index";
 import { useInterceptObservable } from "./instrumentationHooks";
 import { useObservableState } from "./observableHooks";
 
-export function useProperty<T extends object, K extends keyof T>(target: T, propertyKey: K): T[K];
-export function useProperty<T extends object, K extends keyof T>(target: T | null | undefined, propertyKey: K): T[K] | null;
+type PropertyKeys<TargetT, PropertyT> = { [PropertyKeyT in keyof TargetT]: TargetT[PropertyKeyT] extends Nullable<PropertyT> ? PropertyKeyT : never }[keyof TargetT];
+
+export function useProperty<TargetT extends object, PropertyKeyT extends keyof TargetT>(target: TargetT, propertyKey: PropertyKeyT): TargetT[PropertyKeyT];
+export function useProperty<TargetT extends object, PropertyKeyT extends keyof TargetT>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
 /**
  * Translates a property value to react state, updating the state whenever the property changes.
  * @param target The object containing the property to observe.
  * @param propertyKey The key of the property to observe.
  * @returns The current value of the property, or null if the target is null or undefined.
  */
-export function useProperty<T extends object, K extends keyof T>(target: T | null | undefined, propertyKey: K) {
+export function useProperty<TargetT extends object, PropertyKeyT extends keyof TargetT>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
     return useObservableState(() => (target ? target[propertyKey] : null), useInterceptObservable("property", target, propertyKey));
 }
 
-type Vector3Keys<T> = { [K in keyof T]: T[K] extends Nullable<Vector3> ? K : never }[keyof T];
-
-export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T, propertyKey: K): T[K];
-export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T | null | undefined, propertyKey: K): T[K] | null;
+export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(target: TargetT, propertyKey: PropertyKeyT): TargetT[PropertyKeyT];
+export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
 /**
  * Translates a Vector3 property value to react state, updating the state whenever the property changes or when the x/y/z components of the Vector3 change.
  * @param target The object containing the property to observe.
  * @param propertyKey The key of the property to observe.
  * @returns The current value of the property, or null if the target is null or undefined.
  */
-export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T | null | undefined, propertyKey: K) {
+export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
     const vector = useProperty(target, propertyKey);
     useProperty(vector as Vector3 | null | undefined, "x");
     useProperty(vector as Vector3 | null | undefined, "y");
@@ -33,17 +39,18 @@ export function useVector3Property<T extends object, K extends Vector3Keys<T>>(t
     return vector;
 }
 
-type Color3Keys<T> = { [P in keyof T]: T[P] extends Nullable<Color3> ? P : never }[keyof T];
-
-export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T, propertyKey: K): T[K];
-export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T | null | undefined, propertyKey: K): T[K] | null;
+export function useColor3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Color3>>(target: TargetT, propertyKey: PropertyKeyT): TargetT[PropertyKeyT];
+export function useColor3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Color3>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
 /**
  * Translates a Color3 property value to react state, updating the state whenever the property changes or when the r/g/b components of the Color3 change.
  * @param target The object containing the property to observe.
  * @param propertyKey The key of the property to observe.
  * @returns The current value of the property, or null if the target is null or undefined.
  */
-export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T | null | undefined, propertyKey: K) {
+export function useColor3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Color3>>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
     const color = useProperty(target, propertyKey);
     useProperty(color as Color3 | null | undefined, "r");
     useProperty(color as Color3 | null | undefined, "g");
@@ -51,17 +58,24 @@ export function useColor3Property<T extends object, K extends Color3Keys<T>>(tar
     return color;
 }
 
-type QuaternionKeys<T> = { [P in keyof T]: T[P] extends Nullable<Quaternion> ? P : never }[keyof T];
-
-export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T, propertyKey: K): T[K];
-export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T | null | undefined, propertyKey: K): T[K] | null;
+export function useQuaternionProperty<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Quaternion>>(
+    target: TargetT,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT];
+export function useQuaternionProperty<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Quaternion>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
 /**
  * Translates a Quaternion property value to react state, updating the state whenever the property changes or when the x/y/z/w components of the Quaternion change.
  * @param target The object containing the property to observe.
  * @param propertyKey The key of the property to observe.
  * @returns The current value of the property, or null if the target is null or undefined.
  */
-export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T | null | undefined, propertyKey: K) {
+export function useQuaternionProperty<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Quaternion>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+) {
     const quaternion = useProperty(target, propertyKey);
     useProperty(quaternion as Quaternion | null | undefined, "x");
     useProperty(quaternion as Quaternion | null | undefined, "y");

--- a/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-internal-modules
-import type { IDisposable, IReadonlyObservable } from "core/index";
+import type { IDisposable, IReadonlyObservable, Nullable } from "core/index";
 
 import { useEffect, useMemo } from "react";
 
@@ -16,33 +16,35 @@ import { InterceptProperty } from "../instrumentation/propertyInstrumentation";
  * @returns An observable that fires when the function/property is called/set.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function useInterceptObservable<T extends object>(type: "function" | "property", target: T, propertyKey: keyof T): IReadonlyObservable<void> {
+export function useInterceptObservable<T extends object>(type: "function" | "property", target: T | null | undefined, propertyKey: keyof T): IReadonlyObservable<void> {
     // Create a cached observable. It effectively has the lifetime of the component that uses this hook.
     const observable = useMemo(() => new Observable<void>(), []);
 
     // Whenver the type, target, or property key changes, we need to set up a new interceptor.
     useEffect(() => {
-        let interceptToken: IDisposable;
+        let interceptToken: Nullable<IDisposable> = null;
 
-        if (type === "function") {
-            interceptToken = InterceptFunction(target, propertyKey, {
-                afterCall: () => {
-                    observable.notifyObservers();
-                },
-            });
-        } else if (type === "property") {
-            interceptToken = InterceptProperty(target, propertyKey, {
-                afterSet: () => {
-                    observable.notifyObservers();
-                },
-            });
-        } else {
-            throw new Error(`Unknown interceptor type: ${type}`);
+        if (target) {
+            if (type === "function") {
+                interceptToken = InterceptFunction(target, propertyKey, {
+                    afterCall: () => {
+                        observable.notifyObservers();
+                    },
+                });
+            } else if (type === "property") {
+                interceptToken = InterceptProperty(target, propertyKey, {
+                    afterSet: () => {
+                        observable.notifyObservers();
+                    },
+                });
+            } else {
+                throw new Error(`Unknown interceptor type: ${type}`);
+            }
         }
 
         // When the effect is cleaned up, we need to dispose of the interceptor.
         return () => {
-            interceptToken.dispose();
+            interceptToken?.dispose();
         };
     }, [type, target, propertyKey, observable]);
 

--- a/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
@@ -14,7 +14,6 @@ import { InterceptProperty } from "../instrumentation/propertyInstrumentation";
  * @param propertyKey The key of the function/property to intercept.
  * @returns An observable that fires when the function/property is called/set.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useInterceptObservable<T extends object>(type: "function" | "property", target: T | null | undefined, propertyKey: keyof T): IReadonlyObservable<void> {
     // Create a cached observable. It effectively has the lifetime of the component that uses this hook.
     const observable = useMemo(() => new Observable<void>(), []);

--- a/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, IReadonlyObservable, Nullable } from "core/index";
 
 import { useEffect, useMemo } from "react";

--- a/packages/dev/inspector-v2/src/hooks/observableHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/observableHooks.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IReadonlyObservable } from "core/index";
 
 import type { ObservableCollection } from "../misc/observableCollection";

--- a/packages/dev/inspector-v2/src/hooks/observableHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/observableHooks.ts
@@ -11,7 +11,6 @@ import { useEffect, useMemo, useState } from "react";
  * @param eventNames The names of the events to listen for.
  * @returns The current value of the accessor.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useEventfulState<T>(accessor: () => T, element: HTMLElement | null | undefined, ...eventNames: string[]): T {
     const [current, setCurrent] = useState(accessor);
 
@@ -47,7 +46,6 @@ export function useEventfulState<T>(accessor: () => T, element: HTMLElement | nu
  * @param observables The observables to listen for changes on.
  * @returns The current value of the accessor.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useObservableState<T>(accessor: () => T, ...observables: Array<IReadonlyObservable | null | undefined>): T {
     const [current, setCurrent] = useState(accessor);
 
@@ -77,7 +75,6 @@ export function useObservableState<T>(accessor: () => T, ...observables: Array<I
  * @param collection The collection to observe.
  * @returns A copy of the items in the collection.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useObservableCollection<T>(collection: ObservableCollection<T>) {
     return useObservableState(() => [...collection.items], collection.observable);
 }
@@ -87,7 +84,6 @@ export function useObservableCollection<T>(collection: ObservableCollection<T>) 
  * @param collection The collection to observe.
  * @returns A copy of the items in the collection sorted by the order property.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useOrderedObservableCollection<T extends Readonly<{ order?: number }>>(collection: ObservableCollection<T>) {
     const items = useObservableCollection(collection);
     const sortedItems = useMemo(() => items.sort((a, b) => (a.order ?? 0) - (b.order ?? 0)), [items]);

--- a/packages/dev/inspector-v2/src/hooks/pollingHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/pollingHooks.ts
@@ -8,7 +8,6 @@ import { useEffect, useMemo } from "react";
  * @param delay The polling interval in milliseconds.
  * @returns A readonly observable that can be used to subscribe to polling notifications.
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function usePollingObservable(delay: number): IReadonlyObservable<void> {
     const observable = useMemo(() => new Observable<void>(), []);
 

--- a/packages/dev/inspector-v2/src/hooks/pollingHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/pollingHooks.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IReadonlyObservable } from "core/index";
 
 import { Observable } from "core/Misc";

--- a/packages/dev/inspector-v2/src/hooks/teachingMomentHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/teachingMomentHooks.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable } from "core/index";
 
 import type { OnOpenChangeData, PositioningImperativeRef } from "@fluentui/react-components";

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, IInspectorOptions, Nullable, Scene } from "core/index";
 import type { ServiceDefinition } from "./modularity/serviceDefinition";
 import type { ModularToolOptions } from "./modularTool";

--- a/packages/dev/inspector-v2/src/instrumentation/functionInstrumentation.ts
+++ b/packages/dev/inspector-v2/src/instrumentation/functionInstrumentation.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 export type FunctionHooks = {

--- a/packages/dev/inspector-v2/src/instrumentation/propertyInstrumentation.ts
+++ b/packages/dev/inspector-v2/src/instrumentation/propertyInstrumentation.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 export type PropertyHooks = {

--- a/packages/dev/inspector-v2/src/misc/graphUtils.ts
+++ b/packages/dev/inspector-v2/src/misc/graphUtils.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable } from "core/index";
 
 /**

--- a/packages/dev/inspector-v2/src/misc/observableCollection.ts
+++ b/packages/dev/inspector-v2/src/misc/observableCollection.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, IReadonlyObservable } from "core/index";
 
 import { Observable } from "core/Misc/observable";

--- a/packages/dev/inspector-v2/src/modularTool.tsx
+++ b/packages/dev/inspector-v2/src/modularTool.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 import type { ComponentType, FunctionComponent } from "react";

--- a/packages/dev/inspector-v2/src/modularity/serviceContainer.ts
+++ b/packages/dev/inspector-v2/src/modularity/serviceContainer.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 import type { IService, ServiceDefinition } from "./serviceDefinition";

--- a/packages/dev/inspector-v2/src/modularity/serviceDefinition.ts
+++ b/packages/dev/inspector-v2/src/modularity/serviceDefinition.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 /**

--- a/packages/dev/inspector-v2/src/services/panes/debugService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/debugService.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, Scene } from "core/index";
 
 import type { AccordionSection, AccordionSectionContent } from "../../components/accordionPane";

--- a/packages/dev/inspector-v2/src/services/panes/properties/propertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/propertiesService.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 import type { IService, ServiceDefinition } from "../../../modularity/serviceDefinition";

--- a/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 import type { EntityBase, SceneExplorerEntityCommand, SceneExplorerSection } from "../../../components/scene/sceneExplorer";

--- a/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, Scene } from "core/index";
 
 import type { AccordionSection, AccordionSectionContent } from "../../components/accordionPane";

--- a/packages/dev/inspector-v2/src/services/panes/statsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/statsService.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, Scene } from "core/index";
 
 import type { AccordionSection, AccordionSectionContent } from "../../components/accordionPane";

--- a/packages/dev/inspector-v2/src/services/sceneContext.ts
+++ b/packages/dev/inspector-v2/src/services/sceneContext.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IReadonlyObservable, Nullable, Scene } from "core/index";
 
 import type { IService } from "../modularity/serviceDefinition";

--- a/packages/dev/inspector-v2/src/services/selectionService.ts
+++ b/packages/dev/inspector-v2/src/services/selectionService.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, IReadonlyObservable, Nullable } from "core/index";
 
 import type { IService, ServiceDefinition } from "../modularity/serviceDefinition";

--- a/packages/dev/inspector-v2/src/services/settingsContext.ts
+++ b/packages/dev/inspector-v2/src/services/settingsContext.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
-
 import type { IReadonlyObservable } from "core/Misc/observable";
 import type { IService } from "../modularity/serviceDefinition";
 

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -416,7 +416,6 @@ const SidePaneTab: FunctionComponent<{ alignment: "left" | "right"; id: string }
 // This hook provides a side pane container and the tab list.
 // In "compact" mode, the tab list is integrated into the pane itself.
 // In "full" mode, the returned tab list is later injected into the toolbar.
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function usePane(
     alignment: "left" | "right",
     defaultWidth: number,

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable } from "core/index";
 
 import type { SelectTabData, SelectTabEvent } from "@fluentui/react-components";

--- a/packages/dev/inspector-v2/test/app/index.ts
+++ b/packages/dev/inspector-v2/test/app/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ArcRotateCamera, Nullable } from "core/index";
 
 import { Engine } from "core/Engines/engine";

--- a/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
@@ -9,7 +9,6 @@ import { MessageLineComponent } from "shared-ui-components/lines/messageLineComp
 import { faCheck, faTimesCircle } from "@fortawesome/free-solid-svg-icons";
 import { TextLineComponent } from "shared-ui-components/lines/textLineComponent";
 // TODO - does it still work if loading the modules from the correct files?
-// eslint-disable-next-line import/no-internal-modules
 import { GLTFLoaderCoordinateSystemMode, GLTFLoaderAnimationStartMode } from "loaders/glTF/index";
 import type { Nullable } from "core/types";
 import type { Observer } from "core/Misc/observable";

--- a/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/tools/gltfComponent.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as React from "react";
 import type { Scene } from "core/scene";
 import { LineContainerComponent } from "shared-ui-components/lines/lineContainerComponent";

--- a/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import type { IPaneComponentProps } from "../paneComponent";
 import { PaneComponent } from "../paneComponent";
 import { LineContainerComponent } from "shared-ui-components/lines/lineContainerComponent";

--- a/packages/dev/inspector/src/components/globalState.ts
+++ b/packages/dev/inspector/src/components/globalState.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-// eslint-disable-next-line import/no-internal-modules
 import { GLTFLoaderAnimationStartMode, GLTFLoaderCoordinateSystemMode } from "loaders/glTF/index";
 import type { IGLTFValidationResults } from "babylonjs-gltf2interface";
 
@@ -15,7 +14,6 @@ import { CameraGizmo } from "core/Gizmos/cameraGizmo";
 import type { PropertyChangedEvent } from "./propertyChangedEvent";
 import { ReplayRecorder } from "./replayRecorder";
 import { DataStorage } from "core/Misc/dataStorage";
-// eslint-disable-next-line import/no-internal-modules
 import type { IGLTFLoaderExtension, GLTFFileLoader } from "loaders/glTF/index";
 
 export class GlobalState {

--- a/packages/dev/inspector/src/components/globalState.ts
+++ b/packages/dev/inspector/src/components/globalState.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { GLTFLoaderAnimationStartMode, GLTFLoaderCoordinateSystemMode } from "loaders/glTF/index";
 import type { IGLTFValidationResults } from "babylonjs-gltf2interface";
 

--- a/packages/dev/inspector/src/legacy/legacy.ts
+++ b/packages/dev/inspector/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import * as INSPECTOR from "../index";
 

--- a/packages/dev/loaders/src/BVH/bvhFileLoader.metadata.ts
+++ b/packages/dev/loaders/src/BVH/bvhFileLoader.metadata.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ISceneLoaderPluginExtensions, ISceneLoaderPluginMetadata } from "core/index";
 
 export const BVHFileLoaderMetadata = {

--- a/packages/dev/loaders/src/BVH/index.ts
+++ b/packages/dev/loaders/src/BVH/index.ts
@@ -1,2 +1,2 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./bvhLoader";

--- a/packages/dev/loaders/src/OBJ/objFileLoader.metadata.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.metadata.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ISceneLoaderPluginMetadata } from "core/index";
 
 export const OBJFileLoaderMetadata = {

--- a/packages/dev/loaders/src/SPLAT/index.ts
+++ b/packages/dev/loaders/src/SPLAT/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./splatLoadingOptions";
 export * from "./splatFileLoader";

--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.metadata.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.metadata.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ISceneLoaderPluginExtensions, ISceneLoaderPluginMetadata } from "core/index";
 
 export const SPLATFileLoaderMetadata = {

--- a/packages/dev/loaders/src/STL/stlFileLoader.metadata.ts
+++ b/packages/dev/loaders/src/STL/stlFileLoader.metadata.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ISceneLoaderPluginExtensions, ISceneLoaderPluginMetadata } from "core/index";
 
 export const STLFileLoaderMetadata = {

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./objectModelMapping";
 export * from "./EXT_lights_image_based";
 export * from "./EXT_mesh_gpu_instancing";

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/index.ts
@@ -36,5 +36,4 @@ export * from "./KHR_node_visibility";
 export * from "./KHR_node_selectability";
 export * from "./KHR_node_hoverability";
 export * from "./ExtrasAsMetadata";
-// eslint-disable-next-line import/no-internal-modules
 export * from "./KHR_interactivity/index";

--- a/packages/dev/loaders/src/glTF/2.0/index.ts
+++ b/packages/dev/loaders/src/glTF/2.0/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./glTFLoader";
 export * from "./glTFLoaderExtension";
 export * from "./glTFLoaderExtensionRegistry";

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.metadata.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.metadata.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { ISceneLoaderPluginExtensions, ISceneLoaderPluginMetadata } from "core/index";
 
 export const GLTFMagicBase64Encoded = "Z2xURg"; // "glTF" base64 encoded (without the quotes!)

--- a/packages/dev/loaders/src/glTF/index.ts
+++ b/packages/dev/loaders/src/glTF/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./glTFFileLoader";
 export * from "./glTFValidation";
 import * as GLTF1 from "./1.0/index";

--- a/packages/dev/loaders/src/index.ts
+++ b/packages/dev/loaders/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./glTF/index";
 export * from "./OBJ/index";
 export * from "./STL/index";

--- a/packages/dev/materials/src/index.ts
+++ b/packages/dev/materials/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./cell/index";
 export * from "./custom/index";
 export * from "./fire/index";

--- a/packages/dev/postProcesses/src/index.ts
+++ b/packages/dev/postProcesses/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./asciiArt/index";
 export * from "./digitalRain/index";
 export * from "./edgeDetection/index";

--- a/packages/dev/proceduralTextures/src/index.ts
+++ b/packages/dev/proceduralTextures/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./brick/index";
 export * from "./cloud/index";
 export * from "./fire/index";

--- a/packages/dev/serializers/src/USDZ/index.ts
+++ b/packages/dev/serializers/src/USDZ/index.ts
@@ -1,2 +1,2 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./usdzExporter";

--- a/packages/dev/serializers/src/glTF/2.0/index.ts
+++ b/packages/dev/serializers/src/glTF/2.0/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./glTFData";
 export * from "./glTFSerializer";
 export { _SolveMetallic, _ConvertToGLTFPBRMetallicRoughness } from "./glTFMaterialExporter";

--- a/packages/dev/serializers/src/glTF/index.ts
+++ b/packages/dev/serializers/src/glTF/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./glTFFileExporter";
 export * from "./2.0/index";

--- a/packages/dev/serializers/src/index.ts
+++ b/packages/dev/serializers/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./OBJ/index";
 export * from "./glTF/index";
 export * from "./stl/index";

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/checkbox.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/checkbox.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
-
 import type { CheckboxOnChangeData } from "@fluentui/react-components";
 import type { ChangeEvent, FunctionComponent } from "react";
 

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/switch.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/switch.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
-
 import type { SwitchOnChangeData } from "@fluentui/react-components";
 import type { ChangeEvent, FunctionComponent } from "react";
 

--- a/packages/lts/core/src/Legacy/legacy.ts
+++ b/packages/lts/core/src/Legacy/legacy.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as BABYLON from "core/index";
 import * as DebugImport from "core/Debug/index";
 

--- a/packages/lts/gui/src/legacy/legacy.ts
+++ b/packages/lts/gui/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as GUI from "gui/index";
 
 /**

--- a/packages/lts/loaders/src/legacy/legacy-glTF1.ts
+++ b/packages/lts/loaders/src/legacy/legacy-glTF1.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as GLTF1 from "loaders/glTF/1.0/index";
 
 /**

--- a/packages/lts/loaders/src/legacy/legacy-glTF2.ts
+++ b/packages/lts/loaders/src/legacy/legacy-glTF2.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Extensions from "loaders/glTF/2.0/Extensions/index";
 import * as Interfaces from "loaders/glTF/2.0/glTFLoaderInterfaces";
 import * as GLTF2 from "loaders/glTF/2.0/index";

--- a/packages/lts/loaders/src/legacy/legacy-objFileLoader.ts
+++ b/packages/lts/loaders/src/legacy/legacy-objFileLoader.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Loaders from "loaders/OBJ/index";
 
 /**

--- a/packages/lts/loaders/src/legacy/legacy-stlFileLoader.ts
+++ b/packages/lts/loaders/src/legacy/legacy-stlFileLoader.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Loaders from "loaders/STL/index";
 
 /**

--- a/packages/lts/loaders/src/legacy/legacy.ts
+++ b/packages/lts/loaders/src/legacy/legacy.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "loaders/index";
 export * from "./legacy-glTF";
 export * from "./legacy-glTF1";

--- a/packages/lts/materials/src/legacy/legacy-cell.ts
+++ b/packages/lts/materials/src/legacy/legacy-cell.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/cell/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-custom.ts
+++ b/packages/lts/materials/src/legacy/legacy-custom.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/custom/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-fire.ts
+++ b/packages/lts/materials/src/legacy/legacy-fire.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/fire/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-fur.ts
+++ b/packages/lts/materials/src/legacy/legacy-fur.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/fur/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-gradient.ts
+++ b/packages/lts/materials/src/legacy/legacy-gradient.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/gradient/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-grid.ts
+++ b/packages/lts/materials/src/legacy/legacy-grid.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/grid/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-lava.ts
+++ b/packages/lts/materials/src/legacy/legacy-lava.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/lava/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-mix.ts
+++ b/packages/lts/materials/src/legacy/legacy-mix.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/mix/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-normal.ts
+++ b/packages/lts/materials/src/legacy/legacy-normal.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/normal/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-shadowOnly.ts
+++ b/packages/lts/materials/src/legacy/legacy-shadowOnly.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/shadowOnly/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-simple.ts
+++ b/packages/lts/materials/src/legacy/legacy-simple.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/simple/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-sky.ts
+++ b/packages/lts/materials/src/legacy/legacy-sky.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/sky/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-terrain.ts
+++ b/packages/lts/materials/src/legacy/legacy-terrain.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/terrain/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-triPlanar.ts
+++ b/packages/lts/materials/src/legacy/legacy-triPlanar.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/triPlanar/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy-water.ts
+++ b/packages/lts/materials/src/legacy/legacy-water.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/water/index";
 
 /**

--- a/packages/lts/materials/src/legacy/legacy.ts
+++ b/packages/lts/materials/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/index";
 
 /**

--- a/packages/lts/postProcesses/src/legacy/legacy-asciiArt.ts
+++ b/packages/lts/postProcesses/src/legacy/legacy-asciiArt.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as postProcessLibrary from "post-processes/asciiArt/index";
 
 /**

--- a/packages/lts/postProcesses/src/legacy/legacy-digitalRain.ts
+++ b/packages/lts/postProcesses/src/legacy/legacy-digitalRain.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as postProcessLibrary from "post-processes/digitalRain/index";
 
 /**

--- a/packages/lts/postProcesses/src/legacy/legacy.ts
+++ b/packages/lts/postProcesses/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as postProcessLibrary from "post-processes/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-brick.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-brick.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/brick/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-cloud.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-cloud.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/cloud/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-fire.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-fire.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/fire/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-grass.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-grass.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/grass/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-marble.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-marble.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/marble/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-normalMap.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-normalMap.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/normalMap/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-perlinNoise.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-perlinNoise.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/perlinNoise/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-road.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-road.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/road/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-starfield.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-starfield.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/starfield/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy-wood.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy-wood.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "procedural-textures/wood/index";
 
 /**

--- a/packages/lts/proceduralTextures/src/legacy/legacy.ts
+++ b/packages/lts/proceduralTextures/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as ProceduralTexturesLib from "procedural-textures/index";
 
 /**

--- a/packages/lts/serializers/src/legacy/legacy-glTF2Serializer.ts
+++ b/packages/lts/serializers/src/legacy/legacy-glTF2Serializer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Exporters from "serializers/glTF/glTFFileExporter";
 import * as Datas from "serializers/glTF/2.0/glTFData";
 import * as Serializers from "serializers/glTF/2.0/glTFSerializer";

--- a/packages/lts/serializers/src/legacy/legacy-objSerializer.ts
+++ b/packages/lts/serializers/src/legacy/legacy-objSerializer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Serializers from "serializers/OBJ/index";
 
 /**

--- a/packages/lts/serializers/src/legacy/legacy-stlSerializer.ts
+++ b/packages/lts/serializers/src/legacy/legacy-stlSerializer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Serializers from "serializers/stl/index";
 
 /**

--- a/packages/lts/serializers/src/legacy/legacy-usdzSerializer.ts
+++ b/packages/lts/serializers/src/legacy/legacy-usdzSerializer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Serializers from "serializers/USDZ/index";
 
 /**

--- a/packages/lts/serializers/src/legacy/legacy.ts
+++ b/packages/lts/serializers/src/legacy/legacy.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import "serializers/index";
 export * from "./legacy-glTF2Serializer";
 export * from "./legacy-objSerializer";

--- a/packages/public/umd/babylonjs-addons/src/index.ts
+++ b/packages/public/umd/babylonjs-addons/src/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import * as addons from "addons/index";
 
 export { addons };

--- a/packages/public/umd/babylonjs-procedural-textures/src/brick.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/brick.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-brick";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/cloud.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/cloud.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-cloud";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/fire.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/fire.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-fire";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/grass.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/grass.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-grass";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/marble.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/marble.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-marble";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/normalMap.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/normalMap.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-normalMap";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/perlinNoise.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/perlinNoise.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-perlinNoise";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/road.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/road.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-road";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/starfield.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/starfield.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-starfield";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/public/umd/babylonjs-procedural-textures/src/wood.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/wood.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as proceduralTexture from "@lts/procedural-textures/legacy/legacy-wood";
 export { proceduralTexture };
 export default proceduralTexture;

--- a/packages/tools/accessibility/src/index.ts
+++ b/packages/tools/accessibility/src/index.ts
@@ -1,1 +1,2 @@
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./HtmlTwin/index";

--- a/packages/tools/accessibility/src/index.ts
+++ b/packages/tools/accessibility/src/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-internal-modules
 export * from "./HtmlTwin/index";

--- a/packages/tools/accessibility/src/legacy/legacy.ts
+++ b/packages/tools/accessibility/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { HTMLTwinRenderer } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/accessibility/index.ts
+++ b/packages/tools/babylonServer/src/accessibility/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { HTMLTwinRenderer } from "../../../accessibility/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/addons/index.ts
+++ b/packages/tools/babylonServer/src/addons/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Addons from "../../../../dev/addons/src/index";
 
 /**

--- a/packages/tools/babylonServer/src/core/index-dev.ts
+++ b/packages/tools/babylonServer/src/core/index-dev.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 /* eslint-disable @typescript-eslint/naming-convention */
 // import * as BABYLON from "core/index";
 import * as BABYLON from "../../../../dev/core/src/index";

--- a/packages/tools/babylonServer/src/core/index-lts.ts
+++ b/packages/tools/babylonServer/src/core/index-lts.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 /* eslint-disable @typescript-eslint/naming-convention */
 // import * as BABYLON from "core/index";
 import * as BABYLON from "../../../../dev/core/src/index";

--- a/packages/tools/babylonServer/src/gui/index-dev.ts
+++ b/packages/tools/babylonServer/src/gui/index-dev.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as GUI from "../../../../dev/gui/src/index";
 
 /**

--- a/packages/tools/babylonServer/src/gui/index-lts.ts
+++ b/packages/tools/babylonServer/src/gui/index-lts.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as GUI from "../../../../dev/gui/src/index";
 
 /**

--- a/packages/tools/babylonServer/src/guiEditor/index.ts
+++ b/packages/tools/babylonServer/src/guiEditor/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { GUIEditor } from "../../../guiEditor/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/inspector/index.ts
+++ b/packages/tools/babylonServer/src/inspector/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { Inspector } from "../../../../dev/inspector/src/index";
 
 const globalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/ktx2Decoder/index.ts
+++ b/packages/tools/babylonServer/src/ktx2Decoder/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as KTX2Decoder from "../../../ktx2Decoder/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/loaders/index-dev.ts
+++ b/packages/tools/babylonServer/src/loaders/index-dev.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 // export * from "../../../../dev/loaders/src/index";
 // export * from "./legacy-glTF";
 // export * from "./legacy-glTF1";

--- a/packages/tools/babylonServer/src/loaders/index-lts.ts
+++ b/packages/tools/babylonServer/src/loaders/index-lts.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/export */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 // export * from "./legacy-glTF";
 // export * from "./legacy-glTF1";
 // export * from "./legacy-glTF2";
@@ -26,7 +26,7 @@ if (typeof GlobalObject !== "undefined") {
 
 export { FileLoader, Validation };
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as GLTF1 from "../../../../dev/loaders/src/glTF/1.0/index";
 
 /**
@@ -43,7 +43,7 @@ if (typeof GlobalObject !== "undefined") {
 
 export { GLTF1 };
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Extensions from "../../../../dev/loaders/src/glTF/2.0/Extensions/index";
 import * as Interfaces from "../../../../dev/loaders/src/glTF/2.0/glTFLoaderInterfaces";
 import * as GLTF2 from "../../../../dev/loaders/src/glTF/2.0/index";
@@ -82,7 +82,7 @@ if (typeof GlobalObject !== "undefined") {
 
 export { GLTF2 };
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as OBJLoaders from "../../../../dev/loaders/src/OBJ/index";
 
 /**
@@ -97,7 +97,7 @@ if (typeof GlobalObject !== "undefined") {
 
 export * from "../../../../dev/loaders/src/OBJ/index";
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Loaders from "../../../../dev/loaders/src/STL/index";
 
 /**

--- a/packages/tools/babylonServer/src/materials/index-dev.ts
+++ b/packages/tools/babylonServer/src/materials/index-dev.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "../../../../dev/materials/src/index";
 
 /**

--- a/packages/tools/babylonServer/src/materials/index-lts.ts
+++ b/packages/tools/babylonServer/src/materials/index-lts.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as MatLib from "materials/index";
 
 /**

--- a/packages/tools/babylonServer/src/nodeEditor/index.ts
+++ b/packages/tools/babylonServer/src/nodeEditor/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeEditor } from "../../../nodeEditor/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/nodeGeometryEditor/index.ts
+++ b/packages/tools/babylonServer/src/nodeGeometryEditor/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeGeometryEditor } from "../../../nodeGeometryEditor/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/nodeParticleEditor/index.ts
+++ b/packages/tools/babylonServer/src/nodeParticleEditor/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeParticleEditor } from "../../../nodeParticleEditor/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/nodeRenderGraphEditor/index.ts
+++ b/packages/tools/babylonServer/src/nodeRenderGraphEditor/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeRenderGraphEditor } from "../../../nodeRenderGraphEditor/src/index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/babylonServer/src/postProcesses/index-dev.ts
+++ b/packages/tools/babylonServer/src/postProcesses/index-dev.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as postProcessLibrary from "../../../../dev/postProcesses/src/index";
 
 /**

--- a/packages/tools/babylonServer/src/postProcesses/index-lts.ts
+++ b/packages/tools/babylonServer/src/postProcesses/index-lts.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as postProcessLibrary from "post-processes/index";
 
 /**

--- a/packages/tools/babylonServer/src/proceduralTextures/index-dev.ts
+++ b/packages/tools/babylonServer/src/proceduralTextures/index-dev.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as ProceduralTexturesLib from "../../../../dev/proceduralTextures/src/index";
 
 /**

--- a/packages/tools/babylonServer/src/proceduralTextures/index-lts.ts
+++ b/packages/tools/babylonServer/src/proceduralTextures/index-lts.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as ProceduralTexturesLib from "procedural-textures/index";
 
 /**

--- a/packages/tools/babylonServer/src/serializers/legacy-dev.ts
+++ b/packages/tools/babylonServer/src/serializers/legacy-dev.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as OBJSerializers from "../../../../dev/serializers/src/OBJ/index";
 
 /**
@@ -12,7 +12,7 @@ if (typeof GlobalObject !== "undefined") {
     }
 }
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as STLSerializers from "../../../../dev/serializers/src/stl/index";
 
 /**
@@ -32,7 +32,7 @@ if (typeof GlobalObject !== "undefined") {
     }
 }
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Exporters from "../../../../dev/serializers/src/glTF/glTFFileExporter";
 import * as Datas from "../../../../dev/serializers/src/glTF/2.0/glTFData";
 import * as Serializers from "../../../../dev/serializers/src/glTF/2.0/glTFSerializer";

--- a/packages/tools/babylonServer/src/serializers/legacy-lts.ts
+++ b/packages/tools/babylonServer/src/serializers/legacy-lts.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as OBJSerializers from "serializers/OBJ/index";
 
 /**
@@ -12,7 +12,7 @@ if (typeof GlobalObject !== "undefined") {
     }
 }
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as STLSerializers from "serializers/stl/index";
 
 /**
@@ -32,7 +32,7 @@ if (typeof GlobalObject !== "undefined") {
     }
 }
 
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as Exporters from "serializers/glTF/glTFFileExporter";
 import * as Datas from "serializers/glTF/2.0/glTFData";
 import * as Serializers from "serializers/glTF/2.0/glTFSerializer";

--- a/packages/tools/guiEditor/src/legacy/legacy.ts
+++ b/packages/tools/guiEditor/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { GUIEditor } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/ktx2Decoder/src/index.ts
+++ b/packages/tools/ktx2Decoder/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./ktx2Decoder";
 export * from "./ktx2FileReader";
 export * from "./transcoder";

--- a/packages/tools/ktx2Decoder/src/legacy/legacy.ts
+++ b/packages/tools/ktx2Decoder/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { KTX2Decoder } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/nodeEditor/src/legacy/legacy.ts
+++ b/packages/tools/nodeEditor/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeEditor } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/nodeGeometryEditor/src/legacy/legacy.ts
+++ b/packages/tools/nodeGeometryEditor/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeGeometryEditor } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/nodeParticleEditor/src/legacy/legacy.ts
+++ b/packages/tools/nodeParticleEditor/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeParticleEditor } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/nodeRenderGraphEditor/src/legacy/legacy.ts
+++ b/packages/tools/nodeRenderGraphEditor/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { NodeRenderGraphEditor } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/playground/src/legacy/legacy.ts
+++ b/packages/tools/playground/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { Playground } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/sandbox/src/legacy/legacy.ts
+++ b/packages/tools/sandbox/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { Sandbox } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;

--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import "./configurator.scss";
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, IInspectableOptions, Nullable, Observable } from "core/index";
-// eslint-disable-next-line import/no-internal-modules
 import type { HotSpot, ShadowQuality, ToneMapping, Viewer, ViewerDetails, ViewerElement, ViewerOptions } from "viewer/index";
 import type { DragEndEvent } from "@dnd-kit/core";
 

--- a/packages/tools/viewer-configurator/src/hooks/observableHooks.ts
+++ b/packages/tools/viewer-configurator/src/hooks/observableHooks.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Observable } from "core/index";
 
 import { useEffect, useState } from "react";

--- a/packages/tools/viewer-configurator/src/modelLoader.ts
+++ b/packages/tools/viewer-configurator/src/modelLoader.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable } from "core/index";
-// eslint-disable-next-line import/no-internal-modules
 import type { LoadModelOptions, ViewerElement } from "viewer/index";
 
 import { Deferred } from "core/Misc/deferred";

--- a/packages/tools/viewer-legacy/src/configuration/index.ts
+++ b/packages/tools/viewer-legacy/src/configuration/index.ts
@@ -1,3 +1,3 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./configuration";
 export * from "./interfaces/index";

--- a/packages/tools/viewer-legacy/src/configuration/loader.ts
+++ b/packages/tools/viewer-legacy/src/configuration/loader.ts
@@ -1,5 +1,5 @@
 import { RenderOnlyConfigurationLoader } from "./renderOnlyLoader";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getConfigurationType } from "./types/index";
 
 export class ConfigurationLoader extends RenderOnlyConfigurationLoader {

--- a/packages/tools/viewer-legacy/src/configuration/mappers.ts
+++ b/packages/tools/viewer-legacy/src/configuration/mappers.ts
@@ -1,7 +1,7 @@
 import { Tools } from "core/Misc/tools";
 import type { ViewerConfiguration } from "./configuration";
 
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { kebabToCamel } from "../helper/index";
 
 /**

--- a/packages/tools/viewer-legacy/src/configuration/renderOnlyLoader.ts
+++ b/packages/tools/viewer-legacy/src/configuration/renderOnlyLoader.ts
@@ -3,7 +3,7 @@ import { mapperManager } from "./mappers";
 import type { ViewerConfiguration } from "./configuration";
 import { processConfigurationCompatibility } from "./configurationCompatibility";
 
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { deepmerge } from "../helper/index";
 import { Tools } from "core/Misc/tools";
 import { extendedConfiguration } from "./types/extended";

--- a/packages/tools/viewer-legacy/src/configuration/types/default.ts
+++ b/packages/tools/viewer-legacy/src/configuration/types/default.ts
@@ -3,7 +3,7 @@ import type { ViewerConfiguration } from "../configuration";
 import { babylonFont, defaultTemplate, fillContainer, loadingScreen, defaultViewer, navbar, overlay, help, share, error } from "babylonjs-viewer-assets";
 import * as images from "babylonjs-viewer-assets";
 import { renderOnlyDefaultConfiguration } from "./renderOnlyDefault";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { deepmerge } from "../../helper/index";
 
 /**

--- a/packages/tools/viewer-legacy/src/configuration/types/index.ts
+++ b/packages/tools/viewer-legacy/src/configuration/types/index.ts
@@ -4,7 +4,7 @@ import { extendedConfiguration } from "./extended";
 import type { ViewerConfiguration } from "../configuration";
 import { shadowDirectionalLightConfiguration, shadowSpotlLightConfiguration } from "./shadowLight";
 import { environmentMapConfiguration } from "./environmentMap";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { deepmerge } from "../../helper/index";
 
 /**

--- a/packages/tools/viewer-legacy/src/index.ts
+++ b/packages/tools/viewer-legacy/src/index.ts
@@ -10,7 +10,7 @@ import { ViewerModel, ModelState } from "./model/viewerModel";
 import { AnimationPlayMode, AnimationState } from "./model/modelAnimation";
 import { ILoaderPlugin } from "./loader/plugins/loaderPlugin";
 import { AbstractViewerNavbarButton } from "./templating/viewerTemplatePlugin";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { registerCustomOptimizer } from "./optimizer/custom/index";
 import { Logger } from "core/Misc/logger";
 
@@ -20,11 +20,11 @@ import { Logger } from "core/Misc/logger";
  * An HTML-Based viewer for 3D models, based on BabylonJS and its extensions.
  */
 
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import * as BABYLON from "core/index";
 
 // load needed modules.
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import "loaders/index";
 import "pepjs";
 
@@ -70,8 +70,8 @@ export {
     AbstractViewerNavbarButton,
     registerCustomOptimizer,
 };
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export { GLTF2 } from "loaders/glTF/index";
 // export publicliy all configuration interfaces
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export * from "./configuration/index";

--- a/packages/tools/viewer-legacy/src/loader/modelLoader.ts
+++ b/packages/tools/viewer-legacy/src/loader/modelLoader.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import type { GLTFFileLoader } from "loaders/glTF/glTFFileLoader";
 import { GLTFLoaderAnimationStartMode } from "loaders/glTF/glTFFileLoader";
 import type { ISceneLoaderPlugin, ISceneLoaderPluginAsync } from "core/Loading/sceneLoader";

--- a/packages/tools/viewer-legacy/src/managers/sceneManager.ts
+++ b/packages/tools/viewer-legacy/src/managers/sceneManager.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import type {
     ILightConfiguration,
     ISceneConfiguration,

--- a/packages/tools/viewer-legacy/src/model/viewerModel.ts
+++ b/packages/tools/viewer-legacy/src/model/viewerModel.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import type { IDisposable } from "core/scene";
 import type { ISceneLoaderPlugin, ISceneLoaderPluginAsync, ISceneLoaderProgressEvent } from "core/Loading/sceneLoader";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";

--- a/packages/tools/viewer-legacy/src/templating/templateManager.ts
+++ b/packages/tools/viewer-legacy/src/templating/templateManager.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Observable } from "core/Misc/observable";
 import { Tools } from "core/Misc/tools";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { isUrl, camelToKebab, kebabToCamel, deepmerge } from "../helper/index";
 
 import * as Handlebars from "handlebars";

--- a/packages/tools/viewer-legacy/src/viewer/defaultViewer.ts
+++ b/packages/tools/viewer-legacy/src/viewer/defaultViewer.ts
@@ -10,7 +10,7 @@ import { Vector3 } from "core/Maths/math";
 import { AbstractViewerWithTemplate } from "./viewerWithTemplate";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { extendClassWithConfig } from "../helper/index";
 import type { ViewerModel } from "../model/viewerModel";
 import type { IModelAnimation } from "../model/modelAnimation";

--- a/packages/tools/viewer-legacy/src/viewer/viewer.ts
+++ b/packages/tools/viewer-legacy/src/viewer/viewer.ts
@@ -15,7 +15,7 @@ import { processConfigurationCompatibility } from "../configuration/configuratio
 import { ConfigurationContainer } from "../configuration/configurationContainer";
 import { viewerGlobals } from "../configuration/globals";
 import { RenderOnlyConfigurationLoader } from "../configuration/renderOnlyLoader";
-// eslint-disable-next-line import/no-internal-modules
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { deepmerge } from "../helper/index";
 import { ModelLoader } from "../loader/modelLoader";
 import { ObservablesManager } from "../managers/observablesManager";

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -22,7 +22,6 @@ import type {
     ShadowLight,
     ShaderMaterial,
     ShadowGenerator,
-    // eslint-disable-next-line import/no-internal-modules
 } from "core/index";
 
 import type { MaterialVariantsController } from "loaders/glTF/2.0/Extensions/KHR_materials_variants";

--- a/packages/tools/viewer/src/viewerAnnotationElement.ts
+++ b/packages/tools/viewer/src/viewerAnnotationElement.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { IDisposable, Nullable } from "core/index";
 import type { PropertyValues } from "lit";
 

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable @typescript-eslint/naming-convention */
-// eslint-disable-next-line import/no-internal-modules
 import type { Nullable, Observable } from "core/index";
 import type { CSSResultGroup, PropertyValues, TemplateResult } from "lit";
 import type { CameraOrbit, EnvironmentOptions, HotSpot, ResetFlag, ShadowQuality, ToneMapping, ViewerDetails, ViewerHotSpotResult } from "./viewer";

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-internal-modules
 import type { AbstractEngine, AbstractEngineOptions, EngineOptions, IDisposable, Nullable, WebGPUEngineOptions } from "core/index";
 import type { ViewerDetails, ViewerOptions } from "./viewer";
 

--- a/packages/tools/vsm/src/legacy/legacy.ts
+++ b/packages/tools/vsm/src/legacy/legacy.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-internal-modules */
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import { VSM } from "../index";
 
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;


### PR DESCRIPTION
1. Type only imports from index files. We already do this a lot, but always have to suppress the eslint rule. This change allows type only imports from index, but not runtime imports from index (since those would cause unwanted side effects).
2. Functions that start with `use` are allowed, even though they are not PascalCase. This is for react hooks. We already have a similar rule that allows react hooks defined as lambdas, this just extends it to regular functions as well.

And update a load of files to remove now unnecessary eslint supressions.