### PR TITLE
Inspector v2: Allow target to be null or undefined in useProperty (and related functions)

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/transformNodeTransformProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/transformNodeTransformProperties.tsx
@@ -22,7 +22,7 @@ export const TransformNodeTransformProperties: FunctionComponent<{ node: Transfo
     return (
         <>
             <Vector3PropertyLine key="PositionTransform" label="Position" value={position} onChange={(val) => (node.position = val)} />
-            {node.rotationQuaternion ? (
+            {quatRotation ? (
                 <QuaternionPropertyLine
                     key="QuaternionRotationTransform"
                     label="Rotation (Quaternion)"

--- a/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
@@ -1,51 +1,89 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
 // eslint-disable-next-line import/no-internal-modules
 import type { Vector3, Color3, Nullable, Quaternion } from "core/index";
 
 import { useInterceptObservable } from "./instrumentationHooks";
 import { useObservableState } from "./observableHooks";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useProperty<T extends object, K extends keyof T>(target: T, propertyKey: K): T[K] {
-    return useObservableState(() => target[propertyKey], useInterceptObservable("property", target, propertyKey));
+type PropertyKeys<TargetT, PropertyT> = { [PropertyKeyT in keyof TargetT]: TargetT[PropertyKeyT] extends Nullable<PropertyT> ? PropertyKeyT : never }[keyof TargetT];
+
+export function useProperty<TargetT extends object, PropertyKeyT extends keyof TargetT>(target: TargetT, propertyKey: PropertyKeyT): TargetT[PropertyKeyT];
+export function useProperty<TargetT extends object, PropertyKeyT extends keyof TargetT>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
+/**
+ * Translates a property value to react state, updating the state whenever the property changes.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useProperty<TargetT extends object, PropertyKeyT extends keyof TargetT>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
+    return useObservableState(() => (target ? target[propertyKey] : null), useInterceptObservable("property", target, propertyKey));
 }
 
-type Vector3Keys<T> = { [P in keyof T]: T[P] extends Vector3 ? P : never }[keyof T];
-
-// This helper hook gets the value of a Vector3 property from a target object and causes the component
-// to re-render when the property changes or when the x/y/z components of the Vector3 change.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useVector3Property<T extends object, K extends Vector3Keys<T>>(target: T, propertyKey: K): Vector3 {
-    const vector = useProperty(target, propertyKey) as Vector3;
-    useProperty(vector, "x");
-    useProperty(vector, "y");
-    useProperty(vector, "z");
+export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(target: TargetT, propertyKey: PropertyKeyT): TargetT[PropertyKeyT];
+export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
+/**
+ * Translates a Vector3 property value to react state, updating the state whenever the property changes or when the x/y/z components of the Vector3 change.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
+    const vector = useProperty(target, propertyKey);
+    useProperty(vector as Vector3 | null | undefined, "x");
+    useProperty(vector as Vector3 | null | undefined, "y");
+    useProperty(vector as Vector3 | null | undefined, "z");
     return vector;
 }
 
-type Color3Keys<T> = { [P in keyof T]: T[P] extends Color3 ? P : never }[keyof T];
-
-// This helper hook gets the value of a Color3 property from a target object and causes the component
-// to re-render when the property changes or when the r/g/b components of the Color3 change.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useColor3Property<T extends object, K extends Color3Keys<T>>(target: T, propertyKey: K): Color3 {
-    const color = useProperty(target, propertyKey) as Color3;
-    useProperty(color, "r");
-    useProperty(color, "g");
-    useProperty(color, "b");
+export function useColor3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Color3>>(target: TargetT, propertyKey: PropertyKeyT): TargetT[PropertyKeyT];
+export function useColor3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Color3>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
+/**
+ * Translates a Color3 property value to react state, updating the state whenever the property changes or when the r/g/b components of the Color3 change.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useColor3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Color3>>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
+    const color = useProperty(target, propertyKey);
+    useProperty(color as Color3 | null | undefined, "r");
+    useProperty(color as Color3 | null | undefined, "g");
+    useProperty(color as Color3 | null | undefined, "b");
     return color;
 }
 
-type QuaternionKeys<T> = { [P in keyof T]: T[P] extends Nullable<Quaternion> ? P : never }[keyof T];
-
-// This helper hook gets the value of a Quaternion property from a target object and causes the component
-// to re-render when the property changes or when the x/y/z components of the Quaternion change.
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export function useQuaternionProperty<T extends object, K extends QuaternionKeys<T>>(target: T, propertyKey: K): Quaternion {
-    const quaternion = useProperty(target, propertyKey) as Quaternion;
-    useProperty(quaternion, "x");
-    useProperty(quaternion, "y");
-    useProperty(quaternion, "z");
-    useProperty(quaternion, "w");
+export function useQuaternionProperty<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Quaternion>>(
+    target: TargetT,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT];
+export function useQuaternionProperty<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Quaternion>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+): TargetT[PropertyKeyT] | null;
+/**
+ * Translates a Quaternion property value to react state, updating the state whenever the property changes or when the x/y/z/w components of the Quaternion change.
+ * @param target The object containing the property to observe.
+ * @param propertyKey The key of the property to observe.
+ * @returns The current value of the property, or null if the target is null or undefined.
+ */
+export function useQuaternionProperty<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Quaternion>>(
+    target: TargetT | null | undefined,
+    propertyKey: PropertyKeyT
+) {
+    const quaternion = useProperty(target, propertyKey);
+    useProperty(quaternion as Quaternion | null | undefined, "x");
+    useProperty(quaternion as Quaternion | null | undefined, "y");
+    useProperty(quaternion as Quaternion | null | undefined, "z");
+    useProperty(quaternion as Quaternion | null | undefined, "w");
 
     return quaternion;
 }

--- a/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/instrumentationHooks.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-internal-modules
-import type { IDisposable, IReadonlyObservable } from "core/index";
+import type { IDisposable, IReadonlyObservable, Nullable } from "core/index";
 
 import { useEffect, useMemo } from "react";
 
@@ -16,33 +16,35 @@ import { InterceptProperty } from "../instrumentation/propertyInstrumentation";
  * @returns An observable that fires when the function/property is called/set.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function useInterceptObservable<T extends object>(type: "function" | "property", target: T, propertyKey: keyof T): IReadonlyObservable<void> {
+export function useInterceptObservable<T extends object>(type: "function" | "property", target: T | null | undefined, propertyKey: keyof T): IReadonlyObservable<void> {
     // Create a cached observable. It effectively has the lifetime of the component that uses this hook.
     const observable = useMemo(() => new Observable<void>(), []);
 
     // Whenver the type, target, or property key changes, we need to set up a new interceptor.
     useEffect(() => {
-        let interceptToken: IDisposable;
+        let interceptToken: Nullable<IDisposable> = null;
 
-        if (type === "function") {
-            interceptToken = InterceptFunction(target, propertyKey, {
-                afterCall: () => {
-                    observable.notifyObservers();
-                },
-            });
-        } else if (type === "property") {
-            interceptToken = InterceptProperty(target, propertyKey, {
-                afterSet: () => {
-                    observable.notifyObservers();
-                },
-            });
-        } else {
-            throw new Error(`Unknown interceptor type: ${type}`);
+        if (target) {
+            if (type === "function") {
+                interceptToken = InterceptFunction(target, propertyKey, {
+                    afterCall: () => {
+                        observable.notifyObservers();
+                    },
+                });
+            } else if (type === "property") {
+                interceptToken = InterceptProperty(target, propertyKey, {
+                    afterSet: () => {
+                        observable.notifyObservers();
+                    },
+                });
+            } else {
+                throw new Error(`Unknown interceptor type: ${type}`);
+            }
         }
 
         // When the effect is cleaned up, we need to dispose of the interceptor.
         return () => {
-            interceptToken.dispose();
+            interceptToken?.dispose();
         };
     }, [type, target, propertyKey, observable]);
 


### PR DESCRIPTION
Previously we were not allowing for the case where the target object is null or undefined. This happens in cases like the rotationQuaternion property, which can be undefined. If it is, then the follow up hooks for intercepting the x/y/z properties of the quaternion fail at runtime, because the target was undefined. React hooks cannot be conditional, so they must handle the null/undefined case.

This also required tightening up the typing, such that if target is known at compile time to not be null, then the resulting property will not be null (unless the property itself is allowed to be null). If target might be null at compile time, then the resulting property value is always possibly null. This makes usage easy (like with BoundProperty, where the value might be expected to not be null or undefined).