### PR TITLE
Support vertex pulling

### DIFF
--- a/packages/dev/core/src/Engines/IMaterialContext.ts
+++ b/packages/dev/core/src/Engines/IMaterialContext.ts
@@ -1,6 +1,7 @@
 /** @internal */
 export interface IMaterialContext {
     uniqueId: number;
+    useVertexPulling: boolean;
 
     reset(): void;
 }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -194,7 +194,7 @@ export abstract class WebGPUCacheRenderPipeline {
     public readonly mrtTextureArray: InternalTexture[];
     public readonly mrtTextureCount: number = 0;
 
-    public getRenderPipeline(fillMode: number, effect: Effect, sampleCount: number, textureState = 0, useVertexPulling: boolean = false): GPURenderPipeline {
+    public getRenderPipeline(fillMode: number, effect: Effect, sampleCount: number, textureState = 0): GPURenderPipeline {
         sampleCount = WebGPUTextureHelper.GetSample(sampleCount);
 
         if (this.disabled) {
@@ -215,7 +215,7 @@ export abstract class WebGPUCacheRenderPipeline {
         this._setRasterizationState(fillMode, sampleCount);
         this._setColorStates();
         this._setDepthStencilState();
-        this._setVertexState(effect, useVertexPulling);
+        this._setVertexState(effect);
         this._setTextureState(textureState);
 
         this.lastStateDirtyLowestIndex = this._stateDirtyLowestIndex;
@@ -853,13 +853,13 @@ export abstract class WebGPUCacheRenderPipeline {
         }
     }
 
-    private _setVertexState(effect: Effect, useVertexPulling: boolean = false): void {
+    private _setVertexState(effect: Effect): void {
         const currStateLen = this._statesLength;
         let newNumStates = StatePosition.VertexState;
 
         const webgpuPipelineContext = effect._pipelineContext as WebGPUPipelineContext;
-        const attributes = useVertexPulling ? [] : webgpuPipelineContext.shaderProcessingContext.attributeNamesFromEffect;
-        const locations = useVertexPulling ? [] : webgpuPipelineContext.shaderProcessingContext.attributeLocationsFromEffect;
+        const attributes = webgpuPipelineContext.shaderProcessingContext.attributeNamesFromEffect;
+        const locations = webgpuPipelineContext.shaderProcessingContext.attributeLocationsFromEffect;
 
         let currentGPUBuffer;
         let numVertexBuffers = 0;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -194,7 +194,7 @@ export abstract class WebGPUCacheRenderPipeline {
     public readonly mrtTextureArray: InternalTexture[];
     public readonly mrtTextureCount: number = 0;
 
-    public getRenderPipeline(fillMode: number, effect: Effect, sampleCount: number, textureState = 0): GPURenderPipeline {
+    public getRenderPipeline(fillMode: number, effect: Effect, sampleCount: number, textureState = 0, useVertexPulling: boolean = false): GPURenderPipeline {
         sampleCount = WebGPUTextureHelper.GetSample(sampleCount);
 
         if (this.disabled) {
@@ -215,7 +215,7 @@ export abstract class WebGPUCacheRenderPipeline {
         this._setRasterizationState(fillMode, sampleCount);
         this._setColorStates();
         this._setDepthStencilState();
-        this._setVertexState(effect);
+        this._setVertexState(effect, useVertexPulling);
         this._setTextureState(textureState);
 
         this.lastStateDirtyLowestIndex = this._stateDirtyLowestIndex;
@@ -853,13 +853,13 @@ export abstract class WebGPUCacheRenderPipeline {
         }
     }
 
-    private _setVertexState(effect: Effect): void {
+    private _setVertexState(effect: Effect, useVertexPulling: boolean = false): void {
         const currStateLen = this._statesLength;
         let newNumStates = StatePosition.VertexState;
 
         const webgpuPipelineContext = effect._pipelineContext as WebGPUPipelineContext;
-        const attributes = webgpuPipelineContext.shaderProcessingContext.attributeNamesFromEffect;
-        const locations = webgpuPipelineContext.shaderProcessingContext.attributeLocationsFromEffect;
+        const attributes = useVertexPulling ? [] : webgpuPipelineContext.shaderProcessingContext.attributeNamesFromEffect;
+        const locations = useVertexPulling ? [] : webgpuPipelineContext.shaderProcessingContext.attributeLocationsFromEffect;
 
         let currentGPUBuffer;
         let numVertexBuffers = 0;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -141,7 +141,6 @@ export abstract class WebGPUCacheRenderPipeline {
     private _depthStencilState: number;
     private _vertexBuffers: Nullable<{ [key: string]: Nullable<VertexBuffer> }>;
     private _overrideVertexBuffers: Nullable<{ [key: string]: Nullable<VertexBuffer> }>;
-    private _indexBuffer: Nullable<DataBuffer>;
     private _textureState: number;
     private _useTextureStage: boolean;
 
@@ -185,6 +184,7 @@ export abstract class WebGPUCacheRenderPipeline {
     protected abstract _setRenderPipeline(param: { token: any; pipeline: Nullable<GPURenderPipeline> }): void;
 
     public readonly vertexBuffers: VertexBuffer[];
+    public readonly indexBuffer: Nullable<DataBuffer>;
 
     public get colorFormats(): (GPUTextureFormat | null)[] {
         return this._mrtAttachments > 0 ? this._mrtFormats : this._webgpuColorFormat;
@@ -500,7 +500,7 @@ export abstract class WebGPUCacheRenderPipeline {
     ): void {
         this._vertexBuffers = vertexBuffers;
         this._overrideVertexBuffers = overrideVertexBuffers;
-        this._indexBuffer = indexBuffer;
+        (this.indexBuffer as Nullable<DataBuffer>) = indexBuffer;
     }
 
     private static _GetTopology(fillMode: number): GPUPrimitiveTopology {
@@ -1116,7 +1116,7 @@ export abstract class WebGPUCacheRenderPipeline {
 
         let stripIndexFormat: GPUIndexFormat | undefined = undefined;
         if (topology === WebGPUConstants.PrimitiveTopology.LineStrip || topology === WebGPUConstants.PrimitiveTopology.TriangleStrip) {
-            stripIndexFormat = !this._indexBuffer || this._indexBuffer.is32Bits ? WebGPUConstants.IndexFormat.Uint32 : WebGPUConstants.IndexFormat.Uint16;
+            stripIndexFormat = !this.indexBuffer || this.indexBuffer.is32Bits ? WebGPUConstants.IndexFormat.Uint32 : WebGPUConstants.IndexFormat.Uint16;
         }
 
         const depthStencilFormatHasStencil = this._webgpuDepthStencilFormat ? WebGPUTextureHelper.HasStencilAspect(this._webgpuDepthStencilFormat) : false;

--- a/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
@@ -202,27 +202,7 @@ export class WebGPUDrawContext implements IDrawContext {
         }
 
         if (bufferNames.indexOf("indices") !== -1) {
-            if (!useVertexPulling) {
-                this.setBuffer("indices", null);
-            } else {
-                let is32bits = false;
-                if (indexBuffer) {
-                    this.setBuffer("indices", indexBuffer as WebGPUDataBuffer);
-                    is32bits = indexBuffer.is32Bits;
-                } else {
-                    // If no index buffer exists but the vertex shader uses the "indices" buffer, we need
-                    // to bind a dummy index buffer (of size 4 to avoid WebGPU errors). Then we'll set the
-                    // uniform to indicate that indices aren't used by the mesh.
-                    this.setBuffer("indices", this._dummyIndexBuffer);
-                }
-                // Set uniforms to indicate that the index buffer is used and whether it is 32-bit or 16-bit.
-                if (webgpuPipelineContext.uniformBuffer?.has("hasIndices")) {
-                    webgpuPipelineContext.uniformBuffer.updateInt("hasIndices", indexBuffer ? 1 : 0);
-                }
-                if (webgpuPipelineContext.uniformBuffer?.has("indicesAre32bit")) {
-                    webgpuPipelineContext.uniformBuffer?.updateInt("indicesAre32bit", is32bits ? 1 : 0);
-                }
-            }
+            this.setBuffer("indices", !useVertexPulling ? null : ((indexBuffer as WebGPUDataBuffer) ?? this._dummyIndexBuffer));
         }
     }
 

--- a/packages/dev/core/src/Engines/WebGPU/webgpuMaterialContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuMaterialContext.ts
@@ -39,6 +39,8 @@ export class WebGPUMaterialContext implements IMaterialContext {
     // There's the same problem with depth textures, where "float" filtering is not supported either.
     public textureState: number;
 
+    public useVertexPulling = false;
+
     public get forceBindGroupCreation() {
         // If there is at least one external texture to bind, we must recreate the bind groups each time
         // because we need to retrieve a new texture each frame (by calling device.importExternalTexture)

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -249,6 +249,8 @@ export abstract class AbstractEngine {
     protected _cachedViewport: Nullable<IViewportLike>;
     /** @internal */
     public _currentDrawContext: IDrawContext;
+    /** @internal */
+    public _currentMaterialContext: IMaterialContext;
 
     /** @internal */
     protected _boundTexturesCache: { [key: string]: Nullable<InternalTexture> } = {};

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -225,9 +225,6 @@ export abstract class AbstractEngine {
     /** @internal */
     public _videoTextureSupported: boolean;
 
-    /** @internal */
-    public _useVertexPulling: boolean = false;
-
     protected _compatibilityMode = true;
     /** @internal */
     public _pointerLockRequested: boolean;

--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -225,6 +225,9 @@ export abstract class AbstractEngine {
     /** @internal */
     public _videoTextureSupported: boolean;
 
+    /** @internal */
+    public _useVertexPulling: boolean = false;
+
     protected _compatibilityMode = true;
     /** @internal */
     public _pointerLockRequested: boolean;

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -211,8 +211,6 @@ export class ThinEngine extends AbstractEngine {
     // Cache
 
     /** @internal */
-    public _currentMaterialContext: IMaterialContext;
-    /** @internal */
     protected _currentProgram: Nullable<WebGLProgram>;
     private _vertexAttribArraysEnabled: boolean[] = [];
     private _cachedVertexArrayObject: Nullable<WebGLVertexArrayObject>;

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -347,7 +347,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     /** @internal */
     public override _currentDrawContext: WebGPUDrawContext;
     /** @internal */
-    public _currentMaterialContext: WebGPUMaterialContext;
+    public override _currentMaterialContext: WebGPUMaterialContext;
     private _currentVertexBuffers: { [key: string]: Nullable<VertexBuffer> } = {};
     private _currentOverrideVertexBuffers: Nullable<{ [key: string]: Nullable<VertexBuffer> }> = null;
     private _currentIndexBuffer: Nullable<DataBuffer> = null;

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -1618,7 +1618,11 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             view = data;
         }
 
-        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Vertex | WebGPUConstants.BufferUsage.CopyDst, label);
+        const dataBuffer = this._bufferManager.createBuffer(
+            view,
+            WebGPUConstants.BufferUsage.Vertex | WebGPUConstants.BufferUsage.CopyDst | WebGPUConstants.BufferUsage.Storage,
+            label
+        );
         return dataBuffer;
     }
 
@@ -3702,6 +3706,35 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         this._currentMaterialContext.textureState = textureState;
 
         const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState);
+
+        // Compare the vertex buffers that we have to the ones that are bound to the pipeline.
+        // If there are vertex buffers that are not bound to the pipeline, AND they're used
+        // by the shader, we will bind them to the current draw context.
+        const availableVertexBuffers: { [key: string]: VertexBuffer } = (this._cacheRenderPipeline as any)._vertexBuffers;
+        const appliedVertexBuffers = this._cacheRenderPipeline.vertexBuffers;
+        const vertexBufferNames = Object.keys(availableVertexBuffers);
+        if (Object.keys(availableVertexBuffers).length !== appliedVertexBuffers.length) {
+            const unboundVertexBuffers: { [key: string]: VertexBuffer } = {};
+            for (let i = 0; i < vertexBufferNames.length; i++) {
+                const name = vertexBufferNames[i];
+                if (appliedVertexBuffers.findIndex((v) => v === availableVertexBuffers[name]) === -1) {
+                    unboundVertexBuffers[name] = availableVertexBuffers[name];
+                }
+            }
+            if (Object.keys(unboundVertexBuffers).length > 0) {
+                for (const unboundVertexBufferName of Object.keys(unboundVertexBuffers)) {
+                    if (webgpuPipelineContext.shaderProcessingContext.bufferNames.findIndex((name) => name === unboundVertexBufferName) !== -1) {
+                        this._currentDrawContext.buffers[unboundVertexBufferName] = unboundVertexBuffers[unboundVertexBufferName].effectiveBuffer as WebGPUDataBuffer;
+                    }
+                }
+            }
+            // TODO - handle binding index buffer.
+            // if (webgpuPipelineContext.shaderProcessingContext.bufferNames.findIndex((name) => name === "indices") !== -1) {
+            //     const indexBuffer = this._currentIndexBuffer ? this._currentIndexBuffer : (this._cacheRenderPipeline as any)._indexBuffer;
+            //     this._currentDrawContext.buffers["indices"] = indexBuffer as WebGPUDataBuffer;
+            // }
+        }
+
         const bindGroups = this._cacheBindGroups.getBindGroups(webgpuPipelineContext, this._currentDrawContext, this._currentMaterialContext);
 
         if (!this._snapshotRendering.record) {

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -320,6 +320,8 @@ export class WebGPUEngine extends ThinWebGPUEngine {
 
     private _commandBuffers: GPUCommandBuffer[] = [null as any, null as any];
 
+    private _dummyVertexBuffer: DataBuffer;
+
     // Frame Buffer Life Cycle (recreated for each render target pass)
 
     private _mainRenderPassWrapper: IWebGPURenderPassWrapper = {
@@ -3701,7 +3703,9 @@ export class WebGPUEngine extends ThinWebGPUEngine {
 
         this._currentMaterialContext.textureState = textureState;
 
-        const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState);
+        // If vertex pulling, get a cached pipeline with empty vertex layout
+        // Pass a boolean here to getRenderPipeline that will cause the vertex layout to be empty
+        const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState, this._useVertexPulling);
         const bindGroups = this._cacheBindGroups.getBindGroups(webgpuPipelineContext, this._currentDrawContext, this._currentMaterialContext);
 
         if (!this._snapshotRendering.record) {
@@ -3728,6 +3732,13 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             );
         }
 
+        // If vertex pulling, bind a cached empty vertex buffer
+        if (this._useVertexPulling) {
+            if (!this._dummyVertexBuffer) {
+                this._dummyVertexBuffer = this.createVertexBuffer(new Float32Array(0), false, "DummyVertexPullingBuffer");
+            }
+            renderPass2.setVertexBuffer(0, this._dummyVertexBuffer.underlyingResource, 0, 0);
+        }
         const vertexBuffers = this._cacheRenderPipeline.vertexBuffers;
         for (let index = 0; index < vertexBuffers.length; index++) {
             const vertexBuffer = vertexBuffers[index];

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -320,8 +320,6 @@ export class WebGPUEngine extends ThinWebGPUEngine {
 
     private _commandBuffers: GPUCommandBuffer[] = [null as any, null as any];
 
-    private _dummyVertexBuffer: DataBuffer;
-
     // Frame Buffer Life Cycle (recreated for each render target pass)
 
     private _mainRenderPassWrapper: IWebGPURenderPassWrapper = {
@@ -3703,9 +3701,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
 
         this._currentMaterialContext.textureState = textureState;
 
-        // If vertex pulling, get a cached pipeline with empty vertex layout
-        // Pass a boolean here to getRenderPipeline that will cause the vertex layout to be empty
-        const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState, this._useVertexPulling);
+        const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState);
         const bindGroups = this._cacheBindGroups.getBindGroups(webgpuPipelineContext, this._currentDrawContext, this._currentMaterialContext);
 
         if (!this._snapshotRendering.record) {
@@ -3732,13 +3728,6 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             );
         }
 
-        // If vertex pulling, bind a cached empty vertex buffer
-        if (this._useVertexPulling) {
-            if (!this._dummyVertexBuffer) {
-                this._dummyVertexBuffer = this.createVertexBuffer(new Float32Array(0), false, "DummyVertexPullingBuffer");
-            }
-            renderPass2.setVertexBuffer(0, this._dummyVertexBuffer.underlyingResource, 0, 0);
-        }
         const vertexBuffers = this._cacheRenderPipeline.vertexBuffers;
         for (let index = 0; index < vertexBuffers.length; index++) {
             const vertexBuffer = vertexBuffers[index];

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -350,6 +350,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     public _currentMaterialContext: WebGPUMaterialContext;
     private _currentOverrideVertexBuffers: Nullable<{ [key: string]: Nullable<VertexBuffer> }> = null;
     private _currentIndexBuffer: Nullable<DataBuffer> = null;
+    private _dummyIndexBuffer: Nullable<DataBuffer> = null;
     private _colorWriteLocal = true;
     private _forceEnableEffect = false;
 
@@ -1666,7 +1667,11 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             }
         }
 
-        const dataBuffer = this._bufferManager.createBuffer(view, WebGPUConstants.BufferUsage.Index | WebGPUConstants.BufferUsage.CopyDst, label);
+        const dataBuffer = this._bufferManager.createBuffer(
+            view,
+            WebGPUConstants.BufferUsage.Index | WebGPUConstants.BufferUsage.CopyDst | WebGPUConstants.BufferUsage.Storage,
+            label
+        );
         dataBuffer.is32Bits = is32Bits;
         return dataBuffer;
     }
@@ -3708,8 +3713,9 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         const pipeline = this._cacheRenderPipeline.getRenderPipeline(fillMode, this._currentEffect!, this.currentSampleCount, textureState);
 
         // Compare the vertex buffers that we have to the ones that are bound to the pipeline.
-        // If there are vertex buffers that are not bound to the pipeline, AND they're used
-        // by the shader, we will bind them to the current draw context.
+        // If there are vertex buffers that are not bound to the pipeline, AND there are storage buffers
+        // used by the shader with the same name, we will bind them to the current draw context because they
+        // are being used to do vertex pulling.
         const availableVertexBuffers: { [key: string]: VertexBuffer } = (this._cacheRenderPipeline as any)._vertexBuffers;
         const appliedVertexBuffers = this._cacheRenderPipeline.vertexBuffers;
         const vertexBufferNames = Object.keys(availableVertexBuffers);
@@ -3728,11 +3734,35 @@ export class WebGPUEngine extends ThinWebGPUEngine {
                     }
                 }
             }
-            // TODO - handle binding index buffer.
-            // if (webgpuPipelineContext.shaderProcessingContext.bufferNames.findIndex((name) => name === "indices") !== -1) {
-            //     const indexBuffer = this._currentIndexBuffer ? this._currentIndexBuffer : (this._cacheRenderPipeline as any)._indexBuffer;
-            //     this._currentDrawContext.buffers["indices"] = indexBuffer as WebGPUDataBuffer;
-            // }
+        }
+        // Handle binding index buffer for vertex pulling. This happens when the index buffer is not already bound
+        // and the shader uses the "indices" buffer.
+        if (!this._currentIndexBuffer && webgpuPipelineContext.shaderProcessingContext.bufferNames.findIndex((name) => name === "indices") !== -1) {
+            const indexBuffer = (this._cacheRenderPipeline as any)._indexBuffer;
+            let is32bits = false;
+            if (indexBuffer) {
+                this._currentDrawContext.buffers["indices"] = indexBuffer as WebGPUDataBuffer;
+                is32bits = indexBuffer.is32Bits;
+            } else {
+                // If no index buffer exists but the vertex shader uses the "indices" buffer, we need
+                // to create a dummy index buffer (of size 4 to avoid WebGPU errors). Then we'll set the
+                // uniform to indicate that indices aren't used by the mesh.
+                if (!this._dummyIndexBuffer) {
+                    this._dummyIndexBuffer = this._bufferManager.createBuffer(
+                        new Uint16Array([0, 0, 0, 0]),
+                        WebGPUConstants.BufferUsage.Storage | WebGPUConstants.BufferUsage.CopyDst,
+                        "DummyIndices"
+                    );
+                }
+                this._currentDrawContext.buffers["indices"] = this._dummyIndexBuffer as WebGPUDataBuffer;
+            }
+            // Set uniforms to indicate that the index buffer is used and whether it is 32-bit or 16-bit.
+            if ((webgpuPipelineContext.uniformBuffer as any)._uniformLocations["hasIndices"] !== undefined) {
+                webgpuPipelineContext.uniformBuffer?.updateInt("hasIndices", indexBuffer !== undefined ? 1 : 0);
+            }
+            if ((webgpuPipelineContext.uniformBuffer as any)._uniformLocations["indicesAre32bit"] !== undefined) {
+                webgpuPipelineContext.uniformBuffer?.updateInt("indicesAre32bit", is32bits ? 1 : 0);
+            }
         }
 
         const bindGroups = this._cacheBindGroups.getBindGroups(webgpuPipelineContext, this._currentDrawContext, this._currentMaterialContext);

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -302,6 +302,7 @@ export class PBRMaterialDefines extends MaterialDefines implements IImageProcess
     public DECAL_AFTER_DETAIL = false;
 
     public DEBUGMODE = 0;
+    public USE_VERTEX_PULLING = false;
 
     /**
      * Initializes the PBR Material defines.
@@ -2005,7 +2006,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 this.fogEnabled,
                 this.needAlphaTestingForMesh(mesh),
                 defines,
-                this._applyDecalMapAfterDetailMap
+                this._applyDecalMapAfterDetailMap,
+                this._useVertexPulling
             );
             defines.UNLIT = this._unlit || ((this.pointsCloud || this.wireframe) && !mesh.isVerticesDataPresent(VertexBuffer.NormalKind));
             defines.DEBUGMODE = this._debugMode;

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1276,7 +1276,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
         const previousEffect = subMesh.effect;
         const lightDisposed = defines._areLightsDisposed;
-        let effect = this._prepareEffect(mesh, defines, this.onCompiled, this.onError, useInstances, null, subMesh.getRenderingMesh().hasThinInstances);
+        let effect = this._prepareEffect(mesh, subMesh.getRenderingMesh(), defines, this.onCompiled, this.onError, useInstances, null);
 
         let forceWasNotReadyPreviously = false;
 
@@ -1332,14 +1332,14 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
     private _prepareEffect(
         mesh: AbstractMesh,
+        renderingMesh: AbstractMesh,
         defines: PBRMaterialDefines,
         onCompiled: Nullable<(effect: Effect) => void> = null,
         onError: Nullable<(effect: Effect, errors: string) => void> = null,
         useInstances: Nullable<boolean> = null,
-        useClipPlane: Nullable<boolean> = null,
-        useThinInstances: boolean
+        useClipPlane: Nullable<boolean> = null
     ): Nullable<Effect> {
-        this._prepareDefines(mesh, defines, useInstances, useClipPlane, useThinInstances);
+        this._prepareDefines(mesh, renderingMesh, defines, useInstances, useClipPlane);
 
         if (!defines.isDirty) {
             return null;
@@ -1647,11 +1647,13 @@ export abstract class PBRBaseMaterial extends PushMaterial {
 
     private _prepareDefines(
         mesh: AbstractMesh,
+        renderingMesh: AbstractMesh,
         defines: PBRMaterialDefines,
         useInstances: Nullable<boolean> = null,
-        useClipPlane: Nullable<boolean> = null,
-        useThinInstances: boolean = false
+        useClipPlane: Nullable<boolean> = null
     ): void {
+        const useThinInstances = renderingMesh.hasThinInstances;
+
         const scene = this.getScene();
         const engine = scene.getEngine();
 
@@ -2007,7 +2009,8 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 this.needAlphaTestingForMesh(mesh),
                 defines,
                 this._applyDecalMapAfterDetailMap,
-                this._useVertexPulling
+                this._useVertexPulling,
+                renderingMesh
             );
             defines.UNLIT = this._unlit || ((this.pointsCloud || this.wireframe) && !mesh.isVerticesDataPresent(VertexBuffer.NormalKind));
             defines.DEBUGMODE = this._debugMode;
@@ -2051,7 +2054,7 @@ export abstract class PBRBaseMaterial extends PushMaterial {
                 return;
             }
             const defines = new PBRMaterialDefines(this._eventInfo.defineNames);
-            const effect = this._prepareEffect(mesh, defines, undefined, undefined, localOptions.useInstances, localOptions.clipPlane, mesh.hasThinInstances)!;
+            const effect = this._prepareEffect(mesh, mesh, defines, undefined, undefined, localOptions.useInstances, localOptions.clipPlane)!;
             if (this._onEffectCreatedObservable) {
                 onCreatedEffectParameters.effect = effect;
                 onCreatedEffectParameters.subMesh = null;

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -239,6 +239,12 @@ export class Material implements IAnimatable, IClipPlanesHolder {
 
     protected _forceGLSL = false;
 
+    /**
+     * Tells the engine to draw geometry using vertex pulling instead of index drawing. This will automatically
+     * set the vertex buffers as storage buffers and make them accessible to the vertex shader.
+     */
+    public useVertexPulling = false;
+
     /** @internal */
     public get _supportGlowLayer() {
         return false;

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -240,11 +240,23 @@ export class Material implements IAnimatable, IClipPlanesHolder {
 
     protected _forceGLSL = false;
 
+    protected _useVertexPulling = false;
     /**
      * Tells the engine to draw geometry using vertex pulling instead of index drawing. This will automatically
-     * set the vertex buffers as storage buffers and make them accessible to the vertex shader.
+     * set the vertex buffers as storage buffers and make them accessible to the vertex shader (WebGPU only).
      */
-    public useVertexPulling = false;
+    public get useVertexPulling() {
+        return this._useVertexPulling;
+    }
+
+    public set useVertexPulling(value: boolean) {
+        if (this._useVertexPulling === value) {
+            return;
+        }
+
+        this._useVertexPulling = value;
+        this.markAsDirty(Material.MiscDirtyFlag);
+    }
 
     /** @internal */
     public get _supportGlowLayer() {

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -52,6 +52,7 @@ import { BindSceneUniformBuffer } from "./materialHelper.functions";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import { ShaderLanguage } from "./shaderLanguage";
 import type { IAssetContainer } from "core/IAssetContainer";
+import { IsWrapper } from "./drawWrapper.functions";
 
 declare let BABYLON: any;
 
@@ -1298,7 +1299,13 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         const orientation = overrideOrientation == null ? this.sideOrientation : overrideOrientation;
         const reverse = orientation === Material.ClockWiseSideOrientation;
 
-        engine.enableEffect(effect ? effect : this._getDrawWrapper());
+        const effectiveDrawWrapper = effect ? effect : this._getDrawWrapper();
+
+        if (IsWrapper(effectiveDrawWrapper) && effectiveDrawWrapper.materialContext) {
+            effectiveDrawWrapper.materialContext.useVertexPulling = this.useVertexPulling;
+        }
+
+        engine.enableEffect(effectiveDrawWrapper);
         engine.setState(
             this.backFaceCulling,
             this.zOffset,

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -500,6 +500,7 @@ export function GetFogState(mesh: AbstractMesh, scene: Scene) {
  * @param defines defines the current list of defines
  * @param applyDecalAfterDetail Defines if the decal is applied after or before the detail
  * @param useVertexPulling Defines if vertex pulling is used
+ * @param renderingMesh The mesh used for rendering
  */
 export function PrepareDefinesForMisc(
     mesh: AbstractMesh,
@@ -510,7 +511,8 @@ export function PrepareDefinesForMisc(
     alphaTest: boolean,
     defines: any,
     applyDecalAfterDetail: boolean = false,
-    useVertexPulling: boolean = false
+    useVertexPulling: boolean = false,
+    renderingMesh?: AbstractMesh
 ): void {
     if (defines._areMiscDirty) {
         defines["LOGARITHMICDEPTH"] = useLogarithmicDepth;
@@ -520,6 +522,11 @@ export function PrepareDefinesForMisc(
         defines["ALPHATEST"] = alphaTest;
         defines["DECAL_AFTER_DETAIL"] = applyDecalAfterDetail;
         defines["USE_VERTEX_PULLING"] = useVertexPulling;
+
+        const indexBuffer = renderingMesh?.geometry?.getIndexBuffer();
+
+        defines["VERTEX_PULLING_USE_INDEX_BUFFER"] = !!indexBuffer;
+        defines["VERTEX_PULLING_INDEX_BUFFER_32BITS"] = indexBuffer ? indexBuffer.is32Bits : false;
     }
 }
 

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -499,6 +499,7 @@ export function GetFogState(mesh: AbstractMesh, scene: Scene) {
  * @param alphaTest defines if alpha testing has to be turned on
  * @param defines defines the current list of defines
  * @param applyDecalAfterDetail Defines if the decal is applied after or before the detail
+ * @param useVertexPulling Defines if vertex pulling is used
  */
 export function PrepareDefinesForMisc(
     mesh: AbstractMesh,
@@ -508,7 +509,8 @@ export function PrepareDefinesForMisc(
     fogEnabled: boolean,
     alphaTest: boolean,
     defines: any,
-    applyDecalAfterDetail: boolean = false
+    applyDecalAfterDetail: boolean = false,
+    useVertexPulling: boolean = false
 ): void {
     if (defines._areMiscDirty) {
         defines["LOGARITHMICDEPTH"] = useLogarithmicDepth;
@@ -517,6 +519,7 @@ export function PrepareDefinesForMisc(
         defines["NONUNIFORMSCALING"] = mesh.nonUniformScaling;
         defines["ALPHATEST"] = alphaTest;
         defines["DECAL_AFTER_DETAIL"] = applyDecalAfterDetail;
+        defines["USE_VERTEX_PULLING"] = useVertexPulling;
     }
 }
 

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -880,8 +880,17 @@ export class ShaderMaterial extends PushMaterial {
             shaderName = this.customShaderNameResolve(this.name, uniforms, uniformBuffers, samplers, defines, attribs);
         }
 
-        if (this.useVertexPulling) {
+        const renderingMesh = subMesh ? subMesh.getRenderingMesh() : mesh;
+        if (renderingMesh && this.useVertexPulling) {
             defines.push("#define USE_VERTEX_PULLING");
+
+            const indexBuffer = renderingMesh.geometry?.getIndexBuffer();
+            if (indexBuffer) {
+                defines.push("#define VERTEX_PULLING_USE_INDEX_BUFFER");
+                if (indexBuffer.is32Bits) {
+                    defines.push("#define VERTEX_PULLING_INDEX_BUFFER_32BITS");
+                }
+            }
         }
 
         const drawWrapper = storeEffectOnSubMeshes ? subMesh._getDrawWrapper(undefined, true) : this._drawWrapper;

--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -880,6 +880,10 @@ export class ShaderMaterial extends PushMaterial {
             shaderName = this.customShaderNameResolve(this.name, uniforms, uniformBuffers, samplers, defines, attribs);
         }
 
+        if (this.useVertexPulling) {
+            defines.push("#define USE_VERTEX_PULLING");
+        }
+
         const drawWrapper = storeEffectOnSubMeshes ? subMesh._getDrawWrapper(undefined, true) : this._drawWrapper;
         const previousEffect = drawWrapper?.effect ?? null;
         const previousDefines = drawWrapper?.defines ?? null;

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -231,6 +231,7 @@ export class StandardMaterialDefines extends MaterialDefines implements IImagePr
     public CAMERA_ORTHOGRAPHIC = false;
     public CAMERA_PERSPECTIVE = false;
     public AREALIGHTSUPPORTED = true;
+    public USE_VERTEX_PULLING = false;
 
     /**
      * If the reflection texture on this material is in linear color space
@@ -1247,7 +1248,8 @@ export class StandardMaterial extends PushMaterial {
             this.fogEnabled,
             this.needAlphaTestingForMesh(mesh),
             defines,
-            this._applyDecalMapAfterDetailMap
+            this._applyDecalMapAfterDetailMap,
+            this._useVertexPulling
         );
 
         // Values that need to be evaluated on every frame

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1249,7 +1249,8 @@ export class StandardMaterial extends PushMaterial {
             this.needAlphaTestingForMesh(mesh),
             defines,
             this._applyDecalMapAfterDetailMap,
-            this._useVertexPulling
+            this._useVertexPulling,
+            subMesh.getRenderingMesh()
         );
 
         // Values that need to be evaluated on every frame

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -1190,6 +1190,15 @@ export class UniformBuffer {
     }
 
     /**
+     * Checks if the uniform buffer has a uniform with the given name.
+     * @param name Name of the uniform to check
+     * @returns True if the uniform exists, false otherwise.
+     */
+    public has(name: string): boolean {
+        return this._uniformLocations[name] !== undefined;
+    }
+
+    /**
      * Disposes the uniform buffer.
      */
     public dispose(): void {

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -957,9 +957,6 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     public _unIndexed = false;
 
     /** @internal */
-    public _useVertexPulling = false;
-
-    /** @internal */
     public _lightSources = new Array<Light>();
 
     /** Gets the list of lights affecting that mesh */

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -957,6 +957,9 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     public _unIndexed = false;
 
     /** @internal */
+    public _useVertexPulling = false;
+
+    /** @internal */
     public _lightSources = new Array<Light>();
 
     /** Gets the list of lights affecting that mesh */

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1057,6 +1057,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     protected _buildUniformLayout(): void {
         this._uniformBuffer.addUniform("world", 16);
         this._uniformBuffer.addUniform("visibility", 1);
+        this._uniformBuffer.addUniform("hasIndices", 1);
         this._uniformBuffer.create();
     }
 

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1057,7 +1057,6 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     protected _buildUniformLayout(): void {
         this._uniformBuffer.addUniform("world", 16);
         this._uniformBuffer.addUniform("visibility", 1);
-        this._uniformBuffer.addUniform("hasIndices", 1);
         this._uniformBuffer.create();
     }
 

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2063,9 +2063,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             engine.drawElementsType(fillMode, 0, subMesh._linesIndexCount, this.forcedInstanceCount || instancesCount);
         } else if (this._useVertexPulling) {
             // We're rendering the number of indices in the index buffer but the vertex shader is handling the data itself.
-            engine._useVertexPulling = true;
             engine.drawArraysType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
-            engine._useVertexPulling = false;
         } else {
             engine.drawElementsType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
         }

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2061,6 +2061,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         } else if (fillMode == Material.WireFrameFillMode) {
             // Triangles as wireframe
             engine.drawElementsType(fillMode, 0, subMesh._linesIndexCount, this.forcedInstanceCount || instancesCount);
+        } else if (this._useVertexPulling) {
+            // We're rendering the number of indices in the index buffer but the vertex shader is handling the data itself.
+            engine._useVertexPulling = true;
+            engine.drawArraysType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
+            engine._useVertexPulling = false;
         } else {
             engine.drawElementsType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
         }

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2054,7 +2054,8 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         const scene = this.getScene();
         const engine = scene.getEngine();
-        const material = subMesh.getMaterial();
+        const currentMaterialContext = engine._currentMaterialContext;
+        const useVertexPulling = currentMaterialContext && currentMaterialContext.useVertexPulling;
 
         if ((this._unIndexed && fillMode !== Material.WireFrameFillMode) || fillMode == Material.PointFillMode) {
             // or triangles as points
@@ -2062,7 +2063,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         } else if (fillMode == Material.WireFrameFillMode) {
             // Triangles as wireframe
             engine.drawElementsType(fillMode, 0, subMesh._linesIndexCount, this.forcedInstanceCount || instancesCount);
-        } else if (material && material.useVertexPulling) {
+        } else if (useVertexPulling) {
             // We're rendering the number of indices in the index buffer but the vertex shader is handling the data itself.
             engine.drawArraysType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
         } else {

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2054,6 +2054,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
         const scene = this.getScene();
         const engine = scene.getEngine();
+        const material = subMesh.getMaterial();
 
         if ((this._unIndexed && fillMode !== Material.WireFrameFillMode) || fillMode == Material.PointFillMode) {
             // or triangles as points
@@ -2061,7 +2062,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         } else if (fillMode == Material.WireFrameFillMode) {
             // Triangles as wireframe
             engine.drawElementsType(fillMode, 0, subMesh._linesIndexCount, this.forcedInstanceCount || instancesCount);
-        } else if (this._useVertexPulling) {
+        } else if (material && material.useVertexPulling) {
             // We're rendering the number of indices in the index buffer but the vertex shader is handling the data itself.
             engine.drawArraysType(fillMode, subMesh.indexStart, subMesh.indexCount, this.forcedInstanceCount || instancesCount);
         } else {


### PR DESCRIPTION
Vertex pulling is where you do your own reading of vertex data in the vertex shader instead of relying on the standard vertex attribute pipeline. I'm not sure of the best approach in Babylon but I made some minimal changes to make it work. I'd appreciate some feedback and ideas for a better way to set this up.

First, some motivation:
I want vertex pulling as a way of selecting vertex data from neighboring vertices in the IBL Shadows voxelization shader. By retrieving normal info for the provoking vertex of a triangle, I can selectively swizzle the axes of the position to maximize rasterization area and avoid missing voxels. This eliminates the need for 3-pass voxelization and opens the door for doing realtime voxelization of animated geometry (in WebGPU only due to the need for 3D storage textures).
https://playground.babylonjs.com/?snapshot=refs/pull/16826/merge#XSNYAU#131

For vertex pulling to work, we typically need:
1. An empty vertex layout.
2. Our needed vertex buffers assigned as storage buffers
3. A non-indexed draw call with the number of vertices to process. This causes `@builtin(vertex_index)` to be sequential which is critical for fetching info about neighboring vertices.

No changes are needed to Babylon for the first two requirements. For the 3rd point though, we want to do a `engine.drawArraysType` even though the mesh has indices. To do this, we set `material.useVertexPulling`.
The shader must also _not_ declare vertex attributes.
