### PR TITLE
GPUParticleSystem serialization and IBL Shadows

### DIFF
--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -2121,6 +2121,9 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         serializationObject.randomTextureSize = this._randomTextureSize;
         serializationObject.customShader = this.customShader;
 
+        serializationObject.preventAutoStart = this.preventAutoStart;
+        serializationObject.worldOffset = this.worldOffset.asArray();
+
         return serializationObject;
     }
 
@@ -2180,6 +2183,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         ParticleSystem._Parse(parsedParticleSystem, particleSystem, sceneOrEngine, rootUrl);
+
+        if (parsedParticleSystem.worldOffset) {
+            particleSystem.worldOffset = Vector3.FromArray(parsedParticleSystem.worldOffset);
+        }
 
         // Auto start
         if (parsedParticleSystem.preventAutoStart) {

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsPluginMaterial.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsPluginMaterial.ts
@@ -6,7 +6,7 @@ import { Constants } from "core/Engines/constants";
 import type { StandardMaterial } from "core/Materials/standardMaterial";
 import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
 import type { UniformBuffer } from "core/Materials/uniformBuffer";
-import { expandToProperty, serialize, serializeAsTexture } from "core/Misc/decorators";
+import { expandToProperty, serialize } from "core/Misc/decorators";
 import { RegisterClass } from "core/Misc/typeStore";
 
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -30,7 +30,6 @@ export class IBLShadowsPluginMaterial extends MaterialPluginBase {
     /**
      * The texture containing the contribution from IBL shadows.
      */
-    @serializeAsTexture()
     public iblShadowsTexture: InternalTexture;
 
     /**


### PR DESCRIPTION
- Add `worldOffset` and `preventAutoStart` into serialization for GPUParticleSystem
- Realized that iblShadowsTexture was serialized but was useless as it's re-created each time ibl post-process is created