### PR TITLE
Fix overlapping audio parameter ramps

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
@@ -46,6 +46,11 @@ export class _WebAudioParameterComponent {
     }
 
     /** @internal */
+    public get isRamping(): boolean {
+        return this._engine.currentTime < this._rampEndTime;
+    }
+
+    /** @internal */
     public get targetValue(): number {
         return this._targetValue;
     }

--- a/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
@@ -25,14 +25,11 @@ const MaxWaitTime = 0.011;
  */
 const MinRampDuration = 0.000001;
 
-// let Id = 1;
-
 /** @internal */
 export class _WebAudioParameterComponent {
     private _deferredRampEndTime = 0;
     private _deferredRampShape: AudioParameterRampShape = AudioParameterRampShape.Linear;
     private _deferredTargetValue = -1;
-    // private _id: number = Id++;
     private _rampEndTime: number = 0;
     private _engine: _WebAudioEngine;
     private _param: AudioParam;
@@ -103,10 +100,6 @@ export class _WebAudioParameterComponent {
             const timeLeft = this._rampEndTime - startTime;
 
             if (MaxWaitTime < timeLeft) {
-                // console.log(
-                //     `Waiting for active ramp to finish before setting new target value: ${this._id}, Current value: ${this._targetValue}, Target value: ${value}, Time left: ${timeLeft}`
-                // );
-
                 throw new Error("Audio parameter not set. Wait for current ramp to finish.");
             } else {
                 this._deferRamp(value, duration, shape);
@@ -118,8 +111,6 @@ export class _WebAudioParameterComponent {
             this._param.setValueAtTime((this._targetValue = value), startTime);
             return;
         }
-
-        // console.log("Starting audio parameter ramp:", this._id, "Target value:", value, "End time:", startTime + duration);
 
         this._param.cancelScheduledValues(startTime);
         this._param.setValueCurveAtTime(_GetAudioParamCurveValues(shape, this._targetValue, (this._targetValue = value)), startTime, duration);
@@ -140,8 +131,6 @@ export class _WebAudioParameterComponent {
                     return;
                 }
 
-                // console.log("Applying deferred ramp to audio parameter:", this._id, "Target value:", this._deferredTargetValue, "End time:", this._deferredRampEndTime);
-
                 this.setTargetValue(this._deferredTargetValue, {
                     duration: this._deferredRampEndTime - this._engine.currentTime,
                     shape: this._deferredRampShape,
@@ -157,15 +146,6 @@ export class _WebAudioParameterComponent {
         this._deferredRampShape = shape;
         this._deferredTargetValue = value;
 
-        // console.log("Deferring ramp for audio parameter:", this._id, "Target value:", this._deferredTargetValue, "End time:", this._deferredRampEndTime);
-
         this._applyDeferredRamp();
     }
 }
-
-// Example for testing:
-//  http://localhost:1338/#1BZK59#14
-// Stress test:
-//  http://localhost:1338/#1BZK59#59 = 200 spatial sounds - runs at full 60 FPS on a MacBook Air M3.
-//  http://localhost:1338/#1BZK59#60 = 500 spatial sounds - runs at 5 FPS on a MacBook Air M3.
-//  http://localhost:1338/#1BZK59#63 = 300 spatial sounds - doesn't play any sound. 224 spatial sounds seems to be the limit on Chrome on a MacBook Air M3.

--- a/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
@@ -28,7 +28,10 @@ const MinRampDuration = 0.000001;
 /** @internal */
 export class _WebAudioParameterComponent {
     private _deferredRampEndTime = 0;
-    private _deferredRampShape: AudioParameterRampShape = AudioParameterRampShape.Linear;
+    private _deferredRampOptions = {
+        duration: 0,
+        shape: AudioParameterRampShape.Linear,
+    };
     private _deferredTargetValue = -1;
     private _rampEndTime: number = 0;
     private _engine: _WebAudioEngine;
@@ -131,10 +134,9 @@ export class _WebAudioParameterComponent {
                     return;
                 }
 
-                this.setTargetValue(this._deferredTargetValue, {
-                    duration: this._deferredRampEndTime - this._engine.currentTime,
-                    shape: this._deferredRampShape,
-                });
+                this._deferredRampOptions.duration = this._deferredRampEndTime - this._engine.currentTime;
+
+                this.setTargetValue(this._deferredTargetValue, this._deferredRampOptions);
 
                 this._deferredRampEndTime = 0;
             }
@@ -143,7 +145,7 @@ export class _WebAudioParameterComponent {
 
     private _deferRamp(value: number, duration: number, shape: AudioParameterRampShape): void {
         this._deferredRampEndTime = this._rampEndTime + duration;
-        this._deferredRampShape = shape;
+        this._deferredRampOptions.shape = shape;
         this._deferredTargetValue = value;
 
         this._applyDeferredRamp();

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
@@ -170,6 +170,12 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
             return;
         }
 
+        // If attached and there is a ramp in progress, we assume another update is coming soon that we can wait for.
+        // We don't do this for unattached nodes because there may not be another update coming.
+        if (this.isAttached && (this._positionX.isRamping || this._positionY.isRamping || this._positionZ.isRamping)) {
+            return;
+        }
+
         this._positionX.targetValue = this.position.x;
         this._positionY.targetValue = this.position.y;
         this._positionZ.targetValue = this.position.z;
@@ -179,6 +185,12 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
 
     /** @internal */
     public _updateRotation(): void {
+        // If attached and there is a ramp in progress, we assume another update is coming soon that we can wait for.
+        // We don't do this for unattached nodes because there may not be another update coming.
+        if (this.isAttached && (this._orientationX.isRamping || this._orientationY.isRamping || this._orientationZ.isRamping)) {
+            return;
+        }
+
         if (!this._lastRotationQuaternion.equalsWithEpsilon(this.rotationQuaternion)) {
             TmpQuaternion.copyFrom(this.rotationQuaternion);
             this._lastRotationQuaternion.copyFrom(this.rotationQuaternion);

--- a/packages/dev/core/src/AudioV2/webAudio/subProperties/spatialWebAudioListener.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subProperties/spatialWebAudioListener.ts
@@ -159,12 +159,27 @@ class _SpatialWebAudioListener extends _AbstractSpatialWebAudioListener {
     }
 
     protected override _setWebAudioPosition(position: Vector3): void {
+        // If attached and there is a ramp in progress, we assume another update is coming soon that we can wait for.
+        // We don't do this for unattached nodes because there may not be another update coming.
+        if (this.isAttached && (this._positionX.isRamping || this._positionY.isRamping || this._positionZ.isRamping)) {
+            return;
+        }
+
         this._positionX.targetValue = position.x;
         this._positionY.targetValue = position.y;
         this._positionZ.targetValue = position.z;
     }
 
     protected override _setWebAudioOrientation(forward: Vector3, up: Vector3): void {
+        // If attached and there is a ramp in progress, we assume another update is coming soon that we can wait for.
+        // We don't do this for unattached nodes because there may not be another update coming.
+        if (
+            this.isAttached &&
+            (this._forwardX.isRamping || this._forwardY.isRamping || this._forwardZ.isRamping || this._upX.isRamping || this._upY.isRamping || this._upZ.isRamping)
+        ) {
+            return;
+        }
+
         this._forwardX.targetValue = forward.x;
         this._forwardY.targetValue = forward.y;
         this._forwardZ.targetValue = forward.z;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -88,7 +88,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private _resumePromise: Nullable<Promise<void>> = null;
     private _silentHtmlAudio: Nullable<HTMLAudioElement> = null;
     private _unmuteUI: Nullable<_WebAudioUnmuteUI> = null;
-    private _updateObservable = new Observable<void>();
+    private _updateObservable: Nullable<Observable<void>> = null;
     private readonly _validFormats = new Set<string>();
     private _volume = 1;
 
@@ -295,6 +295,9 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
         this._silentHtmlAudio?.remove();
 
+        this._updateObservable?.clear();
+        this._updateObservable = null;
+
         this._unmuteUI?.dispose();
         this._unmuteUI = null;
     }
@@ -381,8 +384,13 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
     /** @internal */
     public _addUpdateObserver(callback: () => void): Observable<void> {
+        if (!this._updateObservable) {
+            this._updateObservable = new Observable<void>();
+        }
+
         this._updateObservable.add(callback);
         this._startUpdating();
+
         return this._updateObservable;
     }
 
@@ -452,7 +460,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
     }
 
     private _update = (): void => {
-        if (this._updateObservable.hasObservers()) {
+        if (this._updateObservable?.hasObservers()) {
             this._updateObservable.notifyObservers();
             requestAnimationFrame(this._update);
         } else {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -380,9 +380,10 @@ export class _WebAudioEngine extends AudioEngineV2 {
     }
 
     /** @internal */
-    public _addUpdateObserver(callback: () => void): void {
+    public _addUpdateObserver(callback: () => void): Observable<void> {
         this._updateObservable.add(callback);
         this._startUpdating();
+        return this._updateObservable;
     }
 
     /** @internal */

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -386,11 +386,6 @@ export class _WebAudioEngine extends AudioEngineV2 {
         return this._updateObservable;
     }
 
-    /** @internal */
-    public _removeUpdateObserver(callback: () => void): void {
-        this._updateObservable.removeCallback(callback);
-    }
-
     private _initAudioContextAsync: () => Promise<void> = async () => {
         this._audioContext.addEventListener("statechange", this._onAudioContextStateChange);
 

--- a/packages/tools/babylonServer/public/audiov2-test.js
+++ b/packages/tools/babylonServer/public/audiov2-test.js
@@ -460,4 +460,8 @@ class AudioV2Test {
             throw new Error("Unknown audio context type.");
         }
     }
+
+    static async WaitForParameterRampDurationAsync(callback) {
+        await AudioV2Test.WaitAsync(audioEngine.parameterRampDuration, callback);
+    }
 }

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -99,12 +99,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Default ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.1x volume at 0.1 seconds with default linear shape", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1 });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -120,12 +120,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.5 seconds with default linear shape", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1 });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -141,12 +141,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.9x volume at 0.9 seconds with default linear shape", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1 });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -221,12 +221,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Linear ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.1x volume at 0.1 seconds shape set to linear", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -242,12 +242,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.5 seconds with shape set to linear", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -263,12 +263,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.9x volume at 0.9 seconds with shape set to linear", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -343,12 +343,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Exponential ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.1 seconds shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -364,12 +364,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.5 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -385,12 +385,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.3x volume at 0.9 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -471,12 +471,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Logarithmic ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.1 seconds shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -492,12 +492,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.85x volume at 0.5 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {
@@ -513,12 +513,12 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 1x volume at 0.9 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                    await AudioV2Test.WaitForParameterRampDurationAsync(async () => {
                         outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
                         sound.play();
                         await AudioV2Test.WaitAsync(1, () => {

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -99,15 +99,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Default ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.1x volume at 0.1 seconds with default linear shape", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1 });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1 });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -118,15 +120,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.5 seconds with default linear shape", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1 });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1 });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -137,15 +141,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.9x volume at 0.9 seconds with default linear shape", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1 });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1 });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -215,15 +221,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Linear ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.1x volume at 0.1 seconds shape set to linear", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -234,15 +242,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.5 seconds with shape set to linear", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -253,15 +263,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.9x volume at 0.9 seconds with shape set to linear", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Linear });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -331,15 +343,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Exponential ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.1 seconds shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -350,15 +364,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0 volume at 0.5 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -369,15 +385,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.3x volume at 0.9 seconds with shape set to exponential", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Exponential });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -407,7 +425,7 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
                 } else {
                     // Expect larger range due to timing variations.
                     expect(volumes[Channel.L]).toBeGreaterThan(0.25);
-                    expect(volumes[Channel.L]).toBeLessThan(0.36);
+                    expect(volumes[Channel.L]).toBeLessThan(0.4);
                 }
             });
 
@@ -453,15 +471,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
         test.describe("Logarithmic ramp", () => {
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.5x volume at 0.1 seconds shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -472,15 +492,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 0.85x volume at 0.5 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -491,15 +513,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 0 to 1 over 1 second should play sound at 1x volume at 0.9 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: audioNodeType === "AudioEngineV2" ? 0 : 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: audioNodeType !== "AudioEngineV2" ? 0 : 1,
                     });
 
-                    outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioContext instanceof OfflineAudioContext ? audioEngine.parameterRampDuration : 0, async () => {
+                        outputNode.setVolume(1, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 
@@ -510,15 +534,17 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
             test("Ramping volume from 1 to 0 over 1 second should play sound at 1x volume at 0.1 seconds with shape set to logarithmic", async ({ page }) => {
                 await EvaluateAbstractAudioNodeTestAsync(page, audioNodeType, async ({ audioNodeType }) => {
-                    await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
+                    const audioEngine = await AudioV2Test.CreateAudioEngineAsync(audioNodeType, undefined, { volume: 1 });
                     const { sound, outputNode } = await AudioV2Test.CreateAbstractSoundAndOutputNodeAsync(audioNodeType, audioTestConfig.pulseTrainSoundFile, {
                         volume: 1,
                     });
 
-                    outputNode.setVolume(0, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
-                    sound.play();
-                    await AudioV2Test.WaitAsync(1, () => {
-                        sound.stop();
+                    await AudioV2Test.WaitAsync(audioEngine.parameterRampDuration, async () => {
+                        outputNode.setVolume(0, { duration: 1, shape: BABYLON.AudioParameterRampShape.Logarithmic });
+                        sound.play();
+                        await AudioV2Test.WaitAsync(1, () => {
+                            sound.stop();
+                        });
                     });
                 });
 

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -588,7 +588,13 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.9);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
+                if ((await EvaluateAudioContextType(page)) === "Offline") {
+                    expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
+                } else {
+                    // Expect larger range due to timing variations.
+                    expect(volumes[Channel.L]).toBeGreaterThanOrEqual(0.45);
+                    expect(volumes[Channel.L]).toBeLessThanOrEqual(0.56);
+                }
             });
         });
 

--- a/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractAudioNode.volume.ts
@@ -401,7 +401,13 @@ export const AddSharedAbstractAudioNodeVolumeTests = (audioNodeType: AudioNodeTy
 
                 const volumes = await EvaluateVolumesAtTimeAsync(page, 0.9);
 
-                expect(volumes[Channel.L]).toBeCloseTo(0.3, VolumePrecision);
+                if ((await EvaluateAudioContextType(page)) === "Offline") {
+                    expect(volumes[Channel.L]).toBeCloseTo(0.3, VolumePrecision);
+                } else {
+                    // Expect larger range due to timing variations.
+                    expect(volumes[Channel.L]).toBeGreaterThan(0.23);
+                    expect(volumes[Channel.L]).toBeLessThan(0.4);
+                }
             });
 
             test("Ramping volume from 1 to 0 over 1 second should play sound at 0.3x volume at 0.1 seconds with shape set to exponential", async ({ page }) => {

--- a/packages/tools/tests/test/audioV2/utils/audioV2.utils.ts
+++ b/packages/tools/tests/test/audioV2/utils/audioV2.utils.ts
@@ -82,6 +82,7 @@ declare global {
         public static GetResultAsync(): Promise<AudioTestResult>;
         public static GetVolumesAtTimeAsync(time: number): Promise<number[]>;
         public static WaitAsync(seconds: number, callback?: () => void): Promise<void>;
+        public static WaitForParameterRampDurationAsync(callback?: () => void): Promise<void>;
     }
 }
 


### PR DESCRIPTION
In some cases, short audio parameter ramps are being created faster than they can be processed, which results in later and later ramp end times until they are longer than the `MaxWaitTime` of `0.011` seconds, which throws an error.

To fix the issue this change adds a ramp deferral system that makes new ramps override previously deferred ramps that have not started, yet.

This change also skips spatial audio parameter updates if the spatial audio node is attached and ramping, since subsequent updates will be coming soon and will be more likely to succeed. This reduces pressure on the ramp deferral system without noticeable difference in audio quality. This cannot be done for spatial audio nodes that are not attached because it cannot be assumed that the position and/or rotation will be updated again soon.