### PR TITLE
WebGPU: Fix wrong instances displayed in custom RTT

### DIFF
--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -684,6 +684,9 @@ declare module "./mesh" {
             vertexBuffers: { [key: string]: Nullable<VertexBuffer> };
             strides: { [key: string]: number };
             vertexArrayObjects?: { [key: string]: WebGLVertexArrayObject };
+            renderPasses?: {
+                [renderPassId: number]: { [kind: string]: Nullable<VertexBuffer> };
+            };
         };
     }
 }
@@ -827,10 +830,10 @@ Mesh.prototype._invalidateInstanceVertexArrayObject = function () {
 };
 
 Mesh.prototype._disposeInstanceSpecificData = function () {
-    if (this._instanceDataStorage.instancesBuffer) {
-        this._instanceDataStorage.instancesBuffer.dispose();
-        this._instanceDataStorage.instancesBuffer = null;
+    for (const renderPassId in this._instanceDataStorage.renderPasses) {
+        this._instanceDataStorage.renderPasses[renderPassId].instancesBuffer?.dispose();
     }
+    this._instanceDataStorage.renderPasses = {};
 
     while (this.instances.length) {
         this.instances[0].dispose();

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -521,6 +521,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
             (!this._scene.useRightHandedSystem && value === Constants.MATERIAL_ClockWiseSideOrientation);
     }
 
+    /** @internal */
+    public get _effectiveSideOrientation(): number {
+        return this._internalMeshDataInfo._effectiveSideOrientation;
+    }
+
     /**
      * @deprecated Please use sideOrientation instead.
      * @see https://doc.babylonjs.com/breaking-changes#7110

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -598,13 +598,13 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     /** Gets the array buffer used to store the instanced buffer used for instances' world matrices */
     public get worldMatrixInstancedBuffer(): Float32Array {
-        const instanceDataStorage = this._instanceDataStorage.renderPasses[this._instanceDataStorage.engine.currentRenderPassId];
+        const instanceDataStorage = this._instanceDataStorage.renderPasses[this._instanceDataStorage.engine.isWebGPU ? this._instanceDataStorage.engine.currentRenderPassId : 0];
         return instanceDataStorage ? instanceDataStorage.instancesData : (undefined as any);
     }
 
     /** Gets the array buffer used to store the instanced buffer used for instances' previous world matrices */
     public get previousWorldMatrixInstancedBuffer(): Float32Array {
-        const instanceDataStorage = this._instanceDataStorage.renderPasses[this._instanceDataStorage.engine.currentRenderPassId];
+        const instanceDataStorage = this._instanceDataStorage.renderPasses[this._instanceDataStorage.engine.isWebGPU ? this._instanceDataStorage.engine.currentRenderPassId : 0];
         return instanceDataStorage ? instanceDataStorage.instancesPreviousData : (undefined as any);
     }
 

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -300,7 +300,8 @@ export class SnapshotRenderingHelper {
             if (mesh.subMeshes) {
                 const sourceMesh = mesh as Mesh;
                 for (const subMesh of sourceMesh.subMeshes) {
-                    sourceMesh._updateInstancedBuffers(subMesh, sourceMesh._getInstancesRenderList(subMesh._id), sourceMesh._instanceDataStorage.instancesBufferSize, this._engine);
+                    const batch = sourceMesh._getInstancesRenderList(subMesh._id);
+                    sourceMesh._updateInstancedBuffers(subMesh, batch, batch.parent.instancesBufferSize, this._engine);
                 }
             }
             return true;

--- a/packages/dev/core/src/Rendering/edgesRenderer.ts
+++ b/packages/dev/core/src/Rendering/edgesRenderer.ts
@@ -973,7 +973,8 @@ export class EdgesRenderer implements IEdgesRenderer {
             this._buffersForInstances["world3"] = (this._source as Mesh).getVertexBuffer("world3");
 
             if (hasInstances) {
-                const instanceStorage = (this._source as Mesh)._instanceDataStorage;
+                const instanceStorage = (this._source as Mesh)._getInstanceDataStorage();
+                const isFrozen = (this._source as Mesh)._instanceDataStorage.isFrozen;
 
                 instanceCount = this.customInstances.length;
 
@@ -984,7 +985,7 @@ export class EdgesRenderer implements IEdgesRenderer {
                     return;
                 }
 
-                if (!instanceStorage.isFrozen) {
+                if (!isFrozen) {
                     let offset = 0;
 
                     for (let i = 0; i < instanceCount; ++i) {

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -1095,7 +1095,7 @@ export class GeometryBufferRenderer {
                         sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;
                     }
                 } else {
-                    sideOrientation = renderingMesh._getInstanceDataStorage().sideOrientation;
+                    sideOrientation = renderingMesh._effectiveSideOrientation;
                 }
 
                 material._preBind(drawWrapper, sideOrientation);

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.ts
@@ -1095,7 +1095,7 @@ export class GeometryBufferRenderer {
                         sideOrientation = sideOrientation === Material.ClockWiseSideOrientation ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation;
                     }
                 } else {
-                    sideOrientation = instanceDataStorage.sideOrientation;
+                    sideOrientation = renderingMesh._getInstanceDataStorage().sideOrientation;
                 }
 
                 material._preBind(drawWrapper, sideOrientation);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-displays-wrong-instance-in-rtt-when-triggered-via-actions/59331

The problem is that when instances are rendered in a custom RTT, we need different **world0**...**world3** vertex buffers for the RTT than for normal scene rendering, because vertex buffer updates are performed on the queue timeline. This means that all updates (those we do when managing the RTT and those we do when rendering the normal scene) are done before the graphics commands are submitted. Ultimately, the draw calls for the RTT and normal scene rendering use the same buffers, and those buffers contain what we last wrote...

This works in WebGL because Angle can detect that in the current frame, we are updating a buffer already used by a pending graphics command, and can act accordingly (either allocate a new buffer to copy the updated data, or reserve unused space in an existing buffer and remap it to a new vertex buffer under the hood).

We haven't encountered this issue in WebGPU before, probably because we usually always render the mesh + all its instances in the custom RTT. In this case, the **world0**...**world3** vertex buffers contain the same data for the RTT and normal scene rendering.

As for the implementation, I “simply” moved the instance data one level down: it is now by render pass ID, see `_InstanceDataStorage.renderPasses`. A number of properties that were accessible in `_InstanceDataStorage` are now accessible in `_InstanceDataStorage.renderPasses[renderPassId]`.

To avoid too many changes in WebGL and stay as close as possible to the old way of working (and also because VAO management was tedious with the new changes...), we access everything via `_InstanceDataStorage.renderPasses[0]` (see `Mesh._getInstanceDataStorage`, we force the `renderPassId` to 0 in WebGL before accessing `_InstanceDataStorage.renderPasses`).