### PR TITLE
Optimize performance of AnimationGroup.Parse

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -7,6 +7,7 @@ import type { Scene, IDisposable } from "../scene";
 import { Observable } from "../Misc/observable";
 import type { Nullable } from "../types";
 import { EngineStore } from "../Engines/engineStore";
+import type { Node } from "../node";
 
 import { Tags } from "../Misc/tags";
 import type { AnimationGroupMask } from "./animationGroupMask";
@@ -995,9 +996,10 @@ export class AnimationGroup implements IDisposable {
      * Returns a new AnimationGroup object parsed from the source provided.
      * @param parsedAnimationGroup defines the source
      * @param scene defines the scene that will receive the animationGroup
+     * @param nodeMap a map of node.id to node in this scene, to accelerate node lookup
      * @returns a new AnimationGroup
      */
-    public static Parse(parsedAnimationGroup: any, scene: Scene): AnimationGroup {
+    public static Parse(parsedAnimationGroup: any, scene: Scene, nodeMap?: Map<Node["id"], Node>): AnimationGroup {
         const animationGroup = new AnimationGroup(parsedAnimationGroup.name, scene, parsedAnimationGroup.weight, parsedAnimationGroup.playOrder);
         for (let i = 0; i < parsedAnimationGroup.targetedAnimations.length; i++) {
             const targetedAnimation = parsedAnimationGroup.targetedAnimations[i];
@@ -1010,7 +1012,7 @@ export class AnimationGroup implements IDisposable {
                     animationGroup.addTargetedAnimation(animation, morphTarget);
                 }
             } else {
-                const targetNode = scene.getNodeById(id);
+                const targetNode = nodeMap ? nodeMap.get(id) : scene.getNodeById(id);
 
                 if (targetNode != null) {
                     animationGroup.addTargetedAnimation(animation, targetNode);


### PR DESCRIPTION
AnimationGroup.Parse currently invokes scene.getNodeById for each targetedAnimation,
resulting in O(m × n) behavior (m = # of targetedAnimations, n = # of scene nodes)
and causing major slowdown when loading large scenes.

This change introduces an optional `nodeMap: Map<string, Node>` parameter to
AnimationGroup.Parse. In the BabylonFileLoader, we build a one‐time hash map
for all meshes, transformNodes, cameras, etc., in O(n), then pass it to
AnimationGroup.Parse. When provided, the parse method does O(1) lookups per
targetedAnimation, reducing overall parsing cost to O(m + n).

Fallback to scene.getNodeById is preserved when no nodeMap is supplied.

Forum post: <https://forum.babylonjs.com/t/optimize-performance-of-animationgroup-parse/59124>