### PR TITLE
gizmo mem leak

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -1055,6 +1055,9 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
         this.onScaleBoxDragEndObservable.clear();
         this.onRotationSphereDragObservable.clear();
         this.onRotationSphereDragEndObservable.clear();
+
+        this._coloredMaterial.dispose();
+        this._hoverColoredMaterial.dispose();
         super.dispose();
     }
 


### PR DESCRIPTION
https://forum.babylonjs.com/t/linesmesh-no-longer-disposes-shadermaterial-by-default-causes-memory-leak-in-boundingboxgizmo/59194/4
