### PR TITLE
Fix sandbox in Chromium based browsers v138

### DIFF
--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -416,7 +416,9 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
             if (this._currentPluginName === "gltf") {
                 const loader = plugin as GLTFFileLoader;
                 loader.transparencyAsCoverage = this.props.globalState.commerceMode;
-                loader.validate = true;
+
+                // Disable validation temporarily until Chrome 139 is in stable release due to https://issues.chromium.org/issues/419503126
+                loader.validate = false;
 
                 loader.onExtensionLoadedObservable.add((extension: import("loaders/glTF/index").IGLTFLoaderExtension) => {
                     this.props.globalState.glTFLoaderExtensions[extension.name] = extension;


### PR DESCRIPTION
https://forum.babylonjs.com/t/sandbox-3dcommerce-viewer-crashing-in-chrome/59359/2