### PR TITLE
Allow lights to change without shader recompilation

### DIFF
--- a/packages/dev/core/src/Lights/areaLight.ts
+++ b/packages/dev/core/src/Lights/areaLight.ts
@@ -100,10 +100,8 @@ export abstract class AreaLight extends Light {
     /**
      * Prepares the list of defines specific to the light type.
      * @param defines the list of defines
-     * @param lightIndex defines the index of the light for the effect
      */
-    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
-        defines["AREALIGHT" + lightIndex] = true;
+    public override prepareLightSpecificDefines(defines: any): void {
         defines["AREALIGHTUSED"] = true;
     }
 

--- a/packages/dev/core/src/Lights/defaultLight.ts
+++ b/packages/dev/core/src/Lights/defaultLight.ts
@@ -1,0 +1,19 @@
+import { Light } from "./light";
+import { LightConstants } from "./lightConstants";
+
+export class DefaultLight extends Light {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    public override getTypeID(): number {
+        return LightConstants.LIGHTTYPEID_NONE;
+    }
+
+    public prepareLightSpecificDefines(): void {}
+
+    public transferToEffect(): Light {
+        return this;
+    }
+
+    public override transferToNodeMaterialEffect(): Light {
+        return this;
+    }
+}

--- a/packages/dev/core/src/Lights/directionalLight.ts
+++ b/packages/dev/core/src/Lights/directionalLight.ts
@@ -280,15 +280,6 @@ export class DirectionalLight extends ShadowLight {
         );
     }
 
-    protected _buildUniformLayout(): void {
-        this._uniformBuffer.addUniform("vLightData", 4);
-        this._uniformBuffer.addUniform("vLightDiffuse", 4);
-        this._uniformBuffer.addUniform("vLightSpecular", 4);
-        this._uniformBuffer.addUniform("shadowsInfo", 3);
-        this._uniformBuffer.addUniform("depthValues", 2);
-        this._uniformBuffer.create();
-    }
-
     /**
      * Sets the passed Effect object with the DirectionalLight transformed position (or position if not parented) and the passed name.
      * @param effect The effect to update
@@ -297,10 +288,10 @@ export class DirectionalLight extends ShadowLight {
      */
     public transferToEffect(effect: Effect, lightIndex: string): DirectionalLight {
         if (this.computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4("vLightData", this.transformedDirection.x, this.transformedDirection.y, this.transformedDirection.z, 1, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightDataA", this.transformedDirection.x, this.transformedDirection.y, this.transformedDirection.z, 1, lightIndex);
             return this;
         }
-        this._uniformBuffer.updateFloat4("vLightData", this.direction.x, this.direction.y, this.direction.z, 1, lightIndex);
+        this._uniformBuffer.updateFloat4("vLightDataA", this.direction.x, this.direction.y, this.direction.z, 1, lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Lights/directionalLight.ts
+++ b/packages/dev/core/src/Lights/directionalLight.ts
@@ -334,15 +334,6 @@ export class DirectionalLight extends ShadowLight {
         const engine = this._scene.getEngine();
         return engine.useReverseDepthBuffer && engine.isNDCHalfZRange ? 0 : 1;
     }
-
-    /**
-     * Prepares the list of defines specific to the light type.
-     * @param defines the list of defines
-     * @param lightIndex defines the index of the light for the effect
-     */
-    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
-        defines["DIRLIGHT" + lightIndex] = true;
-    }
 }
 
 // Register Class Name

--- a/packages/dev/core/src/Lights/disabledLight.ts
+++ b/packages/dev/core/src/Lights/disabledLight.ts
@@ -1,13 +1,11 @@
 import { Light } from "./light";
 import { LightConstants } from "./lightConstants";
 
-export class DefaultLight extends Light {
+export class DisabledLight extends Light {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public override getTypeID(): number {
-        return LightConstants.LIGHTTYPEID_NONE;
+        return LightConstants.LIGHTTYPEID_DISABLED;
     }
-
-    public prepareLightSpecificDefines(): void {}
 
     public transferToEffect(): Light {
         return this;

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -110,15 +110,6 @@ export class HemisphericLight extends Light {
     public override getTypeID(): number {
         return Light.LIGHTTYPEID_HEMISPHERICLIGHT;
     }
-
-    /**
-     * Prepares the list of defines specific to the light type.
-     * @param defines the list of defines
-     * @param lightIndex defines the index of the light for the effect
-     */
-    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
-        defines["HEMILIGHT" + lightIndex] = true;
-    }
 }
 
 // Register Class Name

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -45,16 +45,6 @@ export class HemisphericLight extends Light {
         this.direction = direction || Vector3.Up();
     }
 
-    protected _buildUniformLayout(): void {
-        this._uniformBuffer.addUniform("vLightData", 4);
-        this._uniformBuffer.addUniform("vLightDiffuse", 4);
-        this._uniformBuffer.addUniform("vLightSpecular", 4);
-        this._uniformBuffer.addUniform("vLightGround", 3);
-        this._uniformBuffer.addUniform("shadowsInfo", 3);
-        this._uniformBuffer.addUniform("depthValues", 2);
-        this._uniformBuffer.create();
-    }
-
     /**
      * Returns the string "HemisphericLight".
      * @returns The class name
@@ -90,8 +80,8 @@ export class HemisphericLight extends Light {
      */
     public transferToEffect(_effect: Effect, lightIndex: string): HemisphericLight {
         const normalizeDirection = Vector3.Normalize(this.direction);
-        this._uniformBuffer.updateFloat4("vLightData", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, 0.0, lightIndex);
-        this._uniformBuffer.updateColor3("vLightGround", this.groundColor.scale(this.intensity), lightIndex);
+        this._uniformBuffer.updateFloat4("vLightDataA", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, 0.0, lightIndex);
+        this._uniformBuffer.updateColor3("vLightDataB", this.groundColor.scale(this.intensity), lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -81,7 +81,7 @@ export class HemisphericLight extends Light {
     public transferToEffect(_effect: Effect, lightIndex: string): HemisphericLight {
         const normalizeDirection = Vector3.Normalize(this.direction);
         this._uniformBuffer.updateFloat4("vLightDataA", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, 0.0, lightIndex);
-        this._uniformBuffer.updateColor3("vLightDataB", this.groundColor.scale(this.intensity), lightIndex);
+        this._uniformBuffer.updateColor4("vLightDataB", this.groundColor.scale(this.intensity), 1.0, lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -949,7 +949,7 @@ export abstract class Light extends Node implements ISortableLight {
      * @param defines the list of defines
      * @param lightIndex defines the index of the light for the effect
      */
-    public abstract prepareLightSpecificDefines(defines: any, lightIndex: number): void;
+    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {}
 
     /**
      * @internal

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -385,7 +385,26 @@ export abstract class Light extends Node implements ISortableLight {
         this._resyncMeshes();
     }
 
-    protected abstract _buildUniformLayout(): void;
+    private _buildUniformLayout(): void {
+        this._uniformBuffer.addUniform("vLightType", 1);
+        this._uniformBuffer.addUniform("vLightPosition", 4);
+        this._uniformBuffer.addUniform("vLightDiffuse", 4);
+        this._uniformBuffer.addUniform("vLightSpecular", 4);
+
+        // | Type        | Data A    | Data B  |
+        // | ----------- | --------- | ------- |
+        // | Point       | -         | Falloff |
+        // | Directional | Direction | -       |
+        // | Spot        | Direction | Falloff |
+        // | Hemispheric | Direction | Ground  |
+        // | Area        | Width     | Height  |
+        this._uniformBuffer.addUniform("vLightDataA", 4);
+        this._uniformBuffer.addUniform("vLightDataB", 4);
+
+        this._uniformBuffer.addUniform("shadowsInfo", 4);
+        this._uniformBuffer.addUniform("depthValues", 2);
+        this._uniformBuffer.create();
+    }
 
     /**
      * Sets the passed Effect "effect" with the Light information.
@@ -428,6 +447,8 @@ export abstract class Light extends Node implements ISortableLight {
             const scaledIntensity = this.getScaledIntensity();
 
             this.transferToEffect(effect, iAsString);
+
+            this._uniformBuffer.updateFloat("vLightType", this.getTypeID(), iAsString);
 
             this.diffuse.scaleToRef(scaledIntensity, TmpColors.Color3[0]);
             this._uniformBuffer.updateColor4("vLightDiffuse", TmpColors.Color3[0], this.range, iAsString);

--- a/packages/dev/core/src/Lights/lightConstants.ts
+++ b/packages/dev/core/src/Lights/lightConstants.ts
@@ -69,7 +69,7 @@ export class LightConstants {
     public static readonly INTENSITYMODE_LUMINANCE = 4;
 
     // Light types ids const.
-    public static readonly LIGHTTYPEID_NONE = -1;
+    public static readonly LIGHTTYPEID_DISABLED = -1;
     /**
      * Light type const id of the point light.
      */

--- a/packages/dev/core/src/Lights/lightConstants.ts
+++ b/packages/dev/core/src/Lights/lightConstants.ts
@@ -69,6 +69,7 @@ export class LightConstants {
     public static readonly INTENSITYMODE_LUMINANCE = 4;
 
     // Light types ids const.
+    public static readonly LIGHTTYPEID_NONE = -1;
     /**
      * Light type const id of the point light.
      */

--- a/packages/dev/core/src/Lights/pointLight.ts
+++ b/packages/dev/core/src/Lights/pointLight.ts
@@ -197,15 +197,6 @@ export class PointLight extends ShadowLight {
 
         return this;
     }
-
-    /**
-     * Prepares the list of defines specific to the light type.
-     * @param defines the list of defines
-     * @param lightIndex defines the index of the light for the effect
-     */
-    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
-        defines["POINTLIGHT" + lightIndex] = true;
-    }
 }
 
 // Register Class Name

--- a/packages/dev/core/src/Lights/pointLight.ts
+++ b/packages/dev/core/src/Lights/pointLight.ts
@@ -171,16 +171,6 @@ export class PointLight extends ShadowLight {
         );
     }
 
-    protected _buildUniformLayout(): void {
-        this._uniformBuffer.addUniform("vLightData", 4);
-        this._uniformBuffer.addUniform("vLightDiffuse", 4);
-        this._uniformBuffer.addUniform("vLightSpecular", 4);
-        this._uniformBuffer.addUniform("vLightFalloff", 4);
-        this._uniformBuffer.addUniform("shadowsInfo", 3);
-        this._uniformBuffer.addUniform("depthValues", 2);
-        this._uniformBuffer.create();
-    }
-
     /**
      * Sets the passed Effect "effect" with the PointLight transformed position (or position, if none) and passed name (string).
      * @param effect The effect to update
@@ -189,12 +179,12 @@ export class PointLight extends ShadowLight {
      */
     public transferToEffect(effect: Effect, lightIndex: string): PointLight {
         if (this.computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4("vLightData", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, 0.0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightPosition", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, 0.0, lightIndex);
         } else {
-            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, 0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightPosition", this.position.x, this.position.y, this.position.z, 0, lightIndex);
         }
 
-        this._uniformBuffer.updateFloat4("vLightFalloff", this.range, this._inverseSquaredRange, 0, 0, lightIndex);
+        this._uniformBuffer.updateFloat4("vLightDataB", this.range, this._inverseSquaredRange, 0, 0, lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Lights/rectAreaLight.ts
+++ b/packages/dev/core/src/Lights/rectAreaLight.ts
@@ -85,17 +85,6 @@ export class RectAreaLight extends AreaLight {
         return Light.LIGHTTYPEID_RECT_AREALIGHT;
     }
 
-    protected _buildUniformLayout(): void {
-        this._uniformBuffer.addUniform("vLightData", 4);
-        this._uniformBuffer.addUniform("vLightDiffuse", 4);
-        this._uniformBuffer.addUniform("vLightSpecular", 4);
-        this._uniformBuffer.addUniform("vLightWidth", 4);
-        this._uniformBuffer.addUniform("vLightHeight", 4);
-        this._uniformBuffer.addUniform("shadowsInfo", 3);
-        this._uniformBuffer.addUniform("depthValues", 2);
-        this._uniformBuffer.create();
-    }
-
     protected _computeTransformedInformation(): boolean {
         if (this.parent && this.parent.getWorldMatrix) {
             Vector3.TransformCoordinatesToRef(this.position, this.parent.getWorldMatrix(), this._pointTransformedPosition);
@@ -115,10 +104,10 @@ export class RectAreaLight extends AreaLight {
      */
     public transferToEffect(effect: Effect, lightIndex: string): RectAreaLight {
         if (this._computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4("vLightData", this._pointTransformedPosition.x, this._pointTransformedPosition.y, this._pointTransformedPosition.z, 0, lightIndex);
-            this._uniformBuffer.updateFloat4("vLightWidth", this._pointTransformedWidth.x / 2, this._pointTransformedWidth.y / 2, this._pointTransformedWidth.z / 2, 0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightPosition", this._pointTransformedPosition.x, this._pointTransformedPosition.y, this._pointTransformedPosition.z, 0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightDataA", this._pointTransformedWidth.x / 2, this._pointTransformedWidth.y / 2, this._pointTransformedWidth.z / 2, 0, lightIndex);
             this._uniformBuffer.updateFloat4(
-                "vLightHeight",
+                "vLightDataB",
                 this._pointTransformedHeight.x / 2,
                 this._pointTransformedHeight.y / 2,
                 this._pointTransformedHeight.z / 2,
@@ -126,9 +115,9 @@ export class RectAreaLight extends AreaLight {
                 lightIndex
             );
         } else {
-            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, 0, lightIndex);
-            this._uniformBuffer.updateFloat4("vLightWidth", this._width.x / 2, this._width.y / 2, this._width.z / 2, 0.0, lightIndex);
-            this._uniformBuffer.updateFloat4("vLightHeight", this._height.x / 2, this._height.y / 2, this._height.z / 2, 0.0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightPosition", this.position.x, this.position.y, this.position.z, 0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightDataA", this._width.x / 2, this._width.y / 2, this._width.z / 2, 0.0, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightDataB", this._height.x / 2, this._height.y / 2, this._height.z / 2, 0.0, lightIndex);
         }
         return this;
     }

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -493,8 +493,7 @@ export class SpotLight extends ShadowLight {
      * @param defines the list of defines
      * @param lightIndex defines the index of the light for the effect
      */
-    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
-        defines["SPOTLIGHT" + lightIndex] = true;
+    public override prepareLightSpecificDefines(defines: any, lightIndex: number): void {
         defines["PROJECTEDLIGHTTEXTURE" + lightIndex] = this.projectionTexture && this.projectionTexture.isReady() ? true : false;
         defines["IESLIGHTTEXTURE" + lightIndex] = this._iesProfileTexture && this._iesProfileTexture.isReady() ? true : false;
     }

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -375,17 +375,6 @@ export class SpotLight extends ShadowLight {
         this._projectionTextureMatrix.multiplyToRef(this._projectionTextureScalingMatrix, this._projectionTextureMatrix);
     }
 
-    protected _buildUniformLayout(): void {
-        this._uniformBuffer.addUniform("vLightData", 4);
-        this._uniformBuffer.addUniform("vLightDiffuse", 4);
-        this._uniformBuffer.addUniform("vLightSpecular", 4);
-        this._uniformBuffer.addUniform("vLightDirection", 3);
-        this._uniformBuffer.addUniform("vLightFalloff", 4);
-        this._uniformBuffer.addUniform("shadowsInfo", 3);
-        this._uniformBuffer.addUniform("depthValues", 2);
-        this._uniformBuffer.create();
-    }
-
     private _computeAngleValues(): void {
         this._lightAngleScale = 1.0 / Math.max(0.001, Math.cos(this._innerAngle * 0.5) - this._cosHalfAngle);
         this._lightAngleOffset = -this._cosHalfAngle * this._lightAngleScale;
@@ -428,18 +417,18 @@ export class SpotLight extends ShadowLight {
         let normalizeDirection;
 
         if (this.computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4("vLightData", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, this.exponent, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightPosition", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, this.exponent, lightIndex);
 
             normalizeDirection = Vector3.Normalize(this.transformedDirection);
         } else {
-            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.exponent, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightPosition", this.position.x, this.position.y, this.position.z, this.exponent, lightIndex);
 
             normalizeDirection = Vector3.Normalize(this.direction);
         }
 
-        this._uniformBuffer.updateFloat4("vLightDirection", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, this._cosHalfAngle, lightIndex);
+        this._uniformBuffer.updateFloat4("vLightDataA", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, this._cosHalfAngle, lightIndex);
 
-        this._uniformBuffer.updateFloat4("vLightFalloff", this.range, this._inverseSquaredRange, this._lightAngleScale, this._lightAngleOffset, lightIndex);
+        this._uniformBuffer.updateFloat4("vLightDataB", this.range, this._inverseSquaredRange, this._lightAngleScale, this._lightAngleOffset, lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -66,7 +66,7 @@ export class UniformBuffer {
      * This is dynamic to allow compat with webgl 1 and 2.
      * You will need to pass the name of the uniform as well as the value.
      */
-    public updateFloat: (name: string, x: number) => void;
+    public updateFloat: (name: string, x: number, suffix?: string) => void;
 
     /**
      * Lambda to Update a vec2 of float in a uniform buffer.
@@ -856,8 +856,8 @@ export class UniformBuffer {
         this.updateUniform(name, UniformBuffer._TempBuffer, 8);
     }
 
-    private _updateFloatForEffect(name: string, x: number) {
-        this._currentEffect.setFloat(name, x);
+    private _updateFloatForEffect(name: string, x: number, suffix = "") {
+        this._currentEffect.setFloat(name + suffix, x);
     }
 
     private _updateFloatForUniform(name: string, x: number) {

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -196,15 +196,6 @@ if (light{X}.vLightType >= 0.0) {
                 #endif
             #endif
         #else
-            #ifdef AREALIGHT{X}
-                info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightPosition.xyz, light{X}.vLightDataA.rgb, light{X}.vLightDataB.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
-                #ifdef AREALIGHTNOROUGHTNESS
-                    0.5
-                #else
-                    vReflectionInfos.y
-                #endif
-                );
-            #else
             if (lightTypeId == LIGHTTYPEID_SPOTLIGHT) {
                 #ifdef IESLIGHTTEXTURE{X}
                     info = computeIESSpotLighting(viewDirectionW, normalW, light{X}.vLightPosition, light{X}.vLightDataA, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness, iesLightTexture{X});
@@ -220,8 +211,17 @@ if (light{X}.vLightType >= 0.0) {
                 info = computeLighting(viewDirectionW, normalW, direction, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, attenuation, glossiness);
             } else if (lightTypeId == LIGHTTYPEID_DIRECTIONALLIGHT) {
                 info = computeLighting(viewDirectionW, normalW, -light{X}.vLightDataA.xyz, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, 1.0, glossiness);
-            }
+            #if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
+            } else if (lightTypeId == LIGHTTYPEID_RECT_AREALIGHT) {
+                info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightPosition.xyz, light{X}.vLightDataA.rgb, light{X}.vLightDataB.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
+                #ifdef AREALIGHTNOROUGHTNESS
+                    0.5
+                #else
+                    vReflectionInfos.y
+                #endif
+                );
             #endif
+            }
         #endif
 
         #ifdef PROJECTEDLIGHTTEXTURE{X}

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragmentDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragmentDeclaration.fx
@@ -1,93 +1,78 @@
-﻿#ifdef LIGHT{X}
-	uniform vec4 vLightData{X};
-	uniform vec4 vLightDiffuse{X};
+﻿uniform float vLightType{X};
+uniform vec4 vLightPosition{X};
+uniform vec4 vLightDiffuse{X};
+uniform vec4 vLightSpecular{X};
+uniform vec4 vLightDataA{X};
+uniform vec4 vLightDataB{X};
+uniform vec4 shadowsInfo{X};
+uniform vec2 depthValues{X};
 
-	#ifdef SPECULARTERM
-		uniform vec4 vLightSpecular{X};
-	#else
-		vec4 vLightSpecular{X} = vec4(0.);
-	#endif
-	#ifdef SHADOW{X}
-        #ifdef SHADOWCSM{X}
-            uniform mat4 lightMatrix{X}[SHADOWCSMNUM_CASCADES{X}];
-            uniform float viewFrustumZ{X}[SHADOWCSMNUM_CASCADES{X}];
-            uniform float frustumLengths{X}[SHADOWCSMNUM_CASCADES{X}];
-            uniform float cascadeBlendFactor{X};
+#ifdef SHADOW{X}
+    #ifdef SHADOWCSM{X}
+        uniform mat4 lightMatrix{X}[SHADOWCSMNUM_CASCADES{X}];
+        uniform float viewFrustumZ{X}[SHADOWCSMNUM_CASCADES{X}];
+        uniform float frustumLengths{X}[SHADOWCSMNUM_CASCADES{X}];
+        uniform float cascadeBlendFactor{X};
 
-            varying vec4 vPositionFromLight{X}[SHADOWCSMNUM_CASCADES{X}];
-            varying float vDepthMetric{X}[SHADOWCSMNUM_CASCADES{X}];
-            varying vec4 vPositionFromCamera{X};
+        varying vec4 vPositionFromLight{X}[SHADOWCSMNUM_CASCADES{X}];
+        varying float vDepthMetric{X}[SHADOWCSMNUM_CASCADES{X}];
+        varying vec4 vPositionFromCamera{X};
 
-            #if defined(SHADOWPCSS{X})
-                uniform highp sampler2DArrayShadow shadowTexture{X};
-                uniform highp sampler2DArray depthTexture{X};
-                uniform vec2 lightSizeUVCorrection{X}[SHADOWCSMNUM_CASCADES{X}];
-                uniform float depthCorrection{X}[SHADOWCSMNUM_CASCADES{X}];
-                uniform float penumbraDarkness{X};
-            #elif defined(SHADOWPCF{X})
-                uniform highp sampler2DArrayShadow shadowTexture{X};
-            #else
-                uniform highp sampler2DArray shadowTexture{X};
-            #endif
+        #if defined(SHADOWPCSS{X})
+            uniform highp sampler2DArrayShadow shadowTexture{X};
+            uniform highp sampler2DArray depthTexture{X};
+            uniform vec2 lightSizeUVCorrection{X}[SHADOWCSMNUM_CASCADES{X}];
+            uniform float depthCorrection{X}[SHADOWCSMNUM_CASCADES{X}];
+            uniform float penumbraDarkness{X};
+        #elif defined(SHADOWPCF{X})
+            uniform highp sampler2DArrayShadow shadowTexture{X};
+        #else
+            uniform highp sampler2DArray shadowTexture{X};
+        #endif
 
-            #ifdef SHADOWCSMDEBUG{X}
-                const vec3 vCascadeColorsMultiplier{X}[8] = vec3[8]
-                (
-                    vec3 ( 1.5, 0.0, 0.0 ),
-                    vec3 ( 0.0, 1.5, 0.0 ),
-                    vec3 ( 0.0, 0.0, 5.5 ),
-                    vec3 ( 1.5, 0.0, 5.5 ),
-                    vec3 ( 1.5, 1.5, 0.0 ),
-                    vec3 ( 1.0, 1.0, 1.0 ),
-                    vec3 ( 0.0, 1.0, 5.5 ),
-                    vec3 ( 0.5, 3.5, 0.75 )
-                );
-                vec3 shadowDebug{X};
-            #endif
+        #ifdef SHADOWCSMDEBUG{X}
+            const vec3 vCascadeColorsMultiplier{X}[8] = vec3[8]
+            (
+                vec3 ( 1.5, 0.0, 0.0 ),
+                vec3 ( 0.0, 1.5, 0.0 ),
+                vec3 ( 0.0, 0.0, 5.5 ),
+                vec3 ( 1.5, 0.0, 5.5 ),
+                vec3 ( 1.5, 1.5, 0.0 ),
+                vec3 ( 1.0, 1.0, 1.0 ),
+                vec3 ( 0.0, 1.0, 5.5 ),
+                vec3 ( 0.5, 3.5, 0.75 )
+            );
+            vec3 shadowDebug{X};
+        #endif
 
-            #ifdef SHADOWCSMUSESHADOWMAXZ{X}
-                int index{X} = -1;
-            #else
-                int index{X} = SHADOWCSMNUM_CASCADES{X} - 1;
-            #endif
+        #ifdef SHADOWCSMUSESHADOWMAXZ{X}
+            int index{X} = -1;
+        #else
+            int index{X} = SHADOWCSMNUM_CASCADES{X} - 1;
+        #endif
 
-            float diff{X} = 0.;
-        #elif defined(SHADOWCUBE{X})
-			uniform samplerCube shadowTexture{X};
-		#else
-			varying vec4 vPositionFromLight{X};
-			varying float vDepthMetric{X};
+        float diff{X} = 0.;
+    #elif defined(SHADOWCUBE{X})
+        uniform samplerCube shadowTexture{X};
+    #else
+        varying vec4 vPositionFromLight{X};
+        varying float vDepthMetric{X};
 
-			#if defined(SHADOWPCSS{X})
-				uniform highp sampler2DShadow shadowTexture{X};
-				uniform highp sampler2D depthTexture{X};
-			#elif defined(SHADOWPCF{X})
-				uniform highp sampler2DShadow shadowTexture{X};
-			#else
-				uniform sampler2D shadowTexture{X};
-			#endif
-			uniform mat4 lightMatrix{X};
-		#endif
-		uniform vec4 shadowsInfo{X};
-		uniform vec2 depthValues{X};
-	#endif
-	#ifdef SPOTLIGHT{X}
-		uniform vec4 vLightDirection{X};
-		uniform vec4 vLightFalloff{X};
-	#elif defined(POINTLIGHT{X})
-		uniform vec4 vLightFalloff{X};
-	#elif defined(HEMILIGHT{X})
-		uniform vec3 vLightGround{X};
+        #if defined(SHADOWPCSS{X})
+            uniform highp sampler2DShadow shadowTexture{X};
+            uniform highp sampler2D depthTexture{X};
+        #elif defined(SHADOWPCF{X})
+            uniform highp sampler2DShadow shadowTexture{X};
+        #else
+            uniform sampler2D shadowTexture{X};
+        #endif
+        uniform mat4 lightMatrix{X};
     #endif
-    #ifdef AREALIGHT{X}
-        uniform vec4 vLightWidth{X};
-        uniform vec4 vLightHeight{X};
-	#endif
-	#ifdef IESLIGHTTEXTURE{X}
-		uniform sampler2D iesLightTexture{X};
-	#endif
-	#ifdef PROJECTEDLIGHTTEXTURE{X}
-		uniform mat4 textureProjectionMatrix{X};
-		uniform sampler2D projectionLightTexture{X};
-	#endif
+#endif
+#ifdef IESLIGHTTEXTURE{X}
+    uniform sampler2D iesLightTexture{X};
+#endif
+#ifdef PROJECTEDLIGHTTEXTURE{X}
+    uniform mat4 textureProjectionMatrix{X};
+    uniform sampler2D projectionLightTexture{X};
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightVxFragmentDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightVxFragmentDeclaration.fx
@@ -1,39 +1,24 @@
-﻿#ifdef LIGHT{X}
-	uniform vec4 vLightData{X};
-	uniform vec4 vLightDiffuse{X};
+﻿uniform float vLightType{X};
+uniform vec4 vLightPosition{X};
+uniform vec4 vLightDiffuse{X};
+uniform vec4 vLightSpecular{X};
+uniform vec4 vLightDataA{X};
+uniform vec4 vLightDataB{X};
+uniform vec4 shadowsInfo{X};
+uniform vec2 depthValues{X};
 
-	#ifdef SPECULARTERM
-		uniform vec4 vLightSpecular{X};
+#ifdef SHADOW{X}
+	#ifdef SHADOWCSM{X}
+		uniform mat4 lightMatrix{X}[SHADOWCSMNUM_CASCADES{X}];
+
+		varying vec4 vPositionFromLight{X}[SHADOWCSMNUM_CASCADES{X}];
+		varying float vDepthMetric{X}[SHADOWCSMNUM_CASCADES{X}];
+		varying vec4 vPositionFromCamera{X};
+	#elif defined(SHADOWCUBE{X})
 	#else
-		vec4 vLightSpecular{X} = vec4(0.);
-	#endif
-	#ifdef SHADOW{X}
-        #ifdef SHADOWCSM{X}
-            uniform mat4 lightMatrix{X}[SHADOWCSMNUM_CASCADES{X}];
+		varying vec4 vPositionFromLight{X};
+		varying float vDepthMetric{X};
 
-            varying vec4 vPositionFromLight{X}[SHADOWCSMNUM_CASCADES{X}];
-            varying float vDepthMetric{X}[SHADOWCSMNUM_CASCADES{X}];
-            varying vec4 vPositionFromCamera{X};
-        #elif defined(SHADOWCUBE{X})
-		#else
-			varying vec4 vPositionFromLight{X};
-			varying float vDepthMetric{X};
-
-			uniform mat4 lightMatrix{X};
-		#endif
-		uniform vec4 shadowsInfo{X};
-		uniform vec2 depthValues{X};
-	#endif
-	#ifdef SPOTLIGHT{X}
-		uniform vec4 vLightDirection{X};
-		uniform vec4 vLightFalloff{X};
-	#elif defined(POINTLIGHT{X})
-		uniform vec4 vLightFalloff{X};
-	#elif defined(HEMILIGHT{X})
-		uniform vec3 vLightGround{X};
-	#endif
-	#if defined(AREALIGHT{X})
-		uniform vec4 vLightWidth{X};
-		uniform vec4 vLightHeight{X};
+		uniform mat4 lightMatrix{X};
 	#endif
 #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -10,22 +10,10 @@ struct lightingInfo
 #endif
 };
 
-lightingInfo computeLighting(vec3 viewDirectionW, vec3 vNormal, vec4 lightData, vec3 diffuseColor, vec3 specularColor, float range, float glossiness) {
+lightingInfo computeLighting(vec3 viewDirectionW, vec3 vNormal, vec3 direction, vec3 diffuseColor, vec3 specularColor, float attenuation, float glossiness) {
 	lightingInfo result;
 
-	vec3 lightVectorW;
-	float attenuation = 1.0;
-	if (lightData.w == 0.)
-	{
-		vec3 direction = lightData.xyz - vPositionW;
-
-		attenuation = max(0., 1.0 - length(direction) / range);
-		lightVectorW = normalize(direction);
-	}
-	else
-	{
-		lightVectorW = normalize(-lightData.xyz);
-	}
+	vec3 lightVectorW = normalize(direction);
 
 	// diffuse
 	float ndl = max(0., dot(vNormal, lightVectorW));

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrDirectLightingSetupFunctions.fx
@@ -27,13 +27,10 @@ struct preLightingInfo
         float iridescenceIntensity;
     #endif
 
-    #if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
-        vec3 areaLightDiffuse;
-
-        #ifdef SPECULARTERM
-            vec3 areaLightSpecular;
-            vec4 areaLightFresnel;
-        #endif
+    vec3 areaLightDiffuse;
+    #ifdef SPECULARTERM
+        vec3 areaLightSpecular;
+        vec4 areaLightFresnel;
     #endif
 };
 
@@ -104,7 +101,6 @@ preLightingInfo computeHemisphericPreLightingInfo(vec4 lightData, vec3 V, vec3 N
     return result;
 }
 
-#if defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 #include<ltcHelperFunctions>
 
 uniform sampler2D areaLightsLTC1Sampler;
@@ -132,4 +128,3 @@ preLightingInfo computeAreaPreLightingInfo(sampler2D ltc1, sampler2D ltc2, vec3 
     result.surfaceAlbedo = vec3(0.);
 	return result;
 }
-#endif

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -1358,6 +1358,9 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         return this._lightsEnabled;
     }
 
+    /** @internal */
+    public _defaultLight?: Light;
+
     private _activeCameras: Nullable<Camera[]>;
     private _unObserveActiveCameras: Nullable<() => void> = null;
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -68,6 +68,7 @@ import type { Camera } from "./Cameras/camera";
 import type { Collider } from "./Collisions/collider";
 import type { Ray, MeshPredicate, TrianglePickingPredicate } from "./Culling/ray.core";
 import type { Light } from "./Lights/light";
+import { DisabledLight } from "./Lights/disabledLight";
 import type { PerformanceViewerCollector } from "./Misc/PerformanceViewer/performanceViewerCollector";
 import type { MorphTarget } from "./Morph/morphTarget";
 import type { MorphTargetManager } from "./Morph/morphTargetManager";
@@ -1359,7 +1360,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     }
 
     /** @internal */
-    public _defaultLight?: Light;
+    public _disabledLight: DisabledLight;
 
     private _activeCameras: Nullable<Camera[]>;
     private _unObserveActiveCameras: Nullable<() => void> = null;
@@ -1961,6 +1962,8 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         if (!options || !options.virtual) {
             engine.onNewSceneAddedObservable.notifyObservers(this);
         }
+
+        this._disabledLight = new DisabledLight("disabled", this);
     }
 
     /**


### PR DESCRIPTION
This is just the groundwork so far, making all the lights share the same uniforms. A lot isn't supported right now, notably:
- [ ] PBR materials
- [ ] area lights (need to figure out if I can have a default for the LTC textures? or maybe I just add them to the "not dynamic" list)
- [ ] all the defines are still added and recompilation occurs, need to reduce that down
- [ ] sort the lights that can be dynamic after the lights that can't (for example a sun light with shadows should always the first light)
- [ ] filter out lights that are both dynamic and too far away (might be seperate PR?)

I don't currently plan to make these dynamic (notably since I _assume_ there won't be many lights with these, and also I feel like it would add too much branching in the shader):
- Shadows
- lights with falloff other than `FALLOFF_DEFAULT` (maybe an option could be added to set the default falloff?)