### PR TITLE
glTF Exporter: Don't modify original quaternion reference!

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -654,7 +654,7 @@ export class GLTFExporter {
         }
 
         const rotationQuaternion =
-            babylonTransformNode.rotationQuaternion ||
+            babylonTransformNode.rotationQuaternion?.clone() ||
             Quaternion.FromEulerAngles(babylonTransformNode.rotation.x, babylonTransformNode.rotation.y, babylonTransformNode.rotation.z);
 
         if (!rotationQuaternion.equalsWithEpsilon(DefaultRotation, Epsilon)) {


### PR DESCRIPTION
Fixes bug from #16708