### PR TITLE
Inspector v2: Rendering Pipelines in Scene Explorer

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderPipeline.ts
@@ -1,6 +1,7 @@
 import type { Nullable } from "../../types";
 import { Tools } from "../../Misc/tools";
 import { serialize } from "../../Misc/decorators";
+import { UniqueIdGenerator } from "core/Misc/uniqueIdGenerator";
 import type { Camera } from "../../Cameras/camera";
 import type { AbstractEngine } from "../../Engines/abstractEngine";
 import type { PostProcessRenderEffect } from "./postProcessRenderEffect";
@@ -37,6 +38,11 @@ export class PostProcessRenderPipeline {
     public get name(): string {
         return this._name;
     }
+
+    /**
+     * Gets the unique id of the post process rendering pipeline
+     */
+    public readonly uniqueId = UniqueIdGenerator.UniqueId;
 
     /** Gets the list of attached cameras */
     public get cameras() {

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderPipelineManager.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderPipelineManager.ts
@@ -1,18 +1,34 @@
-import type { Camera } from "../../Cameras/camera";
-import type { PostProcessRenderPipeline } from "./postProcessRenderPipeline";
+import type { Camera, IReadonlyObservable, PostProcessRenderPipeline } from "core/index";
+
+import { Observable } from "../../Misc/observable";
+
 /**
  * PostProcessRenderPipelineManager class
  * @see https://doc.babylonjs.com/features/featuresDeepDive/postProcesses/postProcessRenderPipeline
  */
 export class PostProcessRenderPipelineManager {
-    private _renderPipelines: { [Key: string]: PostProcessRenderPipeline };
+    private readonly _renderPipelines: { [Key: string]: PostProcessRenderPipeline } = {};
+    private readonly _onNewPipelineAddedObservable = new Observable<PostProcessRenderPipeline>();
+    private readonly _onPipelineRemovedObservable = new Observable<PostProcessRenderPipeline>();
 
     /**
      * Initializes a PostProcessRenderPipelineManager
      * @see https://doc.babylonjs.com/features/featuresDeepDive/postProcesses/postProcessRenderPipeline
      */
-    constructor() {
-        this._renderPipelines = {};
+    constructor() {}
+
+    /**
+     * An event triggered when a pipeline is added to the manager
+     */
+    public get onNewPipelineAddedObservable(): IReadonlyObservable<PostProcessRenderPipeline> {
+        return this._onNewPipelineAddedObservable;
+    }
+
+    /**
+     * An event triggered when a pipeline is removed from the manager
+     */
+    public get onPipelineRemovedObservable(): IReadonlyObservable<PostProcessRenderPipeline> {
+        return this._onPipelineRemovedObservable;
     }
 
     /**
@@ -38,7 +54,9 @@ export class PostProcessRenderPipelineManager {
      * @param renderPipeline The pipeline to add
      */
     public addPipeline(renderPipeline: PostProcessRenderPipeline): void {
+        this.removePipeline(renderPipeline._name);
         this._renderPipelines[renderPipeline._name] = renderPipeline;
+        this._onNewPipelineAddedObservable.notifyObservers(renderPipeline);
     }
 
     /**
@@ -46,7 +64,11 @@ export class PostProcessRenderPipelineManager {
      * @param renderPipelineName the name of the pipeline to remove
      */
     public removePipeline(renderPipelineName: string): void {
-        delete this._renderPipelines[renderPipelineName];
+        const pipeline = this._renderPipelines[renderPipelineName];
+        if (pipeline) {
+            this._onPipelineRemovedObservable.notifyObservers(pipeline);
+            delete this._renderPipelines[renderPipelineName];
+        }
     }
 
     /**

--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -1,8 +1,11 @@
 import type { FunctionComponent } from "react";
 
+import { useMemo } from "react";
+
 import { TextInputPropertyLine } from "shared-ui-components/fluent/hoc/inputPropertyLine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/textPropertyLine";
 import { useProperty } from "../../hooks/compoundPropertyHooks";
+import { GetPropertyDescriptor, IsPropertyReadonly } from "../../instrumentation/propertyInstrumentation";
 
 type CommonEntity = {
     readonly id?: number;
@@ -15,14 +18,20 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
     const { commonEntity } = props;
 
     const name = useProperty(commonEntity, "name");
+    const namePropertyDescriptor = useMemo(() => GetPropertyDescriptor(commonEntity, "name")?.[1], [commonEntity]);
+    const isNameReadonly = !namePropertyDescriptor || IsPropertyReadonly(namePropertyDescriptor);
+
     const className = commonEntity.constructor?.name || commonEntity.getClassName?.();
 
     return (
         <>
             {commonEntity.id !== undefined && <TextPropertyLine key="EntityId" label="ID" description="The id of the node." value={commonEntity.id.toString()} />}
-            {name !== undefined && (
-                <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
-            )}
+            {name !== undefined &&
+                (isNameReadonly ? (
+                    <TextPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} />
+                ) : (
+                    <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
+                ))}
             {commonEntity.uniqueId !== undefined && (
                 <TextPropertyLine key="EntityUniqueId" label="Unique ID" description="The unique id of the node." value={commonEntity.uniqueId.toString()} />
             )}

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -29,6 +29,7 @@ import { PhysicsPropertiesServiceDefinition } from "./services/panes/properties/
 import { MaterialExplorerServiceDefinition } from "./services/panes/scene/materialExplorerService";
 import { NodeHierarchyServiceDefinition } from "./services/panes/scene/nodeExplorerService";
 import { SceneExplorerServiceDefinition } from "./services/panes/scene/sceneExplorerService";
+import { RenderingPipelineHierarchyServiceDefinition } from "./services/panes/scene/renderingPipelinesExplorerService";
 import { SkeletonHierarchyServiceDefinition } from "./services/panes/scene/skeletonExplorerService";
 import { SpriteManagerHierarchyServiceDefinition } from "./services/panes/scene/spriteManagerExplorerService";
 import { TextureHierarchyServiceDefinition } from "./services/panes/scene/texturesExplorerService";
@@ -183,6 +184,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             SkeletonHierarchyServiceDefinition,
             TextureHierarchyServiceDefinition,
             SpriteManagerHierarchyServiceDefinition,
+            RenderingPipelineHierarchyServiceDefinition,
 
             // Properties pane tab and related services.
             PropertiesServiceDefinition,

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -1,0 +1,39 @@
+import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneExplorerService } from "./sceneExplorerService";
+
+import { PipelineRegular } from "@fluentui/react-icons";
+
+import { PostProcessRenderPipeline } from "core/PostProcesses/RenderPipeline/postProcessRenderPipeline";
+import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
+
+import "core/PostProcesses/RenderPipeline/postProcessRenderPipelineManagerSceneComponent";
+
+export const RenderingPipelineHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+    friendlyName: "Rendering Pipeline Hierarchy",
+    consumes: [SceneExplorerServiceIdentity],
+    factory: (sceneExplorerService) => {
+        const sectionRegistration = sceneExplorerService.addSection<PostProcessRenderPipeline>({
+            displayName: "Rendering Pipelines",
+            order: 4,
+            predicate: (entity) => entity instanceof PostProcessRenderPipeline,
+            getRootEntities: (scene) => scene.postProcessRenderPipelineManager.supportedPipelines ?? [],
+            getEntityDisplayInfo: (pipeline) => {
+                return {
+                    get name() {
+                        const typeName = pipeline.constructor.name || pipeline.getClassName();
+                        return `${pipeline.name} (${typeName})`;
+                    },
+                };
+            },
+            entityIcon: () => <PipelineRegular />,
+            getEntityAddedObservables: (scene) => [scene.postProcessRenderPipelineManager.onNewPipelineAddedObservable],
+            getEntityRemovedObservables: (scene) => [scene.postProcessRenderPipelineManager.onPipelineRemovedObservable],
+        });
+
+        return {
+            dispose: () => {
+                sectionRegistration?.dispose();
+            },
+        };
+    },
+};


### PR DESCRIPTION
This change is mostly just adding basic support for rendering pipelines in scene explorer, but required a few additional changes:
- Added a `uniqueId` to rendering pipelines (everything in the tree needs a unique id, and it is simplest if it is defined directly on the entity, which is usually the case).
- Added observables for adding/removing rendering pipelines.
- Updated the common properties to handle the case where the `name` property is readonly (as is the case with rendering pipelines).