### PR TITLE
Initial clustered lights implementation (tiled clustering only)

### DIFF
--- a/packages/dev/core/src/Engines/engineCapabilities.ts
+++ b/packages/dev/core/src/Engines/engineCapabilities.ts
@@ -80,6 +80,8 @@ export interface EngineCapabilities {
     depthTextureExtension: boolean;
     /** Defines if float color buffer are supported */
     colorBufferFloat: boolean;
+    /** Defines if float color blending is supported */
+    blendFloat: boolean;
     /** Defines if half float color buffer are supported */
     colorBufferHalfFloat?: boolean;
     /** Gets disjoint timer query extension (null if not supported) */

--- a/packages/dev/core/src/Engines/nativeEngine.ts
+++ b/packages/dev/core/src/Engines/nativeEngine.ts
@@ -297,6 +297,7 @@ export class NativeEngine extends Engine {
             fragmentDepthSupported: false,
             highPrecisionShaderSupported: true,
             colorBufferFloat: false,
+            blendFloat: false,
             supportFloatTexturesResolve: false,
             rg11b10ufColorRenderable: false,
             textureFloat: true,

--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -144,6 +144,7 @@ export class NullEngine extends Engine {
             fragmentDepthSupported: false,
             highPrecisionShaderSupported: true,
             colorBufferFloat: false,
+            blendFloat: false,
             supportFloatTexturesResolve: false,
             rg11b10ufColorRenderable: false,
             textureFloat: false,

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -122,7 +122,7 @@ export class ThinEngine extends AbstractEngine {
         { key: "Chrome/74.+?Mobile", capture: null, captureConstraint: null, targets: ["vao"] },
         { key: "Mac OS.+Chrome/71", capture: null, captureConstraint: null, targets: ["vao"] },
         { key: "Mac OS.+Chrome/72", capture: null, captureConstraint: null, targets: ["vao"] },
-        // { key: "Mac OS.+Chrome", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
+        { key: "Mac OS.+Chrome", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
         { key: "Chrome/12\\d\\..+?Mobile", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
         // desktop osx safari 15.4
         { key: ".*AppleWebKit.*(15.4).*Safari", capture: null, captureConstraint: null, targets: ["antialias", "maxMSAASamples"] },
@@ -533,6 +533,7 @@ export class ThinEngine extends AbstractEngine {
             drawBuffersExtension: false,
             maxMSAASamples: 1,
             colorBufferFloat: !!(this._webGLVersion > 1 && this._gl.getExtension("EXT_color_buffer_float")),
+            blendFloat: this._gl.getExtension("EXT_float_blend") !== null,
             supportFloatTexturesResolve: false,
             rg11b10ufColorRenderable: false,
             colorBufferHalfFloat: !!(this._webGLVersion > 1 && this._gl.getExtension("EXT_color_buffer_half_float")),

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -122,7 +122,7 @@ export class ThinEngine extends AbstractEngine {
         { key: "Chrome/74.+?Mobile", capture: null, captureConstraint: null, targets: ["vao"] },
         { key: "Mac OS.+Chrome/71", capture: null, captureConstraint: null, targets: ["vao"] },
         { key: "Mac OS.+Chrome/72", capture: null, captureConstraint: null, targets: ["vao"] },
-        { key: "Mac OS.+Chrome", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
+        // { key: "Mac OS.+Chrome", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
         { key: "Chrome/12\\d\\..+?Mobile", capture: null, captureConstraint: null, targets: ["uniformBuffer"] },
         // desktop osx safari 15.4
         { key: ".*AppleWebKit.*(15.4).*Safari", capture: null, captureConstraint: null, targets: ["antialias", "maxMSAASamples"] },

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -869,6 +869,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             fragmentDepthSupported: true,
             highPrecisionShaderSupported: true,
             colorBufferFloat: true,
+            blendFloat: this._deviceEnabledExtensions.indexOf(WebGPUConstants.FeatureName.Float32Blendable) >= 0,
             supportFloatTexturesResolve: false, // See https://github.com/gpuweb/gpuweb/issues/3844
             rg11b10ufColorRenderable: this._deviceEnabledExtensions.indexOf(WebGPUConstants.FeatureName.RG11B10UFloatRenderable) >= 0,
             textureFloat: true,

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightSceneComponent.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightSceneComponent.ts
@@ -1,0 +1,52 @@
+import { CreateSphere } from "core/Meshes/Builders/sphereBuilder";
+import type { Mesh } from "core/Meshes/mesh";
+import type { Scene } from "core/scene";
+import { type RenderTargetsStageAction, SceneComponentConstants, type ISceneComponent } from "core/sceneComponent";
+
+import { ClusteredLight } from "./clusteredLight";
+
+import { StandardMaterial } from "core/Materials/standardMaterial";
+
+class ClusteredLightSceneComponent implements ISceneComponent {
+    public name = SceneComponentConstants.NAME_CLUSTEREDLIGHT;
+
+    public scene: Scene;
+    public readonly sphere: Mesh;
+
+    constructor(scene: Scene) {
+        this.scene = scene;
+        this.sphere = CreateSphere("LightSphere", { segments: 8, diameter: 2 }, scene);
+        scene.removeMesh(this.sphere);
+
+        const material = new StandardMaterial("SphereMaterial", scene);
+        material.disableLighting = true;
+        this.sphere.material = material;
+    }
+
+    public dispose(): void {
+        this.sphere.dispose();
+    }
+
+    public rebuild(): void {}
+
+    public register(): void {
+        this.scene._gatherRenderTargetsStage.registerStep(SceneComponentConstants.STEP_GATHERRENDERTARGETS_CLUSTEREDLIGHT, this, this._gatherRenderTargets);
+    }
+
+    private _gatherRenderTargets: RenderTargetsStageAction = (renderTargets) => {
+        for (const light of this.scene.lights) {
+            if (light instanceof ClusteredLight && light.isSupported) {
+                renderTargets.push(light._lightMask);
+            }
+        }
+    };
+}
+
+ClusteredLight._SceneComponentInitialization = (scene) => {
+    let component = <ClusteredLightSceneComponent>scene._getComponent(SceneComponentConstants.NAME_CLUSTEREDLIGHT);
+    if (!component) {
+        component = new ClusteredLightSceneComponent(scene);
+        scene._addComponent(component);
+    }
+    return component.sphere;
+};

--- a/packages/dev/core/src/Lights/Clustered/index.ts
+++ b/packages/dev/core/src/Lights/Clustered/index.ts
@@ -1,0 +1,2 @@
+export * from "./clusteredLight";
+export * from "./clusteredLightSceneComponent";

--- a/packages/dev/core/src/Lights/Clustered/lightMaskMaterial.ts
+++ b/packages/dev/core/src/Lights/Clustered/lightMaskMaterial.ts
@@ -1,0 +1,23 @@
+import { Constants } from "core/Engines/constants";
+import type { Scene } from "core/scene";
+import { ShaderMaterial } from "core/Materials/shaderMaterial";
+
+import type { ClusteredLight } from "./clusteredLight";
+
+export class LightMaskMaterial extends ShaderMaterial {
+    constructor(name: string, light: ClusteredLight, index: number, scene: Scene) {
+        super(name, scene, "lightMask", {
+            attributes: ["position"],
+            uniforms: ["index", "world", "viewProjection"],
+            uniformBuffers: ["Scene", "Mesh", "Light0"],
+            defines: ["LIGHT0", "CLUSTLIGHT0", `CLUSTLIGHT_MAX ${light.maxLights}`],
+            extraInitializationsAsync: async () => {
+                await Promise.all([import("../../Shaders/lightMask.vertex"), import("../../Shaders/lightMask.fragment")]);
+            },
+        });
+
+        this.setUniformBuffer("Light0", light._uniformBuffer);
+        this.setUInt("index", index);
+        this.alphaMode = Constants.ALPHA_ADD;
+    }
+}

--- a/packages/dev/core/src/Lights/clusteredLight.ts
+++ b/packages/dev/core/src/Lights/clusteredLight.ts
@@ -1,33 +1,53 @@
+import type { AbstractEngine } from "core/Engines/abstractEngine";
+import { ThinEngine } from "core/Engines/thinEngine";
 import type { Effect } from "core/Materials/effect";
+import { Vector3 } from "core/Maths/math.vector";
+import { TmpColors } from "core/Maths/math.color";
 import type { Scene } from "core/scene";
-import type { Nullable } from "core/types";
 
 import { Light } from "./light";
+import { PointLight } from "./pointLight";
 import { SpotLight } from "./spotLight";
 
 const MAX_CLUSTERED_LIGHTS = 32;
 
 export class ClusteredLight extends Light {
-    private static _GetUnsupportedReason(light: Light): Nullable<string> {
-        // light.getEngine()._alphaMode
-        if (!(light instanceof SpotLight)) {
-            return "light is not a spot light";
+    private static _IsEngineSupported(engine: AbstractEngine): boolean {
+        if (engine.isWebGPU) {
+            return true;
+        } else if (engine instanceof ThinEngine && engine.version > 1) {
+            // On WebGL 2 we use additive float blending as the light mask
+            return engine._caps.colorBufferFloat && engine._caps.blendFloat;
+        } else {
+            // WebGL 1 is not supported due to lack of dynamic for loops
+            return false;
         }
-        // TODO: don't allow lights with shadows
-        return null;
     }
 
     public static IsLightSupported(light: Light): boolean {
-        return this._GetUnsupportedReason(light) === null;
+        if (!ClusteredLight._IsEngineSupported(light.getEngine())) {
+            return false;
+        } else if (light.shadowEnabled && light._scene.shadowsEnabled && light.getShadowGenerators()) {
+            // Shadows are not supported
+            return false;
+        } else if (light instanceof PointLight) {
+            return true;
+        } else if (light instanceof SpotLight) {
+            // Extra texture bindings per light are not supported
+            return !(light.projectionTexture || light.iesProfileTexture);
+        } else {
+            // Currently only point and spot lights are supported
+            return false;
+        }
     }
 
-    private _lights: Light[] = [];
+    private _lights: (PointLight | SpotLight)[] = [];
     public get lights(): readonly Light[] {
         return this._lights;
     }
 
-    private get _clusteredLights(): number {
-        return Math.min(this._lights.length, MAX_CLUSTERED_LIGHTS);
+    public get isSupported(): boolean {
+        return ClusteredLight._IsEngineSupported(this.getEngine());
     }
 
     constructor(name: string, lights: Light[] = [], scene?: Scene) {
@@ -42,53 +62,66 @@ export class ClusteredLight extends Light {
     }
 
     public addLight(light: Light): void {
-        const reason = ClusteredLight._GetUnsupportedReason(light);
-        if (reason !== null) {
-            throw new Error(`Cannot cluster light: ${reason}`);
+        if (ClusteredLight.IsLightSupported(light)) {
+            this._scene.removeLight(light);
+            this._lights.push(<PointLight | SpotLight>light);
         }
-        this._scene.removeLight(light);
-        this._lights.push(light);
-        this._markMeshesAsLightDirty();
     }
 
     protected _buildUniformLayout(): void {
+        this._uniformBuffer.addUniform("vLightData", 4);
+        this._uniformBuffer.addUniform("vLightDiffuse", 4);
+        this._uniformBuffer.addUniform("vLightSpecular", 4);
         for (let i = 0; i < MAX_CLUSTERED_LIGHTS; i += 1) {
-            const iAsString = i.toString();
-            this._uniformBuffer.addUniform("vLightData" + iAsString, 4);
-            this._uniformBuffer.addUniform("vLightDiffuse" + iAsString, 4);
-            this._uniformBuffer.addUniform("vLightSpecular" + iAsString, 4);
-            this._uniformBuffer.addUniform("vLightDirection" + iAsString, 4);
-            this._uniformBuffer.addUniform("vLightFalloff" + iAsString, 4);
+            // These technically don't have to match the field name but also why not
+            const struct = `vLights[${i}].`;
+            this._uniformBuffer.addUniform(struct + "position", 4);
+            this._uniformBuffer.addUniform(struct + "direction", 4);
+            this._uniformBuffer.addUniform(struct + "diffuse", 4);
+            this._uniformBuffer.addUniform(struct + "specular", 4);
+            this._uniformBuffer.addUniform(struct + "falloff", 4);
         }
-        this._uniformBuffer.create(true);
+        this._uniformBuffer.addUniform("shadowsInfo", 3);
+        this._uniformBuffer.addUniform("depthValues", 2);
+        this._uniformBuffer.create();
     }
 
-    /**
-     * Binds the lights information from the scene to the effect for the given mesh.
-     * @param lightIndex Light index
-     * @param scene The scene where the light belongs to
-     * @param effect The effect we are binding the data to
-     * @param useSpecular Defines if specular is supported
-     */
-    public override _bindLight(lightIndex: number, scene: Scene, effect: Effect, useSpecular: boolean): void {
-        let needUpdate = false;
+    public transferToEffect(effect: Effect, lightIndex: string): Light {
+        const len = Math.min(this._lights.length, MAX_CLUSTERED_LIGHTS);
+        this._uniformBuffer.updateFloat4("vLightData", len, 0, 0, 0, lightIndex);
 
-        this._uniformBuffer.bindToEffect(effect, "Light" + lightIndex.toString());
+        for (let i = 0; i < len; i += 1) {
+            const light = this._lights[i];
+            const spotLight = light instanceof SpotLight ? light : null;
+            const struct = `vLights[${i}].`;
 
-        for (let i = 0; i < this._clusteredLights; i += 1) {
-            if (this._lights[i]._bindLightToUniform(i, scene, effect, this._uniformBuffer, useSpecular, false)) {
-                needUpdate = true;
+            let position: Vector3;
+            let direction: Vector3;
+            if (light.computeTransformedInformation()) {
+                position = light.transformedPosition;
+                direction = Vector3.Normalize(light.transformedDirection);
+            } else {
+                position = light.position;
+                direction = Vector3.Normalize(light.direction);
             }
-        }
+            this._uniformBuffer.updateFloat4(struct + "position", position.x, position.y, position.z, spotLight?.exponent ?? 0, lightIndex);
+            this._uniformBuffer.updateFloat4(struct + "direction", direction.x, direction.y, direction.z, spotLight?._cosHalfAngle ?? 0, lightIndex);
 
-        if (needUpdate) {
-            this._uniformBuffer.update();
-        } else {
-            this._uniformBuffer.bindUniformBuffer();
-        }
-    }
+            const scaledIntensity = light.getScaledIntensity();
+            light.diffuse.scaleToRef(scaledIntensity, TmpColors.Color3[0]);
+            this._uniformBuffer.updateColor4(struct + "diffuse", TmpColors.Color3[0], light.range, lightIndex);
+            light.specular.scaleToRef(scaledIntensity, TmpColors.Color3[1]);
+            this._uniformBuffer.updateColor4(struct + "specular", TmpColors.Color3[1], light.radius, lightIndex);
 
-    public transferToEffect(): Light {
+            this._uniformBuffer.updateFloat4(
+                struct + "falloff",
+                light.range,
+                light._inverseSquaredRange,
+                spotLight?._lightAngleScale ?? 0,
+                spotLight?._lightAngleOffset ?? 0,
+                lightIndex
+            );
+        }
         return this;
     }
 
@@ -99,8 +132,6 @@ export class ClusteredLight extends Light {
 
     public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
         defines["CLUSTLIGHT" + lightIndex] = true;
-        // We're just using a define for now until we add proper light clustering
-        defines["CLUSTLIGHT_COUNT" + lightIndex] = this._clusteredLights;
-        defines["CLUSTLIGHTSUPPORTED"] = true;
+        defines["CLUSTLIGHTSUPPORTED"] = this.isSupported;
     }
 }

--- a/packages/dev/core/src/Lights/clusteredLight.ts
+++ b/packages/dev/core/src/Lights/clusteredLight.ts
@@ -1,0 +1,106 @@
+import type { Effect } from "core/Materials/effect";
+import type { Scene } from "core/scene";
+import type { Nullable } from "core/types";
+
+import { Light } from "./light";
+import { SpotLight } from "./spotLight";
+
+const MAX_CLUSTERED_LIGHTS = 32;
+
+export class ClusteredLight extends Light {
+    private static _GetUnsupportedReason(light: Light): Nullable<string> {
+        // light.getEngine()._alphaMode
+        if (!(light instanceof SpotLight)) {
+            return "light is not a spot light";
+        }
+        // TODO: don't allow lights with shadows
+        return null;
+    }
+
+    public static IsLightSupported(light: Light): boolean {
+        return this._GetUnsupportedReason(light) === null;
+    }
+
+    private _lights: Light[] = [];
+    public get lights(): readonly Light[] {
+        return this._lights;
+    }
+
+    private get _clusteredLights(): number {
+        return Math.min(this._lights.length, MAX_CLUSTERED_LIGHTS);
+    }
+
+    constructor(name: string, lights: Light[] = [], scene?: Scene) {
+        super(name, scene);
+        for (const light of lights) {
+            this.addLight(light);
+        }
+    }
+
+    public override getClassName(): string {
+        return "ClusteredLight";
+    }
+
+    public addLight(light: Light): void {
+        const reason = ClusteredLight._GetUnsupportedReason(light);
+        if (reason !== null) {
+            throw new Error(`Cannot cluster light: ${reason}`);
+        }
+        this._scene.removeLight(light);
+        this._lights.push(light);
+        this._markMeshesAsLightDirty();
+    }
+
+    protected _buildUniformLayout(): void {
+        for (let i = 0; i < MAX_CLUSTERED_LIGHTS; i += 1) {
+            const iAsString = i.toString();
+            this._uniformBuffer.addUniform("vLightData" + iAsString, 4);
+            this._uniformBuffer.addUniform("vLightDiffuse" + iAsString, 4);
+            this._uniformBuffer.addUniform("vLightSpecular" + iAsString, 4);
+            this._uniformBuffer.addUniform("vLightDirection" + iAsString, 4);
+            this._uniformBuffer.addUniform("vLightFalloff" + iAsString, 4);
+        }
+        this._uniformBuffer.create(true);
+    }
+
+    /**
+     * Binds the lights information from the scene to the effect for the given mesh.
+     * @param lightIndex Light index
+     * @param scene The scene where the light belongs to
+     * @param effect The effect we are binding the data to
+     * @param useSpecular Defines if specular is supported
+     */
+    public override _bindLight(lightIndex: number, scene: Scene, effect: Effect, useSpecular: boolean): void {
+        let needUpdate = false;
+
+        this._uniformBuffer.bindToEffect(effect, "Light" + lightIndex.toString());
+
+        for (let i = 0; i < this._clusteredLights; i += 1) {
+            if (this._lights[i]._bindLightToUniform(i, scene, effect, this._uniformBuffer, useSpecular, false)) {
+                needUpdate = true;
+            }
+        }
+
+        if (needUpdate) {
+            this._uniformBuffer.update();
+        } else {
+            this._uniformBuffer.bindUniformBuffer();
+        }
+    }
+
+    public transferToEffect(): Light {
+        return this;
+    }
+
+    public transferToNodeMaterialEffect(): Light {
+        // TODO: ????
+        return this;
+    }
+
+    public prepareLightSpecificDefines(defines: any, lightIndex: number): void {
+        defines["CLUSTLIGHT" + lightIndex] = true;
+        // We're just using a define for now until we add proper light clustering
+        defines["CLUSTLIGHT_COUNT" + lightIndex] = this._clusteredLights;
+        defines["CLUSTLIGHTSUPPORTED"] = true;
+    }
+}

--- a/packages/dev/core/src/Lights/index.ts
+++ b/packages/dev/core/src/Lights/index.ts
@@ -8,4 +8,5 @@ export * from "./pointLight";
 export * from "./spotLight";
 export * from "./areaLight";
 export * from "./rectAreaLight";
+export * from "./clusteredLight";
 export * from "./IES/iesLoader";

--- a/packages/dev/core/src/Lights/index.ts
+++ b/packages/dev/core/src/Lights/index.ts
@@ -8,5 +8,5 @@ export * from "./pointLight";
 export * from "./spotLight";
 export * from "./areaLight";
 export * from "./rectAreaLight";
-export * from "./clusteredLight";
+export * from "./Clustered/index";
 export * from "./IES/iesLoader";

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -484,7 +484,7 @@ export abstract class Light extends Node implements ISortableLight {
      */
     public override toString(fullDetails?: boolean): string {
         let ret = "Name: " + this.name;
-        ret += ", type: " + ["Point", "Directional", "Spot", "Hemispheric"][this.getTypeID()];
+        ret += ", type: " + ["Point", "Directional", "Spot", "Hemispheric", "Clustered"][this.getTypeID()];
         if (this.animations) {
             for (let i = 0; i < this.animations.length; i++) {
                 ret += ", animation[0]: " + this.animations[i].toString(fullDetails);

--- a/packages/dev/core/src/Lights/lightConstants.ts
+++ b/packages/dev/core/src/Lights/lightConstants.ts
@@ -91,6 +91,8 @@ export class LightConstants {
      */
     public static readonly LIGHTTYPEID_RECT_AREALIGHT = 4;
 
+    public static readonly LIGHTTYPEID_CLUSTERED = 5;
+
     /**
      * Sort function to order lights for rendering.
      * @param a First Light object to compare to second.

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -41,10 +41,13 @@ export class SpotLight extends ShadowLight {
 
     private _angle: number;
     private _innerAngle: number = 0;
-    private _cosHalfAngle: number;
+    /** @internal */
+    public _cosHalfAngle: number;
 
-    private _lightAngleScale: number;
-    private _lightAngleOffset: number;
+    /** @internal */
+    public _lightAngleScale: number;
+    /** @internal */
+    public _lightAngleOffset: number;
 
     private _iesProfileTexture: Nullable<BaseTexture> = null;
 
@@ -422,25 +425,24 @@ export class SpotLight extends ShadowLight {
      * Sets the passed Effect object with the SpotLight transformed position (or position if not parented) and normalized direction.
      * @param effect The effect to update
      * @param lightIndex The index of the light in the effect to update
-     * @param uniformBuffer The uniform buffer to update
      * @returns The spot light
      */
-    public transferToEffect(effect: Effect, lightIndex: string, uniformBuffer = this._uniformBuffer): SpotLight {
+    public transferToEffect(effect: Effect, lightIndex: string): SpotLight {
         let normalizeDirection;
 
         if (this.computeTransformedInformation()) {
-            uniformBuffer.updateFloat4("vLightData", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, this.exponent, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightData", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, this.exponent, lightIndex);
 
             normalizeDirection = Vector3.Normalize(this.transformedDirection);
         } else {
-            uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.exponent, lightIndex);
+            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.exponent, lightIndex);
 
             normalizeDirection = Vector3.Normalize(this.direction);
         }
 
-        uniformBuffer.updateFloat4("vLightDirection", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, this._cosHalfAngle, lightIndex);
+        this._uniformBuffer.updateFloat4("vLightDirection", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, this._cosHalfAngle, lightIndex);
 
-        uniformBuffer.updateFloat4("vLightFalloff", this.range, this._inverseSquaredRange, this._lightAngleScale, this._lightAngleOffset, lightIndex);
+        this._uniformBuffer.updateFloat4("vLightFalloff", this.range, this._inverseSquaredRange, this._lightAngleScale, this._lightAngleOffset, lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -422,24 +422,25 @@ export class SpotLight extends ShadowLight {
      * Sets the passed Effect object with the SpotLight transformed position (or position if not parented) and normalized direction.
      * @param effect The effect to update
      * @param lightIndex The index of the light in the effect to update
+     * @param uniformBuffer The uniform buffer to update
      * @returns The spot light
      */
-    public transferToEffect(effect: Effect, lightIndex: string): SpotLight {
+    public transferToEffect(effect: Effect, lightIndex: string, uniformBuffer = this._uniformBuffer): SpotLight {
         let normalizeDirection;
 
         if (this.computeTransformedInformation()) {
-            this._uniformBuffer.updateFloat4("vLightData", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, this.exponent, lightIndex);
+            uniformBuffer.updateFloat4("vLightData", this.transformedPosition.x, this.transformedPosition.y, this.transformedPosition.z, this.exponent, lightIndex);
 
             normalizeDirection = Vector3.Normalize(this.transformedDirection);
         } else {
-            this._uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.exponent, lightIndex);
+            uniformBuffer.updateFloat4("vLightData", this.position.x, this.position.y, this.position.z, this.exponent, lightIndex);
 
             normalizeDirection = Vector3.Normalize(this.direction);
         }
 
-        this._uniformBuffer.updateFloat4("vLightDirection", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, this._cosHalfAngle, lightIndex);
+        uniformBuffer.updateFloat4("vLightDirection", normalizeDirection.x, normalizeDirection.y, normalizeDirection.z, this._cosHalfAngle, lightIndex);
 
-        this._uniformBuffer.updateFloat4("vLightFalloff", this.range, this._inverseSquaredRange, this._lightAngleScale, this._lightAngleOffset, lightIndex);
+        uniformBuffer.updateFloat4("vLightFalloff", this.range, this._inverseSquaredRange, this._lightAngleScale, this._lightAngleOffset, lightIndex);
         return this;
     }
 

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -1074,6 +1074,7 @@ export function PrepareDefinesForCamera(scene: Scene, defines: any): boolean {
  * @param uniformBuffersList defines an optional list of uniform buffers
  * @param updateOnlyBuffersList True to only update the uniformBuffersList array
  * @param iesLightTexture defines if IES texture must be used
+ * @param lightMaskTexture defines if light mask texture must be used
  */
 export function PrepareUniformsAndSamplersForLight(
     lightIndex: number,
@@ -1082,7 +1083,8 @@ export function PrepareUniformsAndSamplersForLight(
     projectedLightTexture?: any,
     uniformBuffersList: Nullable<string[]> = null,
     updateOnlyBuffersList = false,
-    iesLightTexture = false
+    iesLightTexture = false,
+    lightMaskTexture = false
 ) {
     if (uniformBuffersList) {
         uniformBuffersList.push("Light" + lightIndex);
@@ -1125,6 +1127,9 @@ export function PrepareUniformsAndSamplersForLight(
     if (iesLightTexture) {
         samplersList.push("iesLightTexture" + lightIndex);
     }
+    if (lightMaskTexture) {
+        samplersList.push("lightMaskTexture" + lightIndex);
+    }
 }
 
 /**
@@ -1163,7 +1168,8 @@ export function PrepareUniformsAndSamplersList(uniformsListOrOptions: string[] |
             defines["PROJECTEDLIGHTTEXTURE" + lightIndex],
             uniformBuffersList,
             false,
-            defines["IESLIGHTTEXTURE" + lightIndex]
+            defines["IESLIGHTTEXTURE" + lightIndex],
+            defines["CLUSTLIGHT" + lightIndex]
         );
     }
 

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -567,6 +567,7 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
             defines["DIRLIGHT" + index] = false;
             defines["SPOTLIGHT" + index] = false;
             defines["AREALIGHT" + index] = false;
+            defines["CLUSTLIGHT" + index] = false;
             defines["SHADOW" + index] = false;
             defines["SHADOWCSM" + index] = false;
             defines["SHADOWCSMDEBUG" + index] = false;

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -40,6 +40,7 @@ export class UniformBuffer {
     private _currentEffectName: string;
     private _name: string;
     private _currentFrameId: number;
+    private _suffixUbo = false;
 
     // Pool for avoiding memory leaks
     private static _MAX_UNIFORM_SIZE = 256;
@@ -538,8 +539,9 @@ export class UniformBuffer {
 
     /**
      * Effectively creates the WebGL Uniform Buffer, once layout is completed with `addUniform`.
+     * @param suffixUbo Set to true to apply the suffixes to UBOs as well
      */
-    public create(): void {
+    public create(suffixUbo = false): void {
         if (this._noUBO) {
             return;
         }
@@ -554,6 +556,7 @@ export class UniformBuffer {
         this._rebuild();
 
         this._needSync = true;
+        this._suffixUbo = suffixUbo;
     }
 
     // The result of this method is used for debugging purpose, as part of the buffer name
@@ -890,7 +893,10 @@ export class UniformBuffer {
         this._currentEffect.setFloat4(name + suffix, x, y, z, w);
     }
 
-    private _updateFloat4ForUniform(name: string, x: number, y: number, z: number, w: number) {
+    private _updateFloat4ForUniform(name: string, x: number, y: number, z: number, w: number, suffix = "") {
+        if (this._suffixUbo) {
+            name += suffix;
+        }
         UniformBuffer._TempBuffer[0] = x;
         UniformBuffer._TempBuffer[1] = y;
         UniformBuffer._TempBuffer[2] = z;
@@ -992,7 +998,10 @@ export class UniformBuffer {
         this._currentEffect.setDirectColor4(name + suffix, color);
     }
 
-    private _updateColor4ForUniform(name: string, color: IColor3Like, alpha: number) {
+    private _updateColor4ForUniform(name: string, color: IColor3Like, alpha: number, suffix = "") {
+        if (this._suffixUbo) {
+            name += suffix;
+        }
         UniformBuffer._TempBuffer[0] = color.r;
         UniformBuffer._TempBuffer[1] = color.g;
         UniformBuffer._TempBuffer[2] = color.b;

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -40,7 +40,6 @@ export class UniformBuffer {
     private _currentEffectName: string;
     private _name: string;
     private _currentFrameId: number;
-    private _suffixUbo = false;
 
     // Pool for avoiding memory leaks
     private static _MAX_UNIFORM_SIZE = 256;
@@ -539,9 +538,8 @@ export class UniformBuffer {
 
     /**
      * Effectively creates the WebGL Uniform Buffer, once layout is completed with `addUniform`.
-     * @param suffixUbo Set to true to apply the suffixes to UBOs as well
      */
-    public create(suffixUbo = false): void {
+    public create(): void {
         if (this._noUBO) {
             return;
         }
@@ -556,7 +554,6 @@ export class UniformBuffer {
         this._rebuild();
 
         this._needSync = true;
-        this._suffixUbo = suffixUbo;
     }
 
     // The result of this method is used for debugging purpose, as part of the buffer name
@@ -893,10 +890,7 @@ export class UniformBuffer {
         this._currentEffect.setFloat4(name + suffix, x, y, z, w);
     }
 
-    private _updateFloat4ForUniform(name: string, x: number, y: number, z: number, w: number, suffix = "") {
-        if (this._suffixUbo) {
-            name += suffix;
-        }
+    private _updateFloat4ForUniform(name: string, x: number, y: number, z: number, w: number) {
         UniformBuffer._TempBuffer[0] = x;
         UniformBuffer._TempBuffer[1] = y;
         UniformBuffer._TempBuffer[2] = z;
@@ -998,10 +992,7 @@ export class UniformBuffer {
         this._currentEffect.setDirectColor4(name + suffix, color);
     }
 
-    private _updateColor4ForUniform(name: string, color: IColor3Like, alpha: number, suffix = "") {
-        if (this._suffixUbo) {
-            name += suffix;
-        }
+    private _updateColor4ForUniform(name: string, color: IColor3Like, alpha: number) {
         UniformBuffer._TempBuffer[0] = color.r;
         UniformBuffer._TempBuffer[1] = color.g;
         UniformBuffer._TempBuffer[2] = color.b;

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightClusteredDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightClusteredDeclaration.fx
@@ -1,7 +1,7 @@
 struct ClusteredLight {
-	vec4 vLightData; // Position
-	vec4 vLightDiffuse;
-	vec4 vLightSpecular;
-	vec4 vLightDirection;
-	vec4 vLightFalloff;
+	vec4 position;
+	vec4 direction;
+	vec4 diffuse;
+	vec4 specular;
+	vec4 falloff;
 };

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightClusteredDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightClusteredDeclaration.fx
@@ -1,0 +1,7 @@
+struct ClusteredLight {
+	vec4 vLightData; // Position
+	vec4 vLightDiffuse;
+	vec4 vLightSpecular;
+	vec4 vLightDirection;
+	vec4 vLightFalloff;
+};

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -3,7 +3,11 @@
         //No light calculation
     #else
 
-        vec4 diffuse{X} = light{X}.vLightDiffuse;
+        #ifdef CLUSTLIGHT{X}
+            vec4 diffuse{X} = vec4(1);
+        #else
+            vec4 diffuse{X} = light{X}.vLightDiffuse;
+        #endif
         #define CUSTOM_LIGHT{X}_COLOR // Use to modify light color. Currently only supports diffuse.
 
         #ifdef PBR
@@ -205,6 +209,8 @@
                     vReflectionInfos.y
                 #endif
                 );
+            #elif defined(CLUSTLIGHT{X})
+                info = computeClusteredLighting(light{X}.vLights, CLUSTLIGHT_COUNT{X}, viewDirectionW, normalW, diffuse{X}, glossiness);
             #endif
         #endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -205,7 +205,7 @@
                     vReflectionInfos.y
                 #endif
                 );
-            #elif defined(CLUSTLIGHT{X}) && defined(CLUSTLIGHTSUPPORTED)
+            #elif defined(CLUSTLIGHT{X}) && CLUSTLIGHT_MAX > 0
                 info = computeClusteredLighting(viewDirectionW, normalW, light{X}.vLightData, light{X}.vLights, diffuse{X}, light{X}.vLightSpecular.rgb, glossiness);
             #endif
         #endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -206,7 +206,7 @@
                 #endif
                 );
             #elif defined(CLUSTLIGHT{X}) && CLUSTLIGHT_MAX > 0
-                info = computeClusteredLighting(viewDirectionW, normalW, light{X}.vLightData, light{X}.vLights, diffuse{X}, light{X}.vLightSpecular.rgb, glossiness);
+                info = computeClusteredLighting(lightMaskTexture{X}, viewDirectionW, normalW, light{X}.vLightData, light{X}.vLights, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, glossiness);
             #endif
         #endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -3,11 +3,7 @@
         //No light calculation
     #else
 
-        #ifdef CLUSTLIGHT{X}
-            vec4 diffuse{X} = vec4(1);
-        #else
-            vec4 diffuse{X} = light{X}.vLightDiffuse;
-        #endif
+        vec4 diffuse{X} = light{X}.vLightDiffuse;
         #define CUSTOM_LIGHT{X}_COLOR // Use to modify light color. Currently only supports diffuse.
 
         #ifdef PBR
@@ -209,8 +205,8 @@
                     vReflectionInfos.y
                 #endif
                 );
-            #elif defined(CLUSTLIGHT{X})
-                info = computeClusteredLighting(light{X}.vLights, CLUSTLIGHT_COUNT{X}, viewDirectionW, normalW, diffuse{X}, glossiness);
+            #elif defined(CLUSTLIGHT{X}) && defined(CLUSTLIGHTSUPPORTED)
+                info = computeClusteredLighting(viewDirectionW, normalW, light{X}.vLightData, light{X}.vLights, diffuse{X}, light{X}.vLightSpecular.rgb, glossiness);
             #endif
         #endif
 

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
@@ -1,6 +1,9 @@
 ﻿#ifdef LIGHT{X}
 	uniform Light{X}
 	{
+		#ifdef CLUSTLIGHT{X}
+			ClusteredLight vLights[32];
+		#else
 		vec4 vLightData;
 
 		vec4 vLightDiffuse;
@@ -19,6 +22,7 @@
 		#endif
 		vec4 shadowsInfo;
 		vec2 depthValues;
+		#endif
 	} light{X};
 #ifdef IESLIGHTTEXTURE{X}
 	uniform sampler2D iesLightTexture{X};

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
@@ -1,9 +1,6 @@
 ﻿#ifdef LIGHT{X}
 	uniform Light{X}
 	{
-		#ifdef CLUSTLIGHT{X}
-			ClusteredLight vLights[32];
-		#else
 		vec4 vLightData;
 
 		vec4 vLightDiffuse;
@@ -15,6 +12,8 @@
 			vec4 vLightFalloff;
 		#elif defined(HEMILIGHT{X})
 			vec3 vLightGround;
+		#elif defined(CLUSTLIGHT{X})
+			ClusteredLight vLights[32];
 		#endif
 		#if defined(AREALIGHT{X})
 			vec4 vLightWidth;
@@ -22,7 +21,6 @@
 		#endif
 		vec4 shadowsInfo;
 		vec2 depthValues;
-		#endif
 	} light{X};
 #ifdef IESLIGHTTEXTURE{X}
 	uniform sampler2D iesLightTexture{X};

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
@@ -13,7 +13,7 @@
 		#elif defined(HEMILIGHT{X})
 			vec3 vLightGround;
 		#elif defined(CLUSTLIGHT{X})
-			ClusteredLight vLights[32];
+			ClusteredLight vLights[CLUSTLIGHT_MAX];
 		#endif
 		#if defined(AREALIGHT{X})
 			vec4 vLightWidth;

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
@@ -29,6 +29,9 @@
 	uniform mat4 textureProjectionMatrix{X};
 	uniform sampler2D projectionLightTexture{X};
 #endif
+#ifdef CLUSTLIGHT{X}
+	uniform sampler2D lightMaskTexture{X};
+#endif
 #ifdef SHADOW{X}
 	#ifdef SHADOWCSM{X}
 		uniform mat4 lightMatrix{X}[SHADOWCSMNUM_CASCADES{X}];

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
@@ -13,7 +13,7 @@
 		#elif defined(HEMILIGHT{X})
 			vec3 vLightGround;
 		#elif defined(CLUSTLIGHT{X})
-			ClusteredLight vLights[32];
+			ClusteredLight vLights[CLUSTLIGHT_MAX];
 		#endif
 		#if defined(AREALIGHT{X})
 			vec4 vLightWidth;

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
@@ -1,9 +1,6 @@
 ﻿#ifdef LIGHT{X}
 	uniform Light{X}
 	{
-		#ifdef CLUSTLIGHT{X}
-			ClusteredLight vLights[32];
-		#else
 		vec4 vLightData;
 
 		vec4 vLightDiffuse;
@@ -15,6 +12,8 @@
 			vec4 vLightFalloff;
 		#elif defined(HEMILIGHT{X})
 			vec3 vLightGround;
+		#elif defined(CLUSTLIGHT{X})
+			ClusteredLight vLights[32];
 		#endif
 		#if defined(AREALIGHT{X})
 			vec4 vLightWidth;
@@ -22,7 +21,6 @@
 		#endif
 		vec4 shadowsInfo;
 		vec2 depthValues;
-		#endif
 	} light{X};
 #ifdef SHADOW{X}
 	#ifdef SHADOWCSM{X}

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
@@ -1,6 +1,9 @@
 ﻿#ifdef LIGHT{X}
 	uniform Light{X}
 	{
+		#ifdef CLUSTLIGHT{X}
+			ClusteredLight vLights[32];
+		#else
 		vec4 vLightData;
 
 		vec4 vLightDiffuse;
@@ -19,6 +22,7 @@
 		#endif
 		vec4 shadowsInfo;
 		vec2 depthValues;
+		#endif
 	} light{X};
 #ifdef SHADOW{X}
 	#ifdef SHADOWCSM{X}

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -180,12 +180,11 @@ lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirect
 // End Area Light
 #endif
 
-#ifdef CLUSTLIGHTSUPPORTED
-lightingInfo computeClusteredLighting(vec3 viewDirectionW, vec3 vNormal, vec4 lightData, ClusteredLight lights[32], vec4 diffuseScale, vec3 specularScale, float glossiness) {
+#if defined(CLUSTLIGHT_MAX) && CLUSTLIGHT_MAX > 0
+lightingInfo computeClusteredLighting(vec3 viewDirectionW, vec3 vNormal, vec4 lightData, ClusteredLight lights[CLUSTLIGHT_MAX], vec4 diffuseScale, vec3 specularScale, float glossiness) {
 	lightingInfo result;
 	int len = int(lightData.x);
 
-	// TODO: Dynamic for loops aren't supported on WebGL 1
 	for (int i = 0; i < len; i += 1) {
 		vec4 diffuse = lights[i].diffuse * diffuseScale;
 		vec3 specular = lights[i].specular.rgb * specularScale;

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -180,16 +180,21 @@ lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirect
 // End Area Light
 #endif
 
-lightingInfo computeClusteredLighting(ClusteredLight lights[32], int lightCount, vec3 viewDirectionW, vec3 vNormal, vec4 diffuseColor, float glossiness) {
-	lightingInfo aggInfo;
-	// TODO: only do this on WebGL 2
-	for (int i = 0; i < lightCount; i += 1) {
-		vec4 lightDiffuse = lights[i].vLightDiffuse * diffuseColor;
-		lightingInfo info = computeSpotLighting(viewDirectionW, vNormal, lights[i].vLightData, lights[i].vLightDirection, lightDiffuse.rgb, lights[i].vLightSpecular.rgb, lightDiffuse.a, glossiness);
-		aggInfo.diffuse += info.diffuse;
+#ifdef CLUSTLIGHTSUPPORTED
+lightingInfo computeClusteredLighting(vec3 viewDirectionW, vec3 vNormal, vec4 lightData, ClusteredLight lights[32], vec4 diffuseScale, vec3 specularScale, float glossiness) {
+	lightingInfo result;
+	int len = int(lightData.x);
+
+	// TODO: Dynamic for loops aren't supported on WebGL 1
+	for (int i = 0; i < len; i += 1) {
+		vec4 diffuse = lights[i].diffuse * diffuseScale;
+		vec3 specular = lights[i].specular.rgb * specularScale;
+		lightingInfo info = computeSpotLighting(viewDirectionW, vNormal, lights[i].position, lights[i].direction, diffuse.rgb, specular, diffuse.a, glossiness);
+		result.diffuse += info.diffuse;
 		#ifdef SPECULARTERM
-			aggInfo.specular += info.specular;
+			result.specular += info.specular;
 		#endif
 	}
-	return aggInfo;
+	return result;
 }
+#endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -179,3 +179,17 @@ lightingInfo computeAreaLighting(sampler2D ltc1, sampler2D ltc2, vec3 viewDirect
 
 // End Area Light
 #endif
+
+lightingInfo computeClusteredLighting(ClusteredLight lights[32], int lightCount, vec3 viewDirectionW, vec3 vNormal, vec4 diffuseColor, float glossiness) {
+	lightingInfo aggInfo;
+	// TODO: only do this on WebGL 2
+	for (int i = 0; i < lightCount; i += 1) {
+		vec4 lightDiffuse = lights[i].vLightDiffuse * diffuseColor;
+		lightingInfo info = computeSpotLighting(viewDirectionW, vNormal, lights[i].vLightData, lights[i].vLightDirection, lightDiffuse.rgb, lights[i].vLightSpecular.rgb, lightDiffuse.a, glossiness);
+		aggInfo.diffuse += info.diffuse;
+		#ifdef SPECULARTERM
+			aggInfo.specular += info.specular;
+		#endif
+	}
+	return aggInfo;
+}

--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -32,6 +32,7 @@ varying vec4 vColor;
 #include<helperFunctions>
 
 // Lights
+#include<lightClusteredDeclaration>
 #include<__decl__lightFragment>[0..maxSimultaneousLights]
 
 #include<lightsFragmentFunctions>

--- a/packages/dev/core/src/Shaders/default.vertex.fx
+++ b/packages/dev/core/src/Shaders/default.vertex.fx
@@ -58,6 +58,7 @@ varying vec4 vColor;
 #include<clipPlaneVertexDeclaration>
 
 #include<fogVertexDeclaration>
+#include<lightClusteredDeclaration>
 #include<__decl__lightVxFragment>[0..maxSimultaneousLights]
 
 #include<morphTargetsVertexGlobalDeclaration>

--- a/packages/dev/core/src/Shaders/lightMask.fragment.fx
+++ b/packages/dev/core/src/Shaders/lightMask.fragment.fx
@@ -1,0 +1,9 @@
+// Uniforms
+uniform highp uint index;
+
+#include<lightClusteredDeclaration>
+#include<lightVxUboDeclaration>[0..1]
+
+void main(void) {
+    gl_FragColor = vec4(1 << index, 0, 0, 1);
+}

--- a/packages/dev/core/src/Shaders/lightMask.vertex.fx
+++ b/packages/dev/core/src/Shaders/lightMask.vertex.fx
@@ -1,0 +1,27 @@
+attribute vec3 position;
+
+// Uniforms
+uniform highp uint index;
+
+#include<sceneUboDeclaration>
+#include<meshUboDeclaration>
+
+#include<lightClusteredDeclaration>
+#include<lightVxUboDeclaration>[0..1]
+
+// TODO: switch default direction to up??
+const vec3 down = vec3(0, -1, 0);
+
+float acosClamped(float v) {
+    return acos(clamp(v, 0.0, 1.0));
+}
+
+void main(void) {
+    float lightAngle = acosClamped(light0.vLights[index].direction.a);
+    float posAngle = acosClamped(dot(down, position));
+    // We allow some wiggle room equal to the rotation of one slice of the sphere
+    vec3 vPosition = posAngle - lightAngle < 0.32 ? position : vec3(0);
+
+    vPosition *= light0.vLights[index].diffuse.a;
+    gl_Position = viewProjection * world * vec4(vPosition, 1);
+}

--- a/packages/dev/core/src/sceneComponent.ts
+++ b/packages/dev/core/src/sceneComponent.ts
@@ -39,6 +39,7 @@ export class SceneComponentConstants {
     public static readonly NAME_AUDIO = "Audio";
     public static readonly NAME_FLUIDRENDERER = "FluidRenderer";
     public static readonly NAME_IBLCDFGENERATOR = "iblCDFGenerator";
+    public static readonly NAME_CLUSTEREDLIGHT = "ClusteredLight";
 
     public static readonly STEP_ISREADYFORMESH_EFFECTLAYER = 0;
 
@@ -92,6 +93,7 @@ export class SceneComponentConstants {
     public static readonly STEP_GATHERRENDERTARGETS_DEPTHRENDERER = 0;
     public static readonly STEP_GATHERRENDERTARGETS_GEOMETRYBUFFERRENDERER = 1;
     public static readonly STEP_GATHERRENDERTARGETS_SHADOWGENERATOR = 2;
+    public static readonly STEP_GATHERRENDERTARGETS_CLUSTEREDLIGHT = 3;
     public static readonly STEP_GATHERRENDERTARGETS_POSTPROCESSRENDERPIPELINEMANAGER = 3;
 
     public static readonly STEP_GATHERACTIVECAMERARENDERTARGETS_DEPTHRENDERER = 0;


### PR DESCRIPTION
# Implementation Details
When this work is more complete ill move all this over to the official docs, but for now just using this PR as a rough set of notes/thoughts/todos

The implementation is mainly inspired by these CoD slides: https://advances.realtimerendering.com/s2017/2017_Sig_Improved_Culling_final.pdf

The main idea is to split the clustering into separate X/Y "tiled" clustering AND a Z "depth" clustering, and then checking if the lights is in both the tile and the depth slice.

## Tiled Clustering
This uses the rendering pipeline to draw meshes for each light and writes bits out to a light mask texture if there are pixels infront of the depth buffer (effectively finding lights that intersect the depth buffer).

The render target with the light mask texture and depth buffer has a resolution equal to the amount of tiles.

### Depth pre-pass
All the scene geometry is rendered to a low resolution render target. Currently this is repeated per `ClusteredLight`, in future these depth texture might be able to get shared

### Stencil Pass (removed)
Draws all the light geometry with depthFunction=GREATER and sets stencil bits to 1.

This is combined with the next pass to only mark pixels that contain light geometry both behind AND infront of the depth buffer.

However this ended up causing issues due to the low-resolution aliased depth buffer where stencil bits weren't set for the edges of meshes.
![image](https://github.com/user-attachments/assets/66310a5d-8da1-4fb1-be6b-faae7f7fa8cb)

In future we could maybe get around this by doing a post-process pass over the depth pre-pass to expand the max depth values out by one tile. Although for now this just adds extra complexity and we probably don't really need this pass.

### Light Mask Pass
Each light mesh is drawn with a different index and any fragment pixels which pass the depth test (meaning the light is in front of the depth pre-pass) will set its bit in the light mask texture with an atomic OR.

Atleast thats the plan on WebGPU which isn't implemented yet. WebGL doesn't have support for storage textures or atomic operations, so we instead use a float buffer with additive blending.

To prevent accuracy issues with floating point values we ensure the mask doesn't go above the bits in the floating-point fraction, which limits us to 23 lights per clusteredlight on most systems.

### Lighting pass
This light mask is then queried bit-by-bit in the lighting calculation to figure out which lights are in that "tile"

### Light Meshes
All the light meshes are just spheres. To reduce the pixels set for spotlights they are modified in the vertex shader so positions on the sphere that are outside the spotlight angle are set to 0,0,0. This causes the sphere to end up having a more cone shape

## Depth Clustering
TODO. not currently implemented

CoD seems to do this in CPU which makes sense since its only a min/max index per slice so can be cheaply calculated and uploaded.

## Not Implemented / Broken
- [ ] PBR materials
- [ ] I have code for point lights but its untested. I feel like they likely won't work rn
- [ ] moving the camera too close or too far from the lights make them disappear
  - this is an issue with the camera intersecting with the light geometry, on WebGPU this can be fixed by disabling back-face culling but on WebGL this will cause more issues due to its additive blending
  - on WebGL we could test if the light mesh intersects with the 
- [ ] spot lights that point in any other direction but down
  - to make the light mesh vertex shader simpler we assume a direction of down. this will have to get changed or (better) we just rotate the world matrix by the light direction
- [ ] lights with a default range. trying to scale the light geometry by `Number.MAX_VALUE` seems to break it
  - maybe we should clamp it?
- [ ] WebGPU support
- [ ] Using instancing for the light meshes

I don't plan to support these kinda lights:
- anything that requires textures like IES textures or shadowed lights
- anything other than point/spot lights
- lights using anything other than the default falloff
