### PR TITLE
Inspector v2: Add missing add/remove observables to scene and use ISceneContext for scene explorer sections

### DIFF
--- a/packages/dev/core/src/Particles/IParticleSystem.ts
+++ b/packages/dev/core/src/Particles/IParticleSystem.ts
@@ -31,6 +31,11 @@ import type { AbstractMesh } from "../Meshes/abstractMesh";
  */
 export interface IParticleSystem {
     /**
+     * Gets or sets the unique id of the particle system.
+     */
+    uniqueId: number;
+
+    /**
      * List of animations used by the particle system.
      */
     animations: Animation[];

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -30,7 +30,7 @@ declare const Reflect: any;
  */
 export interface ISpriteManager extends IDisposable {
     /**
-     * Gets or sets the unique id of the texture
+     * Gets or sets the unique id of the sprite manager
      */
     uniqueId: number;
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -847,6 +847,26 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     public onSkeletonRemovedObservable = new Observable<Skeleton>();
 
     /**
+     * An event triggered when a particle system is created
+     */
+    public onNewParticleSystemAddedObservable = new Observable<IParticleSystem>();
+
+    /**
+     * An event triggered when a particle system is removed
+     */
+    public onParticleSystemRemovedObservable = new Observable<IParticleSystem>();
+
+    /**
+     * An event triggered when an animation group is created
+     */
+    public onNewAnimationGroupAddedObservable = new Observable<AnimationGroup>();
+
+    /**
+     * An event triggered when an animation group is removed
+     */
+    public onAnimationGroupRemovedObservable = new Observable<AnimationGroup>();
+
+    /**
      * An event triggered when a material is created
      */
     public onNewMaterialAddedObservable = new Observable<Material>();
@@ -875,6 +895,16 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
      * An event triggered when a texture is removed
      */
     public onTextureRemovedObservable = new Observable<BaseTexture>();
+
+    /**
+     * An event triggered when a frame graph is created
+     */
+    public onNewFrameGraphAddedObservable = new Observable<FrameGraph>();
+
+    /**
+     * An event triggered when a frame graph is removed
+     */
+    public onFrameGraphRemovedObservable = new Observable<FrameGraph>();
 
     /**
      * An event triggered when render targets are about to be rendered
@@ -2908,6 +2938,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             // Clean active container
             this._executeActiveContainerCleanup(this._activeParticleSystems);
         }
+        this.onParticleSystemRemovedObservable.notifyObservers(toRemove);
         return index;
     }
 
@@ -2944,6 +2975,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         if (index !== -1) {
             this.animationGroups.splice(index, 1);
         }
+        this.onAnimationGroupRemovedObservable.notifyObservers(toRemove);
         return index;
     }
 
@@ -3011,6 +3043,21 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             this.textures.splice(index, 1);
         }
         this.onTextureRemovedObservable.notifyObservers(toRemove);
+
+        return index;
+    }
+
+    /**
+     * Removes the given frame graph from this scene.
+     * @param toRemove The frame graph to remove
+     * @returns The index of the removed frame graph
+     */
+    public removeFrameGraph(toRemove: FrameGraph): number {
+        const index = this.frameGraphs.indexOf(toRemove);
+        if (index !== -1) {
+            this.frameGraphs.splice(index, 1);
+        }
+        this.onFrameGraphRemovedObservable.notifyObservers(toRemove);
 
         return index;
     }
@@ -3095,6 +3142,10 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             return;
         }
         this.particleSystems.push(newParticleSystem);
+
+        Tools.SetImmediate(() => {
+            this.onNewParticleSystemAddedObservable.notifyObservers(newParticleSystem);
+        });
     }
 
     /**
@@ -3117,6 +3168,10 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             return;
         }
         this.animationGroups.push(newAnimationGroup);
+
+        Tools.SetImmediate(() => {
+            this.onNewAnimationGroupAddedObservable.notifyObservers(newAnimationGroup);
+        });
     }
 
     /**
@@ -3200,6 +3255,17 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         }
         this.textures.push(newTexture);
         this.onNewTextureAddedObservable.notifyObservers(newTexture);
+    }
+
+    /**
+     * Adds the given frame graph to this scene.
+     * @param newFrameGraph The frame graph to add
+     */
+    public addFrameGraph(newFrameGraph: FrameGraph): void {
+        this.frameGraphs.push(newFrameGraph);
+        Tools.SetImmediate(() => {
+            this.onNewFrameGraphAddedObservable.notifyObservers(newFrameGraph);
+        });
     }
 
     /**

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -50,7 +50,7 @@ export type SceneExplorerSection<T extends EntityBase> = Readonly<{
     /**
      * A function that returns the root entities for this section.
      */
-    getRootEntities: (scene: Scene) => readonly T[];
+    getRootEntities: () => readonly T[];
 
     /**
      * An optional function that returns the children of a given entity.
@@ -77,17 +77,17 @@ export type SceneExplorerSection<T extends EntityBase> = Readonly<{
     /**
      * A function that returns an array of observables for when entities are added to the scene.
      */
-    getEntityAddedObservables: (scene: Scene) => readonly IReadonlyObservable<T>[];
+    getEntityAddedObservables: () => readonly IReadonlyObservable<T>[];
 
     /**
      * A function that returns an array of observables for when entities are removed from the scene.
      */
-    getEntityRemovedObservables: (scene: Scene) => readonly IReadonlyObservable<T>[];
+    getEntityRemovedObservables: () => readonly IReadonlyObservable<T>[];
 
     /**
      * A function that returns an array of observables for when entities are moved (e.g. re-parented) within the scene.
      */
-    getEntityMovedObservables?: (scene: Scene) => readonly IReadonlyObservable<T>[];
+    getEntityMovedObservables?: () => readonly IReadonlyObservable<T>[];
 }>;
 
 type EntityCommandBase<T extends EntityBase> = Readonly<{
@@ -281,12 +281,12 @@ export const SceneExplorer: FunctionComponent<{
             }
         };
 
-        const addObservers = sections.flatMap((section) => section.getEntityAddedObservables(scene).map((observable) => observable.add(onSceneItemAdded)));
-        const removeObservers = sections.flatMap((section) => section.getEntityRemovedObservables(scene).map((observable) => observable.add(onSceneItemRemoved)));
+        const addObservers = sections.flatMap((section) => section.getEntityAddedObservables().map((observable) => observable.add(onSceneItemAdded)));
+        const removeObservers = sections.flatMap((section) => section.getEntityRemovedObservables().map((observable) => observable.add(onSceneItemRemoved)));
         const moveObservers = sections
             .map((section) => section.getEntityMovedObservables)
             .filter((getEntityMovedObservable) => !!getEntityMovedObservable)
-            .flatMap((getEntityMovedObservable) => getEntityMovedObservable(scene).map((observable) => observable.add(onSceneItemAdded)));
+            .flatMap((getEntityMovedObservable) => getEntityMovedObservable().map((observable) => observable.add(onSceneItemAdded)));
 
         return () => {
             for (const observer of addObservers) {
@@ -311,7 +311,7 @@ export const SceneExplorer: FunctionComponent<{
         });
 
         for (const section of sections) {
-            const rootEntities = section.getRootEntities(scene);
+            const rootEntities = section.getRootEntities();
 
             visibleItems.push({
                 type: "section",

--- a/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
@@ -1,4 +1,5 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { PaintBrushRegular } from "@fluentui/react-icons";
@@ -6,17 +7,23 @@ import { PaintBrushRegular } from "@fluentui/react-icons";
 import { Material } from "core/Materials/material";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Material Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Materials",
-            order: 2,
+            order: 300,
             predicate: (entity) => entity instanceof Material,
-            getRootEntities: (scene) => scene.materials,
+            getRootEntities: () => scene.materials,
             getEntityDisplayInfo: (material) => {
                 const onChangeObservable = new Observable<void>();
 
@@ -38,8 +45,8 @@ export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
                 };
             },
             entityIcon: () => <PaintBrushRegular />,
-            getEntityAddedObservables: (scene) => [scene.onNewMaterialAddedObservable],
-            getEntityRemovedObservables: (scene) => [scene.onMaterialRemovedObservable],
+            getEntityAddedObservables: () => [scene.onNewMaterialAddedObservable],
+            getEntityRemovedObservables: () => [scene.onMaterialRemovedObservable],
         });
 
         return {

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -1,4 +1,5 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { BoxRegular, BranchRegular, CameraRegular, EyeOffRegular, EyeRegular, LightbulbRegular } from "@fluentui/react-icons";
@@ -10,19 +11,25 @@ import { TransformNode } from "core/Meshes/transformNode";
 import { Observable } from "core/Misc";
 import { Node } from "core/node";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const NodeHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const NodeHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Node Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const nodeMovedObservable = new Observable<Node>();
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Nodes",
-            order: 0,
+            order: 100,
             predicate: (entity) => entity instanceof Node,
-            getRootEntities: (scene) => scene.rootNodes,
+            getRootEntities: () => scene.rootNodes,
             getEntityChildren: (node) => node.getChildren(),
             getEntityParent: (node) => node.parent,
             getEntityDisplayInfo: (node) => {
@@ -62,13 +69,13 @@ export const NodeHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplor
                 ) : (
                     <></>
                 ),
-            getEntityAddedObservables: (scene) => [
+            getEntityAddedObservables: () => [
                 scene.onNewMeshAddedObservable,
                 scene.onNewTransformNodeAddedObservable,
                 scene.onNewCameraAddedObservable,
                 scene.onNewLightAddedObservable,
             ],
-            getEntityRemovedObservables: (scene) => [
+            getEntityRemovedObservables: () => [
                 scene.onMeshRemovedObservable,
                 scene.onTransformNodeRemovedObservable,
                 scene.onCameraRemovedObservable,

--- a/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
@@ -1,22 +1,29 @@
+import type { IParticleSystem } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { DropRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
-import { ParticleSystem } from "core/Particles";
 
-export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Particle System Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Particle Systems",
-            order: 4,
-            predicate: (entity) => entity instanceof ParticleSystem, //  TODO-iv2: Implement a more robust predicate to filter for IParticleSystems (perhaps checking if contained in scene.particleSystems)
-            getRootEntities: (scene) => scene.particleSystems.map((ps) => ps as ParticleSystem),
+            order: 600,
+            predicate: (entity): entity is IParticleSystem => scene.particleSystems.includes(entity as IParticleSystem),
+            getRootEntities: () => scene.particleSystems,
             getEntityDisplayInfo: (particleSystem) => {
                 const onChangeObservable = new Observable<void>();
 
@@ -38,8 +45,8 @@ export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISc
                 };
             },
             entityIcon: () => <DropRegular />,
-            getEntityAddedObservables: (scene) => [], // TODO-iv2: Implement scene-level observables for particle system additions/removals
-            getEntityRemovedObservables: (scene) => [],
+            getEntityAddedObservables: () => [scene.onNewParticleSystemAddedObservable],
+            getEntityRemovedObservables: () => [scene.onParticleSystemRemovedObservable],
         });
 
         return {

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -1,22 +1,29 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { PipelineRegular } from "@fluentui/react-icons";
 
 import { PostProcessRenderPipeline } from "core/PostProcesses/RenderPipeline/postProcessRenderPipeline";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 import "core/PostProcesses/RenderPipeline/postProcessRenderPipelineManagerSceneComponent";
 
-export const RenderingPipelineHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const RenderingPipelineHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Rendering Pipeline Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const sectionRegistration = sceneExplorerService.addSection<PostProcessRenderPipeline>({
             displayName: "Rendering Pipelines",
-            order: 4,
+            order: 500,
             predicate: (entity) => entity instanceof PostProcessRenderPipeline,
-            getRootEntities: (scene) => scene.postProcessRenderPipelineManager.supportedPipelines ?? [],
+            getRootEntities: () => scene.postProcessRenderPipelineManager.supportedPipelines ?? [],
             getEntityDisplayInfo: (pipeline) => {
                 return {
                     get name() {
@@ -26,13 +33,13 @@ export const RenderingPipelineHierarchyServiceDefinition: ServiceDefinition<[], 
                 };
             },
             entityIcon: () => <PipelineRegular />,
-            getEntityAddedObservables: (scene) => [scene.postProcessRenderPipelineManager.onNewPipelineAddedObservable],
-            getEntityRemovedObservables: (scene) => [scene.postProcessRenderPipelineManager.onPipelineRemovedObservable],
+            getEntityAddedObservables: () => [scene.postProcessRenderPipelineManager.onNewPipelineAddedObservable],
+            getEntityRemovedObservables: () => [scene.postProcessRenderPipelineManager.onPipelineRemovedObservable],
         });
 
         return {
             dispose: () => {
-                sectionRegistration?.dispose();
+                sectionRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
@@ -1,4 +1,5 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { DataLineRegular, PersonWalkingRegular } from "@fluentui/react-icons";
@@ -7,19 +8,25 @@ import { Bone } from "core/Bones/bone";
 import { Skeleton } from "core/Bones/skeleton";
 import { Observable } from "core/Misc/observable";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const SkeletonHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const SkeletonHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Skeleton Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const boneMovedObservable = new Observable<Bone>();
 
         const sectionRegistration = sceneExplorerService.addSection<Skeleton | Bone>({
             displayName: "Skeletons",
-            order: 0,
+            order: 200,
             predicate: (entity) => entity instanceof Skeleton || entity instanceof Bone,
-            getRootEntities: (scene) => scene.skeletons,
+            getRootEntities: () => scene.skeletons,
             getEntityChildren: (skeletonOrBone) => skeletonOrBone.getChildren(),
             getEntityParent: (skeletonOrBone) => (skeletonOrBone instanceof Skeleton ? null : skeletonOrBone.getParent() || skeletonOrBone.getSkeleton()),
             getEntityDisplayInfo: (skeletonOrBone) => {
@@ -51,8 +58,8 @@ export const SkeletonHierarchyServiceDefinition: ServiceDefinition<[], [ISceneEx
                 };
             },
             entityIcon: ({ entity: skeletonOrBone }) => (skeletonOrBone instanceof Skeleton ? <PersonWalkingRegular /> : <DataLineRegular />),
-            getEntityAddedObservables: (scene) => [scene.onNewSkeletonAddedObservable],
-            getEntityRemovedObservables: (scene) => [scene.onSkeletonRemovedObservable],
+            getEntityAddedObservables: () => [scene.onNewSkeletonAddedObservable],
+            getEntityRemovedObservables: () => [scene.onSkeletonRemovedObservable],
             getEntityMovedObservables: () => [boneMovedObservable],
         });
 

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -1,11 +1,13 @@
 import type { ISpriteManager, Sprite } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { LayerDiagonalPersonRegular, PersonSquareRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 import "core/Sprites/spriteSceneComponent";
@@ -18,15 +20,20 @@ function IsSprite(entity: unknown): entity is Sprite {
     return (entity as Sprite).manager !== undefined;
 }
 
-export const SpriteManagerHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const SpriteManagerHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Sprite Manager Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const sectionRegistration = sceneExplorerService.addSection<ISpriteManager | Sprite>({
             displayName: "Sprite Managers",
-            order: 3,
+            order: 700,
             predicate: (entity) => IsSpriteManager(entity) || IsSprite(entity),
-            getRootEntities: (scene) => scene.spriteManagers ?? [],
+            getRootEntities: () => scene.spriteManagers ?? [],
             getEntityChildren: (spriteEntity) => (IsSpriteManager(spriteEntity) ? spriteEntity.sprites : ([] as ISpriteManager[])),
             getEntityParent: (spriteEntity) => (IsSprite(spriteEntity) ? spriteEntity.manager : null),
             getEntityDisplayInfo: (spriteEntity) => {
@@ -48,13 +55,13 @@ export const SpriteManagerHierarchyServiceDefinition: ServiceDefinition<[], [ISc
                 };
             },
             entityIcon: ({ entity: spriteEntity }) => (IsSpriteManager(spriteEntity) ? <LayerDiagonalPersonRegular /> : <PersonSquareRegular />),
-            getEntityAddedObservables: (scene) => [scene.onNewSpriteManagerAddedObservable],
-            getEntityRemovedObservables: (scene) => [scene.onSpriteManagerRemovedObservable],
+            getEntityAddedObservables: () => [scene.onNewSpriteManagerAddedObservable],
+            getEntityRemovedObservables: () => [scene.onSpriteManagerRemovedObservable],
         });
 
         return {
             dispose: () => {
-                sectionRegistration?.dispose();
+                sectionRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
@@ -1,4 +1,5 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { ImageRegular } from "@fluentui/react-icons";
@@ -6,17 +7,23 @@ import { ImageRegular } from "@fluentui/react-icons";
 import { Texture } from "core/Materials/Textures/texture";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService]> = {
+export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Texture Hierarchy",
-    consumes: [SceneExplorerServiceIdentity],
-    factory: (sceneExplorerService) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return void 0;
+        }
+
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Textures",
-            order: 3,
+            order: 400,
             predicate: (entity) => entity instanceof Texture,
-            getRootEntities: (scene) => scene.textures,
+            getRootEntities: () => scene.textures,
             getEntityDisplayInfo: (texture) => {
                 const onChangeObservable = new Observable<void>();
 
@@ -38,8 +45,8 @@ export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExp
                 };
             },
             entityIcon: () => <ImageRegular />,
-            getEntityAddedObservables: (scene) => [scene.onNewTextureAddedObservable],
-            getEntityRemovedObservables: (scene) => [scene.onTextureRemovedObservable],
+            getEntityAddedObservables: () => [scene.onNewTextureAddedObservable],
+            getEntityRemovedObservables: () => [scene.onTextureRemovedObservable],
         });
 
         return {


### PR DESCRIPTION
This PR contains a couple of related changes:
1. Update the particle system scene explorer section such that it determines if an entity is a particle system by checking if it is in scene.particleSystems. This works regardless of the concrete implementation of IParticleSystem.
2. Doing this though requires the scene. Originally I had scene explorer pass the scene to the sections various functions to try to make things simpler, but this is kind of just guessing what the scene explorer sections will need to do what they want. Since this isn't always the case (as seen in bullet 1), I decided to just remove this and let the scene explorer sections get the scene from the ISceneContext if they need it, and then it is implicitly available in any of the section functions that need it. This also makes the scene explorer sections more flexible to put whatever they want, which lets us make scene explorer more broad if we want (such as including audio, etc.).
3. Added scene observables for adding/removing particle systems.
4. Added scene observables for adding/removing other scene entities that are not currently available.
5. Added a uniqueId to `IParticleSystem`. This is technically a breaking change, but I suspect this is ok as there probably aren't many (if any) custom IParticleSystem implementations. Also we already did this for ISpriteManager.