### PR TITLE
Inspector v2: Animation Groups in Scene Explorer

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -13,6 +13,7 @@ import { Tags } from "../Misc/tags";
 import type { AnimationGroupMask } from "./animationGroupMask";
 import "./animatable";
 import type { IAssetContainer } from "core/IAssetContainer";
+import { UniqueIdGenerator } from "core/Misc/uniqueIdGenerator";
 
 /**
  * This class defines the direct association between an animation and a target
@@ -22,10 +23,16 @@ export class TargetedAnimation {
      * Animation to perform
      */
     public animation: Animation;
+
     /**
      * Target to animate
      */
     public target: any;
+
+    /**
+     * Gets or sets the unique id of the targeted animation
+     */
+    public readonly uniqueId = UniqueIdGenerator.UniqueId;
 
     /**
      * Returns the string "TargetedAnimation"
@@ -34,6 +41,12 @@ export class TargetedAnimation {
     public getClassName(): string {
         return "TargetedAnimation";
     }
+
+    /**
+     * Creates a new targeted animation
+     * @param parent The animation group to which the animation belongs
+     */
+    constructor(public readonly parent: AnimationGroup) {}
 
     /**
      * Serialize the object
@@ -524,7 +537,7 @@ export class AnimationGroup implements IDisposable {
      * @returns the TargetedAnimation object
      */
     public addTargetedAnimation(animation: Animation, target: any): TargetedAnimation {
-        const targetedAnimation = new TargetedAnimation();
+        const targetedAnimation = new TargetedAnimation(this);
         targetedAnimation.animation = animation;
         targetedAnimation.target = target;
 

--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -14,10 +14,24 @@ type CommonEntity = {
     getClassName?: () => string;
 };
 
+const NameProperty: FunctionComponent<{ commonEntity: CommonEntity; isReadonly: boolean }> = (props) => {
+    const { commonEntity, isReadonly } = props;
+
+    const name = useProperty(commonEntity, "name");
+
+    return (
+        name !== undefined &&
+        (isReadonly ? (
+            <TextPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} />
+        ) : (
+            <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
+        ))
+    );
+};
+
 export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEntity }> = (props) => {
     const { commonEntity } = props;
 
-    const name = useProperty(commonEntity, "name");
     const namePropertyDescriptor = useMemo(() => GetPropertyDescriptor(commonEntity, "name")?.[1], [commonEntity]);
     const isNameReadonly = !namePropertyDescriptor || IsPropertyReadonly(namePropertyDescriptor);
 
@@ -26,12 +40,7 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
     return (
         <>
             {commonEntity.id !== undefined && <TextPropertyLine key="EntityId" label="ID" description="The id of the node." value={commonEntity.id.toString()} />}
-            {name !== undefined &&
-                (isNameReadonly ? (
-                    <TextPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} />
-                ) : (
-                    <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
-                ))}
+            {namePropertyDescriptor !== undefined && <NameProperty commonEntity={commonEntity} isReadonly={isNameReadonly} />}
             {commonEntity.uniqueId !== undefined && (
                 <TextPropertyLine key="EntityUniqueId" label="Unique ID" description="The unique id of the node." value={commonEntity.uniqueId.toString()} />
             )}

--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -14,24 +14,10 @@ type CommonEntity = {
     getClassName?: () => string;
 };
 
-const NameProperty: FunctionComponent<{ commonEntity: CommonEntity; isReadonly: boolean }> = (props) => {
-    const { commonEntity, isReadonly } = props;
-
-    const name = useProperty(commonEntity, "name");
-
-    return (
-        name !== undefined &&
-        (isReadonly ? (
-            <TextPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} />
-        ) : (
-            <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
-        ))
-    );
-};
-
 export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEntity }> = (props) => {
     const { commonEntity } = props;
 
+    const name = useProperty(commonEntity, "name");
     const namePropertyDescriptor = useMemo(() => GetPropertyDescriptor(commonEntity, "name")?.[1], [commonEntity]);
     const isNameReadonly = !namePropertyDescriptor || IsPropertyReadonly(namePropertyDescriptor);
 
@@ -40,7 +26,12 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
     return (
         <>
             {commonEntity.id !== undefined && <TextPropertyLine key="EntityId" label="ID" description="The id of the node." value={commonEntity.id.toString()} />}
-            {namePropertyDescriptor !== undefined && <NameProperty commonEntity={commonEntity} isReadonly={isNameReadonly} />}
+            {name !== undefined &&
+                (isNameReadonly ? (
+                    <TextPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} />
+                ) : (
+                    <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
+                ))}
             {commonEntity.uniqueId !== undefined && (
                 <TextPropertyLine key="EntityUniqueId" label="Unique ID" description="The unique id of the node." value={commonEntity.uniqueId.toString()} />
             )}

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -21,19 +21,20 @@ import { SpotLightPropertiesServiceDefinition } from "./services/panes/propertie
 import { MaterialPropertiesServiceDefinition } from "./services/panes/properties/materialPropertiesService";
 import { MeshPropertiesServiceDefinition } from "./services/panes/properties/meshPropertiesService";
 import { NodePropertiesServiceDefinition } from "./services/panes/properties/nodePropertiesService";
+import { ParticleSystemPropertiesServiceDefinition } from "./services/panes/properties/particleSystemPropertiesService";
+import { PhysicsPropertiesServiceDefinition } from "./services/panes/properties/physicsPropertiesService";
 import { PropertiesServiceDefinition } from "./services/panes/properties/propertiesService";
 import { SkeletonPropertiesServiceDefinition } from "./services/panes/properties/skeletonPropertiesService";
 import { SpritePropertiesServiceDefinition } from "./services/panes/properties/spritePropertiesService";
 import { TransformPropertiesServiceDefinition } from "./services/panes/properties/transformPropertiesService";
-import { PhysicsPropertiesServiceDefinition } from "./services/panes/properties/physicsPropertiesService";
-import { ParticleSystemPropertiesServiceDefinition } from "./services/panes/properties/particleSystemPropertiesService";
+import { AnimationGroupExplorerServiceDefinition } from "./services/panes/scene/animationGroupExplorerService";
 import { MaterialExplorerServiceDefinition } from "./services/panes/scene/materialExplorerService";
 import { NodeHierarchyServiceDefinition } from "./services/panes/scene/nodeExplorerService";
-import { SceneExplorerServiceDefinition } from "./services/panes/scene/sceneExplorerService";
+import { ParticleSystemExplorerServiceDefinition } from "./services/panes/scene/particleSystemExplorerService";
 import { RenderingPipelineHierarchyServiceDefinition } from "./services/panes/scene/renderingPipelinesExplorerService";
+import { SceneExplorerServiceDefinition } from "./services/panes/scene/sceneExplorerService";
 import { SkeletonHierarchyServiceDefinition } from "./services/panes/scene/skeletonExplorerService";
 import { SpriteManagerHierarchyServiceDefinition } from "./services/panes/scene/spriteManagerExplorerService";
-import { ParticleSystemExplorerServiceDefinition } from "./services/panes/scene/particleSystemExplorerService";
 import { TextureHierarchyServiceDefinition } from "./services/panes/scene/texturesExplorerService";
 import { SettingsServiceDefinition } from "./services/panes/settingsService";
 import { StatsServiceDefinition } from "./services/panes/statsService";
@@ -182,12 +183,13 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             // Scene explorer tab and related services.
             SceneExplorerServiceDefinition,
             NodeHierarchyServiceDefinition,
-            MaterialExplorerServiceDefinition,
-            ParticleSystemExplorerServiceDefinition,
             SkeletonHierarchyServiceDefinition,
+            MaterialExplorerServiceDefinition,
             TextureHierarchyServiceDefinition,
-            SpriteManagerHierarchyServiceDefinition,
             RenderingPipelineHierarchyServiceDefinition,
+            ParticleSystemExplorerServiceDefinition,
+            SpriteManagerHierarchyServiceDefinition,
+            AnimationGroupExplorerServiceDefinition,
 
             // Properties pane tab and related services.
             PropertiesServiceDefinition,

--- a/packages/dev/inspector-v2/src/instrumentation/propertyInstrumentation.ts
+++ b/packages/dev/inspector-v2/src/instrumentation/propertyInstrumentation.ts
@@ -118,9 +118,6 @@ export function InterceptProperty<T extends object>(target: T, propertyKey: keyo
     }
     hooksForKey.push(hooks);
 
-    // Take note of whether the property is owned by the target object or inherited from its prototype chain.
-    const isOwnProperty = propertyOwner === target;
-
     let isDisposed = false;
     return {
         dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
@@ -1,0 +1,62 @@
+import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
+import type { ISceneExplorerService } from "./sceneExplorerService";
+
+import { FilmstripRegular, StackRegular } from "@fluentui/react-icons";
+
+import { AnimationGroup, TargetedAnimation } from "core/Animations/animationGroup";
+import { Observable } from "core/Misc";
+import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
+import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
+
+export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+    friendlyName: "Animation Group Hierarchy",
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return undefined;
+        }
+
+        const sectionRegistration = sceneExplorerService.addSection({
+            displayName: "Animation Groups",
+            order: 800,
+            predicate: (entity) => entity instanceof AnimationGroup || entity instanceof TargetedAnimation,
+            getRootEntities: () => scene.animationGroups,
+            getEntityChildren: (entity) => (entity instanceof AnimationGroup ? entity.targetedAnimations : []),
+            getEntityParent: (entity) => (entity instanceof TargetedAnimation ? entity.parent : null),
+            getEntityDisplayInfo: (entity) => {
+                const namedEntity = entity instanceof AnimationGroup ? entity : entity.animation;
+
+                const onChangeObservable = new Observable<void>();
+
+                const nameHookToken = InterceptProperty(namedEntity, "name", {
+                    afterSet: () => {
+                        onChangeObservable.notifyObservers();
+                    },
+                });
+
+                return {
+                    get name() {
+                        return namedEntity.name;
+                    },
+                    onChange: onChangeObservable,
+                    dispose: () => {
+                        nameHookToken.dispose();
+                        onChangeObservable.clear();
+                    },
+                };
+            },
+            entityIcon: ({ entity }) => (entity instanceof AnimationGroup ? <StackRegular /> : <FilmstripRegular />),
+            getEntityAddedObservables: () => [scene.onNewAnimationGroupAddedObservable],
+            getEntityRemovedObservables: () => [scene.onAnimationGroupRemovedObservable],
+        });
+
+        return {
+            dispose: () => {
+                sectionRegistration.dispose();
+            },
+        };
+    },
+};


### PR DESCRIPTION
This PR adds support for Animation Groups in Scene Explorer, along with some other related/needed changes:
- Adding a `uniqueId` and `parent` to `TargetedAnimation`
- Updating the property instrumentation to be able to hook a property that is not yet defined. This makes cases like the CommonGeneralProperties stay simple, where it can try to hook the `name` property, even if it doesn't exist. Otherwise it would make it a hassle since hooks in react function components can't be conditional.

<img width="912" height="415" alt="image" src="https://github.com/user-attachments/assets/3c42f2cc-2fd3-4c99-93de-fff2f8d9af7c" />