### PR TITLE
Inspector v2: Add GUI and Frame Graphs to Scene Explorer

### DIFF
--- a/packages/dev/inspector-v2/package.json
+++ b/packages/dev/inspector-v2/package.json
@@ -18,6 +18,7 @@
     "devDependencies": {
         "@dev/addons": "^1.0.0",
         "@dev/core": "1.0.0",
+        "@dev/gui": "^1.0.0",
         "@dev/loaders": "1.0.0",
         "@dev/materials": "^1.0.0",
         "@fluentui/react-components": "^9.62.0",

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -28,6 +28,8 @@ import { SkeletonPropertiesServiceDefinition } from "./services/panes/properties
 import { SpritePropertiesServiceDefinition } from "./services/panes/properties/spritePropertiesService";
 import { TransformPropertiesServiceDefinition } from "./services/panes/properties/transformPropertiesService";
 import { AnimationGroupExplorerServiceDefinition } from "./services/panes/scene/animationGroupExplorerService";
+import { FrameGraphExplorerServiceDefinition } from "./services/panes/scene/frameGraphExplorerService";
+import { GuiExplorerServiceDefinition } from "./services/panes/scene/guiExplorerService";
 import { MaterialExplorerServiceDefinition } from "./services/panes/scene/materialExplorerService";
 import { NodeHierarchyServiceDefinition } from "./services/panes/scene/nodeExplorerService";
 import { ParticleSystemExplorerServiceDefinition } from "./services/panes/scene/particleSystemExplorerService";
@@ -190,6 +192,8 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             ParticleSystemExplorerServiceDefinition,
             SpriteManagerHierarchyServiceDefinition,
             AnimationGroupExplorerServiceDefinition,
+            GuiExplorerServiceDefinition,
+            FrameGraphExplorerServiceDefinition,
 
             // Properties pane tab and related services.
             PropertiesServiceDefinition,

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -2,17 +2,16 @@ import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
-import { ImageEditRegular, ImageRegular } from "@fluentui/react-icons";
+import { FrameRegular } from "@fluentui/react-icons";
 
-import { BaseTexture } from "core/Materials/Textures/baseTexture";
-import { DynamicTexture } from "core/Materials/Textures/dynamicTexture";
+import { FrameGraph } from "core/FrameGraph/frameGraph";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Texture Hierarchy",
+export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+    friendlyName: "Frame Graph Hierarchy",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,14 +20,14 @@ export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExp
         }
 
         const sectionRegistration = sceneExplorerService.addSection({
-            displayName: "Textures",
-            order: 400,
-            predicate: (entity): entity is BaseTexture => entity instanceof BaseTexture && entity.getClassName() !== "AdvancedDynamicTexture",
-            getRootEntities: () => scene.textures.filter((texture) => texture.getClassName() !== "AdvancedDynamicTexture"),
-            getEntityDisplayInfo: (texture) => {
+            displayName: "Frame Graph",
+            order: 1000,
+            predicate: (entity) => entity instanceof FrameGraph,
+            getRootEntities: () => scene.frameGraphs,
+            getEntityDisplayInfo: (frameGraph) => {
                 const onChangeObservable = new Observable<void>();
 
-                const nameHookToken = InterceptProperty(texture, "name", {
+                const nameHookToken = InterceptProperty(frameGraph, "name", {
                     afterSet: () => {
                         onChangeObservable.notifyObservers();
                     },
@@ -36,7 +35,7 @@ export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExp
 
                 return {
                     get name() {
-                        return texture.displayName || texture.name || `${texture.constructor?.name || "Unnamed Texture"} (${texture.uniqueId})`;
+                        return frameGraph.name;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {
@@ -45,9 +44,9 @@ export const TextureHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExp
                     },
                 };
             },
-            entityIcon: ({ entity: texture }) => (texture instanceof DynamicTexture ? <ImageEditRegular /> : <ImageRegular />),
-            getEntityAddedObservables: () => [scene.onNewTextureAddedObservable],
-            getEntityRemovedObservables: () => [scene.onTextureRemovedObservable],
+            entityIcon: () => <FrameRegular />,
+            getEntityAddedObservables: () => [scene.onNewFrameGraphAddedObservable],
+            getEntityRemovedObservables: () => [scene.onFrameGraphRemovedObservable],
         });
 
         return {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -1,0 +1,86 @@
+import type { IDisposable, IObserver, Nullable } from "core/index";
+
+import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
+import type { ISceneExplorerService } from "./sceneExplorerService";
+
+import { AppGenericRegular } from "@fluentui/react-icons";
+
+import { Observable } from "core/Misc";
+import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
+import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
+
+export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+    friendlyName: "GUI Hierarchy",
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return undefined;
+        }
+
+        let disposed = false;
+        let sectionRegistration: Nullable<IDisposable> = null;
+        let textureAddedObserver: Nullable<IObserver> = null;
+
+        const addSectionAsync = async () => {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            const { AdvancedDynamicTexture } = await import("gui/2D/advancedDynamicTexture");
+            if (disposed || sectionRegistration) {
+                return;
+            }
+
+            sectionRegistration = sceneExplorerService.addSection({
+                displayName: "GUI",
+                order: 900,
+                predicate: (entity) => entity instanceof AdvancedDynamicTexture,
+                getRootEntities: () => scene.textures.filter((texture) => texture instanceof AdvancedDynamicTexture),
+                getEntityDisplayInfo: (advancedDynamicTexture) => {
+                    const onChangeObservable = new Observable<void>();
+
+                    const nameHookToken = InterceptProperty(advancedDynamicTexture, "name", {
+                        afterSet: () => {
+                            onChangeObservable.notifyObservers();
+                        },
+                    });
+
+                    return {
+                        get name() {
+                            return advancedDynamicTexture.name;
+                        },
+                        onChange: onChangeObservable,
+                        dispose: () => {
+                            nameHookToken.dispose();
+                            onChangeObservable.clear();
+                        },
+                    };
+                },
+                entityIcon: () => <AppGenericRegular />,
+                getEntityAddedObservables: () => [scene.onNewTextureAddedObservable],
+                getEntityRemovedObservables: () => [scene.onTextureRemovedObservable],
+            });
+        };
+
+        if (scene.textures.some((texture) => texture.getClassName() === "AdvancedDynamicTexture")) {
+            // If an AdvancedDynamicTexture is already present, we can register the section immediately.
+            void addSectionAsync();
+        } else {
+            // Otherwise, we defer the registration until an AdvancedDynamicTexture is added.
+            textureAddedObserver = scene.onNewTextureAddedObservable.add((texture) => {
+                if (texture.getClassName() === "AdvancedDynamicTexture") {
+                    textureAddedObserver?.remove();
+                    void addSectionAsync();
+                }
+            });
+        }
+
+        return {
+            dispose: () => {
+                disposed = true;
+                textureAddedObserver?.remove();
+                sectionRegistration?.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -10,8 +10,9 @@ import { InterceptProperty } from "../../../instrumentation/propertyInstrumentat
 import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
+// Don't use instanceof in this case as we don't want to bring in the gui package just to check if the entity is an AdvancedDynamicTexture.
 function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTexture {
-    return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";
+    return (entity as AdvancedDynamicTexture)?.constructor?.name === "AdvancedDynamicTexture";
 }
 
 export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -1,5 +1,4 @@
-import type { IDisposable, IObserver, Nullable } from "core/index";
-
+import type { AdvancedDynamicTexture } from "gui/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
@@ -11,6 +10,10 @@ import { InterceptProperty } from "../../../instrumentation/propertyInstrumentat
 import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
+function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTexture {
+    return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";
+}
+
 export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "GUI Hierarchy",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
@@ -20,66 +23,39 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
             return undefined;
         }
 
-        let disposed = false;
-        let sectionRegistration: Nullable<IDisposable> = null;
-        let textureAddedObserver: Nullable<IObserver> = null;
+        const sectionRegistration = sceneExplorerService.addSection({
+            displayName: "GUI",
+            order: 900,
+            predicate: IsAdvancedDynamicTexture,
+            getRootEntities: () => scene.textures.filter(IsAdvancedDynamicTexture),
+            getEntityDisplayInfo: (texture) => {
+                const onChangeObservable = new Observable<void>();
 
-        const addSectionAsync = async () => {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            const { AdvancedDynamicTexture } = await import("gui/2D/advancedDynamicTexture");
-            if (disposed || sectionRegistration) {
-                return;
-            }
+                const nameHookToken = InterceptProperty(texture, "name", {
+                    afterSet: () => {
+                        onChangeObservable.notifyObservers();
+                    },
+                });
 
-            sectionRegistration = sceneExplorerService.addSection({
-                displayName: "GUI",
-                order: 900,
-                predicate: (entity) => entity instanceof AdvancedDynamicTexture,
-                getRootEntities: () => scene.textures.filter((texture) => texture instanceof AdvancedDynamicTexture),
-                getEntityDisplayInfo: (advancedDynamicTexture) => {
-                    const onChangeObservable = new Observable<void>();
-
-                    const nameHookToken = InterceptProperty(advancedDynamicTexture, "name", {
-                        afterSet: () => {
-                            onChangeObservable.notifyObservers();
-                        },
-                    });
-
-                    return {
-                        get name() {
-                            return advancedDynamicTexture.name;
-                        },
-                        onChange: onChangeObservable,
-                        dispose: () => {
-                            nameHookToken.dispose();
-                            onChangeObservable.clear();
-                        },
-                    };
-                },
-                entityIcon: () => <AppGenericRegular />,
-                getEntityAddedObservables: () => [scene.onNewTextureAddedObservable],
-                getEntityRemovedObservables: () => [scene.onTextureRemovedObservable],
-            });
-        };
-
-        if (scene.textures.some((texture) => texture.getClassName() === "AdvancedDynamicTexture")) {
-            // If an AdvancedDynamicTexture is already present, we can register the section immediately.
-            void addSectionAsync();
-        } else {
-            // Otherwise, we defer the registration until an AdvancedDynamicTexture is added.
-            textureAddedObserver = scene.onNewTextureAddedObservable.add((texture) => {
-                if (texture.getClassName() === "AdvancedDynamicTexture") {
-                    textureAddedObserver?.remove();
-                    void addSectionAsync();
-                }
-            });
-        }
+                return {
+                    get name() {
+                        return texture.name;
+                    },
+                    onChange: onChangeObservable,
+                    dispose: () => {
+                        nameHookToken.dispose();
+                        onChangeObservable.clear();
+                    },
+                };
+            },
+            entityIcon: () => <AppGenericRegular />,
+            getEntityAddedObservables: () => [scene.onNewTextureAddedObservable],
+            getEntityRemovedObservables: () => [scene.onTextureRemovedObservable],
+        });
 
         return {
             dispose: () => {
-                disposed = true;
-                textureAddedObserver?.remove();
-                sectionRegistration?.dispose();
+                sectionRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/webpack.config.js
+++ b/packages/dev/inspector-v2/webpack.config.js
@@ -23,9 +23,10 @@ module.exports = (env) => {
         resolve: {
             extensions: [".ts", ".tsx", ".js", ".jsx"],
             alias: {
-                core: path.resolve("../../dev/core/dist"),
-                loaders: path.resolve("../../dev/loaders/dist"),
                 addons: path.resolve("../../dev/addons/dist"),
+                core: path.resolve("../../dev/core/dist"),
+                gui: path.resolve("../../dev/gui/dist"),
+                loaders: path.resolve("../../dev/loaders/dist"),
                 materials: path.resolve("../../dev/materials/dist"),
                 "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
             },

--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -25,6 +25,7 @@ module.exports = (env) => {
                 materials: path.resolve("../../dev/materials/dist"),
                 core: path.resolve("../../dev/core/dist"),
                 loaders: path.resolve("../../dev/loaders/dist"),
+                gui: path.resolve("../../dev/gui/dist"),
             },
         },
         externals: [
@@ -42,6 +43,8 @@ module.exports = (env) => {
                         return callback(null, "ADDONS");
                     } else if (/^materials\//.test(request)) {
                         return callback(null, "BABYLON");
+                    } else if (/^gui\//.test(request)) {
+                        return callback(null, "BABYLON.GUI");
                     }
                 }
 


### PR DESCRIPTION
This PR adds support for GUI (AdvancedDynamicTexture) and Frame Graphs to Scene Explorer.
- Configures the gui dependency in the inspector v2 test app and in Playground (when it uses inspector v2).
- Add support for the two new scene explorer sections.
- NOTE: The gui scene explorer service only imports types from the gui package so that it doesn't cause the gui package to be loaded when it otherwise often will not be.

<img width="345" height="495" alt="image" src="https://github.com/user-attachments/assets/1c9006d5-392b-46e1-8d8b-4443d1563c6b" />