### PR TITLE
Inspector v2: Post Processes in Scene Explorer

### DIFF
--- a/packages/dev/core/src/PostProcesses/postProcess.ts
+++ b/packages/dev/core/src/PostProcesses/postProcess.ts
@@ -678,7 +678,7 @@ export class PostProcess {
             camera.attachPostProcess(this);
             this._engine = this._scene.getEngine();
 
-            this._scene.postProcesses.push(this);
+            this._scene.addPostProcess(this);
             this.uniqueId = this._scene.getUniqueId();
         } else if (engine) {
             this._engine = engine;
@@ -1147,10 +1147,7 @@ export class PostProcess {
 
         let index;
         if (this._scene) {
-            index = this._scene.postProcesses.indexOf(this);
-            if (index !== -1) {
-                this._scene.postProcesses.splice(index, 1);
-            }
+            index = this._scene.removePostProcess(this);
         }
 
         if (this._parentContainer) {

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -877,6 +877,11 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     public onNewMultiMaterialAddedObservable = new Observable<MultiMaterial>();
 
     /**
+     * An event triggered when a post process is created
+     */
+    public onNewPostProcessAddedObservable = new Observable<PostProcess>();
+
+    /**
      * An event triggered when a material is removed
      */
     public onMaterialRemovedObservable = new Observable<Material>();
@@ -905,6 +910,11 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
      * An event triggered when a frame graph is removed
      */
     public onFrameGraphRemovedObservable = new Observable<FrameGraph>();
+
+    /**
+     * An event triggered when a post process is removed
+     */
+    public onPostProcessRemovedObservable = new Observable<PostProcess>();
 
     /**
      * An event triggered when render targets are about to be rendered
@@ -3063,6 +3073,21 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     }
 
     /**
+     * Removes the given post-process from this scene.
+     * @param toRemove The post-process to remove
+     * @returns The index of the removed post-process
+     */
+    public removePostProcess(toRemove: PostProcess): number {
+        const index = this.postProcesses.indexOf(toRemove);
+        if (index !== -1) {
+            this.postProcesses.splice(index, 1);
+        }
+        this.onPostProcessRemovedObservable.notifyObservers(toRemove);
+
+        return index;
+    }
+
+    /**
      * Adds the given light to this scene
      * @param newLight The light to add
      */
@@ -3265,6 +3290,20 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         this.frameGraphs.push(newFrameGraph);
         Tools.SetImmediate(() => {
             this.onNewFrameGraphAddedObservable.notifyObservers(newFrameGraph);
+        });
+    }
+
+    /**
+     * Adds the given post process to this scene.
+     * @param newPostProcess The post process to add
+     */
+    public addPostProcess(newPostProcess: PostProcess): void {
+        if (this._blockEntityCollection) {
+            return;
+        }
+        this.postProcesses.push(newPostProcess);
+        Tools.SetImmediate(() => {
+            this.onNewPostProcessAddedObservable.notifyObservers(newPostProcess);
         });
     }
 

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -31,13 +31,14 @@ import { AnimationGroupExplorerServiceDefinition } from "./services/panes/scene/
 import { FrameGraphExplorerServiceDefinition } from "./services/panes/scene/frameGraphExplorerService";
 import { GuiExplorerServiceDefinition } from "./services/panes/scene/guiExplorerService";
 import { MaterialExplorerServiceDefinition } from "./services/panes/scene/materialExplorerService";
-import { NodeHierarchyServiceDefinition } from "./services/panes/scene/nodeExplorerService";
+import { NodeExplorerServiceDefinition } from "./services/panes/scene/nodeExplorerService";
 import { ParticleSystemExplorerServiceDefinition } from "./services/panes/scene/particleSystemExplorerService";
-import { RenderingPipelineHierarchyServiceDefinition } from "./services/panes/scene/renderingPipelinesExplorerService";
+import { PostProcessExplorerServiceDefinition } from "./services/panes/scene/postProcessExplorerService";
+import { RenderingPipelineExplorerServiceDefinition } from "./services/panes/scene/renderingPipelinesExplorerService";
 import { SceneExplorerServiceDefinition } from "./services/panes/scene/sceneExplorerService";
-import { SkeletonHierarchyServiceDefinition } from "./services/panes/scene/skeletonExplorerService";
-import { SpriteManagerHierarchyServiceDefinition } from "./services/panes/scene/spriteManagerExplorerService";
-import { TextureHierarchyServiceDefinition } from "./services/panes/scene/texturesExplorerService";
+import { SkeletonExplorerServiceDefinition } from "./services/panes/scene/skeletonExplorerService";
+import { SpriteManagerExplorerServiceDefinition } from "./services/panes/scene/spriteManagerExplorerService";
+import { TextureExplorerServiceDefinition } from "./services/panes/scene/texturesExplorerService";
 import { SettingsServiceDefinition } from "./services/panes/settingsService";
 import { StatsServiceDefinition } from "./services/panes/statsService";
 import { ToolsServiceDefinition } from "./services/panes/toolsService";
@@ -184,13 +185,14 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
 
             // Scene explorer tab and related services.
             SceneExplorerServiceDefinition,
-            NodeHierarchyServiceDefinition,
-            SkeletonHierarchyServiceDefinition,
+            NodeExplorerServiceDefinition,
+            SkeletonExplorerServiceDefinition,
             MaterialExplorerServiceDefinition,
-            TextureHierarchyServiceDefinition,
-            RenderingPipelineHierarchyServiceDefinition,
+            TextureExplorerServiceDefinition,
+            PostProcessExplorerServiceDefinition,
+            RenderingPipelineExplorerServiceDefinition,
             ParticleSystemExplorerServiceDefinition,
-            SpriteManagerHierarchyServiceDefinition,
+            SpriteManagerExplorerServiceDefinition,
             AnimationGroupExplorerServiceDefinition,
             GuiExplorerServiceDefinition,
             FrameGraphExplorerServiceDefinition,

--- a/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
@@ -21,7 +21,7 @@ export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISc
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Animation Groups",
-            order: 800,
+            order: 900,
             predicate: (entity) => entity instanceof AnimationGroup || entity instanceof TargetedAnimation,
             getRootEntities: () => scene.animationGroups,
             getEntityChildren: (entity) => (entity instanceof AnimationGroup ? entity.targetedAnimations : []),

--- a/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
@@ -8,10 +8,11 @@ import { AnimationGroup, TargetedAnimation } from "core/Animations/animationGrou
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Animation Group Hierarchy",
+    friendlyName: "Animation Group Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,7 +22,7 @@ export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISc
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Animation Groups",
-            order: 900,
+            order: DefaultSectionsOrder.AnimationGroups,
             predicate: (entity) => entity instanceof AnimationGroup || entity instanceof TargetedAnimation,
             getRootEntities: () => scene.animationGroups,
             getEntityChildren: (entity) => (entity instanceof AnimationGroup ? entity.targetedAnimations : []),

--- a/packages/dev/inspector-v2/src/services/panes/scene/defaultSectionsMetadata.ts
+++ b/packages/dev/inspector-v2/src/services/panes/scene/defaultSectionsMetadata.ts
@@ -1,0 +1,13 @@
+export const enum DefaultSectionsOrder {
+    Nodes = 100,
+    Skeletons = 200,
+    Materials = 300,
+    Textures = 400,
+    PostProcesses = 500,
+    RenderingPipelines = 600,
+    ParticleSystems = 700,
+    SpriteManagers = 800,
+    AnimationGroups = 900,
+    GUIs = 1000,
+    FrameGraphs = 1100,
+}

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -21,7 +21,7 @@ export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Frame Graph",
-            order: 1000,
+            order: 1100,
             predicate: (entity) => entity instanceof FrameGraph,
             getRootEntities: () => scene.frameGraphs,
             getEntityDisplayInfo: (frameGraph) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -8,10 +8,11 @@ import { FrameGraph } from "core/FrameGraph/frameGraph";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Frame Graph Hierarchy",
+    friendlyName: "Frame Graph Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,7 +22,7 @@ export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Frame Graph",
-            order: 1100,
+            order: DefaultSectionsOrder.FrameGraphs,
             predicate: (entity) => entity instanceof FrameGraph,
             getRootEntities: () => scene.frameGraphs,
             getEntityDisplayInfo: (frameGraph) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -26,7 +26,7 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "GUI",
-            order: 900,
+            order: 1000,
             predicate: IsAdvancedDynamicTexture,
             getRootEntities: () => scene.textures.filter(IsAdvancedDynamicTexture),
             getEntityDisplayInfo: (texture) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -8,6 +8,7 @@ import { AppGenericRegular } from "@fluentui/react-icons";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 // Don't use instanceof in this case as we don't want to bring in the gui package just to check if the entity is an AdvancedDynamicTexture.
@@ -16,7 +17,7 @@ function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTex
 }
 
 export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "GUI Hierarchy",
+    friendlyName: "GUI Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -26,7 +27,7 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "GUI",
-            order: 1000,
+            order: DefaultSectionsOrder.GUIs,
             predicate: IsAdvancedDynamicTexture,
             getRootEntities: () => scene.textures.filter(IsAdvancedDynamicTexture),
             getEntityDisplayInfo: (texture) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
@@ -8,10 +8,11 @@ import { Material } from "core/Materials/material";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Material Hierarchy",
+    friendlyName: "Material Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,7 +22,7 @@ export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Materials",
-            order: 300,
+            order: DefaultSectionsOrder.Materials,
             predicate: (entity) => entity instanceof Material,
             getRootEntities: () => scene.materials,
             getEntityDisplayInfo: (material) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -14,7 +14,7 @@ import { InterceptProperty } from "../../../instrumentation/propertyInstrumentat
 import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const NodeHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Node Hierarchy",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -12,10 +12,11 @@ import { Observable } from "core/Misc";
 import { Node } from "core/node";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Node Hierarchy",
+    friendlyName: "Node Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -27,7 +28,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Nodes",
-            order: 100,
+            order: DefaultSectionsOrder.Nodes,
             predicate: (entity) => entity instanceof Node,
             getRootEntities: () => scene.rootNodes,
             getEntityChildren: (node) => node.getChildren(),

--- a/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
@@ -21,7 +21,7 @@ export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISc
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Particle Systems",
-            order: 600,
+            order: 700,
             predicate: (entity): entity is IParticleSystem => scene.particleSystems.includes(entity as IParticleSystem),
             getRootEntities: () => scene.particleSystems,
             getEntityDisplayInfo: (particleSystem) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
@@ -8,10 +8,11 @@ import { DropRegular } from "@fluentui/react-icons";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Particle System Hierarchy",
+    friendlyName: "Particle System Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,7 +22,7 @@ export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISc
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Particle Systems",
-            order: 700,
+            order: DefaultSectionsOrder.ParticleSystems,
             predicate: (entity): entity is IParticleSystem => scene.particleSystems.includes(entity as IParticleSystem),
             getRootEntities: () => scene.particleSystems,
             getEntityDisplayInfo: (particleSystem) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/postProcessExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/postProcessExplorerService.tsx
@@ -8,10 +8,11 @@ import { Observable } from "core/Misc";
 import { PostProcess } from "core/PostProcesses/postProcess";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const PostProcessExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Rendering Pipeline Hierarchy",
+    friendlyName: "Post Process Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,7 +22,7 @@ export const PostProcessExplorerServiceDefinition: ServiceDefinition<[], [IScene
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Post Processes",
-            order: 500,
+            order: DefaultSectionsOrder.PostProcesses,
             predicate: (entity) => entity instanceof PostProcess,
             getRootEntities: () => scene.postProcesses,
             getEntityDisplayInfo: (postProcess) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -6,12 +6,13 @@ import { PipelineRegular } from "@fluentui/react-icons";
 
 import { PostProcessRenderPipeline } from "core/PostProcesses/RenderPipeline/postProcessRenderPipeline";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 import "core/PostProcesses/RenderPipeline/postProcessRenderPipelineManagerSceneComponent";
 
 export const RenderingPipelineExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Rendering Pipeline Hierarchy",
+    friendlyName: "Rendering Pipeline Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -21,7 +22,7 @@ export const RenderingPipelineExplorerServiceDefinition: ServiceDefinition<[], [
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Rendering Pipelines",
-            order: 600,
+            order: DefaultSectionsOrder.RenderingPipelines,
             predicate: (entity) => entity instanceof PostProcessRenderPipeline,
             getRootEntities: () => scene.postProcessRenderPipelineManager.supportedPipelines ?? [],
             getEntityDisplayInfo: (pipeline) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -10,7 +10,7 @@ import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 import "core/PostProcesses/RenderPipeline/postProcessRenderPipelineManagerSceneComponent";
 
-export const RenderingPipelineHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+export const RenderingPipelineExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Rendering Pipeline Hierarchy",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
@@ -19,9 +19,9 @@ export const RenderingPipelineHierarchyServiceDefinition: ServiceDefinition<[], 
             return undefined;
         }
 
-        const sectionRegistration = sceneExplorerService.addSection<PostProcessRenderPipeline>({
+        const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Rendering Pipelines",
-            order: 500,
+            order: 600,
             predicate: (entity) => entity instanceof PostProcessRenderPipeline,
             getRootEntities: () => scene.postProcessRenderPipelineManager.supportedPipelines ?? [],
             getEntityDisplayInfo: (pipeline) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
@@ -9,10 +9,11 @@ import { Skeleton } from "core/Bones/skeleton";
 import { Observable } from "core/Misc/observable";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const SkeletonExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Skeleton Hierarchy",
+    friendlyName: "Skeleton Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -24,7 +25,7 @@ export const SkeletonExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
 
         const sectionRegistration = sceneExplorerService.addSection<Skeleton | Bone>({
             displayName: "Skeletons",
-            order: 200,
+            order: DefaultSectionsOrder.Skeletons,
             predicate: (entity) => entity instanceof Skeleton || entity instanceof Bone,
             getRootEntities: () => scene.skeletons,
             getEntityChildren: (skeletonOrBone) => skeletonOrBone.getChildren(),

--- a/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
@@ -11,7 +11,7 @@ import { InterceptProperty } from "../../../instrumentation/propertyInstrumentat
 import { SceneContextIdentity } from "../../sceneContext";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const SkeletonHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+export const SkeletonExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Skeleton Hierarchy",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -20,7 +20,7 @@ function IsSprite(entity: unknown): entity is Sprite {
     return (entity as Sprite).manager !== undefined;
 }
 
-export const SpriteManagerHierarchyServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Sprite Manager Hierarchy",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
@@ -29,9 +29,9 @@ export const SpriteManagerHierarchyServiceDefinition: ServiceDefinition<[], [ISc
             return undefined;
         }
 
-        const sectionRegistration = sceneExplorerService.addSection<ISpriteManager | Sprite>({
+        const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Sprite Managers",
-            order: 700,
+            order: 800,
             predicate: (entity) => IsSpriteManager(entity) || IsSprite(entity),
             getRootEntities: () => scene.spriteManagers ?? [],
             getEntityChildren: (spriteEntity) => (IsSpriteManager(spriteEntity) ? spriteEntity.sprites : ([] as ISpriteManager[])),

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -8,6 +8,7 @@ import { LayerDiagonalPersonRegular, PersonSquareRegular } from "@fluentui/react
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 import "core/Sprites/spriteSceneComponent";
@@ -21,7 +22,7 @@ function IsSprite(entity: unknown): entity is Sprite {
 }
 
 export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Sprite Manager Hierarchy",
+    friendlyName: "Sprite Manager Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -31,7 +32,7 @@ export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISce
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Sprite Managers",
-            order: 800,
+            order: DefaultSectionsOrder.SpriteManagers,
             predicate: (entity) => IsSpriteManager(entity) || IsSprite(entity),
             getRootEntities: () => scene.spriteManagers ?? [],
             getEntityChildren: (spriteEntity) => (IsSpriteManager(spriteEntity) ? spriteEntity.sprites : ([] as ISpriteManager[])),

--- a/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
@@ -9,10 +9,11 @@ import { DynamicTexture } from "core/Materials/Textures/dynamicTexture";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const TextureExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
-    friendlyName: "Texture Hierarchy",
+    friendlyName: "Texture Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
     factory: (sceneExplorerService, sceneContext) => {
         const scene = sceneContext.currentScene;
@@ -22,7 +23,7 @@ export const TextureExplorerServiceDefinition: ServiceDefinition<[], [ISceneExpl
 
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Textures",
-            order: 400,
+            order: DefaultSectionsOrder.Textures,
             predicate: (entity): entity is BaseTexture => entity instanceof BaseTexture && entity.getClassName() !== "AdvancedDynamicTexture",
             getRootEntities: () => scene.textures.filter((texture) => texture.getClassName() !== "AdvancedDynamicTexture"),
             getEntityDisplayInfo: (texture) => {


### PR DESCRIPTION
Adds post processes to scene explorer.
- Add missing observables and functions for add/remove post processes in scene.
- Update orders for scene explorer sections.
- Make scene explorer section service definition naming consistent (Hierarchy -> Explorer).