### PR TITLE
playground: allow zip download in self-hosted server with non-root path

### DIFF
--- a/packages/tools/playground/src/tools/downloadManager.ts
+++ b/packages/tools/playground/src/tools/downloadManager.ts
@@ -146,7 +146,7 @@ export class DownloadManager {
         } while (true);
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        this._addContentToZipAsync(zip, "index.html", "/zipContent/index.html", zipCode)
+        this._addContentToZipAsync(zip, "index.html", "./zipContent/index.html", zipCode)
             .then(async () => {
                 return await this._addTexturesToZipAsync(zip, 0, textures, null);
             })


### PR DESCRIPTION
When the playground is served from a subdirectory (e.g. `http://127.0.0.1:8080/dev/babylon.js/playground/`), the hard-coded `/zipContent/index.html` URL breaks, because it always resolves against the server root. Changing it to `./zipContent/index.html` makes the request relative to the current path, restoring zip download functionality on self-hosted and non-root environments.

Forum post: <https://forum.babylonjs.com/t/playground-allow-zip-download-in-self-hosted-server-with-non-root-path/59541>