### PR TITLE
Add settings to prefer project relative paths for the VS Code import quick fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,7 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "editor.formatOnSave": true,
-    "jest.runMode": "on-demand"
+    "jest.runMode": "on-demand",
+    "typescript.preferences.importModuleSpecifier": "project-relative",
+    "javascript.preferences.importModuleSpecifier": "project-relative"
 }

--- a/packages/dev/inspector-v2/webpack.config.js
+++ b/packages/dev/inspector-v2/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = (env) => {
                 loaders: path.resolve("../../dev/loaders/dist"),
                 materials: path.resolve("../../dev/materials/dist"),
                 "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
+                "inspector-v2": path.resolve("./src"),
             },
         },
 


### PR DESCRIPTION
Two changes here:

## VSCode settings for import quickfix
For the entire workspace/repo, prefer project relative paths for the import quick fix. The default setting is to prefer whatever form of the import has the fewest characters, which means it may choose a relative path or it may choose an "absolute" path (starting with the module name).

### Before:
<img width="798" height="183" alt="image" src="https://github.com/user-attachments/assets/79af60bf-fda0-4456-bf61-41a54bf5b04f" />

### After:
<img width="797" height="181" alt="image" src="https://github.com/user-attachments/assets/888868e7-abf1-44e0-8387-b5aa77106afa" />

## Allow absolute module imports in the inspector-v2 test app
Even with the first configuration, it should still not be an error to import from `"inspector-v2/..."` in the inspector-v2 test app. This is consistent with other projects in the repo. This is just a small change in the webpack config for the test app.