### PR TITLE
enum fix for ktx/basis

### DIFF
--- a/packages/dev/core/src/Materials/Textures/ktx2decoderTypes.ts
+++ b/packages/dev/core/src/Materials/Textures/ktx2decoderTypes.ts
@@ -6,6 +6,8 @@ export enum SourceTextureFormat {
 
 export enum TranscodeTarget {
     ASTC_4X4_RGBA,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    ASTC_4x4_RGBA = ASTC_4X4_RGBA,
     BC7_RGBA,
     BC3_RGBA,
     BC1_RGB,


### PR DESCRIPTION
while investigating

https://forum.babylonjs.com/t/ktx2-ios-mipmap-issue/59136

Found an issue here:

https://github.com/BabylonJS/Babylon.js/blob/2a36f70486180195605b4b381a569d8b43fbf986/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts#L146

To make it short, `KTX2.TranscodeTarget[dst]` returned `ASTC_4X4_RGBA` while expected value for basis is `ASTC_4x4_RGBA`. Keeping old enum value to not break back compat.