### PR TITLE
Fix some boolean options

### DIFF
--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -29,7 +29,7 @@ export class UniformBuffer {
     private _createBufferOnWrite: boolean;
     private _data: number[];
     private _bufferData: Float32Array;
-    private _dynamic?: boolean;
+    private _dynamic: boolean;
     private _uniformLocations: { [key: string]: number };
     private _uniformSizes: { [key: string]: number };
     private _uniformArraySizes: { [key: string]: { strideSize: number; arraySize: number } };
@@ -237,7 +237,7 @@ export class UniformBuffer {
      * @param name to assign to the buffer (debugging purpose)
      * @param forceNoUniformBuffer define that this object must not rely on UBO objects
      */
-    constructor(engine: AbstractEngine, data?: number[], dynamic?: boolean, name?: string, forceNoUniformBuffer = false) {
+    constructor(engine: AbstractEngine, data?: number[], dynamic = false, name?: string, forceNoUniformBuffer = false) {
         this._engine = engine;
         this._noUBO = !engine.supportsUniformBuffers || forceNoUniformBuffer;
         this._dynamic = dynamic;
@@ -338,7 +338,7 @@ export class UniformBuffer {
      * @returns if Dynamic, otherwise false
      */
     public isDynamic(): boolean {
-        return this._dynamic !== undefined;
+        return this._dynamic;
     }
 
     /**

--- a/packages/dev/core/src/Meshes/trailMesh.ts
+++ b/packages/dev/core/src/Meshes/trailMesh.ts
@@ -95,8 +95,8 @@ export class TrailMesh extends Mesh {
             this._length = diameterOrOptions.length || 60;
             this._segments = diameterOrOptions.segments ? (diameterOrOptions.segments > this._length ? this._length : diameterOrOptions.segments) : this._length;
             this._sectionPolygonPointsCount = diameterOrOptions.sections || 4;
-            this._doNotTaper = diameterOrOptions.doNotTaper || false;
-            this._autoStart = diameterOrOptions.autoStart || true;
+            this._doNotTaper = diameterOrOptions.doNotTaper ?? false;
+            this._autoStart = diameterOrOptions.autoStart ?? true;
         } else {
             this.diameter = diameterOrOptions || 1;
             this._length = length;

--- a/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderEffect.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderEffect.ts
@@ -31,9 +31,9 @@ export class PostProcessRenderEffect {
      * @param getPostProcesses A function that returns a set of post processes which the effect will run in order to be run.
      * @param singleInstance False if this post process can be run on multiple cameras. (default: true)
      */
-    constructor(engine: AbstractEngine, name: string, getPostProcesses: () => Nullable<PostProcess | Array<PostProcess>>, singleInstance?: boolean) {
+    constructor(engine: AbstractEngine, name: string, getPostProcesses: () => Nullable<PostProcess | Array<PostProcess>>, singleInstance = true) {
         this._name = name;
-        this._singleInstance = singleInstance || true;
+        this._singleInstance = singleInstance;
 
         this._getPostProcesses = getPostProcesses;
 

--- a/packages/dev/core/src/XR/features/WebXRControllerMovement.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerMovement.ts
@@ -338,7 +338,7 @@ export class WebXRControllerMovement extends WebXRAbstractFeature {
 
         // synchronized from feature setter properties
         this._featureContext = {
-            movementEnabled: options.movementEnabled || true,
+            movementEnabled: options.movementEnabled ?? true,
             movementOrientationFollowsViewerPose: options.movementOrientationFollowsViewerPose ?? true,
             movementOrientationFollowsController: options.movementOrientationFollowsController ?? false,
             orientationPreferredHandedness: options.orientationPreferredHandedness,


### PR DESCRIPTION
Just noticed these while working on some other stuff and they were sending me insane
- `|| true` will always make the value true regardless of what the option is set to since the RHS will be used if the LHS is false
- also noticed `UniformBuffer` having its `isDynamic` be `!== undefined` so will be marked as `true` if u explicitly set it to `false`. Might be more like this but a lot harder to find/replace