### PR TITLE
Fix bug where glow layer is recreated every frame under NullEngine

### DIFF
--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -536,8 +536,7 @@ export abstract class EffectLayer {
         // Handle size changes.
         this._setMainTextureSize();
         if (
-            (this._mainTextureCreatedSize.width !== this._mainTextureDesiredSize.width ||
-                this._mainTextureCreatedSize.height !== this._mainTextureDesiredSize.height) &&
+            (this._mainTextureCreatedSize.width !== this._mainTextureDesiredSize.width || this._mainTextureCreatedSize.height !== this._mainTextureDesiredSize.height) &&
             this._mainTextureDesiredSize.width !== 0 &&
             this._mainTextureDesiredSize.height !== 0
         ) {

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -76,7 +76,7 @@ export interface IEffectLayerOptions {
  */
 export abstract class EffectLayer {
     private _effectLayerOptions: IEffectLayerOptions;
-    private _mainTextureCreatedSize: ISize = {width: 0, height: 0};
+    private _mainTextureCreatedSize: ISize = { width: 0, height: 0 };
 
     protected _scene: Scene;
     protected _engine: AbstractEngine;

--- a/packages/dev/core/src/Layers/effectLayer.ts
+++ b/packages/dev/core/src/Layers/effectLayer.ts
@@ -76,6 +76,7 @@ export interface IEffectLayerOptions {
  */
 export abstract class EffectLayer {
     private _effectLayerOptions: IEffectLayerOptions;
+    private _mainTextureCreatedSize: ISize = {width: 0, height: 0};
 
     protected _scene: Scene;
     protected _engine: AbstractEngine;
@@ -533,10 +534,10 @@ export abstract class EffectLayer {
         }
 
         // Handle size changes.
-        const size = this._mainTexture.getSize();
         this._setMainTextureSize();
         if (
-            (size.width !== this._mainTextureDesiredSize.width || size.height !== this._mainTextureDesiredSize.height) &&
+            (this._mainTextureCreatedSize.width !== this._mainTextureDesiredSize.width ||
+                this._mainTextureCreatedSize.height !== this._mainTextureDesiredSize.height) &&
             this._mainTextureDesiredSize.width !== 0 &&
             this._mainTextureDesiredSize.height !== 0
         ) {
@@ -545,6 +546,8 @@ export abstract class EffectLayer {
             this._disposeTextureAndPostProcesses();
             this._createMainTexture();
             this._createTextureAndPostProcesses();
+            this._mainTextureCreatedSize.width = this._mainTextureDesiredSize.width;
+            this._mainTextureCreatedSize.height = this._mainTextureDesiredSize.height;
         }
     }
 


### PR DESCRIPTION
The render() method in effectLayer.ts checks whether the current main texture size matches the desired size; it disposes and recreates it if it doesn't. Unfortunately when running with the null engine, the size of the created texture is always zero (whatever size arguments are passed into its constructor) so it never matches the desired size and is thus recreated every time.

Changing things such that textures return their intended size when running under the null engine seemed like quite an invasive and risky change, so my fix just changes effectLayer.ts to remember the size it asked for and check against that rather than the reported size of the texture.