### PR TITLE
native morph workaround

### DIFF
--- a/packages/dev/core/src/Culling/Helper/computeShaderBoundingHelper.ts
+++ b/packages/dev/core/src/Culling/Helper/computeShaderBoundingHelper.ts
@@ -268,7 +268,7 @@ export class ComputeShaderBoundingHelper implements IBoundingInfoHelperPlatform 
                 );
 
                 ubo.updateFloat3("morphTargetTextureInfo", manager._textureVertexStride, manager._textureWidth, manager._textureHeight);
-                ubo.updateInt("morphTargetCount", manager.numInfluencers);
+                ubo.updateFloat("morphTargetCount", manager.numInfluencers);
                 ubo.update();
             }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -292,7 +292,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         const uniformsPrefix = isWebGPU ? "uniforms." : "";
         if (manager?.isUsingTextureForTargets) {
             injectionCode += `for (${isWebGPU ? "var" : "int"} i = 0; i < NUM_MORPH_INFLUENCERS; i++) {\n`;
-            injectionCode += `if (i >= ${uniformsPrefix}morphTargetCount) { break; }\n`;
+            injectionCode += `if (float(i) >= ${uniformsPrefix}morphTargetCount) { break; }\n`;
 
             injectionCode += `vertexID = ${isWebGPU ? "f32(vertexInputs.vertexIndex" : "float(gl_VertexID"}) * ${uniformsPrefix}morphTargetTextureInfo.x;\n`;
             if (supportPositions) {

--- a/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Vertex/morphTargetsBlock.ts
@@ -292,7 +292,7 @@ export class MorphTargetsBlock extends NodeMaterialBlock {
         const uniformsPrefix = isWebGPU ? "uniforms." : "";
         if (manager?.isUsingTextureForTargets) {
             injectionCode += `for (${isWebGPU ? "var" : "int"} i = 0; i < NUM_MORPH_INFLUENCERS; i++) {\n`;
-            injectionCode += `if (float(i) >= ${uniformsPrefix}morphTargetCount) { break; }\n`;
+            injectionCode += `if (${isWebGPU ? "f32" : "float"}(i) >= ${uniformsPrefix}morphTargetCount) { break; }\n`;
 
             injectionCode += `vertexID = ${isWebGPU ? "f32(vertexInputs.vertexIndex" : "float(gl_VertexID"}) * ${uniformsPrefix}morphTargetTextureInfo.x;\n`;
             if (supportPositions) {

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -403,7 +403,7 @@ export class MorphTargetManager implements IDisposable {
         effect.setFloat3("morphTargetTextureInfo", this._textureVertexStride, this._textureWidth, this._textureHeight);
         effect.setFloatArray("morphTargetTextureIndices", this._morphTargetTextureIndices);
         effect.setTexture("morphTargets", this._targetStoreTexture);
-        effect.setInt("morphTargetCount", this.numInfluencers);
+        effect.setFloat("morphTargetCount", this.numInfluencers);
     }
 
     /**

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -3,8 +3,11 @@
 		#if {X} == 0
 		float floatIndex = 0.;
 		for (int i = 0; i < NUM_MORPH_INFLUENCERS; i++) {
+#if defined(NATIVE)			
 			if (floatIndex >= morphTargetCount) break;
-
+#else
+			if (i >= morphTargetCount) break;
+#endif
 			vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;
 
 			#ifdef MORPHTARGETS_POSITION

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -1,8 +1,9 @@
 ﻿#ifdef MORPHTARGETS
 	#ifdef MORPHTARGETS_TEXTURE
 		#if {X} == 0
+		float floatIndex = 0.;
 		for (int i = 0; i < NUM_MORPH_INFLUENCERS; i++) {
-			if (i >= morphTargetCount) break;
+			if (floatIndex >= morphTargetCount) break;
 
 			vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;
 
@@ -44,6 +45,7 @@
 			#ifdef MORPHTARGETS_COLOR
 				colorUpdated += (readVector4FromRawSampler(i, vertexID) - color) * morphTargetInfluences[i];
 			#endif
+			floatIndex += 1.;
 		}
 		#endif
 	#else

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertex.fx
@@ -1,13 +1,9 @@
 ﻿#ifdef MORPHTARGETS
 	#ifdef MORPHTARGETS_TEXTURE
 		#if {X} == 0
-		float floatIndex = 0.;
 		for (int i = 0; i < NUM_MORPH_INFLUENCERS; i++) {
-#if defined(NATIVE)			
-			if (floatIndex >= morphTargetCount) break;
-#else
-			if (i >= morphTargetCount) break;
-#endif
+			if (float(i) >= morphTargetCount) break;
+
 			vertexID = float(gl_VertexID) * morphTargetTextureInfo.x;
 
 			#ifdef MORPHTARGETS_POSITION
@@ -48,7 +44,6 @@
 			#ifdef MORPHTARGETS_COLOR
 				colorUpdated += (readVector4FromRawSampler(i, vertexID) - color) * morphTargetInfluences[i];
 			#endif
-			floatIndex += 1.;
 		}
 		#endif
 	#else

--- a/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -24,6 +24,6 @@
 		attribute vec4 color{X};
 		#endif
 	#elif {X} == 0
-		uniform int morphTargetCount;
+		uniform float morphTargetCount;
 	#endif
 #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -2,7 +2,7 @@
 	#ifdef MORPHTARGETS_TEXTURE
 		#if {X} == 0
 		for (var i = 0; i < NUM_MORPH_INFLUENCERS; i = i + 1) {
-			if (float(i) >= uniforms.morphTargetCount) {
+			if (f32(i) >= uniforms.morphTargetCount) {
 				break;
 			}
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertex.fx
@@ -2,7 +2,7 @@
 	#ifdef MORPHTARGETS_TEXTURE
 		#if {X} == 0
 		for (var i = 0; i < NUM_MORPH_INFLUENCERS; i = i + 1) {
-			if (i >= uniforms.morphTargetCount) {
+			if (float(i) >= uniforms.morphTargetCount) {
 				break;
 			}
 

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/morphTargetsVertexDeclaration.fx
@@ -24,6 +24,6 @@
         attribute color{X} : vec4<f32>;
         #endif
 	#elif {X} == 0
-		uniform morphTargetCount: i32;
+		uniform morphTargetCount: f32;
 	#endif
 #endif

--- a/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
@@ -165,7 +165,7 @@ fn main(@builtin(global_invocation_id) global_id : vec3<u32>) {
 
 #ifdef MORPHTARGETS
     for (var i = 0; i < NUM_MORPH_INFLUENCERS; i = i + 1) {
-        if (float(i) >= settings.morphTargetCount) {
+        if (f32(i) >= settings.morphTargetCount) {
             break;
         }
         positionUpdated = positionUpdated + (readVector3FromRawSampler(i, index) - position) * morphTargetInfluences[i];

--- a/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/boundingInfo.compute.fx
@@ -71,7 +71,7 @@ const identity = mat4x4f(
 
 struct Settings {
     morphTargetTextureInfo: vec3f,
-    morphTargetCount: i32,
+    morphTargetCount: f32,
     indexResult : u32,
 };
 
@@ -165,7 +165,7 @@ fn main(@builtin(global_invocation_id) global_id : vec3<u32>) {
 
 #ifdef MORPHTARGETS
     for (var i = 0; i < NUM_MORPH_INFLUENCERS; i = i + 1) {
-        if (i >= settings.morphTargetCount) {
+        if (float(i) >= settings.morphTargetCount) {
             break;
         }
         positionUpdated = positionUpdated + (readVector3FromRawSampler(i, index) - position) * morphTargetInfluences[i];


### PR DESCRIPTION
morphTargetCount is a uniform int;
but bgfx only support vec4 as uniform.
when doing the replacement, morphTargetCount.x is used and comparison between `int i` and `morphTargetCount.x` which is a float break shader compilation with GLSL.
casting `morphTargetCount` to int doesn't work: casting qualifier is removed becaused it's still an int before shader traversers.
Setting morphTargetCount a float in the engine and casting iterators to float seems to work better. 
I've also done the change for WGSL to pass the tests.

Long term is to add (or change) traversers for float/int comparison.