### PR TITLE
Inspector v2: Add useResource hook and use it to correctly manage some object lifetimes in stats

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
@@ -47,16 +47,18 @@ export const AnimationsProperties: FunctionComponent<{ scene: Scene; entity: Par
         lastLoop.current = mainAnimatable.loopAnimation;
     }
 
+    const hasAnimations = animations.length > 0 || ranges.length > 0 || childAnimatables.length > 0;
+
     const currentFrame = useObservableState(
         useCallback(() => {
             return mainAnimatable ? mainAnimatable.masterFrame : (scene.getAllAnimatablesByTarget(entity)[0]?.masterFrame ?? 0);
         }, [scene, entity, mainAnimatable]),
-        scene.onAfterAnimationsObservable
+        hasAnimations ? scene.onAfterAnimationsObservable : undefined
     );
 
     return (
         <>
-            {animations.length === 0 && ranges.length === 0 && childAnimatables.length === 0 ? (
+            {!hasAnimations ? (
                 <MessageBar
                     intent="info"
                     title="No Animations"

--- a/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
@@ -2,7 +2,7 @@ import type { Scene } from "core/index";
 
 import type { FunctionComponent } from "react";
 
-import { useEffect, useRef } from "react";
+import { useCallback } from "react";
 
 import { EngineInstrumentation } from "core/Instrumentation/engineInstrumentation";
 import { SceneInstrumentation } from "core/Instrumentation/sceneInstrumentation";
@@ -10,6 +10,7 @@ import { SceneInstrumentation } from "core/Instrumentation/sceneInstrumentation"
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
 import { usePollingObservable } from "../../hooks/pollingHooks";
+import { useResource } from "../../hooks/resourceHooks";
 
 // TODO: Dynamically import the right engine.query module based on the type of engine?
 import "core/Engines/AbstractEngine/abstractEngine.timeQuery";
@@ -18,57 +19,41 @@ import "core/Engines/WebGPU/Extensions/engine.query";
 
 export const FrameStepsStats: FunctionComponent<{ context: Scene }> = ({ context: scene }) => {
     const pollingObservable = usePollingObservable(1000);
-    const sceneInstrumentationRef = useRef<SceneInstrumentation>(new SceneInstrumentation(scene));
-    const engineInstrumentationRef = useRef<EngineInstrumentation>(new EngineInstrumentation(scene.getEngine()));
 
-    useEffect(() => {
-        let sceneInstrumentation = sceneInstrumentationRef.current;
+    const sceneInstrumentation = useResource(
+        useCallback(() => {
+            const sceneInstrumentation = new SceneInstrumentation(scene);
+            sceneInstrumentation.captureActiveMeshesEvaluationTime = true;
+            sceneInstrumentation.captureRenderTargetsRenderTime = true;
+            sceneInstrumentation.captureFrameTime = true;
+            sceneInstrumentation.captureRenderTime = true;
+            sceneInstrumentation.captureInterFrameTime = true;
+            sceneInstrumentation.captureParticlesRenderTime = true;
+            sceneInstrumentation.captureSpritesRenderTime = true;
+            sceneInstrumentation.capturePhysicsTime = true;
+            sceneInstrumentation.captureAnimationsTime = true;
+            return sceneInstrumentation;
+        }, [scene])
+    );
 
-        if (sceneInstrumentation.scene !== scene) {
-            sceneInstrumentation.dispose();
-            sceneInstrumentation = new SceneInstrumentation(scene);
-            sceneInstrumentationRef.current = sceneInstrumentation;
-        }
-        sceneInstrumentation.captureActiveMeshesEvaluationTime = true;
-        sceneInstrumentation.captureRenderTargetsRenderTime = true;
-        sceneInstrumentation.captureFrameTime = true;
-        sceneInstrumentation.captureRenderTime = true;
-        sceneInstrumentation.captureInterFrameTime = true;
-        sceneInstrumentation.captureParticlesRenderTime = true;
-        sceneInstrumentation.captureSpritesRenderTime = true;
-        sceneInstrumentation.capturePhysicsTime = true;
-        sceneInstrumentation.captureAnimationsTime = true;
+    const engineInstrumentation = useResource(
+        useCallback(() => {
+            const engineInstrumentation = new EngineInstrumentation(scene.getEngine());
+            engineInstrumentation.captureGPUFrameTime = true;
+            return engineInstrumentation;
+        }, [scene.getEngine()])
+    );
 
-        return () => {
-            sceneInstrumentation.dispose();
-        };
-    }, [scene]);
-
-    useEffect(() => {
-        let engineInstrumentation = engineInstrumentationRef.current;
-        const engine = scene.getEngine();
-        if (engineInstrumentation.engine !== engine) {
-            engineInstrumentation.dispose();
-            engineInstrumentation = new EngineInstrumentation(engine);
-            engineInstrumentationRef.current = engineInstrumentation;
-        }
-        engineInstrumentation.captureGPUFrameTime = true;
-
-        return () => {
-            engineInstrumentation.dispose();
-        };
-    }, [scene]);
-
-    const absoluteFPS = useObservableState(() => Math.floor(1000.0 / sceneInstrumentationRef.current.frameTimeCounter.lastSecAverage), pollingObservable);
-    const meshesSelection = useObservableState(() => sceneInstrumentationRef.current.activeMeshesEvaluationTimeCounter.lastSecAverage, pollingObservable);
-    const renderTargets = useObservableState(() => sceneInstrumentationRef.current.renderTargetsRenderTimeCounter.lastSecAverage, pollingObservable);
-    const particles = useObservableState(() => sceneInstrumentationRef.current.particlesRenderTimeCounter.lastSecAverage, pollingObservable);
-    const sprites = useObservableState(() => sceneInstrumentationRef.current.spritesRenderTimeCounter.lastSecAverage, pollingObservable);
-    const animations = useObservableState(() => sceneInstrumentationRef.current.animationsTimeCounter.lastSecAverage, pollingObservable);
-    const physics = useObservableState(() => sceneInstrumentationRef.current.physicsTimeCounter.lastSecAverage, pollingObservable);
-    const interFrameTime = useObservableState(() => sceneInstrumentationRef.current.interFrameTimeCounter.lastSecAverage, pollingObservable);
-    const gpuFrameTime = useObservableState(() => engineInstrumentationRef.current.gpuFrameTimeCounter.lastSecAverage * 0.000001, pollingObservable);
-    const gpuFrameTimeAverage = useObservableState(() => engineInstrumentationRef.current.gpuFrameTimeCounter.average * 0.000001, pollingObservable);
+    const absoluteFPS = useObservableState(() => Math.floor(1000.0 / sceneInstrumentation.frameTimeCounter.lastSecAverage), pollingObservable);
+    const meshesSelection = useObservableState(() => sceneInstrumentation.activeMeshesEvaluationTimeCounter.lastSecAverage, pollingObservable);
+    const renderTargets = useObservableState(() => sceneInstrumentation.renderTargetsRenderTimeCounter.lastSecAverage, pollingObservable);
+    const particles = useObservableState(() => sceneInstrumentation.particlesRenderTimeCounter.lastSecAverage, pollingObservable);
+    const sprites = useObservableState(() => sceneInstrumentation.spritesRenderTimeCounter.lastSecAverage, pollingObservable);
+    const animations = useObservableState(() => sceneInstrumentation.animationsTimeCounter.lastSecAverage, pollingObservable);
+    const physics = useObservableState(() => sceneInstrumentation.physicsTimeCounter.lastSecAverage, pollingObservable);
+    const interFrameTime = useObservableState(() => sceneInstrumentation.interFrameTimeCounter.lastSecAverage, pollingObservable);
+    const gpuFrameTime = useObservableState(() => engineInstrumentation.gpuFrameTimeCounter.lastSecAverage * 0.000001, pollingObservable);
+    const gpuFrameTimeAverage = useObservableState(() => engineInstrumentation.gpuFrameTimeCounter.average * 0.000001, pollingObservable);
 
     return (
         <>

--- a/packages/dev/inspector-v2/src/hooks/resourceHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/resourceHooks.ts
@@ -1,0 +1,37 @@
+import type { IDisposable } from "core/index";
+
+import { useRef, useEffect } from "react";
+
+/**
+ * Custom hook to manage a resource with automatic disposal. The resource is created once initially, and recreated
+ * if the factory function changes. Whenever the resource is recreated, the previous instance is disposed. The final
+ * instance is disposed when the component using this hook unmounts.
+ * @param factory A function that creates the resource.
+ * @returns The created resource.
+ */
+export function useResource<T extends IDisposable>(factory: () => T): T {
+    const resourceRef = useRef<T>();
+    const factoryRef = useRef(factory);
+
+    // Initialize resource synchronously on first call or when factory changes
+    if (!resourceRef.current || factoryRef.current !== factory) {
+        // Dispose old resource if it exists
+        resourceRef.current?.dispose();
+
+        // Create new resource
+        resourceRef.current = factory();
+    }
+
+    // Update refs to capture latest values
+    factoryRef.current = factory;
+
+    // Cleanup effect for component unmount
+    useEffect(() => {
+        return () => {
+            resourceRef.current?.dispose();
+            resourceRef.current = undefined;
+        };
+    }, []);
+
+    return resourceRef.current;
+}


### PR DESCRIPTION
One challenge with React function components is managing lifetimes of disposable resources. I noticed that my previous implementation in stats was totally wrong and recreating a ton of `SceneInstrumentation` and `EngineInstrumentation` instances that were never disposed. I have more cases of this kind of resource management as well, so I'm introducing a `useResource` custom hook that makes it easy to correctly manage disposable resources in a React function component, and using this in stats.

Also, I included one other small fix that prevents registering for the animation callback for animation properties when the entity has no animations.