### PR TITLE
Don't apply fog on skybox by default

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -210,6 +210,7 @@ function createSkybox(scene: Scene, camera: Camera, reflectionTexture: BaseTextu
         hdrSkybox.material = hdrSkyboxMaterial;
         hdrSkybox.isPickable = false;
         hdrSkybox.infiniteDistance = true;
+        hdrSkybox.applyFog = false;
 
         updateSkybox(hdrSkybox, camera);
 


### PR DESCRIPTION
By default the fog should not apply on the skybox for the viewer in case there is some grid used.