### PR TITLE
_updateLight now works with _loadedModels

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -2701,13 +2701,13 @@ export class Viewer implements IDisposable {
 
     private _updateLight() {
         let shouldHaveDefaultLight: boolean;
-        if (!this._activeModel) {
+        if (this._loadedModels.length === 0) {
             shouldHaveDefaultLight = false;
         } else {
-            const hasModelProvidedLights = this._activeModel.assetContainer.lights.length > 0;
+            const hasModelProvidedLights = this._loadedModels.some((model) => model.assetContainer.lights.length > 0);
             const hasImageBasedLighting = !!this._reflectionTexture;
-            const hasMaterials = this._activeModel.assetContainer.materials.length > 0;
-            const hasNonPBRMaterials = this._activeModel.assetContainer.materials.some((material) => !(material instanceof PBRMaterial));
+            const hasMaterials = this._loadedModels.some((model) => model.assetContainer.materials.length > 0);
+            const hasNonPBRMaterials = this._loadedModels.some((model) => model.assetContainer.materials.some((material) => !(material instanceof PBRMaterial)));
 
             if (hasModelProvidedLights) {
                 shouldHaveDefaultLight = false;


### PR DESCRIPTION
if the viewer is used with multiple models, _activeModel property is never set which make the use a multiple models that don't have pbr support all black