### PR TITLE
USDZ Exporter: Place "Materials" under the default prim

### DIFF
--- a/packages/dev/serializers/src/USDZ/usdzExporter.ts
+++ b/packages/dev/serializers/src/USDZ/usdzExporter.ts
@@ -75,7 +75,7 @@ function BuildHeader() {
     )`;
 }
 
-function BuildSceneStart(options: IUSDZExportOptions) {
+function BuildRootAndSceneStart(options: IUSDZExportOptions) {
     const alignment =
         options.includeAnchoringProperties === true
             ? `
@@ -102,7 +102,11 @@ function BuildSceneStart(options: IUSDZExportOptions) {
 function BuildSceneEnd() {
     return `
             }
-        }
+        }`;
+}
+
+function BuildRootEnd() {
+    return `
     }`;
 }
 
@@ -251,7 +255,7 @@ function BuildXform(mesh: Mesh, matrix: Matrix) {
 	matrix4d xformOp:transform = ${transform}
 	uniform token[] xformOpOrder = ["xformOp:transform"]	
 
-    rel material:binding = </Materials/Material_${mesh.material!.uniqueId}>
+    rel material:binding = </Root/Materials/Material_${mesh.material!.uniqueId}>
 }
 
 `;
@@ -338,7 +342,7 @@ function BuildTexture(
     def Shader "Transform2d_${mapType}"
     {
         uniform token info:id = "UsdTransform2d"
-        token inputs:in.connect = </Materials/Material_${material.uniqueId}/PrimvarReader_${mapType}.outputs:result>
+        token inputs:in.connect = </Root/Materials/Material_${material.uniqueId}/PrimvarReader_${mapType}.outputs:result>
         float inputs:rotation = ${(rotation * (180 / Math.PI)).toFixed(options.precision)}
         float2 inputs:scale = ${BuildVector2(repeat)}
         float2 inputs:translation = ${BuildVector2(offset)}
@@ -349,7 +353,7 @@ function BuildTexture(
     {
         uniform token info:id = "UsdUVTexture"
         asset inputs:file = @textures/Texture_${id}.png@
-        float2 inputs:st.connect = </Materials/Material_${material.uniqueId}/Transform2d_${mapType}.outputs:result>
+        float2 inputs:st.connect = </Root/Materials/Material_${material.uniqueId}/Transform2d_${mapType}.outputs:result>
         ${color ? "float4 inputs:scale = " + BuildColor4(color) : ""}
         token inputs:sourceColorSpace = "${texture.gammaSpace ? "sRGB" : "raw"}"
         token inputs:wrapS = "${BuildWrapping(texture.wrapU)}"
@@ -463,12 +467,12 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
     } = ExtractTextureInformations(material);
 
     if (diffuseMap !== null) {
-        inputs.push(`${pad}color3f inputs:diffuseColor.connect = </Materials/Material_${material.uniqueId}/Texture_${diffuseMap.uniqueId}_diffuse.outputs:rgb>`);
+        inputs.push(`${pad}color3f inputs:diffuseColor.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${diffuseMap.uniqueId}_diffuse.outputs:rgb>`);
 
         if (material.needAlphaBlending()) {
-            inputs.push(`${pad}float inputs:opacity.connect = </Materials/Material_${material.uniqueId}/Texture_${diffuseMap.uniqueId}_diffuse.outputs:a>`);
+            inputs.push(`${pad}float inputs:opacity.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${diffuseMap.uniqueId}_diffuse.outputs:a>`);
         } else if (material.needAlphaTesting()) {
-            inputs.push(`${pad}float inputs:opacity.connect = </Materials/Material_${material.uniqueId}/Texture_${diffuseMap.uniqueId}_diffuse.outputs:a>`);
+            inputs.push(`${pad}float inputs:opacity.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${diffuseMap.uniqueId}_diffuse.outputs:a>`);
             inputs.push(`${pad}float inputs:opacityThreshold = ${alphaCutOff}`);
         }
 
@@ -478,7 +482,7 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
     }
 
     if (emissiveMap !== null) {
-        inputs.push(`${pad}color3f inputs:emissiveColor.connect = </Materials/Material_${material.uniqueId}/Texture_${emissiveMap.uniqueId}_emissive.outputs:rgb>`);
+        inputs.push(`${pad}color3f inputs:emissiveColor.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${emissiveMap.uniqueId}_emissive.outputs:rgb>`);
 
         samplers.push(BuildTexture(emissiveMap as Texture, material, "emissive", emissive, textureToExports, options));
     } else if (emissive && emissive.toLuminance() > 0) {
@@ -486,19 +490,21 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
     }
 
     if (normalMap !== null) {
-        inputs.push(`${pad}normal3f inputs:normal.connect = </Materials/Material_${material.uniqueId}/Texture_${normalMap.uniqueId}_normal.outputs:rgb>`);
+        inputs.push(`${pad}normal3f inputs:normal.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${normalMap.uniqueId}_normal.outputs:rgb>`);
 
         samplers.push(BuildTexture(normalMap as Texture, material, "normal", null, textureToExports, options));
     }
 
     if (aoMap !== null) {
-        inputs.push(`${pad}float inputs:occlusion.connect = </Materials/Material_${material.uniqueId}/Texture_${aoMap.uniqueId}_occlusion.outputs:${aoMapChannel}>`);
+        inputs.push(`${pad}float inputs:occlusion.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${aoMap.uniqueId}_occlusion.outputs:${aoMapChannel}>`);
 
         samplers.push(BuildTexture(aoMap as Texture, material, "occlusion", new Color3(aoMapIntensity, aoMapIntensity, aoMapIntensity), textureToExports, options));
     }
 
     if (roughnessMap !== null) {
-        inputs.push(`${pad}float inputs:roughness.connect = </Materials/Material_${material.uniqueId}/Texture_${roughnessMap.uniqueId}_roughness.outputs:${roughnessChannel}>`);
+        inputs.push(
+            `${pad}float inputs:roughness.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${roughnessMap.uniqueId}_roughness.outputs:${roughnessChannel}>`
+        );
 
         samplers.push(BuildTexture(roughnessMap as Texture, material, "roughness", new Color3(roughness, roughness, roughness), textureToExports, options));
     } else {
@@ -506,7 +512,7 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
     }
 
     if (metalnessMap !== null) {
-        inputs.push(`${pad}float inputs:metallic.connect = </Materials/Material_${material.uniqueId}/Texture_${metalnessMap.uniqueId}_metallic.outputs:${metalnessChannel}>`);
+        inputs.push(`${pad}float inputs:metallic.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${metalnessMap.uniqueId}_metallic.outputs:${metalnessChannel}>`);
 
         samplers.push(BuildTexture(metalnessMap as Texture, material, "metallic", new Color3(metalness, metalness, metalness), textureToExports, options));
     } else {
@@ -514,7 +520,7 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
     }
 
     if (alphaMap !== null) {
-        inputs.push(`${pad}float inputs:opacity.connect = </Materials/Material_${material.uniqueId}/Texture_${alphaMap.uniqueId}_opacity.outputs:r>`);
+        inputs.push(`${pad}float inputs:opacity.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${alphaMap.uniqueId}_opacity.outputs:r>`);
         inputs.push(`${pad}float inputs:opacityThreshold = 0.0001`);
 
         samplers.push(BuildTexture(alphaMap as Texture, material, "opacity", null, textureToExports, options));
@@ -524,7 +530,7 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
 
     if (clearCoatEnabled) {
         if (clearCoatMap !== null) {
-            inputs.push(`${pad}float inputs:clearcoat.connect = </Materials/Material_${material.uniqueId}/Texture_${clearCoatMap.uniqueId}_clearcoat.outputs:r>`);
+            inputs.push(`${pad}float inputs:clearcoat.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${clearCoatMap.uniqueId}_clearcoat.outputs:r>`);
             samplers.push(BuildTexture(clearCoatMap as Texture, material, "clearcoat", new Color3(clearCoat, clearCoat, clearCoat), textureToExports, options));
         } else {
             inputs.push(`${pad}float inputs:clearcoat = ${clearCoat}`);
@@ -532,7 +538,7 @@ function BuildMaterial(material: Material, textureToExports: { [key: string]: Ba
 
         if (clearCoatRoughnessMap !== null) {
             inputs.push(
-                `${pad}float inputs:clearcoatRoughness.connect = </Materials/Material_${material.uniqueId}/Texture_${clearCoatRoughnessMap.uniqueId}_clearcoatRoughness.outputs:g>`
+                `${pad}float inputs:clearcoatRoughness.connect = </Root/Materials/Material_${material.uniqueId}/Texture_${clearCoatRoughnessMap.uniqueId}_clearcoatRoughness.outputs:g>`
             );
             samplers.push(
                 BuildTexture(
@@ -562,7 +568,7 @@ ${inputs.join("\n")}
 			token outputs:surface
 		}
 
-		token outputs:surface.connect = </Materials/Material_${material.uniqueId}/PreviewSurface.outputs:surface>
+		token outputs:surface.connect = </Root/Materials/Material_${material.uniqueId}/PreviewSurface.outputs:surface>
 
 ${samplers.join("\n")}
 
@@ -677,7 +683,7 @@ export async function USDZExportAsync(scene: Scene, options: Partial<IUSDZExport
     files[localOptions.modelFileName] = null;
 
     let output = BuildHeader();
-    output += BuildSceneStart(localOptions);
+    output += BuildRootAndSceneStart(localOptions);
 
     const materialToExports: { [key: string]: Material } = {};
 
@@ -726,6 +732,9 @@ export async function USDZExportAsync(scene: Scene, options: Partial<IUSDZExport
     // Materials
     const textureToExports: { [key: string]: BaseTexture } = {};
     output += BuildMaterials(materialToExports, textureToExports, localOptions);
+
+    // Close root
+    output += BuildRootEnd();
 
     // Compress
     files[localOptions.modelFileName] = fflate.strToU8(output);

--- a/packages/dev/serializers/src/USDZ/usdzExporter.ts
+++ b/packages/dev/serializers/src/USDZ/usdzExporter.ts
@@ -616,6 +616,7 @@ function BuildCamera(camera: Camera, options: IUSDZExportOptions) {
 }
 
 function ExtractMeshInformations(mesh: Mesh) {
+    mesh.computeWorldMatrix(true);
     const matrix = mesh.getWorldMatrix().clone();
     const sceneIsRightHanded = mesh.getScene().useRightHandedSystem;
     let sideOrientation = mesh.material?._getEffectiveOrientation(mesh) ?? mesh.sideOrientation;
@@ -638,7 +639,7 @@ function ExtractMeshInformations(mesh: Mesh) {
 
     if (matrix.determinant() < 0) {
         // RealityKit doesn't seem to automatically flip faces of a mesh with negative scale, like other engines do (including us).
-        Tools.Warn(`Mesh ${mesh} has a negative scale, which may look incorrect in destinations like QuickLook.`);
+        Tools.Warn(`Mesh ${mesh.name} has a negative scale, which may look incorrect in destinations like QuickLook.`);
     }
 
     return {


### PR DESCRIPTION
Having multiple root prims ("Root" and "Materials") in a USD can lead to odd behavior, like this error from Reality Composer Pro:
<img width="720" height="722" alt="image" src="https://github.com/user-attachments/assets/eba11705-a048-4b4c-87be-794236c85529" />
So let's just move the "Materials" def under "Root", which is the default prim of the main USD. 

Extras
- Clean up an error message
- Compute world matrix before use, in case it was modified before the scene was rendered with the changes