### PR TITLE
Make CustomShaderBlock resilient to incompatible default values, simplify log/warning/error handling in SFE

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,7 +47,7 @@
             "label": "Watch Smart Filters",
             "type": "shell",
             "command": "npm run watch:source:smart-filters",
-            "dependsOn": ["Watch Smart Filters Assets"],
+            "dependsOn": ["Watch Smart Filters Assets", "Watch Assets"],
             "isBackground": true,
             "runOptions": {
                 "instanceLimit": 1
@@ -82,6 +82,34 @@
                     "activeOnStart": true,
                     "beginsPattern": ".*",
                     "endsPattern": "Watching for changes"
+                }
+            }
+        },
+        {
+            "label": "Watch Assets",
+            "type": "shell",
+            "command": "npm run watch:assets",
+            "isBackground": true,
+            "runOptions": {
+                "instanceLimit": 1
+            },
+            "presentation": {
+                "group": "watch"
+            },
+            "problemMatcher": {
+                "fileLocation": "relative",
+                "pattern": {
+                    "regexp": "(error|warning|info)",
+                    "file": 1,
+                    "location": 2,
+                    "severity": 3,
+                    "code": 4,
+                    "message": 5
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Babylon.js build tools",
+                    "endsPattern": "watching for asset changes..."
                 }
             }
         },

--- a/packages/dev/smartFilters/src/blockFoundation/customShaderBlock.ts
+++ b/packages/dev/smartFilters/src/blockFoundation/customShaderBlock.ts
@@ -1,5 +1,6 @@
+import { Logger } from "core/Misc/logger.js";
 import type { Effect } from "core/Materials/effect.js";
-import { ConnectionPointType } from "../connection/connectionPointType.js";
+import { ConnectionPointType, type ConnectionPointValue } from "../connection/connectionPointType.js";
 import { ShaderBinding } from "../runtime/shaderRuntime.js";
 import { CreateStrongRef } from "../runtime/strongRef.js";
 import type { SerializedShaderBlockDefinition } from "../serialization/serializedShaderBlockDefinition.js";
@@ -187,8 +188,9 @@ export class CustomShaderBlock extends ShaderBlock {
             this._autoBoundInputs.push(connectionPoint);
         } else {
             // If not auto bound, register as an input connection point
-            if (connectionPoint.defaultValue !== undefined) {
-                this._registerOptionalInput(connectionPoint.name, connectionPoint.type, CreateStrongRef(connectionPoint.defaultValue));
+            const defaultValue = this._validateDefaultValue(connectionPoint.type, connectionPoint.name, connectionPoint.defaultValue);
+            if (defaultValue) {
+                this._registerOptionalInput(connectionPoint.name, connectionPoint.type, CreateStrongRef(defaultValue));
             } else {
                 this._registerInput(connectionPoint.name, connectionPoint.type);
             }
@@ -229,6 +231,54 @@ export class CustomShaderBlock extends ShaderBlock {
         }
 
         return new CustomShaderBlockBinding(inputsToBind);
+    }
+
+    /**
+     * Validates the default value of a connection point and returns the runtime data for it.
+     * If the default value is not provided, returns null.
+     * @param connectionPointType - The type of the connection point
+     * @param connectionPointName - The name of the connection point
+     * @param defaultValue - The default value of the connection point
+     * @returns The runtime data for the default value, or null if no default value is provided
+     */
+    private _validateDefaultValue<U extends ConnectionPointType>(
+        connectionPointType: U,
+        connectionPointName: string,
+        defaultValue?: ConnectionPointValue<U>
+    ): Nullable<ConnectionPointValue<U>> {
+        if (defaultValue === undefined || defaultValue === null) {
+            return null;
+        }
+
+        // Validate the default value based on the connection point type
+        let returnValue: Nullable<ConnectionPointValue<U>> = null;
+        switch (connectionPointType) {
+            case ConnectionPointType.Float:
+                returnValue = typeof defaultValue === "number" ? defaultValue : null;
+                break;
+            case ConnectionPointType.Color3:
+                returnValue = typeof defaultValue === "object" && "r" in defaultValue && "g" in defaultValue && "b" in defaultValue ? defaultValue : null;
+                break;
+            case ConnectionPointType.Color4:
+                returnValue = typeof defaultValue === "object" && "r" in defaultValue && "g" in defaultValue && "b" in defaultValue && "a" in defaultValue ? defaultValue : null;
+                break;
+            case ConnectionPointType.Boolean:
+                returnValue = typeof defaultValue === "boolean" ? defaultValue : null;
+                break;
+            case ConnectionPointType.Vector2:
+                returnValue = typeof defaultValue === "object" && "x" in defaultValue && "y" in defaultValue ? defaultValue : null;
+                break;
+            default: {
+                Logger.Warn(`Default value supplied when unsupported. Block Type: "${this.blockType}" Connection Point: "${connectionPointName}"`);
+                return null;
+            }
+        }
+
+        if (returnValue === null) {
+            Logger.Warn(`Invalid default value. Block Type: "${this.blockType}" Connection Point: "${connectionPointName}"`);
+        }
+
+        return returnValue;
     }
 }
 

--- a/packages/dev/smartFilters/src/blockFoundation/customShaderBlock.ts
+++ b/packages/dev/smartFilters/src/blockFoundation/customShaderBlock.ts
@@ -234,12 +234,12 @@ export class CustomShaderBlock extends ShaderBlock {
     }
 
     /**
-     * Validates the default value of a connection point and returns the runtime data for it.
-     * If the default value is not provided, returns null.
+     * Validates the default value of a connection point and returns it if valid.
+     * If the default value is not provided or is invalid, this returns null.
      * @param connectionPointType - The type of the connection point
      * @param connectionPointName - The name of the connection point
      * @param defaultValue - The default value of the connection point
-     * @returns The runtime data for the default value, or null if no default value is provided
+     * @returns The default value, or null if no default value is provided or it was invalid
      */
     private _validateDefaultValue<U extends ConnectionPointType>(
         connectionPointType: U,

--- a/packages/dev/smartFilters/test/unit/customShaderBlock.test.ts
+++ b/packages/dev/smartFilters/test/unit/customShaderBlock.test.ts
@@ -1,0 +1,161 @@
+import { Logger } from "../../src";
+import { SmartFilter } from "../../src/smartFilter.js";
+import { ImportCustomBlockDefinition } from "../../src/serialization/importCustomBlockDefinition.js";
+import { CustomShaderBlock } from "../../src/blockFoundation/customShaderBlock.js";
+import { SerializedShaderBlockDefinitionV1 } from "../../src/serialization/v1/shaderBlockSerialization.types";
+
+const glslValidFloatDefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : 42.0 }
+uniform float testFloat;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, testFloat, 1.);
+}`;
+
+const glslInvalidFloatDefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : false }
+uniform float testFloat;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, testFloat, 1.);
+}`;
+
+const glslValidBoolDefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : true }
+uniform bool testBool;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslInvalidBoolDefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : 2.0 }
+uniform bool testBool;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslValidColor3DefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : { "x": 1.0, "y": 2.0, "z": 3.0 } }
+uniform vec3 testColor3;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslInvalidColor3DefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : true }
+uniform vec3 testColor3;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslValidColor4DefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : { "x": 1.0, "y": 2.0, "z": 3.0, "w": 4.0 } }
+uniform vec4 testColor4;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslInvalidColor4DefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : true }
+uniform vec4 testColor4;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslValidVector2DefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : { "x": 1.0, "y": 2.0 } }
+uniform vec2 testVector2;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+const glslInvalidVector2DefaultValue = `
+// { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
+// { "default" : true }
+uniform vec2 testVector2;
+vec4 test(vec2 vUV) { // main
+    return vec4(vUV, 1., 1.);
+}`;
+
+describe("CustomShaderBlock", () => {
+    const smartFilter = new SmartFilter("TestSmartFilter");
+    const warnFn = jest.fn();
+    const errorFn = jest.fn();
+
+    beforeAll(() => {
+        Logger.Warn = warnFn;
+        Logger.Error = errorFn;
+    });
+
+    describe("Default Value Parsing", () => {
+        [
+            {
+                description: "When invalid Float default value is provided",
+                glsl: glslInvalidFloatDefaultValue,
+                expectedWarning: 'Invalid default value. Block Type: "TestBlock" Connection Point: "testFloat"',
+            },
+            {
+                description: "When valid Float default value is provided",
+                glsl: glslValidFloatDefaultValue,
+                expectedWarning: undefined,
+            },
+            {
+                description: "When invalid Bool default value is provided",
+                glsl: glslInvalidBoolDefaultValue,
+                expectedWarning: 'Invalid default value. Block Type: "TestBlock" Connection Point: "testBool"',
+            },
+            {
+                description: "When valid Bool default value is provided",
+                glsl: glslValidBoolDefaultValue,
+                expectedWarning: undefined,
+            },
+            {
+                description: "When invalid Color3 default value is provided",
+                glsl: glslInvalidColor3DefaultValue,
+                expectedWarning: 'Invalid default value. Block Type: "TestBlock" Connection Point: "testColor3"',
+            },
+            {
+                description: "When valid Color3 default value is provided",
+                glsl: glslValidColor3DefaultValue,
+                expectedWarning: undefined,
+            },
+            {
+                description: "When invalid Color4 default value is provided",
+                glsl: glslInvalidColor4DefaultValue,
+                expectedWarning: 'Invalid default value. Block Type: "TestBlock" Connection Point: "testColor4"',
+            },
+            {
+                description: "When valid Color4 default value is provided",
+                glsl: glslValidColor4DefaultValue,
+                expectedWarning: undefined,
+            },
+            {
+                description: "When invalid Vector2 default value is provided",
+                glsl: glslInvalidVector2DefaultValue,
+                expectedWarning: 'Invalid default value. Block Type: "TestBlock" Connection Point: "testVector2"',
+            },
+            {
+                description: "When valid Vector2 default value is provided",
+                glsl: glslValidVector2DefaultValue,
+                expectedWarning: undefined,
+            },
+        ].forEach((testCase) => {
+            it(`${testCase.description}`, () => {
+                const blockDefinition = ImportCustomBlockDefinition(testCase.glsl) as SerializedShaderBlockDefinitionV1;
+                CustomShaderBlock.Create(smartFilter, "TestBlock", blockDefinition);
+                if (testCase.expectedWarning) {
+                    // eslint-disable-next-line jest/no-conditional-expect
+                    expect(warnFn).toHaveBeenCalledWith(testCase.expectedWarning);
+                }
+                expect(errorFn).not.toHaveBeenCalled();
+            });
+        });
+    });
+});

--- a/packages/dev/smartFilters/test/unit/customShaderBlock.test.ts
+++ b/packages/dev/smartFilters/test/unit/customShaderBlock.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-conditional-expect */
 import { Logger } from "../../src";
 import { SmartFilter } from "../../src/smartFilter.js";
 import { ImportCustomBlockDefinition } from "../../src/serialization/importCustomBlockDefinition.js";
@@ -38,7 +39,7 @@ vec4 test(vec2 vUV) { // main
 
 const glslValidColor3DefaultValue = `
 // { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
-// { "default" : { "x": 1.0, "y": 2.0, "z": 3.0 } }
+// { "default" : { "r": 1.0, "g": 2.0, "b": 3.0 } }
 uniform vec3 testColor3;
 vec4 test(vec2 vUV) { // main
     return vec4(vUV, 1., 1.);
@@ -54,7 +55,7 @@ vec4 test(vec2 vUV) { // main
 
 const glslValidColor4DefaultValue = `
 // { "smartFilterBlockType": "TestBlock", "namespace": "Bug.Repro" }
-// { "default" : { "x": 1.0, "y": 2.0, "z": 3.0, "w": 4.0 } }
+// { "default" : { "r": 1.0, "g": 2.0, "b": 3.0, "a": 4.0 } }
 uniform vec4 testColor4;
 vec4 test(vec2 vUV) { // main
     return vec4(vUV, 1., 1.);
@@ -92,6 +93,10 @@ describe("CustomShaderBlock", () => {
     beforeAll(() => {
         Logger.Warn = warnFn;
         Logger.Error = errorFn;
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
     describe("Default Value Parsing", () => {
@@ -151,8 +156,9 @@ describe("CustomShaderBlock", () => {
                 const blockDefinition = ImportCustomBlockDefinition(testCase.glsl) as SerializedShaderBlockDefinitionV1;
                 CustomShaderBlock.Create(smartFilter, "TestBlock", blockDefinition);
                 if (testCase.expectedWarning) {
-                    // eslint-disable-next-line jest/no-conditional-expect
                     expect(warnFn).toHaveBeenCalledWith(testCase.expectedWarning);
+                } else {
+                    expect(warnFn).not.toHaveBeenCalled();
                 }
                 expect(errorFn).not.toHaveBeenCalled();
             });

--- a/packages/tools/smartFiltersEditor/src/smartFilterRenderer.ts
+++ b/packages/tools/smartFiltersEditor/src/smartFilterRenderer.ts
@@ -2,7 +2,7 @@ import { Observable } from "core/Misc/observable";
 import type { ThinEngine } from "core/Engines/thinEngine";
 import type { Nullable } from "core/types";
 import { RenderTargetGenerator, ConnectionPointType, SmartFilterOptimizer, type InputBlock, type SmartFilter, type SmartFilterRuntime, Logger } from "smart-filters";
-import { LogEntry, RegisterAnimations, TextureAssetCache } from "smart-filters-editor-control";
+import { RegisterAnimations, TextureAssetCache } from "smart-filters-editor-control";
 
 /**
  * Describes the result of rendering a Smart Filter
@@ -79,10 +79,9 @@ export class SmartFilterRenderer {
     /**
      * Starts rendering the filter. (won't stop until dispose is called)
      * @param filter - The Smart Filter to render
-     * @param onLogRequiredObservable - The observable to use to notify when a log entry is required
      * @returns A promise that resolves as true if the rendering started successfully, false otherwise
      */
-    public async startRenderingAsync(filter: SmartFilter, onLogRequiredObservable: Observable<LogEntry>): Promise<RenderResult> {
+    public async startRenderingAsync(filter: SmartFilter): Promise<RenderResult> {
         let optimizationTimeMs: Nullable<number> = null;
         let runtimeCreationTimeMs: Nullable<number> = null;
 
@@ -117,7 +116,7 @@ export class SmartFilterRenderer {
             };
         } catch (err: any) {
             const message = err["message"] || err["_compilationError"] || err;
-            onLogRequiredObservable.notifyObservers(new LogEntry(`Could not render Smart Filter:\n${message}`, true));
+            Logger.Error(`Could not render Smart Filter:\n${message}`);
             return {
                 succeeded: false,
                 optimizationTimeMs: null,

--- a/packages/tools/smartFiltersEditorControl/src/assets/styles/components/log.scss
+++ b/packages/tools/smartFiltersEditorControl/src/assets/styles/components/log.scss
@@ -16,7 +16,13 @@
         font-family: "Courier New", Courier, monospace;
     }
 
+    .warn {
+        color: yellow;
+        font-weight: bold;
+    }
+
     .error {
-        color: red;
+        color: orangered;
+        font-weight: bold;
     }
 }

--- a/packages/tools/smartFiltersEditorControl/src/components/log/logComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/components/log/logComponent.tsx
@@ -7,12 +7,18 @@ interface ILogComponentProps {
     globalState: GlobalState;
 }
 
+export enum LogLevel {
+    Log = "log",
+    Warn = "warn",
+    Error = "error",
+}
+
 export class LogEntry {
     public time = new Date();
 
     constructor(
         public message: string,
-        public isError: boolean
+        public level: LogLevel
     ) {}
 }
 
@@ -48,7 +54,7 @@ export class LogComponent extends react.Component<ILogComponentProps, { logs: Lo
             <div id="sfe-log-console" ref={this._logConsoleRef}>
                 {this.state.logs.map((l, i) => {
                     return (
-                        <div key={i} className={"log" + (l.isError ? " error" : "")}>
+                        <div key={i} className={"log " + l.level}>
                             {l.time.getHours() +
                                 ":" +
                                 l.time.getMinutes().toLocaleString(undefined, { minimumIntegerDigits: 2 }) +

--- a/packages/tools/smartFiltersEditorControl/src/configuration/getBlockEditorRegistration.ts
+++ b/packages/tools/smartFiltersEditorControl/src/configuration/getBlockEditorRegistration.ts
@@ -5,22 +5,18 @@ import { inputsNamespace, type IBlockRegistration } from "smart-filters-blocks";
 import type { BlockEditorRegistration } from "./blockEditorRegistration";
 import { CustomInputDisplayManager } from "./customInputDisplayManager.js";
 import { CustomBlocksNamespace, OutputBlockName } from "./constants.js";
-import type { Observable } from "core/Misc/observable";
-import { LogEntry } from "../components/log/logComponent.js";
 
 /**
  * Creates the block editor registration for the editor.
  * @param smartFilterDeserializer - The smart filter deserializer to use
  * @param allBlockRegistrations - All block registrations to use
  * @param includeCustomBlocksCategory - If true, includes the custom blocks category even if there are no blocks in that category
- * @param onLogRequiredObservable - If supplied, instead of console errors, log entries will be sent to this observable
  * @returns The block registration
  */
 export function GetBlockEditorRegistration(
     smartFilterDeserializer: SmartFilterDeserializer,
     allBlockRegistrations: IBlockRegistration[],
-    includeCustomBlocksCategory: boolean,
-    onLogRequiredObservable?: Observable<LogEntry>
+    includeCustomBlocksCategory: boolean
 ): BlockEditorRegistration {
     const allBlocks: { [key: string]: IBlockRegistration[] } = {};
 
@@ -51,11 +47,7 @@ export function GetBlockEditorRegistration(
                 return await registration.factory(smartFilter, engine, smartFilterDeserializer);
             } catch (err) {
                 const errorString = `Error creating block ${blockType} in namespace ${namespace}:\n ${err}`;
-                if (onLogRequiredObservable) {
-                    onLogRequiredObservable.notifyObservers(new LogEntry(errorString, true));
-                } else {
-                    Logger.Error(errorString);
-                }
+                Logger.Error(errorString);
             }
         }
         return null;

--- a/packages/tools/smartFiltersEditorControl/src/graphEditor.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/graphEditor.tsx
@@ -10,7 +10,7 @@ import { Portal } from "./portal.js";
 
 import { MessageDialog } from "shared-ui-components/components/MessageDialog.js";
 import { GraphCanvasComponent } from "shared-ui-components/nodeGraphSystem/graphCanvas.js";
-import { LogComponent, LogEntry } from "./components/log/logComponent.js";
+import { LogComponent } from "./components/log/logComponent.js";
 import { TypeLedger } from "shared-ui-components/nodeGraphSystem/typeLedger.js";
 import { BlockTools } from "./blockTools.js";
 import { PropertyTabComponent } from "./components/propertyTab/propertyTabComponent.js";
@@ -19,7 +19,7 @@ import { CreateDefaultInput } from "./graphSystem/registerDefaultInput.js";
 import type { INodeData } from "shared-ui-components/nodeGraphSystem/interfaces/nodeData";
 import type { IEditorData } from "shared-ui-components/nodeGraphSystem/interfaces/nodeLocationInfo";
 import type { Nullable } from "core/types";
-import type { BaseBlock, SmartFilter } from "smart-filters";
+import { Logger, type BaseBlock, type SmartFilter } from "smart-filters";
 import { inputsNamespace } from "smart-filters-blocks";
 import { SetEditorData } from "./helpers/serializationTools.js";
 import { SplitContainer } from "shared-ui-components/split/splitContainer.js";
@@ -117,7 +117,7 @@ export class GraphEditor extends react.Component<IGraphEditorProps, IGraphEditor
             if (canvas && this.props.globalState.onNewEngine) {
                 const engine = InitializePreview(canvas, this.props.globalState.forceWebGL1);
                 const versionToLog = `Babylon.js v${ThinEngine.Version} - WebGL${engine.webGLVersion}`;
-                this.props.globalState.onLogRequiredObservable.notifyObservers(new LogEntry(versionToLog, false));
+                Logger.Log(versionToLog);
                 this.props.globalState.engine = engine;
                 this.props.globalState.onNewEngine(engine);
                 this._canvasResizeObserver.observe(canvas);

--- a/packages/tools/smartFiltersEditorControl/src/index.ts
+++ b/packages/tools/smartFiltersEditorControl/src/index.ts
@@ -8,7 +8,7 @@ export { CreateDefaultValue as createDefaultValue } from "./graphSystem/register
 export type { TexturePreset } from "./globalState.js";
 export * from "./helpers/serializationTools.js";
 export * from "./helpers/blockKeyConverters.js";
-export { LogEntry } from "./components/log/logComponent.js";
+export { LogEntry, LogLevel } from "./components/log/logComponent.js";
 export * from "./helpers/textureAssetCache.js";
 export * from "./configuration/getBlockEditorRegistration.js";
 export * from "./configuration/blockEditorRegistration.js";


### PR DESCRIPTION
This change adds type checking for default values when loading a custom shader block, so you now get an actionable warning in SFE if you get the type wrong on a custom block you're trying to load. This change also adds the ability for warnings, not just logs and errors, to show in the SFE UI. It also simplifies the way logs/warning/errors are recorded in SFE, no longer requiring an observable to be passed around, but instead in one place wiring it up to the Logger class, then using Logger everywhere. This means SF core logs can show up in the SFE UI as well, such as these new custom shader block warnings this PR adds. This change also adds watching assets (e.g. scss files) to the SFE VSCode launch config.