### PR TITLE
[Fluent/InspectorV2] StringifiedPropertyLine

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 
 import { TextInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
+import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 import { useProperty } from "../../hooks/compoundPropertyHooks";
 import { GetPropertyDescriptor, IsPropertyReadonly } from "../../instrumentation/propertyInstrumentation";
 
@@ -25,7 +26,7 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
 
     return (
         <>
-            {commonEntity.id !== undefined && <TextPropertyLine key="EntityId" label="ID" description="The id of the node." value={commonEntity.id.toString()} />}
+            {commonEntity.id !== undefined && <StringifiedPropertyLine key="EntityId" label="ID" description="The id of the node." value={commonEntity.id} />}
             {name !== undefined &&
                 (isNameReadonly ? (
                     <TextPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} />
@@ -33,7 +34,7 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
                     <TextInputPropertyLine key="EntityName" label="Name" description="The name of the node." value={name} onChange={(newName) => (commonEntity.name = newName)} />
                 ))}
             {commonEntity.uniqueId !== undefined && (
-                <TextPropertyLine key="EntityUniqueId" label="Unique ID" description="The unique id of the node." value={commonEntity.uniqueId.toString()} />
+                <StringifiedPropertyLine key="EntityUniqueId" label="Unique ID" description="The unique id of the node." value={commonEntity.uniqueId} />
             )}
             {className !== undefined && <TextPropertyLine key="EntityClassName" label="Class" description="The class of the node." value={className} />}
         </>

--- a/packages/dev/inspector-v2/src/components/properties/skeleton/skeletonProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/skeleton/skeletonProperties.tsx
@@ -12,15 +12,15 @@ import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
-import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { BoundProperty } from "../boundProperty";
+import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 
 export const SkeletonGeneralProperties: FunctionComponent<{ skeleton: Skeleton }> = (props) => {
     const { skeleton } = props;
 
     return (
         <>
-            <TextPropertyLine key="SkeletonBoneCount" label="Bone count" description="The number of bones of the skeleton." value={skeleton.bones.length.toString()} />
+            <StringifiedPropertyLine key="SkeletonBoneCount" label="Bone count" description="The number of bones of the skeleton." value={skeleton.bones.length} />
             <BoundProperty
                 key="SkeletonUseTextureToStoreBoneMatrices2"
                 component={SwitchPropertyLine}

--- a/packages/dev/inspector-v2/src/components/stats/countStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/countStats.tsx
@@ -2,9 +2,9 @@ import type { FunctionComponent } from "react";
 
 import type { Scene } from "core/index";
 
-import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
 import { usePollingObservable } from "../../hooks/pollingHooks";
+import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 
 export const CountStats: FunctionComponent<{ context: Scene }> = ({ context: scene }) => {
     const pollingObservable = usePollingObservable(1000);
@@ -22,17 +22,17 @@ export const CountStats: FunctionComponent<{ context: Scene }> = ({ context: sce
 
     return (
         <>
-            <TextPropertyLine key="TotalMeshes" label="Total Meshes" value={totalMeshes.toLocaleString()} />
-            <TextPropertyLine key="ActiveMeshes" label="Active Meshes" value={activeMeshes.toLocaleString()} />
-            <TextPropertyLine key="ActiveIndices" label="Active Indeces" value={activeIndices.toLocaleString()} />
-            <TextPropertyLine key="ActiveFaces" label="Active Faces" value={(activeIndices / 3).toLocaleString()} />
-            <TextPropertyLine key="ActiveBones" label="Active Bones" value={activeBones.toLocaleString()} />
-            <TextPropertyLine key="ActiveParticles" label="Active Particles" value={activeParticles.toLocaleString()} />
-            <TextPropertyLine key="DrawCalls" label="Draw Calls" value={drawCalls.toLocaleString()} />
-            <TextPropertyLine key="TotalLights" label="Total Lights" value={totalLights.toLocaleString()} />
-            <TextPropertyLine key="TotalVertices" label="Total Vertices" value={totalVertices.toLocaleString()} />
-            <TextPropertyLine key="TotalMaterials" label="Total Materials" value={totalMaterials.toLocaleString()} />
-            <TextPropertyLine key="TotalTextures" label="Total Textures" value={totalTextures.toLocaleString()} />
+            <StringifiedPropertyLine key="TotalMeshes" label="Total Meshes" value={totalMeshes} />
+            <StringifiedPropertyLine key="ActiveMeshes" label="Active Meshes" value={activeMeshes} />
+            <StringifiedPropertyLine key="ActiveIndices" label="Active Indeces" value={activeIndices} />
+            <StringifiedPropertyLine key="ActiveFaces" label="Active Faces" value={activeIndices / 3} />
+            <StringifiedPropertyLine key="ActiveBones" label="Active Bones" value={activeBones} />
+            <StringifiedPropertyLine key="ActiveParticles" label="Active Particles" value={activeParticles} />
+            <StringifiedPropertyLine key="DrawCalls" label="Draw Calls" value={drawCalls} />
+            <StringifiedPropertyLine key="TotalLights" label="Total Lights" value={totalLights} />
+            <StringifiedPropertyLine key="TotalVertices" label="Total Vertices" value={totalVertices} />
+            <StringifiedPropertyLine key="TotalMaterials" label="Total Materials" value={totalMaterials} />
+            <StringifiedPropertyLine key="TotalTextures" label="Total Textures" value={totalTextures} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/frameStepStats.tsx
@@ -7,7 +7,6 @@ import { useCallback } from "react";
 import { EngineInstrumentation } from "core/Instrumentation/engineInstrumentation";
 import { SceneInstrumentation } from "core/Instrumentation/sceneInstrumentation";
 
-import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
 import { usePollingObservable } from "../../hooks/pollingHooks";
 import { useResource } from "../../hooks/resourceHooks";
@@ -16,6 +15,7 @@ import { useResource } from "../../hooks/resourceHooks";
 import "core/Engines/AbstractEngine/abstractEngine.timeQuery";
 import "core/Engines/Extensions/engine.query";
 import "core/Engines/WebGPU/Extensions/engine.query";
+import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 
 export const FrameStepsStats: FunctionComponent<{ context: Scene }> = ({ context: scene }) => {
     const pollingObservable = usePollingObservable(1000);
@@ -57,16 +57,16 @@ export const FrameStepsStats: FunctionComponent<{ context: Scene }> = ({ context
 
     return (
         <>
-            <TextPropertyLine key="AbsoluteFPS" label="Absolute FPS" value={absoluteFPS.toLocaleString()} />
-            <TextPropertyLine key="MeshesSelection" label="Meshes Selection" value={meshesSelection.toFixed(2) + " ms"} />
-            <TextPropertyLine key="RenderTargets" label="Render Targets" value={renderTargets.toFixed(2) + " ms"} />
-            <TextPropertyLine key="Particles" label="Particles" value={particles.toFixed(2) + " ms"} />
-            <TextPropertyLine key="Sprites" label="Sprites" value={sprites.toFixed(2) + " ms"} />
-            <TextPropertyLine key="Animations" label="Animations" value={animations.toFixed(2) + " ms"} />
-            <TextPropertyLine key="Physics" label="Physics" value={physics.toFixed(2) + " ms"} />
-            <TextPropertyLine key="InterFrameTime" label="Inter-Frame Time" value={interFrameTime.toFixed(2) + " ms"} />
-            <TextPropertyLine key="GPUFrameTime" label="GPU Frame Time" value={gpuFrameTime.toFixed(2) + " ms"} />
-            <TextPropertyLine key="GPUFrameTimeAverage" label="GPU Frame Time (Average)" value={gpuFrameTimeAverage.toFixed(2) + " ms"} />
+            <StringifiedPropertyLine key="AbsoluteFPS" label="Absolute FPS" value={absoluteFPS} />
+            <StringifiedPropertyLine key="MeshesSelection" label="Meshes Selection" value={meshesSelection} precision={2} units="ms" />
+            <StringifiedPropertyLine key="RenderTargets" label="Render Targets" value={renderTargets} precision={2} units="ms" />
+            <StringifiedPropertyLine key="Particles" label="Particles" value={particles} precision={2} units="ms" />
+            <StringifiedPropertyLine key="Sprites" label="Sprites" value={sprites} precision={2} units="ms" />
+            <StringifiedPropertyLine key="Animations" label="Animations" value={animations} precision={2} units="ms" />
+            <StringifiedPropertyLine key="Physics" label="Physics" value={physics} precision={2} units="ms" />
+            <StringifiedPropertyLine key="InterFrameTime" label="Inter-Frame Time" value={interFrameTime} precision={2} units="ms" />
+            <StringifiedPropertyLine key="GPUFrameTime" label="GPU Frame Time" value={gpuFrameTime} precision={2} units="ms" />
+            <StringifiedPropertyLine key="GPUFrameTimeAverage" label="GPU Frame Time (Average)" value={gpuFrameTimeAverage} precision={2} units="ms" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
@@ -2,6 +2,7 @@ import type { Scene } from "core/index";
 
 import { AbstractEngine } from "core/Engines/abstractEngine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
+import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
 import { ExtensibleAccordion } from "../extensibleAccordion";
 import { Pane } from "../pane";
@@ -15,7 +16,7 @@ export const StatsPane: typeof ExtensibleAccordion<Scene> = (props) => {
         <>
             <Pane>
                 <TextPropertyLine key="EngineVersion" label="Version" description="The Babylon.js engine version." value={AbstractEngine.Version} />
-                <TextPropertyLine key="FPS" label="FPS:" description="The current framerate" value={fps.toString()} />
+                <StringifiedPropertyLine key="FPS" label="FPS:" description="The current framerate" value={fps} />
             </Pane>
             <ExtensibleAccordion {...props} />
         </>

--- a/packages/dev/inspector-v2/src/components/stats/systemStats.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/systemStats.tsx
@@ -4,6 +4,7 @@ import type { FunctionComponent } from "react";
 
 import { BooleanBadgePropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/booleanBadgePropertyLine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
+import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
 
 export const SystemStats: FunctionComponent<{ context: Scene }> = ({ context: scene }) => {
@@ -15,7 +16,7 @@ export const SystemStats: FunctionComponent<{ context: Scene }> = ({ context: sc
     return (
         <>
             <TextPropertyLine key="Resolution" label="Resolution" value={resolution} />
-            <TextPropertyLine key="HardwareScalingLevel" label="Hardware Scaling Level" value={hardwareScalingLevel.toString()} />
+            <StringifiedPropertyLine key="HardwareScalingLevel" label="Hardware Scaling Level" value={hardwareScalingLevel} />
             <TextPropertyLine key="Engine" label="Engine" value={engine.description} />
             <BooleanBadgePropertyLine key="StdDerivatives" label="StdDerivatives" value={caps.standardDerivatives} />
             <BooleanBadgePropertyLine key="CompressedTextures" label="Compressed Textures" value={caps.s3tc !== undefined} />
@@ -32,9 +33,9 @@ export const SystemStats: FunctionComponent<{ context: Scene }> = ({ context: sc
             <BooleanBadgePropertyLine key="TimerQuery" label="Timer Query" value={caps.timerQuery !== undefined} />
             <BooleanBadgePropertyLine key="Stencil" label="Stencil" value={engine.isStencilEnable} />
             <BooleanBadgePropertyLine key="ParallelShaderCompilation" label="Parallel Shader Compilation" value={caps.parallelShaderCompile != null} />
-            <TextPropertyLine key="MaxTexturesUnits" label="Max Textures Units" value={caps.maxTexturesImageUnits.toLocaleString()} />
-            <TextPropertyLine key="MaxTexturesSize" label="Max Textures Size" value={caps.maxTextureSize.toLocaleString()} />
-            <TextPropertyLine key="MaxAnisotropy" label="Max Anisotropy" value={caps.maxAnisotropy.toLocaleString()} />
+            <StringifiedPropertyLine key="MaxTexturesUnits" label="Max Textures Units" value={caps.maxTexturesImageUnits} />
+            <StringifiedPropertyLine key="MaxTexturesSize" label="Max Textures Size" value={caps.maxTextureSize} />
+            <StringifiedPropertyLine key="MaxAnisotropy" label="Max Anisotropy" value={caps.maxAnisotropy} />
             <TextPropertyLine key="Driver" label="Driver" value={engine.extractDriverInfo()} />
         </>
     );

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/stringifiedPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/stringifiedPropertyLine.tsx
@@ -7,16 +7,16 @@ type StringifiedPropertyLineProps = PropertyLineProps<number> &
     ImmutablePrimitiveProps<number> & {
         precision?: number;
         units?: string;
-        converter?: (value: number) => string;
     };
 
 /**
  * Expects a numerical value and converts it to a fixed string
- * Can pass optional precision, units, and converter function (default uses value.toString())
+ * Can pass optional precision, units, and converter function (default uses value.toLocaleString())
  * @param props
  * @returns
  */
 export const StringifiedPropertyLine: FunctionComponent<StringifiedPropertyLineProps> = (props) => {
-    const value = props.precision !== undefined ? props.value.toFixed(props.precision) : props.value;
-    return <TextPropertyLine {...props} nullable={false} value={`${value.toString()} ${props.units}`} />;
+    const value = props.precision !== undefined ? props.value.toFixed(props.precision) : props.value.toLocaleString();
+    const withUnits = props.units ? `${value} ${props.units}` : value;
+    return <TextPropertyLine {...props} nullable={false} value={withUnits} />;
 };

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/stringifiedPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/stringifiedPropertyLine.tsx
@@ -10,8 +10,8 @@ type StringifiedPropertyLineProps = PropertyLineProps<number> &
     };
 
 /**
- * Expects a numerical value and converts it to a fixed string
- * Can pass optional precision, units, and converter function (default uses value.toLocaleString())
+ * Expects a numerical value and converts it toFixed(if precision is supplied) or toLocaleString
+ * Can pass optional units to be appending to the end of the string
  * @param props
  * @returns
  */

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/stringifiedPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/stringifiedPropertyLine.tsx
@@ -1,0 +1,22 @@
+import type { ImmutablePrimitiveProps } from "../../primitives/primitive";
+import type { PropertyLineProps } from "./propertyLine";
+import type { FunctionComponent } from "react";
+import { TextPropertyLine } from "./textPropertyLine";
+
+type StringifiedPropertyLineProps = PropertyLineProps<number> &
+    ImmutablePrimitiveProps<number> & {
+        precision?: number;
+        units?: string;
+        converter?: (value: number) => string;
+    };
+
+/**
+ * Expects a numerical value and converts it to a fixed string
+ * Can pass optional precision, units, and converter function (default uses value.toString())
+ * @param props
+ * @returns
+ */
+export const StringifiedPropertyLine: FunctionComponent<StringifiedPropertyLineProps> = (props) => {
+    const value = props.precision !== undefined ? props.value.toFixed(props.precision) : props.value;
+    return <TextPropertyLine {...props} nullable={false} value={`${value.toString()} ${props.units}`} />;
+};


### PR DESCRIPTION
Takes in a number and converts to a string with optional unit / precision parameters so that caller doesn't need to do the casting / string formatting

Can be used with BoundProperty for numerical values 