### PR TITLE
Inspector v2: Scene Explorer filtering

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -259,8 +259,6 @@ export const SceneExplorer: FunctionComponent<{
         props.setSelectedEntity?.(entity);
     };
 
-    // For the filter, we should maybe to the traversal but use onAfterNode so that if the filter matches, we make sure to include the full parent chain.
-    // Then just reverse the array of nodes before returning it.
     const [itemsFilter, setItemsFilter] = useState("");
 
     useEffect(() => {


### PR DESCRIPTION
This PR adds a filtering implementation for Scene Explorer. I opted for a relatively simple implementation that behaves a bit differently from inspector v1. Specifically, when filtering, the tree expansion state is completely ignored - all matched items (and their ancestor items) are displayed, and no items are collapsible in this state. When the filter is cleared, the expansion state prior to filtering is restored. I think this behavior is more useful than v1, and the implementation was relatively simple, so I think this is a good first pass. I will talk with @PatrickRyanMS later and see if we want to refine this behavior.

https://github.com/user-attachments/assets/9cf57f90-cc6a-4c86-9ba8-559c8c25e558