### PR TITLE
Fix GUI 2D optimization and consistently apply states when measuring

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1647,8 +1647,7 @@ export class Control implements IAnimatable, IFocusableControl {
         let newLeft = projectedPosition.x + this._linkOffsetX.getValue(this._host) - this._currentMeasure.width / 2;
         let newTop = projectedPosition.y + this._linkOffsetY.getValue(this._host) - this._currentMeasure.height / 2;
 
-        const leftAndTopIgnoreAdaptiveScaling = this._left.ignoreAdaptiveScaling && this._top.ignoreAdaptiveScaling;
-        if (leftAndTopIgnoreAdaptiveScaling) {
+        if (this._left.ignoreAdaptiveScaling && this._top.ignoreAdaptiveScaling) {
             if (Math.abs(newLeft - oldLeft) < 0.5) {
                 newLeft = oldLeft;
             }
@@ -1658,7 +1657,7 @@ export class Control implements IAnimatable, IFocusableControl {
             }
         }
 
-        if (!leftAndTopIgnoreAdaptiveScaling && oldLeft === newLeft && oldTop === newTop) {
+        if (oldLeft === newLeft && oldTop === newTop) {
             return;
         }
 
@@ -1919,8 +1918,6 @@ export class Control implements IAnimatable, IFocusableControl {
 
             context.save();
 
-            this._applyStates(context);
-
             let rebuildCount = 0;
             do {
                 this._rebuildLayout = false;
@@ -1947,6 +1944,9 @@ export class Control implements IAnimatable, IFocusableControl {
      * @internal
      */
     protected _processMeasures(parentMeasure: Measure, context: ICanvasRenderingContext): void {
+        // Ensure we always apply states before measuring
+        this._applyStates(context);
+
         this._tempPaddingMeasure.copyFrom(parentMeasure);
 
         // Apply padding if in correct mode


### PR DESCRIPTION
An old [bug report about TextBlock elements jittering](https://forum.babylonjs.com/t/glitches-with-textblocks-not-wrapped-in-container/39092) was fixed by [disabling](https://github.com/BabylonJS/Babylon.js/commit/b8ce95dd02f7e835f11b4725d7868201f42a7681) a [prior optimization](https://github.com/BabylonJS/Babylon.js/pull/13430/files) to not redraw the 2D control if the new position was the same as the old position.

That did have the effect of preventing the jitter, but the root cause of the jitter was that the measurement of the size of the TextBlock sometimes used the requested font, and sometimes used a default font. If those were different, the wrong measurement might be used to position the element, resulting the horizontal shifting back and forth.  

With this fix, we consistently apply the requested font before measuring so the measurement is always correct, and we can now re-enable the perf optimization to no longer redraw if the projected position of the 2D control hasn't changed.  This addresses the perf concern reported [here](https://forum.babylonjs.com/t/custom-control-linked-to-a-mesh-is-not-cached-and-redraws-every-frame-dubious-workaround/59822).