### PR TITLE
Viewer v2: Switch back to WebGL as the default for now

### DIFF
--- a/packages/tools/viewer-configurator/src/components/babylonViewer/viewer.tsx
+++ b/packages/tools/viewer-configurator/src/components/babylonViewer/viewer.tsx
@@ -45,5 +45,11 @@ export const Viewer: FunctionComponent<{ onViewerCreated: (element: ViewerElemen
         })();
     }, []);
 
-    return <configured-babylon-viewer class="viewerElement" ref={props.onViewerCreated}></configured-babylon-viewer>;
+    // Allow engine selection through query param for testing. Later we may add an option in the UI for engine selection.
+    let engine: string | null | undefined = new URLSearchParams(window.location.search).get("engine");
+    if (engine !== "WebGL" && engine !== "WebGPU") {
+        engine = undefined;
+    }
+
+    return <configured-babylon-viewer class="viewerElement" ref={props.onViewerCreated} engine={engine}></configured-babylon-viewer>;
 };

--- a/packages/tools/viewer-configurator/src/components/babylonViewer/viewer.tsx
+++ b/packages/tools/viewer-configurator/src/components/babylonViewer/viewer.tsx
@@ -46,9 +46,11 @@ export const Viewer: FunctionComponent<{ onViewerCreated: (element: ViewerElemen
     }, []);
 
     // Allow engine selection through query param for testing. Later we may add an option in the UI for engine selection.
-    let engine: string | null | undefined = new URLSearchParams(window.location.search).get("engine");
-    if (engine !== "WebGL" && engine !== "WebGPU") {
-        engine = undefined;
+    const engineQueryParam: string | null | undefined = new URLSearchParams(window.location.search).get("engine");
+    const engine = engineQueryParam?.toLowerCase() === "webgl" ? "WebGL" : engineQueryParam?.toLowerCase() === "webgpu" ? "WebGPU" : undefined;
+
+    if (engineQueryParam && !engine) {
+        Logger.Warn(`Invalid engine specified in query param: ${engineQueryParam}. 'webgl' or 'webgpu' expected.`);
     }
 
     return <configured-babylon-viewer class="viewerElement" ref={props.onViewerCreated} engine={engine}></configured-babylon-viewer>;

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -25,14 +25,18 @@ const DefaultCanvasViewerOptions = {
  * @returns The default engine to use.
  */
 export function GetDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
-    // First check for WebGPU support.
-    if ("gpu" in navigator) {
-        // For now, only use WebGPU with chromium-based browsers.
-        // WebGPU can be enabled in other browsers once they are fully functional and the performance is at least as good as WebGL.
-        if ("chrome" in window) {
-            return "WebGPU";
-        }
-    }
+    // TODO: There are some difficult to repro timing issues with WebGPU + snapshot rendering.
+    //       We need to do deeper diagnosis to understand the issues and make this more reliable.
+    //       For now, we will default to WebGL.
+
+    // // First check for WebGPU support.
+    // if ("gpu" in navigator) {
+    //     // For now, only use WebGPU with chromium-based browsers.
+    //     // WebGPU can be enabled in other browsers once they are fully functional and the performance is at least as good as WebGL.
+    //     if ("chrome" in window) {
+    //         return "WebGPU";
+    //     }
+    // }
 
     return "WebGL";
 }


### PR DESCRIPTION
Unfortunately we've hit some reliability issues with WebGPU + snapshot rendering that are difficult to repro and seem to be timing related. We need to investigate more, but the quick fix to make sure the Viewer is stable is to switch back to WebGL as the default for now. Might wait for @Popov72 availability for deeper investigation.

I also added a query param for the Viewer Configurator so that in that context its easy to test both WebGL and WebGPU.