### PR TITLE
Adding debug properties for mesh in InspectorV2

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -1,8 +1,5 @@
 import type { FunctionComponent } from "react";
 
-import { Color3, CreateLineSystem, FrameGraphUtils, StandardMaterial, TmpVectors, Tools, Vector3, VertexBuffer, type AbstractMesh, type Scene } from "core/index";
-import { NormalMaterial } from "materials/normal/normalMaterial";
-
 import type { ISelectionService } from "../../../services/selectionService";
 
 import { Collapse } from "@fluentui/react-motion-components-preview";
@@ -16,6 +13,15 @@ import { BoundProperty } from "../boundProperty";
 
 // Ensures that the outlineRenderer properties exist on the prototype of the Mesh
 import "core/Rendering/outlineRenderer";
+import { type AbstractMesh } from "core/Meshes/abstractMesh";
+import { NormalMaterial } from "materials/normal/normalMaterial";
+import { Tools } from "core/Misc/tools";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Color3 } from "core/Maths/math.color";
+import { VertexBuffer } from "core/Meshes/buffer";
+import { TmpVectors, Vector3 } from "core/Maths/math.vector";
+import { CreateLineSystem } from "core/Meshes/Builders/linesBuilder";
+import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
 
 const DisplayNormals = function (mesh: AbstractMesh) {
     const scene = mesh.getScene();

--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -14,7 +14,6 @@ import { BoundProperty } from "../boundProperty";
 // Ensures that the outlineRenderer properties exist on the prototype of the Mesh
 import "core/Rendering/outlineRenderer";
 import { type AbstractMesh } from "core/Meshes/abstractMesh";
-import { NormalMaterial } from "materials/normal/normalMaterial";
 import { Tools } from "core/Misc/tools";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { Color3 } from "core/Maths/math.color";
@@ -23,103 +22,10 @@ import { TmpVectors, Vector3 } from "core/Maths/math.vector";
 import { CreateLineSystem } from "core/Meshes/Builders/linesBuilder";
 import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
 import { SkeletonViewer } from "core/Debug/skeletonViewer";
-
-const RenderNormalVectors = function (mesh: AbstractMesh) {
-    const scene = mesh.getScene();
-
-    if (mesh.reservedDataStore && mesh.reservedDataStore.normalLines) {
-        mesh.reservedDataStore.normalLines.dispose();
-        mesh.reservedDataStore.normalLines = null;
-
-        return;
-    }
-
-    const normals = mesh.getVerticesData(VertexBuffer.NormalKind);
-    const positions = mesh.getVerticesData(VertexBuffer.PositionKind);
-
-    const color = Color3.White();
-    const bbox = mesh.getBoundingInfo();
-    const diag = bbox.maximum.subtractToRef(bbox.minimum, TmpVectors.Vector3[0]);
-    const size = diag.length() * 0.05;
-
-    const lines = [];
-    for (let i = 0; i < normals!.length; i += 3) {
-        const v1 = Vector3.FromArray(positions!, i);
-        const v2 = v1.add(Vector3.FromArray(normals!, i).scaleInPlace(size));
-        lines.push([v1, v2]);
-    }
-
-    const normalLines = CreateLineSystem("normalLines", { lines: lines }, scene);
-    normalLines.color = color;
-    normalLines.parent = mesh;
-    normalLines.reservedDataStore = { hidden: true };
-
-    if (!mesh.reservedDataStore) {
-        mesh.reservedDataStore = {};
-    }
-
-    mesh.reservedDataStore.normalLines = normalLines;
-};
-
-const RenderWireframeOver = function (mesh: AbstractMesh) {
-    const scene = mesh.getScene();
-
-    if (mesh.reservedDataStore && mesh.reservedDataStore.wireframeOver) {
-        const frameGraph = scene.frameGraph;
-        if (frameGraph) {
-            const objectRenderer = FrameGraphUtils.FindMainObjectRenderer(frameGraph);
-            if (objectRenderer && objectRenderer.objectList.meshes) {
-                const idx = objectRenderer.objectList.meshes.indexOf(mesh.reservedDataStore.wireframeOver);
-                if (idx !== -1) {
-                    objectRenderer.objectList.meshes!.splice(idx, 1);
-                }
-            }
-        }
-
-        mesh.reservedDataStore.wireframeOver.dispose(false, true);
-        mesh.reservedDataStore.wireframeOver = null;
-
-        return;
-    }
-
-    const wireframeOver = mesh.clone(mesh.name + "_wireframeover", null, true);
-    if (wireframeOver === null) {
-        return;
-    }
-
-    wireframeOver.reservedDataStore = { hidden: true };
-
-    // Sets up the mesh to be attached to the parent.
-    // So all neutral in local space.
-    wireframeOver.parent = mesh;
-    wireframeOver.position = Vector3.Zero();
-    wireframeOver.scaling = new Vector3(1, 1, 1);
-    wireframeOver.rotation = Vector3.Zero();
-    wireframeOver.rotationQuaternion = null;
-
-    const material = new StandardMaterial("wireframeOver", scene);
-    material.reservedDataStore = { hidden: true };
-    wireframeOver.material = material;
-    material.disableLighting = true;
-    material.backFaceCulling = false;
-    material.emissiveColor = Color3.White();
-
-    material.wireframe = true;
-
-    if (!mesh.reservedDataStore) {
-        mesh.reservedDataStore = {};
-    }
-
-    mesh.reservedDataStore.wireframeOver = wireframeOver;
-
-    const frameGraph = scene.frameGraph;
-    if (frameGraph) {
-        const objectRenderer = FrameGraphUtils.FindMainObjectRenderer(frameGraph);
-        if (objectRenderer && objectRenderer.objectList.meshes) {
-            objectRenderer.objectList.meshes.push(wireframeOver);
-        }
-    }
-};
+import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
+import { type DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";
+import { type ShaderMaterial } from "core/Materials/shaderMaterial";
+import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 
 export const AbstractMeshGeneralProperties: FunctionComponent<{ mesh: AbstractMesh; selectionService: ISelectionService }> = (props) => {
     const { mesh, selectionService } = props;
@@ -200,59 +106,71 @@ export const AbstractMeshOutlineOverlayProperties: FunctionComponent<{ mesh: Abs
 export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh }> = (props) => {
     const { mesh } = props;
 
-    const [displayNormals, setDisplayNormals] = useState(mesh.material != null && mesh.material.getClassName() === "NormalMaterial");
-    const [displayVertexColors, setDisplayVertexColors] = useState(
-        mesh.material != null && mesh.material.reservedDataStore && mesh.material.reservedDataStore.isVertexColorMaterial ? true : false
+    const [displayNormals, setDisplayNormals] = useState(mesh.material?.getClassName() === "NormalMaterial");
+    const [displayVertexColors, setDisplayVertexColors] = useState(mesh.material?.reservedDataStore?.isVertexColorMaterial ? true : false);
+    const [renderNormalVectors] = useState(mesh.reservedDataStore?.normalLines ? true : false);
+    const [renderWireframeOver] = useState(mesh.reservedDataStore?.wireframeOver ? true : false);
+    const [displayBoneWeights, setDisplayBoneWeights] = useState(mesh.material?.getClassName() === "BoneWeightShader");
+    const [displaySkeletonMap, setDisplaySkeletonMap] = useState(mesh.material?.getClassName() === "SkeletonMapShader");
+    const [displayBoneIndex, setDisplayBoneIndex] = useState(mesh.reservedDataStore?.displayBoneIndex ?? 0);
+
+    const [targetBoneOptions] = useState<DropdownOption[]>(
+        mesh.skeleton
+            ? mesh.skeleton.bones
+                  .filter((bone) => bone.getIndex() >= 0)
+                  .sort((bone1, bone2) => bone1.getIndex() - bone2.getIndex())
+                  .map((bone) => {
+                      return {
+                          label: bone.name,
+                          value: bone.getIndex(),
+                      };
+                  })
+            : []
     );
-    const [renderNormalVectors] = useState(mesh.reservedDataStore && mesh.reservedDataStore.normalLines ? true : false);
-    const [renderWireframeOver] = useState(mesh.reservedDataStore && mesh.reservedDataStore.wireframeOver ? true : false);
-    const [displayBoneWeights, setDisplayBoneWeights] = useState(mesh.material != null && mesh.material.getClassName() === "BoneWeightShader");
-    const [displaySkeletonMap, setDisplaySkeletonMap] = useState(mesh.material != null && mesh.material.getClassName() === "SkeletonMapShader");
 
-    const overlayColor = useColor3Property(mesh, "overlayColor");
-
-    const displayNormalsHandler = function (mesh: AbstractMesh) {
+    const displayNormalsHandlerAsync = async function () {
         const scene = mesh.getScene();
 
-        if (mesh.material && mesh.material.getClassName() === "NormalMaterial") {
+        if (mesh.material?.getClassName() === "NormalMaterial") {
             mesh.material.dispose();
 
             mesh.material = mesh.reservedDataStore.originalMaterial;
             mesh.reservedDataStore.originalMaterial = null;
             setDisplayNormals(false);
         } else {
-            if (typeof NormalMaterial === "undefined") {
-                Tools.Warn("NormalMaterial not found. Make sure to load the materials library.");
-                return;
-            }
+            try {
+                const { NormalMaterial: normalMaterialClass } = await import("materials/normal/normalMaterial");
 
-            if (!mesh.reservedDataStore) {
-                mesh.reservedDataStore = {};
-            }
+                if (!mesh.reservedDataStore) {
+                    mesh.reservedDataStore = {};
+                }
 
-            if (!mesh.reservedDataStore.originalMaterial) {
-                mesh.reservedDataStore.originalMaterial = mesh.material;
-            }
+                if (!mesh.reservedDataStore.originalMaterial) {
+                    mesh.reservedDataStore.originalMaterial = mesh.material;
+                }
 
-            const normalMaterial = new NormalMaterial("normalMaterial", scene);
-            normalMaterial.disableLighting = true;
-            if (mesh.material) {
-                normalMaterial.sideOrientation = mesh.material.sideOrientation;
-            }
-            normalMaterial.reservedDataStore = { hidden: true };
-            mesh.material = normalMaterial;
+                const normalMaterial = new normalMaterialClass("normalMaterial", scene);
+                normalMaterial.disableLighting = true;
+                if (mesh.material) {
+                    normalMaterial.sideOrientation = mesh.material.sideOrientation;
+                }
+                normalMaterial.reservedDataStore = { hidden: true };
+                mesh.material = normalMaterial;
 
-            setDisplayVertexColors(false);
-            setDisplayBoneWeights(false);
-            setDisplaySkeletonMap(false);
-            setDisplayNormals(true);
+                setDisplayVertexColors(false);
+                setDisplayBoneWeights(false);
+                setDisplaySkeletonMap(false);
+                setDisplayNormals(true);
+            } catch {
+                Tools.Warn("NormalMaterial could not be loaded.");
+            }
         }
     };
 
-    const displayVertexColorsHandler = function (mesh: AbstractMesh) {
+    const displayVertexColorsHandler = function () {
         const scene = mesh.getScene();
 
-        if (mesh.material && mesh.material.reservedDataStore && mesh.material.reservedDataStore.isVertexColorMaterial) {
+        if (mesh.material?.reservedDataStore?.isVertexColorMaterial) {
             mesh.material.dispose();
 
             mesh.material = mesh.reservedDataStore.originalMaterial;
@@ -282,10 +200,108 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
             setDisplayVertexColors(true);
         }
     };
-    const displayBoneWeightsHandler = function (mesh: AbstractMesh) {
+
+    const renderNormalVectorsHandler = function () {
         const scene = mesh.getScene();
 
-        if (mesh.material && mesh.material.getClassName() === "BoneWeightShader") {
+        if (mesh.reservedDataStore && mesh.reservedDataStore.normalLines) {
+            mesh.reservedDataStore.normalLines.dispose();
+            mesh.reservedDataStore.normalLines = null;
+
+            return;
+        }
+
+        const normals = mesh.getVerticesData(VertexBuffer.NormalKind);
+        const positions = mesh.getVerticesData(VertexBuffer.PositionKind);
+
+        const color = Color3.White();
+        const bbox = mesh.getBoundingInfo();
+        const diag = bbox.maximum.subtractToRef(bbox.minimum, TmpVectors.Vector3[0]);
+        const size = diag.length() * 0.05;
+
+        const lines: [Vector3, Vector3][] = [];
+        for (let i = 0; i < normals!.length; i += 3) {
+            const v1 = Vector3.FromArray(positions!, i);
+            const v2 = v1.add(Vector3.FromArray(normals!, i).scaleInPlace(size));
+            lines.push([v1, v2]);
+        }
+
+        const normalLines = CreateLineSystem("normalLines", { lines: lines }, scene);
+        normalLines.color = color;
+        normalLines.parent = mesh;
+        normalLines.reservedDataStore = { hidden: true };
+
+        if (!mesh.reservedDataStore) {
+            mesh.reservedDataStore = {};
+        }
+
+        mesh.reservedDataStore.normalLines = normalLines;
+    };
+
+    const renderWireframeOverHandler = function () {
+        const scene = mesh.getScene();
+
+        if (mesh.reservedDataStore?.wireframeOver) {
+            const frameGraph = scene.frameGraph;
+            if (frameGraph) {
+                const objectRenderer = FrameGraphUtils.FindMainObjectRenderer(frameGraph);
+                if (objectRenderer && objectRenderer.objectList.meshes) {
+                    const idx = objectRenderer.objectList.meshes.indexOf(mesh.reservedDataStore.wireframeOver);
+                    if (idx !== -1) {
+                        objectRenderer.objectList.meshes!.splice(idx, 1);
+                    }
+                }
+            }
+
+            mesh.reservedDataStore.wireframeOver.dispose(false, true);
+            mesh.reservedDataStore.wireframeOver = null;
+
+            return;
+        }
+
+        const wireframeOver = mesh.clone(mesh.name + "_wireframeover", null, true);
+        if (wireframeOver === null) {
+            return;
+        }
+
+        wireframeOver.reservedDataStore = { hidden: true };
+
+        // Sets up the mesh to be attached to the parent.
+        // So all neutral in local space.
+        wireframeOver.parent = mesh;
+        wireframeOver.position = Vector3.Zero();
+        wireframeOver.scaling = new Vector3(1, 1, 1);
+        wireframeOver.rotation = Vector3.Zero();
+        wireframeOver.rotationQuaternion = null;
+
+        const material = new StandardMaterial("wireframeOver", scene);
+        material.reservedDataStore = { hidden: true };
+        wireframeOver.material = material;
+        material.disableLighting = true;
+        material.backFaceCulling = false;
+        material.emissiveColor = Color3.White();
+
+        material.wireframe = true;
+
+        if (!mesh.reservedDataStore) {
+            mesh.reservedDataStore = {};
+        }
+
+        mesh.reservedDataStore.wireframeOver = wireframeOver;
+
+        const frameGraph = scene.frameGraph;
+        if (frameGraph) {
+            const objectRenderer = FrameGraphUtils.FindMainObjectRenderer(frameGraph);
+            if (objectRenderer && objectRenderer.objectList.meshes) {
+                objectRenderer.objectList.meshes.push(wireframeOver);
+            }
+        }
+    };
+
+    const displayBoneWeightsHandler = function () {
+        const scene = mesh.getScene();
+
+        if (mesh.material?.getClassName() === "BoneWeightShader") {
             mesh.material.dispose();
             mesh.material = mesh.reservedDataStore.originalMaterial;
             mesh.reservedDataStore.originalMaterial = null;
@@ -312,10 +328,10 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
         }
     };
 
-    const displaySkeletonMapHandler = function (mesh: AbstractMesh) {
+    const displaySkeletonMapHandler = function () {
         const scene = mesh.getScene();
 
-        if (mesh.material && mesh.material.getClassName() === "SkeletonMapShader") {
+        if (mesh.material?.getClassName() === "SkeletonMapShader") {
             mesh.material.dispose();
             mesh.material = mesh.reservedDataStore.originalMaterial;
             mesh.reservedDataStore.originalMaterial = null;
@@ -339,24 +355,42 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
         }
     };
 
+    const onBoneDisplayIndexChangeHandler = function (value: number): void {
+        mesh.reservedDataStore.displayBoneIndex = value;
+        setDisplayBoneIndex(value);
+        if (mesh.material && mesh.material.getClassName() === "BoneWeightShader") {
+            (mesh.material as ShaderMaterial).setFloat("targetBoneIndex", value);
+        }
+    };
+
     return (
         <>
-            <SwitchPropertyLine label="Display Normals" value={displayNormals} onChange={() => displayNormalsHandler(mesh)} />
-            <SwitchPropertyLine label="Display Vertex Colors" value={displayVertexColors} onChange={() => displayVertexColorsHandler(mesh)} />
-            <SwitchPropertyLine label="Render Vertex Normals" value={renderNormalVectors} onChange={() => RenderNormalVectors(mesh)} />
-            <SwitchPropertyLine label="Render Wireframe over Mesh" value={renderWireframeOver} onChange={() => RenderWireframeOver(mesh)} />
-            {mesh.skeleton && <SwitchPropertyLine label="Display Bone Weights" value={displayBoneWeights} onChange={() => displayBoneWeightsHandler(mesh)} />}
+            <SwitchPropertyLine label="Display Normals" value={displayNormals} onChange={async () => await displayNormalsHandlerAsync()} />
+            <SwitchPropertyLine label="Display Vertex Colors" value={displayVertexColors} onChange={() => displayVertexColorsHandler()} />
+            <SwitchPropertyLine label="Render Vertex Normals" value={renderNormalVectors} onChange={() => renderNormalVectorsHandler()} />
+            <SwitchPropertyLine label="Render Wireframe over Mesh" value={renderWireframeOver} onChange={() => renderWireframeOverHandler()} />
+            {mesh.skeleton && <SwitchPropertyLine label="Display Bone Weights" value={displayBoneWeights} onChange={() => displayBoneWeightsHandler()} />}
             <Collapse visible={displayBoneWeights}>
-                <Color3PropertyLine
-                    key="OverlayColor"
-                    label="Overlay Color"
-                    value={overlayColor}
-                    onChange={(color) => {
-                        mesh.overlayColor = color;
-                    }}
-                />
+                <div>
+                    <NumberDropdownPropertyLine
+                        label="Target Bone Name"
+                        options={targetBoneOptions}
+                        value={displayBoneIndex}
+                        onChange={(value) => {
+                            onBoneDisplayIndexChangeHandler(value);
+                        }}
+                    />
+                    <SyncedSliderPropertyLine
+                        label="Target Bone"
+                        value={displayBoneIndex}
+                        min={0}
+                        max={targetBoneOptions.length - 1}
+                        step={1}
+                        onChange={(value) => onBoneDisplayIndexChangeHandler(value)}
+                    />
+                </div>
             </Collapse>
-            {mesh.skeleton && <SwitchPropertyLine label="Display Skeleton Map" value={displaySkeletonMap} onChange={() => displaySkeletonMapHandler(mesh)} />}
+            {mesh.skeleton && <SwitchPropertyLine label="Display Skeleton Map" value={displaySkeletonMap} onChange={() => displaySkeletonMapHandler()} />}
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -1,6 +1,8 @@
 import type { FunctionComponent } from "react";
 
-import type { AbstractMesh } from "core/index";
+import { Color3, CreateLineSystem, FrameGraphUtils, StandardMaterial, TmpVectors, Tools, Vector3, VertexBuffer, type AbstractMesh, type Scene } from "core/index";
+import { NormalMaterial } from "materials/normal/normalMaterial";
+
 import type { ISelectionService } from "../../../services/selectionService";
 
 import { Collapse } from "@fluentui/react-motion-components-preview";
@@ -14,6 +16,163 @@ import { BoundProperty } from "../boundProperty";
 
 // Ensures that the outlineRenderer properties exist on the prototype of the Mesh
 import "core/Rendering/outlineRenderer";
+
+const DisplayNormals = function (mesh: AbstractMesh) {
+    const scene = mesh.getScene();
+
+    if (mesh.material && mesh.material.getClassName() === "NormalMaterial") {
+        mesh.material.dispose();
+
+        mesh.material = mesh.reservedDataStore.originalMaterial;
+        mesh.reservedDataStore.originalMaterial = null;
+    } else {
+        if (typeof NormalMaterial === "undefined") {
+            Tools.Warn("NormalMaterial not found. Make sure to load the materials library.");
+            return;
+        }
+
+        if (!mesh.reservedDataStore) {
+            mesh.reservedDataStore = {};
+        }
+
+        if (!mesh.reservedDataStore.originalMaterial) {
+            mesh.reservedDataStore.originalMaterial = mesh.material;
+        }
+
+        const normalMaterial = new NormalMaterial("normalMaterial", scene);
+        normalMaterial.disableLighting = true;
+        if (mesh.material) {
+            normalMaterial.sideOrientation = mesh.material.sideOrientation;
+        }
+        normalMaterial.reservedDataStore = { hidden: true };
+        mesh.material = normalMaterial;
+    }
+};
+
+const DisplayVertexColors = function (mesh: AbstractMesh) {
+    const scene = mesh.getScene();
+
+    if (mesh.material && mesh.material.reservedDataStore && mesh.material.reservedDataStore.isVertexColorMaterial) {
+        mesh.material.dispose();
+
+        mesh.material = mesh.reservedDataStore.originalMaterial;
+        mesh.reservedDataStore.originalMaterial = null;
+    } else {
+        if (!mesh.reservedDataStore) {
+            mesh.reservedDataStore = {};
+        }
+
+        if (!mesh.reservedDataStore.originalMaterial) {
+            mesh.reservedDataStore.originalMaterial = mesh.material;
+        }
+        const vertexColorMaterial = new StandardMaterial("vertex colors", scene);
+        vertexColorMaterial.disableLighting = true;
+        vertexColorMaterial.emissiveColor = Color3.White();
+        if (mesh.material) {
+            vertexColorMaterial.sideOrientation = mesh.material.sideOrientation;
+        }
+        vertexColorMaterial.reservedDataStore = { hidden: true, isVertexColorMaterial: true };
+        mesh.useVertexColors = true;
+        mesh.material = vertexColorMaterial;
+    }
+};
+
+const RenderNormalVectors = function (mesh: AbstractMesh) {
+    const scene = mesh.getScene();
+
+    if (mesh.reservedDataStore && mesh.reservedDataStore.normalLines) {
+        mesh.reservedDataStore.normalLines.dispose();
+        mesh.reservedDataStore.normalLines = null;
+
+        return;
+    }
+
+    const normals = mesh.getVerticesData(VertexBuffer.NormalKind);
+    const positions = mesh.getVerticesData(VertexBuffer.PositionKind);
+
+    const color = Color3.White();
+    const bbox = mesh.getBoundingInfo();
+    const diag = bbox.maximum.subtractToRef(bbox.minimum, TmpVectors.Vector3[0]);
+    const size = diag.length() * 0.05;
+
+    const lines = [];
+    for (let i = 0; i < normals!.length; i += 3) {
+        const v1 = Vector3.FromArray(positions!, i);
+        const v2 = v1.add(Vector3.FromArray(normals!, i).scaleInPlace(size));
+        lines.push([v1, v2]);
+    }
+
+    const normalLines = CreateLineSystem("normalLines", { lines: lines }, scene);
+    normalLines.color = color;
+    normalLines.parent = mesh;
+    normalLines.reservedDataStore = { hidden: true };
+
+    if (!mesh.reservedDataStore) {
+        mesh.reservedDataStore = {};
+    }
+
+    mesh.reservedDataStore.normalLines = normalLines;
+};
+
+const RenderWireframeOver = function (mesh: AbstractMesh) {
+    const scene = mesh.getScene();
+
+    if (mesh.reservedDataStore && mesh.reservedDataStore.wireframeOver) {
+        const frameGraph = scene.frameGraph;
+        if (frameGraph) {
+            const objectRenderer = FrameGraphUtils.FindMainObjectRenderer(frameGraph);
+            if (objectRenderer && objectRenderer.objectList.meshes) {
+                const idx = objectRenderer.objectList.meshes.indexOf(mesh.reservedDataStore.wireframeOver);
+                if (idx !== -1) {
+                    objectRenderer.objectList.meshes!.splice(idx, 1);
+                }
+            }
+        }
+
+        mesh.reservedDataStore.wireframeOver.dispose(false, true);
+        mesh.reservedDataStore.wireframeOver = null;
+
+        return;
+    }
+
+    const wireframeOver = mesh.clone(mesh.name + "_wireframeover", null, true);
+    if (wireframeOver === null) {
+        return;
+    }
+
+    wireframeOver.reservedDataStore = { hidden: true };
+
+    // Sets up the mesh to be attached to the parent.
+    // So all neutral in local space.
+    wireframeOver.parent = mesh;
+    wireframeOver.position = Vector3.Zero();
+    wireframeOver.scaling = new Vector3(1, 1, 1);
+    wireframeOver.rotation = Vector3.Zero();
+    wireframeOver.rotationQuaternion = null;
+
+    const material = new StandardMaterial("wireframeOver", scene);
+    material.reservedDataStore = { hidden: true };
+    wireframeOver.material = material;
+    material.disableLighting = true;
+    material.backFaceCulling = false;
+    material.emissiveColor = Color3.White();
+
+    material.wireframe = true;
+
+    if (!mesh.reservedDataStore) {
+        mesh.reservedDataStore = {};
+    }
+
+    mesh.reservedDataStore.wireframeOver = wireframeOver;
+
+    const frameGraph = scene.frameGraph;
+    if (frameGraph) {
+        const objectRenderer = FrameGraphUtils.FindMainObjectRenderer(frameGraph);
+        if (objectRenderer && objectRenderer.objectList.meshes) {
+            objectRenderer.objectList.meshes.push(wireframeOver);
+        }
+    }
+};
 
 export const AbstractMeshGeneralProperties: FunctionComponent<{ mesh: AbstractMesh; selectionService: ISelectionService }> = (props) => {
     const { mesh, selectionService } = props;
@@ -87,6 +246,44 @@ export const AbstractMeshOutlineOverlayProperties: FunctionComponent<{ mesh: Abs
                     }}
                 />
             </Collapse>
+        </>
+    );
+};
+
+export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh }> = (props) => {
+    const { mesh } = props;
+
+    const displayNormals = mesh.material != null && mesh.material.getClassName() === "NormalMaterial";
+    const displayVertexColors = !!(mesh.material != null && mesh.material.reservedDataStore && mesh.material.reservedDataStore.isVertexColorMaterial);
+    const renderNormalVectors = mesh.reservedDataStore && mesh.reservedDataStore.normalLines ? true : false;
+    const renderWireframeOver = mesh.reservedDataStore && mesh.reservedDataStore.wireframeOver ? true : false;
+
+    return (
+        <>
+            <SwitchPropertyLine
+                label="Display normals"
+                description="Displays the normals for each face of the mesh."
+                value={displayNormals}
+                onChange={() => DisplayNormals(mesh)}
+            />
+            <SwitchPropertyLine
+                label="Display vertex colors"
+                description="Displays the colors for each vertex of the mesh."
+                value={displayVertexColors}
+                onChange={() => DisplayVertexColors(mesh)}
+            />
+            <SwitchPropertyLine
+                label="Render vertex normals"
+                description="Renders the vertex normals for the mesh."
+                value={renderNormalVectors}
+                onChange={() => RenderNormalVectors(mesh)}
+            />
+            <SwitchPropertyLine
+                label="Render wireframe over mesh"
+                description="Display the mesh wireframe over itself."
+                value={renderWireframeOver}
+                onChange={() => RenderWireframeOver(mesh)}
+            />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -1,4 +1,5 @@
-import { useState, type FunctionComponent } from "react";
+import type { FunctionComponent } from "react";
+import { useState } from "react";
 
 import type { ISelectionService } from "../../../services/selectionService";
 
@@ -13,7 +14,7 @@ import { BoundProperty } from "../boundProperty";
 
 // Ensures that the outlineRenderer properties exist on the prototype of the Mesh
 import "core/Rendering/outlineRenderer";
-import { type AbstractMesh } from "core/Meshes/abstractMesh";
+import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import { Tools } from "core/Misc/tools";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { Color3 } from "core/Maths/math.color";
@@ -23,8 +24,8 @@ import { CreateLineSystem } from "core/Meshes/Builders/linesBuilder";
 import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
 import { SkeletonViewer } from "core/Debug/skeletonViewer";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
-import { type DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";
-import { type ShaderMaterial } from "core/Materials/shaderMaterial";
+import type { DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";
+import type { ShaderMaterial } from "core/Materials/shaderMaterial";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 
 export const AbstractMeshGeneralProperties: FunctionComponent<{ mesh: AbstractMesh; selectionService: ISelectionService }> = (props) => {
@@ -105,6 +106,8 @@ export const AbstractMeshOutlineOverlayProperties: FunctionComponent<{ mesh: Abs
 
 export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh }> = (props) => {
     const { mesh } = props;
+
+    const skeleton = useProperty(mesh, "skeleton");
 
     const [displayNormals, setDisplayNormals] = useState(mesh.material?.getClassName() === "NormalMaterial");
     const [displayVertexColors, setDisplayVertexColors] = useState(mesh.material?.reservedDataStore?.isVertexColorMaterial ? true : false);
@@ -369,7 +372,7 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
             <SwitchPropertyLine label="Display Vertex Colors" value={displayVertexColors} onChange={() => displayVertexColorsHandler()} />
             <SwitchPropertyLine label="Render Vertex Normals" value={renderNormalVectors} onChange={() => renderNormalVectorsHandler()} />
             <SwitchPropertyLine label="Render Wireframe over Mesh" value={renderWireframeOver} onChange={() => renderWireframeOverHandler()} />
-            {mesh.skeleton && <SwitchPropertyLine label="Display Bone Weights" value={displayBoneWeights} onChange={() => displayBoneWeightsHandler()} />}
+            {skeleton && <SwitchPropertyLine label="Display Bone Weights" value={displayBoneWeights} onChange={() => displayBoneWeightsHandler()} />}
             <Collapse visible={displayBoneWeights}>
                 <div>
                     <NumberDropdownPropertyLine
@@ -390,7 +393,7 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
                     />
                 </div>
             </Collapse>
-            {mesh.skeleton && <SwitchPropertyLine label="Display Skeleton Map" value={displaySkeletonMap} onChange={() => displaySkeletonMapHandler()} />}
+            {skeleton && <SwitchPropertyLine label="Display Skeleton Map" value={displaySkeletonMap} onChange={() => displaySkeletonMapHandler()} />}
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
@@ -38,7 +38,6 @@ export const NodePropertiesServiceDefinition: ServiceDefinition<[], [IProperties
                     section: "General",
                     component: ({ context }) => <AbstractMeshGeneralProperties mesh={context} selectionService={selectionService} />,
                 },
-
                 {
                     section: "Advanced",
                     component: ({ context }) => <AbstractMeshAdvancedProperties mesh={context} />,

--- a/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
@@ -4,7 +4,12 @@ import type { IPropertiesService } from "./propertiesService";
 
 import { Node } from "core/node";
 import { AbstractMesh } from "core/Meshes/abstractMesh";
-import { AbstractMeshAdvancedProperties, AbstractMeshGeneralProperties, AbstractMeshOutlineOverlayProperties } from "../../../components/properties/nodes/abstractMeshProperties";
+import {
+    AbstractMeshAdvancedProperties,
+    AbstractMeshGeneralProperties,
+    AbstractMeshOutlineOverlayProperties,
+    AbstractMeshDebugProperties,
+} from "../../../components/properties/nodes/abstractMeshProperties";
 import { SelectionServiceIdentity } from "../../selectionService";
 import { PropertiesServiceIdentity } from "./propertiesService";
 import { NodeGeneralProperties } from "../../../components/properties/nodes/nodeProperties";
@@ -41,6 +46,10 @@ export const NodePropertiesServiceDefinition: ServiceDefinition<[], [IProperties
                 {
                     section: "Outlines & Overlays",
                     component: ({ context }) => <AbstractMeshOutlineOverlayProperties mesh={context} />,
+                },
+                {
+                    section: "Debug",
+                    component: ({ context }) => <AbstractMeshDebugProperties mesh={context} />,
                 },
             ],
         });

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/dropdownPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/dropdownPropertyLine.tsx
@@ -2,7 +2,7 @@ import { Dropdown } from "../../primitives/dropdown";
 import type { AcceptedDropdownValue, DropdownProps } from "../../primitives/dropdown";
 import { PropertyLine } from "./propertyLine";
 import type { PropertyLineProps } from "./propertyLine";
-import type { FunctionComponent } from "react";
+import { forwardRef, type FunctionComponent } from "react";
 
 // In a follow-up PR i will remove the nullAs concept from dropdown
 type DropdownPropertyLineProps<V extends AcceptedDropdownValue> = Omit<DropdownProps<V>, "includeNullAs"> & PropertyLineProps<AcceptedDropdownValue>;
@@ -12,13 +12,14 @@ type DropdownPropertyLineProps<V extends AcceptedDropdownValue> = Omit<DropdownP
  * @param props - PropertyLineProps and DropdownProps
  * @returns property-line wrapped dropdown
  */
-const DropdownPropertyLine: FunctionComponent<DropdownProps<AcceptedDropdownValue> & PropertyLineProps<AcceptedDropdownValue>> = (props) => {
+
+const DropdownPropertyLine = forwardRef<HTMLDivElement, DropdownProps<AcceptedDropdownValue> & PropertyLineProps<AcceptedDropdownValue>>((props, ref) => {
     return (
-        <PropertyLine {...props}>
+        <PropertyLine {...props} ref={ref}>
             <Dropdown {...props} />
         </PropertyLine>
     );
-};
+});
 
 /**
  * Dropdown component for number values.

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/dropdownPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/dropdownPropertyLine.tsx
@@ -2,7 +2,8 @@ import { Dropdown } from "../../primitives/dropdown";
 import type { AcceptedDropdownValue, DropdownProps } from "../../primitives/dropdown";
 import { PropertyLine } from "./propertyLine";
 import type { PropertyLineProps } from "./propertyLine";
-import { forwardRef, type FunctionComponent } from "react";
+import { forwardRef } from "react";
+import type { FunctionComponent } from "react";
 
 // In a follow-up PR i will remove the nullAs concept from dropdown
 type DropdownPropertyLineProps<V extends AcceptedDropdownValue> = Omit<DropdownProps<V>, "includeNullAs"> & PropertyLineProps<AcceptedDropdownValue>;
@@ -29,3 +30,4 @@ export const NumberDropdownPropertyLine = DropdownPropertyLine as FunctionCompon
  * Dropdown component for string values
  */
 export const StringDropdownPropertyLine = DropdownPropertyLine as FunctionComponent<DropdownPropertyLineProps<string>>;
+

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/dropdownPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/dropdownPropertyLine.tsx
@@ -30,4 +30,3 @@ export const NumberDropdownPropertyLine = DropdownPropertyLine as FunctionCompon
  * Dropdown component for string values
  */
 export const StringDropdownPropertyLine = DropdownPropertyLine as FunctionComponent<DropdownPropertyLineProps<string>>;
-


### PR DESCRIPTION
These ports the V1 debug properties for Mesh to Inspector V2. In Inspector V1 the properties with "display" in their name can only be enabled individually, so there is state management that handles enabling and disabling them as they get selected.

<img width="1484" height="606" alt="image" src="https://github.com/user-attachments/assets/c0c47af7-b33c-4c37-9d07-41e0e7f50f3a" />
