### PR TITLE
Revert "Fix shader material clone missing the alphaMode"

### DIFF
--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -579,7 +579,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     /**
      * Stores the value of the alpha mode
      */
-    @serialize()
     protected _alphaMode: number[] = [Constants.ALPHA_COMBINE];
 
     /**


### PR DESCRIPTION
Reverts BabylonJS/Babylon.js#16970
<img width="431" height="177" alt="image" src="https://github.com/user-attachments/assets/11cd8102-b545-497d-8ed7-ff9850471283" />
