### PR TITLE
GreasedLine far positions precision loss fix

### DIFF
--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts
@@ -56,7 +56,7 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                     float grlWidth = grlBaseWidth * grl_widths;
                     
                     vec3 worldDir = normalize(grlNext - grlPrevious);
-                    vec3 nearPosition = positionUpdated + (worldDir * 0.001);
+                    vec3 nearPosition = positionUpdated + (worldDir * 0.01);
                     mat4 grlMatrix = viewProjection * finalWorld;
                     vec4 grlFinalPosition = grlMatrix * vec4(positionUpdated , 1.0);
                     vec4 screenNearPos = grlMatrix * vec4(nearPosition, 1.0);

--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersWGSL.ts
@@ -67,7 +67,7 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                     let grlWidth: f32 = grlBaseWidth * input.grl_widths;
 
                     let worldDir: vec3f = normalize(grlNext - grlPrevious);
-                    let nearPosition: vec3f = positionUpdated + (worldDir * 0.001);
+                    let nearPosition: vec3f = positionUpdated + (worldDir * 0.01);
                     let grlMatrix: mat4x4f = uniforms.viewProjection * finalWorld;
                     let grlFinalPosition: vec4f = grlMatrix * vec4f(positionUpdated, 1.0); 
                     let screenNearPos: vec4f = grlMatrix * vec4(nearPosition, 1.0);

--- a/packages/dev/core/src/Shaders/greasedLine.vertex.fx
+++ b/packages/dev/core/src/Shaders/greasedLine.vertex.fx
@@ -46,7 +46,7 @@ void main() {
 
         vec3 positionUpdated = position + grl_offsets;
         vec3 worldDir = normalize(grlNext - grlPrevious);
-        vec3 nearPosition = positionUpdated + (worldDir * 0.001);
+        vec3 nearPosition = positionUpdated + (worldDir * 0.01);
         vec4 grlFinalPosition = grlMatrix * vec4( positionUpdated , 1.0);
         vec4 screenNearPos = grlMatrix * vec4(nearPosition, 1.0);
         vec2 grlLinePosition = grlFix(grlFinalPosition, grlAspect);


### PR DESCRIPTION
Fixes this issue:
https://forum.babylonjs.com/t/greased-line-visual-glitch-at-large-scale/59320 

It might need a more elaborate solution in the future, but since this fixes the only reported issue so far, I wouldn't add more calculations to the shader. (calculate the direction in world space and convert the resulting offset to clip space).
