### PR TITLE
ESLint: Relax naming conventions for destructured vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -261,6 +261,12 @@ const rules = {
                         selector: "import",
                         format: ["strictCamelCase", "StrictPascalCase"],
                     },
+                    // Allow any casing for destructured variables, particularly for dynamic imports.
+                    {
+                        selector: "variable",
+                        format: null,
+                        modifiers: ["destructured"],
+                    },
                     {
                         selector: "variable",
                         format: ["StrictPascalCase", "UPPER_CASE"],

--- a/packages/dev/core/src/Engines/Extensions/engine.prefilteredCubeTexture.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.prefilteredCubeTexture.ts
@@ -81,7 +81,6 @@ ThinEngine.prototype.createPrefilteredCubeTexture = function (
             return;
         }
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { DDSTools } = await import("core/Misc/dds");
 
         const textures: BaseTexture[] = [];

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -2775,7 +2775,6 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
             return this;
         }
 
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { OptimizeIndices } = await import("./mesh.vertexData.functions");
 
         OptimizeIndices(indices);

--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -290,7 +290,7 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
             setDisplayNormals(false);
         } else {
             try {
-                const { NormalMaterial: normalMaterialClass } = await import("materials/normal/normalMaterial");
+                const { NormalMaterial } = await import("materials/normal/normalMaterial");
 
                 if (!mesh.reservedDataStore) {
                     mesh.reservedDataStore = {};
@@ -300,7 +300,7 @@ export const AbstractMeshDebugProperties: FunctionComponent<{ mesh: AbstractMesh
                     mesh.reservedDataStore.originalMaterial = mesh.material;
                 }
 
-                const normalMaterial = new normalMaterialClass("normalMaterial", scene);
+                const normalMaterial = new NormalMaterial("normalMaterial", scene);
                 normalMaterial.disableLighting = true;
                 if (mesh.material) {
                     normalMaterial.sideOrientation = mesh.material.sideOrientation;

--- a/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
@@ -15,7 +15,6 @@ import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propert
 export const AdvancedDynamicTextureGeneralProperties = MakeLazyComponent(
     async () => {
         // Defer importing anything from the gui package until this component is actually mounted.
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         const { AdvancedDynamicTextureInstrumentation } = await import("gui/2D/adtInstrumentation");
 
         return (props: { texture: AdvancedDynamicTexture }) => {

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -183,11 +183,9 @@ async function createCubeTexture(url: string, scene: Scene, extension?: string) 
     extension = extension ?? GetExtensionFromUrl(url);
     const instantiateTexture = await (async () => {
         if (extension === ".hdr") {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             const { HDRCubeTexture } = await import("core/Materials/Textures/hdrCubeTexture");
             return () => new HDRCubeTexture(url, scene, 256, false, true, false, true, undefined, undefined, undefined, true, true);
         } else {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             const { CubeTexture } = await import("core/Materials/Textures/cubeTexture");
             return () => new CubeTexture(url, scene, null, false, null, null, null, undefined, true, extension, true);
         }

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -100,13 +100,11 @@ export async function CreateViewerForCanvas(
     let engine: AbstractEngine;
     switch (options.engine ?? GetDefaultEngine()) {
         case "WebGL": {
-            // eslint-disable-next-line @typescript-eslint/naming-convention, no-case-declarations
             const { Engine } = await import("core/Engines/engine");
             engine = new Engine(canvas, undefined, options);
             break;
         }
         case "WebGPU": {
-            // eslint-disable-next-line @typescript-eslint/naming-convention, no-case-declarations
             const { WebGPUEngine } = await import("core/Engines/webgpuEngine");
             const webGPUEngine = new WebGPUEngine(canvas, options);
             await webGPUEngine.initAsync();


### PR DESCRIPTION
This change makes it so that if you do something like:

`const { NormalMaterial } = await import("materials/normal/normalMaterial");`

This is on longer considered a naming convention violation. This applies to all destructured variables, not just dynamic imports, but since it is destructuring properties of an object, those properties should already have been checked for naming conventions (e.g. camelCase).