### PR TITLE
Allow node to display visual clue when a port is not active due to th…

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterialBlockConnectionPoint.ts
@@ -72,6 +72,16 @@ export class NodeMaterialConnectionPoint {
     }
 
     /** @internal */
+    public _isInactive: boolean = false;
+
+    /**
+     * Boolean used to provide visual clue to users when some ports are not active in the current block configuration
+     */
+    public get isInactive(): boolean {
+        return this._isInactive;
+    }
+
+    /** @internal */
     public _preventBubbleUp = false;
 
     /** @internal */

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/automaticProperties.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/automaticProperties.ts
@@ -13,6 +13,14 @@ export function ForceRebuild(source: any, stateManager: StateManager, propertyNa
         return;
     }
 
+    if (stateManager.getScene) {
+        const rebuild = notifiers?.callback?.(stateManager.getScene(), source) ?? false;
+
+        if (rebuild) {
+            stateManager.onRebuildRequiredObservable.notifyObservers();
+        }
+    }
+
     if (!notifiers || notifiers.update) {
         stateManager.onUpdateRequiredObservable.notifyObservers(source);
     }
@@ -23,13 +31,5 @@ export function ForceRebuild(source: any, stateManager: StateManager, propertyNa
 
     if (notifiers?.activatePreviewCommand) {
         stateManager.onPreviewCommandActivated.notifyObservers(true);
-    }
-
-    if (stateManager.getScene) {
-        const rebuild = notifiers?.callback?.(stateManager.getScene(), source) ?? false;
-
-        if (rebuild) {
-            stateManager.onRebuildRequiredObservable.notifyObservers();
-        }
     }
 }

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/interfaces/portData.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/interfaces/portData.ts
@@ -46,6 +46,7 @@ export interface IPortData {
     isExposedOnFrame: boolean;
     exposedPortPosition: number;
     isConnected: boolean;
+    isInactive: boolean;
     direction: PortDataDirection;
     ownerData: any;
     connectedPort: Nullable<IPortData>;

--- a/packages/tools/nodeEditor/src/graphSystem/connectionPointPortData.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/connectionPointPortData.ts
@@ -53,6 +53,10 @@ export class ConnectionPointPortData implements IPortData {
         return this.data.isConnected;
     }
 
+    public get isInactive() {
+        return this.data.isInactive;
+    }
+
     public get connectedPort() {
         if (!this.isConnected) {
             return null;

--- a/packages/tools/nodeEditor/src/graphSystem/registerNodePortDesign.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/registerNodePortDesign.ts
@@ -50,7 +50,7 @@ export const RegisterNodePortDesign = (stateManager: StateManager) => {
                 break;
         }
 
-        const isOptional = point.isOptional && !point.isConnected;
+        const isOptional = point.isInactive || (point.isOptional && !point.isConnected);
 
         if (isOptional) {
             const decoded = atob(svg);

--- a/packages/tools/nodeGeometryEditor/src/graphSystem/connectionPointPortData.ts
+++ b/packages/tools/nodeGeometryEditor/src/graphSystem/connectionPointPortData.ts
@@ -55,6 +55,10 @@ export class ConnectionPointPortData implements IPortData {
         return this.data.isConnected;
     }
 
+    public get isInactive() {
+        return false;
+    }
+
     public get connectedPort() {
         if (!this.isConnected) {
             return null;

--- a/packages/tools/nodeParticleEditor/src/graphSystem/connectionPointPortData.ts
+++ b/packages/tools/nodeParticleEditor/src/graphSystem/connectionPointPortData.ts
@@ -55,6 +55,10 @@ export class ConnectionPointPortData implements IPortData {
         return this.data.isConnected;
     }
 
+    public get isInactive() {
+        return false;
+    }
+
     public get connectedPort() {
         if (!this.isConnected) {
             return null;

--- a/packages/tools/nodeRenderGraphEditor/src/graphSystem/connectionPointPortData.ts
+++ b/packages/tools/nodeRenderGraphEditor/src/graphSystem/connectionPointPortData.ts
@@ -55,6 +55,10 @@ export class ConnectionPointPortData implements IPortData {
         return this.data.isConnected;
     }
 
+    public get isInactive() {
+        return false;
+    }
+
     public get connectedPort() {
         if (!this.isConnected) {
             return null;

--- a/packages/tools/smartFiltersEditorControl/src/graphSystem/connectionPointPortData.ts
+++ b/packages/tools/smartFiltersEditorControl/src/graphSystem/connectionPointPortData.ts
@@ -50,6 +50,10 @@ export class ConnectionPointPortData implements IPortData {
         return this.data.connectedTo !== null || this.hasEndpoints;
     }
 
+    public get isInactive() {
+        return false;
+    }
+
     public get connectedPort() {
         if (!this.isConnected) {
             return null;


### PR DESCRIPTION
…e node configuration

example here with perturbnormal:

<img width="246" height="512" alt="image" src="https://github.com/user-attachments/assets/b47f879b-ca05-40ce-9e5e-ea057f7631ae" />
<img width="288" height="542" alt="image" src="https://github.com/user-attachments/assets/884cd5a8-3e17-470d-afa9-a923a93382fe" />

The use parallax occlusion check will flag the parallaxScale and parallaxHeight as inactive