### PR TITLE
Inspector v2: Add activate and gizmo commands for cameras

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -9,7 +9,7 @@ import { VirtualizerScrollView } from "@fluentui/react-components/unstable";
 import { FilterRegular, MoviesAndTvRegular } from "@fluentui/react-icons";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useObservableState } from "../../hooks/observableHooks";
+import { useObservableRenderer, useObservableState } from "../../hooks/observableHooks";
 import { useResource } from "../../hooks/resourceHooks";
 import { TraverseGraph } from "../../misc/graphUtils";
 
@@ -101,7 +101,7 @@ type Command<T extends EntityBase> = Partial<IDisposable> &
         /**
          * An icon component to render for the command.
          */
-        icon: ComponentType<{ entity: T }>;
+        icon: ComponentType;
 
         /**
          * An observable that notifies when the command state changes.
@@ -113,9 +113,9 @@ type ActionCommand<T extends EntityBase> = Command<T> & {
     readonly type: "action";
 
     /**
-     * The function that executes the command on the given entity.
+     * The function that executes the command.
      */
-    execute(entity: T): void;
+    execute(): void;
 };
 
 type ToggleCommand<T extends EntityBase> = Command<T> & {
@@ -190,29 +190,25 @@ const useStyles = makeStyles({
 });
 
 const ActionCommand: FunctionComponent<{ command: ActionCommand<EntityBase>; entity: EntityBase }> = (props) => {
-    const { command, entity } = props;
+    const { command } = props;
+
+    useObservableRenderer(command.onChange);
 
     return (
         <Tooltip key={command.displayName} content={command.displayName} relationship="label">
-            <Button icon={<command.icon entity={entity} />} appearance="subtle" onClick={() => command.execute(entity)} />
+            <Button icon={<command.icon />} appearance="subtle" onClick={() => command.execute()} />
         </Tooltip>
     );
 };
 
 const ToggleCommand: FunctionComponent<{ command: ToggleCommand<EntityBase>; entity: EntityBase }> = (props) => {
-    const { command, entity } = props;
-    const [checked, setChecked] = useState(command.isEnabled);
-    const toggle = useCallback(() => {
-        setChecked((prev) => {
-            const enabled = !prev;
-            command.isEnabled = enabled;
-            return enabled;
-        });
-    }, [setChecked]);
+    const { command } = props;
+
+    useObservableRenderer(command.onChange);
 
     return (
         <Tooltip content={command.displayName} relationship="label">
-            <ToggleButton icon={<command.icon entity={entity} />} appearance="transparent" checked={checked} onClick={toggle} />
+            <ToggleButton icon={<command.icon />} appearance="transparent" checked={command.isEnabled} onClick={() => (command.isEnabled = !command.isEnabled)} />
         </Tooltip>
     );
 };

--- a/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
@@ -28,7 +28,7 @@ const ImportToolsExtensionMetadata = {
     keywords: ["import", "tools"],
 } as const;
 
-const Extensions: readonly ExtensionMetadata[] = [CreationToolsExtensionMetadata, ExportToolsExtensionMetadata, CaptureToolsExtensionMetadata, ImportToolsExtensionMetadata];
+const Extensions: readonly ExtensionMetadata[] = [/*CreationToolsExtensionMetadata, */ ExportToolsExtensionMetadata, CaptureToolsExtensionMetadata, ImportToolsExtensionMetadata];
 
 /**
  * @internal

--- a/packages/dev/inspector-v2/src/hooks/observableHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/observableHooks.ts
@@ -4,6 +4,8 @@ import type { ObservableCollection } from "../misc/observableCollection";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { UniqueIdGenerator } from "core/Misc/uniqueIdGenerator";
+
 /**
  * Returns the current value of the accessor and updates it when the specified event is fired on the specified element.
  * @param accessor A function that returns the current value.
@@ -72,6 +74,17 @@ export function useObservableState<T>(accessor: () => T, ...observables: Array<I
     }, [accessor, ...observables]);
 
     return current;
+}
+
+/**
+ * Triggers a re-render when any of the observables fire.
+ * @param observables The observables to listen for changes on.
+ */
+export function useObservableRenderer(...observables: Array<IReadonlyObservable | null | undefined>) {
+    useObservableState(
+        useCallback(() => UniqueIdGenerator.UniqueId, []),
+        ...observables
+    );
 }
 
 /**

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -1,15 +1,30 @@
+import type { Gizmo, Nullable } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
-import { BoxRegular, BranchRegular, CameraRegular, EyeOffRegular, EyeRegular, LightbulbRegular } from "@fluentui/react-icons";
+import {
+    BoxRegular,
+    BranchRegular,
+    CameraRegular,
+    Cone16Filled,
+    Cone16Regular,
+    EyeOffRegular,
+    EyeRegular,
+    LightbulbRegular,
+    VideoFilled,
+    VideoRegular,
+} from "@fluentui/react-icons";
 
 import { Camera } from "core/Cameras/camera";
+import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
+import { CameraGizmo } from "core/Gizmos/cameraGizmo";
 import { Light } from "core/Lights/light";
 import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { TransformNode } from "core/Meshes/transformNode";
 import { Observable } from "core/Misc";
 import { Node } from "core/node";
+import { UtilityLayerRenderer } from "core/Rendering";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
@@ -85,8 +100,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             getEntityMovedObservables: () => [nodeMovedObservable],
         });
 
-        const visibilityCommandRegistration = sceneExplorerService.addCommand({
-            order: 0,
+        const abstractMeshVisibilityCommandRegistration = sceneExplorerService.addCommand({
             predicate: (entity: unknown): entity is AbstractMesh => entity instanceof AbstractMesh && entity.getTotalVertices() > 0,
             getCommand: (mesh) => {
                 const onChangeObservable = new Observable<void>();
@@ -115,10 +129,117 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             },
         });
 
+        const activeCameraCommandRegistration = sceneExplorerService.addCommand({
+            predicate: (entity: unknown) => entity instanceof Camera,
+            getCommand: (camera) => {
+                const scene = camera.getScene();
+                const onChangeObservable = new Observable<void>();
+                const activeCameraChangedObserver = scene.onActiveCameraChanged.add(() => {
+                    onChangeObservable.notifyObservers();
+                });
+
+                return {
+                    type: "toggle",
+                    displayName: "Activate and Attach Controls",
+                    icon: () => (scene.activeCamera === camera ? <VideoFilled /> : <VideoRegular />),
+                    get isEnabled() {
+                        return scene.activeCamera === camera;
+                    },
+                    set isEnabled(enabled: boolean) {
+                        if (enabled && scene.activeCamera !== camera) {
+                            scene.activeCamera?.detachControl();
+                            scene.activeCamera = camera;
+                            camera.attachControl(true);
+                        }
+                    },
+                    onChange: onChangeObservable,
+                    dispose: () => {
+                        activeCameraChangedObserver.remove();
+                        onChangeObservable.clear();
+                    },
+                };
+            },
+        });
+
+        const gizmos = new Set<Gizmo>();
+        let utilityLayer: Nullable<UtilityLayerRenderer> = null;
+        const getOrCreateUtilityLayer = () => {
+            if (!utilityLayer) {
+                utilityLayer = scene.frameGraph ? FrameGraphUtils.CreateUtilityLayerRenderer(scene.frameGraph) : new UtilityLayerRenderer(scene);
+            }
+            return utilityLayer;
+        };
+
+        const cameraGizmoCommandRegistration = sceneExplorerService.addCommand({
+            predicate: (entity: unknown) => entity instanceof Camera,
+            getCommand: (camera) => {
+                const onChangeObservable = new Observable<void>();
+
+                const getGizmo = () => {
+                    return camera.reservedDataStore?.cameraGizmo as Nullable<CameraGizmo>;
+                };
+
+                const createGizmo = () => {
+                    const gizmo = new CameraGizmo(getOrCreateUtilityLayer());
+                    gizmo.camera = camera;
+                    gizmo.material.reservedDataStore = { hidden: true };
+
+                    gizmos.add(gizmo);
+                    if (!camera.reservedDataStore) {
+                        camera.reservedDataStore = {};
+                    }
+                    camera.reservedDataStore.cameraGizmo = gizmo;
+
+                    onChangeObservable.notifyObservers();
+
+                    return gizmo;
+                };
+
+                const disposeGizmo = () => {
+                    const gizmo = getGizmo();
+                    if (gizmo) {
+                        gizmos.delete(gizmo);
+                        delete camera.reservedDataStore.cameraGizmo;
+                        gizmo.dispose();
+                    }
+
+                    onChangeObservable.notifyObservers();
+                };
+
+                return {
+                    type: "toggle",
+                    get displayName() {
+                        return `Turn ${getGizmo() ? "Off" : "On"} Gizmo`;
+                    },
+                    icon: () => (getGizmo() ? <Cone16Filled /> : <Cone16Regular />),
+                    get isEnabled() {
+                        return !!getGizmo();
+                    },
+                    set isEnabled(enabled: boolean) {
+                        if (enabled) {
+                            if (!getGizmo()) {
+                                createGizmo();
+                            }
+                        } else {
+                            disposeGizmo();
+                        }
+                    },
+                    onChange: onChangeObservable,
+                    dispose: () => {
+                        onChangeObservable.clear();
+                    },
+                };
+            },
+        });
+
         return {
             dispose: () => {
-                visibilityCommandRegistration.dispose();
                 sectionRegistration.dispose();
+                gizmos.forEach((gizmo) => gizmo.dispose());
+                utilityLayer?.dispose();
+                abstractMeshVisibilityCommandRegistration.dispose();
+                activeCameraCommandRegistration.dispose();
+                cameraGizmoCommandRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/test/app/index.ts
+++ b/packages/dev/inspector-v2/test/app/index.ts
@@ -45,6 +45,12 @@ function createCamera() {
     camera = scene.activeCamera as ArcRotateCamera;
     camera.alpha = 1.8;
     camera.beta = 1.3;
+
+    const camera2 = camera.clone("camera2") as ArcRotateCamera;
+    camera2.alpha += Math.PI;
+
+    const camera3 = camera.clone("camera3") as ArcRotateCamera;
+    camera3.alpha += Math.PI * 0.5;
 }
 
 function createPostProcess() {


### PR DESCRIPTION
This change adds the "Activate and Attach Controls" and "Enable/Disable Gizmo" commands to Camera nodes in scene explorer.

<img width="1054" height="737" alt="image" src="https://github.com/user-attachments/assets/3e719425-2005-49cd-b713-a445fd18a800" />

This includes a change that adds a `useObservableRenderer` hook, which builds on `useObservableState` and simply sets a number state to trigger a re-render. Arguably this is a React anti-pattern, but the alternative is to have a much more verbose useObservableState that replicates each property I care about on the command. I'm a bit torn on this and open to feedback.