### PR TITLE
Remove unnecessary BBox computation

### DIFF
--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -578,9 +578,6 @@ export class InstancedMesh extends AbstractMesh {
             []
         );
 
-        // Bounding info
-        this.refreshBoundingInfo();
-
         // Parent
         if (newParent) {
             result.parent = newParent;


### PR DESCRIPTION
Discussion:
https://forum.babylonjs.com/t/instancedmesh-duplicated-call-to-refreshboundinginfo-in-clone/59939

My analysis:
- The createInstance already calls the bbox computation
- The DeepClone does not affect properties related to BBox
