### PR TITLE
Update GUI control to be forgiving of text resizeToFit layout calculations

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -2893,4 +2893,3 @@ export class Control implements IAnimatable, IFocusableControl {
     }
 }
 RegisterClass("BABYLON.GUI.Control", Control);
-


### PR DESCRIPTION
Control.ts expects less than 3 layouts to occur but textBlock.ts will layout 3 times when resizeToFit is true -- this is because isDirty is set to true causing a recreation of fontOffset (even if font offset has the proper height) and thus fontOffset.height is getting recalculated to the old value We should fix the logic so that fontOffset retains the updated height value. Until then, upping the layout cycle detection error threshold

Relayout 1: NewHeight 106, InternalHeight 187 --> updates internal height to be new height unnecessarily since the internalheight is valid 
Relayout 2: NewHeight 187, InternalHeight 106 
Relayout 3: Both 187 --> exit loop (but at this point we're already at 3) 
<img width="236" height="39" alt="image" src="https://github.com/user-attachments/assets/2e2508c5-377e-42d1-be79-0a3d15d50529" />

See https://forum.babylonjs.com/t/jumping-text-with-resizetofit-false/59949 for more details
