### PR TITLE
Inspector v2: Scene explorer light commands

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -9,7 +9,7 @@ import { VirtualizerScrollView } from "@fluentui/react-components/unstable";
 import { FilterRegular, MoviesAndTvRegular } from "@fluentui/react-icons";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useObservableRenderer, useObservableState } from "../../hooks/observableHooks";
+import { useObservableState } from "../../hooks/observableHooks";
 import { useResource } from "../../hooks/resourceHooks";
 import { TraverseGraph } from "../../misc/graphUtils";
 
@@ -106,7 +106,7 @@ type Command<T extends EntityBase> = Partial<IDisposable> &
         /**
          * An observable that notifies when the command state changes.
          */
-        onChange?: IReadonlyObservable<void>;
+        onChange?: IReadonlyObservable<unknown>;
     }>;
 
 type ActionCommand<T extends EntityBase> = Command<T> & {
@@ -192,11 +192,15 @@ const useStyles = makeStyles({
 const ActionCommand: FunctionComponent<{ command: ActionCommand<EntityBase>; entity: EntityBase }> = (props) => {
     const { command } = props;
 
-    useObservableRenderer(command.onChange);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const [displayName, Icon, execute] = useObservableState(
+        useCallback(() => [command.displayName, command.icon, command.execute] as const, [command]),
+        command.onChange
+    );
 
     return (
-        <Tooltip key={command.displayName} content={command.displayName} relationship="label">
-            <Button icon={<command.icon />} appearance="subtle" onClick={() => command.execute()} />
+        <Tooltip content={displayName} relationship="label" positioning={"after"}>
+            <Button icon={<Icon />} appearance="subtle" onClick={() => execute()} />
         </Tooltip>
     );
 };
@@ -204,11 +208,15 @@ const ActionCommand: FunctionComponent<{ command: ActionCommand<EntityBase>; ent
 const ToggleCommand: FunctionComponent<{ command: ToggleCommand<EntityBase>; entity: EntityBase }> = (props) => {
     const { command } = props;
 
-    useObservableRenderer(command.onChange);
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const [displayName, Icon, isEnabled] = useObservableState(
+        useCallback(() => [command.displayName, command.icon, command.isEnabled] as const, [command]),
+        command.onChange
+    );
 
     return (
-        <Tooltip content={command.displayName} relationship="label">
-            <ToggleButton icon={<command.icon />} appearance="transparent" checked={command.isEnabled} onClick={() => (command.isEnabled = !command.isEnabled)} />
+        <Tooltip content={displayName} relationship="label" positioning={"after"}>
+            <ToggleButton icon={<Icon />} appearance="transparent" checked={isEnabled} onClick={() => (command.isEnabled = !command.isEnabled)} />
         </Tooltip>
     );
 };

--- a/packages/dev/inspector-v2/src/hooks/observableHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/observableHooks.ts
@@ -4,8 +4,6 @@ import type { ObservableCollection } from "../misc/observableCollection";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { UniqueIdGenerator } from "core/Misc/uniqueIdGenerator";
-
 /**
  * Returns the current value of the accessor and updates it when the specified event is fired on the specified element.
  * @param accessor A function that returns the current value.
@@ -74,17 +72,6 @@ export function useObservableState<T>(accessor: () => T, ...observables: Array<I
     }, [accessor, ...observables]);
 
     return current;
-}
-
-/**
- * Triggers a re-render when any of the observables fire.
- * @param observables The observables to listen for changes on.
- */
-export function useObservableRenderer(...observables: Array<IReadonlyObservable | null | undefined>) {
-    useObservableState(
-        useCallback(() => UniqueIdGenerator.UniqueId, []),
-        ...observables
-    );
 }
 
 /**


### PR DESCRIPTION
This change adds the enable/disable command and the gizmo command to lights in scene explorer.

<img width="660" height="377" alt="image" src="https://github.com/user-attachments/assets/a62e10a8-07ed-41dd-80f8-b00f1f9a87c1" />

- Remove the previously added `useObservableRenderer`. Using `useObservableState` avoids the anti-pattern and with returning a tuple, it's still compact and one less concept to understand.
- Fixed an issue where action commands were not updating, though I ended up not using action commands in this PR.
- Factored out a helper function to create gizmo commands.
- Added a command for toggling light gizmos.
- Added a command to toggle the enabled state of lights (e.g. turn light on/off).