### PR TITLE
Inspector v2: Pass on title case labels for properties

### DIFF
--- a/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
+++ b/packages/dev/inspector-v2/src/components/debug/debugPane.tsx
@@ -199,14 +199,14 @@ export const DebugPane: typeof ExtensibleAccordion<Scene> = (props) => {
                 <BoundProperty component={SwitchPropertyLine} key="Physics" label="Physics" target={scene} propertyKey="physicsEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Collisions" label="Collisions" target={scene} propertyKey="collisionsEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Fog" label="Fog" target={scene} propertyKey="fogEnabled" />
-                <BoundProperty component={SwitchPropertyLine} key="Lens flares" label="Lens flares" target={scene} propertyKey="lensFlaresEnabled" />
+                <BoundProperty component={SwitchPropertyLine} key="Lens flares" label="Lens Flares" target={scene} propertyKey="lensFlaresEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Lights" label="Lights" target={scene} propertyKey="lightsEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Particles" label="Particles" target={scene} propertyKey="particlesEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Post-processes" label="Post-processes" target={scene} propertyKey="postProcessesEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Probes" label="Probes" target={scene} propertyKey="probesEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Textures" label="Textures" target={scene} propertyKey="texturesEnabled" />
-                <BoundProperty component={SwitchPropertyLine} key="Procedural textures" label="Procedural textures" target={scene} propertyKey="proceduralTexturesEnabled" />
-                <BoundProperty component={SwitchPropertyLine} key="Render targets" label="Render targets" target={scene} propertyKey="renderTargetsEnabled" />
+                <BoundProperty component={SwitchPropertyLine} key="Procedural textures" label="Procedural Textures" target={scene} propertyKey="proceduralTexturesEnabled" />
+                <BoundProperty component={SwitchPropertyLine} key="Render targets" label="Render Targets" target={scene} propertyKey="renderTargetsEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Shadows" label="Shadows" target={scene} propertyKey="shadowsEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Skeletons" label="Skeletons" target={scene} propertyKey="skeletonsEnabled" />
                 <BoundProperty component={SwitchPropertyLine} key="Sprites" label="Sprites" target={scene} propertyKey="spritesEnabled" />

--- a/packages/dev/inspector-v2/src/components/properties/animation/animationGroupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/animation/animationGroupProperties.tsx
@@ -43,10 +43,10 @@ export const AnimationGroupControlProperties: FunctionComponent<{ animationGroup
         <>
             <ButtonLine label={isPlaying ? "Pause" : "Play"} onClick={() => (isPlaying ? animationGroup.pause() : animationGroup.play(true))} />
             <ButtonLine label="Stop" onClick={() => animationGroup.stop()} />
-            <BoundProperty component={SyncedSliderPropertyLine} label="Speed ratio" min={0} max={10} step={0.1} target={animationGroup} propertyKey="speedRatio" />
+            <BoundProperty component={SyncedSliderPropertyLine} label="Speed Ratio" min={0} max={10} step={0.1} target={animationGroup} propertyKey="speedRatio" />
             {currentFrameHolder ? (
                 <SyncedSliderPropertyLine
-                    label="Current frame"
+                    label="Current Frame"
                     min={animationGroup.from}
                     max={animationGroup.to}
                     step={(animationGroup.to - animationGroup.from) / 1000.0}
@@ -67,7 +67,7 @@ export const AnimationGroupControlProperties: FunctionComponent<{ animationGroup
                 <>
                     <BoundProperty
                         component={SyncedSliderPropertyLine}
-                        label="Blending speed"
+                        label="Blending Speed"
                         min={0}
                         max={1}
                         step={0.01}
@@ -76,9 +76,9 @@ export const AnimationGroupControlProperties: FunctionComponent<{ animationGroup
                         ignoreNullable
                         defaultValue={0}
                     />
-                    <BoundProperty component={SwitchPropertyLine} label="Is additive" target={animationGroup} propertyKey="isAdditive" />
+                    <BoundProperty component={SwitchPropertyLine} label="Is Additive" target={animationGroup} propertyKey="isAdditive" />
                     <BoundProperty component={NumberInputPropertyLine} label="Weight" target={animationGroup} propertyKey="weight" step={0.1} />
-                    <BoundProperty component={NumberInputPropertyLine} label="Play order" target={animationGroup} propertyKey="playOrder" step={0} />
+                    <BoundProperty component={NumberInputPropertyLine} label="Play Order" target={animationGroup} propertyKey="playOrder" step={0} />
                     {/* TODO: Hey georgie :<Play order> should be integer (even when typing)*/}
                 </>
             </Collapse>

--- a/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
@@ -175,7 +175,7 @@ export const AnimationsProperties: FunctionComponent<{ scene: Scene; entity: Par
                             {mainAnimatable && (ranges.length > 0 || animations.length > 0) ? (
                                 <>
                                     <SwitchPropertyLine
-                                        label="Enable override"
+                                        label="Enable Override"
                                         value={animationPropertiesOverride != null}
                                         onChange={(value) => {
                                             if (value) {
@@ -196,7 +196,7 @@ export const AnimationsProperties: FunctionComponent<{ scene: Scene; entity: Par
                                             />
                                             <BoundProperty
                                                 component={SyncedSliderPropertyLine}
-                                                label="Blending speed"
+                                                label="Blending Speed"
                                                 target={animationPropertiesOverride!}
                                                 propertyKey="blendingSpeed"
                                                 min={0}

--- a/packages/dev/inspector-v2/src/components/properties/frameGraph/frameGraphProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/frameGraph/frameGraphProperties.tsx
@@ -30,14 +30,14 @@ export const FrameGraphGeneralProperties: FunctionComponent<{ frameGraph: FrameG
         <>
             <BoundProperty
                 component={CheckboxPropertyLine}
-                label="Optimize texture allocation"
+                label="Optimize Texture Allocation"
                 description="Whether to optimize texture allocation."
                 target={frameGraph}
                 propertyKey="optimizeTextureAllocation"
             ></BoundProperty>
             {isSceneFrameGraph !== frameGraph && <ButtonLine onClick={() => (frameGraph.scene.frameGraph = frameGraph)} label="Set as scene's frame graph" />}
             <ButtonLine
-                label="Edit graph"
+                label="Edit Graph"
                 onClick={() => {
                     void frameGraph.getLinkedNodeRenderGraph()!.edit({ nodeRenderGraphEditorConfig: { hostScene: frameGraph.scene } });
                 }}

--- a/packages/dev/inspector-v2/src/components/properties/materials/materialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/materialProperties.tsx
@@ -85,7 +85,7 @@ export const MaterialGeneralProperties: FunctionComponent<{ material: Material }
                 defaultValue={material.getScene().useRightHandedSystem ? Material.CounterClockWiseSideOrientation : Material.ClockWiseSideOrientation}
             />
             {/* TODO: Property name is different per material type
-            <BoundProperty component={SwitchPropertyLine} label="Disable lighting" target={material} propertyKey="disableLighting" /> */}
+            <BoundProperty component={SwitchPropertyLine} label="Disable Lighting" target={material} propertyKey="disableLighting" /> */}
             <BoundProperty component={SwitchPropertyLine} label="Disable Color Write" target={material} propertyKey="disableColorWrite" />
             <BoundProperty component={SwitchPropertyLine} label="Disable Depth Write" target={material} propertyKey="disableDepthWrite" />
             <BoundProperty component={NumberDropdownPropertyLine} label="Depth Function" options={DepthFunctionOptions} target={material} propertyKey="depthFunction" />
@@ -147,8 +147,8 @@ export const MaterialStencilProperties: FunctionComponent<{ material: Material }
             <Collapse visible={stencilEnabled}>
                 <>
                     {/* TODO: Make HexPropertyLine work in the case of simply editing a hex value */}
-                    {/* <BoundProperty component={HexPropertyLine} label="Write mask" target={material.stencil} propertyKey="mask" /> */}
-                    {/* <BoundProperty component={HexPropertyLine} label="Read mask" target={material.stencil} propertyKey="funcMask" /> */}
+                    {/* <BoundProperty component={HexPropertyLine} label="Write Mask" target={material.stencil} propertyKey="mask" /> */}
+                    {/* <BoundProperty component={HexPropertyLine} label="Read Mask" target={material.stencil} propertyKey="funcMask" /> */}
                     {/** TODO: Force int integer-only for NumberInputPropertyLine */}
                     <BoundProperty component={NumberInputPropertyLine} label="Reference Value" target={material.stencil} propertyKey="funcRef" step={0} />
                     <PropertyLine

--- a/packages/dev/inspector-v2/src/components/properties/particles/particleSystemProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/particles/particleSystemProperties.tsx
@@ -27,7 +27,7 @@ export const ParticleSystemEmissionProperties: FunctionComponent<{ particleSyste
             {!system.isNodeGenerated && (
                 <FactorGradientList
                     gradients={emitRateGradients}
-                    label="Emit rate gradient"
+                    label="Emit Rate Gradient"
                     removeGradient={(gradient: IValueGradient) => {
                         system.removeEmitRateGradient(gradient.gradient);
                         system.forceRefreshGradients();
@@ -63,7 +63,7 @@ export const ParticleSystemColorProperties: FunctionComponent<{ particleSystem: 
             {!system.isNodeGenerated && (
                 <Color4GradientList
                     gradients={colorGradients}
-                    label="Color gradient"
+                    label="Color Gradient"
                     removeGradient={(gradient: IValueGradient) => {
                         system.removeEmitRateGradient(gradient.gradient);
                         system.forceRefreshGradients();

--- a/packages/dev/inspector-v2/src/components/properties/skeleton/boneProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/skeleton/boneProperties.tsx
@@ -11,7 +11,7 @@ export const BoneGeneralProperties: FunctionComponent<{ bone: Bone; selectionSer
         <>
             <LinkToEntityPropertyLine
                 key="Linked Transform Node"
-                label="Linked node"
+                label="Linked Node"
                 description="The transform node linked to this bone."
                 entity={bone.getTransformNode()}
                 selectionService={props.selectionService}

--- a/packages/dev/inspector-v2/src/components/properties/skeleton/skeletonProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/skeleton/skeletonProperties.tsx
@@ -19,15 +19,15 @@ export const SkeletonGeneralProperties: FunctionComponent<{ skeleton: Skeleton }
 
     return (
         <>
-            <StringifiedPropertyLine key="SkeletonBoneCount" label="Bone count" description="The number of bones of the skeleton." value={skeleton.bones.length} />
+            <StringifiedPropertyLine key="SkeletonBoneCount" label="Bone Count" description="The number of bones of the skeleton." value={skeleton.bones.length} />
             <BoundProperty
                 key="SkeletonUseTextureToStoreBoneMatrices2"
                 component={SwitchPropertyLine}
-                label="Use texture to store bone matrices"
+                label="Use Texture to Store Bone Matrices"
                 target={skeleton}
                 propertyKey="useTextureToStoreBoneMatrices"
             />
-            <ButtonLine key="SkeletonReturnToRest" label="Return to rest" onClick={() => skeleton.returnToRest()} />
+            <ButtonLine key="SkeletonReturnToRest" label="Return to Rest" onClick={() => skeleton.returnToRest()} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/textures/baseTextureProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/textures/baseTextureProperties.tsx
@@ -177,7 +177,7 @@ export const BaseTextureTransformProperties: FunctionComponent<{ texture: BaseTe
         <>
             {texture.canRescale && (
                 <ButtonLine
-                    label="Scale up"
+                    label="Scale Up"
                     onClick={() => {
                         texture.scale(2);
                     }}
@@ -185,7 +185,7 @@ export const BaseTextureTransformProperties: FunctionComponent<{ texture: BaseTe
             )}
             {texture.canRescale && (
                 <ButtonLine
-                    label="Scale down"
+                    label="Scale Down"
                     onClick={() => {
                         texture.scale(0.5);
                     }}

--- a/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
@@ -31,7 +31,7 @@ export const SceneMaterialImageProcessingProperties: FunctionComponent<{ scene: 
         <>
             <BoundProperty component={SyncedSliderPropertyLine} label="Contrast" min={0} max={4} step={0.1} target={imageProcessing} propertyKey="contrast" />
             <BoundProperty component={SyncedSliderPropertyLine} label="Exposure" min={0} max={4} step={0.1} target={imageProcessing} propertyKey="exposure" />
-            <BoundProperty component={SwitchPropertyLine} label="Tone mapping" target={imageProcessing} propertyKey="toneMappingEnabled" />
+            <BoundProperty component={SwitchPropertyLine} label="Tone Mapping" target={imageProcessing} propertyKey="toneMappingEnabled" />
             <Collapse visible={imageProcessing.toneMappingEnabled}>
                 <BoundProperty
                     component={NumberDropdownPropertyLine}
@@ -42,16 +42,16 @@ export const SceneMaterialImageProcessingProperties: FunctionComponent<{ scene: 
                             { label: "Khronos PBR Neutral", value: ImageProcessingConfiguration.TONEMAPPING_KHR_PBR_NEUTRAL },
                         ] as const
                     }
-                    label="Tone mapping type"
+                    label="Tone Mapping Type"
                     target={imageProcessing}
                     propertyKey="toneMappingType"
                 />
             </Collapse>
             <BoundProperty component={SwitchPropertyLine} label="Vignette" target={imageProcessing} propertyKey="vignetteEnabled" />
             <BoundProperty component={SyncedSliderPropertyLine} label="Vignette FOV" min={0} max={Math.PI} step={0.1} target={imageProcessing} propertyKey="vignetteCameraFov" />
-            <BoundProperty component={SyncedSliderPropertyLine} label="Vignette center X" min={0} max={1} step={0.1} target={imageProcessing} propertyKey="vignetteCenterX" />
-            <BoundProperty component={SyncedSliderPropertyLine} label="Vignette center Y" min={0} max={1} step={0.1} target={imageProcessing} propertyKey="vignetteCenterY" />
-            <BoundProperty component={Color4PropertyLine} label="Vignette color" target={imageProcessing} propertyKey="vignetteColor" />
+            <BoundProperty component={SyncedSliderPropertyLine} label="Vignette Center X" min={0} max={1} step={0.1} target={imageProcessing} propertyKey="vignetteCenterX" />
+            <BoundProperty component={SyncedSliderPropertyLine} label="Vignette Center Y" min={0} max={1} step={0.1} target={imageProcessing} propertyKey="vignetteCenterY" />
+            <BoundProperty component={Color4PropertyLine} label="Vignette Color" target={imageProcessing} propertyKey="vignetteColor" />
             <BoundProperty
                 component={NumberDropdownPropertyLine}
                 options={
@@ -60,14 +60,14 @@ export const SceneMaterialImageProcessingProperties: FunctionComponent<{ scene: 
                         { label: "Opaque", value: ImageProcessingConfiguration.VIGNETTEMODE_OPAQUE },
                     ] as const
                 }
-                label="Vignette blend mode"
+                label="Vignette Blend Mode"
                 target={imageProcessing}
                 propertyKey="vignetteBlendMode"
             />
             <BoundProperty component={SwitchPropertyLine} label="Dithering" target={imageProcessing} propertyKey="ditheringEnabled" />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
-                label="Dithering intensity"
+                label="Dithering Intensity"
                 min={0}
                 max={1}
                 step={0.5 / 255.0}
@@ -88,7 +88,7 @@ export const ScenePhysicsProperties: FunctionComponent<{ scene: Scene }> = (prop
             {physicsEngine !== null ? (
                 <>
                     <NumberInputPropertyLine
-                        label="Time step"
+                        label="Time Step"
                         value={physicsEngine.getTimeStep()}
                         onChange={(value) => {
                             physicsEngine.setTimeStep(value);
@@ -158,7 +158,7 @@ export const SceneRenderingProperties: FunctionComponent<{ scene: Scene; selecti
                         { label: "Solid", value: 2 },
                     ] as const
                 }
-                label="Rendering mode"
+                label="Rendering Mode"
                 value={scene.forcePointsCloud ? 0 : scene.forceWireframe ? 1 : 2}
                 onChange={(value) => {
                     switch (value) {
@@ -178,14 +178,14 @@ export const SceneRenderingProperties: FunctionComponent<{ scene: Scene; selecti
                 }}
             />
 
-            <BoundProperty component={Color4PropertyLine} label="Clear color" target={scene} propertyKey="clearColor" />
+            <BoundProperty component={Color4PropertyLine} label="Clear Color" target={scene} propertyKey="clearColor" />
 
-            <BoundProperty component={SwitchPropertyLine} label="Clear color enabled" target={scene} propertyKey="autoClear" />
+            <BoundProperty component={SwitchPropertyLine} label="Clear Color Enabled" target={scene} propertyKey="autoClear" />
 
-            <BoundProperty component={Color3PropertyLine} label="Ambient color" target={scene} propertyKey="ambientColor" />
+            <BoundProperty component={Color3PropertyLine} label="Ambient Color" target={scene} propertyKey="ambientColor" />
 
             <SwitchPropertyLine
-                label="Environment texture (IBL)"
+                label="Environment Texture (IBL)"
                 value={envTexture ? true : false}
                 onChange={() => {
                     if (envTexture) {
@@ -203,7 +203,7 @@ export const SceneRenderingProperties: FunctionComponent<{ scene: Scene; selecti
             )}
 
             <FileUploadLine
-                label="Update environment texture"
+                label="Update Environment Texture"
                 accept=".dds, .env"
                 onClick={(files) => {
                     if (files.length > 0) {
@@ -260,18 +260,18 @@ export const SceneRenderingProperties: FunctionComponent<{ scene: Scene; selecti
                         { label: "Exp2", value: Scene.FOGMODE_EXP2 },
                     ] as const
                 }
-                label="Fog mode"
+                label="Fog Mode"
                 target={scene}
                 propertyKey="fogMode"
             />
             <Collapse visible={fogMode !== Scene.FOGMODE_NONE}>
                 <>
-                    {fogMode !== Scene.FOGMODE_NONE && <BoundProperty component={Color3PropertyLine} label="Fog color" target={scene} propertyKey="fogColor" />}
+                    {fogMode !== Scene.FOGMODE_NONE && <BoundProperty component={Color3PropertyLine} label="Fog Color" target={scene} propertyKey="fogColor" />}
                     {(fogMode === Scene.FOGMODE_EXP || fogMode === Scene.FOGMODE_EXP2) && (
-                        <BoundProperty component={NumberInputPropertyLine} label="Fog density" target={scene} propertyKey="fogDensity" step={0.1} />
+                        <BoundProperty component={NumberInputPropertyLine} label="Fog Density" target={scene} propertyKey="fogDensity" step={0.1} />
                     )}
-                    {fogMode === Scene.FOGMODE_LINEAR && <BoundProperty component={NumberInputPropertyLine} label="Fog start" target={scene} propertyKey="fogStart" step={0.1} />}
-                    {fogMode === Scene.FOGMODE_LINEAR && <BoundProperty component={NumberInputPropertyLine} label="Fog end" target={scene} propertyKey="fogEnd" step={0.1} />}
+                    {fogMode === Scene.FOGMODE_LINEAR && <BoundProperty component={NumberInputPropertyLine} label="Fog Start" target={scene} propertyKey="fogStart" step={0.1} />}
+                    {fogMode === Scene.FOGMODE_LINEAR && <BoundProperty component={NumberInputPropertyLine} label="Fog End" target={scene} propertyKey="fogEnd" step={0.1} />}
                 </>
             </Collapse>
         </>

--- a/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
@@ -105,7 +105,7 @@ export const SettingsServiceDefinition: ServiceDefinition<[ISettingsContext, ISe
                                         }}
                                     />
                                     <SwitchPropertyLine
-                                        label="Ignore backfaces for picking"
+                                        label="Ignore Backfaces for Picking"
                                         description="Ignore backfaces when picking."
                                         value={settings.ignoreBackfacesForPicking}
                                         onChange={(checked) => {


### PR DESCRIPTION
This change is just a pass on all the labels of properties in the property pane to make them consistently "Title Case".