### PR TITLE
Add check for build errors before running CopyMinToMax Webpack plugin

### DIFF
--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -251,6 +251,10 @@ export const commonDevWebpackConfiguration = (
 class CopyMinToMaxWebpackPlugin {
     apply(compiler: Compiler) {
         compiler.hooks.done.tap("CopyToMax", (stats) => {
+            if (stats.hasErrors()) {
+                console.error("Build had errors, skipping CopyMinToMax plugin");
+                return;
+            }
             const outputPath = stats.compilation.outputOptions.path;
             if (outputPath) {
                 for (const chunk of stats.compilation.chunks) {


### PR DESCRIPTION
Previously if UMD failed the webpackPlugin would still try to copy minified.js file over (which wouldnt exist) so it would error out and that error would appear in build, hiding the actual underlying error. 

This change skips the webpackPlugin copy if there is a build error, and logs to console to notify.