### PR TITLE
Inspector v2: Add scene explorer command for playing/pausing animation groups

### DIFF
--- a/packages/dev/inspector-v2/test/app/index.ts
+++ b/packages/dev/inspector-v2/test/app/index.ts
@@ -1,3 +1,7 @@
+// NOTE: This app is an easy place to test Inspector v2.
+// Additionally, here are some PGs that are helpful for testing specific features:
+// Animation groups: http://localhost:1338/?inspectorv2#FMAYKS
+
 import HavokPhysics from "@babylonjs/havok";
 import type { Nullable } from "core/types";
 


### PR DESCRIPTION
This change adds a play/pause command for animation groups. There is already a button in the property grid, but this makes it easy to see at a glance in scene explorer which animation groups are playing and quickly toggle there state.

<img width="477" height="168" alt="image" src="https://github.com/user-attachments/assets/8d679a4b-86ec-4df9-a5b0-0e7b4df0ab48" />
