### PR TITLE
Updating gitignore for devhost public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ packages/public/@babylonjs/smart-filters-blocks/src
 # Smart Filters Editor files
 packages/tools/smartFiltersEditor/www/scripts/**
 packages/tools/smartFiltersEditor/www/index.html
+
+# Dev Host public folder
+packages/tools/devHost/public/**
+!packages/tools/devHost/public/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ junit.xml
 *.pem
 packages/tools/babylonServer/public/localDev
 packages/tools/babylonServer/public/localDevWebGPU
+packages/tools/devHost/public/localDev
 packages/tools/playground/public/temp
 #playwright
 test-results
@@ -46,7 +47,3 @@ packages/public/@babylonjs/smart-filters-blocks/src
 # Smart Filters Editor files
 packages/tools/smartFiltersEditor/www/scripts/**
 packages/tools/smartFiltersEditor/www/index.html
-
-# Dev Host public folder
-packages/tools/devHost/public/**
-!packages/tools/devHost/public/index.html


### PR DESCRIPTION
When using devhost it is useful to put data in the public folder to test (like textures or other data), but this should not be checked on the repo because it's something just useful for local testing. Right now to avoid checking the data you have to copy them to public and then delete them by hand, which is easy but annoying.

Adding some lines to gitignore to allow this scenario.