### PR TITLE
Updating index for top level export

### DIFF
--- a/packages/dev/addons/src/index.ts
+++ b/packages/dev/addons/src/index.ts
@@ -1,3 +1,4 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./htmlMesh/index";
 export * from "./msdfText/index";
+export * from "./lottie/index";


### PR DESCRIPTION
This update will allow lottie to be imported directly from addons, instead of having to use the path addons/lottie