### PR TITLE
enable bvhFileLoader

### DIFF
--- a/packages/dev/loaders/src/BVH/bvhFileLoader.ts
+++ b/packages/dev/loaders/src/BVH/bvhFileLoader.ts
@@ -54,10 +54,19 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
 
     /**
      * If the data string can be loaded directly.
+     * @param data - direct load data
      * @returns if the data can be loaded directly
      */
-    public canDirectLoad(): boolean {
-        return true;
+    public canDirectLoad(data: string): boolean {
+        return this.isBvhHeader(data);
+    }
+
+    public isBvhHeader(text: string): boolean {
+        return text.split("\n")[0] == "HIERARCHY";
+    }
+
+    public isNotBvhHeader(text: string): boolean {
+        return !this.isBvhHeader(text);
     }
 
     /**
@@ -72,6 +81,10 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         if (typeof data !== "string") {
             // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
             return Promise.reject("BVH loader expects string data.");
+        }
+        if (this.isNotBvhHeader(data as string)) {
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            return Promise.reject("BVH loader expects HIERARCHY header.");
         }
         try {
             const skeleton = ReadBvh(data, scene, null, this._loadingOptions);
@@ -103,6 +116,10 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
             // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
             return Promise.reject("BVH loader expects string data.");
         }
+        if (this.isNotBvhHeader(data as string)) {
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            return Promise.reject("BVH loader expects HIERARCHY header.");
+        }
 
         // eslint-disable-next-line github/no-then
         return this.importMeshAsync(null, scene, data).then(() => {
@@ -121,6 +138,10 @@ export class BVHFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         if (typeof data !== "string") {
             // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
             return Promise.reject("BVH loader expects string data.");
+        }
+        if (this.isNotBvhHeader(data as string)) {
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            return Promise.reject("BVH loader expects HIERARCHY header.");
         }
         const assetContainer = new AssetContainer(scene);
         try {

--- a/packages/dev/loaders/src/BVH/bvhLoader.ts
+++ b/packages/dev/loaders/src/BVH/bvhLoader.ts
@@ -382,8 +382,11 @@ export function ReadBvh(text: string, scene: Scene, assetContainer: Nullable<Ass
     if (isNaN(frameTime)) {
         throw new Error("Failed to read frame time.");
     }
+    if (frameTime <= 0) {
+        throw new Error("Failed to read frame time. Invalid value " + frameTime);
+    }
 
-    context.frameRate = frameTime;
+    context.frameRate = 1 / frameTime;
 
     // read frame data line by line
     for (let i = 0; i < numFrames; ++i) {

--- a/packages/dev/loaders/src/BVH/index.ts
+++ b/packages/dev/loaders/src/BVH/index.ts
@@ -1,2 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "./bvhLoader";
+export * from "./bvhFileLoader";

--- a/packages/dev/loaders/src/index.ts
+++ b/packages/dev/loaders/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
+export * from "./BVH/index";
 export * from "./glTF/index";
 export * from "./OBJ/index";
 export * from "./STL/index";

--- a/packages/lts/loaders/src/legacy/legacy-bvhFileLoader.ts
+++ b/packages/lts/loaders/src/legacy/legacy-bvhFileLoader.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-restricted-imports */
+import * as Loaders from "loaders/BVH/index";
+
+/**
+ * This is the entry point for the UMD module.
+ * The entry point for a future ESM package should be index.ts
+ */
+const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;
+if (typeof GlobalObject !== "undefined") {
+    for (const key in Loaders) {
+        if (!(<any>GlobalObject).BABYLON[key]) {
+            (<any>GlobalObject).BABYLON[key] = (<any>Loaders)[key];
+        }
+    }
+}
+
+export * from "loaders/BVH/index";

--- a/packages/lts/loaders/src/legacy/legacy.ts
+++ b/packages/lts/loaders/src/legacy/legacy.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/export */
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from "loaders/index";
+export * from "./legacy-bvhFileLoader";
 export * from "./legacy-glTF";
 export * from "./legacy-glTF1";
 export * from "./legacy-glTF2";

--- a/packages/public/umd/babylonjs-loaders/src/bvhFileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/bvhFileLoader.ts
@@ -1,0 +1,3 @@
+import * as loaders from "@lts/loaders/legacy/legacy-bvhFileLoader";
+export { loaders };
+export default loaders;

--- a/packages/public/umd/babylonjs-loaders/webpack.config.js
+++ b/packages/public/umd/babylonjs-loaders/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = (env) => {
         outputPath: path.resolve(__dirname),
         entryPoints: {
             loaders: "./src/index.ts",
+            bvhFileLoader: "./src/bvhFileLoader.ts",
             glTF1FileLoader: "./src/glTF1FileLoader.ts",
             glTF2FileLoader: "./src/glTF2FileLoader.ts",
             glTFFileLoader: "./src/glTFFileLoader.ts",


### PR DESCRIPTION
Please help to enable bvhFileLoader.

In latest version of babylonjs, the built babylon.loaders.js didnot contains hvhFileLoader. And there is no way to get bvhFileLoader from cdnSnapshot. So the bvhFileLooader is disabled. Please help to enable it.

The second party is change frameRate from 0.025 to 40 (1 / 0.025)