### PR TITLE
Inspector v2: Scene Explorer expand/collapse all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,6 +2702,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@fluentui-contrib/react-virtualizer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-0.1.0.tgz",
+            "integrity": "sha512-AFdick4akTpDhscGl22cSLGg5Q7OFg+1gt5cNz3RrzQHEFC3Z+HfiQutINYUL7Nvzjden26tktsrnXgsmGQSmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@fluentui/react-utilities": "^9.16.0",
+                "@griffel/react": "^1.5.14",
+                "@swc/helpers": "~0.5.11",
+                "jsonc-eslint-parser": "2.4.0"
+            },
+            "peerDependencies": {
+                "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
+                "@types/react": ">=16.8.0 <19.0.0",
+                "@types/react-dom": ">=16.9.0 <19.0.0",
+                "react": ">=16.8.0 <19.0.0",
+                "react-dom": ">=16.8.0 <19.0.0"
+            }
+        },
         "node_modules/@fluentui/keyboard-keys": {
             "version": "9.0.8",
             "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
@@ -18635,6 +18655,25 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-eslint-parser": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+            "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.5.0",
+                "eslint-visitor-keys": "^3.0.0",
+                "espree": "^9.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ota-meshi"
+            }
+        },
         "node_modules/jsonc-parser": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
@@ -28347,6 +28386,7 @@
                 "@dev/loaders": "1.0.0",
                 "@dev/materials": "^1.0.0",
                 "@dev/serializers": "1.0.0",
+                "@fluentui-contrib/react-virtualizer": "^0.1.0",
                 "@fluentui/react-components": "^9.62.0",
                 "@fluentui/react-icons": "^2.0.271",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",
@@ -29304,6 +29344,7 @@
             "name": "@tools/dev-host",
             "version": "1.0.0",
             "devDependencies": {
+                "@dev/addons": "^1.0.0",
                 "@dev/build-tools": "1.0.0",
                 "@dev/core": "1.0.0",
                 "@dev/gui": "1.0.0",

--- a/packages/dev/inspector-v2/package.json
+++ b/packages/dev/inspector-v2/package.json
@@ -22,6 +22,7 @@
         "@dev/loaders": "1.0.0",
         "@dev/materials": "^1.0.0",
         "@dev/serializers": "1.0.0",
+        "@fluentui-contrib/react-virtualizer": "^0.1.0",
         "@fluentui/react-components": "^9.62.0",
         "@fluentui/react-icons": "^2.0.271",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -580,17 +580,13 @@ export const SceneExplorer: FunctionComponent<{
         [sectionTreeItems, allTreeItems, sections]
     );
 
-    // We only want the effect below to execute when the selectedEntity changes, so we use a ref to keep the latest version of getParentStack.
-    const getParentStackRef = useRef(getParentStack);
-    getParentStackRef.current = getParentStack;
-
     const [isScrollToPending, setIsScrollToPending] = useState(false);
 
     useEffect(() => {
         if (selectedEntity && selectedEntity !== previousSelectedEntity.current) {
             const entity = selectedEntity as EntityBase;
             if (entity.uniqueId != undefined) {
-                const parentStack = getParentStackRef.current(entity);
+                const parentStack = getParentStack(entity);
                 if (parentStack.length > 0) {
                     const newOpenItems = new Set<TreeItemValue>(openItems);
                     for (const parent of parentStack) {
@@ -603,7 +599,7 @@ export const SceneExplorer: FunctionComponent<{
         }
 
         previousSelectedEntity.current = selectedEntity;
-    }, [selectedEntity, setOpenItems, setIsScrollToPending]);
+    }, [selectedEntity]);
 
     // We need to wait for a render to complete before we can scroll to the item, hence the isScrollToPending.
     useEffect(() => {

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -294,10 +294,10 @@ const SectionTreeItem: FunctionComponent<{
             <MenuPopover hidden={!section.children.length}>
                 <MenuList>
                     <MenuItem onClick={expandAll}>
-                        <Body1>Expand All Descendants</Body1>
+                        <Body1>Expand All</Body1>
                     </MenuItem>
                     <MenuItem onClick={collapseAll}>
-                        <Body1>Collapse All Descendants</Body1>
+                        <Body1>Collapse All</Body1>
                     </MenuItem>
                 </MenuList>
             </MenuPopover>
@@ -409,10 +409,10 @@ const EntityTreeItem: FunctionComponent<{
             <MenuPopover hidden={!entityItem.children?.length}>
                 <MenuList>
                     <MenuItem onClick={expandAll}>
-                        <Body1>Expand All Descendants</Body1>
+                        <Body1>Expand All</Body1>
                     </MenuItem>
                     <MenuItem onClick={collapseAll}>
-                        <Body1>Collapse All Descendants</Body1>
+                        <Body1>Collapse All</Body1>
                     </MenuItem>
                 </MenuList>
             </MenuPopover>

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -620,10 +620,22 @@ export const SceneExplorer: FunctionComponent<{
         (event: TreeOpenChangeEvent, data: TreeOpenChangeData) => {
             // This makes it so we only consider a click on the chevron to be expanding/collapsing an item, not clicking anywhere on the item.
             if (data.type !== "Click" && data.type !== "Enter") {
+                // Shift or Ctrl mean expand/collapse all descendants.
+                if (event.shiftKey || event.ctrlKey) {
+                    const treeItem = allTreeItems.get(data.value);
+                    if (treeItem) {
+                        const addOrRemove = data.open ? data.openItems.add.bind(data.openItems) : data.openItems.delete.bind(data.openItems);
+                        TraverseGraph(
+                            [treeItem],
+                            (treeItem) => treeItem.children ?? null,
+                            (treeItem) => addOrRemove(treeItem.type === "entity" ? treeItem.entity.uniqueId : treeItem.sectionName)
+                        );
+                    }
+                }
                 setOpenItems(data.openItems);
             }
         },
-        [setOpenItems]
+        [setOpenItems, allTreeItems]
     );
 
     return (

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -570,14 +570,12 @@ export const SceneExplorer: FunctionComponent<{
     const getParentStack = useCallback(
         (entity: EntityBase) => {
             const parentStack: TreeItemValue[] = [];
-
             for (let treeItem = allTreeItems.get(entity.uniqueId); treeItem; treeItem = treeItem?.type === "entity" ? treeItem.parent : undefined) {
                 parentStack.push(treeItem.type === "entity" ? treeItem.entity.uniqueId : treeItem.sectionName);
             }
-
             return parentStack;
         },
-        [sectionTreeItems, allTreeItems, sections]
+        [allTreeItems]
     );
 
     const [isScrollToPending, setIsScrollToPending] = useState(false);

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -91,7 +91,7 @@ export type SceneExplorerSection<T extends EntityBase> = Readonly<{
     getEntityMovedObservables?: () => readonly IReadonlyObservable<T>[];
 }>;
 
-type Command<T extends EntityBase> = Partial<IDisposable> &
+type Command = Partial<IDisposable> &
     Readonly<{
         /**
          * The display name of the command (e.g. "Delete", "Rename", etc.).
@@ -109,7 +109,7 @@ type Command<T extends EntityBase> = Partial<IDisposable> &
         onChange?: IReadonlyObservable<unknown>;
     }>;
 
-type ActionCommand<T extends EntityBase> = Command<T> & {
+type ActionCommand = Command & {
     readonly type: "action";
 
     /**
@@ -118,7 +118,7 @@ type ActionCommand<T extends EntityBase> = Command<T> & {
     execute(): void;
 };
 
-type ToggleCommand<T extends EntityBase> = Command<T> & {
+type ToggleCommand = Command & {
     readonly type: "toggle";
 
     /**
@@ -127,7 +127,7 @@ type ToggleCommand<T extends EntityBase> = Command<T> & {
     isEnabled: boolean;
 };
 
-export type SceneExplorerCommand<T extends EntityBase> = ActionCommand<T> | ToggleCommand<T>;
+export type SceneExplorerCommand = ActionCommand | ToggleCommand;
 
 export type SceneExplorerCommandProvider<T extends EntityBase> = Readonly<{
     /**
@@ -144,7 +144,7 @@ export type SceneExplorerCommandProvider<T extends EntityBase> = Readonly<{
     /**
      * Gets the command information for the given entity.
      */
-    getCommand: (entity: T) => SceneExplorerCommand<T>;
+    getCommand: (entity: T) => SceneExplorerCommand;
 }>;
 
 type SceneTreeItemData = { type: "scene"; scene: Scene };
@@ -189,7 +189,7 @@ const useStyles = makeStyles({
     },
 });
 
-const ActionCommand: FunctionComponent<{ command: ActionCommand<EntityBase>; entity: EntityBase }> = (props) => {
+const ActionCommand: FunctionComponent<{ command: ActionCommand; entity: EntityBase }> = (props) => {
     const { command } = props;
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -205,7 +205,7 @@ const ActionCommand: FunctionComponent<{ command: ActionCommand<EntityBase>; ent
     );
 };
 
-const ToggleCommand: FunctionComponent<{ command: ToggleCommand<EntityBase>; entity: EntityBase }> = (props) => {
+const ToggleCommand: FunctionComponent<{ command: ToggleCommand; entity: EntityBase }> = (props) => {
     const { command } = props;
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -300,7 +300,7 @@ const EntityTreeItem: FunctionComponent<{
     // Get the commands that apply to this entity.
     const commands = useResource(
         useCallback(() => {
-            const commands: readonly SceneExplorerCommand<EntityBase>[] = commandProviders
+            const commands: readonly SceneExplorerCommand[] = commandProviders
                 .filter((provider) => provider.predicate(entityItem.entity))
                 .map((provider) => provider.getCommand(entityItem.entity));
 
@@ -310,7 +310,7 @@ const EntityTreeItem: FunctionComponent<{
         }, [entityItem.entity, commandProviders])
     );
 
-    const [enabledToggleCommands, setEnabledToggleCommands] = useState<readonly ToggleCommand<EntityBase>[]>([]);
+    const [enabledToggleCommands, setEnabledToggleCommands] = useState<readonly ToggleCommand[]>([]);
 
     // For enabled/active toggle commands, we should always show them so the user knows this command is toggled on.
     useEffect(() => {

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -4,8 +4,8 @@ import type { TreeItemValue, TreeOpenChangeData, TreeOpenChangeEvent } from "@fl
 import type { ScrollToInterface } from "@fluentui/react-components/unstable";
 import type { ComponentType, FunctionComponent } from "react";
 
+import { VirtualizerScrollView } from "@fluentui-contrib/react-virtualizer";
 import { Body1, Body1Strong, Button, FlatTree, FlatTreeItem, makeStyles, SearchBox, ToggleButton, tokens, Tooltip, TreeItemLayout } from "@fluentui/react-components";
-import { VirtualizerScrollView } from "@fluentui/react-components/unstable";
 import { FilterRegular, MoviesAndTvRegular } from "@fluentui/react-icons";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -157,6 +157,15 @@ type EntityTreeItemData = {
 
 type TreeItemData = SceneTreeItemData | SectionTreeItemData | EntityTreeItemData;
 
+function ExpandOrCollapseAll(treeItem: SectionTreeItemData | EntityTreeItemData, open: boolean, openItems: Set<TreeItemValue>) {
+    const addOrRemove = open ? openItems.add.bind(openItems) : openItems.delete.bind(openItems);
+    TraverseGraph(
+        [treeItem],
+        (treeItem) => treeItem.children,
+        (treeItem) => addOrRemove(treeItem.type === "entity" ? treeItem.entity.uniqueId : treeItem.sectionName)
+    );
+}
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     rootDiv: {
@@ -618,12 +627,7 @@ export const SceneExplorer: FunctionComponent<{
                 if (event.shiftKey || event.ctrlKey) {
                     const treeItem = allTreeItems.get(data.value);
                     if (treeItem) {
-                        const addOrRemove = data.open ? data.openItems.add.bind(data.openItems) : data.openItems.delete.bind(data.openItems);
-                        TraverseGraph(
-                            [treeItem],
-                            (treeItem) => treeItem.children ?? null,
-                            (treeItem) => addOrRemove(treeItem.type === "entity" ? treeItem.entity.uniqueId : treeItem.sectionName)
-                        );
+                        ExpandOrCollapseAll(treeItem, data.open, data.openItems);
                     }
                 }
                 setOpenItems(data.openItems);

--- a/packages/dev/inspector-v2/src/misc/graphUtils.ts
+++ b/packages/dev/inspector-v2/src/misc/graphUtils.ts
@@ -1,5 +1,3 @@
-import type { Nullable } from "core/index";
-
 /**
  * Performs a topological sort on a graph.
  * @param graph The set of nodes that make up the graph.
@@ -24,7 +22,7 @@ export function SortGraph<NodeT>(graph: Iterable<NodeT>, getAdjacentNodes: (node
  */
 export function TraverseGraph<NodeT>(
     graph: Iterable<NodeT>,
-    getAdjacentNodes: (node: NodeT) => Nullable<Iterable<NodeT>>,
+    getAdjacentNodes: (node: NodeT) => Iterable<NodeT> | null | undefined,
     onBeforeTraverse?: (node: NodeT) => void,
     onAfterTraverse?: (node: NodeT) => void
 ) {
@@ -64,7 +62,7 @@ export class GraphUtils<DefaultNodeT = unknown> {
      */
     public traverse<NodeT extends DefaultNodeT>(
         graph: Iterable<NodeT>,
-        getAdjacentNodes: (node: NodeT) => Nullable<Iterable<NodeT>>,
+        getAdjacentNodes: (node: NodeT) => Iterable<NodeT> | null | undefined,
         onBeforeTraverse?: (node: NodeT) => void,
         onAfterTraverse?: (node: NodeT) => void
     ) {
@@ -87,7 +85,7 @@ export class GraphUtils<DefaultNodeT = unknown> {
 
     private _traverseCore<NodeT extends DefaultNodeT>(
         node: NodeT,
-        getAdjacentNodes: (node: NodeT) => Nullable<Iterable<NodeT>>,
+        getAdjacentNodes: (node: NodeT) => Iterable<NodeT> | null | undefined,
         onBeforeTraverse?: (node: NodeT) => void,
         onAfterTraverse?: (node: NodeT) => void
     ) {

--- a/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
@@ -1,10 +1,11 @@
+import type { TargetedAnimation } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { FilmstripRegular, StackRegular } from "@fluentui/react-icons";
 
-import { AnimationGroup, TargetedAnimation } from "core/Animations/animationGroup";
+import { AnimationGroup } from "core/Animations/animationGroup";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
@@ -20,13 +21,11 @@ export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISc
             return undefined;
         }
 
-        const sectionRegistration = sceneExplorerService.addSection({
+        const sectionRegistration = sceneExplorerService.addSection<AnimationGroup | TargetedAnimation>({
             displayName: "Animation Groups",
             order: DefaultSectionsOrder.AnimationGroups,
-            predicate: (entity) => entity instanceof AnimationGroup || entity instanceof TargetedAnimation,
             getRootEntities: () => scene.animationGroups,
             getEntityChildren: (entity) => (entity instanceof AnimationGroup ? entity.targetedAnimations : []),
-            getEntityParent: (entity) => (entity instanceof TargetedAnimation ? entity.parent : null),
             getEntityDisplayInfo: (entity) => {
                 const namedEntity = entity instanceof AnimationGroup ? entity : entity.animation;
 

--- a/packages/dev/inspector-v2/src/services/panes/scene/effectLayersExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/effectLayersExplorerService.tsx
@@ -5,7 +5,6 @@ import type { ISceneExplorerService } from "./sceneExplorerService";
 import { LayerRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc";
-import { EffectLayer } from "core/Layers/effectLayer";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
@@ -23,7 +22,6 @@ export const EffectLayerExplorerServiceDefinition: ServiceDefinition<[], [IScene
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Effect Layers",
             order: DefaultSectionsOrder.EffectLayers,
-            predicate: (entity) => entity instanceof EffectLayer,
             getRootEntities: () => scene.effectLayers,
             getEntityDisplayInfo: (effectLayer) => {
                 const onChangeObservable = new Observable<void>();

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -23,7 +23,6 @@ export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Frame Graph",
             order: DefaultSectionsOrder.FrameGraphs,
-            predicate: (entity) => entity instanceof FrameGraph,
             getRootEntities: () => scene.frameGraphs,
             getEntityDisplayInfo: (frameGraph) => {
                 const onChangeObservable = new Observable<void>();

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -28,7 +28,6 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "GUI",
             order: DefaultSectionsOrder.GUIs,
-            predicate: IsAdvancedDynamicTexture,
             getRootEntities: () => scene.textures.filter(IsAdvancedDynamicTexture),
             getEntityDisplayInfo: (texture) => {
                 const onChangeObservable = new Observable<void>();

--- a/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
@@ -4,7 +4,6 @@ import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { PaintBrushRegular } from "@fluentui/react-icons";
 
-import { Material } from "core/Materials/material";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
@@ -23,7 +22,6 @@ export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Materials",
             order: DefaultSectionsOrder.Materials,
-            predicate: (entity) => entity instanceof Material,
             getRootEntities: () => [...scene.materials, ...scene.multiMaterials],
             getEntityDisplayInfo: (material) => {
                 const onChangeObservable = new Observable<void>();

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -1,4 +1,4 @@
-import type { Gizmo, IObserver, Nullable } from "core/index";
+import type { Gizmo, IObserver, Node, Nullable } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
@@ -26,7 +26,6 @@ import { Light } from "core/Lights/light";
 import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { TransformNode } from "core/Meshes/transformNode";
 import { Observable } from "core/Misc";
-import { Node } from "core/node";
 import { UtilityLayerRenderer } from "core/Rendering";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
@@ -47,10 +46,8 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Nodes",
             order: DefaultSectionsOrder.Nodes,
-            predicate: (entity) => entity instanceof Node,
             getRootEntities: () => scene.rootNodes,
             getEntityChildren: (node) => node.getChildren(),
-            getEntityParent: (node) => node.parent,
             getEntityDisplayInfo: (node) => {
                 const onChangeObservable = new Observable<void>();
 

--- a/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
@@ -1,4 +1,3 @@
-import type { IParticleSystem } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
@@ -23,7 +22,6 @@ export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISc
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Particle Systems",
             order: DefaultSectionsOrder.ParticleSystems,
-            predicate: (entity): entity is IParticleSystem => scene.particleSystems.includes(entity as IParticleSystem),
             getRootEntities: () => scene.particleSystems,
             getEntityDisplayInfo: (particleSystem) => {
                 const onChangeObservable = new Observable<void>();

--- a/packages/dev/inspector-v2/src/services/panes/scene/postProcessExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/postProcessExplorerService.tsx
@@ -5,7 +5,6 @@ import type { ISceneExplorerService } from "./sceneExplorerService";
 import { BlurRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc";
-import { PostProcess } from "core/PostProcesses/postProcess";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
@@ -23,7 +22,6 @@ export const PostProcessExplorerServiceDefinition: ServiceDefinition<[], [IScene
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Post Processes",
             order: DefaultSectionsOrder.PostProcesses,
-            predicate: (entity) => entity instanceof PostProcess,
             getRootEntities: () => scene.postProcesses,
             getEntityDisplayInfo: (postProcess) => {
                 const onChangeObservable = new Observable<void>();

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -4,7 +4,6 @@ import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { PipelineRegular } from "@fluentui/react-icons";
 
-import { PostProcessRenderPipeline } from "core/PostProcesses/RenderPipeline/postProcessRenderPipeline";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
@@ -23,7 +22,6 @@ export const RenderingPipelineExplorerServiceDefinition: ServiceDefinition<[], [
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Rendering Pipelines",
             order: DefaultSectionsOrder.RenderingPipelines,
-            predicate: (entity) => entity instanceof PostProcessRenderPipeline,
             getRootEntities: () => scene.postProcessRenderPipelineManager.supportedPipelines ?? [],
             getEntityDisplayInfo: (pipeline) => {
                 return {

--- a/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
@@ -1,10 +1,10 @@
+import type { Bone } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { DataLineRegular, PersonWalkingRegular } from "@fluentui/react-icons";
 
-import { Bone } from "core/Bones/bone";
 import { Skeleton } from "core/Bones/skeleton";
 import { Observable } from "core/Misc/observable";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
@@ -26,10 +26,8 @@ export const SkeletonExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
         const sectionRegistration = sceneExplorerService.addSection<Skeleton | Bone>({
             displayName: "Skeletons",
             order: DefaultSectionsOrder.Skeletons,
-            predicate: (entity) => entity instanceof Skeleton || entity instanceof Bone,
             getRootEntities: () => scene.skeletons,
             getEntityChildren: (skeletonOrBone) => skeletonOrBone.getChildren(),
-            getEntityParent: (skeletonOrBone) => (skeletonOrBone instanceof Skeleton ? null : skeletonOrBone.getParent() || skeletonOrBone.getSkeleton()),
             getEntityDisplayInfo: (skeletonOrBone) => {
                 const onChangeObservable = new Observable<void>();
 

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -1,4 +1,4 @@
-import type { ISpriteManager, Sprite } from "core/index";
+import type { ISpriteManager } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
@@ -6,20 +6,13 @@ import type { ISceneExplorerService } from "./sceneExplorerService";
 import { LayerDiagonalPersonRegular, PersonSquareRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc";
+import { Sprite } from "core/Sprites/sprite";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 import "core/Sprites/spriteSceneComponent";
-
-function IsSpriteManager(entity: unknown): entity is ISpriteManager {
-    return (entity as ISpriteManager).sprites !== undefined;
-}
-
-function IsSprite(entity: unknown): entity is Sprite {
-    return (entity as Sprite).manager !== undefined;
-}
 
 export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
     friendlyName: "Sprite Manager Explorer",
@@ -30,13 +23,11 @@ export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISce
             return undefined;
         }
 
-        const sectionRegistration = sceneExplorerService.addSection({
+        const sectionRegistration = sceneExplorerService.addSection<Sprite | ISpriteManager>({
             displayName: "Sprite Managers",
             order: DefaultSectionsOrder.SpriteManagers,
-            predicate: (entity) => IsSpriteManager(entity) || IsSprite(entity),
             getRootEntities: () => scene.spriteManagers ?? [],
-            getEntityChildren: (spriteEntity) => (IsSpriteManager(spriteEntity) ? spriteEntity.sprites : ([] as ISpriteManager[])),
-            getEntityParent: (spriteEntity) => (IsSprite(spriteEntity) ? spriteEntity.manager : null),
+            getEntityChildren: (spriteEntity) => (spriteEntity instanceof Sprite ? [] : spriteEntity.sprites),
             getEntityDisplayInfo: (spriteEntity) => {
                 const onChangeObservable = new Observable<void>();
 
@@ -55,7 +46,7 @@ export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISce
                     },
                 };
             },
-            entityIcon: ({ entity: spriteEntity }) => (IsSpriteManager(spriteEntity) ? <LayerDiagonalPersonRegular /> : <PersonSquareRegular />),
+            entityIcon: ({ entity: spriteEntity }) => (spriteEntity instanceof Sprite ? <PersonSquareRegular /> : <LayerDiagonalPersonRegular />),
             getEntityAddedObservables: () => [scene.onNewSpriteManagerAddedObservable],
             getEntityRemovedObservables: () => [scene.onSpriteManagerRemovedObservable],
         });

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -53,7 +53,7 @@ export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISce
         });
 
         const spritePlayStopCommandRegistration = sceneExplorerService.addCommand({
-            predicate: (entity: unknown) => IsSprite(entity),
+            predicate: (entity: unknown) => entity instanceof Sprite,
             getCommand: (sprite) => {
                 const onChangeObservable = new Observable<void>();
                 const playHook = InterceptFunction(sprite, "playAnimation", {

--- a/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
@@ -4,7 +4,6 @@ import type { ISceneExplorerService } from "./sceneExplorerService";
 
 import { ImageEditRegular, ImageRegular } from "@fluentui/react-icons";
 
-import { BaseTexture } from "core/Materials/Textures/baseTexture";
 import { DynamicTexture } from "core/Materials/Textures/dynamicTexture";
 import { Observable } from "core/Misc";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
@@ -24,7 +23,6 @@ export const TextureExplorerServiceDefinition: ServiceDefinition<[], [ISceneExpl
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Textures",
             order: DefaultSectionsOrder.Textures,
-            predicate: (entity): entity is BaseTexture => entity instanceof BaseTexture && entity.getClassName() !== "AdvancedDynamicTexture",
             getRootEntities: () => scene.textures.filter((texture) => texture.getClassName() !== "AdvancedDynamicTexture"),
             getEntityDisplayInfo: (texture) => {
                 const onChangeObservable = new Observable<void>();


### PR DESCRIPTION
This change brings expand/collapse all to scene explorer.
- Previously there was a single useMemo that traversed the expanded part of the scene and created TreeItemData only for the expanded nodes. I've broken this out now into two different useMemos. The first one creates TreeItemData for *all* entities, and the second one filters down those TreeItemData into only those that are expanded/visible. I'd already been thinking about reworking it like this for other reasons as it simplifies a lot of things. As part of this, I was able to simplify the interface a scene explorer section in that it no longer needs to provide a predicate or a function to get the parent (which can now be inferred from the internal TreeItemData tree structure).
- Removed the unnecessary type param from all the scene explorer command interfaces and components. This was needed when a command instance was not tied to a specific entity instance, but now they are 1:1, so there is no need to pass an entity into a command instance (it holds it internally). This is just cleanup that I missed in previous changes.
- Expand/collapse all can be triggered in a similar way as inspector v1 by holding down shift (or ctrl) when clicking the expand/collapse button on a tree node. I also added explicit context menus to help make it more discoverable. I did not make the context menus extensible in this PR, but may in a future change if we think it makes sense to be able to add in more items to the context menu dynamically.
- Also updated to the virtualizer that is no longer in preview state. It is part of the fluent contrib package family, which is analogous to Babylon's Addons package.

<img width="374" height="395" alt="image" src="https://github.com/user-attachments/assets/386244a1-f521-47e1-beee-d4cea7d32426" />

