### PR TITLE
Add metadata to Skeleton, MorphTargetManager, and ParticleSystem

### DIFF
--- a/packages/dev/core/src/Bones/skeleton.ts
+++ b/packages/dev/core/src/Bones/skeleton.ts
@@ -129,6 +129,11 @@ export class Skeleton implements IAnimatable {
     }
 
     /**
+     * Gets or sets an object used to store user defined information for the skeleton
+     */
+    public metadata: any = null;
+
+    /**
      * Creates a new skeleton
      * @param name defines the skeleton name
      * @param id defines the skeleton Id
@@ -648,6 +653,7 @@ export class Skeleton implements IAnimatable {
         const result = new Skeleton(name, id || name, this._scene);
 
         result.needInitialSkinMatrix = this.needInitialSkinMatrix;
+        result.metadata = this.metadata;
 
         for (let index = 0; index < this.bones.length; index++) {
             const source = this.bones[index];
@@ -706,6 +712,7 @@ export class Skeleton implements IAnimatable {
      */
     public dispose() {
         this._meshesWithPoseMatrix.length = 0;
+        this.metadata = null;
 
         // Animations
         this.getScene().stopAnimation(this);
@@ -744,6 +751,10 @@ export class Skeleton implements IAnimatable {
         serializationObject.bones = [];
 
         serializationObject.needInitialSkinMatrix = this.needInitialSkinMatrix;
+
+        if (this.metadata) {
+            serializationObject.metadata = this.metadata;
+        }
 
         for (let index = 0; index < this.bones.length; index++) {
             const bone = this.bones[index];
@@ -804,6 +815,10 @@ export class Skeleton implements IAnimatable {
         }
 
         skeleton.needInitialSkinMatrix = parsedSkeleton.needInitialSkinMatrix;
+
+        if (parsedSkeleton.metadata) {
+            skeleton.metadata = parsedSkeleton.metadata;
+        }
 
         let index: number;
         for (index = 0; index < parsedSkeleton.bones.length; index++) {

--- a/packages/dev/core/src/Morph/morphTargetManager.ts
+++ b/packages/dev/core/src/Morph/morphTargetManager.ts
@@ -320,6 +320,11 @@ export class MorphTargetManager implements IDisposable {
     }
 
     /**
+     * Gets or sets an object used to store user defined information for the MorphTargetManager
+     */
+    public metadata: any = null;
+
+    /**
      * Gets the active target at specified index. An active target is a target with an influence > 0
      * @param index defines the index to check
      * @returns the requested target
@@ -425,6 +430,7 @@ export class MorphTargetManager implements IDisposable {
         copy.enableUVMorphing = this.enableUVMorphing;
         copy.enableUV2Morphing = this.enableUV2Morphing;
         copy.enableColorMorphing = this.enableColorMorphing;
+        copy.metadata = this.metadata;
 
         return copy;
     }
@@ -441,6 +447,10 @@ export class MorphTargetManager implements IDisposable {
         serializationObject.targets = [];
         for (const target of this._targets) {
             serializationObject.targets.push(target.serialize());
+        }
+
+        if (this.metadata) {
+            serializationObject.metadata = this.metadata;
         }
 
         return serializationObject;
@@ -660,6 +670,7 @@ export class MorphTargetManager implements IDisposable {
         }
 
         this._targetStoreTexture = null;
+        this.metadata = null;
 
         // Remove from scene
         if (this._scene) {
@@ -692,6 +703,10 @@ export class MorphTargetManager implements IDisposable {
 
         for (const targetData of serializationObject.targets) {
             result.addTarget(MorphTarget.Parse(targetData, scene));
+        }
+
+        if (serializationObject.metadata) {
+            result.metadata = serializationObject.metadata;
         }
 
         return result;

--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -191,6 +191,11 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
     public defaultProjectionMatrix: Matrix;
 
     /**
+     * Gets or sets an object used to store user defined information for the particle system
+     */
+    public metadata: any = null;
+
+    /**
      * Creates a Point Emitter for the particle system (emits directly from the emitter position)
      * @param direction1 Particles are emitted between the direction1 and direction2 from within the box
      * @param direction2 Particles are emitted between the direction1 and direction2 from within the box
@@ -2124,6 +2129,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         serializationObject.preventAutoStart = this.preventAutoStart;
         serializationObject.worldOffset = this.worldOffset.asArray();
 
+        if (this.metadata) {
+            serializationObject.metadata = this.metadata;
+        }
+
         return serializationObject;
     }
 
@@ -2191,6 +2200,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         // Auto start
         if (parsedParticleSystem.preventAutoStart) {
             particleSystem.preventAutoStart = parsedParticleSystem.preventAutoStart;
+        }
+
+        if (parsedParticleSystem.metadata) {
+            particleSystem.metadata = parsedParticleSystem.metadata;
         }
 
         if (!doNotStart && !particleSystem.preventAutoStart) {

--- a/packages/dev/core/src/Particles/particleSystem.ts
+++ b/packages/dev/core/src/Particles/particleSystem.ts
@@ -169,6 +169,11 @@ export class ParticleSystem extends ThinParticleSystem {
     }
 
     /**
+     * Gets or sets an object used to store user defined information for the particle system
+     */
+    public metadata: any = null;
+
+    /**
      * Add an attractor to the particle system. Attractors are used to change the direction of the particles in the system.
      * @param attractor The attractor to add to the particle system
      */
@@ -829,6 +834,10 @@ export class ParticleSystem extends ThinParticleSystem {
             particleSystem.preventAutoStart = parsedParticleSystem.preventAutoStart;
         }
 
+        if (parsedParticleSystem.metadata) {
+            particleSystem.metadata = parsedParticleSystem.metadata;
+        }
+
         if (!doNotStart && !particleSystem.preventAutoStart) {
             particleSystem.start();
         }
@@ -850,6 +859,10 @@ export class ParticleSystem extends ThinParticleSystem {
         serializationObject.customShader = this.customShader;
         serializationObject.preventAutoStart = this.preventAutoStart;
         serializationObject.worldOffset = this.worldOffset.asArray();
+
+        if (this.metadata) {
+            serializationObject.metadata = this.metadata;
+        }
 
         // SubEmitters
         if (this.subEmitters) {


### PR DESCRIPTION
Currently nodes, materials, textures, and bones come with metadata, where user can put custom info about the object and can be serialized with it. But in case of `Skeleton`, `MorphTargetManager`, and `ParticleSystem`, there does not seem to be a metadata there. This commit adds a metadata field to `Skeleton`, `MorphTargetManager`, and `ParticleSystem`, and preserved it in `serialize()`, `Parse()`, and `clone()`.

Forum post: <https://forum.babylonjs.com/t/is-there-metadata-for-skeleton/60036>