### PR TITLE
fix(viewer): adjust IBL direction with useRightHandedSystem

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1917,6 +1917,11 @@ export class Viewer implements IDisposable {
                 },
                 refreshLightPositionDirection(reflectionRotation: number) {
                     let effectiveSourceDir = this.iblDirection.direction.normalizeToNew();
+
+                    if (this.light.getScene().useRightHandedSystem) {
+                        effectiveSourceDir.z *= -1;
+                    }
+
                     const rotationYMatrix = Matrix.RotationY(reflectionRotation * -1);
                     effectiveSourceDir = Vector3.TransformCoordinates(effectiveSourceDir, rotationYMatrix);
 


### PR DESCRIPTION
The viewer's IBL shadow-map direction was not properly adjusted when `useRightHandedSystem` is set to `true`. 
I added coordinate system handedness compensation in the `refreshLightPositionDirection`.