### PR TITLE
Fix Image Control Render Nine Patch

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -1017,11 +1017,13 @@ export class Image extends Control {
     }
 
     private _renderNinePatch(context: ICanvasRenderingContext, sx: number, sy: number, sw: number, sh: number): void {
-        const idealRatio = this.host.idealWidth
-            ? this._currentMeasure.width / this.host.idealWidth
-            : this.host.idealHeight
-              ? this._currentMeasure.height / this.host.idealHeight
-              : 1;
+        const idealRatio = this.host.idealRatio
+            ? this.host.idealRatio
+            : this.host.idealWidth
+                ? this._currentMeasure.width / this.host.idealWidth
+                : this.host.idealHeight
+                    ? this._currentMeasure.height / this.host.idealHeight
+                    : 1;
         const leftWidth = this._sliceLeft;
         const topHeight = this._sliceTop;
         const bottomHeight = sh - this._sliceBottom;


### PR DESCRIPTION
This address the ideal ratio calculation for nine sliced image support.

https://forum.babylonjs.com/t/render-nine-patch-bug-fix/60043/6

Summary

Fix nine-patch rendering for BABYLON.GUI.Image when width/height are percentages and ADT has idealWidth/idealHeight. The old code used ValueAndUnit.getValue(this.host) (raw %) for idealRatio; the fix uses resolved pixels from _currentMeasure.

Root cause

_renderNinePatch used this._width.getValue(this.host)/idealWidth (and height variant). For percentage sizes, getValue(host) is normalized, not pixels, collapsing slice scaling when ideal* is set.
Fix (2 lines)

Compute idealRatio from resolved measure:

        const idealRatio = this.host.idealRatio
            ? this.host.idealRatio
            : this.host.idealWidth
                ? this._currentMeasure.width / this.host.idealWidth
                : this.host.idealHeight
                    ? this._currentMeasure.height / this.host.idealHeight
                    : 1;
Safety

Try ADT idealRatio first, then _currentMeasure is the resolved pixel size post-layout, so pixel-sized images are unchanged; nine-patch math/draw remains identical otherwise.
Repro (before fix)

ADT with idealWidth or idealHeight

Image: stretch = Image.STRETCH_NINE_PATCH, width = "100%", height = "100%", slice props or populateNinePatchSlicesFromImage = true

Borders disappear/crop with % sizing; OK with px.

After fix

Borders render correctly with % sizing and ADT idealRatio
