### PR TITLE
Fix RenderNinePatch bug in GUI image

### DIFF
--- a/packages/dev/gui/src/2D/controls/image.ts
+++ b/packages/dev/gui/src/2D/controls/image.ts
@@ -1017,11 +1017,7 @@ export class Image extends Control {
     }
 
     private _renderNinePatch(context: ICanvasRenderingContext, sx: number, sy: number, sw: number, sh: number): void {
-        const idealRatio = this.host.idealWidth
-            ? this._currentMeasure.width / this.host.idealWidth
-            : this.host.idealHeight
-              ? this._currentMeasure.height / this.host.idealHeight
-              : 1;
+        const idealRatio = this.host.idealRatio;
         const leftWidth = this._sliceLeft;
         const topHeight = this._sliceTop;
         const bottomHeight = sh - this._sliceBottom;


### PR DESCRIPTION
See [this ](https://forum.babylonjs.com/t/render-nine-patch-bug-fix/60043/7 )forum post as well as [this first PR ](https://github.com/BabylonJS/Babylon.js/pull/17018)attempt to fix, followed by [this final PR](https://github.com/BabylonJS/Babylon.js/pull/17028) where we solved the correct fix 

<img width="1051" height="393" alt="image" src="https://github.com/user-attachments/assets/7cb96b4b-54fb-46a1-929c-746407bdcdd1" />

I didn't have permissions to push to @MackeyK24 's branch so creating a new PR, thank you @MackeyK24 for raising the issue and finding the fix! 