### PR TITLE
geometry: skip getFloatData if not needed

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1679,4 +1679,3 @@ export class Geometry implements IGetSetVerticesData {
         return geometry;
     }
 }
-


### PR DESCRIPTION
The `setVerticesBuffer` method currently unconditionally calls `buffer.getFloatData` when setting a position buffer. However, if `useBoundingInfoFromGeometry` is true and `_boundingInfo` is already set (a common scenario for glTF models), the data returned by `getFloatData` is ignored within the `_updateExtend` method.

This `getFloatData` operation is profiled to be CPU and RAM intensive, contributing significantly to model loading times and potentially causing major garbage collection events.

This change optimizes performance by conditionally calling `buffer.getFloatData`. It now passes `null` to `_updateExtend` when `useBoundingInfoFromGeometry` is true and `_boundingInfo` exists, ensuring the expensive data retrieval is only performed when its result is actually needed and used. This will improve loading performance and reduce GC pressure, particularly for glTF assets.

Forum post: <https://forum.babylonjs.com/t/redundant-getfloatdata-in-geometry-setverticesbuffer/60063>