### PR TITLE
[InspectorV2/Fluent] BoundProperty auto-detects known compoundProperties and uses their compoundPropertyHooks

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/lights/areaLightProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/areaLightProperties.tsx
@@ -5,22 +5,17 @@ import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLine
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
 
-import { useColor3Property, useVector3Property } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
 
 export const AreaLightSetupProperties: FunctionComponent<{ context: RectAreaLight }> = ({ context: areaLight }) => {
-    const position = useVector3Property(areaLight, "position");
-    const diffuseColor = useColor3Property(areaLight, "diffuse");
-    const specularColor = useColor3Property(areaLight, "specular");
-
     return (
         <>
-            <Color3PropertyLine label="Diffuse" value={diffuseColor} onChange={(val) => (areaLight.diffuse = val)} />
-            <Color3PropertyLine label="Specular" value={specularColor} onChange={(val) => (areaLight.specular = val)} />
-            <Vector3PropertyLine label="Position" value={position} onChange={(val) => (areaLight.position = val)} />
-            <BoundProperty component={NumberInputPropertyLine} label="Width" target={areaLight} propertyKey="width" />
-            <BoundProperty component={NumberInputPropertyLine} label="Height" target={areaLight} propertyKey="height" />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={areaLight} propertyKey="intensity" />
+            <BoundProperty label="Diffuse" component={Color3PropertyLine} target={areaLight} propertyKey="diffuse" />
+            <BoundProperty label="Specular" component={Color3PropertyLine} target={areaLight} propertyKey="specular" />
+            <BoundProperty label="Position" component={Vector3PropertyLine} target={areaLight} propertyKey="position" />
+            <BoundProperty label="Width" component={NumberInputPropertyLine} target={areaLight} propertyKey="width" />
+            <BoundProperty label="Height" component={NumberInputPropertyLine} target={areaLight} propertyKey="height" />
+            <BoundProperty label="Intensity" component={NumberInputPropertyLine} target={areaLight} propertyKey="intensity" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/lights/directionalLightProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/directionalLightProperties.tsx
@@ -5,22 +5,16 @@ import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLine
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
 
-import { useColor3Property, useVector3Property } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
 
 export const DirectionalLightSetupProperties: FunctionComponent<{ context: DirectionalLight }> = ({ context: directionalLight }) => {
-    const position = useVector3Property(directionalLight, "position");
-    const direction = useVector3Property(directionalLight, "direction");
-    const diffuseColor = useColor3Property(directionalLight, "diffuse");
-    const specularColor = useColor3Property(directionalLight, "specular");
-
     return (
         <>
-            <Vector3PropertyLine label="Position" value={position} onChange={(val) => (directionalLight.position = val)} />
-            <Vector3PropertyLine label="Direction" value={direction} onChange={(val) => (directionalLight.direction = val)} />
-            <Color3PropertyLine label="Diffuse" value={diffuseColor} onChange={(val) => (directionalLight.diffuse = val)} />
-            <Color3PropertyLine label="Specular" value={specularColor} onChange={(val) => (directionalLight.specular = val)} />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={directionalLight} propertyKey="intensity" />
+            <BoundProperty label="Position" component={Vector3PropertyLine} target={directionalLight} propertyKey="position" />
+            <BoundProperty label="Direction" component={Vector3PropertyLine} target={directionalLight} propertyKey="direction" />
+            <BoundProperty label="Diffuse" component={Color3PropertyLine} target={directionalLight} propertyKey="diffuse" />
+            <BoundProperty label="Specular" component={Color3PropertyLine} target={directionalLight} propertyKey="specular" />
+            <BoundProperty label="Intensity" component={NumberInputPropertyLine} target={directionalLight} propertyKey="intensity" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/lights/hemisphericLightProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/hemisphericLightProperties.tsx
@@ -5,20 +5,15 @@ import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLine
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
 
-import { useColor3Property, useVector3Property } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
 
 export const HemisphericLightSetupProperties: FunctionComponent<{ context: HemisphericLight }> = ({ context: hemisphericLight }) => {
-    const direction = useVector3Property(hemisphericLight, "direction");
-    const diffuseColor = useColor3Property(hemisphericLight, "diffuse");
-    const groundColor = useColor3Property(hemisphericLight, "groundColor");
-
     return (
         <>
-            <Vector3PropertyLine label="Direction" value={direction} onChange={(val) => (hemisphericLight.direction = val)} />
-            <Color3PropertyLine label="Diffuse" value={diffuseColor} onChange={(val) => (hemisphericLight.diffuse = val)} />
-            <Color3PropertyLine label="Ground" value={groundColor} onChange={(val) => (hemisphericLight.groundColor = val)} />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={hemisphericLight} propertyKey="intensity" />
+            <BoundProperty label="Direction" component={Vector3PropertyLine} target={hemisphericLight} propertyKey="direction" />
+            <BoundProperty label="Diffuse" component={Color3PropertyLine} target={hemisphericLight} propertyKey="diffuse" />
+            <BoundProperty label="Ground" component={Color3PropertyLine} target={hemisphericLight} propertyKey="groundColor" />
+            <BoundProperty label="Intensity" component={NumberInputPropertyLine} target={hemisphericLight} propertyKey="intensity" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/lights/pointLightProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/pointLightProperties.tsx
@@ -5,20 +5,15 @@ import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLine
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
 
-import { useColor3Property, useVector3Property } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
 
 export const PointLightSetupProperties: FunctionComponent<{ context: PointLight }> = ({ context: pointLight }) => {
-    const position = useVector3Property(pointLight, "position");
-    const diffuseColor = useColor3Property(pointLight, "diffuse");
-    const groundColor = useColor3Property(pointLight, "specular");
-
     return (
         <>
-            <Color3PropertyLine label="Diffuse" value={diffuseColor} onChange={(val) => (pointLight.diffuse = val)} />
-            <Color3PropertyLine label="Specular" value={groundColor} onChange={(val) => (pointLight.specular = val)} />
-            <Vector3PropertyLine label="Position" value={position} onChange={(val) => (pointLight.position = val)} />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={pointLight} propertyKey="intensity" />
+            <BoundProperty label="Diffuse" component={Color3PropertyLine} target={pointLight} propertyKey="diffuse" />
+            <BoundProperty label="Specular" component={Color3PropertyLine} target={pointLight} propertyKey="specular" />
+            <BoundProperty label="Position" component={Vector3PropertyLine} target={pointLight} propertyKey="position" />
+            <BoundProperty label="Intensity" component={NumberInputPropertyLine} target={pointLight} propertyKey="intensity" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/lights/spotLightProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/lights/spotLightProperties.tsx
@@ -7,33 +7,38 @@ import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propert
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
 
-import { useColor3Property, useProperty, useVector3Property } from "../../../hooks/compoundPropertyHooks";
+import { BoundProperty } from "../boundProperty";
 
 export const SpotLightSetupProperties: FunctionComponent<{ context: SpotLight }> = ({ context: spotLight }) => {
-    const position = useVector3Property(spotLight, "position");
-    const direction = useVector3Property(spotLight, "direction");
-    const diffuseColor = useColor3Property(spotLight, "diffuse");
-    const groundColor = useColor3Property(spotLight, "specular");
-    const angle = useProperty(spotLight, "angle");
-    const innerAngle = useProperty(spotLight, "innerAngle");
-    const exponent = useProperty(spotLight, "exponent");
-
     return (
         <>
-            <Color3PropertyLine label="Diffuse" value={diffuseColor} onChange={(val) => (spotLight.diffuse = val)} />
-            <Color3PropertyLine label="Specular" value={groundColor} onChange={(val) => (spotLight.specular = val)} />
-            <Vector3PropertyLine label="Direction" value={direction} onChange={(val) => (spotLight.direction = val)} />
-            <Vector3PropertyLine label="Position" value={position} onChange={(val) => (spotLight.position = val)} />
-            <SyncedSliderPropertyLine label="Angle" value={Tools.ToDegrees(angle)} min={0} max={90} step={0.1} onChange={(value) => (spotLight.angle = Tools.ToRadians(value))} />
-            <SyncedSliderPropertyLine
-                label="Inner Angle"
-                value={Tools.ToDegrees(innerAngle)}
+            <BoundProperty label="Diffuse" component={Color3PropertyLine} target={spotLight} propertyKey="diffuse" />
+            <BoundProperty label="Specular" component={Color3PropertyLine} target={spotLight} propertyKey="specular" />
+            <BoundProperty label="Direction" component={Vector3PropertyLine} target={spotLight} propertyKey="direction" />
+            <BoundProperty label="Position" component={Vector3PropertyLine} target={spotLight} propertyKey="position" />
+            <BoundProperty
+                label="Angle"
+                component={SyncedSliderPropertyLine}
+                target={spotLight}
+                propertyKey="angle"
+                convertTo={Tools.ToDegrees}
+                convertFrom={Tools.ToRadians}
                 min={0}
                 max={90}
                 step={0.1}
-                onChange={(value) => (spotLight.innerAngle = Tools.ToRadians(value))}
             />
-            <NumberInputPropertyLine label="Exponent" value={exponent} onChange={(value) => (spotLight.exponent = value)} />
+            <BoundProperty
+                label="InnerAngle"
+                component={SyncedSliderPropertyLine}
+                target={spotLight}
+                propertyKey="innerAngle"
+                convertTo={Tools.ToDegrees}
+                convertFrom={Tools.ToRadians}
+                min={0}
+                max={90}
+                step={0.1}
+            />
+            <BoundProperty label="Exponent" component={NumberInputPropertyLine} target={spotLight} propertyKey="exponent" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -27,7 +27,7 @@ import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propert
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
-import { useColor3Property, useProperty } from "../../../hooks/compoundPropertyHooks";
+import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { useObservableState } from "../../../hooks/observableHooks";
 import { BoundProperty } from "../boundProperty";
 
@@ -123,33 +123,17 @@ export const AbstractMeshOutlineOverlayProperties: FunctionComponent<{ mesh: Abs
     const { mesh } = props;
 
     const renderOverlay = useProperty(mesh, "renderOverlay");
-    const overlayColor = useColor3Property(mesh, "overlayColor");
     const renderOutline = useProperty(mesh, "renderOutline");
-    const outlineColor = useColor3Property(mesh, "outlineColor");
 
     return (
         <>
-            <BoundProperty component={SwitchPropertyLine} label="Render Overlay" target={mesh} propertyKey={"renderOverlay"} />
+            <BoundProperty component={SwitchPropertyLine} label="Render Overlay" target={mesh} propertyKey="renderOverlay" />
             <Collapse visible={renderOverlay}>
-                <Color3PropertyLine
-                    key="OverlayColor"
-                    label="Overlay Color"
-                    value={overlayColor}
-                    onChange={(color) => {
-                        mesh.overlayColor = color;
-                    }}
-                />
+                <BoundProperty label="Overlay Color" component={Color3PropertyLine} target={mesh} propertyKey="overlayColor" />
             </Collapse>
-            <BoundProperty component={SwitchPropertyLine} label="Render Outline" target={mesh} propertyKey={"renderOutline"} />
+            <BoundProperty component={SwitchPropertyLine} label="Render Outline" target={mesh} propertyKey="renderOutline" />
             <Collapse visible={renderOutline}>
-                <Color3PropertyLine
-                    key="OutlineColor"
-                    label="Outline Color"
-                    value={outlineColor}
-                    onChange={(color) => {
-                        mesh.outlineColor = color;
-                    }}
-                />
+                <BoundProperty label="Outline Color" component={Color3PropertyLine} target={mesh} propertyKey="outlineColor" />
             </Collapse>
         </>
     );

--- a/packages/dev/inspector-v2/src/components/properties/sprites/spriteTransformProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/sprites/spriteTransformProperties.tsx
@@ -5,20 +5,17 @@ import type { ISettingsContext } from "../../../services/settingsContext";
 
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
-import { useVector3Property } from "../../../hooks/compoundPropertyHooks";
 import { useAngleConverters } from "../../../hooks/settingsHooks";
 import { BoundProperty } from "../boundProperty";
 
 export const SpriteTransformProperties: FunctionComponent<{ sprite: Sprite; settings: ISettingsContext }> = (props) => {
     const { sprite, settings } = props;
 
-    const position = useVector3Property(sprite, "position");
-
     const [toDisplayAngle, fromDisplayAngle, useDegrees] = useAngleConverters(settings);
 
     return (
         <>
-            <Vector3PropertyLine key="PositionTransform" label="Position" value={position} onChange={(val) => (sprite.position = val)} />
+            <BoundProperty component={Vector3PropertyLine} label="Position" target={sprite} propertyKey="position" />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
                 key="Angle"

--- a/packages/dev/inspector-v2/src/components/properties/transformProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/transformProperties.tsx
@@ -4,24 +4,22 @@ import type { Nullable, Quaternion, Vector3 } from "core/index";
 import type { ISettingsContext } from "../../services/settingsContext";
 
 import { QuaternionPropertyLine, RotationVectorPropertyLine, Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
-import { useQuaternionProperty, useVector3Property } from "../../hooks/compoundPropertyHooks";
+import { useQuaternionProperty } from "../../hooks/compoundPropertyHooks";
 import { useObservableState } from "../../hooks/observableHooks";
+import { BoundProperty } from "./boundProperty";
 
 export type Transform = { position: Vector3; rotation: Vector3; rotationQuaternion: Nullable<Quaternion>; scaling: Vector3 };
 
 export const TransformProperties: FunctionComponent<{ transform: Transform; settings: ISettingsContext }> = (props) => {
     const { transform, settings } = props;
 
-    const position = useVector3Property(transform, "position");
-    const rotation = useVector3Property(transform, "rotation");
     const quatRotation = useQuaternionProperty(transform, "rotationQuaternion");
-    const scaling = useVector3Property(transform, "scaling");
 
     const useDegrees = useObservableState(() => settings.useDegrees, settings.settingsChangedObservable);
 
     return (
         <>
-            <Vector3PropertyLine key="PositionTransform" label="Position" value={position} onChange={(val) => (transform.position = val)} />
+            <BoundProperty component={Vector3PropertyLine} label="Position" target={transform} propertyKey="position" />
             {quatRotation ? (
                 <QuaternionPropertyLine
                     key="QuaternionRotationTransform"
@@ -31,9 +29,9 @@ export const TransformProperties: FunctionComponent<{ transform: Transform; sett
                     useDegrees={useDegrees}
                 />
             ) : (
-                <RotationVectorPropertyLine key="RotationTransform" label="Rotation" value={rotation} onChange={(val) => (transform.rotation = val)} useDegrees={useDegrees} />
+                <BoundProperty component={RotationVectorPropertyLine} label="Rotation" target={transform} propertyKey="rotation" useDegrees={useDegrees} />
             )}
-            <Vector3PropertyLine key="ScalingTransform" label="Scaling" value={scaling} onChange={(val) => (transform.scaling = val)} />
+            <BoundProperty component={Vector3PropertyLine} label="Scaling" target={transform} propertyKey="scaling" />
         </>
     );
 };


### PR DESCRIPTION
BoundProperty now detects whether the passed in property is of type vector , color, or quaternion and uses the corresponding compound hook automatically, that way caller doesn't need to know about this nuance. 

In future would be nice to expand this to be more flexible so that we can still use boundproperty with other complex hooks, but the typing was a bit too complex for what I needed at the moment