### PR TITLE
ObjectRenderer: Fix crash when bounding box renderer not present (follow up)

### DIFF
--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -599,7 +599,8 @@ export class ObjectRenderer {
 
         this._renderingManager.reset();
 
-        const boundingBoxRenderer = scene.getBoundingBoxRenderer?.();
+        // The cast to "any" is to avoid an error in ES6 in case you don't import boundingBoxRenderer
+        const boundingBoxRenderer = (scene as any).getBoundingBoxRenderer?.() as Nullable<BoundingBoxRenderer>;
 
         boundingBoxRenderer && boundingBoxRenderer.reset();
 
@@ -785,3 +786,4 @@ export class ObjectRenderer {
         }
     }
 }
+


### PR DESCRIPTION
Hoping it's a better fix than #17032.