### PR TITLE
Add Lazy helper class and use it for dynamic imports

### DIFF
--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -78,6 +78,7 @@ export * from "./decorators.serialization";
 export * from "./asyncLock";
 export * from "./bitArray";
 export * from "./urlTools";
+export * from "./lazy";
 
 // RGBDTextureTools
 export * from "../Shaders/rgbdDecode.fragment";

--- a/packages/dev/core/src/Misc/lazy.ts
+++ b/packages/dev/core/src/Misc/lazy.ts
@@ -1,0 +1,28 @@
+/**
+ * A class that lazily initializes a value given a factory function.
+ */
+export class Lazy<T> {
+    private _factory: (() => T) | undefined;
+    private _value: T | undefined;
+
+    /**
+     * Creates a new instance of the Lazy class.
+     * @param factory A function that creates the value.
+     */
+    constructor(factory: () => T) {
+        this._factory = factory;
+    }
+
+    /**
+     * Gets the lazily initialized value.
+     */
+    public get value(): T {
+        // If the factory function is still defined, it means we haven't called it yet.
+        if (this._factory) {
+            this._value = this._factory();
+            // Set the factory function to undefined to allow it to be garbage collected.
+            this._factory = undefined;
+        }
+        return this._value as T;
+    }
+}


### PR DESCRIPTION
This is a follow up from https://github.com/BabylonJS/Babylon.js/pull/17043. It adds a generic `Lazy<T>` helper class, and then I use it in gltfLoader. There are a couple nice things about this pattern:

1. It keeps the import paths all in one place at the top of the file, rather than sprinkled throughout the file, which makes it easier to understand dependencies quickly.
2. It reduces the amount of code and makes it trivial to use this pattern anywhere we have dynamic imports in high traffic critical parts of the code.