### PR TITLE
glTF exporter image extensions

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/Extensions/EXT_texture_avif.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/EXT_texture_avif.ts
@@ -1,0 +1,59 @@
+/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable babylonjs/available */
+import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
+import { GLTFExporter } from "../glTFExporter";
+import { GetMimeType } from "core/Misc";
+import { ImageMimeType } from "babylonjs-gltf2interface";
+
+const NAME = "EXT_texture_avif";
+
+/**
+ * [Proposed Specification](https://github.com/KhronosGroup/glTF/blob/5cb7518cf9a1bfb8268320026961b21caf5a4aac/extensions/2.0/Vendor/EXT_texture_avif/README.md)
+ * @experimental
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class EXT_texture_avif implements IGLTFExporterExtensionV2 {
+    public readonly name = NAME;
+
+    public enabled = true;
+
+    public required = true;
+
+    private _wasUsed = false;
+
+    public get wasUsed() {
+        return this._wasUsed;
+    }
+
+    private _exporter: GLTFExporter;
+
+    constructor(exporter: GLTFExporter) {
+        this._exporter = exporter;
+    }
+
+    public dispose() {}
+
+    public postExportTexture(_: string, textureInfo: BABYLON.GLTF2.ITextureInfo): void {
+        const texture = this._exporter._textures[textureInfo.index];
+        const imageIndex = texture.source;
+        if (imageIndex === undefined) {
+            return;
+        }
+
+        const image = this._exporter._images[imageIndex];
+        const sourceMimeType = image.mimeType || GetMimeType(image.uri!);
+        if (sourceMimeType !== ImageMimeType.AVIF) {
+            return;
+        }
+
+        texture.source = undefined;
+        texture.extensions ||= {};
+        texture.extensions[NAME] = {
+            source: imageIndex,
+        };
+
+        this._wasUsed = true;
+    }
+}
+
+GLTFExporter.RegisterExtension(NAME, (exporter) => new EXT_texture_avif(exporter));

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/EXT_texture_webp.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/EXT_texture_webp.ts
@@ -1,0 +1,58 @@
+/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable babylonjs/available */
+import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
+import { GLTFExporter } from "../glTFExporter";
+import { GetMimeType } from "core/Misc";
+import { ImageMimeType } from "babylonjs-gltf2interface";
+
+const NAME = "EXT_texture_webp";
+
+/**
+ * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_texture_webp/README.md)
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class EXT_texture_webp implements IGLTFExporterExtensionV2 {
+    public readonly name = NAME;
+
+    public enabled = true;
+
+    public required = true;
+
+    private _wasUsed = false;
+
+    public get wasUsed() {
+        return this._wasUsed;
+    }
+
+    private _exporter: GLTFExporter;
+
+    constructor(exporter: GLTFExporter) {
+        this._exporter = exporter;
+    }
+
+    public dispose() {}
+
+    public postExportTexture(_: string, textureInfo: BABYLON.GLTF2.ITextureInfo): void {
+        const texture = this._exporter._textures[textureInfo.index];
+        const imageIndex = texture.source;
+        if (imageIndex === undefined) {
+            return;
+        }
+
+        const image = this._exporter._images[imageIndex];
+        const sourceMimeType = image.mimeType || GetMimeType(image.uri!);
+        if (sourceMimeType !== ImageMimeType.WEBP) {
+            return;
+        }
+
+        texture.source = undefined;
+        texture.extensions ||= {};
+        texture.extensions[NAME] = {
+            source: imageIndex,
+        };
+
+        this._wasUsed = true;
+    }
+}
+
+GLTFExporter.RegisterExtension(NAME, (exporter) => new EXT_texture_webp(exporter));

--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_texture_basisu.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_texture_basisu.ts
@@ -1,0 +1,58 @@
+/* eslint-disable jsdoc/require-jsdoc */
+/* eslint-disable babylonjs/available */
+import type { IGLTFExporterExtensionV2 } from "../glTFExporterExtension";
+import { GLTFExporter } from "../glTFExporter";
+import { GetMimeType } from "core/Misc";
+import { ImageMimeType } from "babylonjs-gltf2interface";
+
+const NAME = "KHR_texture_basisu";
+
+/**
+ * [Specification](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_texture_basisu/README.md)
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export class KHR_texture_basisu implements IGLTFExporterExtensionV2 {
+    public readonly name = NAME;
+
+    public enabled = true;
+
+    public required = true;
+
+    private _wasUsed = false;
+
+    public get wasUsed() {
+        return this._wasUsed;
+    }
+
+    private _exporter: GLTFExporter;
+
+    constructor(exporter: GLTFExporter) {
+        this._exporter = exporter;
+    }
+
+    public dispose() {}
+
+    public postExportTexture(_: string, textureInfo: BABYLON.GLTF2.ITextureInfo): void {
+        const texture = this._exporter._textures[textureInfo.index];
+        const imageIndex = texture.source;
+        if (imageIndex === undefined) {
+            return;
+        }
+
+        const image = this._exporter._images[imageIndex];
+        const sourceMimeType = image.mimeType || GetMimeType(image.uri!);
+        if (sourceMimeType !== ImageMimeType.KTX2) {
+            return;
+        }
+
+        texture.source = undefined;
+        texture.extensions ||= {};
+        texture.extensions[NAME] = {
+            source: imageIndex,
+        };
+
+        this._wasUsed = true;
+    }
+}
+
+GLTFExporter.RegisterExtension(NAME, (exporter) => new KHR_texture_basisu(exporter));

--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -64,6 +64,8 @@ function GetFileExtensionFromMimeType(mimeType: ImageMimeType): string {
             return ".webp";
         case ImageMimeType.AVIF:
             return ".avif";
+        case ImageMimeType.KTX2:
+            return ".ktx2";
     }
 }
 

--- a/packages/dev/serializers/test/integration/glTFSerializer.test.ts
+++ b/packages/dev/serializers/test/integration/glTFSerializer.test.ts
@@ -1,6 +1,7 @@
 import { evaluateDisposeEngine, evaluateCreateScene, evaluateInitEngine, getGlobalConfig, logPageErrors } from "@tools/test-tools";
 import type { IAnimationKey } from "core/Animations/animationKey";
 import { Constants } from "core/Engines";
+import { GetMimeType } from "core/Misc";
 
 declare const BABYLON: typeof import("core/index") &
     typeof import("serializers/index") & {
@@ -689,6 +690,34 @@ describe("Babylon glTF Serializer", () => {
             expect(assertionData.meshes.every((mesh: any) => mesh.primitives[0].attributes.JOINTS_0 === jointAccessor)).toBe(true);
             expect(accessorData.type).toEqual("VEC4");
             expect(accessorData.componentType).toEqual(Constants.UNSIGNED_BYTE);
+        });
+
+        describe("texture image extensions", () => {
+            const testRoundtripImage = async (imageUrl: string, mimeType: string, extensionName: string) => {
+                const assertionData = await page.evaluate(async (imageUrl) => {
+                    const material = new BABYLON.PBRMaterial("mat");
+                    material.albedoTexture = new BABYLON.Texture(imageUrl);
+                    BABYLON.MeshBuilder.CreatePlane("plane").material = material;
+
+                    const glTFData = await BABYLON.GLTF2Export.GLTFAsync(window.scene!, "test");
+                    const jsonString = glTFData.files["test.gltf"] as string;
+                    return JSON.parse(jsonString);
+                }, imageUrl);
+                const imageIndex = assertionData.textures[0].extensions[extensionName].source;
+                const image = assertionData.images[imageIndex];
+                const mime = image.mimeType || GetMimeType(image.uri);
+
+                expect(assertionData.textures).toHaveLength(1);
+                expect(imageIndex).toBeDefined();
+                expect(image).toBeDefined();
+                expect(mime).toEqual(mimeType);
+            };
+            it("uses KHR_texture_basisu to export a KTX2 image", async () => {
+                await testRoundtripImage("textures/ktx2/sample_uastc.ktx2", "image/ktx2", "KHR_texture_basisu");
+            });
+            it("uses EXT_texture_webp to export a WEBP image", async () => {
+                await testRoundtripImage("http://assets.babylonjs.com/meshes/webp/webp_DefaultMaterial_Normal.webp", "image/webp", "EXT_texture_webp");
+            });
         });
     });
 });

--- a/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
+++ b/packages/public/glTF2Interface/babylon.glTF2Interface.d.ts
@@ -145,13 +145,17 @@ declare module BABYLON.GLTF2 {
          */
         PNG = "image/png",
         /**
-         * WEBP Mime-type
+         * WEBP Mime-type, available via KHR_texture_webp
          */
         WEBP = "image/webp",
         /**
-         * AVIF Mime-type
+         * AVIF Mime-type, available via EXT_texture_avif
          */
         AVIF = "image/avif",
+        /**
+         * KTX2 Mime-type, available via KHR_texture_basisu
+         */
+        KTX2 = "image/ktx2",
     }
 
     /**
@@ -813,9 +817,9 @@ declare module BABYLON.GLTF2 {
          */
         sampler?: number;
         /**
-         * The index of the image used by this texture
+         * The index of the image used by this texture. When undefined, an extension or other mechanism should supply an alternate texture source, otherwise behavior is undefined.
          */
-        source: number;
+        source?: number;
     }
 
     /**


### PR DESCRIPTION
Since it's now possible to export .ktx2, .avif, and .webp, this PR brings the rest of the exporter up-to-speed by filling out each image's corresponding glTF extensions and other interfaces.

<details>
<summary>Side note</summary>
I'd factor the extensions out into common parts, but I think it's better to wait to see how some of their full implementations, like ktx2, pan out. 
</details>