### PR TITLE
Inspector v2: Gizmo toolbar

### DIFF
--- a/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
@@ -1,24 +1,42 @@
+import type { MenuButtonProps, MenuCheckedValueChangeData, MenuCheckedValueChangeEvent } from "@fluentui/react-components";
 import type { FunctionComponent } from "react";
 
 import type { IDisposable, Nullable, Scene, TransformNode } from "core/index";
 import type { IGizmoService } from "../services/gizmoService";
 
-import { ToggleButton, Tooltip } from "@fluentui/react-components";
-import { ArrowExpandRegular, ArrowMoveRegular, ArrowRotateClockwiseRegular, SelectObjectRegular } from "@fluentui/react-icons";
+import { makeStyles, Menu, MenuItemRadio, MenuList, MenuPopover, MenuTrigger, SplitButton, ToggleButton, tokens, Tooltip } from "@fluentui/react-components";
+import { ArrowExpandRegular, ArrowMoveRegular, ArrowRotateClockwiseRegular, CubeRegular, MoviesAndTvRegular, SelectObjectRegular } from "@fluentui/react-icons";
+import { Collapse } from "@fluentui/react-motion-components-preview";
 import { useCallback, useEffect, useState } from "react";
 
 import { Bone } from "core/Bones/bone";
 import { Camera } from "core/Cameras/camera";
+import { GizmoCoordinatesMode } from "core/Gizmos/gizmo";
 import { GizmoManager } from "core/Gizmos/gizmoManager";
 import { Light } from "core/Lights/light";
 import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { Node } from "core/node";
+import { useProperty } from "../hooks/compoundPropertyHooks";
 import { useResource } from "../hooks/resourceHooks";
 
 type GizmoMode = "translate" | "rotate" | "scale" | "boundingBox";
 
+const useStyles = makeStyles({
+    coordinatesModeDiv: {
+        display: "flex",
+    },
+    coordinatesModeButton: {
+        margin: `0px ${tokens.spacingVerticalXS}`,
+    },
+    coordinatesModeMenu: {
+        minWidth: 0,
+    },
+});
+
 export const GizmoToolbar: FunctionComponent<{ scene: Scene; entity: unknown; gizmoService: IGizmoService }> = (props) => {
     const { scene, entity, gizmoService } = props;
+
+    const classes = useStyles();
 
     const gizmoManager = useResource(
         useCallback(() => {
@@ -36,6 +54,8 @@ export const GizmoToolbar: FunctionComponent<{ scene: Scene; entity: unknown; gi
             return gizmoManager;
         }, [scene])
     );
+
+    const coordinatesMode = useProperty(gizmoManager, "coordinatesMode");
 
     const [gizmoMode, setGizmoMode] = useState<GizmoMode>();
 
@@ -108,6 +128,14 @@ export const GizmoToolbar: FunctionComponent<{ scene: Scene; entity: unknown; gi
         setGizmoMode((currentMode) => (currentMode === mode ? undefined : mode));
     }, []);
 
+    const onCoordinatesModeChange = useCallback((e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => {
+        gizmoManager.coordinatesMode = Number(data.checkedItems[0]);
+    }, []);
+
+    const toggleCoordinatesMode = useCallback(() => {
+        gizmoManager.coordinatesMode = coordinatesMode === GizmoCoordinatesMode.Local ? GizmoCoordinatesMode.World : GizmoCoordinatesMode.Local;
+    }, [gizmoManager, coordinatesMode]);
+
     return (
         <>
             <Tooltip content="Translate" relationship="label">
@@ -122,6 +150,40 @@ export const GizmoToolbar: FunctionComponent<{ scene: Scene; entity: unknown; gi
             <Tooltip content="Bounding Box" relationship="label">
                 <ToggleButton appearance="subtle" icon={<SelectObjectRegular />} checked={gizmoMode === "boundingBox"} onClick={() => updateGizmoMode("boundingBox")} />
             </Tooltip>
+            <Collapse visible={!!gizmoMode} orientation="horizontal">
+                <div className={classes.coordinatesModeDiv}>
+                    <Menu positioning="below-end" checkedValues={{ coordinatesMode: [coordinatesMode.toString()] }} onCheckedValueChange={onCoordinatesModeChange}>
+                        <MenuTrigger disableButtonEnhancement={true}>
+                            {(triggerProps: MenuButtonProps) => (
+                                <Tooltip content="Coordinates Mode" relationship="label">
+                                    <SplitButton
+                                        className={classes.coordinatesModeButton}
+                                        menuButton={triggerProps}
+                                        primaryActionButton={{
+                                            onClick: toggleCoordinatesMode,
+                                        }}
+                                        size="small"
+                                        appearance="secondary"
+                                        shape="rounded"
+                                        icon={coordinatesMode === GizmoCoordinatesMode.Local ? <CubeRegular /> : <MoviesAndTvRegular />}
+                                    ></SplitButton>
+                                </Tooltip>
+                            )}
+                        </MenuTrigger>
+
+                        <MenuPopover className={classes.coordinatesModeMenu}>
+                            <MenuList>
+                                <MenuItemRadio name="coordinatesMode" value={GizmoCoordinatesMode.Local.toString()}>
+                                    Local
+                                </MenuItemRadio>
+                                <MenuItemRadio name="coordinatesMode" value={GizmoCoordinatesMode.World.toString()}>
+                                    World
+                                </MenuItemRadio>
+                            </MenuList>
+                        </MenuPopover>
+                    </Menu>
+                </div>
+            </Collapse>
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
@@ -1,0 +1,127 @@
+import type { FunctionComponent } from "react";
+
+import type { IDisposable, Nullable, Scene, TransformNode } from "core/index";
+import type { IGizmoService } from "../services/gizmoService";
+
+import { ToggleButton, Tooltip } from "@fluentui/react-components";
+import { ArrowExpandRegular, ArrowMoveRegular, ArrowRotateClockwiseRegular, SelectObjectRegular } from "@fluentui/react-icons";
+import { useCallback, useEffect, useState } from "react";
+
+import { Bone } from "core/Bones/bone";
+import { Camera } from "core/Cameras/camera";
+import { GizmoManager } from "core/Gizmos/gizmoManager";
+import { Light } from "core/Lights/light";
+import { AbstractMesh } from "core/Meshes/abstractMesh";
+import { Node } from "core/node";
+import { useResource } from "../hooks/resourceHooks";
+
+type GizmoMode = "translate" | "rotate" | "scale" | "boundingBox";
+
+export const GizmoToolbar: FunctionComponent<{ scene: Scene; entity: unknown; gizmoService: IGizmoService }> = (props) => {
+    const { scene, entity, gizmoService } = props;
+
+    const gizmoManager = useResource(
+        useCallback(() => {
+            const utilityLayerRef = gizmoService.getUtilityLayer(scene);
+            const keepDepthUtilityLayerRef = gizmoService.getUtilityLayer(scene, "keepDepth");
+            const gizmoManager = new GizmoManager(scene, undefined, utilityLayerRef.value, keepDepthUtilityLayerRef.value);
+
+            const disposeGizmoManager = gizmoManager.dispose.bind(gizmoManager);
+            gizmoManager.dispose = () => {
+                disposeGizmoManager();
+                utilityLayerRef.dispose();
+                keepDepthUtilityLayerRef.dispose();
+            };
+
+            return gizmoManager;
+        }, [scene])
+    );
+
+    const [gizmoMode, setGizmoMode] = useState<GizmoMode>();
+
+    useEffect(() => {
+        let visualizationGizmoRef: Nullable<IDisposable> = null;
+        let resolvedEntity = entity;
+        if (gizmoMode) {
+            if (entity instanceof Camera) {
+                const cameraGizmoRef = gizmoService.getCameraGizmo(entity);
+                visualizationGizmoRef = cameraGizmoRef;
+                resolvedEntity = cameraGizmoRef.value.attachedNode;
+            } else if (entity instanceof Light) {
+                const lightGizmoRef = gizmoService.getLightGizmo(entity);
+                visualizationGizmoRef = lightGizmoRef;
+                resolvedEntity = lightGizmoRef.value.attachedNode;
+            } else if (entity instanceof Bone) {
+                resolvedEntity = entity.getTransformNode() ?? entity;
+            }
+        }
+
+        let resolvedGizmoMode = gizmoMode;
+        if (!resolvedEntity) {
+            resolvedGizmoMode = undefined;
+        } else {
+            if (resolvedGizmoMode === "translate") {
+                if (!(resolvedEntity as TransformNode).position) {
+                    resolvedGizmoMode = undefined;
+                }
+            } else if (resolvedGizmoMode === "rotate") {
+                if (!(resolvedEntity as TransformNode).rotation) {
+                    resolvedGizmoMode = undefined;
+                }
+            } else if (resolvedGizmoMode === "scale") {
+                if (!(resolvedEntity as TransformNode).scaling) {
+                    resolvedGizmoMode = undefined;
+                }
+            } else {
+                if (!(resolvedEntity instanceof AbstractMesh)) {
+                    resolvedGizmoMode = undefined;
+                }
+            }
+        }
+
+        gizmoManager.positionGizmoEnabled = resolvedGizmoMode === "translate";
+        gizmoManager.rotationGizmoEnabled = resolvedGizmoMode === "rotate";
+        gizmoManager.scaleGizmoEnabled = resolvedGizmoMode === "scale";
+        gizmoManager.boundingBoxGizmoEnabled = resolvedGizmoMode === "boundingBox";
+
+        if (gizmoManager.gizmos.boundingBoxGizmo) {
+            gizmoManager.gizmos.boundingBoxGizmo.fixedDragMeshScreenSize = true;
+        }
+
+        if (!resolvedGizmoMode) {
+            gizmoManager.attachToNode(null);
+        } else {
+            if (resolvedEntity instanceof AbstractMesh) {
+                gizmoManager.attachToMesh(resolvedEntity);
+            } else if (resolvedEntity instanceof Node) {
+                gizmoManager.attachToNode(resolvedEntity);
+            }
+        }
+
+        return () => {
+            gizmoManager.attachToNode(null);
+            visualizationGizmoRef?.dispose();
+        };
+    }, [gizmoManager, gizmoMode, entity]);
+
+    const updateGizmoMode = useCallback((mode: GizmoMode) => {
+        setGizmoMode((currentMode) => (currentMode === mode ? undefined : mode));
+    }, []);
+
+    return (
+        <>
+            <Tooltip content="Translate" relationship="label">
+                <ToggleButton appearance="subtle" icon={<ArrowMoveRegular />} checked={gizmoMode === "translate"} onClick={() => updateGizmoMode("translate")} />
+            </Tooltip>
+            <Tooltip content="Rotate" relationship="label">
+                <ToggleButton appearance="subtle" icon={<ArrowRotateClockwiseRegular />} checked={gizmoMode === "rotate"} onClick={() => updateGizmoMode("rotate")} />
+            </Tooltip>
+            <Tooltip content="Scale" relationship="label">
+                <ToggleButton appearance="subtle" icon={<ArrowExpandRegular />} checked={gizmoMode === "scale"} onClick={() => updateGizmoMode("scale")} />
+            </Tooltip>
+            <Tooltip content="Bounding Box" relationship="label">
+                <ToggleButton appearance="subtle" icon={<SelectObjectRegular />} checked={gizmoMode === "boundingBox"} onClick={() => updateGizmoMode("boundingBox")} />
+            </Tooltip>
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles({
         display: "flex",
     },
     coordinatesModeButton: {
-        margin: `0px ${tokens.spacingVerticalXS}`,
+        margin: `0 ${tokens.spacingVerticalXS}`,
     },
     coordinatesModeMenu: {
         minWidth: 0,

--- a/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/compoundPropertyHooks.ts
@@ -38,9 +38,9 @@ export function useVector3Property<TargetT extends object, PropertyKeyT extends 
  */
 export function useVector3Property<TargetT extends object, PropertyKeyT extends PropertyKeys<TargetT, Vector3>>(target: TargetT | null | undefined, propertyKey: PropertyKeyT) {
     const vector = useProperty(target, propertyKey);
-    useProperty(vector as Vector3 | null | undefined, "x");
-    useProperty(vector as Vector3 | null | undefined, "y");
-    useProperty(vector as Vector3 | null | undefined, "z");
+    useProperty(vector as Vector3 | null | undefined, "_x");
+    useProperty(vector as Vector3 | null | undefined, "_y");
+    useProperty(vector as Vector3 | null | undefined, "_z");
     return vector;
 }
 
@@ -102,10 +102,10 @@ export function useQuaternionProperty<TargetT extends object, PropertyKeyT exten
     propertyKey: PropertyKeyT
 ) {
     const quaternion = useProperty(target, propertyKey);
-    useProperty(quaternion as Quaternion | null | undefined, "x");
-    useProperty(quaternion as Quaternion | null | undefined, "y");
-    useProperty(quaternion as Quaternion | null | undefined, "z");
-    useProperty(quaternion as Quaternion | null | undefined, "w");
+    useProperty(quaternion as Quaternion | null | undefined, "_x");
+    useProperty(quaternion as Quaternion | null | undefined, "_y");
+    useProperty(quaternion as Quaternion | null | undefined, "_z");
+    useProperty(quaternion as Quaternion | null | undefined, "_w");
 
     return quaternion;
 }

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -80,7 +80,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
         handleResize: true,
         enablePopup: true,
         isExtensible: true,
-        isThemeable: false,
+        isThemeable: true,
         ...options,
     };
 

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -1,3 +1,6 @@
+import type { IInspectorOptions } from "core/Debug/debugLayer";
+import type { IDisposable, Scene } from "core/scene";
+import type { Nullable } from "core/types";
 import type { ServiceDefinition } from "./modularity/serviceDefinition";
 import type { ModularToolOptions } from "./modularTool";
 import type { ISceneContext } from "./services/sceneContext";
@@ -9,6 +12,8 @@ import { Observable } from "core/Misc/observable";
 import { useEffect, useRef } from "react";
 import { BuiltInsExtensionFeed } from "./extensibility/builtInsExtensionFeed";
 import { MakeModularTool } from "./modularTool";
+import { GizmoServiceDefinition } from "./services/gizmoService";
+import { GizmoToolbarServiceDefinition } from "./services/gizmoToolbarService";
 import { DebugServiceDefinition } from "./services/panes/debugService";
 import { AnimationGroupPropertiesServiceDefinition } from "./services/panes/properties/animationGroupPropertiesService";
 import { AnimationPropertiesServiceDefinition } from "./services/panes/properties/animationPropertiesService";
@@ -18,13 +23,14 @@ import { EffectLayerPropertiesServiceDefinition } from "./services/panes/propert
 import { FrameGraphPropertiesServiceDefinition } from "./services/panes/properties/frameGraphPropertiesService";
 import { LightPropertiesServiceDefinition } from "./services/panes/properties/lightPropertiesServices";
 import { MaterialPropertiesServiceDefinition } from "./services/panes/properties/materialPropertiesService";
-import { NodePropertiesServiceDefinition } from "./services/panes/properties/nodePropertiesService";
 import { MetadataPropertiesServiceDefinition } from "./services/panes/properties/metadataPropertiesService";
+import { NodePropertiesServiceDefinition } from "./services/panes/properties/nodePropertiesService";
 import { ParticleSystemPropertiesServiceDefinition } from "./services/panes/properties/particleSystemPropertiesService";
 import { PhysicsPropertiesServiceDefinition } from "./services/panes/properties/physicsPropertiesService";
 import { PostProcessPropertiesServiceDefinition } from "./services/panes/properties/postProcessPropertiesService";
 import { PropertiesServiceDefinition } from "./services/panes/properties/propertiesService";
 import { RenderingPipelinePropertiesServiceDefinition } from "./services/panes/properties/renderingPipelinePropertiesService";
+import { ScenePropertiesServiceDefinition } from "./services/panes/properties/scenePropertiesService";
 import { SkeletonPropertiesServiceDefinition } from "./services/panes/properties/skeletonPropertiesService";
 import { SpritePropertiesServiceDefinition } from "./services/panes/properties/spritePropertiesService";
 import { TexturePropertiesServiceDefinition } from "./services/panes/properties/texturePropertiesService";
@@ -48,10 +54,6 @@ import { ToolsServiceDefinition } from "./services/panes/toolsService";
 import { SceneContextIdentity } from "./services/sceneContext";
 import { SelectionServiceDefinition } from "./services/selectionService";
 import { ShellServiceIdentity } from "./services/shellService";
-import { ScenePropertiesServiceDefinition } from "./services/panes/properties/scenePropertiesService";
-import type { IDisposable, Scene } from "core/scene";
-import type { Nullable } from "core/types";
-import type { IInspectorOptions } from "core/Debug/debugLayer";
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
@@ -190,6 +192,9 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             // Provides access to the scene in a generic way (other tools might provide a scene in a different way).
             sceneContextServiceDefinition,
 
+            // Helps with managing gizmos and a shared utility layer.
+            GizmoServiceDefinition,
+
             // Scene explorer tab and related services.
             SceneExplorerServiceDefinition,
             NodeExplorerServiceDefinition,
@@ -241,6 +246,9 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
 
             // Tracks entity selection state (e.g. which Mesh or Material or other entity is currently selected in scene explorer and bound to the properties pane, etc.).
             SelectionServiceDefinition,
+
+            // Gizmos for manipulating objects in the scene.
+            GizmoToolbarServiceDefinition,
 
             // Additional services passed in to the Inspector.
             ...(options.serviceDefinitions ?? []),

--- a/packages/dev/inspector-v2/src/services/creationToolsService.tsx
+++ b/packages/dev/inspector-v2/src/services/creationToolsService.tsx
@@ -31,7 +31,6 @@ export const CreationToolsServiceDefinition: ServiceDefinition<[], [IShellServic
             content: () => {
                 const classes = useStyles();
 
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
                 // eslint-disable-next-line no-console
                 console.log(scene);

--- a/packages/dev/inspector-v2/src/services/gizmoService.ts
+++ b/packages/dev/inspector-v2/src/services/gizmoService.ts
@@ -1,0 +1,110 @@
+import type { Camera, Gizmo, IDisposable, Light, Node, Scene } from "core/index";
+import type { IService, ServiceDefinition } from "../modularity/serviceDefinition";
+
+import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
+import { CameraGizmo } from "core/Gizmos/cameraGizmo";
+import { LightGizmo } from "core/Gizmos/lightGizmo";
+import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";
+
+type Reference<T> = {
+    value: T;
+} & IDisposable;
+
+export const GizmoServiceIdentity = Symbol("GizmoService");
+
+export interface IGizmoService extends IService<typeof GizmoServiceIdentity> {
+    getUtilityLayer(scene: Scene, layer?: string): Reference<UtilityLayerRenderer>;
+    getCameraGizmo(camera: Camera): Reference<CameraGizmo>;
+    getLightGizmo(light: Light): Reference<LightGizmo>;
+}
+
+export const GizmoServiceDefinition: ServiceDefinition<[IGizmoService], []> = {
+    friendlyName: "Gizmo Service",
+    produces: [GizmoServiceIdentity],
+    factory: () => {
+        const utilityLayers = new WeakMap<Scene, Map<string, { utilityLayer: UtilityLayerRenderer; refCount: number }>>();
+        const getUtilityLayer = (scene: Scene, layer = "default") => {
+            let utilityLayerInfoForScene = utilityLayers.get(scene);
+            if (!utilityLayerInfoForScene) {
+                utilityLayerInfoForScene = new Map();
+                utilityLayers.set(scene, utilityLayerInfoForScene);
+            }
+            let utilityLayerInfo = utilityLayerInfoForScene.get(layer);
+            if (!utilityLayerInfo) {
+                const utilityLayer = scene.frameGraph ? FrameGraphUtils.CreateUtilityLayerRenderer(scene.frameGraph) : new UtilityLayerRenderer(scene);
+                utilityLayerInfo = { utilityLayer, refCount: 0 };
+                utilityLayerInfoForScene.set(layer, utilityLayerInfo);
+            }
+
+            utilityLayerInfo.refCount++;
+            return {
+                value: utilityLayerInfo.utilityLayer,
+                dispose: () => {
+                    utilityLayerInfo.refCount--;
+                    if (utilityLayerInfo.refCount === 0) {
+                        utilityLayerInfo.utilityLayer.dispose();
+                        utilityLayerInfoForScene.delete(layer);
+                        if (utilityLayerInfoForScene.size === 0) {
+                            utilityLayers.delete(scene);
+                        }
+                    }
+                },
+            } satisfies Reference<UtilityLayerRenderer>;
+        };
+
+        function getGizmo<NodeT extends Node, GizmoT extends Gizmo>(
+            node: NodeT,
+            scene: Scene,
+            gizmoClass: new (...args: ConstructorParameters<typeof Gizmo>) => GizmoT,
+            gizmoMap: WeakMap<NodeT, { gizmo: GizmoT; refCount: number }>,
+            onGizmoCreated: (node: NodeT, gizmo: GizmoT) => void
+        ) {
+            let refCountedGizmo = gizmoMap.get(node);
+
+            if (!refCountedGizmo) {
+                const utilityLayerRef = getUtilityLayer(scene);
+                const gizmo = new gizmoClass(utilityLayerRef.value);
+                onGizmoCreated(node, gizmo);
+                const nodeDisposedObserver = node.onDisposeObservable.addOnce(() => gizmo.dispose());
+                const disposeGizmo = gizmo.dispose.bind(gizmo);
+                gizmo.dispose = () => {
+                    nodeDisposedObserver.remove();
+                    disposeGizmo();
+                    utilityLayerRef.dispose();
+                };
+                refCountedGizmo = { gizmo, refCount: 0 };
+                gizmoMap.set(node, refCountedGizmo);
+                onGizmoCreated(node, gizmo);
+            }
+
+            refCountedGizmo.refCount++;
+
+            let disposed = false;
+            return {
+                value: refCountedGizmo.gizmo,
+                dispose: () => {
+                    if (!disposed) {
+                        disposed = true;
+                        refCountedGizmo.refCount--;
+                        if (refCountedGizmo.refCount === 0) {
+                            refCountedGizmo.gizmo.dispose();
+                            gizmoMap.delete(node);
+                        }
+                    }
+                },
+            } satisfies Reference<GizmoT>;
+        }
+
+        const cameraGizmos = new WeakMap<Camera, { gizmo: CameraGizmo; refCount: number }>();
+        const getCameraGizmo = (camera: Camera) => getGizmo(camera, camera.getScene(), CameraGizmo, cameraGizmos, (camera, gizmo) => (gizmo.camera = camera));
+
+        const lightGizmos = new WeakMap<Light, { gizmo: LightGizmo; refCount: number }>();
+        const getLightGizmo = (light: Light) => getGizmo(light, light.getScene(), LightGizmo, lightGizmos, (light, gizmo) => (gizmo.light = light));
+
+        return {
+            getUtilityLayer,
+            getCameraGizmo,
+            getLightGizmo,
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/services/gizmoToolbarService.tsx
+++ b/packages/dev/inspector-v2/src/services/gizmoToolbarService.tsx
@@ -1,0 +1,30 @@
+import type { ServiceDefinition } from "../modularity/serviceDefinition";
+import type { ISceneContext } from "./sceneContext";
+import type { ISelectionService } from "./selectionService";
+import type { IShellService } from "./shellService";
+import type { IGizmoService } from "./gizmoService";
+
+import { SceneContextIdentity } from "./sceneContext";
+import { SelectionServiceIdentity } from "./selectionService";
+import { ShellServiceIdentity } from "./shellService";
+import { GizmoToolbar } from "../components/gizmoToolbar";
+import { useObservableState } from "../hooks/observableHooks";
+import { GizmoServiceIdentity } from "./gizmoService";
+
+export const GizmoToolbarServiceDefinition: ServiceDefinition<[], [ISceneContext, IShellService, ISelectionService, IGizmoService]> = {
+    friendlyName: "Gizmo Toolbar",
+    consumes: [SceneContextIdentity, ShellServiceIdentity, SelectionServiceIdentity, GizmoServiceIdentity],
+    factory: (sceneContext, shellService, selectionService, gizmoService) => {
+        shellService.addToolbarItem({
+            key: "Test",
+            verticalLocation: "top",
+            horizontalLocation: "left",
+            suppressTeachingMoment: true,
+            component: () => {
+                const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
+                const selectedEntity = useObservableState(() => selectionService.selectedEntity, selectionService.onSelectedEntityChanged);
+                return scene ? <GizmoToolbar scene={scene} entity={selectedEntity} gizmoService={gizmoService} /> : null;
+            },
+        });
+    },
+};

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -1,5 +1,6 @@
-import type { Gizmo, IObserver, Node, Nullable } from "core/index";
+import type { IDisposable, Node, Nullable } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { IGizmoService } from "../../gizmoService";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
@@ -19,23 +20,20 @@ import {
 } from "@fluentui/react-icons";
 
 import { Camera } from "core/Cameras/camera";
-import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
-import { CameraGizmo } from "core/Gizmos/cameraGizmo";
-import { LightGizmo } from "core/Gizmos/lightGizmo";
 import { Light } from "core/Lights/light";
 import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { TransformNode } from "core/Meshes/transformNode";
 import { Observable } from "core/Misc";
-import { UtilityLayerRenderer } from "core/Rendering";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { GizmoServiceIdentity } from "../../gizmoService";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
-export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext, IGizmoService]> = {
     friendlyName: "Node Explorer",
-    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
-    factory: (sceneExplorerService, sceneContext) => {
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity, GizmoServiceIdentity],
+    factory: (sceneExplorerService, sceneContext, gizmoService) => {
         const scene = sceneContext.currentScene;
         if (!scene) {
             return undefined;
@@ -161,66 +159,35 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             },
         });
 
-        let utilityLayer: Nullable<UtilityLayerRenderer> = null;
-        const getOrCreateUtilityLayer = () => {
-            if (!utilityLayer) {
-                utilityLayer = scene.frameGraph ? FrameGraphUtils.CreateUtilityLayerRenderer(scene.frameGraph) : new UtilityLayerRenderer(scene);
-            }
-            return utilityLayer;
-        };
-
-        function addGizmoCommand<NodeT extends Node, GizmoT extends Gizmo>(
-            nodeClass: abstract new (...args: any[]) => NodeT,
-            gizmoClass: new (...args: ConstructorParameters<typeof Gizmo>) => GizmoT,
-            gizmoMap: WeakMap<NodeT, GizmoT>,
-            onGizmoCreated: (node: NodeT, gizmo: GizmoT) => void
-        ) {
+        function addGizmoCommand<NodeT extends Node>(nodeClass: abstract new (...args: any[]) => NodeT, getGizmo: (node: NodeT) => IDisposable) {
             return sceneExplorerService.addCommand({
                 predicate: (entity: unknown): entity is NodeT => entity instanceof nodeClass,
                 getCommand: (node) => {
                     const onChangeObservable = new Observable<void>();
 
-                    const getGizmo = () => {
-                        return gizmoMap.get(node);
-                    };
-
-                    let nodeDisposedObserver: Nullable<IObserver> = null;
-
-                    const disposeGizmo = () => {
-                        const gizmo = getGizmo();
-                        if (gizmo) {
-                            gizmoMap.delete(node);
-                            gizmo.dispose();
-                            nodeDisposedObserver?.remove();
-                            onChangeObservable.notifyObservers();
-                        }
-                    };
-
-                    const createGizmo = () => {
-                        const gizmo = new gizmoClass(getOrCreateUtilityLayer());
-                        onGizmoCreated(node, gizmo);
-                        gizmoMap.set(node, gizmo);
-                        nodeDisposedObserver = node.onDisposeObservable.addOnce(disposeGizmo);
-                        onChangeObservable.notifyObservers();
-                        return gizmo;
-                    };
+                    let gizmo: Nullable<IDisposable> = null;
 
                     return {
                         type: "toggle",
                         get displayName() {
-                            return `Turn ${getGizmo() ? "Off" : "On"} Gizmo`;
+                            return `Turn ${gizmo ? "Off" : "On"} Gizmo`;
                         },
-                        icon: () => (getGizmo() ? <Cone16Filled /> : <Cone16Regular />),
+                        icon: () => (gizmo ? <Cone16Filled /> : <Cone16Regular />),
                         get isEnabled() {
-                            return !!getGizmo();
+                            return !!gizmo;
                         },
                         set isEnabled(enabled: boolean) {
                             if (enabled) {
-                                if (!getGizmo()) {
-                                    createGizmo();
+                                if (!gizmo) {
+                                    gizmo = getGizmo(node);
+                                    onChangeObservable.notifyObservers();
                                 }
                             } else {
-                                disposeGizmo();
+                                if (gizmo) {
+                                    gizmo.dispose();
+                                    gizmo = null;
+                                    onChangeObservable.notifyObservers();
+                                }
                             }
                         },
                         onChange: onChangeObservable,
@@ -232,8 +199,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             });
         }
 
-        const cameraGizmos = new WeakMap<Camera, CameraGizmo>();
-        const cameraGizmoCommandRegistration = addGizmoCommand(Camera, CameraGizmo, cameraGizmos, (camera, gizmo) => (gizmo.camera = camera));
+        const cameraGizmoCommandRegistration = addGizmoCommand(Camera, gizmoService.getCameraGizmo.bind(gizmoService));
 
         const lightEnabledCommandRegistration = sceneExplorerService.addCommand({
             predicate: (entity: unknown): entity is Light => entity instanceof Light,
@@ -255,13 +221,11 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             },
         });
 
-        const lightGizmos = new WeakMap<Light, LightGizmo>();
-        const lightGizmoCommandRegistration = addGizmoCommand(Light, LightGizmo, lightGizmos, (light, gizmo) => (gizmo.light = light));
+        const lightGizmoCommandRegistration = addGizmoCommand(Light, gizmoService.getLightGizmo.bind(gizmoService));
 
         return {
             dispose: () => {
                 sectionRegistration.dispose();
-                utilityLayer?.dispose();
                 abstractMeshVisibilityCommandRegistration.dispose();
                 activeCameraCommandRegistration.dispose();
                 cameraGizmoCommandRegistration.dispose();

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -159,33 +159,33 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             },
         });
 
-        function addGizmoCommand<NodeT extends Node>(nodeClass: abstract new (...args: any[]) => NodeT, getGizmo: (node: NodeT) => IDisposable) {
+        function addGizmoCommand<NodeT extends Node>(nodeClass: abstract new (...args: any[]) => NodeT, getGizmoRef: (node: NodeT) => IDisposable) {
             return sceneExplorerService.addCommand({
                 predicate: (entity: unknown): entity is NodeT => entity instanceof nodeClass,
                 getCommand: (node) => {
                     const onChangeObservable = new Observable<void>();
 
-                    let gizmo: Nullable<IDisposable> = null;
+                    let gizmoRef: Nullable<IDisposable> = null;
 
                     return {
                         type: "toggle",
                         get displayName() {
-                            return `Turn ${gizmo ? "Off" : "On"} Gizmo`;
+                            return `Turn ${gizmoRef ? "Off" : "On"} Gizmo`;
                         },
-                        icon: () => (gizmo ? <Cone16Filled /> : <Cone16Regular />),
+                        icon: () => (gizmoRef ? <Cone16Filled /> : <Cone16Regular />),
                         get isEnabled() {
-                            return !!gizmo;
+                            return !!gizmoRef;
                         },
                         set isEnabled(enabled: boolean) {
                             if (enabled) {
-                                if (!gizmo) {
-                                    gizmo = getGizmo(node);
+                                if (!gizmoRef) {
+                                    gizmoRef = getGizmoRef(node);
                                     onChangeObservable.notifyObservers();
                                 }
                             } else {
-                                if (gizmo) {
-                                    gizmo.dispose();
-                                    gizmo = null;
+                                if (gizmoRef) {
+                                    gizmoRef.dispose();
+                                    gizmoRef = null;
                                     onChangeObservable.notifyObservers();
                                 }
                             }

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -280,6 +280,8 @@ const useStyles = makeStyles({
     tab: {
         paddingTop: tokens.spacingVerticalXS,
         paddingBottom: tokens.spacingVerticalXS,
+        paddingLeft: tokens.spacingHorizontalS,
+        paddingRight: tokens.spacingHorizontalS,
         alignSelf: "center",
     },
     resizer: {
@@ -499,28 +501,30 @@ function usePane(
             <>
                 {paneComponents.length > 0 && (
                     <div className={`${classes.paneTabListDiv} ${alignment === "left" || toolbarMode === "compact" ? classes.paneTabListDivLeft : classes.paneTabListDivRight}`}>
-                        <Divider vertical inset />
                         {/* Only render the tab list if there is more than tab. It's kind of pointless to show a tab list with just one tab. */}
                         {paneComponents.length > 1 && (
-                            <TabList
-                                selectedValue={selectedTab?.key ?? ""}
-                                onTabSelect={(event: SelectTabEvent, data: SelectTabData) => {
-                                    const tab = paneComponents.find((entry) => entry.key === data.value);
-                                    setSelectedTab(tab);
-                                    setCollapsed(false);
-                                }}
-                            >
-                                {paneComponents.map((entry) => (
-                                    <SidePaneTab
-                                        key={entry.key}
-                                        alignment={alignment}
-                                        id={entry.key}
-                                        title={entry.title}
-                                        icon={entry.icon}
-                                        suppressTeachingMoment={entry.suppressTeachingMoment}
-                                    />
-                                ))}
-                            </TabList>
+                            <>
+                                <Divider vertical inset />
+                                <TabList
+                                    selectedValue={selectedTab?.key ?? ""}
+                                    onTabSelect={(event: SelectTabEvent, data: SelectTabData) => {
+                                        const tab = paneComponents.find((entry) => entry.key === data.value);
+                                        setSelectedTab(tab);
+                                        setCollapsed(false);
+                                    }}
+                                >
+                                    {paneComponents.map((entry) => (
+                                        <SidePaneTab
+                                            key={entry.key}
+                                            alignment={alignment}
+                                            id={entry.key}
+                                            title={entry.title}
+                                            icon={entry.icon}
+                                            suppressTeachingMoment={entry.suppressTeachingMoment}
+                                        />
+                                    ))}
+                                </TabList>
+                            </>
                         )}
 
                         {/* When the toolbar mode is "full", we add an extra button that allows the side panes to be collapsed. */}

--- a/packages/dev/inspector-v2/src/services/themeSelectorService.tsx
+++ b/packages/dev/inspector-v2/src/services/themeSelectorService.tsx
@@ -3,17 +3,18 @@ import type { TernaryDarkMode } from "usehooks-ts";
 import type { ServiceDefinition } from "../modularity/serviceDefinition";
 import type { IShellService } from "../services/shellService";
 
-import { makeStyles, Menu, MenuItemRadio, MenuList, MenuPopover, MenuTrigger, SplitButton, Tooltip } from "@fluentui/react-components";
+import { makeStyles, Menu, MenuItemRadio, MenuList, MenuPopover, MenuTrigger, SplitButton, tokens, Tooltip } from "@fluentui/react-components";
 import { WeatherMoonRegular, WeatherSunnyRegular } from "@fluentui/react-icons";
 import { useCallback } from "react";
 import { useTernaryDarkMode } from "usehooks-ts";
 
 import { ShellServiceIdentity } from "../services/shellService";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
-    themeButton: {},
-    themeMenu: {
+    themeButton: {
+        margin: `${tokens.spacingVerticalXXS} 0`,
+    },
+    themeMenuPopover: {
         minWidth: 0,
     },
 });
@@ -59,7 +60,7 @@ export const ThemeSelectorServiceDefinition: ServiceDefinition<[], [IShellServic
                             )}
                         </MenuTrigger>
 
-                        <MenuPopover className={classes.themeMenu}>
+                        <MenuPopover className={classes.themeMenuPopover}>
                             <MenuList>
                                 <MenuItemRadio name="theme" value={"system" satisfies TernaryDarkMode}>
                                     System


### PR DESCRIPTION
This PR adds a gizmo toolbar at the top of the left pane.

<img width="441" height="232" alt="image" src="https://github.com/user-attachments/assets/eba74d2e-1bc8-4e1e-84cb-d28dc015929a" />

<img width="663" height="312" alt="image" src="https://github.com/user-attachments/assets/3b08eac3-a8cd-4f17-9811-daa3ae91eabd" />

- These buttons are in the main toolbar, not attached to the scene node in scene explorer or even the scene explorer pane itself. Talked with @PatrickRyanMS about this before implementing it this way.
- The button to switch between local and world coordinate mode on the gizmos only shows when a gizmo is enabled.
- I factored out some existing code from nodeExplorerService that manages light and camera gizmos as well as a shared utility layer. These are ref counted to make the behavior sane when toggling transform gizmos (toolbar) and visualization gizmos (scene explorer tree item commands).