### PR TITLE
Rendering Engine: Fix blending when blending parameters per target are not supported

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.ts
@@ -210,7 +210,7 @@ export abstract class AbstractEngine {
     /** @internal */
     public _stencilState = new StencilState();
     /** @internal */
-    public _alphaState = new AlphaState();
+    public _alphaState = new AlphaState(false);
     /** @internal */
     public _alphaMode = Array(8).fill(-1);
     /** @internal */

--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -53,6 +53,7 @@ import { Effect } from "../Materials/effect";
 import { _ConcatenateShader, _GetGlobalDefines } from "./abstractEngine.functions";
 import { resetCachedPipeline } from "core/Materials/effect.functions";
 import { HasStencilAspect, IsDepthTexture } from "core/Materials/Textures/textureHelper.functions";
+import { AlphaState } from "../States/alphaCullingState";
 
 /**
  * Keeps track of all the buffer info used in engine.
@@ -627,6 +628,8 @@ export class ThinEngine extends AbstractEngine {
 
         const oesDrawBuffersIndexed = this._gl.getExtension("OES_draw_buffers_indexed");
         this._caps.blendParametersPerTarget = oesDrawBuffersIndexed ? true : false;
+
+        this._alphaState = new AlphaState(this._caps.blendParametersPerTarget);
 
         if (oesDrawBuffersIndexed) {
             this._gl.blendEquationSeparateIndexed = oesDrawBuffersIndexed.blendEquationSeparateiOES.bind(oesDrawBuffersIndexed);

--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -55,6 +55,7 @@ import type { InternalTextureCreationOptions, TextureSize } from "../Materials/T
 import { WebGPUSnapshotRendering } from "./WebGPU/webgpuSnapshotRendering";
 import type { WebGPUDataBuffer } from "../Meshes/WebGPU/webgpuDataBuffer";
 import type { WebGPURenderTargetWrapper } from "./WebGPU/webgpuRenderTargetWrapper";
+import { AlphaState } from "../States/alphaCullingState";
 
 import "../Buffers/buffer.align";
 
@@ -947,6 +948,8 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             _checkNonFloatVertexBuffersDontRecreatePipelineContext: true,
             _collectUbosUpdatedInFrame: false,
         };
+
+        this._alphaState = new AlphaState(this._caps.blendParametersPerTarget);
     }
 
     private _initializeContextAndSwapChain(): void {

--- a/packages/dev/core/src/States/alphaCullingState.ts
+++ b/packages/dev/core/src/States/alphaCullingState.ts
@@ -19,8 +19,9 @@ export class AlphaState {
 
     /**
      * Initializes the state.
+     * @param _supportBlendParametersPerTarget - Whether blend parameters per target is supported
      */
-    public constructor() {
+    public constructor(private _supportBlendParametersPerTarget: boolean) {
         this.reset();
     }
 
@@ -117,7 +118,7 @@ export class AlphaState {
 
         // Alpha blend
         if (this._isAlphaBlendDirty) {
-            if (numTargets === 1) {
+            if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
                 if (this._alphaBlend[0]) {
                     gl.enable(gl.BLEND);
                 } else {
@@ -140,7 +141,7 @@ export class AlphaState {
 
         // Alpha function
         if (this._isBlendFunctionParametersDirty) {
-            if (numTargets === 1) {
+            if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
                 gl.blendFuncSeparate(
                     <number>this._blendFunctionParameters[0],
                     <number>this._blendFunctionParameters[1],
@@ -165,7 +166,7 @@ export class AlphaState {
 
         // Alpha equation
         if (this._isBlendEquationParametersDirty) {
-            if (numTargets === 1) {
+            if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
                 gl.blendEquationSeparate(<number>this._blendEquationParameters[0], <number>this._blendEquationParameters[1]);
             } else {
                 const gl2 = gl as WebGL2RenderingContext;

--- a/packages/dev/core/src/States/alphaCullingState.ts
+++ b/packages/dev/core/src/States/alphaCullingState.ts
@@ -116,23 +116,51 @@ export class AlphaState {
             return;
         }
 
-        // Alpha blend
-        if (this._isAlphaBlendDirty) {
-            if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
+        // Constants
+        if (this._isBlendConstantsDirty) {
+            gl.blendColor(<number>this._blendConstants[0], <number>this._blendConstants[1], <number>this._blendConstants[2], <number>this._blendConstants[3]);
+            this._isBlendConstantsDirty = false;
+        }
+
+        if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
+            // Single target or no support for per-target parameters
+            if (this._isAlphaBlendDirty) {
                 if (this._alphaBlend[0]) {
                     gl.enable(gl.BLEND);
                 } else {
                     gl.disable(gl.BLEND);
                 }
-            } else {
-                const gl2 = gl as WebGL2RenderingContext;
-                for (let i = 0; i < numTargets; i++) {
-                    const index = i < this._numTargetEnabled ? i : 0;
-                    if (this._alphaBlend[index]) {
-                        gl2.enableIndexed(gl.BLEND, i);
-                    } else {
-                        gl2.disableIndexed(gl.BLEND, i);
-                    }
+                this._isAlphaBlendDirty = false;
+            }
+
+            if (this._isBlendFunctionParametersDirty) {
+                gl.blendFuncSeparate(
+                    <number>this._blendFunctionParameters[0],
+                    <number>this._blendFunctionParameters[1],
+                    <number>this._blendFunctionParameters[2],
+                    <number>this._blendFunctionParameters[3]
+                );
+                this._isBlendFunctionParametersDirty = false;
+            }
+
+            if (this._isBlendEquationParametersDirty) {
+                gl.blendEquationSeparate(<number>this._blendEquationParameters[0], <number>this._blendEquationParameters[1]);
+                this._isBlendEquationParametersDirty = false;
+            }
+            return;
+        }
+
+        // Multi-target
+        const gl2 = gl as WebGL2RenderingContext;
+
+        // Alpha blend
+        if (this._isAlphaBlendDirty) {
+            for (let i = 0; i < numTargets; i++) {
+                const index = i < this._numTargetEnabled ? i : 0;
+                if (this._alphaBlend[index]) {
+                    gl2.enableIndexed(gl.BLEND, i);
+                } else {
+                    gl2.disableIndexed(gl.BLEND, i);
                 }
             }
 
@@ -141,47 +169,26 @@ export class AlphaState {
 
         // Alpha function
         if (this._isBlendFunctionParametersDirty) {
-            if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
-                gl.blendFuncSeparate(
-                    <number>this._blendFunctionParameters[0],
-                    <number>this._blendFunctionParameters[1],
-                    <number>this._blendFunctionParameters[2],
-                    <number>this._blendFunctionParameters[3]
+            for (let i = 0; i < numTargets; i++) {
+                const offset = i < this._numTargetEnabled ? i * 4 : 0;
+                gl2.blendFuncSeparateIndexed(
+                    i,
+                    <number>this._blendFunctionParameters[offset + 0],
+                    <number>this._blendFunctionParameters[offset + 1],
+                    <number>this._blendFunctionParameters[offset + 2],
+                    <number>this._blendFunctionParameters[offset + 3]
                 );
-            } else {
-                const gl2 = gl as WebGL2RenderingContext;
-                for (let i = 0; i < numTargets; i++) {
-                    const offset = i < this._numTargetEnabled ? i * 4 : 0;
-                    gl2.blendFuncSeparateIndexed(
-                        i,
-                        <number>this._blendFunctionParameters[offset + 0],
-                        <number>this._blendFunctionParameters[offset + 1],
-                        <number>this._blendFunctionParameters[offset + 2],
-                        <number>this._blendFunctionParameters[offset + 3]
-                    );
-                }
             }
             this._isBlendFunctionParametersDirty = false;
         }
 
         // Alpha equation
         if (this._isBlendEquationParametersDirty) {
-            if (numTargets === 1 || !this._supportBlendParametersPerTarget) {
-                gl.blendEquationSeparate(<number>this._blendEquationParameters[0], <number>this._blendEquationParameters[1]);
-            } else {
-                const gl2 = gl as WebGL2RenderingContext;
-                for (let i = 0; i < numTargets; i++) {
-                    const offset = i < this._numTargetEnabled ? i * 2 : 0;
-                    gl2.blendEquationSeparateIndexed(i, <number>this._blendEquationParameters[offset + 0], <number>this._blendEquationParameters[offset + 1]);
-                }
+            for (let i = 0; i < numTargets; i++) {
+                const offset = i < this._numTargetEnabled ? i * 2 : 0;
+                gl2.blendEquationSeparateIndexed(i, <number>this._blendEquationParameters[offset + 0], <number>this._blendEquationParameters[offset + 1]);
             }
             this._isBlendEquationParametersDirty = false;
-        }
-
-        // Constants
-        if (this._isBlendConstantsDirty) {
-            gl.blendColor(<number>this._blendConstants[0], <number>this._blendConstants[1], <number>this._blendConstants[2], <number>this._blendConstants[3]);
-            this._isBlendConstantsDirty = false;
         }
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/possible-incompatibility-between-order-independent-transparency-and-transparent-gridmaterial/60163/12