### PR TITLE
Inspector v2: Picking toolbar

### DIFF
--- a/packages/dev/core/src/Gizmos/cameraGizmo.ts
+++ b/packages/dev/core/src/Gizmos/cameraGizmo.ts
@@ -67,10 +67,10 @@ export class CameraGizmo extends Gizmo implements ICameraGizmo {
             }
 
             this._isHovered = !!(pointerInfo.pickInfo && this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
-            if (this._isHovered && pointerInfo.event.button === 0) {
+            if (this._isHovered && pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.button === 0) {
                 this.onClickedObservable.notifyObservers(this._camera);
             }
-        }, PointerEventTypes.POINTERDOWN);
+        });
     }
     protected _camera: Nullable<Camera> = null;
 

--- a/packages/dev/core/src/Gizmos/lightGizmo.ts
+++ b/packages/dev/core/src/Gizmos/lightGizmo.ts
@@ -70,10 +70,10 @@ export class LightGizmo extends Gizmo implements ILightGizmo {
             }
 
             this._isHovered = !!(pointerInfo.pickInfo && this._rootMesh.getChildMeshes().indexOf(<Mesh>pointerInfo.pickInfo.pickedMesh) != -1);
-            if (this._isHovered && pointerInfo.event.button === 0) {
+            if (this._isHovered && pointerInfo.type === PointerEventTypes.POINTERDOWN && pointerInfo.event.button === 0) {
                 this.onClickedObservable.notifyObservers(this._light);
             }
-        }, PointerEventTypes.POINTERDOWN);
+        });
     }
     protected _light: Nullable<Light> = null;
 

--- a/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
@@ -1,0 +1,107 @@
+import type { FunctionComponent } from "react";
+
+import type { AbstractMesh, IMeshDataCache, Scene } from "core/index";
+import type { IGizmoService } from "../services/gizmoService";
+
+import { TargetRegular } from "@fluentui/react-icons";
+import { useEffect, useMemo, useState } from "react";
+
+import { PointerEventTypes } from "core/Events/pointerEvents";
+import { ToggleButton } from "shared-ui-components/fluent/primitives/toggleButton";
+
+export const PickingToolbar: FunctionComponent<{ scene: Scene; selectEntity: (entity: unknown) => void; gizmoService: IGizmoService }> = (props) => {
+    const { scene, selectEntity, gizmoService } = props;
+
+    const meshDataCache = useMemo(() => new WeakMap<AbstractMesh, IMeshDataCache>(), [scene]);
+    // Not sure why changing the cursor on the canvas itself doesn't work, so change it on the parent.
+    const sceneElement = scene.getEngine().getRenderingCanvas()?.parentElement;
+
+    const [pickingEnabled, setPickingEnabled] = useState(false);
+
+    useEffect(() => {
+        if (pickingEnabled && sceneElement) {
+            const originalCursor = getComputedStyle(sceneElement).cursor;
+            sceneElement.style.cursor = "crosshair";
+
+            const pointerObserver = scene.onPrePointerObservable.add(() => {
+                let pickedEntity: unknown = null;
+
+                // Check camera gizmos.
+                if (!pickedEntity) {
+                    for (const cameraGizmo of gizmoService.getCameraGizmos(scene)) {
+                        if (cameraGizmo.isHovered) {
+                            pickedEntity = cameraGizmo.camera;
+                        }
+                    }
+                }
+
+                // Check light gizmos.
+                if (!pickedEntity) {
+                    for (const lightGizmo of gizmoService.getLightGizmos(scene)) {
+                        if (lightGizmo.isHovered) {
+                            pickedEntity = lightGizmo.light;
+                        }
+                    }
+                }
+
+                // Check the main scene.
+                if (!pickedEntity) {
+                    // Refresh bounding info to ensure morph target and skeletal animations are taken into account.
+                    for (const mesh of scene.meshes) {
+                        let cache = meshDataCache.get(mesh);
+                        if (!cache) {
+                            cache = {};
+                            meshDataCache.set(mesh, cache);
+                        }
+                        mesh.refreshBoundingInfo({ applyMorph: true, applySkeleton: true, cache });
+                    }
+
+                    const pickingInfo = scene.pick(
+                        scene.unTranslatedPointer.x,
+                        scene.unTranslatedPointer.y,
+                        (mesh) => mesh.isEnabled() && mesh.isVisible && mesh.getTotalVertices() > 0,
+                        false,
+                        undefined,
+                        undefined
+                    );
+
+                    pickedEntity = pickingInfo.pickedMesh;
+                }
+
+                // If an entity was picked, select it.
+                if (pickedEntity) {
+                    selectEntity(pickedEntity);
+                }
+            }, PointerEventTypes.POINTERTAP);
+
+            // Exit picking mode if the escape key is pressed.
+            const handleKeyDown = (e: KeyboardEvent) => {
+                if (e.key === "Escape") {
+                    setPickingEnabled(false);
+                }
+            };
+            document.addEventListener("keydown", handleKeyDown);
+
+            return () => {
+                sceneElement.style.cursor = originalCursor;
+                pointerObserver.remove();
+                document.removeEventListener("keydown", handleKeyDown);
+            };
+        }
+
+        return () => {
+            /* No-op */
+        };
+    }, [pickingEnabled, sceneElement]);
+
+    return (
+        sceneElement && (
+            <ToggleButton
+                title={`${pickingEnabled ? "Disable" : "Enable"} Picking`}
+                enabledIcon={TargetRegular}
+                value={pickingEnabled}
+                onChange={() => setPickingEnabled((prev) => !prev)}
+            />
+        )
+    );
+};

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -51,6 +51,7 @@ import { TextureExplorerServiceDefinition } from "./services/panes/scene/texture
 import { SettingsServiceDefinition } from "./services/panes/settingsService";
 import { StatsServiceDefinition } from "./services/panes/statsService";
 import { ToolsServiceDefinition } from "./services/panes/toolsService";
+import { PickingServiceDefinition } from "./services/pickingService";
 import { SceneContextIdentity } from "./services/sceneContext";
 import { SelectionServiceDefinition } from "./services/selectionService";
 import { ShellServiceIdentity } from "./services/shellService";
@@ -249,6 +250,9 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
 
             // Gizmos for manipulating objects in the scene.
             GizmoToolbarServiceDefinition,
+
+            // Allows picking objects from the scene to select them.
+            PickingServiceDefinition,
 
             // Additional services passed in to the Inspector.
             ...(options.serviceDefinitions ?? []),

--- a/packages/dev/inspector-v2/src/services/gizmoService.ts
+++ b/packages/dev/inspector-v2/src/services/gizmoService.ts
@@ -16,6 +16,8 @@ export interface IGizmoService extends IService<typeof GizmoServiceIdentity> {
     getUtilityLayer(scene: Scene, layer?: string): Reference<UtilityLayerRenderer>;
     getCameraGizmo(camera: Camera): Reference<CameraGizmo>;
     getLightGizmo(light: Light): Reference<LightGizmo>;
+    getCameraGizmos(scene: Scene): readonly CameraGizmo[];
+    getLightGizmos(scene: Scene): readonly LightGizmo[];
 }
 
 export const GizmoServiceDefinition: ServiceDefinition<[IGizmoService], []> = {
@@ -110,6 +112,8 @@ export const GizmoServiceDefinition: ServiceDefinition<[IGizmoService], []> = {
             getUtilityLayer,
             getCameraGizmo,
             getLightGizmo,
+            getCameraGizmos: (scene) => scene.cameras.map((camera) => cameraGizmos.get(camera)?.gizmo).filter(Boolean) as readonly CameraGizmo[],
+            getLightGizmos: (scene) => scene.lights.map((light) => lightGizmos.get(light)?.gizmo).filter(Boolean) as readonly LightGizmo[],
         };
     },
 };

--- a/packages/dev/inspector-v2/src/services/pickingService.tsx
+++ b/packages/dev/inspector-v2/src/services/pickingService.tsx
@@ -1,0 +1,31 @@
+import type { ServiceDefinition } from "../modularity/serviceDefinition";
+import type { IGizmoService } from "./gizmoService";
+import type { ISceneContext } from "./sceneContext";
+import type { ISelectionService } from "./selectionService";
+import type { IShellService } from "./shellService";
+
+import { useCallback } from "react";
+import { PickingToolbar } from "../components/pickingToolbar";
+import { useObservableState } from "../hooks/observableHooks";
+import { GizmoServiceIdentity } from "./gizmoService";
+import { SceneContextIdentity } from "./sceneContext";
+import { SelectionServiceIdentity } from "./selectionService";
+import { ShellServiceIdentity } from "./shellService";
+
+export const PickingServiceDefinition: ServiceDefinition<[], [ISceneContext, IShellService, ISelectionService, IGizmoService]> = {
+    friendlyName: "Picking Service",
+    consumes: [SceneContextIdentity, ShellServiceIdentity, SelectionServiceIdentity, GizmoServiceIdentity],
+    factory: (sceneContext, shellService, selectionService, gizmoService) => {
+        shellService.addToolbarItem({
+            key: "Picking Service",
+            verticalLocation: "top",
+            horizontalLocation: "left",
+            suppressTeachingMoment: true,
+            component: () => {
+                const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
+                const selectEntity = useCallback((entity: unknown) => (selectionService.selectedEntity = entity), []);
+                return scene ? <PickingToolbar scene={scene} selectEntity={selectEntity} gizmoService={gizmoService} /> : null;
+            },
+        });
+    },
+};

--- a/packages/dev/inspector-v2/src/services/pickingService.tsx
+++ b/packages/dev/inspector-v2/src/services/pickingService.tsx
@@ -2,6 +2,7 @@ import type { ServiceDefinition } from "../modularity/serviceDefinition";
 import type { IGizmoService } from "./gizmoService";
 import type { ISceneContext } from "./sceneContext";
 import type { ISelectionService } from "./selectionService";
+import type { ISettingsContext } from "./settingsContext";
 import type { IShellService } from "./shellService";
 
 import { useCallback } from "react";
@@ -10,12 +11,13 @@ import { useObservableState } from "../hooks/observableHooks";
 import { GizmoServiceIdentity } from "./gizmoService";
 import { SceneContextIdentity } from "./sceneContext";
 import { SelectionServiceIdentity } from "./selectionService";
+import { SettingsContextIdentity } from "./settingsContext";
 import { ShellServiceIdentity } from "./shellService";
 
-export const PickingServiceDefinition: ServiceDefinition<[], [ISceneContext, IShellService, ISelectionService, IGizmoService]> = {
+export const PickingServiceDefinition: ServiceDefinition<[], [ISceneContext, IShellService, ISelectionService, IGizmoService, ISettingsContext]> = {
     friendlyName: "Picking Service",
-    consumes: [SceneContextIdentity, ShellServiceIdentity, SelectionServiceIdentity, GizmoServiceIdentity],
-    factory: (sceneContext, shellService, selectionService, gizmoService) => {
+    consumes: [SceneContextIdentity, ShellServiceIdentity, SelectionServiceIdentity, GizmoServiceIdentity, SettingsContextIdentity],
+    factory: (sceneContext, shellService, selectionService, gizmoService, settingsContext) => {
         shellService.addToolbarItem({
             key: "Picking Service",
             verticalLocation: "top",
@@ -24,7 +26,8 @@ export const PickingServiceDefinition: ServiceDefinition<[], [ISceneContext, ISh
             component: () => {
                 const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
                 const selectEntity = useCallback((entity: unknown) => (selectionService.selectedEntity = entity), []);
-                return scene ? <PickingToolbar scene={scene} selectEntity={selectEntity} gizmoService={gizmoService} /> : null;
+                const ignoreBackfacesForPicking = useObservableState(() => settingsContext.ignoreBackfacesForPicking, settingsContext.settingsChangedObservable);
+                return scene ? <PickingToolbar scene={scene} selectEntity={selectEntity} gizmoService={gizmoService} ignoreBackfaces={ignoreBackfacesForPicking} /> : null;
             },
         });
     },


### PR DESCRIPTION
This PR adds a picking button to the toolbar for picking objects from the scene.

<img width="406" height="189" alt="image" src="https://github.com/user-attachments/assets/324bdb17-6340-410e-9ebc-d2eedc73c2ea" />

The picking logic is similar to inspector v1, but fixes a handful of bugs as well.
- Picking gizmos doesn't work in v1, at least not in any way I expect it to as a user or looking at the existing code. It works in v2.
- Picking meshes with morph target or skeletal animations does not work in v1. It works in v2.

The picking logic also uses the "Ignore Backfaces for Picking" setting that @deltakosh already added to the settings pane.

<img width="396" height="161" alt="image" src="https://github.com/user-attachments/assets/ffbd1542-1099-4705-8734-1fdf64b20957" />

Other changes:
- Fixed a bug that was [introduced 5 years ago](https://github.com/BabylonJS/Babylon.js/pull/8853/files) where the `isHovered` state on a gizmo is only updated on pointer click, not on pointer move, which means if you click on it, it just stays in the "hovered" state indefinitely.