### PR TITLE
Revert "KTX2Decoder: Use user options over defaults (#17061)"

### DIFF
--- a/packages/tools/ktx2Decoder/src/ktx2Decoder.ts
+++ b/packages/tools/ktx2Decoder/src/ktx2Decoder.ts
@@ -43,7 +43,7 @@ export class KTX2Decoder {
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public async decode(data: Uint8Array, caps: KTX2.ICompressedFormatCapabilities, options?: KTX2.IKTX2DecoderOptions): Promise<KTX2.IDecodedData> {
-        const finalOptions = { ...KTX2Decoder.DefaultDecoderOptions, ...options };
+        const finalOptions = { ...options, ...KTX2Decoder.DefaultDecoderOptions };
 
         const kfr = new KTX2FileReader(data);
 


### PR DESCRIPTION
This reverts #17061.

Will follow-up later, but essentially, the defaults are currently intended to take precedence over options.