### PR TITLE
Quaternion docs: Update PG link

### DIFF
--- a/packages/dev/core/src/Maths/math.vector.ts
+++ b/packages/dev/core/src/Maths/math.vector.ts
@@ -5658,7 +5658,7 @@ export class Quaternion implements Tensor<Tuple<number, 4>, Quaternion>, IQuater
 
     /**
      * Creates a new rotation from the given Euler float angles (y, x, z) and stores it in the target quaternion
-     * Example Playground https://playground.babylonjs.com/#L49EJ7#78
+     * Example Playground https://playground.babylonjs.com/#L49EJ7#561
      * @param yaw defines the rotation around Y axis
      * @param pitch defines the rotation around X axis
      * @param roll defines the rotation around Z axis


### PR DESCRIPTION
`position` vectors are now shared internally since early 7.0, so the PG was broken.