### PR TITLE
Viewer: Fix perf issue with hotspots

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1355,6 +1355,27 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
     public abstract copyVerticesData(kind: string, vertexData: { [kind: string]: Float32Array }): void;
 
     /**
+     * Returns the mesh VertexBuffer object from the requested `kind`
+     * @param kind defines which buffer to read from (positions, indices, normals, etc). Possible `kind` values :
+     * - VertexBuffer.PositionKind
+     * - VertexBuffer.NormalKind
+     * - VertexBuffer.UVKind
+     * - VertexBuffer.UV2Kind
+     * - VertexBuffer.UV3Kind
+     * - VertexBuffer.UV4Kind
+     * - VertexBuffer.UV5Kind
+     * - VertexBuffer.UV6Kind
+     * - VertexBuffer.ColorKind
+     * - VertexBuffer.MatricesIndicesKind
+     * - VertexBuffer.MatricesIndicesExtraKind
+     * - VertexBuffer.MatricesWeightsKind
+     * - VertexBuffer.MatricesWeightsExtraKind
+     * @param bypassInstanceData defines a boolean indicating that the function should not take into account the instance data (applies only if the mesh has instances). Default: false
+     * @returns a FloatArray or null if the mesh has no vertex buffer for this kind.
+     */
+    public abstract getVertexBuffer(kind: string, bypassInstanceData?: boolean): Nullable<VertexBuffer>;
+
+    /**
      * Sets the vertex data of the mesh geometry for the requested `kind`.
      * If the mesh has no geometry, a new Geometry object is set to the mesh and then passed this vertex data.
      * Note that a new underlying VertexBuffer object is created each call.

--- a/packages/dev/core/src/Meshes/instancedMesh.ts
+++ b/packages/dev/core/src/Meshes/instancedMesh.ts
@@ -246,6 +246,10 @@ export class InstancedMesh extends AbstractMesh {
         this._sourceMesh.copyVerticesData(kind, vertexData);
     }
 
+    public override getVertexBuffer(kind: string, bypassInstanceData?: boolean): Nullable<VertexBuffer> {
+        return this._sourceMesh.getVertexBuffer(kind, bypassInstanceData);
+    }
+
     /**
      * Sets the vertex data of the mesh geometry for the requested `kind`.
      * If the mesh has no geometry, a new Geometry object is set to the mesh and then passed this vertex data.

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1260,26 +1260,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
     }
 
-    /**
-     * Returns the mesh VertexBuffer object from the requested `kind`
-     * @param kind defines which buffer to read from (positions, indices, normals, etc). Possible `kind` values :
-     * - VertexBuffer.PositionKind
-     * - VertexBuffer.NormalKind
-     * - VertexBuffer.UVKind
-     * - VertexBuffer.UV2Kind
-     * - VertexBuffer.UV3Kind
-     * - VertexBuffer.UV4Kind
-     * - VertexBuffer.UV5Kind
-     * - VertexBuffer.UV6Kind
-     * - VertexBuffer.ColorKind
-     * - VertexBuffer.MatricesIndicesKind
-     * - VertexBuffer.MatricesIndicesExtraKind
-     * - VertexBuffer.MatricesWeightsKind
-     * - VertexBuffer.MatricesWeightsExtraKind
-     * @param bypassInstanceData defines a boolean indicating that the function should not take into account the instance data (applies only if the mesh has instances). Default: false
-     * @returns a FloatArray or null if the mesh has no vertex buffer for this kind.
-     */
-    public getVertexBuffer(kind: string, bypassInstanceData?: boolean): Nullable<VertexBuffer> {
+    public override getVertexBuffer(kind: string, bypassInstanceData?: boolean): Nullable<VertexBuffer> {
         if (!this._geometry) {
             return null;
         }

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_variants.ts
@@ -87,7 +87,7 @@ export class KHR_materials_variants implements IGLTFLoaderExtension {
      */
     constructor(loader: GLTFLoader) {
         this._loader = loader;
-        this.enabled = this._loader.isExtensionUsed(NAME);
+        this.enabled = this._loader.isExtensionUsed(NAME) && !this._loader.parent.skipMaterials;
     }
 
     /** @internal */


### PR DESCRIPTION
This change mainly switches from using getVerticesData to getVertexBuffer+EnumerateFloatData to drastically reduce the cost of querying hotspots (about a 266x improvement from my measurements). The issue with getVerticesData is that it makes copies of large buffers, and we were doing this three times per hotspot (one for each point of the triangle). On the other hand, getVertexBuffer just accesses the existing buffer without copying, and EnumerateFloatData basically gives us an easy way to index into that buffer to get just the data subset corresponding to a single element.

So previously it only took about 15 hotspots to use up the entire 16ms frame time on my desktop machine. With the new approach, it takes about 60 microseconds to query 15 hotspots. If needed, we could possibly further improve this in the future by adding caching, but if this is fast enough then it is also more robust since it would work correctly when the hotspot definition changes (e.g. indices for the position buffer) or the position buffers themselves.