### PR TITLE
Adding support for the player to take a json object

### DIFF
--- a/packages/dev/lottiePlayer/src/index.ts
+++ b/packages/dev/lottiePlayer/src/index.ts
@@ -2,3 +2,4 @@
 export { AnimationConfiguration } from "./animationConfiguration";
 export { Player } from "./player";
 export { LocalPlayer } from "./localPlayer";
+export { RawLottieAnimation } from "./parsing/rawTypes";

--- a/packages/dev/lottiePlayer/src/localPlayer.ts
+++ b/packages/dev/lottiePlayer/src/localPlayer.ts
@@ -1,6 +1,6 @@
 import type { AnimationConfiguration } from "./animationConfiguration";
-import { DefaultConfiguration } from "./animationConfiguration";
 import type { RawLottieAnimation } from "./parsing/rawTypes";
+import { DefaultConfiguration } from "./animationConfiguration";
 import { GetRawAnimationDataAsync } from "./parsing/parser";
 import { AnimationController, CalculateScaleFactor } from "./rendering/animationController";
 
@@ -11,7 +11,7 @@ import { AnimationController, CalculateScaleFactor } from "./rendering/animation
  */
 export class LocalPlayer {
     private readonly _container: HTMLDivElement;
-    private readonly _animationFile: string;
+    private readonly _animationSource: string | RawLottieAnimation;
     private readonly _variables: Map<string, string>;
     private readonly _configuration: Partial<AnimationConfiguration>;
 
@@ -26,13 +26,13 @@ export class LocalPlayer {
     /**
      * Creates a new instance of the LottiePlayer.
      * @param container The HTMLDivElement to create the canvas in and render the animation on.
-     * @param animationFile The URL of the Lottie animation file to be played.
+     * @param animationSource The URL of the Lottie animation file to be played, or a parsed Lottie JSON object.
      * @param variables Optional map of variables to replace in the animation file.
      * @param configuration Optional configuration object to customize the animation playback.
      */
-    public constructor(container: HTMLDivElement, animationFile: string, variables?: Map<string, string>, configuration?: Partial<AnimationConfiguration>) {
+    public constructor(container: HTMLDivElement, animationSource: string | RawLottieAnimation, variables?: Map<string, string>, configuration?: Partial<AnimationConfiguration>) {
         this._container = container;
-        this._animationFile = animationFile;
+        this._animationSource = animationSource;
         this._variables = variables ?? new Map<string, string>();
         this._configuration = configuration ?? {};
     }
@@ -46,7 +46,12 @@ export class LocalPlayer {
             return false;
         }
 
-        this._rawAnimation = await GetRawAnimationDataAsync(this._animationFile);
+        // Load the animation from URL or use the provided parsed JSON
+        if (typeof this._animationSource === "string") {
+            this._rawAnimation = await GetRawAnimationDataAsync(this._animationSource);
+        } else {
+            this._rawAnimation = this._animationSource;
+        }
 
         // Create the canvas element
         this._canvas = document.createElement("canvas");

--- a/packages/dev/lottiePlayer/src/messageTypes.ts
+++ b/packages/dev/lottiePlayer/src/messageTypes.ts
@@ -1,5 +1,6 @@
 import type { Nullable } from "core/types";
 import type { AnimationConfiguration } from "./animationConfiguration";
+import type { RawLottieAnimation } from "./parsing/rawTypes";
 
 /**
  * Generic type representing a message sent between the main thread and the worker.
@@ -79,6 +80,8 @@ export type StartAnimationMessagePayload = {
     variables: Nullable<Map<string, string>>;
     /** Optional configuration object to customize the animation playback. */
     configuration: Nullable<Partial<AnimationConfiguration>>;
+    /** The parsed lottie animation if it is available */
+    animationData?: RawLottieAnimation;
 };
 
 /** Payload for the "containerResize" message type */

--- a/packages/dev/lottiePlayer/src/worker.ts
+++ b/packages/dev/lottiePlayer/src/worker.ts
@@ -38,13 +38,13 @@ onmessage = async function (evt) {
             break;
         }
         case "startAnimation": {
-            if (RawAnimation === null) {
-                return;
+            if (AnimationPromises === null) {
+                AnimationPromises = Promise.all([import("./animationConfiguration"), import("./rendering/animationController")]);
             }
 
-            const payload = message.payload as StartAnimationMessagePayload;
             const [{ DefaultConfiguration }, { AnimationController }] = await AnimationPromises;
 
+            const payload = message.payload as StartAnimationMessagePayload;
             const canvas = payload.canvas;
             const scaleFactor = payload.scaleFactor;
             const variables = payload.variables ?? new Map<string, string>();
@@ -53,6 +53,14 @@ onmessage = async function (evt) {
                 ...DefaultConfiguration,
                 ...originalConfig,
             };
+
+            if (RawAnimation === null && payload.animationData) {
+                RawAnimation = payload.animationData;
+            }
+
+            if (RawAnimation === null) {
+                return;
+            }
 
             Controller = new AnimationController(canvas, RawAnimation, scaleFactor, variables, finalConfig);
             Controller.playAnimation();

--- a/packages/tools/devHost/src/lottie/main.ts
+++ b/packages/tools/devHost/src/lottie/main.ts
@@ -1,7 +1,7 @@
 import type { AnimationConfiguration } from "lottie-player/animationConfiguration";
+import type { RawLottieAnimation } from "lottie-player/parsing/rawTypes";
 import { Player } from "lottie-player/player";
 import { LocalPlayer } from "lottie-player/localPlayer";
-import type { RawLottieAnimation } from "lottie-player/parsing/rawTypes";
 
 /** Main entry point for the default scene for lottie-player */
 export async function Main(): Promise<void> {


### PR DESCRIPTION
The current API of the player only accepted the URL of a file to load. This change also adds supporting a JSON object as the input instead of the URL, as in certain scenarios the object may have already been parsed, and we don't need to parse it ourselves.

Also added support for the devHost to test this scenario with the QSP useUrl=boolean. This QSP will tell the devhost to either pass the URL to the player or to download the file and parse the content and pass the json instead. Default is using the URL.