### PR TITLE
NME in SFE mode: Hide blending & texture properties

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -22,7 +22,6 @@ export class SmartFilterTextureBlock extends CurrentScreenBlock {
      * A boolean indicating whether this block should be the main input for the SFE pipeline.
      * If true, it can be used in SFE for auto-disabling.
      */
-    @editableInPropertyPage("Is Main Input", PropertyTypeForEdition.Boolean, undefined, { notifiers: { rebuild: true } })
     public isMainInput: boolean = false;
 
     /**

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/smartFilterTextureBlock.ts
@@ -5,7 +5,6 @@ import { RegisterClass } from "core/Misc/typeStore";
 import { InputBlock } from "../Input/inputBlock";
 import type { NodeMaterialBlock } from "../../nodeMaterialBlock";
 import type { NodeMaterial } from "../../nodeMaterial";
-import { editableInPropertyPage, PropertyTypeForEdition } from "core/Decorators/nodeDecorator";
 import type { Scene } from "core/scene";
 import { SfeModeDefine } from "../Fragment/smartFilterFragmentOutputBlock";
 import { NodeMaterialBlockConnectionPointTypes } from "../../Enums/nodeMaterialBlockConnectionPointTypes";

--- a/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -614,21 +614,23 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                         />
                     </LineContainerComponent>
                 )}
-                <LineContainerComponent title="TRANSPARENCY">
-                    <CheckBoxLineComponent
-                        label="Force alpha blending"
-                        target={this.props.globalState.nodeMaterial}
-                        propertyName="forceAlphaBlending"
-                        onValueChanged={() => this.props.globalState.stateManager.onUpdateRequiredObservable.notifyObservers(null)}
-                    />
-                    <OptionsLine
-                        label="Alpha mode"
-                        options={AlphaModeOptions}
-                        target={this.props.globalState.nodeMaterial}
-                        propertyName="alphaMode"
-                        onSelect={() => this.props.globalState.stateManager.onUpdateRequiredObservable.notifyObservers(null)}
-                    />
-                </LineContainerComponent>
+                {this.props.globalState.mode !== NodeMaterialModes.SFE && (
+                    <LineContainerComponent title="TRANSPARENCY">
+                        <CheckBoxLineComponent
+                            label="Force alpha blending"
+                            target={this.props.globalState.nodeMaterial}
+                            propertyName="forceAlphaBlending"
+                            onValueChanged={() => this.props.globalState.stateManager.onUpdateRequiredObservable.notifyObservers(null)}
+                        />
+                        <OptionsLine
+                            label="Alpha mode"
+                            options={AlphaModeOptions}
+                            target={this.props.globalState.nodeMaterial}
+                            propertyName="alphaMode"
+                            onSelect={() => this.props.globalState.stateManager.onUpdateRequiredObservable.notifyObservers(null)}
+                        />
+                    </LineContainerComponent>
+                )}
                 {GetInputProperties({ lockObject: this.props.lockObject, globalState: this.props.globalState, inputs: this.props.globalState.nodeMaterial.getInputBlocks() })}
             </PropertyTabComponentBase>
         );

--- a/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
@@ -24,6 +24,7 @@ import { FloatLineComponent } from "shared-ui-components/lines/floatLineComponen
 import { SliderLineComponent } from "shared-ui-components/lines/sliderLineComponent";
 import type { TriPlanarBlock } from "core/Materials/Node/Blocks/triPlanarBlock";
 import { PropertyTabComponentBase } from "shared-ui-components/components/propertyTabComponentBase";
+import { SmartFilterTextureBlock } from "core/Materials";
 
 type ReflectionTexture = ReflectionTextureBlock | ReflectionBlock | RefractionBlock;
 
@@ -176,12 +177,12 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
 
         url = url.replace(/\?nocache=\d+/, "");
 
-        const globalState = this.props.stateManager.data as GlobalState;
         const isInReflectionMode =
             this.textureBlock instanceof ReflectionTextureBlock || this.textureBlock instanceof ReflectionBlock || this.textureBlock instanceof RefractionBlock;
         const isFrozenTexture = this.textureBlock instanceof CurrentScreenBlock || this.textureBlock instanceof ParticleTextureBlock;
         const showIsInGammaSpace = this.textureBlock instanceof ReflectionBlock;
-        const showSamplingMode = texture && texture.updateSamplingMode !== undefined && globalState.mode !== NodeMaterialModes.SFE;
+        const showIsMainInput = this.textureBlock instanceof SmartFilterTextureBlock;
+        const showSamplingMode = texture && texture.updateSamplingMode !== undefined && !(this.textureBlock instanceof SmartFilterTextureBlock);
         const showDisableLevelMultiplication = (this.textureBlock as TextureBlock).disableLevelMultiplication !== undefined;
 
         const reflectionModeOptions: { label: string; value: number }[] = [
@@ -292,6 +293,16 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                             onValueChanged={() => {
                                 this.props.stateManager.onUpdateRequiredObservable.notifyObservers(block);
                                 this.props.stateManager.onRebuildRequiredObservable.notifyObservers();
+                            }}
+                        />
+                    )}
+                    {showIsMainInput && (
+                        <CheckBoxLineComponent
+                            label="Is Main Input"
+                            propertyName="isMainInput"
+                            target={block}
+                            onValueChanged={() => {
+                                this.props.stateManager.onUpdateRequiredObservable.notifyObservers(block);
                             }}
                         />
                     )}

--- a/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
@@ -176,10 +176,12 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
 
         url = url.replace(/\?nocache=\d+/, "");
 
+        const globalState = this.props.stateManager.data as GlobalState;
         const isInReflectionMode =
             this.textureBlock instanceof ReflectionTextureBlock || this.textureBlock instanceof ReflectionBlock || this.textureBlock instanceof RefractionBlock;
         const isFrozenTexture = this.textureBlock instanceof CurrentScreenBlock || this.textureBlock instanceof ParticleTextureBlock;
         const showIsInGammaSpace = this.textureBlock instanceof ReflectionBlock;
+        const showSamplingMode = texture && texture.updateSamplingMode !== undefined && globalState.mode !== NodeMaterialModes.SFE;
 
         const reflectionModeOptions: { label: string; value: number }[] = [
             {
@@ -292,7 +294,7 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                             }}
                         />
                     }
-                    {texture && texture.updateSamplingMode && (
+                    {showSamplingMode && (
                         <OptionsLine
                             label="Sampling"
                             options={samplingMode}

--- a/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
+++ b/packages/tools/nodeEditor/src/graphSystem/properties/texturePropertyTabComponent.tsx
@@ -182,6 +182,7 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
         const isFrozenTexture = this.textureBlock instanceof CurrentScreenBlock || this.textureBlock instanceof ParticleTextureBlock;
         const showIsInGammaSpace = this.textureBlock instanceof ReflectionBlock;
         const showSamplingMode = texture && texture.updateSamplingMode !== undefined && globalState.mode !== NodeMaterialModes.SFE;
+        const showDisableLevelMultiplication = (this.textureBlock as TextureBlock).disableLevelMultiplication !== undefined;
 
         const reflectionModeOptions: { label: string; value: number }[] = [
             {
@@ -283,7 +284,7 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                             }}
                         />
                     )}
-                    {
+                    {showDisableLevelMultiplication && (
                         <CheckBoxLineComponent
                             label="Disable multiplying by level"
                             propertyName="disableLevelMultiplication"
@@ -293,7 +294,7 @@ export class TexturePropertyTabComponent extends React.Component<IPropertyCompon
                                 this.props.stateManager.onRebuildRequiredObservable.notifyObservers();
                             }}
                         />
-                    }
+                    )}
                     {showSamplingMode && (
                         <OptionsLine
                             label="Sampling"


### PR DESCRIPTION
A couple of things to hide from the UI in Smart Filters mode. These things aren't related to the shader and should be controlled at the Smart Filters-level.