### PR TITLE
Update tangents doc of VertexData

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.vertexData.ts
+++ b/packages/dev/core/src/Meshes/mesh.vertexData.ts
@@ -109,7 +109,7 @@ export interface IVertexDataLike {
     normals?: Nullable<FloatArray>;
 
     /**
-     * An array of the x, y, z tangent vector of each vertex  [...., x, y, z, .....]
+     * An array of the x, y, z, w tangent vector of each vertex  [...., x, y, z, w, .....]
      */
     tangents?: Nullable<FloatArray>;
 
@@ -208,7 +208,7 @@ export class VertexData implements IVertexDataLike {
     public normals: Nullable<FloatArray>;
 
     /**
-     * An array of the x, y, z tangent vector of each vertex  [...., x, y, z, .....]
+     * An array of the x, y, z, w tangent vector of each vertex  [...., x, y, z, w, .....]
      */
     public tangents: Nullable<FloatArray>;
 


### PR DESCRIPTION
It should be vec4 of xyzw per gltf spec.

> XYZW vertex tangents where the XYZ portion is normalized, and the W component is a sign value (-1 or +1) indicating handedness of the tangent basis

Also note that tangents for morph targets are vec3.

Forum post: <https://forum.babylonjs.com/t/vector-layout-of-tangents-in-ivertexdatalike/60259>
GLTF spec: <https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#meshes-overview>