### PR TITLE
WebGPU: Adds support for sprite rendering in fast snapshot rendering mode

### DIFF
--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -279,6 +279,13 @@ export class SpriteManager implements ISpriteManager {
         }
     }
 
+    /**
+     * Gets the sprite renderer associated with this manager
+     */
+    public get spriteRenderer() {
+        return this._spriteRenderer;
+    }
+
     private _spriteRenderer: SpriteRenderer;
     /** Associative array from JSON sprite data file */
     private _cellData: any;

--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -165,8 +165,10 @@ export class SpriteRenderer {
     private _vertexBuffers: { [key: string]: VertexBuffer } = {};
     private _spriteBuffer: Nullable<Buffer>;
     private _indexBuffer: DataBuffer;
-    private _drawWrapperBase: DrawWrapper;
-    private _drawWrapperDepth: DrawWrapper;
+    /** @internal */
+    public _drawWrapperBase: DrawWrapper;
+    /** @internal */
+    public _drawWrapperDepth: DrawWrapper;
     private _vertexArrayObject: WebGLVertexArrayObject;
     private _isDisposed = false;
 

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -4953,10 +4953,11 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         // Render
         this.onBeforeDrawPhaseObservable.notifyObservers(this);
 
-        if (engine.snapshotRendering && engine.snapshotRenderingMode === Constants.SNAPSHOTRENDERING_FAST) {
+        const fastSnapshotMode = engine.snapshotRendering && engine.snapshotRenderingMode === Constants.SNAPSHOTRENDERING_FAST;
+        if (fastSnapshotMode) {
             this.finalizeSceneUbo();
         }
-        this._renderingManager.render(null, null, true, true);
+        this._renderingManager.render(null, null, true, !fastSnapshotMode);
         this.onAfterDrawPhaseObservable.notifyObservers(this);
 
         // After Camera Draw


### PR DESCRIPTION
See https://forum.babylonjs.com/t/questions-about-using-sprite-with-snapshotrendering/60262/5

Note that animated sprites will still not work in fast snapshot rendering mode, as this would involve recreating the vertex buffer each frame.