### PR TITLE
NodeMaterial: Fix alphaMode being wrong in cloned materials

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2755,4 +2755,3 @@ export class NodeMaterial extends PushMaterial {
 }
 
 RegisterClass("BABYLON.NodeMaterial", NodeMaterial);
-

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2356,7 +2356,8 @@ export class NodeMaterial extends PushMaterial {
     public override serialize(selectedBlocks?: NodeMaterialBlock[]): any {
         const serializationObject = selectedBlocks ? {} : SerializationHelper.Serialize(this);
         serializationObject.editorData = JSON.parse(JSON.stringify(this.editorData)); // Copy
-        serializationObject.alphaMode = this._alphaMode;
+        serializationObject.alphaMode = Array.isArray(this._alphaMode) ? this._alphaMode[0] : this._alphaMode;
+        serializationObject._alphaMode = this._alphaMode;
 
         let blocks: NodeMaterialBlock[] = [];
 
@@ -2754,3 +2755,4 @@ export class NodeMaterial extends PushMaterial {
 }
 
 RegisterClass("BABYLON.NodeMaterial", NodeMaterial);
+


### PR DESCRIPTION
See https://forum.babylonjs.com/t/weird-issue-bug-with-surfaced-in-8-21-1-with-flat-mesh-and-textures-materials/60300/5