### PR TITLE
Materials: don't serialize plugins that shouldn't be serialized + don't inject WebXR depth sensing plugin if not necessary

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/taaMaterialManager.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/taaMaterialManager.ts
@@ -37,6 +37,7 @@ class TAAJitterMaterialPlugin extends MaterialPluginBase {
     constructor(material: Material) {
         super(material, TAAJitterMaterialPlugin.Name, 300, new TAAJitterMaterialDefines());
         this.registerForExtraEvents = true;
+        this.doNotSerialize = true;
     }
 
     /** @internal */

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.ts
@@ -17,7 +17,7 @@ import type { Material } from "core/Materials/material";
 import { MaterialDefines } from "core/Materials/materialDefines";
 import type { UniformBuffer } from "core/Materials/uniformBuffer";
 import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
-import { RegisterMaterialPlugin } from "core/Materials/materialPluginManager";
+import { RegisterMaterialPlugin, UnregisterMaterialPlugin } from "core/Materials/materialPluginManager";
 import type { Camera } from "core/Cameras/camera";
 import { Matrix } from "core/Maths/math.vector";
 import type { Engine } from "core/Engines/engine";
@@ -426,6 +426,8 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         // https://immersive-web.github.io/depth-sensing/
         Tools.Warn("depth-sensing is an experimental and unstable feature.");
         EnableDiscard = !options.useToleranceFactorForDepthSensing;
+
+        RegisterMaterialPlugin("WebXRDepthSensingMaterialPlugin", (material) => new WebXRDepthSensingMaterialPlugin(material));
     }
 
     /**
@@ -495,6 +497,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
      * Dispose this feature and all of the resources attached
      */
     public override dispose(): void {
+        UnregisterMaterialPlugin("WebXRDepthSensingMaterialPlugin");
         this._cachedDepthImageTexture?.dispose();
         this.onGetDepthInMetersAvailable.clear();
         // cleanup
@@ -707,5 +710,3 @@ WebXRFeaturesManager.AddWebXRFeature(
     WebXRDepthSensing.Version,
     false
 );
-
-RegisterMaterialPlugin("WebXRDepthSensingMaterialPlugin", (material) => new WebXRDepthSensingMaterialPlugin(material));

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.ts
@@ -145,6 +145,7 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
     constructor(material: Material) {
         super(material, "DepthSensing", 222, new DepthSensingMaterialDefines());
         this._varColorName = material instanceof PBRBaseMaterial ? "finalColor" : "color";
+        this.doNotSerialize = true;
         ManagedMaterialPlugins.push(this);
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/mark-implicitly-created-material-plugins-donotserialize-by-default/60326