### PR TITLE
SSAO2: Fix artifacts when using an off-center frustum with an orthographic camera

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/ssao2RenderingPipeline.ts
@@ -536,7 +536,11 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
     }
 
     private _getDefinesForSSAO() {
-        const defines = `#define SSAO\n#define SAMPLES ${this.samples}\n#define EPSILON ${this.epsilon.toFixed(4)}`;
+        let defines = `#define SSAO\n#define SAMPLES ${this.samples}\n#define EPSILON ${this.epsilon.toFixed(4)}`;
+
+        if (this._scene.activeCamera?.mode === Camera.ORTHOGRAPHIC_CAMERA) {
+            defines += `\n#define ORTHOGRAPHIC_CAMERA`;
+        }
 
         return defines;
     }
@@ -567,6 +571,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
                 "texelSize",
                 "xViewport",
                 "yViewport",
+                "viewport",
                 "maxZ",
                 "minZAspect",
                 "depthProjection",
@@ -621,8 +626,7 @@ export class SSAO2RenderingPipeline extends PostProcessRenderPipeline {
                 const orthoBottom = this._scene.activeCamera.orthoBottom ?? -halfHeight;
                 const orthoTop = this._scene.activeCamera.orthoTop ?? halfHeight;
                 effect.setMatrix3x3("depthProjection", SSAO2RenderingPipeline.ORTHO_DEPTH_PROJECTION);
-                effect.setFloat("xViewport", (orthoRight - orthoLeft) * 0.5);
-                effect.setFloat("yViewport", (orthoTop - orthoBottom) * 0.5);
+                effect.setFloat4("viewport", orthoLeft, orthoRight, orthoBottom, orthoTop);
             }
             effect.setMatrix("projection", this._scene.getProjectionMatrix());
 

--- a/packages/dev/core/src/Shaders/ssao2.fragment.fx
+++ b/packages/dev/core/src/Shaders/ssao2.fragment.fx
@@ -36,8 +36,12 @@ varying vec2 vUV;
 
 	uniform float totalStrength;
 	uniform float base;
+#ifdef ORTHOGRAPHIC_CAMERA
+	uniform vec4 viewport;
+#else
 	uniform float xViewport;
 	uniform float yViewport;
+#endif
 	uniform mat3 depthProjection;
 	uniform float maxZ;
 	uniform float minZAspect;
@@ -55,7 +59,11 @@ varying vec2 vUV;
 		float occlusion = 0.0;
 		float correctedRadius = min(radius, minZAspect * depth / near);
 
+	#ifdef ORTHOGRAPHIC_CAMERA
+		vec3 vViewRay = vec3(mix(viewport.x, viewport.y, vUV.x), mix(viewport.z, viewport.w, vUV.y), depthSign);
+	#else
 		vec3 vViewRay = vec3((vUV.x * 2.0 - 1.0)*xViewport, (vUV.y * 2.0 - 1.0)*yViewport, depthSign);
+	#endif
 		vec3 vDepthFactor = depthProjection * vec3(1.0, 1.0, depth);
 		vec3 origin = vViewRay * vDepthFactor;
 		vec3 rvec = random * 2.0 - 1.0;

--- a/packages/dev/core/src/ShadersWGSL/ssao2.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ssao2.fragment.fx
@@ -39,8 +39,12 @@ var textureSampler: texture_2d<f32>;
 
 	uniform totalStrength: f32;
 	uniform base: f32;
+#ifdef ORTHOGRAPHIC_CAMERA
+	uniform viewport: vec4f;
+#else
 	uniform xViewport: f32;
 	uniform yViewport: f32;
+#endif
 	uniform depthProjection: mat3x3f;
 	uniform maxZ: f32;
 	uniform minZAspect: f32;
@@ -58,7 +62,11 @@ var textureSampler: texture_2d<f32>;
 		var occlusion: f32 = 0.0;
 		var correctedRadius: f32 = min(uniforms.radius, uniforms.minZAspect * depth / uniforms.near);
 
+	#ifdef ORTHOGRAPHIC_CAMERA
+		var vViewRay: vec3f =  vec3f(mix(uniforms.viewport.x, uniforms.viewport.y, input.vUV.x), mix(uniforms.viewport.z, uniforms.viewport.w, input.vUV.y), depthSign);
+	#else
 		var vViewRay: vec3f =  vec3f((input.vUV.x * 2.0 - 1.0)*uniforms.xViewport, (input.vUV.y * 2.0 - 1.0)*uniforms.yViewport, depthSign);
+	#endif
 		var vDepthFactor: vec3f = uniforms.depthProjection *  vec3f(1.0, 1.0, depth);
 		var origin: vec3f = vViewRay * vDepthFactor;
 		var rvec: vec3f = random * 2.0 - 1.0;


### PR DESCRIPTION
See https://forum.babylonjs.com/t/misalign-of-orthogonal-camera-and-ssao-post-process-image-when-changing-frustum/59820/6