### PR TITLE
Material: Fix alphaMode serialization and parsing

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -57,7 +57,7 @@ import { TrigonometryBlock, TrigonometryBlockOperations } from "./Blocks/trigono
 import { NodeMaterialSystemValues } from "./Enums/nodeMaterialSystemValues";
 import type { ImageSourceBlock } from "./Blocks/Dual/imageSourceBlock";
 import { EngineStore } from "../../Engines/engineStore";
-import type { Material } from "../material";
+import { Material } from "../material";
 import type { TriPlanarBlock } from "./Blocks/triPlanarBlock";
 import type { BiPlanarBlock } from "./Blocks/biPlanarBlock";
 import type { PrePassRenderer } from "../../Rendering/prePassRenderer";
@@ -2356,8 +2356,6 @@ export class NodeMaterial extends PushMaterial {
     public override serialize(selectedBlocks?: NodeMaterialBlock[]): any {
         const serializationObject = selectedBlocks ? {} : SerializationHelper.Serialize(this);
         serializationObject.editorData = JSON.parse(JSON.stringify(this.editorData)); // Copy
-        serializationObject.alphaMode = Array.isArray(this._alphaMode) ? this._alphaMode[0] : this._alphaMode;
-        serializationObject._alphaMode = this._alphaMode;
 
         let blocks: NodeMaterialBlock[] = [];
 
@@ -2525,21 +2523,7 @@ export class NodeMaterial extends PushMaterial {
             this.editorData.map = blockMap;
         }
 
-        this.comment = source.comment;
-
-        if (source.forceAlphaBlending !== undefined) {
-            this.forceAlphaBlending = source.forceAlphaBlending;
-        }
-
-        if (source.alphaMode !== undefined) {
-            this.alphaMode = source.alphaMode;
-        }
-
-        if (!Array.isArray(source.alphaMode)) {
-            this._alphaMode = [source.alphaMode ?? Constants.ALPHA_COMBINE];
-        } else {
-            this._alphaMode = source.alphaMode;
-        }
+        Material.ParseAlphaMode(source, this);
 
         if (!merge) {
             this._mode = source.mode ?? NodeMaterialModes.Material;
@@ -2554,6 +2538,7 @@ export class NodeMaterial extends PushMaterial {
      * @deprecated Please use the parseSerializedObject method instead
      */
     public loadFromSerialization(source: any, rootUrl: string = "", merge = false) {
+        SerializationHelper.ParseProperties(source, this, this.getScene(), rootUrl);
         this.parseSerializedObject(source, rootUrl, merge);
     }
 

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -580,7 +580,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * Stores the value of the alpha mode
      */
     @serialize()
-    protected _alphaMode: number[] = [Constants.ALPHA_COMBINE];
+    private _alphaMode: number[] = [Constants.ALPHA_COMBINE];
 
     /**
      * Sets the value of the alpha mode.
@@ -2016,8 +2016,6 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     public serialize(): any {
         const serializationObject = SerializationHelper.Serialize(this);
 
-        serializationObject.alphaMode = this._alphaMode;
-
         serializationObject.stencil = this.stencil.serialize();
         serializationObject.uniqueId = this.uniqueId;
 
@@ -2035,6 +2033,21 @@ export class Material implements IAnimatable, IClipPlanesHolder {
                     serializationObject.plugins[plugin.getClassName()] = plugin.serialize();
                 }
             }
+        }
+    }
+
+    /**
+     * Parses the alpha mode from the material data to parse
+     * @param parsedMaterial defines the material data to parse
+     * @param material defines the material to update
+     */
+    public static ParseAlphaMode(parsedMaterial: any, material: Material) {
+        if (parsedMaterial._alphaMode !== undefined) {
+            material._alphaMode = Array.isArray(parsedMaterial._alphaMode) ? parsedMaterial._alphaMode : [parsedMaterial._alphaMode];
+        } else if (parsedMaterial.alphaMode !== undefined) {
+            material._alphaMode = Array.isArray(parsedMaterial.alphaMode) ? parsedMaterial.alphaMode : [parsedMaterial.alphaMode];
+        } else {
+            material._alphaMode = [Constants.ALPHA_COMBINE];
         }
     }
 
@@ -2059,11 +2072,8 @@ export class Material implements IAnimatable, IClipPlanesHolder {
         const materialType = Tools.Instantiate(parsedMaterial.customType);
         const material = materialType.Parse(parsedMaterial, scene, rootUrl);
         material._loadedUniqueId = parsedMaterial.uniqueId;
-        if (!Array.isArray(parsedMaterial.alphaMode)) {
-            material._alphaMode = [parsedMaterial.alphaMode ?? Constants.ALPHA_COMBINE];
-        } else {
-            material._alphaMode = parsedMaterial.alphaMode;
-        }
+
+        Material.ParseAlphaMode(parsedMaterial, material);
 
         return material;
     }


### PR DESCRIPTION
The most significant change is adding `SerializationHelper.ParseProperties(source, this, this.getScene(), rootUrl)` to `NodeMaterial.loadFromSerialization`:
* without this change, all properties marked with `@serialize` were not parsed correctly
* That's why there was custom code in `NodeMaterial.parseSerializedObject` to manually parse **forceAlphaBlending**, **alphaMode**, and **comment** (but **name** and all other properties were not parsed).

Calls to `Material.ParseAlphaMode(source, this);` in `Material.Parse` and `NodeMaterial.parseSerializedObject` handle backward compatibility by first extracting the **alphaMode** value from `source._alphaMode` if it is not undefined, then from `source.alphaMode` if it is not undefined, and then setting the default value **ALPHA_COMBINE**.