### PR TITLE
CameraGizmo: merge lines to 1 mesh

### DIFF
--- a/packages/dev/core/src/Gizmos/cameraGizmo.ts
+++ b/packages/dev/core/src/Gizmos/cameraGizmo.ts
@@ -11,7 +11,7 @@ import type { Camera } from "../Cameras/camera";
 import { CreateBox } from "../Meshes/Builders/boxBuilder";
 import { CreateCylinder } from "../Meshes/Builders/cylinderBuilder";
 import { Matrix } from "../Maths/math";
-import { CreateLines } from "../Meshes/Builders/linesBuilder";
+import { CreateLineSystem } from "../Meshes/Builders/linesBuilder";
 import type { PointerInfo } from "../Events/pointerEvents";
 import { PointerEventTypes } from "../Events/pointerEvents";
 import type { Observer } from "../Misc/observable";
@@ -241,22 +241,25 @@ export class CameraGizmo extends Gizmo implements ICameraGizmo {
         const mesh = new Mesh(root.name, scene);
         mesh.parent = root;
 
+        const lines: Vector3[][] = [];
+        const colors: Color4[][] = [];
+
         for (let y = 0; y < 4; y += 2) {
             for (let x = 0; x < 4; x += 2) {
-                let line = CreateLines("lines", { points: [new Vector3(-1 + x, -1 + y, -1), new Vector3(-1 + x, -1 + y, 1)], colors: [linesColor, linesColor] }, scene);
-                line.parent = mesh;
-                line.alwaysSelectAsActiveMesh = true;
-                line.isPickable = false;
-                line = CreateLines("lines", { points: [new Vector3(-1, -1 + x, -1 + y), new Vector3(1, -1 + x, -1 + y)], colors: [linesColor, linesColor] }, scene);
-                line.parent = mesh;
-                line.alwaysSelectAsActiveMesh = true;
-                line.isPickable = false;
-                line = CreateLines("lines", { points: [new Vector3(-1 + x, -1, -1 + y), new Vector3(-1 + x, 1, -1 + y)], colors: [linesColor, linesColor] }, scene);
-                line.parent = mesh;
-                line.alwaysSelectAsActiveMesh = true;
-                line.isPickable = false;
+                lines.push([new Vector3(-1 + x, -1 + y, -1), new Vector3(-1 + x, -1 + y, 1)]);
+
+                lines.push([new Vector3(-1, -1 + x, -1 + y), new Vector3(1, -1 + x, -1 + y)]);
+
+                lines.push([new Vector3(-1 + x, -1, -1 + y), new Vector3(-1 + x, 1, -1 + y)]);
+                colors.push([linesColor, linesColor], [linesColor, linesColor], [linesColor, linesColor]);
             }
         }
+
+        const line = CreateLineSystem("lines", { lines, colors }, scene);
+
+        line.parent = mesh;
+        line.alwaysSelectAsActiveMesh = true;
+        line.isPickable = false;
 
         return root;
     }


### PR DESCRIPTION
Currently a CameraGizmo creates 12 LinesMesh and 12 ShaderMaterial for LinesMeshes by default, this commit merges them to 1 LinesMeshes, to same memory and draw calls.

Forum post: <https://forum.babylonjs.com/t/cameragizmo-reuse-materials/60292>
Playground: <https://playground.babylonjs.com/#I3B4JC%232>