### PR TITLE
make updateLight coherent with other protected update method

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -2756,7 +2756,7 @@ export class Viewer implements IDisposable {
         updateSkybox(this._skybox, this._camera);
     }
 
-    private _updateLight() {
+    protected _updateLight() {
         let shouldHaveDefaultLight: boolean;
         if (this._loadedModels.length === 0) {
             shouldHaveDefaultLight = false;


### PR DESCRIPTION
If an integration extend the viewer and decide to add an additional model after the init the `_updateLight` method will never be called.
Change the visibility so each integration can decide if they need to call again `_updateLight`.