### PR TITLE
Inspector v2: metadata cleanup

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
@@ -136,15 +136,10 @@ export interface IMetadataContainer {
 
 const useStyles = makeStyles({
     buttonDiv: {
-        display: "flex",
-        alignItems: "center",
+        display: "grid",
+        gridAutoFlow: "column",
+        gridTemplateColumns: "1fr auto auto auto",
         gap: tokens.spacingHorizontalXS,
-    },
-    saveButton: {
-        flex: "1",
-    },
-    secondaryButton: {
-        flex: "0 0 auto",
     },
 });
 
@@ -191,25 +186,14 @@ export const MetadataProperties: FunctionComponent<{ entity: IMetadataContainer 
             />
             <LineContainer>
                 <div className={classes.buttonDiv}>
-                    <Button
-                        className={classes.saveButton}
-                        icon={<SaveRegular />}
-                        disabled={stringifiedMetadata === unformattedEditedMetadata}
-                        onClick={() => SaveMetadata(entity, editedMetadata)}
-                    >
+                    <Button icon={<SaveRegular />} disabled={stringifiedMetadata === unformattedEditedMetadata} onClick={() => SaveMetadata(entity, editedMetadata)}>
                         <Body1>Save</Body1>
                     </Button>
                     <Tooltip content="Undo Changes" relationship="label">
-                        <Button
-                            className={classes.secondaryButton}
-                            icon={<ArrowUndoRegular />}
-                            disabled={stringifiedMetadata === unformattedEditedMetadata}
-                            onClick={() => setEditedMetadata(stringifiedMetadata)}
-                        />
+                        <Button icon={<ArrowUndoRegular />} disabled={stringifiedMetadata === unformattedEditedMetadata} onClick={() => setEditedMetadata(stringifiedMetadata)} />
                     </Tooltip>
                     <Tooltip content="Format (Pretty Print)" relationship="label">
                         <Button
-                            className={classes.secondaryButton}
                             icon={
                                 <svg {...props} viewBox="0 0 20 20" fill="none" stroke="currentColor">
                                     <text x="3" y="14" fontSize="14" fill="currentColor">
@@ -222,12 +206,7 @@ export const MetadataProperties: FunctionComponent<{ entity: IMetadataContainer 
                         ></Button>
                     </Tooltip>
                     <Tooltip content="Clear Formatting" relationship="label">
-                        <Button
-                            className={classes.secondaryButton}
-                            icon={<ClearFormattingRegular />}
-                            disabled={!isEditedMetadataJSON}
-                            onClick={() => setEditedMetadata(Restringify(editedMetadata, false))}
-                        />
+                        <Button icon={<ClearFormattingRegular />} disabled={!isEditedMetadataJSON} onClick={() => setEditedMetadata(Restringify(editedMetadata, false))} />
                     </Tooltip>
                 </div>
             </LineContainer>

--- a/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
@@ -186,6 +186,7 @@ export const MetadataProperties: FunctionComponent<{ entity: IMetadataContainer 
             />
             <LineContainer>
                 <div className={classes.buttonDiv}>
+                    {/* TODO: gehalper - need to update our Button primitive to accommodate these scenarios. */}
                     <Button icon={<SaveRegular />} disabled={stringifiedMetadata === unformattedEditedMetadata} onClick={() => SaveMetadata(entity, editedMetadata)}>
                         <Body1>Save</Body1>
                     </Button>

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/switch.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/switch.tsx
@@ -36,5 +36,5 @@ export const Switch: FunctionComponent<SwitchProps> = (props) => {
         setChecked(event.target.checked);
     };
 
-    return <FluentSwitch className={classes.switch} indicator={{ className: classes.indicator }} checked={checked} onChange={onChange} />;
+    return <FluentSwitch className={classes.switch} indicator={{ className: classes.indicator }} checked={checked} disabled={props.disabled} onChange={onChange} />;
 };


### PR DESCRIPTION
This PR updates the MetadataProperties.tsx to use react state and our custom hooks rather than relying on a static helper class. @georginahalpern I used the Fluent Button directly because it looked like it would require a lot of changes to our Button primitive to use it in this scenario, but I added a TODO comment.

I also changed the design a bit, because toggling pretty print doesn't seem to really make sense when you can also edit the string directly (e.g. if you have pretty print enabled, and then you start editing the json but while you are editing it it is invalid json, what should the behavior be? And after you finish editing and it is valid again, should it pretty print it while you are still typing?). Now, there are just buttons to do a one time pretty print or clear formatting, which is more like what you see in other tools like the chrome dev tools for example.

<img width="332" height="269" alt="image" src="https://github.com/user-attachments/assets/60e8158e-9ec3-4e9e-a59d-5e05f28cf6d4" />
