### PR TITLE
Ensure bone's absolute matrix is updated when dirty

### DIFF
--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -347,6 +347,7 @@ export class Bone extends Node {
      * @returns the bone matrix, in world space
      */
     public getAbsoluteMatrix(): Matrix {
+        this._skeleton.computeAbsoluteMatrices();
         return this._absoluteMatrix;
     }
 
@@ -356,7 +357,7 @@ export class Bone extends Node {
      * @deprecated Please use getAbsoluteMatrix instead
      */
     public getAbsoluteTransform(): Matrix {
-        return this._absoluteMatrix;
+        return this.getAbsoluteMatrix();
     }
 
     /**
@@ -545,12 +546,10 @@ export class Bone extends Node {
         } else {
             let wm: Nullable<Matrix> = null;
 
-            //tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()
+            // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
             if (tNode) {
                 wm = tNode.getWorldMatrix();
             }
-
-            this._skeleton.computeAbsoluteMatrices();
 
             const tmat = Bone._TmpMats[0];
             const tvec = Bone._TmpVecs[0];
@@ -850,7 +849,6 @@ export class Bone extends Node {
 
         lmat.setTranslationFromFloats(lx, ly, lz);
 
-        this.computeAbsoluteMatrices();
         this._markAsDirtyAndDecompose();
     }
 
@@ -908,12 +906,10 @@ export class Bone extends Node {
         } else {
             let wm: Nullable<Matrix> = null;
 
-            //tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()
+            // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
             if (tNode) {
                 wm = tNode.getWorldMatrix();
             }
-
-            this._skeleton.computeAbsoluteMatrices();
 
             let tmat = Bone._TmpMats[0];
 
@@ -1009,12 +1005,10 @@ export class Bone extends Node {
     public getDirectionToRef(localAxis: Vector3, tNode: Nullable<TransformNode> = null, result: Vector3): void {
         let wm: Nullable<Matrix> = null;
 
-        //tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()
+        // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY??
         if (tNode) {
             wm = tNode.getWorldMatrix();
         }
-
-        this._skeleton.computeAbsoluteMatrices();
 
         const mat = Bone._TmpMats[0];
 
@@ -1163,12 +1157,10 @@ export class Bone extends Node {
     public getAbsolutePositionFromLocalToRef(position: Vector3, tNode: Nullable<TransformNode> = null, result: Vector3): void {
         let wm: Nullable<Matrix> = null;
 
-        //tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()
+        // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
         if (tNode) {
             wm = tNode.getWorldMatrix();
         }
-
-        this._skeleton.computeAbsoluteMatrices();
 
         const tmat = Bone._TmpMats[0];
 
@@ -1204,12 +1196,10 @@ export class Bone extends Node {
     public getLocalPositionFromAbsoluteToRef(position: Vector3, tNode: Nullable<TransformNode> = null, result: Vector3): void {
         let wm: Nullable<Matrix> = null;
 
-        //tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()
+        // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
         if (tNode) {
             wm = tNode.getWorldMatrix();
         }
-
-        this._skeleton.computeAbsoluteMatrices();
 
         const tmat = Bone._TmpMats[0];
 

--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -544,22 +544,13 @@ export class Bone extends Node {
                 lm.setTranslationFromFloats(vec.x, vec.y, vec.z);
             }
         } else {
-            let wm: Nullable<Matrix> = null;
-
-            // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
-            if (tNode) {
-                wm = tNode.getWorldMatrix();
-            }
-
             const tmat = Bone._TmpMats[0];
             const tvec = Bone._TmpVecs[0];
 
             if (this.parent) {
-                if (tNode && wm) {
-                    tmat.copyFrom(this.parent.getAbsoluteMatrix());
-                    tmat.multiplyToRef(wm, tmat);
-                } else {
-                    tmat.copyFrom(this.parent.getAbsoluteMatrix());
+                tmat.copyFrom(this.parent.getAbsoluteMatrix());
+                if (tNode) {
+                    tmat.multiplyToRef(tNode.getWorldMatrix(), tmat);
                 }
             } else {
                 Matrix.IdentityToRef(tmat);
@@ -1003,22 +994,13 @@ export class Bone extends Node {
      * @param result The vector3 that the world direction will be copied to
      */
     public getDirectionToRef(localAxis: Vector3, tNode: Nullable<TransformNode> = null, result: Vector3): void {
-        let wm: Nullable<Matrix> = null;
+        const tMat = Bone._TmpMats[0].copyFrom(this.getAbsoluteMatrix());
 
-        // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY??
         if (tNode) {
-            wm = tNode.getWorldMatrix();
+            tMat.multiplyToRef(tNode.getWorldMatrix(), tMat);
         }
 
-        const mat = Bone._TmpMats[0];
-
-        mat.copyFrom(this.getAbsoluteMatrix());
-
-        if (tNode && wm) {
-            mat.multiplyToRef(wm, mat);
-        }
-
-        Vector3.TransformNormalToRef(localAxis, mat, result);
+        Vector3.TransformNormalToRef(localAxis, tMat, result);
 
         result.normalize();
     }
@@ -1155,19 +1137,10 @@ export class Bone extends Node {
      * @param result The vector3 that the world position should be copied to
      */
     public getAbsolutePositionFromLocalToRef(position: Vector3, tNode: Nullable<TransformNode> = null, result: Vector3): void {
-        let wm: Nullable<Matrix> = null;
+        const tmat = Bone._TmpMats[0].copyFrom(this.getAbsoluteMatrix());
 
-        // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
         if (tNode) {
-            wm = tNode.getWorldMatrix();
-        }
-
-        const tmat = Bone._TmpMats[0];
-
-        tmat.copyFrom(this.getAbsoluteMatrix());
-
-        if (tNode && wm) {
-            tmat.multiplyToRef(wm, tmat);
+            tmat.multiplyToRef(tNode.getWorldMatrix(), tmat);
         }
 
         Vector3.TransformCoordinatesToRef(position, tmat, result);
@@ -1194,19 +1167,10 @@ export class Bone extends Node {
      * @param result The vector3 that the local position should be copied to
      */
     public getLocalPositionFromAbsoluteToRef(position: Vector3, tNode: Nullable<TransformNode> = null, result: Vector3): void {
-        let wm: Nullable<Matrix> = null;
+        const tmat = Bone._TmpMats[0].copyFrom(this.getAbsoluteMatrix());
 
-        // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
         if (tNode) {
-            wm = tNode.getWorldMatrix();
-        }
-
-        const tmat = Bone._TmpMats[0];
-
-        tmat.copyFrom(this.getAbsoluteMatrix());
-
-        if (tNode && wm) {
-            tmat.multiplyToRef(wm, tmat);
+            tmat.multiplyToRef(tNode.getWorldMatrix(), tmat);
         }
 
         tmat.invert();

--- a/packages/dev/core/src/Bones/bone.ts
+++ b/packages/dev/core/src/Bones/bone.ts
@@ -895,20 +895,10 @@ export class Bone extends Node {
             result.y = lm.m[13];
             result.z = lm.m[14];
         } else {
-            let wm: Nullable<Matrix> = null;
+            const tmat = Bone._TmpMats[0].copyFrom(this.getAbsoluteMatrix());
 
-            // tNode.getWorldMatrix() needs to be called before skeleton.computeAbsoluteMatrices()... WHY???
             if (tNode) {
-                wm = tNode.getWorldMatrix();
-            }
-
-            let tmat = Bone._TmpMats[0];
-
-            if (tNode && wm) {
-                tmat.copyFrom(this.getAbsoluteMatrix());
-                tmat.multiplyToRef(wm, tmat);
-            } else {
-                tmat = this.getAbsoluteMatrix();
+                tmat.multiplyToRef(tNode.getWorldMatrix(), tmat);
             }
 
             result.x = tmat.m[12];


### PR DESCRIPTION
See https://forum.babylonjs.com/t/bones-and-skeletons-sample-results-differ-between-v5-x-and-later/60330.

In [this PR](https://github.com/BabylonJS/Babylon.js/pull/14007), we inadvertently stopped calculating the absolute matrix (what used to be absolute transform), so any code that doesn't explicitly call `computeAbsoluteMatrix` which uses the absolute matrix will get incorrect values. This change ensures the absolute matrix is correct by calling `computeAbsoluteMatrix` when getting absolute matrix. `computeAbsoluteMatrix` checks a dirty flag so it should be cheap when nothing changed.