### PR TITLE
geometry: Ensure GPU buffers upload for delay loaded geometries with multiple meshes

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -784,12 +784,11 @@ export class Geometry implements IGetSetVerticesData {
     }
 
     private _applyToMesh(mesh: Mesh): void {
-        const numOfMeshes = this._meshes.length;
-
         // vertexBuffers
         for (const kind in this._vertexBuffers) {
-            if (numOfMeshes === 1) {
-                this._vertexBuffers[kind].create();
+            const vertexBuffer = this._vertexBuffers[kind];
+            if (!vertexBuffer._buffer.getBuffer()) {
+                vertexBuffer.create();
             }
 
             if (kind === VertexBuffer.PositionKind) {
@@ -806,7 +805,7 @@ export class Geometry implements IGetSetVerticesData {
         }
 
         // indexBuffer
-        if (numOfMeshes === 1 && this._indices && this._indices.length > 0) {
+        if (!this._indexBuffer && this._indices && this._indices.length > 0) {
             this._indexBuffer = this._engine.createIndexBuffer(this._indices, this._updatable, "Geometry_" + this.id + "_IndexBuffer");
         }
 


### PR DESCRIPTION
The `Geometry._applyToMesh` method previously relied on a `numOfMeshes === 1` check to determine when to upload vertex and index buffer data to the GPU. This logic inadvertently prevented GPU uploads for delay loaded geometries bound to more than one mesh.
This commit replaces the mesh count check with a more robust validation of the GPU buffer's existence. For vertex buffers, it checks `!vertexBuffer._buffer.getBuffer()`, and for index buffers, it checks `!this._indexBuffer`.
This ensures that buffer data is uploaded to the GPU as soon as the buffer is ready and needs to be created, regardless of how many meshes are associated with the geometry.

Forum post: <https://forum.babylonjs.com/t/numofmeshes-1-check-in-geometry-applytomesh/60260>