### PR TITLE
Sandbox: Make old versions work again

### DIFF
--- a/packages/tools/sandbox/src/globalState.ts
+++ b/packages/tools/sandbox/src/globalState.ts
@@ -1,4 +1,3 @@
-import "@dev/inspector";
 import type { Vector3 } from "core/Maths/math.vector";
 import type { FilesInput } from "core/Misc/filesInput";
 import { Observable } from "core/Misc/observable";


### PR DESCRIPTION
See https://forum.babylonjs.com/t/sandbox-error-using-old-versions-of-engine/59060

When the new addons package was introduced, code was added to Sandbox to load the new addons UMD bundle from the CDN. However, if you go back to versions prior to 7.32.4, there was no addons package/bundle, and so attempting to load it from the CDN fails. This PR adds an optional minVersion property to each of the script/bundle entries, and doesn't try to load ones that didn't exist for the specified version.

There was also one additional problem. For some reason, the Sandbox main site bundle (not the dynamically loaded ones) was importing Inspector (just the side effects). This import was added in https://github.com/babylonjs/Babylon.js/commit/0fc42fd81941f55dc1dd7ab13fede7795b542dc4. However, nothing in the main sandbox bundle uses Inspector (its only used through the dynamically loaded bundle from the CDN), so I don't know why it was added. However the effect is that it tries to load the latest Inspector code (not the CDN version referenced) which has a dependency on the addons package which doesn't exist for the older version and so it fails (basically things fail because of mismatched versions). I just removed the import as I can't see any reason for it.

This is a bit painful to debug and maintain, so it might be good to discuss in the future the idea of just switching to simply bundling the whole site with all its dependencies, and snapshotting the entire site and switching between versions that way. Then we wouldn't have any complicated logic for managing dependencies, versions, whether the dependency existed in a specific version, etc. Seems like it would be way simpler to maintain.