### PR TITLE
Adding a wrapper over the worker to deal with CSP headers

### DIFF
--- a/packages/dev/lottiePlayer/src/blobWorkerWrapper.ts
+++ b/packages/dev/lottiePlayer/src/blobWorkerWrapper.ts
@@ -1,0 +1,38 @@
+// From https://github.com/webpack/webpack/discussions/14648#discussioncomment-1589272
+/**
+ * This class wraps a regular URL worker into a blob.
+ * It is a common scenario to have the website served from one domain, and scripts from another one.
+ * This can cause CSP issues if worker-src does not include the domain that serves the scripts. By
+ * wrapping the worker into a blob, the only CSP required for worker-src is blob and the worker will
+ * load correctly. script-src must still include the domain that serves the worker script and dependencies.
+ */
+export class BlobWorkerWrapper {
+    private readonly _worker: Worker;
+    /**
+     * Creates a new instance of the BlobWorkerWrapper class.
+     * @param url The URL of the worker script that needs to be wrapper into a blob.
+     */
+    public constructor(url: URL) {
+        const workerScript = `
+            const scriptUrl = new URL("${url.toString()}");
+            const originalImportScripts = self.importScripts;
+            self.importScripts = (url) => originalImportScripts.call(self, new URL(url, scriptUrl).toString());
+            importScripts(scriptUrl.toString());
+        `;
+        const objectURL = URL.createObjectURL(
+            new Blob([workerScript], {
+                type: "application/javascript",
+            })
+        );
+        this._worker = new Worker(objectURL);
+        URL.revokeObjectURL(objectURL);
+    }
+
+    /**
+     * Gets the underlying Worker instance created by this CorsWorker.
+     * @returns The underlying Worker instance created by this CorsWorker.
+     */
+    public getWorker(): Worker {
+        return this._worker;
+    }
+}

--- a/packages/dev/lottiePlayer/src/player.ts
+++ b/packages/dev/lottiePlayer/src/player.ts
@@ -3,6 +3,7 @@ import type { AnimationConfiguration } from "./animationConfiguration";
 import type { AnimationSizeMessagePayload, AnimationUrlMessage, ContainerResizeMessage, Message, StartAnimationMessage } from "./messageTypes";
 import type { RawLottieAnimation } from "./parsing/rawTypes";
 import { CalculateScaleFactor } from "./rendering/animationController";
+import { BlobWorkerWrapper as Worker } from "./blobWorkerWrapper";
 
 /**
  * Allows you to play Lottie animations using Babylon.js.
@@ -17,7 +18,7 @@ export class Player {
 
     private _playing: boolean = false;
     private _disposed: boolean = false;
-    private _worker: Nullable<Worker> = null;
+    private _worker: Nullable<globalThis.Worker> = null;
     private _canvas: Nullable<HTMLCanvasElement> = null;
     private _animationWidth: number = 0;
     private _animationHeight: number = 0;
@@ -54,7 +55,8 @@ export class Player {
         }
 
         if ("OffscreenCanvas" in window) {
-            this._worker = new Worker(new URL("./worker", import.meta.url), { type: "module" });
+            const wrapperWorker = new Worker(new URL("./worker", import.meta.url));
+            this._worker = wrapperWorker.getWorker();
             this._worker.onmessage = (evt: MessageEvent) => {
                 const message = evt.data as Message;
                 if (message === undefined) {

--- a/packages/public/@babylonjs/lottiePlayer/readme.md
+++ b/packages/public/@babylonjs/lottiePlayer/readme.md
@@ -29,6 +29,15 @@ You can pass a variables map in the constructor of Player. These variables will 
 
 You can use the AnimationConfiguration to change certain parameters of the parser/player. For example, loopAnimation to loop the animation, or ignoreOpacityAnimation for performance if you know your animation doesn't modify opacity.
 
+## Security
+
+For this player to work, if you are applying CSP to your website, you need the following headers:
+_worker-src blob:_
+_script-src thedomainservingyourjs_
+
+worker-src is used to load the worker. To simplify configuration, we have a small wrapper over the real worker that loads it as a blob.
+script-src is used by the scripts the worker references, like the classes it needs from babylon.js to render. If your CSP is blocking the domain of those scripts, then the worker will fail. You can use 'self' if you are serving your .js from the same domain you are serving your site, or your domain if your .js is served from a separate domain like a CDN.
+
 ## Remarks
 
 - Prefer to use the class Player that uses an Offscreen canvas and the worker thread. If for some reason that is not available to you, you can use LocalPlayer and call playAnimationAsync which renders in the main JS thread.


### PR DESCRIPTION
Loading a worker from a URL can hit CSP issues in scenarios where the .js is served from a different domain than the page, like a CDN.

This adds an internal wrapper to the worker so it can be loaded as a blob, which simplifies the use of this player in CDN scenarios.