### PR TITLE
Configurable default glTF loader options + expose function to load AssetContainer from serialized Babylon scene

### DIFF
--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -16,7 +16,9 @@ import { HDRCubeTexture } from "../../Materials/Textures/hdrCubeTexture";
 import { AnimationGroup } from "../../Animations/animationGroup";
 import { Light } from "../../Lights/light";
 import { SceneComponentConstants } from "../../sceneComponent";
-import { SceneLoader } from "../../Loading/sceneLoader";
+import { RegisterSceneLoaderPlugin } from "../../Loading/sceneLoader";
+import { SceneLoaderFlags } from "../sceneLoaderFlags";
+import { Constants } from "../../Engines";
 import { AssetContainer } from "../../assetContainer";
 import { ActionManager } from "../../Actions/actionManager";
 import type { IParticleSystem } from "../../Particles/IParticleSystem";
@@ -152,7 +154,18 @@ const FindMaterial = (materialId: any, scene: Scene) => {
     return TempMaterialIndexContainer[materialId];
 };
 
-const LoadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError?: (message: string, exception?: any) => void, addToScene = false): AssetContainer => {
+/**
+ * Loads an AssetContainer from a serialized Babylon scene.
+ * @param scene The scene to load the asset container into.
+ * @param serializedScene The serialized scene data. This can be either a JSON string, or an object (e.g. from a call to JSON.parse).
+ * @param rootUrl The root URL for loading assets.
+ * @returns The loaded AssetContainer.
+ */
+export function LoadAssetContainerFromSerializedScene(scene: Scene, serializedScene: string | object, rootUrl: string): AssetContainer {
+    return LoadAssetContainer(scene, serializedScene, rootUrl);
+}
+
+const LoadAssetContainer = (scene: Scene, data: string | object, rootUrl: string, onError?: (message: string, exception?: any) => void, addToScene = false): AssetContainer => {
     const container = new AssetContainer(scene);
 
     // Entire method running in try block, so ALWAYS logs as far as it got, only actually writes details
@@ -162,9 +175,9 @@ const LoadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError
     let log = "importScene has failed JSON parse";
     try {
         // eslint-disable-next-line no-var
-        var parsedData = JSON.parse(data);
+        var parsedData = typeof data === "object" ? data : JSON.parse(data);
         log = "";
-        const fullDetails = SceneLoader.loggingLevel === SceneLoader.DETAILED_LOGGING;
+        const fullDetails = SceneLoaderFlags.loggingLevel === Constants.SCENELOADER_DETAILED_LOGGING;
 
         let index: number;
         let cache: number;
@@ -635,15 +648,17 @@ const LoadAssetContainer = (scene: Scene, data: string, rootUrl: string, onError
         if (!addToScene) {
             container.removeAllFromScene();
         }
-        if (log !== null && SceneLoader.loggingLevel !== SceneLoader.NO_LOGGING) {
-            Logger.Log(logOperation("loadAssets", parsedData ? parsedData.producer : "Unknown") + (SceneLoader.loggingLevel !== SceneLoader.MINIMAL_LOGGING ? log : ""));
+        if (log !== null && SceneLoaderFlags.loggingLevel !== Constants.SCENELOADER_NO_LOGGING) {
+            Logger.Log(
+                logOperation("loadAssets", parsedData ? parsedData.producer : "Unknown") + (SceneLoaderFlags.loggingLevel !== Constants.SCENELOADER_MINIMAL_LOGGING ? log : "")
+            );
         }
     }
 
     return container;
 };
 
-SceneLoader.RegisterPlugin({
+RegisterSceneLoaderPlugin({
     name: "babylon.js",
     extensions: ".babylon",
     canDirectLoad: (data: string) => {
@@ -673,7 +688,7 @@ SceneLoader.RegisterPlugin({
             // eslint-disable-next-line no-var
             var parsedData = JSON.parse(data);
             log = "";
-            const fullDetails = SceneLoader.loggingLevel === SceneLoader.DETAILED_LOGGING;
+            const fullDetails = SceneLoaderFlags.loggingLevel === Constants.SCENELOADER_DETAILED_LOGGING;
             if (!meshesNames) {
                 meshesNames = null;
             } else if (!Array.isArray(meshesNames)) {
@@ -979,8 +994,10 @@ SceneLoader.RegisterPlugin({
                 throw err;
             }
         } finally {
-            if (log !== null && SceneLoader.loggingLevel !== SceneLoader.NO_LOGGING) {
-                Logger.Log(logOperation("importMesh", parsedData ? parsedData.producer : "Unknown") + (SceneLoader.loggingLevel !== SceneLoader.MINIMAL_LOGGING ? log : ""));
+            if (log !== null && SceneLoaderFlags.loggingLevel !== Constants.SCENELOADER_NO_LOGGING) {
+                Logger.Log(
+                    logOperation("importMesh", parsedData ? parsedData.producer : "Unknown") + (SceneLoaderFlags.loggingLevel !== Constants.SCENELOADER_MINIMAL_LOGGING ? log : "")
+                );
             }
             TempMaterialIndexContainer = {};
             TempMorphTargetManagerIndexContainer = {};
@@ -1001,7 +1018,7 @@ SceneLoader.RegisterPlugin({
 
             // Scene
             if (parsedData.useDelayedTextureLoading !== undefined && parsedData.useDelayedTextureLoading !== null) {
-                scene.useDelayedTextureLoading = parsedData.useDelayedTextureLoading && !SceneLoader.ForceFullSceneLoadingForIncremental;
+                scene.useDelayedTextureLoading = parsedData.useDelayedTextureLoading && !SceneLoaderFlags.ForceFullSceneLoadingForIncremental;
             }
             if (parsedData.autoClear !== undefined && parsedData.autoClear !== null) {
                 scene.autoClear = parsedData.autoClear;
@@ -1103,8 +1120,10 @@ SceneLoader.RegisterPlugin({
                 throw err;
             }
         } finally {
-            if (log !== null && SceneLoader.loggingLevel !== SceneLoader.NO_LOGGING) {
-                Logger.Log(logOperation("importScene", parsedData ? parsedData.producer : "Unknown") + (SceneLoader.loggingLevel !== SceneLoader.MINIMAL_LOGGING ? log : ""));
+            if (log !== null && SceneLoaderFlags.loggingLevel !== Constants.SCENELOADER_NO_LOGGING) {
+                Logger.Log(
+                    logOperation("importScene", parsedData ? parsedData.producer : "Unknown") + (SceneLoaderFlags.loggingLevel !== Constants.SCENELOADER_MINIMAL_LOGGING ? log : "")
+                );
             }
         }
         return false;

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -191,6 +191,14 @@ type DefaultExtensionOptions<BaseExtensionOptions> = {
     enabled?: boolean;
 } & BaseExtensionOptions;
 
+/**
+ * This class contains all the concrete (not abstract) glTF options, excluding callbacks.
+ * The purpose of this class is to make it easy to provide a way to mutate the default
+ * loader options (see the GLTFLoaderDefaultOptions instance below) without duplicating
+ * all the options in yet another object. Since this class is instantiated for the default
+ * options object, abstract properties and callbacks are not included, it's more just
+ * flag-type options.
+ */
 class GLTFLoaderBaseOptions {
     /**
      * Defines if the loader should always compute the bounding boxes of meshes and not use the min/max values from the position accessor. Defaults to false.
@@ -300,6 +308,11 @@ class GLTFLoaderBaseOptions {
     public validate = false;
 }
 
+/**
+ * The default GLTF loader options.
+ * Override the properties of this object to globally change the default loader options.
+ * To specify options for a specific load call, pass those options into the associated load function.
+ */
 export const GLTFLoaderDefaultOptions = new GLTFLoaderBaseOptions();
 
 abstract class GLTFLoaderOptions extends GLTFLoaderBaseOptions {

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.ts
@@ -191,7 +191,118 @@ type DefaultExtensionOptions<BaseExtensionOptions> = {
     enabled?: boolean;
 } & BaseExtensionOptions;
 
-abstract class GLTFLoaderOptions {
+class GLTFLoaderBaseOptions {
+    /**
+     * Defines if the loader should always compute the bounding boxes of meshes and not use the min/max values from the position accessor. Defaults to false.
+     */
+    public alwaysComputeBoundingBox = false;
+
+    /**
+     * Defines if the loader should always compute the nearest common ancestor of the skeleton joints instead of using `skin.skeleton`. Defaults to false.
+     * Set this to true if loading assets with invalid `skin.skeleton` values.
+     */
+    public alwaysComputeSkeletonRootNode = false;
+
+    /**
+     * The animation start mode. Defaults to FIRST.
+     */
+    public animationStartMode = GLTFLoaderAnimationStartMode.FIRST;
+
+    /**
+     * Defines if the loader should compile materials before raising the success callback. Defaults to false.
+     */
+    public compileMaterials = false;
+
+    /**
+     * Defines if the loader should compile shadow generators before raising the success callback. Defaults to false.
+     */
+    public compileShadowGenerators = false;
+
+    /**
+     * The coordinate system mode. Defaults to AUTO.
+     */
+    public coordinateSystemMode = GLTFLoaderCoordinateSystemMode.AUTO;
+
+    /**
+     * Defines if the loader should create instances when multiple glTF nodes point to the same glTF mesh. Defaults to true.
+     */
+    public createInstances = true;
+
+    /**
+     * If true, load all materials defined in the file, even if not used by any mesh. Defaults to false.
+     */
+    public loadAllMaterials = false;
+
+    /**
+     * Defines if the loader should load morph targets. Defaults to true.
+     */
+    public loadMorphTargets = true;
+
+    /**
+     * Defines if the loader should load node animations. Defaults to true.
+     * NOTE: The animation of this node will still load if the node is also a joint of a skin and `loadSkins` is true.
+     */
+    public loadNodeAnimations = true;
+
+    /**
+     * If true, load only the materials defined in the file. Defaults to false.
+     */
+    public loadOnlyMaterials = false;
+
+    /**
+     * Defines if the loader should load skins. Defaults to true.
+     */
+    public loadSkins = true;
+
+    /**
+     * If true, do not load any materials defined in the file. Defaults to false.
+     */
+    public skipMaterials = false;
+
+    /**
+     * When loading glTF animations, which are defined in seconds, target them to this FPS. Defaults to 60.
+     */
+    public targetFps = 60;
+
+    /**
+     * Defines if the Alpha blended materials are only applied as coverage.
+     * If false, (default) The luminance of each pixel will reduce its opacity to simulate the behaviour of most physical materials.
+     * If true, no extra effects are applied to transparent pixels.
+     */
+    public transparencyAsCoverage = false;
+
+    /**
+     * Defines if the loader should also compile materials with clip planes. Defaults to false.
+     */
+    public useClipPlane = false;
+
+    /**
+     * If true, the loader will derive the name for Babylon textures from the glTF texture name, image name, or image url. Defaults to false.
+     * Note that it is possible for multiple Babylon textures to share the same name when the Babylon textures load from the same glTF texture or image.
+     */
+    public useGltfTextureNames = false;
+
+    /**
+     * Defines if the loader should use range requests when load binary glTF files from HTTP.
+     * Enabling will disable offline support and glTF validator.
+     * Defaults to false.
+     */
+    public useRangeRequests = false;
+
+    /**
+     * If true, load the color (gamma encoded) textures into sRGB buffers (if supported by the GPU), which will yield more accurate results when sampling the texture. Defaults to true.
+     */
+    public useSRGBBuffers = true;
+
+    /**
+     * Defines if the loader should validate the asset.
+     */
+    public validate = false;
+}
+
+export const GLTFLoaderDefaultOptions = new GLTFLoaderBaseOptions();
+
+abstract class GLTFLoaderOptions extends GLTFLoaderBaseOptions {
     // eslint-disable-next-line babylonjs/available
     protected copyFrom(options?: Partial<Readonly<GLTFLoaderOptions>>) {
         if (options) {
@@ -244,45 +355,9 @@ abstract class GLTFLoaderOptions {
     // ----------
 
     /**
-     * Defines if the loader should always compute the bounding boxes of meshes and not use the min/max values from the position accessor. Defaults to false.
-     */
-    public alwaysComputeBoundingBox = false;
-
-    /**
-     * Defines if the loader should always compute the nearest common ancestor of the skeleton joints instead of using `skin.skeleton`. Defaults to false.
-     * Set this to true if loading assets with invalid `skin.skeleton` values.
-     */
-    public alwaysComputeSkeletonRootNode = false;
-
-    /**
-     * The animation start mode. Defaults to FIRST.
-     */
-    public animationStartMode = GLTFLoaderAnimationStartMode.FIRST;
-
-    /**
      * Defines if the loader should capture performance counters.
      */
     public abstract capturePerformanceCounters: boolean;
-
-    /**
-     * Defines if the loader should compile materials before raising the success callback. Defaults to false.
-     */
-    public compileMaterials = false;
-
-    /**
-     * Defines if the loader should compile shadow generators before raising the success callback. Defaults to false.
-     */
-    public compileShadowGenerators = false;
-
-    /**
-     * The coordinate system mode. Defaults to AUTO.
-     */
-    public coordinateSystemMode = GLTFLoaderCoordinateSystemMode.AUTO;
-
-    /**
-     * Defines if the loader should create instances when multiple glTF nodes point to the same glTF mesh. Defaults to true.
-     */
-    public createInstances = true;
 
     /**
      * Defines the node to use as the root of the hierarchy when loading the scene (default: undefined). If not defined, a root node will be automatically created.
@@ -301,32 +376,6 @@ abstract class GLTFLoaderOptions {
             [Option in keyof DefaultExtensionOptions<GLTFLoaderExtensionOptions[Extension]>]: DefaultExtensionOptions<GLTFLoaderExtensionOptions[Extension]>[Option];
         };
     } = {};
-
-    /**
-     * If true, load all materials defined in the file, even if not used by any mesh. Defaults to false.
-     */
-    public loadAllMaterials = false;
-
-    /**
-     * Defines if the loader should load morph targets. Defaults to true.
-     */
-    public loadMorphTargets = true;
-
-    /**
-     * Defines if the loader should load node animations. Defaults to true.
-     * NOTE: The animation of this node will still load if the node is also a joint of a skin and `loadSkins` is true.
-     */
-    public loadNodeAnimations = true;
-
-    /**
-     * If true, load only the materials defined in the file. Defaults to false.
-     */
-    public loadOnlyMaterials = false;
-
-    /**
-     * Defines if the loader should load skins. Defaults to true.
-     */
-    public loadSkins = true;
 
     /**
      * If true, enable logging for the loader. Defaults to false.
@@ -371,51 +420,6 @@ abstract class GLTFLoaderOptions {
      * @returns Async url to load
      */
     public preprocessUrlAsync = (url: string) => Promise.resolve(url);
-
-    /**
-     * If true, do not load any materials defined in the file. Defaults to false.
-     */
-    public skipMaterials = false;
-
-    /**
-     * When loading glTF animations, which are defined in seconds, target them to this FPS. Defaults to 60.
-     */
-    public targetFps = 60;
-
-    /**
-     * Defines if the Alpha blended materials are only applied as coverage.
-     * If false, (default) The luminance of each pixel will reduce its opacity to simulate the behaviour of most physical materials.
-     * If true, no extra effects are applied to transparent pixels.
-     */
-    public transparencyAsCoverage = false;
-
-    /**
-     * Defines if the loader should also compile materials with clip planes. Defaults to false.
-     */
-    public useClipPlane = false;
-
-    /**
-     * If true, the loader will derive the name for Babylon textures from the glTF texture name, image name, or image url. Defaults to false.
-     * Note that it is possible for multiple Babylon textures to share the same name when the Babylon textures load from the same glTF texture or image.
-     */
-    public useGltfTextureNames = false;
-
-    /**
-     * Defines if the loader should use range requests when load binary glTF files from HTTP.
-     * Enabling will disable offline support and glTF validator.
-     * Defaults to false.
-     */
-    public useRangeRequests = false;
-
-    /**
-     * If true, load the color (gamma encoded) textures into sRGB buffers (if supported by the GPU), which will yield more accurate results when sampling the texture. Defaults to true.
-     */
-    public useSRGBBuffers = true;
-
-    /**
-     * Defines if the loader should validate the asset.
-     */
-    public validate = false;
 }
 
 /**
@@ -434,7 +438,7 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
      */
     public constructor(options?: Partial<Readonly<GLTFLoaderOptions>>) {
         super();
-        this.copyFrom(options);
+        this.copyFrom(Object.assign({ ...GLTFLoaderDefaultOptions }, options));
     }
 
     // --------------------


### PR DESCRIPTION
These two changes address this forum ask: https://forum.babylonjs.com/t/alternative-to-sceneloader-getpluginforextension/60328/7

1. Expose a `LoadAssetContainerFromSerializedScene` (just calls the existing function), and additionally allow passing in an already `JSON.parse`d object (rather than just a string).
2. Expose a `GLTFLoaderDefaultOptions` object that allows changing the global default options for the glTF loader.

I also removed all references to the deprecated `SceneLoader` from babylonFileLoader.