### PR TITLE
Inspector v2: Fix crash when showing scene properties

### DIFF
--- a/packages/dev/core/src/Physics/joinedPhysicsEngineComponent.ts
+++ b/packages/dev/core/src/Physics/joinedPhysicsEngineComponent.ts
@@ -68,7 +68,7 @@ declare module "../scene" {
  * @returns a IPhysicsEngine or null if none attached
  */
 Scene.prototype.getPhysicsEngine = function (): Nullable<IPhysicsEngine> {
-    return this._physicsEngine;
+    return this._physicsEngine ?? null;
 };
 
 /**

--- a/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
@@ -85,7 +85,7 @@ export const ScenePhysicsProperties: FunctionComponent<{ scene: Scene }> = (prop
 
     return (
         <>
-            {physicsEngine !== null ? (
+            {physicsEngine ? (
                 <>
                     <NumberInputPropertyLine
                         label="Time Step"


### PR DESCRIPTION
If a PhysicsEngine is not imported with side effects setting things up, then `scene.getPhysicsEngine` returns `undefined`, even though according to the type it should return `null`. Additionally, the `SceneProperties` for Inspector v2 only checks for a `null` physics engine, not `undefined`, which leads to an unhandled error. This PR fixes both of these - `getPhysicsEngine` returns `null` rather than `undefined` (consistent with the declared type) and `SceneProperties` is more defensive and checks for both `null` and `undefined`.

@PatrickRyanMS FYI