### PR TITLE
ObjectRenderer: Fix crash in ES6 when outline renderer is not imported

### DIFF
--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -635,7 +635,9 @@ export class ObjectRenderer {
             const outlineRenderer = (this._scene as any).getOutlineRenderer?.();
             const outlineRendererIsEnabled = outlineRenderer?.enabled;
 
-            outlineRenderer.enabled = this.enableOutlineRendering;
+            if (outlineRenderer) {
+                outlineRenderer.enabled = this.enableOutlineRendering;
+            }
 
             this.onBeforeRenderingManagerRenderObservable.notifyObservers(passIndex);
 
@@ -1002,3 +1004,4 @@ export class ObjectRenderer {
         }
     }
 }
+


### PR DESCRIPTION
See https://forum.babylonjs.com/t/crash-when-upgrading-from-8-4-1-to-8-25-2-due-to-module-import-assumption/60366