### PR TITLE
Inspector v2: Remove all usages of constructor.name

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -22,7 +22,7 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
     const namePropertyDescriptor = useMemo(() => GetPropertyDescriptor(commonEntity, "name")?.[1], [commonEntity]);
     const isNameReadonly = !namePropertyDescriptor || IsPropertyReadonly(namePropertyDescriptor);
 
-    const className = commonEntity.constructor?.name || commonEntity.getClassName?.();
+    const className = commonEntity.getClassName?.();
 
     return (
         <>

--- a/packages/dev/inspector-v2/src/services/panes/properties/texturePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/texturePropertiesService.tsx
@@ -26,7 +26,7 @@ import { PropertiesServiceIdentity } from "./propertiesService";
 
 // Don't use instanceof in this case as we don't want to bring in the gui package just to check if the entity is an AdvancedDynamicTexture.
 function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTexture {
-    return (entity as AdvancedDynamicTexture)?.constructor?.name === "AdvancedDynamicTexture";
+    return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";
 }
 
 export const TexturePropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISettingsContext]> = {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -13,7 +13,7 @@ import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 // Don't use instanceof in this case as we don't want to bring in the gui package just to check if the entity is an AdvancedDynamicTexture.
 function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTexture {
-    return (entity as AdvancedDynamicTexture)?.constructor?.name === "AdvancedDynamicTexture";
+    return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";
 }
 
 export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -26,7 +26,7 @@ export const RenderingPipelineExplorerServiceDefinition: ServiceDefinition<[], [
             getEntityDisplayInfo: (pipeline) => {
                 return {
                     get name() {
-                        const typeName = pipeline.constructor.name || pipeline.getClassName();
+                        const typeName = pipeline.getClassName();
                         return `${pipeline.name} (${typeName})`;
                     },
                 };

--- a/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/texturesExplorerService.tsx
@@ -41,7 +41,7 @@ export const TextureExplorerServiceDefinition: ServiceDefinition<[], [ISceneExpl
 
                 return {
                     get name() {
-                        return texture.displayName || texture.name || `${texture.constructor?.name || "Unnamed Texture"} (${texture.uniqueId})`;
+                        return texture.displayName || texture.name || `${texture.getClassName() || "Unnamed Texture"} (${texture.uniqueId})`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {


### PR DESCRIPTION
This change removes all usages of `constructor.name`. Conceptually it's a nice idea, but unfortunately it doesn't work when the code is minified because the class names become arbitrary short (often one character) names that are completely unrelated to the "real" original class names. I only noticed this issue in the deployed Playground where the code is minified (it's not minified in local dev builds).