### PR TITLE
Depth Renderer: Allows a custom RTT to be passed through the constructor

### DIFF
--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -99,6 +99,7 @@ export class DepthRenderer {
      * @param samplingMode The sampling mode to be used with the render target (Linear, Nearest...) (default: TRILINEAR_SAMPLINGMODE)
      * @param storeCameraSpaceZ Defines whether the depth stored is the Z coordinate in camera space. If true, storeNonLinearDepth has no effect. (Default: false)
      * @param name Name of the render target (default: DepthRenderer)
+     * @param existingRenderTargetTexture An existing render target texture to use (default: undefined). If not provided, a new render target texture will be created.
      */
     constructor(
         scene: Scene,
@@ -107,7 +108,8 @@ export class DepthRenderer {
         storeNonLinearDepth = false,
         samplingMode = Texture.TRILINEAR_SAMPLINGMODE,
         storeCameraSpaceZ = false,
-        name?: string
+        name?: string,
+        existingRenderTargetTexture?: RenderTargetTexture
     ) {
         this._scene = scene;
         this._storeNonLinearDepth = storeNonLinearDepth;
@@ -139,20 +141,22 @@ export class DepthRenderer {
 
         // Render target
         const format = this.isPacked || !engine._features.supportExtendedTextureFormats ? Constants.TEXTUREFORMAT_RGBA : Constants.TEXTUREFORMAT_R;
-        this._depthMap = new RenderTargetTexture(
-            name ?? "DepthRenderer",
-            { width: engine.getRenderWidth(), height: engine.getRenderHeight() },
-            this._scene,
-            false,
-            true,
-            type,
-            false,
-            samplingMode,
-            undefined,
-            undefined,
-            undefined,
-            format
-        );
+        this._depthMap =
+            existingRenderTargetTexture ??
+            new RenderTargetTexture(
+                name ?? "DepthRenderer",
+                { width: engine.getRenderWidth(), height: engine.getRenderHeight() },
+                this._scene,
+                false,
+                true,
+                type,
+                false,
+                samplingMode,
+                undefined,
+                undefined,
+                undefined,
+                format
+            );
         this._depthMap.wrapU = Texture.CLAMP_ADDRESSMODE;
         this._depthMap.wrapV = Texture.CLAMP_ADDRESSMODE;
         this._depthMap.refreshRate = 1;

--- a/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
@@ -21,6 +21,7 @@ declare module "../scene" {
          * @param force32bitsFloat Forces 32 bits float when supported (else 16 bits float is prioritized over 32 bits float if supported)
          * @param samplingMode The sampling mode to be used with the render target (Linear, Nearest...)
          * @param storeCameraSpaceZ Defines whether the depth stored is the Z coordinate in camera space. If true, storeNonLinearDepth has no effect. (Default: false)
+         * @param existingRenderTargetTexture An existing render target texture to use (default: undefined). If not provided, a new render target texture will be created.
          * @returns the created depth renderer
          */
         enableDepthRenderer(
@@ -28,7 +29,8 @@ declare module "../scene" {
             storeNonLinearDepth?: boolean,
             force32bitsFloat?: boolean,
             samplingMode?: number,
-            storeCameraSpaceZ?: boolean
+            storeCameraSpaceZ?: boolean,
+            existingRenderTargetTexture?: RenderTargetTexture
         ): DepthRenderer;
 
         /**
@@ -44,7 +46,8 @@ Scene.prototype.enableDepthRenderer = function (
     storeNonLinearDepth = false,
     force32bitsFloat: boolean = false,
     samplingMode = Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-    storeCameraSpaceZ: boolean = false
+    storeCameraSpaceZ: boolean = false,
+    existingRenderTargetTexture?: RenderTargetTexture
 ): DepthRenderer {
     camera = camera || this.activeCamera;
     if (!camera) {
@@ -64,7 +67,7 @@ Scene.prototype.enableDepthRenderer = function (
         } else {
             textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
-        this._depthRenderer[camera.id] = new DepthRenderer(this, textureType, camera, storeNonLinearDepth, samplingMode, storeCameraSpaceZ);
+        this._depthRenderer[camera.id] = new DepthRenderer(this, textureType, camera, storeNonLinearDepth, samplingMode, storeCameraSpaceZ, undefined, existingRenderTargetTexture);
     }
 
     return this._depthRenderer[camera.id];


### PR DESCRIPTION
See https://forum.babylonjs.com/t/using-a-depthrenderer-with-a-specific-texture-size/60374/6