### PR TITLE
Lottie fixes

### DIFF
--- a/packages/dev/lottiePlayer/src/localPlayer.ts
+++ b/packages/dev/lottiePlayer/src/localPlayer.ts
@@ -2,7 +2,8 @@ import type { AnimationConfiguration } from "./animationConfiguration";
 import type { RawLottieAnimation } from "./parsing/rawTypes";
 import { DefaultConfiguration } from "./animationConfiguration";
 import { GetRawAnimationDataAsync } from "./parsing/parser";
-import { AnimationController, CalculateScaleFactor } from "./rendering/animationController";
+import { AnimationController } from "./rendering/animationController";
+import { CalculateScaleFactor } from "./rendering/calculateScaleFactor";
 
 /**
  * Allows you to play Lottie animations using Babylon.js.
@@ -22,6 +23,8 @@ export class LocalPlayer {
     private _canvas: HTMLCanvasElement | null = null;
     private _resizeObserver: ResizeObserver | null = null;
     private _animationController: AnimationController | null = null;
+    private _resizeDebounceHandle: number | null = null;
+    private _resizeDebounceMs: number = 1000 / 60; // Debounce resize updates to approximately 60 FPS
 
     /**
      * Creates a new instance of the LottiePlayer.
@@ -81,21 +84,10 @@ export class LocalPlayer {
         this._animationController.playAnimation();
         this._playing = true;
 
-        window.addEventListener("resize", this._onWindowResize);
-
         if ("ResizeObserver" in window) {
             this._resizeObserver = new ResizeObserver(() => {
-                if (this._disposed || !this._canvas || !this._rawAnimation || this._animationController === null) {
-                    return;
-                }
-
-                this._scaleFactor = CalculateScaleFactor(this._rawAnimation.w, this._rawAnimation.h, this._container);
-                this._canvas.style.width = `${this._rawAnimation.w * this._scaleFactor}px`;
-                this._canvas.style.height = `${this._rawAnimation.h * this._scaleFactor}px`;
-
-                this._animationController.setScale(this._scaleFactor);
+                this._scheduleResizeUpdate();
             });
-
             this._resizeObserver.observe(this._container);
         }
 
@@ -106,11 +98,14 @@ export class LocalPlayer {
      * Disposes the LottiePlayer instance, cleaning up resources and event listeners.
      */
     public dispose(): void {
-        window.removeEventListener("resize", this._onWindowResize);
-
         if (this._resizeObserver) {
             this._resizeObserver.disconnect();
             this._resizeObserver = null;
+        }
+
+        if (this._resizeDebounceHandle !== null) {
+            clearTimeout(this._resizeDebounceHandle);
+            this._resizeDebounceHandle = null;
         }
 
         if (this._canvas) {
@@ -121,15 +116,28 @@ export class LocalPlayer {
         this._disposed = true;
     }
 
-    private _onWindowResize = () => {
+    private _scheduleResizeUpdate(): void {
         if (this._disposed || !this._canvas || !this._rawAnimation || this._animationController === null) {
             return;
         }
 
-        this._scaleFactor = CalculateScaleFactor(this._rawAnimation.w, this._rawAnimation.h, this._container);
-        this._canvas.style.width = `${this._rawAnimation.w * this._scaleFactor}px`;
-        this._canvas.style.height = `${this._rawAnimation.h * this._scaleFactor}px`;
+        if (this._resizeDebounceHandle !== null) {
+            clearTimeout(this._resizeDebounceHandle);
+        }
 
-        this._animationController.setScale(this._scaleFactor);
-    };
+        this._resizeDebounceHandle = window.setTimeout(() => {
+            this._resizeDebounceHandle = null;
+            if (this._disposed || !this._canvas || !this._rawAnimation || this._animationController === null) {
+                return;
+            }
+
+            const newScale = CalculateScaleFactor(this._rawAnimation.w, this._rawAnimation.h, this._container);
+            if (this._scaleFactor !== newScale) {
+                this._scaleFactor = newScale;
+
+                this._canvas.style.width = `${this._rawAnimation.w * newScale}px`;
+                this._canvas.style.height = `${this._rawAnimation.h * newScale}px`;
+            }
+        }, this._resizeDebounceMs);
+    }
 }

--- a/packages/dev/lottiePlayer/src/localPlayer.ts
+++ b/packages/dev/lottiePlayer/src/localPlayer.ts
@@ -137,6 +137,7 @@ export class LocalPlayer {
 
                 this._canvas.style.width = `${this._rawAnimation.w * newScale}px`;
                 this._canvas.style.height = `${this._rawAnimation.h * newScale}px`;
+                this._animationController.setScale(newScale);
             }
         }, this._resizeDebounceMs);
     }

--- a/packages/dev/lottiePlayer/src/rendering/animationController.ts
+++ b/packages/dev/lottiePlayer/src/rendering/animationController.ts
@@ -24,24 +24,6 @@ import type { AnimationConfiguration } from "../animationConfiguration";
 const AlphaCombine = 2;
 
 /**
- * Calculates the scale factor between a container and the animation it is playing
- * @param animationWidth Width of the animaiton
- * @param animationHeight Height of the animation
- * @param container The container where the animation is getting played
- * @returns The scale factor that will modify the size of the animation rendering to adjust to the container
- */
-export function CalculateScaleFactor(animationWidth: number | undefined, animationHeight: number | undefined, container: HTMLElement): number {
-    if (animationWidth === undefined || animationHeight === undefined) {
-        return 1;
-    }
-
-    // The size of the canvas is the relation between the size of the container div and the size of the animation
-    const horizontalScale = container.clientWidth / animationWidth;
-    const verticalScale = container.clientHeight / animationHeight;
-    return Math.min(verticalScale, horizontalScale);
-}
-
-/**
  * Class that controls the playing of lottie animations using Babylon.js
  */
 export class AnimationController {

--- a/packages/dev/lottiePlayer/src/rendering/calculateScaleFactor.ts
+++ b/packages/dev/lottiePlayer/src/rendering/calculateScaleFactor.ts
@@ -1,0 +1,17 @@
+/**
+ * Calculates the scale factor between a container and the animation it is playing
+ * @param animationWidth Width of the animaiton
+ * @param animationHeight Height of the animation
+ * @param container The container where the animation is getting played
+ * @returns The scale factor that will modify the size of the animation rendering to adjust to the container
+ */
+export function CalculateScaleFactor(animationWidth: number | undefined, animationHeight: number | undefined, container: HTMLElement): number {
+    if (animationWidth === undefined || animationHeight === undefined) {
+        return 1;
+    }
+
+    // The size of the canvas is the relation between the size of the container div and the size of the animation
+    const horizontalScale = container.clientWidth / animationWidth;
+    const verticalScale = container.clientHeight / animationHeight;
+    return Math.min(verticalScale, horizontalScale);
+}

--- a/packages/tools/devHost/webpack.config.js
+++ b/packages/tools/devHost/webpack.config.js
@@ -2,6 +2,7 @@ const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const webpackTools = require("@dev/build-tools").webpackTools;
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+const TerserPlugin = require("terser-webpack-plugin");
 
 const outputDirectoryForAliases = "src";
 const buildTools = require("@dev/build-tools");
@@ -20,6 +21,8 @@ const rules = buildTools.webpackTools.getRules({
 
 module.exports = (env) => {
     const source = env.source || process.env.SOURCE || "dev"; // || "lts";
+    // Toggle for production-style optimizations (mode=production, minification, gzip). Set DEVHOST_PROD=true to enable.
+    const enableProd = (env && (env.prod || env.production)) || process.env.DEVHOST_PROD === "true";
     const basePathForSources = path.resolve(__dirname, "../../", source);
     const basePathForTools = path.resolve(__dirname, "../../", "tools");
     const externals = externalsFunction([], "umd");
@@ -38,21 +41,28 @@ module.exports = (env) => {
         exclude: /node_modules/,
         sideEffects: true,
     });
+    const baseDevConfig = buildTools.webpackTools.commonDevWebpackConfiguration(
+        {
+            ...env,
+            outputFilename: "main.js",
+            dirName: __dirname,
+        },
+        {
+            static: ["public"],
+            port: process.env.TOOLS_PORT || 1338,
+            showBuildProgress: true,
+        }
+    );
+
     const commonConfig = {
-        ...buildTools.webpackTools.commonDevWebpackConfiguration(
-            {
-                ...env,
-                outputFilename: "main.js",
-                dirName: __dirname,
-            },
-            {
-                static: ["public"],
-                port: process.env.TOOLS_PORT || 1338,
-                showBuildProgress: true,
-            }
-        ),
+        mode: enableProd ? "production" : "development",
+        ...baseDevConfig,
         entry: {
             entry: "./src/index.ts",
+        },
+        devServer: {
+            ...(baseDevConfig.devServer || {}),
+            compress: !!enableProd, // Enable gzip only when production optimizations are on
         },
         resolve: {
             extensions: [".js", ".ts", ".tsx"],
@@ -102,6 +112,27 @@ module.exports = (env) => {
                 scriptLoading: "module",
             }),
         ],
+        optimization: enableProd
+            ? {
+                  minimize: true,
+                  minimizer: [
+                      new TerserPlugin({
+                          extractComments: false,
+                          terserOptions: {
+                              module: true,
+                              mangle: true,
+                              compress: {
+                                  passes: 2,
+                                  ecma: 2020,
+                              },
+                              format: {
+                                  comments: false,
+                              },
+                          },
+                      }),
+                  ],
+              }
+            : undefined,
     };
 
     return commonConfig;


### PR DESCRIPTION
This fixes three issues in lottie:
- The import for CalculateScaleFactor was causing the side-effects from animationController.ts to be included in the bundle when using the client-side worker player, but that code should only be included by the worker itself.
- Used setTimeout to avoid re-entry issues on the resize observer.
- Added code to re-render the last frame after the animation is over to avoid issues with the engine clearing the canvas.