### PR TITLE
Change the URL for devhost visual tests in the CI

### DIFF
--- a/packages/tools/testTools/src/index.ts
+++ b/packages/tools/testTools/src/index.ts
@@ -8,10 +8,17 @@ import { checkArgs, populateEnvironment } from "@dev/build-tools";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const getGlobalConfig = (overrideConfig: { root?: string; baseUrl?: string; usesDevHost: boolean } = { usesDevHost: false }) => {
     populateEnvironment();
+    let baseUrl = undefined;
+    if (overrideConfig.usesDevHost) {
+        baseUrl = (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:1338";
+    } else {
+        baseUrl = process.env.CDN_BASE_URL || (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:1337";
+    }
+
     return {
         snippetUrl: "https://snippet.babylonjs.com",
         pgRoot: "https://playground.babylonjs.com",
-        baseUrl: process.env.CDN_BASE_URL || (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:" + (overrideConfig.usesDevHost ? 1338 : 1337),
+        baseUrl: baseUrl,
         root: "https://cdn.babylonjs.com",
         assetsUrl: "https://assets.babylonjs.com",
         ...overrideConfig,


### PR DESCRIPTION
Devhost visual tests use a local devhost instead of the CDN, this changes how they run on the CI to use the localhost.