### PR TITLE
Fix legacy audio engine dispose issue

### DIFF
--- a/packages/dev/core/src/Audio/audioEngine.ts
+++ b/packages/dev/core/src/Audio/audioEngine.ts
@@ -5,6 +5,7 @@ import { Observable } from "../Misc/observable";
 import { AbstractEngine } from "../Engines/abstractEngine";
 import type { IAudioEngine } from "./Interfaces/IAudioEngine";
 import { _WebAudioEngine } from "../AudioV2/webAudio/webAudioEngine";
+import type { _WebAudioMainBus } from "../AudioV2/webAudio/webAudioMainBus";
 
 // Sets the default audio engine to Babylon.js
 AbstractEngine.AudioEngineFactory = (
@@ -141,6 +142,12 @@ export class AudioEngine implements IAudioEngine {
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises, github/no-then
         v2._initAsync({ resumeOnInteraction: false }).then(() => {
+            const mainBusOutNode = (v2.defaultMainBus as _WebAudioMainBus)._outNode;
+            if (mainBusOutNode) {
+                mainBusOutNode.disconnect(v2.mainOut._inNode);
+                mainBusOutNode.connect(this._masterGain);
+            }
+
             v2.mainOut._inNode = this._masterGain;
             v2.stateChangedObservable.notifyObservers(v2.state);
         });

--- a/packages/tools/tests/test/audioV2/legacy.test.ts
+++ b/packages/tools/tests/test/audioV2/legacy.test.ts
@@ -1,0 +1,26 @@
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+import { expect, test } from "@playwright/test";
+
+InitAudioV2Tests(true, false);
+
+test.describe(`Legacy`, () => {
+    test("Audio engine should dispose without error", async ({ page }) => {
+        const error = await page.evaluate(async () => {
+            const audioEngine = new BABYLON.AudioEngine();
+            return await new Promise<string | null>((resolve) => {
+                setTimeout(() => {
+                    try {
+                        audioEngine.dispose();
+                        resolve(null);
+                    } catch (e) {
+                        console.error(e);
+                        resolve(e);
+                    }
+                }, 1000);
+            });
+        });
+
+        expect(error).toBeNull();
+    });
+});


### PR DESCRIPTION
The v2 audio engine's main out node is being reset to the legacy audio engine's master gain node but the v2 main bus node is not being informed of the change, so it fails in `disconnect` and throws an error.

This change fixes the issue by updating the internal WebAudio node connections appropriately in the legacy audio engine.