### PR TITLE
WebGL: Fix empty mipmaps for compressed textures

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -3415,7 +3415,10 @@ export class ThinEngine extends AbstractEngine {
             }
         }
 
-        this._gl.compressedTexImage2D(target, lod, internalFormat, width, height, 0, <DataView>data);
+        if (texture.generateMipMaps && width === texture.width && height === texture.height) {
+            gl.texStorage2D(gl.TEXTURE_2D, Math.log2(width), internalFormat, width, height);
+        }
+        this._gl.compressedTexSubImage2D(target, lod, 0, 0, width, height, internalFormat, data);
     }
 
     /**

--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -460,6 +460,8 @@ export class KhronosTextureContainer2 {
 
         internalTexture._gammaSpace = data.isInGammaSpace;
         internalTexture.generateMipMaps = data.mipmaps.length > 1;
+        internalTexture.width = data.mipmaps[0].width;
+        internalTexture.height = data.mipmaps[0].height;
 
         if (data.errors) {
             throw new Error("KTX2 container - could not transcode the data. " + data.errors);
@@ -484,8 +486,6 @@ export class KhronosTextureContainer2 {
         }
 
         internalTexture._extension = ".ktx2";
-        internalTexture.width = data.mipmaps[0].width;
-        internalTexture.height = data.mipmaps[0].height;
         internalTexture.isReady = true;
 
         this._engine._bindTextureDirectly(oglTexture2D, null);


### PR DESCRIPTION
See https://forum.babylonjs.com/t/android-xr-sample-glb-files-are-not-rendered-correctly/60412/4