### PR TITLE
Tools: Check IsAbsoluteUrl

### DIFF
--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -1207,6 +1207,7 @@ export class Tools {
         return DecodeBase64UrlToBinary(uri);
     }
 
+    // eslint-disable-next-line jsdoc/require-returns-check, jsdoc/require-param
     /**
      * @returns the absolute URL of a given (relative) url
      */


### PR DESCRIPTION
If we force using an absolute URL, even when the URL is already absolute, we run into `Tools.GetAbsoluteUrl`, which errors in Native environments.