### PR TITLE
Avoid type error when updating WebXRCamera reference space

### DIFF
--- a/packages/dev/core/src/XR/webXRCamera.ts
+++ b/packages/dev/core/src/XR/webXRCamera.ts
@@ -390,6 +390,7 @@ export class WebXRCamera extends FreeCamera {
                     x: this._referencedPosition.x / this._xrSessionManager.worldScalingFactor,
                     y: this._referencedPosition.y / this._xrSessionManager.worldScalingFactor,
                     z: this._referencedPosition.z / this._xrSessionManager.worldScalingFactor,
+                    w: 1,
                 },
                 {
                     x: this._referenceQuaternion.x,


### PR DESCRIPTION
Per the MDN docs the `XRRigidTransform` constructor's `position` argument takes a `w` coord in addition to the `x/y/z` coords, and `w` must be set to `1` otherwise a `TypeError` exception is thrown. This does not seem to be strictly enforced, but a user has reported the exception is thrown in some cases (see https://forum.babylonjs.com/t/xrrigidtransform-invalid-position-error/60416).

This change fixes the issue by always setting the `w` coordinate to `1`.

Tested with playground https://playground.babylonjs.com/#AZML8U#261.