### PR TITLE
Smart Filter Debugger: Fix CSS issue when host has custom body tag styles, fix VSCode module resolution

### DIFF
--- a/packages/tools/smartFiltersDebugger/tsconfig.json
+++ b/packages/tools/smartFiltersDebugger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../tsconfig.build.json",
+    "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
         "resolveJsonModule": true,

--- a/packages/tools/smartFiltersEditorControl/src/smartFilterEditorControl.ts
+++ b/packages/tools/smartFiltersEditorControl/src/smartFilterEditorControl.ts
@@ -174,7 +174,12 @@ export class SmartFilterEditorControl {
 
         if (!hostElement) {
             hostElement = CreatePopup("BABYLON.JS SMART FILTER EDITOR", {
-                onWindowCreateCallback: (w) => (this._PopupWindow = w),
+                onWindowCreateCallback: (w) => {
+                    this._PopupWindow = w;
+                    // Styles are copied from the launching page which could have custom styles on the body tag,
+                    //  and we require the body display to be block, so ensure that it is set as we need it.
+                    w.document.body.style.display = "block";
+                },
                 width: 1500,
                 height: 800,
             })!;


### PR DESCRIPTION
The way popup work in our shared code, the CSS styles for the contents of the popup get added to the original window, then copied into the popup. In the case of the SF debugger browser extension, this can copy in CSS from the hosting page that we don't want - in this case, it was custom styles on the body tag. This is a small fix to ensure the popup for the SF editor always has the correct display style on the body tag, regardless of the value from the hosting page.

I also noticed that the tsconfig.json used by VS was incorrectly referencing the root tsconfig.build.json, so F12 took you to dist instead of src dependencies - fixed that too.