### PR TITLE
Fixing bug with text size calculation

### DIFF
--- a/packages/dev/lottiePlayer/src/maths/boundingBox.ts
+++ b/packages/dev/lottiePlayer/src/maths/boundingBox.ts
@@ -70,12 +70,14 @@ export function GetShapesBoundingBox(rawElements: RawElement[]): BoundingBox {
  * @param spritesCanvasContext The OffscreenCanvasRenderingContext2D or CanvasRenderingContext2D to use for text measurement
  * @param textData The text to calculate the bounding box for
  * @param rawFonts A map of font names to their raw font data
+ * @param variables A map of variables to be used in the animation as text can be a variable which will affect its length
  * @returns The bounding box for the text
  */
 export function GetTextBoundingBox(
     spritesCanvasContext: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D,
     textData: RawTextData,
-    rawFonts: Map<string, RawFont>
+    rawFonts: Map<string, RawFont>,
+    variables: Map<string, string>
 ): BoundingBox | undefined {
     spritesCanvasContext.save();
     let textInfo: RawTextDocument | undefined = undefined;
@@ -103,7 +105,13 @@ export function GetTextBoundingBox(
         spritesCanvasContext.lineWidth = textInfo.sw;
     }
 
-    const text = textInfo.t;
+    // Text is supported as a possible variable (for localization for example)
+    // Check if the text is a variable and replace it if it is
+    let text = textInfo.t;
+    const variableText = variables.get(text);
+    if (variableText !== undefined) {
+        text = variableText;
+    }
     const metrics = spritesCanvasContext.measureText(text);
 
     const widthPx = Math.ceil(metrics.width);

--- a/packages/dev/lottiePlayer/src/parsing/spritePacker.ts
+++ b/packages/dev/lottiePlayer/src/parsing/spritePacker.ts
@@ -213,7 +213,7 @@ export class SpritePacker {
         }
 
         // If the text information is malformed and we can't get the bounding box, then just return
-        const boundingBox = GetTextBoundingBox(this._spritesCanvasContext, textData, this._rawFonts);
+        const boundingBox = GetTextBoundingBox(this._spritesCanvasContext, textData, this._rawFonts, this._variables);
         if (boundingBox === undefined) {
             return undefined;
         }


### PR DESCRIPTION
Size calculations need to replace the text variable by the real value when doing size calculations.