### PR TITLE
KTX2Container: Use ScriptBaseUrl for WasmBaseUrl

### DIFF
--- a/packages/dev/core/src/Misc/khronosTextureContainer2.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2.ts
@@ -283,6 +283,7 @@ export class KhronosTextureContainer2 {
         }
 
         const urls = {
+            wasmBaseUrl: Tools.ScriptBaseUrl,
             jsDecoderModule: Tools.GetBabylonScriptURL(this.URLConfig.jsDecoderModule, true),
             wasmUASTCToASTC: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToASTC, true),
             wasmUASTCToBC7: Tools.GetBabylonScriptURL(this.URLConfig.wasmUASTCToBC7, true),

--- a/packages/dev/core/src/Misc/khronosTextureContainer2Worker.ts
+++ b/packages/dev/core/src/Misc/khronosTextureContainer2Worker.ts
@@ -2,6 +2,7 @@ import type { IDecodedData } from "core/Materials/Textures/ktx2decoderTypes";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export type AllowedKeys =
+    | "wasmBaseUrl"
     | "wasmUASTCToASTC"
     | "wasmUASTCToBC7"
     | "wasmUASTCToRGBA_UNORM"
@@ -19,7 +20,12 @@ declare let KTX2DECODER: any;
 
 export function applyConfig(urls?: { [key in AllowedKeys]: string }, binariesAndModulesContainer?: { [key in AllowedKeys]: ArrayBuffer | any }): void {
     const KTX2DecoderModule = binariesAndModulesContainer?.jsDecoderModule || KTX2DECODER;
+
     if (urls) {
+        if (urls.wasmBaseUrl) {
+            KTX2DecoderModule.Transcoder.WasmBaseUrl = urls.wasmBaseUrl;
+        }
+
         if (urls.wasmUASTCToASTC) {
             KTX2DecoderModule.LiteTranscoder_UASTC_ASTC.WasmModuleURL = urls.wasmUASTCToASTC;
         }

--- a/packages/tools/ktx2Decoder/src/transcoder.ts
+++ b/packages/tools/ktx2Decoder/src/transcoder.ts
@@ -18,8 +18,11 @@ export class Transcoder {
     public static WasmBaseUrl = "";
 
     public static GetWasmUrl(wasmUrl: string) {
-        if (Transcoder.WasmBaseUrl && wasmUrl.startsWith("https://cdn.babylonjs.com/")) {
-            wasmUrl = wasmUrl.replace("https://cdn.babylonjs.com/", Transcoder.WasmBaseUrl);
+        if (Transcoder.WasmBaseUrl && wasmUrl.startsWith("https://cdn.babylonjs.com")) {
+            // Normalize the base url
+            const baseUrl =
+                Transcoder.WasmBaseUrl[Transcoder.WasmBaseUrl.length - 1] === "/" ? Transcoder.WasmBaseUrl.substring(0, Transcoder.WasmBaseUrl.length - 1) : Transcoder.WasmBaseUrl;
+            wasmUrl = wasmUrl.replace("https://cdn.babylonjs.com", baseUrl);
         }
         return wasmUrl;
     }


### PR DESCRIPTION
Currently, setting `BaseScriptUrl` in Babylon has no effect on the URL configuration of the `ktx2decoder` package. See [forum issue](https://forum.babylonjs.com/t/issues-with-self-deploying-babylonjs-cdn/60222) 
This PR allows the consuming BabylonJS code to configure the decoder module's `WasmBaseUrl` to `BaseScriptUrl`.