### PR TITLE
[InspectorV2] Atmosphere Properties

### DIFF
--- a/packages/dev/addons/src/atmosphere/atmosphere.ts
+++ b/packages/dev/addons/src/atmosphere/atmosphere.ts
@@ -907,6 +907,7 @@ export class Atmosphere implements IDisposable {
             scene.removeExternalData("atmosphere");
             this.dispose();
         });
+        scene.addExternalData("atmosphere", this);
 
         // Registers a material plugin which will allow common materials to sample the atmosphere environment maps e.g.,
         // sky view LUT for glossy reflections and diffuse sky illiminance LUT for irradiance.
@@ -918,8 +919,6 @@ export class Atmosphere implements IDisposable {
             }
             return null;
         });
-
-        scene.addExternalData("atmosphere", [this]);
     }
 
     /**

--- a/packages/dev/addons/src/atmosphere/atmosphere.ts
+++ b/packages/dev/addons/src/atmosphere/atmosphere.ts
@@ -759,6 +759,8 @@ export class Atmosphere implements IDisposable {
         this._physicalProperties.peakOzoneAbsorption = this._peakOzoneAbsorptionKm;
     }
 
+    public uniqueId: number;
+
     /**
      * Constructs the {@link Atmosphere}.
      * @param name - The name of this instance.
@@ -773,6 +775,8 @@ export class Atmosphere implements IDisposable {
         options?: IAtmosphereOptions
     ) {
         const engine = (this._engine = scene.getEngine());
+        this.uniqueId = this.scene.getUniqueId();
+
         if (engine.isWebGPU) {
             throw new Error("Atmosphere is not supported on WebGPU.");
         }
@@ -900,6 +904,7 @@ export class Atmosphere implements IDisposable {
 
         // Ensure the atmosphere is disposed when the scene is disposed.
         scene.onDisposeObservable.addOnce(() => {
+            scene.removeExternalData("atmosphere");
             this.dispose();
         });
 
@@ -913,6 +918,8 @@ export class Atmosphere implements IDisposable {
             }
             return null;
         });
+
+        scene.addExternalData("atmosphere", [this]);
     }
 
     /**

--- a/packages/dev/inspector-v2/src/components/properties/atmosphereProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/atmosphereProperties.tsx
@@ -1,0 +1,192 @@
+import type { FunctionComponent } from "react";
+
+import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
+import { BoundProperty } from "./boundProperty";
+import type { Atmosphere } from "addons/atmosphere/atmosphere";
+import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
+import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
+
+export const GeneralAtmosphereProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
+    const { entity: atmosphere } = props;
+    return (
+        <>
+            <BoundProperty
+                label="Planet Radius (km)"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere.physicalProperties}
+                propertyKey="planetRadius"
+                min={1000.0}
+                max={10000.0}
+                step={1}
+            />
+            <BoundProperty
+                label="Atmosphere Thickness (km)"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere.physicalProperties}
+                propertyKey="atmosphereThickness"
+                min={1.0}
+                max={200.0}
+                step={1}
+            />
+        </>
+    );
+};
+export const ScatteringAndAbsorptionProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
+    const { entity: atmosphere } = props;
+    return (
+        <>
+            <BoundProperty
+                label="Rayleigh Scattering Scale"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere.physicalProperties}
+                propertyKey="rayleighScatteringScale"
+                min={0.0}
+                max={5.0}
+                step={0.01}
+            />
+            <BoundProperty label="Peak Rayleigh Scattering (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakRayleighScattering" />
+            <BoundProperty
+                label="Mie Scattering Scale"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere.physicalProperties}
+                propertyKey="mieScatteringScale"
+                min={0.0}
+                max={5.0}
+                step={0.01}
+            />
+            <BoundProperty label="Peak Mie Scattering (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakMieScattering" />
+            <BoundProperty
+                label="Mie Absorption Scale"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere.physicalProperties}
+                propertyKey="mieAbsorptionScale"
+                min={0.0}
+                max={5.0}
+                step={0.01}
+            />
+            <BoundProperty label="Peak Mie Absorption (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakMieAbsorption" />
+            <BoundProperty
+                label="Ozone Absorption Scale"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere.physicalProperties}
+                propertyKey="ozoneAbsorptionScale"
+                min={0.0}
+                max={5.0}
+                step={0.01}
+            />
+            <BoundProperty label="Peak Ozone Absorption (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakOzoneAbsorption" />
+        </>
+    );
+};
+export const MultipleScatteringProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
+    const { entity: atmosphere } = props;
+
+    return (
+        <>
+            <BoundProperty
+                label="Multiple Scattering Intensity"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="multiScatteringIntensity"
+                min={0}
+                max={5.0}
+                step={0.1}
+            />
+            <BoundProperty
+                label="Min Multiple Scattering Intensity"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="minimumMultiScatteringIntensity"
+                min={0.0}
+                max={0.1}
+                step={0.0001}
+            />
+            <BoundProperty label="Min Multiple Scattering Color" component={Color3PropertyLine} target={atmosphere} propertyKey="minimumMultiScatteringColor" />
+            <BoundProperty label="Ground Albedo" component={Color3PropertyLine} target={atmosphere} propertyKey="groundAlbedo" />
+        </>
+    );
+};
+export const AerialPerspectiveProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
+    const { entity: atmosphere } = props;
+
+    return (
+        <>
+            <BoundProperty
+                label="Aerial Perspective Intensity"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="aerialPerspectiveIntensity"
+                min={0}
+                max={5.0}
+                step={0.1}
+            />
+            <BoundProperty
+                label="Aerial Perspective Transmittance Scale"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="aerialPerspectiveTransmittanceScale"
+                min={0}
+                max={2.0}
+                step={0.01}
+            />
+            <BoundProperty
+                label="Aerial Perspective Saturation"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="aerialPerspectiveSaturation"
+                min={0}
+                max={2.0}
+                step={0.01}
+            />
+        </>
+    );
+};
+export const DiffuseIrradianceProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
+    const { entity: atmosphere } = props;
+
+    return (
+        <>
+            <BoundProperty
+                label="Diffuse Sky Intensity"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="diffuseSkyIrradianceIntensity"
+                min={0}
+                max={5.0}
+                step={0.001}
+            />
+            <BoundProperty
+                label="Diffuse Sky Desaturation"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="diffuseSkyIrradianceDesaturationFactor"
+                min={0}
+                max={1.0}
+                step={0.01}
+            />
+            <BoundProperty
+                label="Additional Diffuse Sky Irradiance Intensity"
+                component={SyncedSliderPropertyLine}
+                target={atmosphere}
+                propertyKey="additionalDiffuseSkyIrradianceIntensity"
+                min={0}
+                max={100000.0}
+                step={1}
+            />
+            <BoundProperty label="Additional Diffuse Sky Irradiance Color" component={Color3PropertyLine} target={atmosphere} propertyKey="additionalDiffuseSkyIrradianceColor" />
+        </>
+    );
+};
+export const RenderingOptionsProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
+    const { entity: atmosphere } = props;
+
+    return (
+        <>
+            <BoundProperty label="Linear Space Output" component={SwitchPropertyLine} target={atmosphere} propertyKey="isLinearSpaceComposition" />
+            <BoundProperty label="Linear Space Light" component={SwitchPropertyLine} target={atmosphere} propertyKey="isLinearSpaceLight" />
+            <BoundProperty label="Use LUT for Sky (Optimization)" component={SwitchPropertyLine} target={atmosphere} propertyKey="isSkyViewLutEnabled" />
+            <BoundProperty label="Use LUT for Aerial Perspective (Optimization)" component={SwitchPropertyLine} target={atmosphere} propertyKey="isAerialPerspectiveLutEnabled" />
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/properties/atmosphereProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/atmosphereProperties.tsx
@@ -6,6 +6,7 @@ import { BoundProperty } from "./boundProperty";
 import type { Atmosphere } from "addons/atmosphere/atmosphere";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
 import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
+import { PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
 
 export const GeneralAtmosphereProperties: FunctionComponent<{ entity: Atmosphere }> = (props) => {
     const { entity: atmosphere } = props;
@@ -36,46 +37,78 @@ export const ScatteringAndAbsorptionProperties: FunctionComponent<{ entity: Atmo
     const { entity: atmosphere } = props;
     return (
         <>
-            <BoundProperty
-                label="Rayleigh Scattering Scale"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere.physicalProperties}
-                propertyKey="rayleighScatteringScale"
-                min={0.0}
-                max={5.0}
-                step={0.01}
+            <PropertyLine
+                label="Rayleigh Scattering"
+                expandByDefault
+                expandedContent={
+                    <>
+                        <BoundProperty
+                            label="Scale"
+                            component={SyncedSliderPropertyLine}
+                            target={atmosphere.physicalProperties}
+                            propertyKey="rayleighScatteringScale"
+                            min={0.0}
+                            max={5.0}
+                            step={0.01}
+                        />
+                        <BoundProperty label="Peak (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakRayleighScattering" />
+                    </>
+                }
             />
-            <BoundProperty label="Peak Rayleigh Scattering (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakRayleighScattering" />
-            <BoundProperty
-                label="Mie Scattering Scale"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere.physicalProperties}
-                propertyKey="mieScatteringScale"
-                min={0.0}
-                max={5.0}
-                step={0.01}
+            <PropertyLine
+                label="Mie Scattering"
+                expandByDefault
+                expandedContent={
+                    <>
+                        <BoundProperty
+                            label="Scale"
+                            component={SyncedSliderPropertyLine}
+                            target={atmosphere.physicalProperties}
+                            propertyKey="mieScatteringScale"
+                            min={0.0}
+                            max={5.0}
+                            step={0.01}
+                        />
+                        <BoundProperty label="Scattering (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakMieScattering" />
+                    </>
+                }
             />
-            <BoundProperty label="Peak Mie Scattering (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakMieScattering" />
-            <BoundProperty
-                label="Mie Absorption Scale"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere.physicalProperties}
-                propertyKey="mieAbsorptionScale"
-                min={0.0}
-                max={5.0}
-                step={0.01}
+            <PropertyLine
+                label="Mie Absorption"
+                expandByDefault
+                expandedContent={
+                    <>
+                        <BoundProperty
+                            label="Scale"
+                            component={SyncedSliderPropertyLine}
+                            target={atmosphere.physicalProperties}
+                            propertyKey="mieAbsorptionScale"
+                            min={0.0}
+                            max={5.0}
+                            step={0.01}
+                        />
+                        <BoundProperty label="Peak (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakMieAbsorption" />
+                    </>
+                }
             />
-            <BoundProperty label="Peak Mie Absorption (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakMieAbsorption" />
-            <BoundProperty
-                label="Ozone Absorption Scale"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere.physicalProperties}
-                propertyKey="ozoneAbsorptionScale"
-                min={0.0}
-                max={5.0}
-                step={0.01}
+            <PropertyLine
+                label="Ozone Absorption"
+                expandByDefault
+                expandedContent={
+                    <>
+                        <BoundProperty
+                            label="Scale"
+                            component={SyncedSliderPropertyLine}
+                            target={atmosphere.physicalProperties}
+                            propertyKey="ozoneAbsorptionScale"
+                            min={0.0}
+                            max={5.0}
+                            step={0.01}
+                        />
+                        <BoundProperty label="Peak (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakOzoneAbsorption" />
+                    </>
+                }
             />
-            <BoundProperty label="Peak Ozone Absorption (Mm)" component={Vector3PropertyLine} target={atmosphere.physicalProperties} propertyKey="peakOzoneAbsorption" />
         </>
     );
 };
@@ -84,17 +117,9 @@ export const MultipleScatteringProperties: FunctionComponent<{ entity: Atmospher
 
     return (
         <>
+            <BoundProperty label="Intensity" component={SyncedSliderPropertyLine} target={atmosphere} propertyKey="multiScatteringIntensity" min={0} max={5.0} step={0.1} />
             <BoundProperty
-                label="Multiple Scattering Intensity"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere}
-                propertyKey="multiScatteringIntensity"
-                min={0}
-                max={5.0}
-                step={0.1}
-            />
-            <BoundProperty
-                label="Min Multiple Scattering Intensity"
+                label="Minimum Intensity"
                 component={SyncedSliderPropertyLine}
                 target={atmosphere}
                 propertyKey="minimumMultiScatteringIntensity"
@@ -102,7 +127,7 @@ export const MultipleScatteringProperties: FunctionComponent<{ entity: Atmospher
                 max={0.1}
                 step={0.0001}
             />
-            <BoundProperty label="Min Multiple Scattering Color" component={Color3PropertyLine} target={atmosphere} propertyKey="minimumMultiScatteringColor" />
+            <BoundProperty label="Minimum Color" component={Color3PropertyLine} target={atmosphere} propertyKey="minimumMultiScatteringColor" />
             <BoundProperty label="Ground Albedo" component={Color3PropertyLine} target={atmosphere} propertyKey="groundAlbedo" />
         </>
     );
@@ -112,17 +137,9 @@ export const AerialPerspectiveProperties: FunctionComponent<{ entity: Atmosphere
 
     return (
         <>
+            <BoundProperty label="Intensity" component={SyncedSliderPropertyLine} target={atmosphere} propertyKey="aerialPerspectiveIntensity" min={0} max={5.0} step={0.1} />
             <BoundProperty
-                label="Aerial Perspective Intensity"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere}
-                propertyKey="aerialPerspectiveIntensity"
-                min={0}
-                max={5.0}
-                step={0.1}
-            />
-            <BoundProperty
-                label="Aerial Perspective Transmittance Scale"
+                label="Transmittance Scale"
                 component={SyncedSliderPropertyLine}
                 target={atmosphere}
                 propertyKey="aerialPerspectiveTransmittanceScale"
@@ -130,15 +147,7 @@ export const AerialPerspectiveProperties: FunctionComponent<{ entity: Atmosphere
                 max={2.0}
                 step={0.01}
             />
-            <BoundProperty
-                label="Aerial Perspective Saturation"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere}
-                propertyKey="aerialPerspectiveSaturation"
-                min={0}
-                max={2.0}
-                step={0.01}
-            />
+            <BoundProperty label="Saturation" component={SyncedSliderPropertyLine} target={atmosphere} propertyKey="aerialPerspectiveSaturation" min={0} max={2.0} step={0.01} />
         </>
     );
 };
@@ -147,17 +156,9 @@ export const DiffuseIrradianceProperties: FunctionComponent<{ entity: Atmosphere
 
     return (
         <>
+            <BoundProperty label="Intensity" component={SyncedSliderPropertyLine} target={atmosphere} propertyKey="diffuseSkyIrradianceIntensity" min={0} max={5.0} step={0.001} />
             <BoundProperty
-                label="Diffuse Sky Intensity"
-                component={SyncedSliderPropertyLine}
-                target={atmosphere}
-                propertyKey="diffuseSkyIrradianceIntensity"
-                min={0}
-                max={5.0}
-                step={0.001}
-            />
-            <BoundProperty
-                label="Diffuse Sky Desaturation"
+                label="Desaturation"
                 component={SyncedSliderPropertyLine}
                 target={atmosphere}
                 propertyKey="diffuseSkyIrradianceDesaturationFactor"
@@ -166,7 +167,7 @@ export const DiffuseIrradianceProperties: FunctionComponent<{ entity: Atmosphere
                 step={0.01}
             />
             <BoundProperty
-                label="Additional Diffuse Sky Irradiance Intensity"
+                label="Additional Intensity"
                 component={SyncedSliderPropertyLine}
                 target={atmosphere}
                 propertyKey="additionalDiffuseSkyIrradianceIntensity"
@@ -174,7 +175,7 @@ export const DiffuseIrradianceProperties: FunctionComponent<{ entity: Atmosphere
                 max={100000.0}
                 step={1}
             />
-            <BoundProperty label="Additional Diffuse Sky Irradiance Color" component={Color3PropertyLine} target={atmosphere} propertyKey="additionalDiffuseSkyIrradianceColor" />
+            <BoundProperty label="Additional Color" component={Color3PropertyLine} target={atmosphere} propertyKey="additionalDiffuseSkyIrradianceColor" />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
@@ -28,6 +28,12 @@ const ImportToolsExtensionMetadata = {
     keywords: ["import", "tools"],
 } as const;
 
+const AtmosphereExtensionMetadata = {
+    name: "Atmosphere Explorer",
+    description: "Explore the atmosphere in your scene.",
+    keywords: ["atmopshere", "explorer"],
+} as const;
+
 const Extensions: readonly ExtensionMetadata[] = [/*CreationToolsExtensionMetadata, */ ExportToolsExtensionMetadata, CaptureToolsExtensionMetadata, ImportToolsExtensionMetadata];
 
 /**
@@ -55,6 +61,8 @@ export class BuiltInsExtensionFeed implements IExtensionFeed {
             return await import("../services/panes/tools/captureService");
         } else if (name === ImportToolsExtensionMetadata.name) {
             return await import("../services/panes/tools/importService");
+        } else if (name === AtmosphereExtensionMetadata.name) {
+            return await import("../services/panes/scene/atmosphereExplorerService");
         }
         return undefined;
     }

--- a/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
@@ -28,12 +28,6 @@ const ImportToolsExtensionMetadata = {
     keywords: ["import", "tools"],
 } as const;
 
-const AtmosphereExtensionMetadata = {
-    name: "Atmosphere Explorer",
-    description: "Explore the atmosphere in your scene.",
-    keywords: ["atmopshere", "explorer"],
-} as const;
-
 const Extensions: readonly ExtensionMetadata[] = [/*CreationToolsExtensionMetadata, */ ExportToolsExtensionMetadata, CaptureToolsExtensionMetadata, ImportToolsExtensionMetadata];
 
 /**
@@ -61,8 +55,6 @@ export class BuiltInsExtensionFeed implements IExtensionFeed {
             return await import("../services/panes/tools/captureService");
         } else if (name === ImportToolsExtensionMetadata.name) {
             return await import("../services/panes/tools/importService");
-        } else if (name === AtmosphereExtensionMetadata.name) {
-            return await import("../services/panes/scene/atmosphereExplorerService");
         }
         return undefined;
     }

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -55,6 +55,8 @@ import { PickingServiceDefinition } from "./services/pickingService";
 import { SceneContextIdentity } from "./services/sceneContext";
 import { SelectionServiceDefinition } from "./services/selectionService";
 import { ShellServiceIdentity } from "./services/shellService";
+import { AtmospherePropertiesServiceDefinition } from "./services/panes/properties/atmospherePropertiesService";
+import { AtmosphereExplorerServiceDefinition } from "./services/panes/scene/atmosphereExplorerService";
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
@@ -210,6 +212,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             AnimationGroupExplorerServiceDefinition,
             GuiExplorerServiceDefinition,
             FrameGraphExplorerServiceDefinition,
+            AtmosphereExplorerServiceDefinition,
 
             // Properties pane tab and related services.
             ScenePropertiesServiceDefinition,
@@ -232,6 +235,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             FrameGraphPropertiesServiceDefinition,
             AnimationGroupPropertiesServiceDefinition,
             MetadataPropertiesServiceDefinition,
+            AtmospherePropertiesServiceDefinition,
 
             // Debug pane tab and related services.
             DebugServiceDefinition,

--- a/packages/dev/inspector-v2/src/services/panes/properties/atmospherePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/atmospherePropertiesService.tsx
@@ -1,0 +1,63 @@
+import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISelectionService } from "../../selectionService";
+import type { IPropertiesService } from "./propertiesService";
+import type { ISceneContext } from "../../../services/sceneContext";
+import { SelectionServiceIdentity } from "../../selectionService";
+import { PropertiesServiceIdentity } from "./propertiesService";
+import { SceneContextIdentity } from "../../../services/sceneContext";
+import { Atmosphere } from "addons/atmosphere/atmosphere";
+import {
+    AerialPerspectiveProperties,
+    DiffuseIrradianceProperties,
+    GeneralAtmosphereProperties,
+    MultipleScatteringProperties,
+    RenderingOptionsProperties,
+    ScatteringAndAbsorptionProperties,
+} from "../../../components/properties/atmosphereProperties";
+export const AtmospherePropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISelectionService, ISceneContext]> = {
+    friendlyName: "Atmosphere Properties",
+    consumes: [PropertiesServiceIdentity, SelectionServiceIdentity, SceneContextIdentity],
+    factory: (propertiesService, selectionService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return undefined;
+        }
+
+        const atmosphereContentRegistration = propertiesService.addSectionContent({
+            key: "Atmosphere Properties",
+            predicate: (entity: unknown) => entity instanceof Atmosphere,
+            content: [
+                {
+                    section: "General",
+                    component: ({ context }) => <GeneralAtmosphereProperties entity={context} />,
+                },
+                {
+                    section: "Scattering And Absorption",
+                    component: ({ context }) => <ScatteringAndAbsorptionProperties entity={context} />,
+                },
+                {
+                    section: "Multiple Scattering",
+                    component: ({ context }) => <MultipleScatteringProperties entity={context} />,
+                },
+                {
+                    section: "Aerial Perspective",
+                    component: ({ context }) => <AerialPerspectiveProperties entity={context} />,
+                },
+                {
+                    section: "Diffuse Irradiance",
+                    component: ({ context }) => <DiffuseIrradianceProperties entity={context} />,
+                },
+                {
+                    section: "Rendering Options",
+                    component: ({ context }) => <RenderingOptionsProperties entity={context} />,
+                },
+            ],
+        });
+
+        return {
+            dispose: () => {
+                atmosphereContentRegistration.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/services/panes/properties/atmospherePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/atmospherePropertiesService.tsx
@@ -44,7 +44,7 @@ export const AtmospherePropertiesServiceDefinition: ServiceDefinition<[], [IProp
                     component: ({ context }) => <AerialPerspectiveProperties entity={context} />,
                 },
                 {
-                    section: "Diffuse Irradiance",
+                    section: "Diffuse Sky Irradiance",
                     component: ({ context }) => <DiffuseIrradianceProperties entity={context} />,
                 },
                 {

--- a/packages/dev/inspector-v2/src/services/panes/scene/atmosphereExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/atmosphereExplorerService.tsx
@@ -19,11 +19,10 @@ export const AtmosphereExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
         if (!scene) {
             return undefined;
         }
-
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Atmosphere",
             order: DefaultSectionsOrder.Atmosphere,
-            getRootEntities: () => (scene.getExternalData("atmosphere") as Atmosphere[]) ?? [],
+            getRootEntities: () => (scene.getExternalData("atmosphere") ? [scene.getExternalData("atmosphere") as Atmosphere] : []),
             getEntityDisplayInfo: (atmosphere) => {
                 const onChangeObservable = new Observable<void>();
 
@@ -45,6 +44,7 @@ export const AtmosphereExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
                 };
             },
             entityIcon: () => <WeatherSunnyLowFilled />,
+            // TODO in order for inspector UX to display atmosphere created after inspector is created
             getEntityAddedObservables: () => [],
             getEntityRemovedObservables: () => [],
         });

--- a/packages/dev/inspector-v2/src/services/panes/scene/atmosphereExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/atmosphereExplorerService.tsx
@@ -1,0 +1,62 @@
+import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISceneContext } from "../../sceneContext";
+import type { ISceneExplorerService } from "./sceneExplorerService";
+
+import { WeatherSunnyLowFilled } from "@fluentui/react-icons";
+
+import { Observable } from "core/Misc/observable";
+import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { SceneContextIdentity } from "../../sceneContext";
+import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
+import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
+import type { Atmosphere } from "addons/atmosphere/atmosphere";
+
+export const AtmosphereExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
+    friendlyName: "Atmosphere Explorer",
+    consumes: [SceneExplorerServiceIdentity, SceneContextIdentity],
+    factory: (sceneExplorerService, sceneContext) => {
+        const scene = sceneContext.currentScene;
+        if (!scene) {
+            return undefined;
+        }
+
+        const sectionRegistration = sceneExplorerService.addSection({
+            displayName: "Atmosphere",
+            order: DefaultSectionsOrder.Atmosphere,
+            getRootEntities: () => (scene.getExternalData("atmosphere") as Atmosphere[]) ?? [],
+            getEntityDisplayInfo: (atmosphere) => {
+                const onChangeObservable = new Observable<void>();
+
+                const nameHookToken = InterceptProperty(atmosphere, "name", {
+                    afterSet: () => {
+                        onChangeObservable.notifyObservers();
+                    },
+                });
+
+                return {
+                    get name() {
+                        return atmosphere.name;
+                    },
+                    onChange: onChangeObservable,
+                    dispose: () => {
+                        nameHookToken.dispose();
+                        onChangeObservable.clear();
+                    },
+                };
+            },
+            entityIcon: () => <WeatherSunnyLowFilled />,
+            getEntityAddedObservables: () => [],
+            getEntityRemovedObservables: () => [],
+        });
+
+        return {
+            dispose: () => {
+                sectionRegistration.dispose();
+            },
+        };
+    },
+};
+
+export default {
+    serviceDefinitions: [AtmosphereExplorerServiceDefinition],
+} as const;

--- a/packages/dev/inspector-v2/src/services/panes/scene/defaultSectionsMetadata.ts
+++ b/packages/dev/inspector-v2/src/services/panes/scene/defaultSectionsMetadata.ts
@@ -11,4 +11,5 @@ export const enum DefaultSectionsOrder {
     AnimationGroups = 1000,
     GUIs = 1100,
     FrameGraphs = 1200,
+    Atmosphere = 1300,
 }


### PR DESCRIPTION
Still need to add in proper observables for knowing when atmosphere is added/removed, but can have the UX pieces reviewed in meantime 
<img width="944" height="559" alt="image" src="https://github.com/user-attachments/assets/cb6b7c9c-1f64-4137-8446-f1e4a4f92f13" />

Note I would prefer all atmosphere-related changes live under inspectorv2/addons/atmosphere, though we'd want to do that only if the rest of inspector is restructured to have same core/sprites,lights,etc folders (which we may do soon)