### PR TITLE
Inspector v2: Fix a couple property pane bugs

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
@@ -51,7 +51,7 @@ export const AnimationsProperties: FunctionComponent<{ scene: Scene; entity: Par
     const isPlaying = animatablesForTarget.length > 0;
     const mainAnimatable = isPlaying ? animatablesForTarget[0] : undefined;
 
-    const animationPropertiesOverride = mainAnimatable ? useProperty(mainAnimatable, "animationPropertiesOverride") : undefined;
+    const animationPropertiesOverride = useProperty(mainAnimatable, "animationPropertiesOverride");
 
     if (mainAnimatable) {
         lastFrom.current = mainAnimatable.fromFrame;

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
@@ -86,7 +86,7 @@ export const Accordion: FunctionComponent<PropsWithChildren> = (props) => {
         <FluentAccordion className={classes.accordion} collapsible multiple onToggle={onToggle} openItems={openItems} {...rest}>
             {validChildren.map((child) => {
                 return (
-                    <AccordionItem key={child.title} value={child.title}>
+                    <AccordionItem key={child.content.key} value={child.title}>
                         <AccordionHeader expandIconPosition="end">
                             <Subtitle1>{child.title}</Subtitle1>
                         </AccordionHeader>

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/collapse.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/collapse.tsx
@@ -12,6 +12,12 @@ const useCollapseStyles = makeStyles({
         overflow: "hidden",
         display: "flex",
     },
+    horizontal: {
+        flexDirection: "row",
+    },
+    vertical: {
+        flexDirection: "column",
+    },
 });
 
 /**
@@ -24,7 +30,7 @@ export const Collapse: FunctionComponent<PropsWithChildren<CollapseProps>> = (pr
     const classes = useCollapseStyles();
     return (
         <FluentCollapse visible={props.visible} orientation={props.orientation}>
-            <div className={classes.collapseContent}>{props.children}</div>
+            <div className={`${classes.collapseContent} ${props.orientation === "horizontal" ? classes.horizontal : classes.vertical}`}>{props.children}</div>
         </FluentCollapse>
     );
 };


### PR DESCRIPTION
This change fixes two issues:
1. An unhandled error that can occur when switching between nodes with and without animations. This was happening due to a violation of the rule of hooks - specifically, there was a conditional hook, which completely breaks React's internal state.
2. Set the flexDirection on the `Collapse` wrapper component to match the collapse orientation. There is no way for us to know the intent of the caller if they use a React fragment, but defaulting to the collapse orientation seems reasonable (and fixes the issues I was seeing in the property pane). If a user wants to override the default, they can just use a div explicitly rather than a React fragment.