### PR TITLE
Create abstraction layer over the inspector gizmo layer

### DIFF
--- a/packages/dev/inspector/src/components/sceneExplorer/entities/cameraTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/cameraTreeItemComponent.tsx
@@ -10,6 +10,7 @@ import { TreeItemLabelComponent } from "../treeItemLabelComponent";
 import { ExtensionsComponent } from "../extensionsComponent";
 import * as React from "react";
 import type { GlobalState } from "../../globalState";
+import { GetInspectorGizmoManager } from "../../../inspectorGizmoManager";
 
 interface ICameraTreeItemComponentProps {
     camera: Camera;
@@ -73,9 +74,7 @@ export class CameraTreeItemComponent extends React.Component<ICameraTreeItemComp
     toggleGizmo(): void {
         const camera = this.props.camera;
         if (camera.reservedDataStore && camera.reservedDataStore.cameraGizmo) {
-            if (camera.getScene().reservedDataStore && camera.getScene().reservedDataStore.gizmoManager) {
-                camera.getScene().reservedDataStore.gizmoManager.attachToMesh(null);
-            }
+            GetInspectorGizmoManager(camera.getScene(), false)?.attachToMesh(null);
             this.props.globalState.enableCameraGizmo(camera, false);
             this.setState({ isGizmoEnabled: false });
         } else {

--- a/packages/dev/inspector/src/components/sceneExplorer/entities/lightTreeItemComponent.tsx
+++ b/packages/dev/inspector/src/components/sceneExplorer/entities/lightTreeItemComponent.tsx
@@ -9,6 +9,7 @@ import { TreeItemLabelComponent } from "../treeItemLabelComponent";
 import { ExtensionsComponent } from "../extensionsComponent";
 import * as React from "react";
 import type { GlobalState } from "../../globalState";
+import { GetInspectorGizmoManager } from "../../../inspectorGizmoManager";
 
 interface ILightTreeItemComponentProps {
     light: Light;
@@ -39,9 +40,7 @@ export class LightTreeItemComponent extends React.Component<ILightTreeItemCompon
     toggleGizmo(): void {
         const light = this.props.light;
         if (light.reservedDataStore && light.reservedDataStore.lightGizmo) {
-            if (light.getScene().reservedDataStore && light.getScene().reservedDataStore.gizmoManager) {
-                light.getScene().reservedDataStore.gizmoManager.attachToMesh(null);
-            }
+            GetInspectorGizmoManager(light.getScene(), false)?.attachToMesh(null);
             this.props.globalState.enableLightGizmo(light, false);
             this.setState({ isGizmoEnabled: false });
         } else {

--- a/packages/dev/inspector/src/inspector.ts
+++ b/packages/dev/inspector/src/inspector.ts
@@ -19,6 +19,7 @@ import type { IPopupComponentProps } from "./components/popupComponent";
 import { PopupComponent } from "./components/popupComponent";
 import { CopyStyles } from "shared-ui-components/styleHelper";
 import { CreatePopup } from "shared-ui-components/popupHelper";
+import { DisposeInspectorGizmoManager } from "./inspectorGizmoManager";
 
 interface IInternalInspectorOptions extends IInspectorOptions {
     popup: boolean;
@@ -538,10 +539,7 @@ export class Inspector {
                 this._GlobalState.enableCameraGizmo(g.camera, false);
             }
         }
-        if (this._Scene && this._Scene.reservedDataStore && this._Scene.reservedDataStore.gizmoManager) {
-            this._Scene.reservedDataStore.gizmoManager.dispose();
-            this._Scene.reservedDataStore.gizmoManager = null;
-        }
+        DisposeInspectorGizmoManager(this._Scene);
 
         if (this._NewCanvasContainer) {
             this._DestroyCanvasContainer();

--- a/packages/dev/inspector/src/inspectorGizmoManager.ts
+++ b/packages/dev/inspector/src/inspectorGizmoManager.ts
@@ -1,0 +1,36 @@
+import type { Scene } from "core/scene";
+import type { Nullable } from "core/types";
+import { UtilityLayerRenderer } from "core/Rendering/utilityLayerRenderer";
+import { GizmoManager } from "core/Gizmos/gizmoManager";
+import { FrameGraphUtils } from "core/FrameGraph/frameGraphUtils";
+
+function CreateInspectorGizmoManager(scene: Scene): GizmoManager {
+    const layer1 = scene.frameGraph ? FrameGraphUtils.CreateUtilityLayerRenderer(scene.frameGraph) : new UtilityLayerRenderer(scene);
+    const layer2 = scene.frameGraph ? FrameGraphUtils.CreateUtilityLayerRenderer(scene.frameGraph) : new UtilityLayerRenderer(scene);
+    const gizmoManager = new GizmoManager(scene, undefined, layer1, layer2);
+    scene.reservedDataStore ??= {};
+    scene.reservedDataStore.gizmoManager = gizmoManager;
+    return gizmoManager;
+}
+
+export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, create: true): GizmoManager;
+export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, create: false): Nullable<GizmoManager>;
+export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, create: boolean): Nullable<GizmoManager> {
+    let gizmoManager = (
+        scene && scene.reservedDataStore && scene.reservedDataStore.gizmoManager
+        ? scene.reservedDataStore.gizmoManager as GizmoManager
+        : null
+    );
+    if (!gizmoManager && create) {
+        if (!scene) { throw new Error('Invalid scene provided to GetInspectorGizmoManager'); }
+        gizmoManager = CreateInspectorGizmoManager(scene);
+    }
+    return gizmoManager;
+}
+
+export function DisposeInspectorGizmoManager(scene: Nullable<Scene> | undefined): void {
+    const gizmoManager = GetInspectorGizmoManager(scene, false);
+    if (!gizmoManager) { return; }
+    gizmoManager.dispose();
+    scene!.reservedDataStore.gizmoManager = null;
+}

--- a/packages/dev/inspector/src/inspectorGizmoManager.ts
+++ b/packages/dev/inspector/src/inspectorGizmoManager.ts
@@ -16,13 +16,11 @@ function CreateInspectorGizmoManager(scene: Scene): GizmoManager {
 export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, create: true): GizmoManager;
 export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, create: false): Nullable<GizmoManager>;
 export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, create: boolean): Nullable<GizmoManager> {
-    let gizmoManager = (
-        scene && scene.reservedDataStore && scene.reservedDataStore.gizmoManager
-        ? scene.reservedDataStore.gizmoManager as GizmoManager
-        : null
-    );
+    let gizmoManager = scene && scene.reservedDataStore && scene.reservedDataStore.gizmoManager ? (scene.reservedDataStore.gizmoManager as GizmoManager) : null;
     if (!gizmoManager && create) {
-        if (!scene) { throw new Error('Invalid scene provided to GetInspectorGizmoManager'); }
+        if (!scene) {
+            throw new Error("Invalid scene provided to GetInspectorGizmoManager");
+        }
         gizmoManager = CreateInspectorGizmoManager(scene);
     }
     return gizmoManager;
@@ -30,7 +28,9 @@ export function GetInspectorGizmoManager(scene: Nullable<Scene> | undefined, cre
 
 export function DisposeInspectorGizmoManager(scene: Nullable<Scene> | undefined): void {
     const gizmoManager = GetInspectorGizmoManager(scene, false);
-    if (!gizmoManager) { return; }
+    if (!gizmoManager) {
+        return;
+    }
     gizmoManager.dispose();
     scene!.reservedDataStore.gizmoManager = null;
 }


### PR DESCRIPTION
This change fixes some issues with the inspector due to its `gizmoManager` being treated as an `any` type.

## Issue Description

To see the issue this is attempting to address, go to [https://sandbox.babylonjs.com/](https://sandbox.babylonjs.com/?asset=https://playground.babylonjs.com/scenes/skull.babylon) and load a model, then open the inspector and click this button:
<img width="536" height="220" alt="image" src="https://github.com/user-attachments/assets/638ce37e-f310-40f8-a424-e557f35ab062" />

A message will appear on screen: `Script error. Check the developer console.` (nothing appears in console).

The actual issue stems from this error:
```log
sceneTreeItemComponent.tsx:185  Uncaught TypeError: Cannot read properties of null (reading 'gizmoManager')
// or
sceneTreeItemComponent.tsx:187  Uncaught TypeError: Cannot set properties of null (setting 'coordinatesMode')
```

Which leads to here:
https://github.com/BabylonJS/Babylon.js/blob/197d8f6728cc57e46df8e63eaab776a023e5a3ff/packages/dev/inspector/src/components/sceneExplorer/entities/sceneTreeItemComponent.tsx#L185-L187

The issue being that this assumes that this value has been initialized, which in this case it has not been.

## Change Description

This change makes all access to the Inspector's `gizmoManager` use one of two helper functions: one for getting and optionally creating, and one for disposing. This abstracts the type-unsafety of the `any` types to one file, rather than spreading them across ~10 different locations.

This code should not make any changes to when the inspector creates the `gizmoManager`, as the code path to create it should only be activated in the place where it was originally created.