### PR TITLE
Disable chunking for umd builds

### DIFF
--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -320,6 +320,12 @@ export const commonUMDWebpackConfiguration = (options: {
             libraryExport: "default",
             umdNamedDefine: true,
             globalObject: '(typeof self !== "undefined" ? self : typeof global !== "undefined" ? global : this)',
+            // This disables chunking / code splitting. For UMD, we always want a single output file per entry point.
+            // NOTE: The normal way of doing this is by limiting the max chunks, as described here: https://webpack.js.org/plugins/limit-chunk-count-plugin/#maxchunks
+            //       However, that didn't work when testing (fewer chunks were created, but still more than 1). There is a long Webpack github issue about this, where
+            //       eventually someone suggests the following config option, which apparently worked for many other people, and worked for us too.
+            //       https://github.com/webpack/webpack/issues/12464#issuecomment-1911309972
+            chunkFormat: false,
         },
         resolve: {
             extensions: [".ts", ".js"],


### PR DESCRIPTION
This disables chunking for umd builds as we always want one chunk per entry point (usually we just have one entry point, but not always, such as with the loaders package). Without this, various circumstances can lead to chunking (such as multiple entry points with a shared dependency on an internal only API).