### PR TITLE
Fix addons path alias in tsconfig

### DIFF
--- a/packages/public/umd/babylonjs-addons/tsconfig.build.json
+++ b/packages/public/umd/babylonjs-addons/tsconfig.build.json
@@ -9,7 +9,7 @@
         "importHelpers": true,
         "paths": {
             "core/*": ["dev/core/dist/*"],
-            "addons/*": ["dev/addons/dist/*"]
+            "addons/*": ["dev/addons/src/*"]
         }
     },
     "include": ["./src/**/*", "../../../dev/addons/src/**/*"]


### PR DESCRIPTION
There is a misconfiguration in the addons package tsconfig.build.json that sets the path alias "addons" to the addons dist, while at the same time the include section lists the addons src, and the "addons" alias is referenced in the root index.ts for the public umd package. This results in TypeScript seeing two different js files (modules) with the same name and structure, but since they are different modules, they are different types from the standpoint of TypeScript, which are not compatible in non-duck-typing scenarios. I'm not sure how we haven't hit this in the past, but we are hitting it now with newer PRs.

The fix is just to update the "addons" alias to point to src, which is exactly how it is configured for other packages. I suspect this was just a typo since addons was first introduced but somehow we just weren't hitting errors caused by it. cc @RolandCsibrei 