### PR TITLE
Fix layout shift when modifying textBlock text

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1917,7 +1917,6 @@ export class Control implements IAnimatable, IFocusableControl {
             );
 
             context.save();
-            this._applyStates(context);
 
             let rebuildCount = 0;
             do {

--- a/packages/dev/gui/src/2D/controls/textBlock.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.ts
@@ -367,10 +367,14 @@ export class TextBlock extends Control {
     }
 
     protected override _processMeasures(parentMeasure: Measure, context: ICanvasRenderingContext): void {
+        // Ensure this is done first so that applyStates is called before remainder of work. If it turns out
+        // we need fontOffset to be set before specific logic inside processMeasures, we can move the below
+        // fontOffset check inside super.processMeasures
+        super._processMeasures(parentMeasure, context);
+
         if (!this._fontOffset || this.isDirty) {
             this._fontOffset = Control._GetFontOffset(context.font, this._host.getScene()?.getEngine());
         }
-        super._processMeasures(parentMeasure, context);
 
         // Prepare lines
         this._lines = this._breakLines(this._currentMeasure.width, this._currentMeasure.height, context);


### PR DESCRIPTION
This [PR](https://github.com/BabylonJS/Babylon.js/commit/20fd25bf114d6b357e26b255360d4289da21cb67) moved applyStates() inside processMeasures() so that applyState was always called when processing measures, regardless of callsite (vs just from layout).

However textBlock's override of processMeasures sets fontOffset _before_ calling super.processMeasures (thus sets fontOffset before applyState), so we see a layout shift if the text has changed since last call to super.processMeasures (see repro when time changes in[ this playground](https://playground.babylonjs.com/#H896C7#162))
<img width="252" height="122" alt="image" src="https://github.com/user-attachments/assets/ec6a4063-92ab-4e18-a801-d9de7c2e3d6f" />
<img width="206" height="88" alt="image" src="https://github.com/user-attachments/assets/0b46b3ae-3698-4c02-a631-2cd02c9e990a" />


We need to ensure applyStates is called before super.processMeasures. Can either explicitly call it inside the overriden processMeasure, or ensure super.processMeasures is first call within overriden function (before fontOffset update). I am going with the latter as I do not see any side effect of setting fontOffset after processMeasures.

This also fixes the bug reported in this forum post
https://forum.babylonjs.com/t/changing-the-text-on-a-textblock-in-an-advanceddynamictexture-changes-vertical-position-upwards/60503/4 