### PR TITLE
NME/SFE: Add UI section and namespace field

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/smartFilterFragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/smartFilterFragmentOutputBlock.ts
@@ -100,8 +100,6 @@ export class SmartFilterFragmentOutputBlock extends FragmentOutputBlock {
 
         const outputString = this._getOutputString();
 
-        state._injectAtTop = `// { "smartFilterBlockType": "${state.sharedData.nodeMaterial.name}", "namespace": "Babylon.NME.Exports" }`;
-
         state._customEntryHeader += `#ifdef ${SfeModeDefine}\n`;
         state._customEntryHeader += `vec4 nmeMain(vec2 ${this._getMainUvName(state)}) { // main\n`;
         state._customEntryHeader += `#else\n`;


### PR DESCRIPTION
This PR consolidates SmartFilter export options into their own UI panel and introduces the ability to set the `namespace` during export.


<img width="591" height="800" alt="image" src="https://github.com/user-attachments/assets/b44b8775-566b-4198-bbef-a0d94945c5fa" />

While we consider what metadata the NodeMaterial should store about the SFE shader block (and where), I'm thinking that we can trial fields like namespace by starting them off in local storage only*. This leaves room to add serialization or proper node support later without risking backwards compatibility issues.

*Except for name, where NodeMaterial.name is a fine fit anyway.