### PR TITLE
OpenPBR: Fix albedo sampler name

### DIFF
--- a/packages/dev/core/src/Shaders/openpbr.vertex.fx
+++ b/packages/dev/core/src/Shaders/openpbr.vertex.fx
@@ -221,7 +221,7 @@ void main(void) {
 
     #include<uvVariableDeclaration>[3..7]
 
-    #include<samplerVertexImplementation>(_DEFINENAME_,BASE_COLOR,_VARYINGNAME_,BaseColor,_MATRIXNAME_,albedo,_INFONAME_,BaseColorInfos.x)
+    #include<samplerVertexImplementation>(_DEFINENAME_,BASE_COLOR,_VARYINGNAME_,BaseColor,_MATRIXNAME_,baseColor,_INFONAME_,BaseColorInfos.x)
     #include<samplerVertexImplementation>(_DEFINENAME_,BASE_WEIGHT,_VARYINGNAME_,BaseWeight,_MATRIXNAME_,baseWeight,_INFONAME_,BaseWeightInfos.x)
     #include<samplerVertexImplementation>(_DEFINENAME_,BASE_DIFFUSE_ROUGHNESS,_VARYINGNAME_,BaseDiffuseRoughness,_MATRIXNAME_,baseDiffuseRoughness,_INFONAME_,BaseDiffuseRoughnessInfos.x)
     #include<samplerVertexImplementation>(_DEFINENAME_,BASE_METALNESS,_VARYINGNAME_,BaseMetalness,_MATRIXNAME_,baseMetalness,_INFONAME_,BaseMetalnessInfos.x)

--- a/packages/dev/core/src/ShadersWGSL/openpbr.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/openpbr.vertex.fx
@@ -29,7 +29,7 @@ attribute color: vec4f;
 #include<instancesDeclaration>
 #include<prePassVertexDeclaration>
 
-#include<samplerVertexDeclaration>(_DEFINENAME_,BASE_COLOR,_VARYINGNAME_,Albedo)
+#include<samplerVertexDeclaration>(_DEFINENAME_,BASE_COLOR,_VARYINGNAME_,BaseColor)
 #include<samplerVertexDeclaration>(_DEFINENAME_,BASE_WEIGHT,_VARYINGNAME_,BaseWeight)
 #include<samplerVertexDeclaration>(_DEFINENAME_,BASE_DIFFUSE_ROUGHNESS,_VARYINGNAME_,BaseDiffuseRoughness)
 #include<samplerVertexDeclaration>(_DEFINENAME_,BASE_METALNESS,_VARYINGNAME_,BaseMetalness)


### PR DESCRIPTION
See https://forum.babylonjs.com/t/using-reflectionprobe-cubetexture-as-scene-environmenttexture-has-different-effects-comparing-with-other-textures-such-as-hdrcubetexture/60641/9