### PR TITLE
Internally expose _panningEpsilon and _rotationEpsilon which are used to calculate inertial limit

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1040,9 +1040,10 @@ export class ArcRotateCamera extends TargetCamera {
         }
 
         this.inputs.checkInputs();
-
         let hasUserInteractions = false;
 
+        // Scale speed by framerate to ensure higher framerate devices don't clamp movement to 0 too early
+        const speed = this._computeLocalCameraSpeed();
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
             hasUserInteractions = true;
@@ -1068,7 +1069,7 @@ export class ArcRotateCamera extends TargetCamera {
             if (Math.abs(this.inertialBetaOffset) < Epsilon) {
                 this.inertialBetaOffset = 0;
             }
-            if (Math.abs(this.inertialRadiusOffset) < this.speed * Epsilon) {
+            if (Math.abs(this.inertialRadiusOffset) < speed * Epsilon) {
                 this.inertialRadiusOffset = 0;
             }
         }
@@ -1114,10 +1115,10 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialPanningX *= this.panningInertia;
             this.inertialPanningY *= this.panningInertia;
 
-            if (Math.abs(this.inertialPanningX) < this.speed * Epsilon) {
+            if (Math.abs(this.inertialPanningX) < speed * Epsilon) {
                 this.inertialPanningX = 0;
             }
-            if (Math.abs(this.inertialPanningY) < this.speed * Epsilon) {
+            if (Math.abs(this.inertialPanningY) < speed * Epsilon) {
                 this.inertialPanningY = 0;
             }
         }

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -16,7 +16,7 @@ import type { ArcRotateCameraPointersInput } from "../Cameras/Inputs/arcRotateCa
 import type { ArcRotateCameraKeyboardMoveInput } from "../Cameras/Inputs/arcRotateCameraKeyboardMoveInput";
 import type { ArcRotateCameraMouseWheelInput } from "../Cameras/Inputs/arcRotateCameraMouseWheelInput";
 import { ArcRotateCameraInputsManager } from "../Cameras/arcRotateCameraInputsManager";
-import { Epsilon, MsPerFrameAt60FPS } from "../Maths/math.constants";
+import { Epsilon } from "../Maths/math.constants";
 import { Tools } from "../Misc/tools";
 import { RegisterClass } from "../Misc/typeStore";
 
@@ -1042,9 +1042,8 @@ export class ArcRotateCamera extends TargetCamera {
         this.inputs.checkInputs();
         let hasUserInteractions = false;
 
-        // At 60FPS, InertialLimit should be == this.speed * Epsilon.
-        // We scale InertialLimit based on time since last frame to ensure a smaller inertialLimit at higher framerates
-        const inertialLimit = (this.speed * Epsilon * this._scene.getEngine().getDeltaTime()) / MsPerFrameAt60FPS;
+        const inertialPanningLimit = this.speed * this._panningEpsilon;
+        const inertialRotationLimit = this.speed * this._rotationEpsilon;
 
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
@@ -1065,13 +1064,13 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialAlphaOffset *= this.inertia;
             this.inertialBetaOffset *= this.inertia;
             this.inertialRadiusOffset *= this.inertia;
-            if (Math.abs(this.inertialAlphaOffset) < inertialLimit) {
+            if (Math.abs(this.inertialAlphaOffset) < inertialRotationLimit) {
                 this.inertialAlphaOffset = 0;
             }
-            if (Math.abs(this.inertialBetaOffset) < inertialLimit) {
+            if (Math.abs(this.inertialBetaOffset) < inertialRotationLimit) {
                 this.inertialBetaOffset = 0;
             }
-            if (Math.abs(this.inertialRadiusOffset) < inertialLimit) {
+            if (Math.abs(this.inertialRadiusOffset) < inertialRotationLimit) {
                 this.inertialRadiusOffset = 0;
             }
         }
@@ -1117,10 +1116,10 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialPanningX *= this.panningInertia;
             this.inertialPanningY *= this.panningInertia;
 
-            if (Math.abs(this.inertialPanningX) < inertialLimit) {
+            if (Math.abs(this.inertialPanningX) < inertialPanningLimit) {
                 this.inertialPanningX = 0;
             }
-            if (Math.abs(this.inertialPanningY) < inertialLimit) {
+            if (Math.abs(this.inertialPanningY) < inertialPanningLimit) {
                 this.inertialPanningY = 0;
             }
         }

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1063,10 +1063,10 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialAlphaOffset *= this.inertia;
             this.inertialBetaOffset *= this.inertia;
             this.inertialRadiusOffset *= this.inertia;
-            if (Math.abs(this.inertialAlphaOffset) < Epsilon) {
+            if (Math.abs(this.inertialAlphaOffset) < speed * Epsilon) {
                 this.inertialAlphaOffset = 0;
             }
-            if (Math.abs(this.inertialBetaOffset) < Epsilon) {
+            if (Math.abs(this.inertialBetaOffset) < speed * Epsilon) {
                 this.inertialBetaOffset = 0;
             }
             if (Math.abs(this.inertialRadiusOffset) < speed * Epsilon) {

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1042,11 +1042,10 @@ export class ArcRotateCamera extends TargetCamera {
         this.inputs.checkInputs();
         let hasUserInteractions = false;
 
-   
         // At 60FPS, InertialLimit should be == this.speed * Epsilon.
         // We scale InertialLimit based on time since last frame to ensure a smaller inertialLimit at higher framerates
-        const InertialLimit = this.speed * Epsilon * this._scene.getEngine().getDeltaTime() / MsPerFrameAt60FPS;
-        
+        const inertialLimit = (this.speed * Epsilon * this._scene.getEngine().getDeltaTime()) / MsPerFrameAt60FPS;
+
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
             hasUserInteractions = true;
@@ -1066,13 +1065,13 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialAlphaOffset *= this.inertia;
             this.inertialBetaOffset *= this.inertia;
             this.inertialRadiusOffset *= this.inertia;
-            if (Math.abs(this.inertialAlphaOffset) < InertialLimit) {
+            if (Math.abs(this.inertialAlphaOffset) < inertialLimit) {
                 this.inertialAlphaOffset = 0;
             }
-            if (Math.abs(this.inertialBetaOffset) < InertialLimit) {
+            if (Math.abs(this.inertialBetaOffset) < inertialLimit) {
                 this.inertialBetaOffset = 0;
             }
-            if (Math.abs(this.inertialRadiusOffset) < InertialLimit) {
+            if (Math.abs(this.inertialRadiusOffset) < inertialLimit) {
                 this.inertialRadiusOffset = 0;
             }
         }
@@ -1118,10 +1117,10 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialPanningX *= this.panningInertia;
             this.inertialPanningY *= this.panningInertia;
 
-            if (Math.abs(this.inertialPanningX) < InertialLimit) {
+            if (Math.abs(this.inertialPanningX) < inertialLimit) {
                 this.inertialPanningX = 0;
             }
-            if (Math.abs(this.inertialPanningY) < InertialLimit) {
+            if (Math.abs(this.inertialPanningY) < inertialLimit) {
                 this.inertialPanningY = 0;
             }
         }

--- a/packages/dev/core/src/Cameras/targetCamera.ts
+++ b/packages/dev/core/src/Cameras/targetCamera.ts
@@ -391,32 +391,32 @@ export class TargetCamera extends Camera {
             }
         }
 
-       // At 60FPS, InertialLimit should be == this.speed * Epsilon.
+        // At 60FPS, InertialLimit should be == this.speed * Epsilon.
         // We scale InertialLimit based on time since last frame to ensure a smaller inertialLimit at higher framerates
-        const InertialLimit = this.speed * Epsilon * this._scene.getEngine().getDeltaTime() / MsPerFrameAt60FPS;
-        
+        const inertialLimit = (this.speed * Epsilon * this._scene.getEngine().getDeltaTime()) / MsPerFrameAt60FPS;
+
         // Inertia
         if (needToMove) {
-            if (Math.abs(this.cameraDirection.x) < InertialLimit) {
+            if (Math.abs(this.cameraDirection.x) < inertialLimit) {
                 this.cameraDirection.x = 0;
             }
 
-            if (Math.abs(this.cameraDirection.y) < InertialLimit) {
+            if (Math.abs(this.cameraDirection.y) < inertialLimit) {
                 this.cameraDirection.y = 0;
             }
 
-            if (Math.abs(this.cameraDirection.z) < InertialLimit) {
+            if (Math.abs(this.cameraDirection.z) < inertialLimit) {
                 this.cameraDirection.z = 0;
             }
 
             this.cameraDirection.scaleInPlace(this.inertia);
         }
         if (needToRotate) {
-            if (Math.abs(this.cameraRotation.x) < InertialLimit) {
+            if (Math.abs(this.cameraRotation.x) < inertialLimit) {
                 this.cameraRotation.x = 0;
             }
 
-            if (Math.abs(this.cameraRotation.y) < InertialLimit) {
+            if (Math.abs(this.cameraRotation.y) < inertialLimit) {
                 this.cameraRotation.y = 0;
             }
             this.cameraRotation.scaleInPlace(this.inertia);

--- a/packages/dev/core/src/Cameras/targetCamera.ts
+++ b/packages/dev/core/src/Cameras/targetCamera.ts
@@ -3,7 +3,7 @@ import type { Nullable } from "../types";
 import { Camera } from "./camera";
 import type { Scene } from "../scene";
 import { Quaternion, Matrix, Vector3, Vector2, TmpVectors } from "../Maths/math.vector";
-import { Epsilon } from "../Maths/math.constants";
+import { Epsilon, MsPerFrameAt60FPS } from "../Maths/math.constants";
 import { Axis } from "../Maths/math.axis";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
 import { Node } from "../node";
@@ -391,30 +391,32 @@ export class TargetCamera extends Camera {
             }
         }
 
-        // Scale speed by framerate to ensure higher framerate devices don't clamp movement to 0 too early
-        const speed = this._computeLocalCameraSpeed();
+       // At 60FPS, InertialLimit should be == this.speed * Epsilon.
+        // We scale InertialLimit based on time since last frame to ensure a smaller inertialLimit at higher framerates
+        const InertialLimit = this.speed * Epsilon * this._scene.getEngine().getDeltaTime() / MsPerFrameAt60FPS;
+        
         // Inertia
         if (needToMove) {
-            if (Math.abs(this.cameraDirection.x) < speed * Epsilon) {
+            if (Math.abs(this.cameraDirection.x) < InertialLimit) {
                 this.cameraDirection.x = 0;
             }
 
-            if (Math.abs(this.cameraDirection.y) < speed * Epsilon) {
+            if (Math.abs(this.cameraDirection.y) < InertialLimit) {
                 this.cameraDirection.y = 0;
             }
 
-            if (Math.abs(this.cameraDirection.z) < speed * Epsilon) {
+            if (Math.abs(this.cameraDirection.z) < InertialLimit) {
                 this.cameraDirection.z = 0;
             }
 
             this.cameraDirection.scaleInPlace(this.inertia);
         }
         if (needToRotate) {
-            if (Math.abs(this.cameraRotation.x) < speed * Epsilon) {
+            if (Math.abs(this.cameraRotation.x) < InertialLimit) {
                 this.cameraRotation.x = 0;
             }
 
-            if (Math.abs(this.cameraRotation.y) < speed * Epsilon) {
+            if (Math.abs(this.cameraRotation.y) < InertialLimit) {
                 this.cameraRotation.y = 0;
             }
             this.cameraRotation.scaleInPlace(this.inertia);

--- a/packages/dev/core/src/Cameras/targetCamera.ts
+++ b/packages/dev/core/src/Cameras/targetCamera.ts
@@ -391,28 +391,30 @@ export class TargetCamera extends Camera {
             }
         }
 
+        // Scale speed by framerate to ensure higher framerate devices don't clamp movement to 0 too early
+        const speed = this._computeLocalCameraSpeed();
         // Inertia
         if (needToMove) {
-            if (Math.abs(this.cameraDirection.x) < this.speed * Epsilon) {
+            if (Math.abs(this.cameraDirection.x) < speed * Epsilon) {
                 this.cameraDirection.x = 0;
             }
 
-            if (Math.abs(this.cameraDirection.y) < this.speed * Epsilon) {
+            if (Math.abs(this.cameraDirection.y) < speed * Epsilon) {
                 this.cameraDirection.y = 0;
             }
 
-            if (Math.abs(this.cameraDirection.z) < this.speed * Epsilon) {
+            if (Math.abs(this.cameraDirection.z) < speed * Epsilon) {
                 this.cameraDirection.z = 0;
             }
 
             this.cameraDirection.scaleInPlace(this.inertia);
         }
         if (needToRotate) {
-            if (Math.abs(this.cameraRotation.x) < this.speed * Epsilon) {
+            if (Math.abs(this.cameraRotation.x) < speed * Epsilon) {
                 this.cameraRotation.x = 0;
             }
 
-            if (Math.abs(this.cameraRotation.y) < this.speed * Epsilon) {
+            if (Math.abs(this.cameraRotation.y) < speed * Epsilon) {
                 this.cameraRotation.y = 0;
             }
             this.cameraRotation.scaleInPlace(this.inertia);

--- a/packages/dev/core/src/Maths/math.constants.ts
+++ b/packages/dev/core/src/Maths/math.constants.ts
@@ -22,3 +22,9 @@ export const PHI = (1 + Math.sqrt(5)) / 2;
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Epsilon = 0.001;
+
+/**
+ * Delta Time in milliseconds at 60 frames per second
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const MsPerFrameAt60FPS = 1000 / 60; // 16.666... ms

--- a/packages/dev/core/src/Maths/math.constants.ts
+++ b/packages/dev/core/src/Maths/math.constants.ts
@@ -22,9 +22,3 @@ export const PHI = (1 + Math.sqrt(5)) / 2;
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const Epsilon = 0.001;
-
-/**
- * Delta Time in milliseconds at 60 frames per second
- */
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const MsPerFrameAt60FPS = 1000 / 60; // 16.666... ms


### PR DESCRIPTION
Until we have framerate-based movement system (feature coming in 9.0), exposing ability for users to override epsilon per-frame to customize clamping behavior.

This helps avoid inconsistent motion behavior on higher framerate devices, described in this forum post.

https://forum.babylonjs.com/t/camera-inertia-causes-inconsistent-motion/60633/11