### PR TITLE
gltfLoader: fully respect the skipMaterials flag

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_minecraftMesh.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/MSFT_minecraftMesh.ts
@@ -46,7 +46,7 @@ export class MSFT_minecraftMesh implements IGLTFLoaderExtension {
     public loadMaterialPropertiesAsync(context: string, material: IMaterial, babylonMaterial: Material): Nullable<Promise<void>> {
         return GLTFLoader.LoadExtraAsync<boolean>(context, material, this.name, async (extraContext, extra) => {
             if (extra) {
-                if (!this._loader._pbrMaterialClass) {
+                if (!this._loader._pbrMaterialImpl) {
                     throw new Error(`${extraContext}: Material type not supported`);
                 }
 

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -2252,9 +2252,6 @@ export class GLTFLoader implements IGLTFLoader {
 
             const babylonMaterial = this.createMaterial(context, material, babylonDrawMode);
 
-            // Create the adapter for this material immediately after creation
-            this._getOrCreateMaterialAdapter(babylonMaterial);
-
             babylonData = {
                 babylonMaterial: babylonMaterial,
                 babylonMeshes: [],


### PR DESCRIPTION
There were two issues with `skipMaterials`:
1. If a mesh in the glTF has a material asigned but `skipMaterials` is on, no material is loaded (correct behavior). If a mesh in the glTF has no material assigned and `skipMaterials` is on, the flag is ignored and a default material is still created and assigned.
2. `PBRMaterial` or `OpenPBRMaterial` are dynamically loaded, depending on `useOpenPBR` flag. However, if `skipMaterials` is on, then we won't be loading any materials anyway, so we should skip this dynamic import.

After these changes, I could see with some testing that when using `skipMaterials` (with either a glb with materials and material references and without), PBRMaterial was neither instantiated nor imported (statically or dynamically).

Additionally, this change introduces the ability to completely disable the default/PBR material loading even when `skipMaterials` is not toggled on, which allows a loader extension to provide an alternative material (such as a `NodeMaterial`).