### PR TITLE
glTF export: Fix submesh indices handling

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -52,7 +52,7 @@ import {
     IsChildCollapsible,
     FloatsNeed16BitInteger,
     IsStandardVertexAttribute,
-    IndicesArrayToTypedArray,
+    IndicesArrayToTypedSubarray,
     GetVertexBufferInfo,
     CollapseChildIntoParent,
     Rotate180Y,
@@ -1336,7 +1336,7 @@ export class GLTFExporter {
                 }
             } else {
                 // No flipping needed - normalize & create a subset of the indices to avoid exporting shared buffers multiple times
-                indicesToExport = IndicesArrayToTypedArray(indices, start, count, is32Bits);
+                indicesToExport = IndicesArrayToTypedSubarray(indices, start, count, is32Bits);
             }
 
             // Create accessor and buffer view


### PR DESCRIPTION
Fixes bug with submeshes where indexStart was improperly handled when creating the buffer view. 
While in the area, I did some contained miscellaneous refactoring. The main points are:
- No more `offset` parameter. I think this was a remnant from before the rework last year, as I couldn't tell what it would've been used for.
- As little copying as possible, which also means subsetting ahead of time.
- Reorganizing and comments for clarity