### PR TITLE
glTF Exporter: Switch to emissiveIntensity for KHR_materials_emissive_strength

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
+++ b/packages/dev/serializers/src/glTF/2.0/Extensions/KHR_materials_emissive_strength.ts
@@ -43,22 +43,15 @@ export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2
                 return resolve(node);
             }
 
-            const emissiveColor = babylonMaterial.emissiveColor.asArray();
-            const tempEmissiveStrength = Math.max(...emissiveColor);
+            const emissiveStrength = babylonMaterial.emissiveIntensity;
 
-            if (tempEmissiveStrength > 1) {
+            if (emissiveStrength !== 1) {
                 this._wasUsed = true;
 
-                node.extensions ||= {};
-
                 const emissiveStrengthInfo: IKHRMaterialsEmissiveStrength = {
-                    emissiveStrength: tempEmissiveStrength,
+                    emissiveStrength,
                 };
-
-                // Normalize each value of the emissive factor to have a max value of 1
-                const newEmissiveFactor = babylonMaterial.emissiveColor.scale(1 / emissiveStrengthInfo.emissiveStrength);
-
-                node.emissiveFactor = newEmissiveFactor.asArray();
+                node.extensions ||= {};
                 node.extensions[NAME] = emissiveStrengthInfo;
             }
 
@@ -67,4 +60,4 @@ export class KHR_materials_emissive_strength implements IGLTFExporterExtensionV2
     }
 }
 
-GLTFExporter.RegisterExtension(NAME, (exporter) => new KHR_materials_emissive_strength());
+GLTFExporter.RegisterExtension(NAME, () => new KHR_materials_emissive_strength());


### PR DESCRIPTION
Move to using `emissiveIntensity` for `emissiveStrength` for parity with #14915. We previously relied on the scale from `emissiveColor`.