### PR TITLE
Inspector v2: Improve configurability of theme mode and extension feeds

### DIFF
--- a/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
@@ -5,7 +5,7 @@ export type BuiltInExtension = ExtensionMetadata & {
      * Gets the extension module, typically dynamically importing the extension.
      * @returns The extension module (e.g. a collection of ServiceDefinitions).
      */
-    getExtensionModuleAsync: () => Promise<ExtensionModule>;
+    getExtensionModuleAsync(): Promise<ExtensionModule>;
 };
 
 /**
@@ -15,7 +15,7 @@ export type BuiltInExtension = ExtensionMetadata & {
  * bundle chunks and downloaded only when first installed.
  */
 export class BuiltInsExtensionFeed implements IExtensionFeed {
-    private readonly _extensions: BuiltInExtension[];
+    private readonly _extensions: readonly BuiltInExtension[];
 
     public constructor(
         public readonly name: string,

--- a/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/builtInsExtensionFeed.ts
@@ -1,43 +1,31 @@
 import type { IExtensionFeed, ExtensionMetadata, IExtensionMetadataQuery, ExtensionModule } from "./extensionFeed";
 
-// This file contains "built in" extensions. They are optional and installed/uninstalled by the user, but they are
-// well-known at build time and the extension is "downloaded" by simply doing a dynamic import. This is different
-// from future extension types that are built and published apart from the inspector, and are downloaded as an isolated script.
-
-const CreationToolsExtensionMetadata = {
-    name: "Asset Creation",
-    description: "Adds new features to enable creating Babylon assets such as node materials, flow graphs, and more.",
-    keywords: ["creation"],
-} as const;
-
-const ExportToolsExtensionMetadata = {
-    name: "Export Tools",
-    description: "Adds new features to enable exporting Babylon assets such as .gltf, .glb, .babylon, and more.",
-    keywords: ["export", "gltf", "glb", "babylon", "exporter", "tools"],
-} as const;
-
-const CaptureToolsExtensionMetadata = {
-    name: "Capture Tools",
-    description: "Adds new features to enable capturing screenshots, GIFs, videos, and more.",
-    keywords: ["capture", "screenshot", "gif", "video", "tools"],
-} as const;
-
-const ImportToolsExtensionMetadata = {
-    name: "Import Tools",
-    description: "Adds new features related to importing Babylon assets.",
-    keywords: ["import", "tools"],
-} as const;
-
-const Extensions: readonly ExtensionMetadata[] = [/*CreationToolsExtensionMetadata, */ ExportToolsExtensionMetadata, CaptureToolsExtensionMetadata, ImportToolsExtensionMetadata];
+export type BuiltInExtension = ExtensionMetadata & {
+    /**
+     * Gets the extension module, typically dynamically importing the extension.
+     * @returns The extension module (e.g. a collection of ServiceDefinitions).
+     */
+    getExtensionModuleAsync: () => Promise<ExtensionModule>;
+};
 
 /**
- * @internal
+ * A simple extension feed implementation that provides a fixed set of "built in" extensions.
+ * "Built in" in this context means extensions that are known at bundling time, and included
+ * in the bundle. Each extension can be dynamically imported so they are split into separate
+ * bundle chunks and downloaded only when first installed.
  */
 export class BuiltInsExtensionFeed implements IExtensionFeed {
-    public readonly name = "Built-ins";
+    private readonly _extensions: BuiltInExtension[];
+
+    public constructor(
+        public readonly name: string,
+        extensions: Iterable<BuiltInExtension>
+    ) {
+        this._extensions = Array.from(extensions);
+    }
 
     public async queryExtensionsAsync(filter?: string): Promise<IExtensionMetadataQuery> {
-        const filteredExtensions = filter ? Extensions.filter((extension) => extension.name.includes(filter)) : Extensions;
+        const filteredExtensions = filter ? this._extensions.filter((extension) => extension.name.includes(filter)) : this._extensions;
         return {
             totalCount: filteredExtensions.length,
             getExtensionMetadataAsync: async (index: number, count: number) => {
@@ -47,15 +35,7 @@ export class BuiltInsExtensionFeed implements IExtensionFeed {
     }
 
     public async getExtensionModuleAsync(name: string): Promise<ExtensionModule | undefined> {
-        if (name === CreationToolsExtensionMetadata.name) {
-            return await import("../services/creationToolsService");
-        } else if (name === ExportToolsExtensionMetadata.name) {
-            return await import("../services/panes/tools/exportService");
-        } else if (name === CaptureToolsExtensionMetadata.name) {
-            return await import("../services/panes/tools/captureService");
-        } else if (name === ImportToolsExtensionMetadata.name) {
-            return await import("../services/panes/tools/importService");
-        }
-        return undefined;
+        const extension = this._extensions.find((ext) => ext.name === name);
+        return extension ? await extension.getExtensionModuleAsync() : undefined;
     }
 }

--- a/packages/dev/inspector-v2/src/extensibility/defaultInspectorExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/defaultInspectorExtensionFeed.ts
@@ -1,0 +1,31 @@
+import { BuiltInsExtensionFeed } from "./builtInsExtensionFeed";
+
+/**
+ * Well-known default built in extensions for the Inspector.
+ */
+export const DefaultInspectorExtensionFeed = new BuiltInsExtensionFeed("Inspector", [
+    // {
+    //     name: "Asset Creation",
+    //     description: "Adds new features to enable creating Babylon assets such as node materials, flow graphs, and more.",
+    //     keywords: ["creation"],
+    //     getExtensionModuleAsync: async () => await import("../services/creationToolsService"),
+    // },
+    {
+        name: "Export Tools",
+        description: "Adds new features to enable exporting Babylon assets such as .gltf, .glb, .babylon, and more.",
+        keywords: ["export", "gltf", "glb", "babylon", "exporter", "tools"],
+        getExtensionModuleAsync: async () => await import("../services/panes/tools/exportService"),
+    },
+    {
+        name: "Capture Tools",
+        description: "Adds new features to enable capturing screenshots, GIFs, videos, and more.",
+        keywords: ["capture", "screenshot", "gif", "video", "tools"],
+        getExtensionModuleAsync: async () => await import("../services/panes/tools/captureService"),
+    },
+    {
+        name: "Import Tools",
+        description: "Adds new features related to importing Babylon assets.",
+        keywords: ["import", "tools"],
+        getExtensionModuleAsync: async () => await import("../services/panes/tools/importService"),
+    },
+]);

--- a/packages/dev/inspector-v2/src/hooks/themeHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/themeHooks.ts
@@ -1,0 +1,20 @@
+import type { TernaryDarkMode } from "usehooks-ts";
+
+import { useTernaryDarkMode } from "usehooks-ts";
+
+const ThemeModeStorageKey = `Babylon/Settings/ThemeMode`;
+
+/**
+ * Custom hook to manage the theme mode (light/dark/auto).
+ * @param defaultMode An optional default theme mode if no theme mode has been configured yet.
+ * @returns An object containing the theme mode state and helper functions.
+ */
+export function useThemeMode(defaultMode?: TernaryDarkMode) {
+    const { isDarkMode, ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode({ defaultValue: defaultMode, localStorageKey: ThemeModeStorageKey });
+    // Make sure there is a stored value initially, even before changing the theme.
+    // This way, other usages of this hook will get the correct initial value.
+    if (!localStorage.getItem(ThemeModeStorageKey)) {
+        localStorage.setItem(ThemeModeStorageKey, JSON.stringify(ternaryDarkMode));
+    }
+    return { isDarkMode, themeMode: ternaryDarkMode, setThemeMode: setTernaryDarkMode };
+}

--- a/packages/dev/inspector-v2/src/hooks/themeHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/themeHooks.ts
@@ -6,14 +6,19 @@ const ThemeModeStorageKey = `Babylon/Settings/ThemeMode`;
 
 /**
  * Custom hook to manage the theme mode (light/dark/auto).
- * @param defaultMode An optional default theme mode if no theme mode has been configured yet.
+ * @param modeOverride If specified, any previously stored theme mode will be replaced with this mode.
  * @returns An object containing the theme mode state and helper functions.
  */
-export function useThemeMode(defaultMode?: TernaryDarkMode) {
-    const { isDarkMode, ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode({ defaultValue: defaultMode, localStorageKey: ThemeModeStorageKey });
-    // Make sure there is a stored value initially, even before changing the theme.
+export function useThemeMode(modeOverride?: TernaryDarkMode) {
+    const { isDarkMode, ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode({
+        defaultValue: modeOverride,
+        initializeWithValue: !modeOverride,
+        localStorageKey: ThemeModeStorageKey,
+    });
+    // If a modeOverride is provided, replace any previously stored mode.
+    // Also make sure there is a stored value initially, even before changing the theme.
     // This way, other usages of this hook will get the correct initial value.
-    if (!localStorage.getItem(ThemeModeStorageKey)) {
+    if (modeOverride || !localStorage.getItem(ThemeModeStorageKey)) {
         localStorage.setItem(ThemeModeStorageKey, JSON.stringify(ternaryDarkMode));
     }
     return { isDarkMode, themeMode: ternaryDarkMode, setThemeMode: setTernaryDarkMode };

--- a/packages/dev/inspector-v2/src/index.ts
+++ b/packages/dev/inspector-v2/src/index.ts
@@ -6,6 +6,7 @@ export * from "./components/extensibleAccordion";
 export { Pane as PaneContainer } from "./components/pane";
 export * from "./components/teachingMoment";
 export * from "./extensibility/extensionFeed";
+export * from "./extensibility/builtInsExtensionFeed";
 export * from "./hooks/compoundPropertyHooks";
 export * from "./hooks/instrumentationHooks";
 export * from "./hooks/observableHooks";

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -10,13 +10,14 @@ import { makeStyles } from "@fluentui/react-components";
 import { EngineStore } from "core/Engines/engineStore";
 import { Observable } from "core/Misc/observable";
 import { useEffect, useRef } from "react";
-import { BuiltInsExtensionFeed } from "./extensibility/builtInsExtensionFeed";
+import { DefaultInspectorExtensionFeed } from "./extensibility/defaultInspectorExtensionFeed";
 import { MakeModularTool } from "./modularTool";
 import { GizmoServiceDefinition } from "./services/gizmoService";
 import { GizmoToolbarServiceDefinition } from "./services/gizmoToolbarService";
 import { DebugServiceDefinition } from "./services/panes/debugService";
 import { AnimationGroupPropertiesServiceDefinition } from "./services/panes/properties/animationGroupPropertiesService";
 import { AnimationPropertiesServiceDefinition } from "./services/panes/properties/animationPropertiesService";
+import { AtmospherePropertiesServiceDefinition } from "./services/panes/properties/atmospherePropertiesService";
 import { CameraPropertiesServiceDefinition } from "./services/panes/properties/cameraPropertiesService";
 import { CommonPropertiesServiceDefinition } from "./services/panes/properties/commonPropertiesService";
 import { EffectLayerPropertiesServiceDefinition } from "./services/panes/properties/effectLayerPropertiesService";
@@ -36,6 +37,7 @@ import { SpritePropertiesServiceDefinition } from "./services/panes/properties/s
 import { TexturePropertiesServiceDefinition } from "./services/panes/properties/texturePropertiesService";
 import { TransformPropertiesServiceDefinition } from "./services/panes/properties/transformPropertiesService";
 import { AnimationGroupExplorerServiceDefinition } from "./services/panes/scene/animationGroupExplorerService";
+import { AtmosphereExplorerServiceDefinition } from "./services/panes/scene/atmosphereExplorerService";
 import { EffectLayerExplorerServiceDefinition } from "./services/panes/scene/effectLayersExplorerService";
 import { FrameGraphExplorerServiceDefinition } from "./services/panes/scene/frameGraphExplorerService";
 import { GuiExplorerServiceDefinition } from "./services/panes/scene/guiExplorerService";
@@ -55,14 +57,10 @@ import { PickingServiceDefinition } from "./services/pickingService";
 import { SceneContextIdentity } from "./services/sceneContext";
 import { SelectionServiceDefinition } from "./services/selectionService";
 import { ShellServiceIdentity } from "./services/shellService";
-import { AtmospherePropertiesServiceDefinition } from "./services/panes/properties/atmospherePropertiesService";
-import { AtmosphereExplorerServiceDefinition } from "./services/panes/scene/atmosphereExplorerService";
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
-type InspectorV2Options = Pick<ModularToolOptions, "serviceDefinitions" | "themeMode" | "showThemeSelector"> & {
-    isExtensible?: boolean;
-};
+type InspectorV2Options = Omit<ModularToolOptions, "containerElement">;
 
 export function IsInspectorVisible(): boolean {
     return CurrentInspectorToken != null;
@@ -82,7 +80,6 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
         enableClose: true,
         handleResize: true,
         enablePopup: true,
-        isExtensible: true,
         ...options,
     };
 
@@ -262,7 +259,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
         ],
         themeMode: options.themeMode,
         showThemeSelector: options.showThemeSelector,
-        extensionFeeds: options.isExtensible ? [new BuiltInsExtensionFeed()] : [],
+        extensionFeeds: [DefaultInspectorExtensionFeed, ...(options.extensionFeeds ?? [])],
         toolbarMode: "compact",
         sidePaneMode: options.embedMode ? "right" : "both",
     });

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -60,7 +60,7 @@ import { AtmosphereExplorerServiceDefinition } from "./services/panes/scene/atmo
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
-type InspectorV2Options = Pick<ModularToolOptions, "serviceDefinitions" | "isThemeable"> & {
+type InspectorV2Options = Pick<ModularToolOptions, "serviceDefinitions" | "defaultTheme" | "showThemeSelector"> & {
     isExtensible?: boolean;
 };
 
@@ -83,7 +83,6 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
         handleResize: true,
         enablePopup: true,
         isExtensible: true,
-        isThemeable: true,
         ...options,
     };
 
@@ -261,7 +260,8 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             // Additional services passed in to the Inspector.
             ...(options.serviceDefinitions ?? []),
         ],
-        isThemeable: options.isThemeable ?? true,
+        defaultTheme: options.defaultTheme,
+        showThemeSelector: options.showThemeSelector,
         extensionFeeds: options.isExtensible ? [new BuiltInsExtensionFeed()] : [],
         toolbarMode: "compact",
         sidePaneMode: options.embedMode ? "right" : "both",

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -60,7 +60,7 @@ import { AtmosphereExplorerServiceDefinition } from "./services/panes/scene/atmo
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
-type InspectorV2Options = Pick<ModularToolOptions, "serviceDefinitions" | "defaultTheme" | "showThemeSelector"> & {
+type InspectorV2Options = Pick<ModularToolOptions, "serviceDefinitions" | "themeMode" | "showThemeSelector"> & {
     isExtensible?: boolean;
 };
 
@@ -260,7 +260,7 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
             // Additional services passed in to the Inspector.
             ...(options.serviceDefinitions ?? []),
         ],
-        defaultTheme: options.defaultTheme,
+        themeMode: options.themeMode,
         showThemeSelector: options.showThemeSelector,
         extensionFeeds: options.isExtensible ? [new BuiltInsExtensionFeed()] : [],
         toolbarMode: "compact",

--- a/packages/dev/inspector-v2/src/modularTool.tsx
+++ b/packages/dev/inspector-v2/src/modularTool.tsx
@@ -77,9 +77,9 @@ export type ModularToolOptions = {
     serviceDefinitions: readonly WeaklyTypedServiceDefinition[];
 
     /**
-     * The default theme to use. If not specified, the default is "system", which uses the system/browser preference.
+     * The theme mode to use. If not specified, the default is "system", which uses the system/browser preference, and the last used mode is persisted.
      */
-    defaultTheme?: TernaryDarkMode;
+    themeMode?: TernaryDarkMode;
 
     /**
      * Whether to show the theme selector in the toolbar. Default is true.
@@ -98,12 +98,12 @@ export type ModularToolOptions = {
  * @returns A token that can be used to dispose of the tool.
  */
 export function MakeModularTool(options: ModularToolOptions): IDisposable {
-    const { containerElement, serviceDefinitions, defaultTheme = "system", showThemeSelector = true, extensionFeeds = [] } = options;
+    const { containerElement, serviceDefinitions, themeMode, showThemeSelector = true, extensionFeeds = [] } = options;
 
     const modularToolRootComponent: FunctionComponent = () => {
         const classes = useStyles();
         const [extensionManagerContext, setExtensionManagerContext] = useState<ExtensionManagerContext>();
-        const { isDarkMode } = useThemeMode(defaultTheme);
+        const { isDarkMode } = useThemeMode(themeMode);
         const [requiredExtensions, setRequiredExtensions] = useState<string[]>();
         const [requiredExtensionsDeferred, setRequiredExtensionsDeferred] = useState<Deferred<boolean>>();
         const [extensionInstallError, setExtensionInstallError] = useState<InstallFailedInfo>();

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -653,19 +653,21 @@ function usePane(
                                 )}
 
                                 {/* Render the bottom pane content. This is the element that can be resized vertically. */}
-                                <div
-                                    ref={paneVerticalResizeElementRef}
-                                    className={classes.paneContent}
-                                    style={{ height: `clamp(200px,calc(45% + var(${paneHeightAdjustCSSVar}, 0px)), 100% - 300px)`, flex: "0 0 auto" }}
-                                >
-                                    {bottomSelectedTab?.title ? (
-                                        <>
-                                            <Title3 className={classes.paneHeader}>{bottomSelectedTab.title}</Title3>
-                                            <Divider inset className={classes.headerDivider} appearance="brand" />
-                                        </>
-                                    ) : null}
-                                    {bottomSelectedTab?.content && <bottomSelectedTab.content />}
-                                </div>
+                                {bottomPaneComponents.length > 0 && (
+                                    <div
+                                        ref={paneVerticalResizeElementRef}
+                                        className={classes.paneContent}
+                                        style={{ height: `clamp(200px,calc(45% + var(${paneHeightAdjustCSSVar}, 0px)), 100% - 300px)`, flex: "0 0 auto" }}
+                                    >
+                                        {bottomSelectedTab?.title ? (
+                                            <>
+                                                <Title3 className={classes.paneHeader}>{bottomSelectedTab.title}</Title3>
+                                                <Divider inset className={classes.headerDivider} appearance="brand" />
+                                            </>
+                                        ) : null}
+                                        {bottomSelectedTab?.content && <bottomSelectedTab.content />}
+                                    </div>
+                                )}
 
                                 {/* If toolbar mode is "compact" then the bottom toolbar is embedded at the bottom of the pane. */}
                                 {toolbarMode === "compact" && bottomBarComponents.length > 0 && (

--- a/packages/dev/inspector-v2/src/services/themeSelectorService.tsx
+++ b/packages/dev/inspector-v2/src/services/themeSelectorService.tsx
@@ -6,8 +6,8 @@ import type { IShellService } from "../services/shellService";
 import { makeStyles, Menu, MenuItemRadio, MenuList, MenuPopover, MenuTrigger, SplitButton, tokens, Tooltip } from "@fluentui/react-components";
 import { WeatherMoonRegular, WeatherSunnyRegular } from "@fluentui/react-icons";
 import { useCallback } from "react";
-import { useTernaryDarkMode } from "usehooks-ts";
 
+import { useThemeMode } from "../hooks/themeHooks";
 import { ShellServiceIdentity } from "../services/shellService";
 
 const useStyles = makeStyles({
@@ -32,18 +32,18 @@ export const ThemeSelectorServiceDefinition: ServiceDefinition<[], [IShellServic
             component: () => {
                 const classes = useStyles();
 
-                const { isDarkMode, ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode();
+                const { isDarkMode, themeMode, setThemeMode } = useThemeMode();
 
                 const onSelectedThemeChange = useCallback((e: MenuCheckedValueChangeEvent, data: MenuCheckedValueChangeData) => {
-                    setTernaryDarkMode(data.checkedItems.includes("System") ? "system" : (data.checkedItems[0].toLocaleLowerCase() as TernaryDarkMode));
+                    setThemeMode(data.checkedItems.includes("System") ? "system" : (data.checkedItems[0].toLocaleLowerCase() as TernaryDarkMode));
                 }, []);
 
                 const toggleTheme = useCallback(() => {
-                    setTernaryDarkMode(isDarkMode ? "light" : "dark");
+                    setThemeMode(isDarkMode ? "light" : "dark");
                 }, [isDarkMode]);
 
                 return (
-                    <Menu positioning="below-end" checkedValues={{ theme: [ternaryDarkMode] }} onCheckedValueChange={onSelectedThemeChange}>
+                    <Menu positioning="below-end" checkedValues={{ theme: [themeMode] }} onCheckedValueChange={onSelectedThemeChange}>
                         <MenuTrigger disableButtonEnhancement={true}>
                             {(triggerProps: MenuButtonProps) => (
                                 <Tooltip content="Select Theme" relationship="label">


### PR DESCRIPTION
This change is primarily two things:
1. Theme mode (e.g. light/dark/system) is more configurable, which will make it possible to improve the integration in Playground such that Playground's theme selection can flow into Inspector and Inspector will not show its own theme mode selection UI (since Playground already has theme mode selection UI and is hosting the Inspector).
2. Factor out `BuiltInsExtensionFeed` to be a reusable class that is a super simple `IExtensionFeed` implementation based on dynamic imports from the bundle (distinct from potential future scenarios where extensions are downloaded as completely separate bundles). Then, use this for a simple exported constant that is the default Inspector extensions (bundled with the Inspector, though chunked separately).

This change also includes a small fix to a previous PR that introduced `embedMode` and bottom panes. I late commit in that PR somehow missed making the bottom pane containers conditional, so currently they are taking up space even if there are no bottom panes.