### PR TITLE
Inspector v2: More shared component exports

### DIFF
--- a/packages/dev/inspector-v2/src/index.ts
+++ b/packages/dev/inspector-v2/src/index.ts
@@ -16,6 +16,7 @@ export * from "./hooks/settingsHooks";
 export * from "./hooks/teachingMomentHooks";
 export * from "./instrumentation/functionInstrumentation";
 export * from "./instrumentation/propertyInstrumentation";
+export * from "./misc/observableCollection";
 export * from "./modularity/serviceDefinition";
 export { IPropertiesService, PropertiesServiceIdentity } from "./services/panes/properties/propertiesService";
 export { ISceneExplorerService, SceneExplorerServiceIdentity } from "./services/panes/scene/sceneExplorerService";


### PR DESCRIPTION
I missed all the *PropertyLine components in the Inspector v2 exports in the first round of adding exports needed for extending the Inspector. This PR just adds them.