### PR TITLE
Prevent WebGL error 'GL_INVALID_OPERATION: glDrawElements: Insufficient buffer size'

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -1661,7 +1661,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         }
 
         this.releaseSubMeshes();
-        return new SubMesh(0, 0, totalVertices, 0, this.getTotalIndices() || totalVertices, this); // getTotalIndices() can be zero if the mesh is unindexed
+        return new SubMesh(0, 0, totalVertices, 0, this.getTotalIndices() || (this.isUnIndexed ? totalVertices : 0), this); // getTotalIndices() can be zero if the mesh is unindexed
     }
 
     /**


### PR DESCRIPTION
When one mesh aggregates several distinct elements, one way to hide or show a subset of these elements is too compute a new Index Buffer depending on which element needs to turned On or Off.

But if all of them are off, this Index Buffer become empty.

Setting an empty Index Buffer to an Indexed Mesh results in a WebGL error  'GL_INVALID_OPERATION: glDrawElements: Insufficient buffer size' because internally the SubMesh that is created is not given `0`as `indexCount`.

One workaround is to disabled the mesh is that case (that's I did in my code), but nevertheless BabylonJs must not trigger WebGL errors.