### PR TITLE
Texture: Update _delayedOnLoad for updateUrl()

### DIFF
--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -587,9 +587,19 @@ export class Texture extends BaseTexture {
         this._forcedExtension = forcedExtension;
         this.delayLoadState = Constants.DELAYLOADSTATE_NOTLOADED;
 
-        if (onLoad) {
-            this._delayedOnLoad = onLoad;
-        }
+        const existingOnLoad = this._delayedOnLoad;
+        const load = () => {
+            if (existingOnLoad) {
+                existingOnLoad();
+            } else if (this.onLoadObservable.hasObservers()) {
+                this.onLoadObservable.notifyObservers(this);
+            }
+            if (onLoad) {
+                onLoad();
+            }
+        };
+
+        this._delayedOnLoad = load;
         this.delayLoad();
     }
 


### PR DESCRIPTION
Fixes an issue with the updateURL() method in the Texture class where onLoadObservable was not properly triggered after the 1st load. Also, I noticed that updateURL's onLoad parameter wasn't always executed as expected.

Solution:
- Create a chain of callbacks that
   1. Executes the existing `_delayedOnLoad` callback first. If it exists, this means...
      1. The texture was constructed but not loaded:
         ```
         const texture = new Texture(null, scene);
         texture.updateURL(dataUrl, data);
         ```
       2. Therefore, the existing  `_delayedOnLoad` must be [this]([https://github.com/BabylonJS/Babylon.js/blob/b6e643730f32b8c5bc91266192919e41af32f8dc/packages/dev/…](https://github.com/BabylonJS/Babylon.js/blob/b6e643730f32b8c5bc91266192919e41af32f8dc/packages/dev/core/src/Materials/Textures/texture.ts#L465)), which was assigned in the constructor:
           ```
           const load = () => {
              if (this._texture) {
                  if (this._texture._invertVScale) {
                      this.vScale *= -1;
                      this.vOffset += 1;
                  }
          
                  // Update texture to match internal texture's wrapping
                  if (this._texture._cachedWrapU !== null) {
                      this.wrapU = this._texture._cachedWrapU;
                      this._texture._cachedWrapU = null;
                  }
                  if (this._texture._cachedWrapV !== null) {
                      this.wrapV = this._texture._cachedWrapV;
                      this._texture._cachedWrapV = null;
                  }
                  if (this._texture._cachedWrapR !== null) {
                      this.wrapR = this._texture._cachedWrapR;
                      this._texture._cachedWrapR = null;
                  }
              }
          
              if (this.onLoadObservable.hasObservers()) {
                  this.onLoadObservable.notifyObservers(this);
              }
              if (onLoad) {
                  onLoad();
              }
          
              if (!this.isBlocking && scene) {
                  scene.resetCachedMaterial();
              }
          };
           ```
   3. Notifies observers of onLoadObservable only if no existing callback (to avoid extra notification-- see above)
   4. Always calls the new `onLoad` function if provided through `updateUrl`