### PR TITLE
Inspector v2: Various fixes and cleanup

### DIFF
--- a/packages/dev/inspector-v2/src/components/pane.tsx
+++ b/packages/dev/inspector-v2/src/components/pane.tsx
@@ -1,20 +1,26 @@
-import { makeStyles, tokens } from "@fluentui/react-components";
-import { forwardRef, type PropsWithChildren } from "react";
+import type { ComponentProps } from "react";
+
+import { makeStyles, mergeClasses, tokens } from "@fluentui/react-components";
+import { forwardRef } from "react";
 
 const useStyles = makeStyles({
     paneRootDiv: {
-        padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,
+        display: "flex",
+        flex: 1,
+        flexDirection: "column",
+        padding: `0 ${tokens.spacingHorizontalM}`,
     },
 });
 
 /**
  * Used to apply common styles to panes.
  */
-export const Pane = forwardRef<HTMLDivElement, PropsWithChildren>((props, ref) => {
+export const SidePaneContainer = forwardRef<HTMLDivElement, ComponentProps<"div">>((props, ref) => {
+    const { className, ...rest } = props;
     const classes = useStyles();
 
     return (
-        <div className={classes.paneRootDiv} ref={ref}>
+        <div className={mergeClasses(classes.paneRootDiv, className)} ref={ref} {...rest}>
             {props.children}
         </div>
     );

--- a/packages/dev/inspector-v2/src/components/properties/animation/animationGroupProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/animation/animationGroupProperties.tsx
@@ -1,14 +1,17 @@
+import type { FunctionComponent } from "react";
+
+import { useCallback } from "react";
+
 import type { AnimationGroup } from "core/Animations/animationGroup";
-import { useCallback, type FunctionComponent } from "react";
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
-import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
-import { BoundProperty } from "../boundProperty";
-import { useObservableState } from "../../../hooks/observableHooks";
-import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
-import { Collapse } from "shared-ui-components/fluent/primitives/collapse";
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
-import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
+import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
+import { Collapse } from "shared-ui-components/fluent/primitives/collapse";
+import { useProperty } from "../../../hooks/compoundPropertyHooks";
+import { useObservableState } from "../../../hooks/observableHooks";
+import { BoundProperty } from "../boundProperty";
 
 interface ICurrentFrameHolder {
     currentFrame: number;

--- a/packages/dev/inspector-v2/src/components/properties/linkToEntityPropertyLine.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/linkToEntityPropertyLine.tsx
@@ -1,8 +1,12 @@
+import type { FunctionComponent } from "react";
+
 import type { PropertyLineProps } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
 import type { ISelectionService } from "../../services/selectionService";
-import { useEffect, useState, type FunctionComponent } from "react";
-import { LinkPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/linkPropertyLine";
+
+import { useEffect, useState } from "react";
+
 import type { Nullable } from "core/types";
+import { LinkPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/linkPropertyLine";
 
 type LinkToEntityProps = { entity: Nullable<{ name: string; reservedDataStore?: Record<PropertyKey, unknown> }>; selectionService: ISelectionService };
 

--- a/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
@@ -1,6 +1,8 @@
+import type { FunctionComponent } from "react";
+
 import { Body1, Button, makeStyles, tokens, Tooltip } from "@fluentui/react-components";
 import { ArrowUndoRegular, ClearFormattingRegular, SaveRegular } from "@fluentui/react-icons";
-import { useMemo, useState, type FunctionComponent } from "react";
+import { useMemo, useState } from "react";
 
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { LineContainer } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";

--- a/packages/dev/inspector-v2/src/components/properties/particles/attractorList.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/particles/attractorList.tsx
@@ -1,18 +1,23 @@
-import { GizmoManager } from "core/Gizmos/gizmoManager";
-import { StandardMaterial } from "core/Materials/standardMaterial";
-import { Color3 } from "core/Maths/math.color";
+import type { FunctionComponent } from "react";
+
+import { useCallback, useEffect, useState } from "react";
+
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
-import { Attractor } from "core/Particles/attractor";
 import type { ParticleSystem } from "core/Particles/particleSystem";
 import type { Scene } from "core/scene";
 import type { Nullable } from "core/types";
-import { useCallback, useEffect, useState, type FunctionComponent } from "react";
+import type { ListItem } from "shared-ui-components/fluent/primitives/list";
+
+import { GizmoManager } from "core/Gizmos/gizmoManager";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Color3 } from "core/Maths/math.color";
+import { Attractor } from "core/Particles/attractor";
 import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { List } from "shared-ui-components/fluent/primitives/list";
-import type { ListItem } from "shared-ui-components/fluent/primitives/list";
 import { useResource } from "../../../hooks/resourceHooks";
 import { AttractorComponent } from "./attractor";
+
 type AttractorListProps = {
     scene: Scene;
     attractors: Array<Attractor>;

--- a/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
@@ -1,23 +1,34 @@
 import type { Scene } from "core/index";
 
+import { makeStyles, tokens } from "@fluentui/react-components";
+
 import { AbstractEngine } from "core/Engines/abstractEngine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
 import { ExtensibleAccordion } from "../extensibleAccordion";
-import { Pane } from "../pane";
+import { SidePaneContainer } from "../pane";
+
+const useStyles = makeStyles({
+    pinnedStatsPane: {
+        flex: "0 1 auto",
+        paddingBottom: tokens.spacingHorizontalM,
+    },
+});
 
 export const StatsPane: typeof ExtensibleAccordion<Scene> = (props) => {
+    const classes = useStyles();
+
     const scene = props.context;
     const engine = scene.getEngine();
     const fps = useObservableState(() => Math.round(engine.getFps()), engine.onBeginFrameObservable);
 
     return (
         <>
-            <Pane>
+            <SidePaneContainer className={classes.pinnedStatsPane}>
                 <TextPropertyLine key="EngineVersion" label="Version" description="The Babylon.js engine version." value={AbstractEngine.Version} />
                 <StringifiedPropertyLine key="FPS" label="FPS:" description="The current framerate" value={fps} />
-            </Pane>
+            </SidePaneContainer>
             <ExtensibleAccordion {...props} />
         </>
     );

--- a/packages/dev/inspector-v2/src/index.ts
+++ b/packages/dev/inspector-v2/src/index.ts
@@ -3,7 +3,7 @@ export * from "./components/properties/boundProperty";
 export * from "./components/properties/linkToEntityPropertyLine";
 export { EntityBase, EntityDisplayInfo, SceneExplorerCommand, SceneExplorerCommandProvider, SceneExplorerSection } from "./components/scene/sceneExplorer";
 export * from "./components/extensibleAccordion";
-export { Pane as PaneContainer } from "./components/pane";
+export { SidePaneContainer } from "./components/pane";
 export * from "./components/teachingMoment";
 export * from "./extensibility/extensionFeed";
 export * from "./extensibility/builtInsExtensionFeed";

--- a/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
@@ -1,3 +1,4 @@
+import type { MaterialWithNormalMaps } from "../../../components/properties/materials/normalMapProperties";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISettingsContext } from "../../../services/settingsContext";
 import type { ISelectionService } from "../../selectionService";
@@ -12,7 +13,7 @@ import { StandardMaterial } from "core/Materials/standardMaterial";
 import { SkyMaterial } from "materials/sky/skyMaterial";
 import { MaterialGeneralProperties, MaterialStencilProperties, MaterialTransparencyProperties } from "../../../components/properties/materials/materialProperties";
 import { MultiMaterialChildrenProperties } from "../../../components/properties/materials/multiMaterialProperties";
-import { type MaterialWithNormalMaps, NormalMapProperties } from "../../../components/properties/materials/normalMapProperties";
+import { NormalMapProperties } from "../../../components/properties/materials/normalMapProperties";
 import {
     PBRBaseMaterialAnisotropicProperties,
     PBRBaseMaterialClearCoatProperties,

--- a/packages/dev/inspector-v2/src/services/panes/properties/spritePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/spritePropertiesService.tsx
@@ -1,16 +1,17 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
-import type { IPropertiesService } from "./propertiesService";
+import type { ISettingsContext } from "../../../services/settingsContext";
 import type { ISelectionService } from "../../selectionService";
+import type { IPropertiesService } from "./propertiesService";
 
 import { Sprite } from "core/Sprites/sprite";
 
-import { PropertiesServiceIdentity } from "./propertiesService";
-import { SelectionServiceIdentity } from "../../selectionService";
 import { SpriteAnimationProperties } from "../../../components/properties/sprites/spriteAnimationProperties";
 import { SpriteGeneralProperties } from "../../../components/properties/sprites/spriteGeneralProperties";
-import { SpriteTransformProperties } from "../../../components/properties/sprites/spriteTransformProperties";
 import { SpriteOtherProperties } from "../../../components/properties/sprites/spriteOtherProperties";
-import { SettingsContextIdentity, type ISettingsContext } from "../../../services/settingsContext";
+import { SpriteTransformProperties } from "../../../components/properties/sprites/spriteTransformProperties";
+import { SettingsContextIdentity } from "../../../services/settingsContext";
+import { SelectionServiceIdentity } from "../../selectionService";
+import { PropertiesServiceIdentity } from "./propertiesService";
 
 export const SpritePropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISelectionService, ISettingsContext]> = {
     friendlyName: "Sprite Properties",

--- a/packages/dev/inspector-v2/src/services/panes/properties/texturePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/texturePropertiesService.tsx
@@ -26,7 +26,7 @@ import { PropertiesServiceIdentity } from "./propertiesService";
 
 // Don't use instanceof in this case as we don't want to bring in the gui package just to check if the entity is an AdvancedDynamicTexture.
 function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTexture {
-    return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";
+    return (entity as AdvancedDynamicTexture)?.getClassName?.() === "AdvancedDynamicTexture";
 }
 
 export const TexturePropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISettingsContext]> = {

--- a/packages/dev/inspector-v2/src/services/panes/properties/transformPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/transformPropertiesService.tsx
@@ -1,10 +1,11 @@
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+import type { ISettingsContext } from "../../settingsContext";
 import type { IPropertiesService } from "./propertiesService";
 
 import { Bone } from "core/Bones/bone";
 import { TransformNode } from "core/Meshes/transformNode";
 import { TransformProperties } from "../../../components/properties/transformProperties";
-import { SettingsContextIdentity, type ISettingsContext } from "../../settingsContext";
+import { SettingsContextIdentity } from "../../settingsContext";
 import { PropertiesServiceIdentity } from "./propertiesService";
 
 export const TransformPropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISettingsContext]> = {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -13,7 +13,7 @@ import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 // Don't use instanceof in this case as we don't want to bring in the gui package just to check if the entity is an AdvancedDynamicTexture.
 function IsAdvancedDynamicTexture(entity: unknown): entity is AdvancedDynamicTexture {
-    return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";
+    return (entity as AdvancedDynamicTexture)?.getClassName?.() === "AdvancedDynamicTexture";
 }
 
 export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {

--- a/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/settingsService.tsx
@@ -1,8 +1,8 @@
 import type { IDisposable, Scene } from "core/index";
-
 import type { DynamicAccordionSection, DynamicAccordionSectionContent } from "../../components/extensibleAccordion";
 import type { IService, ServiceDefinition } from "../../modularity/serviceDefinition";
 import type { ISceneContext } from "../sceneContext";
+import type { ISettingsContext } from "../settingsContext";
 import type { IShellService } from "../shellService";
 
 import { SettingsRegular } from "@fluentui/react-icons";
@@ -15,7 +15,7 @@ import { ExtensibleAccordion } from "../../components/extensibleAccordion";
 import { useObservableCollection, useObservableState, useOrderedObservableCollection } from "../../hooks/observableHooks";
 import { ObservableCollection } from "../../misc/observableCollection";
 import { SceneContextIdentity } from "../sceneContext";
-import { SettingsContextIdentity, type ISettingsContext } from "../settingsContext";
+import { SettingsContextIdentity } from "../settingsContext";
 import { ShellServiceIdentity } from "../shellService";
 
 export const SettingsServiceIdentity = Symbol("SettingsService");

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -442,11 +442,11 @@ function usePane(
     alignment: "left" | "right",
     defaultWidth: number,
     minWidth: number,
-    topPaneComponents: SidePane[],
-    bottomPaneComponents: SidePane[],
+    topPanes: SidePane[],
+    bottomPanes: SidePane[],
     toolbarMode: ToolbarMode,
-    topBarComponents: ToolbarItem[],
-    bottomBarComponents: ToolbarItem[]
+    topBarItems: ToolbarItem[],
+    bottomBarItems: ToolbarItem[]
 ) {
     const classes = useStyles();
 
@@ -465,20 +465,20 @@ function usePane(
     const [resizing, setResizing] = useState(false);
 
     useEffect(() => {
-        if ((topSelectedTab && !topPaneComponents.includes(topSelectedTab)) || (!topSelectedTab && topPaneComponents.length > 0)) {
-            setTopSelectedTab(topPaneComponents[0]);
-        } else if (topSelectedTab && topPaneComponents.length === 0) {
+        if ((topSelectedTab && !topPanes.includes(topSelectedTab)) || (!topSelectedTab && topPanes.length > 0)) {
+            setTopSelectedTab(topPanes[0]);
+        } else if (topSelectedTab && topPanes.length === 0) {
             setTopSelectedTab(undefined);
         }
-    }, [topSelectedTab, topPaneComponents]);
+    }, [topSelectedTab, topPanes]);
 
     useEffect(() => {
-        if ((bottomSelectedTab && !bottomPaneComponents.includes(bottomSelectedTab)) || (!bottomSelectedTab && bottomPaneComponents.length > 0)) {
-            setBottomSelectedTab(bottomPaneComponents[0]);
-        } else if (bottomSelectedTab && bottomPaneComponents.length === 0) {
+        if ((bottomSelectedTab && !bottomPanes.includes(bottomSelectedTab)) || (!bottomSelectedTab && bottomPanes.length > 0)) {
+            setBottomSelectedTab(bottomPanes[0]);
+        } else if (bottomSelectedTab && bottomPanes.length === 0) {
             setBottomSelectedTab(undefined);
         }
-    }, [bottomSelectedTab, bottomPaneComponents]);
+    }, [bottomSelectedTab, bottomPanes]);
 
     const expandCollapseIcon = useMemo(() => {
         if (alignment === "left") {
@@ -578,8 +578,8 @@ function usePane(
     );
 
     // This memos the TabList to make it easy for the JSX to be inserted at the top of the pane (in "compact" mode) or returned to the caller to be used in the toolbar (in "full" mode).
-    const topPaneTabList = useMemo(() => createPaneTabList(topPaneComponents, toolbarMode, topSelectedTab, setTopSelectedTab), [topPaneComponents, toolbarMode, topSelectedTab]);
-    const bottomPaneTabList = useMemo(() => createPaneTabList(bottomPaneComponents, "compact", bottomSelectedTab, setBottomSelectedTab), [bottomPaneComponents, bottomSelectedTab]);
+    const topPaneTabList = useMemo(() => createPaneTabList(topPanes, toolbarMode, topSelectedTab, setTopSelectedTab), [topPanes, toolbarMode, topSelectedTab]);
+    const bottomPaneTabList = useMemo(() => createPaneTabList(bottomPanes, "compact", bottomSelectedTab, setBottomSelectedTab), [bottomPanes, bottomSelectedTab]);
 
     // This manages the CSS variable that controls the height of the bottom pane.
     const paneHeightAdjustCSSVar = "--pane-height-adjust";
@@ -610,17 +610,17 @@ function usePane(
     const pane = useMemo(() => {
         return (
             <>
-                {(topPaneComponents.length > 0 || bottomPaneComponents.length > 0) && (
+                {(topPanes.length > 0 || bottomPanes.length > 0) && (
                     <div className={`${classes.pane} ${alignment === "left" ? classes.paneLeft : classes.paneRight}`}>
                         <Collapse orientation="horizontal" visible={!collapsed}>
                             <div className={classes.paneContainer} style={{ width: `${width}px` }}>
                                 {/* If toolbar mode is "compact" then the top toolbar is embedded at the top of the pane. */}
-                                {toolbarMode === "compact" && (topPaneComponents.length > 1 || topBarComponents.length > 0) && (
+                                {toolbarMode === "compact" && (topPanes.length > 1 || topBarItems.length > 0) && (
                                     <>
                                         <div className={classes.barDiv}>
                                             {/* The tablist gets merged in with the toolbar. */}
                                             {topPaneTabList}
-                                            <Toolbar location="top" components={topBarComponents} />
+                                            <Toolbar location="top" components={topBarItems} />
                                         </div>
                                     </>
                                 )}
@@ -637,7 +637,7 @@ function usePane(
                                 </div>
 
                                 {/* If we have both top and bottom panes, show a divider. This divider is also the resizer for the bottom pane. */}
-                                {topPaneComponents.length > 0 && bottomPaneComponents.length > 0 && (
+                                {topPanes.length > 0 && bottomPanes.length > 0 && (
                                     <Divider
                                         ref={paneVerticalResizeHandleRef}
                                         className={classes.headerDivider}
@@ -646,14 +646,14 @@ function usePane(
                                 )}
 
                                 {/* Render the bottom pane tablist. */}
-                                {bottomPaneComponents.length > 1 && (
+                                {bottomPanes.length > 1 && (
                                     <>
                                         <div className={classes.barDiv}>{bottomPaneTabList}</div>
                                     </>
                                 )}
 
                                 {/* Render the bottom pane content. This is the element that can be resized vertically. */}
-                                {bottomPaneComponents.length > 0 && (
+                                {bottomPanes.length > 0 && (
                                     <div
                                         ref={paneVerticalResizeElementRef}
                                         className={classes.paneContent}
@@ -670,10 +670,10 @@ function usePane(
                                 )}
 
                                 {/* If toolbar mode is "compact" then the bottom toolbar is embedded at the bottom of the pane. */}
-                                {toolbarMode === "compact" && bottomBarComponents.length > 0 && (
+                                {toolbarMode === "compact" && bottomBarItems.length > 0 && (
                                     <>
                                         <div className={classes.barDiv}>
-                                            <Toolbar location="bottom" components={bottomBarComponents} />
+                                            <Toolbar location="bottom" components={bottomBarItems} />
                                         </div>
                                     </>
                                 )}
@@ -689,7 +689,7 @@ function usePane(
                 )}
             </>
         );
-    }, [topPaneComponents, topSelectedTab, bottomPaneComponents, bottomSelectedTab, collapsed, width, resizing]);
+    }, [topPanes, topSelectedTab, bottomPanes, bottomSelectedTab, topBarItems, bottomBarItems, collapsed, width, resizing]);
 
     return [topPaneTabList, pane];
 }
@@ -706,27 +706,27 @@ export function MakeShellServiceDefinition({
         friendlyName: "MainView",
         produces: [ShellServiceIdentity, RootComponentServiceIdentity],
         factory: () => {
-            const topBarComponentCollection = new ObservableCollection<ToolbarItem>();
-            const bottomBarComponentCollection = new ObservableCollection<ToolbarItem>();
-            const topLeftPaneComponentCollection = new ObservableCollection<SidePane>();
-            const topRightPaneComponentCollection = new ObservableCollection<SidePane>();
-            const bottomLeftPaneComponentCollection = new ObservableCollection<SidePane>();
-            const bottomRightPaneComponentCollection = new ObservableCollection<SidePane>();
-            const contentComponentCollection = new ObservableCollection<CentralContent>();
+            const topBarItemCollection = new ObservableCollection<ToolbarItem>();
+            const bottomBarItemCollection = new ObservableCollection<ToolbarItem>();
+            const topLeftPaneCollection = new ObservableCollection<SidePane>();
+            const topRightPaneCollection = new ObservableCollection<SidePane>();
+            const bottomLeftPaneCollection = new ObservableCollection<SidePane>();
+            const bottomRightPaneCollection = new ObservableCollection<SidePane>();
+            const centralContentCollection = new ObservableCollection<CentralContent>();
 
             const rootComponent: FunctionComponent = () => {
                 const classes = useStyles();
 
-                const topBarItems = useOrderedObservableCollection(topBarComponentCollection);
-                const bottomBarItems = useOrderedObservableCollection(bottomBarComponentCollection);
+                const topBarItems = useOrderedObservableCollection(topBarItemCollection);
+                const bottomBarItems = useOrderedObservableCollection(bottomBarItemCollection);
 
-                const topLeftPaneItems = useOrderedObservableCollection(topLeftPaneComponentCollection);
-                const topRightPaneItems = useOrderedObservableCollection(topRightPaneComponentCollection);
-                const bottomLeftPaneItems = useOrderedObservableCollection(bottomLeftPaneComponentCollection);
-                const bottomRightPaneItems = useOrderedObservableCollection(bottomRightPaneComponentCollection);
+                const topLeftPanes = useOrderedObservableCollection(topLeftPaneCollection);
+                const topRightPanes = useOrderedObservableCollection(topRightPaneCollection);
+                const bottomLeftPanes = useOrderedObservableCollection(bottomLeftPaneCollection);
+                const bottomRightPanes = useOrderedObservableCollection(bottomRightPaneCollection);
 
-                const hasLeftPaneItems = topLeftPaneItems.length > 0 || bottomLeftPaneItems.length > 0;
-                const hasRightPaneItems = topRightPaneItems.length > 0 || bottomRightPaneItems.length > 0;
+                const hasLeftPanes = topLeftPanes.length > 0 || bottomLeftPanes.length > 0;
+                const hasRightPanes = topRightPanes.length > 0 || bottomRightPanes.length > 0;
 
                 // If we are in compact toolbar mode, we may need to move toolbar items from the left to the right or vice versa,
                 // depending on whether there are any side panes on that side.
@@ -734,43 +734,43 @@ export function MakeShellServiceDefinition({
                     let location = item.horizontalLocation;
                     // Coercion is only needed in compact toolbar mode since there might not be a left or right pane.
                     if (toolbarMode === "compact") {
-                        if (location === "left" && !hasLeftPaneItems) {
+                        if (location === "left" && !hasLeftPanes) {
                             location = "right";
                         }
-                        if (location === "right" && !hasRightPaneItems) {
+                        if (location === "right" && !hasRightPanes) {
                             location = "left";
                         }
                     }
                     return location;
                 };
 
-                const topBarLeftComponents = useMemo(() => topBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "left"), [topBarItems]);
-                const topBarRightComponents = useMemo(() => topBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "right"), [topBarItems]);
-                const bottomBarLeftComponents = useMemo(() => bottomBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "left"), [bottomBarItems]);
-                const bottomBarRightComponents = useMemo(() => bottomBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "right"), [bottomBarItems]);
+                const topBarLeftItems = useMemo(() => topBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "left"), [topBarItems]);
+                const topBarRightItems = useMemo(() => topBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "right"), [topBarItems]);
+                const bottomBarLeftItems = useMemo(() => bottomBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "left"), [bottomBarItems]);
+                const bottomBarRightItems = useMemo(() => bottomBarItems.filter((entry) => coerceToolBarItemHorizontalLocation(entry) === "right"), [bottomBarItems]);
 
-                const contentComponents = useOrderedObservableCollection(contentComponentCollection);
+                const centralContents = useOrderedObservableCollection(centralContentCollection);
 
                 const [leftPaneTabList, leftPane] = usePane(
                     "left",
                     leftPaneDefaultWidth,
                     leftPaneMinWidth,
-                    topLeftPaneItems,
-                    bottomLeftPaneItems,
+                    topLeftPanes,
+                    bottomLeftPanes,
                     toolbarMode,
-                    topBarLeftComponents,
-                    bottomBarLeftComponents
+                    topBarLeftItems,
+                    bottomBarLeftItems
                 );
 
                 const [rightPaneTabList, rightPane] = usePane(
                     "right",
                     rightPaneDefaultWidth,
                     rightPaneMinWidth,
-                    topRightPaneItems,
-                    bottomRightPaneItems,
+                    topRightPanes,
+                    bottomRightPanes,
                     toolbarMode,
-                    topBarRightComponents,
-                    bottomBarRightComponents
+                    topBarRightItems,
+                    bottomBarRightItems
                 );
 
                 return (
@@ -793,7 +793,7 @@ export function MakeShellServiceDefinition({
 
                             {/* Render the main/central content. */}
                             <div className={classes.centralContent}>
-                                {contentComponents.map((entry) => (
+                                {centralContents.map((entry) => (
                                     <entry.component key={entry.key} />
                                 ))}
                             </div>
@@ -822,9 +822,9 @@ export function MakeShellServiceDefinition({
                     }
 
                     if (entry.verticalLocation === "top") {
-                        return topBarComponentCollection.add(entry);
+                        return topBarItemCollection.add(entry);
                     } else {
-                        return bottomBarComponentCollection.add(entry);
+                        return bottomBarItemCollection.add(entry);
                     }
                 },
                 addSidePane: (entry) => {
@@ -854,19 +854,19 @@ export function MakeShellServiceDefinition({
 
                     if (horizontalLocation === "left") {
                         if (verticalLocation === "top") {
-                            return topLeftPaneComponentCollection.add(entry);
+                            return topLeftPaneCollection.add(entry);
                         } else {
-                            return bottomLeftPaneComponentCollection.add(entry);
+                            return bottomLeftPaneCollection.add(entry);
                         }
                     } else {
                         if (verticalLocation === "top") {
-                            return topRightPaneComponentCollection.add(entry);
+                            return topRightPaneCollection.add(entry);
                         } else {
-                            return bottomRightPaneComponentCollection.add(entry);
+                            return bottomRightPaneCollection.add(entry);
                         }
                     }
                 },
-                addCentralContent: (entry) => contentComponentCollection.add(entry),
+                addCentralContent: (entry) => centralContentCollection.add(entry),
                 rootComponent,
             };
         },

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -20,12 +20,12 @@ import "core/Helpers/sceneHelpers";
 import { Color3, Color4 } from "core/Maths/math.color";
 import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
 
-import { ShowInspector } from "../../src/inspector";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { MultiMaterial } from "core/Materials/multiMaterial";
 import { Texture } from "core/Materials/Textures/texture";
+import { ShowInspector } from "../../src";
 
 // Register scene loader plugins.
 registerBuiltInLoaders();

--- a/packages/dev/inspector-v2/webpack.config.js
+++ b/packages/dev/inspector-v2/webpack.config.js
@@ -4,7 +4,7 @@ const webpackTools = require("@dev/build-tools").webpackTools;
 module.exports = (env) => {
     const production = env.mode === "production" || process.env.NODE_ENV === "production";
     return {
-        entry: "./test/app/index.ts",
+        entry: "./test/app/index.tsx",
 
         ...webpackTools.commonDevWebpackConfiguration(
             {


### PR DESCRIPTION
Sorry for the generic PR title... this is an assortment of fixes for things I ran into while creating the Inspector v2 examples for the docs.

- Rename the test app's index.ts to index.tsx to make it easy to test extensions that use React.
- Fix an issue where we had a couple instances of `return (entity as AdvancedDynamicTexture)?.getClassName() === "AdvancedDynamicTexture";` which will crash if the object does not have a `getClassName` function.
- Update the Pane helper component to be called SidePaneContainer (to not conflict with Pane from shared-ui-components) and to make it fill the space by default. Otherwise its not very useful.
- Fixed an issue where toolbar items added dynamically by extensions did not show up immediately. This was just because of some missing dependencies in a useMemo dependency list.
- Fixed a bunch of cases where we had `import { type foo } from "bar"` instead of `import type { foo } from "bar"`.
- Auto ordered imports in files I touched to make it easier to see at a glance what types are imported compared to real imports.