### PR TITLE
Viewer: Fix lighting regression now that we use PBRMaterial by default

### DIFF
--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -400,7 +400,10 @@ export class Node implements IBehaviorAware<Node> {
         if (this._scene.isLoading && !attachImmediately) {
             // We defer the attach when the scene will be loaded
             this._scene.onDataLoadedObservable.addOnce(() => {
-                behavior.attach(this);
+                // Make sure the behavior has not been removed.
+                if (this._behaviors.includes(behavior)) {
+                    behavior.attach(this);
+                }
             });
         } else {
             behavior.attach(this);

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -918,7 +918,6 @@ export class Viewer implements IDisposable {
             defaultMaterial.metallic = 0;
             defaultMaterial.roughness = 1;
             defaultMaterial.baseDiffuseRoughness = 1;
-            defaultMaterial.environmentIntensity = 0.7;
             defaultMaterial.microSurface = 0;
             scene.defaultMaterial = defaultMaterial;
 
@@ -1695,8 +1694,11 @@ export class Viewer implements IDisposable {
             }
         });
 
-        // If there are PBR materials after the model load operation and an environment texture is not loaded, load the default environment.
-        if (!this._scene.environmentTexture && this._loadedModels.some((model) => model.assetContainer.materials.some((material) => material instanceof PBRMaterial))) {
+        const hasPBRMaterials = this._loadedModels.some((model) => model.assetContainer.materials.some((material) => material instanceof PBRMaterial));
+        const usesDefaultMaterial = this._loadedModels.some((model) => model.assetContainer.meshes.some((mesh) => mesh.material == null));
+        // If PBR is used (either explicitly, or implicitly by a mesh not having a material and therefore using the default PBRMaterial)
+        // and an environment texture is not already loaded, then load the default environment.
+        if (!this._scene.environmentTexture && (hasPBRMaterials || usesDefaultMaterial)) {
             await this.resetEnvironment({ lighting: true }, abortSignal);
         }
 
@@ -2875,13 +2877,12 @@ export class Viewer implements IDisposable {
         } else {
             const hasModelProvidedLights = this._loadedModels.some((model) => model.assetContainer.lights.length > 0);
             const hasImageBasedLighting = !!this._reflectionTexture;
-            const hasMaterials = this._loadedModels.some((model) => model.assetContainer.materials.length > 0);
             const hasNonPBRMaterials = this._loadedModels.some((model) => model.assetContainer.materials.some((material) => !(material instanceof PBRMaterial)));
 
             if (hasModelProvidedLights) {
                 shouldHaveDefaultLight = false;
             } else {
-                shouldHaveDefaultLight = !hasImageBasedLighting || !hasMaterials || hasNonPBRMaterials;
+                shouldHaveDefaultLight = !hasImageBasedLighting || hasNonPBRMaterials;
             }
         }
 

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -1695,7 +1695,7 @@ export class Viewer implements IDisposable {
         });
 
         const hasPBRMaterials = this._loadedModels.some((model) => model.assetContainer.materials.some((material) => material instanceof PBRMaterial));
-        const usesDefaultMaterial = this._loadedModels.some((model) => model.assetContainer.meshes.some((mesh) => mesh.material == null));
+        const usesDefaultMaterial = this._loadedModels.some((model) => model.assetContainer.meshes.some((mesh) => !mesh.material));
         // If PBR is used (either explicitly, or implicitly by a mesh not having a material and therefore using the default PBRMaterial)
         // and an environment texture is not already loaded, then load the default environment.
         if (!this._scene.environmentTexture && (hasPBRMaterials || usesDefaultMaterial)) {


### PR DESCRIPTION
This PR fixes two Viewer regressions I noticed today:

1. For a model that does not have materials, a default PBRMaterial is now used. However, some logic updates were missed that was causing a default light to be created when it is not supposed to be, and an environment not to be created when it is supposed to be. This made the lighting different (and incorrect) depending on whether the model was loaded after another model that does have materials (like a glb).
2. The camera was auto orbiting even if the flag is turned off. This turned out to be an issue in the core behavior logic, where attaching a behavior can be async/deferred, but in the meantime the behavior could be removed. I'm not sure how this ever worked, but I think the change I made here is more correct.