### PR TITLE
Navpluginv2 3

### DIFF
--- a/packages/dev/addons/src/navigation/common/getters.ts
+++ b/packages/dev/addons/src/navigation/common/getters.ts
@@ -7,7 +7,12 @@ import { Mesh } from "core/Meshes/mesh";
  *  @param meshes The array of meshes from which to extract positions and indices.
  *  @returns A tuple containing a Float32Array of positions and a Uint32Array of
  */
-export function GetPositionsAndIndices(meshes: Mesh[]): [positions: Float32Array, indices: Uint32Array] {
+export function GetPositionsAndIndices(
+    meshes: Mesh[],
+    options?: {
+        doNotReverseIndices?: boolean;
+    }
+): [positions: Float32Array, indices: Uint32Array] {
     let offset = 0;
     let index: number;
     let tri: number;
@@ -19,7 +24,7 @@ export function GetPositionsAndIndices(meshes: Mesh[]): [positions: Float32Array
         if (meshes[index]) {
             const mesh = meshes[index];
 
-            const meshIndices = GetReversedIndices(mesh);
+            const meshIndices = options?.doNotReverseIndices ? mesh.getIndices(false, true) : GetReversedIndices(mesh);
             if (!meshIndices) {
                 continue;
             }

--- a/packages/dev/addons/src/navigation/generator/generator.single-thread.ts
+++ b/packages/dev/addons/src/navigation/generator/generator.single-thread.ts
@@ -27,7 +27,7 @@ export function GenerateNavMesh(meshes: Array<Mesh>, parameters: INavMeshParamet
         throw new Error("At least one mesh is needed to create the nav mesh.");
     }
 
-    const [positions, indices] = GetPositionsAndIndices(meshes);
+    const [positions, indices] = GetPositionsAndIndices(meshes, { doNotReverseIndices: parameters.doNotReverseIndices });
     if (!positions || !indices) {
         throw new Error("Unable to get nav mesh. No vertices or indices.");
     }

--- a/packages/dev/addons/src/navigation/generator/generator.worker.ts
+++ b/packages/dev/addons/src/navigation/generator/generator.worker.ts
@@ -68,7 +68,7 @@ export function GenerateNavMeshWithWorker(
     };
 
     // send message to worker
-    const [positions, indices] = GetPositionsAndIndices(meshes);
+    const [positions, indices] = GetPositionsAndIndices(meshes, { doNotReverseIndices: parameters.doNotReverseIndices });
     const positionsCopy = new Float32Array(positions);
     const indicesCopy = new Uint32Array(indices);
     workerOptions.worker.postMessage({ positions: positionsCopy, indices: indicesCopy, parameters }, [positionsCopy.buffer, indicesCopy.buffer]);

--- a/packages/dev/addons/src/navigation/types.ts
+++ b/packages/dev/addons/src/navigation/types.ts
@@ -124,6 +124,10 @@ export interface INavMeshParametersV2 extends INavMeshParameters {
      * Function which is sets the polyAreas and polyFlags for the tile cache mesh. Defaults to a function that sets all areas to 0 and flags to 1.
      */
     tileCacheMeshProcess?: TileCacheMeshProcess;
+    /**
+     * Don't reverse indices of the source mesh
+     */
+    doNotReverseIndices?: boolean;
 }
 
 /**


### PR DESCRIPTION
added `doNotReverseIndices` parameter - in some cases you don't want to reverse the indices of the source mesh for nav mesh generation