### PR TITLE
FrameGraph: miscellaneous

### DIFF
--- a/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/copyTextureBlock.ts
+++ b/packages/dev/core/src/FrameGraph/Node/Blocks/Textures/copyTextureBlock.ts
@@ -33,7 +33,7 @@ export class NodeRenderGraphCopyTextureBlock extends NodeRenderGraphBlock {
 
         this.source.addExcludedConnectionPointFromAllowedTypes(NodeRenderGraphBlockConnectionPointTypes.TextureAllButBackBuffer);
         this.target.addExcludedConnectionPointFromAllowedTypes(NodeRenderGraphBlockConnectionPointTypes.TextureAll);
-        this.output._typeConnectionSource = this.target;
+        this.output._typeConnectionSource = this.source;
 
         this._frameGraphTask = new FrameGraphCopyToTextureTask(name, frameGraph);
     }

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
@@ -279,8 +279,9 @@ export class NodeRenderGraph {
 
     /**
      * Build the final list of blocks that will be executed by the "execute" method
+     * @param dontBuildFrameGraph If the underlying frame graph should not be built (default: false)
      */
-    public build() {
+    public build(dontBuildFrameGraph = false) {
         if (!this.outputBlock) {
             throw new Error("You must define the outputBlock property before building the node render graph");
         }
@@ -307,7 +308,9 @@ export class NodeRenderGraph {
         try {
             this.outputBlock.build(state);
 
-            this._frameGraph.build();
+            if (!dontBuildFrameGraph) {
+                this._frameGraph.build();
+            }
         } finally {
             this._buildId = NodeRenderGraph._BuildIdGenerator++;
 

--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/utilityLayerRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/utilityLayerRendererTask.ts
@@ -45,7 +45,7 @@ export class FrameGraphUtilityLayerRendererTask extends FrameGraphTask {
 
     public record(): void {
         if (!this.targetTexture || !this.camera) {
-            throw new Error("FrameGraphUtilityLayerRendererTask: targetTexture and camera are required");
+            throw new Error(`FrameGraphUtilityLayerRendererTask "${this.name}": targetTexture and camera are required`);
         }
 
         this._frameGraph.textureManager.resolveDanglingHandle(this.outputTexture, this.targetTexture);

--- a/packages/dev/core/src/Shaders/copyTextureToTexture.fragment.fx
+++ b/packages/dev/core/src/Shaders/copyTextureToTexture.fragment.fx
@@ -8,7 +8,11 @@ varying vec2 vUV;
 
 void main(void) 
 {
+#ifdef NO_SAMPLER
+    vec4 color = texelFetch(textureSampler, ivec2(gl_FragCoord.xy), 0);
+#else
     vec4 color = texture2D(textureSampler, vUV);
+#endif
 
 #ifdef DEPTH_TEXTURE
     gl_FragDepth = color.r;

--- a/packages/dev/core/src/ShadersWGSL/copyTextureToTexture.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/copyTextureToTexture.fragment.fx
@@ -1,6 +1,8 @@
 uniform conversion: f32;
 
+#ifndef NO_SAMPLER
 var textureSamplerSampler: sampler;
+#endif
 var textureSampler: texture_2d<f32>;
 
 varying vUV: vec2f;
@@ -10,7 +12,11 @@ varying vUV: vec2f;
 @fragment
 fn main(input: FragmentInputs) -> FragmentOutputs {
 
+#ifdef NO_SAMPLER
+    var color: vec4f = textureLoad(textureSampler, vec2u(fragmentInputs.position.xy), 0);
+#else
     var color: vec4f = textureSample(textureSampler, textureSamplerSampler, input.vUV);
+#endif
 
 #ifdef DEPTH_TEXTURE
     fragmentOutputs.fragDepth = color.r;


### PR DESCRIPTION
Some small changes to frame graph:
* Fix wrong output connection type for the copyTexture block
* Allow not building the frame graph when building a node render graph

Also, I updated the `CopyTextureToTexture` class to handle the special case where the source and destination textures are of the same size.