### PR TITLE
SFE: Context menu to allow removing all custom block definitions

### DIFF
--- a/packages/tools/smartFiltersEditor/src/app.ts
+++ b/packages/tools/smartFiltersEditor/src/app.ts
@@ -13,6 +13,7 @@ import {
     SmartFilterEditorControl,
     LogLevel,
     type SmartFilterEditorOptions,
+    CustomBlocksNamespace,
 } from "smart-filters-editor-control";
 import { SmartFilterRenderer } from "./smartFilterRenderer";
 import { CustomBlockManager } from "./customBlockManager";
@@ -311,6 +312,13 @@ async function Main(): Promise<void> {
             const { blockType, namespace } = blockRegistration;
             customBlockManager.deleteBlockDefinition(blockType, namespace);
             RemoveCustomBlockFromBlockEditorRegistration(blockEditorRegistration, allBlockRegistrations, blockType, namespace);
+        },
+        clearCustomBlocks: () => {
+            const blocksToDelete = customBlockManager.getCustomBlockDefinitions();
+            for (const block of blocksToDelete) {
+                customBlockManager.deleteBlockDefinition(block.blockType, block.namespace);
+                RemoveCustomBlockFromBlockEditorRegistration(blockEditorRegistration, allBlockRegistrations, block.blockType, block.namespace || CustomBlocksNamespace);
+            }
         },
         onLogRequiredObservable,
         onSaveEditorDataRequiredObservable,

--- a/packages/tools/smartFiltersEditorControl/package.json
+++ b/packages/tools/smartFiltersEditorControl/package.json
@@ -34,6 +34,7 @@
         "@dev/smart-filters": "^1.0.0",
         "@dev/smart-filters-blocks": "^1.0.0",
         "@dev/core": "^1.0.0",
-        "@dev/shared-ui-components": "^1.0.0"
+        "@dev/shared-ui-components": "^1.0.0",
+        "react-contextmenu": "RaananW/react-contextmenu#4cb92c957ebff7aee6fc3b0ace61bc143a7373f2"
     }
 }

--- a/packages/tools/smartFiltersEditorControl/src/assets/styles/main.scss
+++ b/packages/tools/smartFiltersEditorControl/src/assets/styles/main.scss
@@ -469,3 +469,17 @@
 
     text-align: center;
 }
+
+.context-menu {
+    background: #222222;
+    z-index: 1000;
+
+    .react-contextmenu-item {
+        padding: 10px;
+        cursor: pointer;
+
+        &:hover {
+            background: #555555;
+        }
+    }
+}

--- a/packages/tools/smartFiltersEditorControl/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/components/nodeList/nodeListComponent.tsx
@@ -108,7 +108,7 @@ export class NodeListComponent extends react.Component<INodeListComponentProps, 
                     return <DraggableBlockLineComponent key={GetBlockKey(block.blockType, block.namespace)} block={block} />;
                 });
 
-            let contextMenu: Nullable<JSX.Element> = null;
+            let contextMenu: JSX.Element | undefined = undefined;
 
             if (key === CustomBlocksNamespace) {
                 const line = (

--- a/packages/tools/smartFiltersEditorControl/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/components/nodeList/nodeListComponent.tsx
@@ -3,6 +3,7 @@ import * as react from "react";
 import type { Nullable } from "core/types";
 import type { Observer } from "core/Misc/observable";
 import { Tools } from "core/Misc/tools.js";
+import { ContextMenu, MenuItem } from "react-contextmenu";
 
 import type { GlobalState } from "../../globalState";
 import { LineContainerComponent } from "../../sharedComponents/lineContainerComponent.js";
@@ -107,6 +108,8 @@ export class NodeListComponent extends react.Component<INodeListComponentProps, 
                     return <DraggableBlockLineComponent key={GetBlockKey(block.blockType, block.namespace)} block={block} />;
                 });
 
+            let contextMenu: Nullable<JSX.Element> = null;
+
             if (key === CustomBlocksNamespace) {
                 const line = (
                     <LineWithFileButtonComponent
@@ -122,11 +125,28 @@ export class NodeListComponent extends react.Component<INodeListComponentProps, 
                     />
                 );
                 blockList.push(line);
+
+                if (this.props.globalState.clearCustomBlocks) {
+                    const clearCustomBlocks = this.props.globalState.clearCustomBlocks;
+                    contextMenu = (
+                        <ContextMenu id={"contextmenu#" + key} className="context-menu">
+                            <MenuItem
+                                key="Remove_All_Custom_Blocks"
+                                onClick={() => {
+                                    clearCustomBlocks();
+                                    this.forceUpdate();
+                                }}
+                            >
+                                Remove All Custom Blocks
+                            </MenuItem>
+                        </ContextMenu>
+                    );
+                }
             }
 
             if (blockList.length) {
                 blockMenu.push(
-                    <LineContainerComponent key={key + " blocks"} title={key.replace("__", ": ").replace("_", " ")} closed={false}>
+                    <LineContainerComponent key={key + " blocks"} title={key.replace("__", ": ").replace("_", " ")} closed={false} contextMenu={contextMenu}>
                         {blockList}
                     </LineContainerComponent>
                 );

--- a/packages/tools/smartFiltersEditorControl/src/globalState.ts
+++ b/packages/tools/smartFiltersEditorControl/src/globalState.ts
@@ -105,6 +105,8 @@ export class GlobalState {
 
     deleteCustomBlock?: (blockRegistration: IBlockRegistration) => void;
 
+    clearCustomBlocks?: () => void;
+
     public get previewBackground(): string {
         return this._previewBackground;
     }
@@ -135,6 +137,7 @@ export class GlobalState {
         saveToSnippetServer?: () => void,
         addCustomBlock?: (serializedData: string) => void,
         deleteCustomBlock?: (blockRegistration: IBlockRegistration) => void,
+        clearCustomBlocks?: () => void,
         onLogRequiredObservable?: Observable<LogEntry>,
         onSaveEditorDataRequiredObservable?: Observable<void>
     ) {
@@ -179,6 +182,7 @@ export class GlobalState {
         this.reloadAssets = reloadAssets;
         this.addCustomBlock = addCustomBlock;
         this.deleteCustomBlock = deleteCustomBlock;
+        this.clearCustomBlocks = clearCustomBlocks;
 
         this.onLogRequiredObservable = onLogRequiredObservable ?? new Observable<LogEntry>();
         this.onSaveEditorDataRequiredObservable = onSaveEditorDataRequiredObservable ?? new Observable<void>();

--- a/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
@@ -1,5 +1,4 @@
 import { DataStorage } from "core/Misc/dataStorage.js";
-import type { Nullable } from "core/types";
 import * as react from "react";
 import downArrow from "../assets/imgs/downArrow.svg";
 import { ContextMenuTrigger } from "react-contextmenu";
@@ -8,7 +7,7 @@ interface ILineContainerComponentProps {
     title: string;
     children: any[] | any;
     closed?: boolean;
-    contextMenu: Nullable<JSX.Element>;
+    contextMenu?: JSX.Element;
 }
 
 export class LineContainerComponent extends react.Component<ILineContainerComponentProps, { isExpanded: boolean }> {

--- a/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
@@ -29,25 +29,18 @@ export class LineContainerComponent extends react.Component<ILineContainerCompon
 
     renderHeader() {
         const className = this.state.isExpanded ? "collapse" : "collapse closed";
-        const header = (
-            <div className="header" onClick={() => this.switchExpandedState()}>
-                <div className="title">{this.props.title}</div>
-                <div className={className}>
-                    <img className="img" title={this.props.title} src={downArrow} />
-                </div>
-            </div>
-        );
 
-        if (this.props.contextMenu) {
-            return (
-                <ContextMenuTrigger id={this.props.contextMenu.props.id}>
-                    {this.props.contextMenu}
-                    {header}
-                </ContextMenuTrigger>
-            );
-        } else {
-            return header;
-        }
+        return (
+            <ContextMenuTrigger id={this.props.contextMenu?.props.id || `NoContextMenu_${this.props.title}`}>
+                {this.props.contextMenu}
+                <div className="header" onClick={() => this.switchExpandedState()}>
+                    <div className="title">{this.props.title}</div>
+                    <div className={className}>
+                        <img className="img" title={this.props.title} src={downArrow} />
+                    </div>
+                </div>
+            </ContextMenuTrigger>
+        );
     }
 
     override render() {

--- a/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
@@ -29,18 +29,25 @@ export class LineContainerComponent extends react.Component<ILineContainerCompon
 
     renderHeader() {
         const className = this.state.isExpanded ? "collapse" : "collapse closed";
-
-        return (
-            <ContextMenuTrigger id={this.props.contextMenu?.props.id || `NoContextMenu_${this.props.title}`}>
-                {this.props.contextMenu}
-                <div className="header" onClick={() => this.switchExpandedState()}>
-                    <div className="title">{this.props.title}</div>
-                    <div className={className}>
-                        <img className="img" title={this.props.title} src={downArrow} />
-                    </div>
+        const header = (
+            <div className="header" onClick={() => this.switchExpandedState()}>
+                <div className="title">{this.props.title}</div>
+                <div className={className}>
+                    <img className="img" title={this.props.title} src={downArrow} />
                 </div>
-            </ContextMenuTrigger>
+            </div>
         );
+
+        if (this.props.contextMenu) {
+            return (
+                <ContextMenuTrigger id={this.props.contextMenu.props.id}>
+                    {this.props.contextMenu}
+                    {header}
+                </ContextMenuTrigger>
+            );
+        } else {
+            return header;
+        }
     }
 
     override render() {

--- a/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
@@ -30,18 +30,25 @@ export class LineContainerComponent extends react.Component<ILineContainerCompon
 
     renderHeader() {
         const className = this.state.isExpanded ? "collapse" : "collapse closed";
-
-        return (
-            <ContextMenuTrigger id={this.props.contextMenu?.props.id || "EmptyContextMenuTrigger_" + this.props.title}>
-                {this.props.contextMenu}
-                <div className="header" onClick={() => this.switchExpandedState()}>
-                    <div className="title">{this.props.title}</div>
-                    <div className={className}>
-                        <img className="img" title={this.props.title} src={downArrow} />
-                    </div>
+        const header = (
+            <div className="header" onClick={() => this.switchExpandedState()}>
+                <div className="title">{this.props.title}</div>
+                <div className={className}>
+                    <img className="img" title={this.props.title} src={downArrow} />
                 </div>
-            </ContextMenuTrigger>
+            </div>
         );
+
+        if (this.props.contextMenu) {
+            return (
+                <ContextMenuTrigger id={this.props.contextMenu.props.id}>
+                    {this.props.contextMenu}
+                    {header}
+                </ContextMenuTrigger>
+            );
+        } else {
+            return header;
+        }
     }
 
     override render() {

--- a/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
@@ -1,11 +1,14 @@
 import { DataStorage } from "core/Misc/dataStorage.js";
+import type { Nullable } from "core/types";
 import * as react from "react";
 import downArrow from "../assets/imgs/downArrow.svg";
+import { ContextMenuTrigger } from "react-contextmenu";
 
 interface ILineContainerComponentProps {
     title: string;
     children: any[] | any;
     closed?: boolean;
+    contextMenu: Nullable<JSX.Element>;
 }
 
 export class LineContainerComponent extends react.Component<ILineContainerComponentProps, { isExpanded: boolean }> {
@@ -29,12 +32,15 @@ export class LineContainerComponent extends react.Component<ILineContainerCompon
         const className = this.state.isExpanded ? "collapse" : "collapse closed";
 
         return (
-            <div className="header" onClick={() => this.switchExpandedState()}>
-                <div className="title">{this.props.title}</div>
-                <div className={className}>
-                    <img className="img" title={this.props.title} src={downArrow} />
+            <ContextMenuTrigger id={this.props.contextMenu?.props.id || "EmptyContextMenuTrigger_" + this.props.title}>
+                {this.props.contextMenu}
+                <div className="header" onClick={() => this.switchExpandedState()}>
+                    <div className="title">{this.props.title}</div>
+                    <div className={className}>
+                        <img className="img" title={this.props.title} src={downArrow} />
+                    </div>
                 </div>
-            </div>
+            </ContextMenuTrigger>
         );
     }
 

--- a/packages/tools/smartFiltersEditorControl/src/smartFilterEditorControl.ts
+++ b/packages/tools/smartFiltersEditorControl/src/smartFilterEditorControl.ts
@@ -141,6 +141,11 @@ export type SmartFilterEditorOptions = {
     deleteCustomBlock?: (blockRegistration: IBlockRegistration) => void;
 
     /**
+     * If supplied, an option to clear all custom blocks will be presented to the user
+     */
+    clearCustomBlocks?: () => void;
+
+    /**
      * An observable that is called when the editor needs to log a message
      */
     onLogRequiredObservable?: Observable<LogEntry>;
@@ -206,6 +211,7 @@ export class SmartFilterEditorControl {
             options.saveToSnippetServer,
             options.addCustomBlock,
             options.deleteCustomBlock,
+            options.clearCustomBlocks,
             options.onLogRequiredObservable,
             options.onSaveEditorDataRequiredObservable
         );


### PR DESCRIPTION
Adds this context menu to make it easier to reset to a clean slate (no custom block definitions):
<img width="327" height="252" alt="image" src="https://github.com/user-attachments/assets/35a5efdf-e714-4189-b28a-e6d49485b40a" />
