### PR TITLE
glTF Exporter: Subset all indices arrays

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -52,7 +52,7 @@ import {
     IsChildCollapsible,
     FloatsNeed16BitInteger,
     IsStandardVertexAttribute,
-    IndicesArrayToTypedArray,
+    IndicesArrayToTypedSubarray,
     GetVertexBufferInfo,
     CollapseChildIntoParent,
     Rotate180Y,
@@ -1383,7 +1383,7 @@ export class GLTFExporter {
         if (indicesToExport) {
             let accessorIndex = state.getIndicesAccessor(indices, start, count, offset, flip);
             if (accessorIndex === undefined) {
-                const bytes = IndicesArrayToTypedArray(indicesToExport, start, count, is32Bits);
+                const bytes = IndicesArrayToTypedSubarray(indicesToExport, start, count, is32Bits);
                 const bufferView = this._bufferManager.createBufferView(bytes);
 
                 const componentType = is32Bits ? AccessorComponentType.UNSIGNED_INT : AccessorComponentType.UNSIGNED_SHORT;

--- a/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -331,7 +331,7 @@ export function IsChildCollapsible(babylonNode: ShadowLight | TargetCamera, pare
  * @param indices input array to be converted
  * @param start starting index
  * @param count number of indices
- * @param is32Bits whether the output should be Uint32Array (true) or Uint16Array (false)
+ * @param is32Bits whether the output should be Uint32Array (true) or Uint16Array (false) when indices is an `Array`
  * @returns a Uint32Array or Uint16Array
  * @internal
  */

--- a/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFUtilities.ts
@@ -339,8 +339,6 @@ export function IndicesArrayToTypedSubarray(indices: IndicesArray, start: number
     let processedIndices = indices;
     if (start !== 0 || count !== indices.length) {
         processedIndices = Array.isArray(indices) ? indices.slice(start, start + count) : indices.subarray(start, start + count);
-    } else {
-        processedIndices = indices;
     }
 
     // If Int32Array, cast the indices (which should all be positive) to Uint32Array


### PR DESCRIPTION
This is a different failure than what #17241 fixes (see: https://playground.babylonjs.com/?snapshot=refs/pull/17241/merge#EW2O08).

When exporting a subset of mesh indices (e.g., for a submesh), the exporter fails if the indices were stored in a typed array (Uint16Array/Uint32Array/Int32Array) rather than a regular JavaScript array. This occurs because the code expected to create one accessor and one buffer view at offset = 0 per indices subset, but the `IndicesArrayToTypedSubarray` function only handled subsetting for number[] arrays.

This PR updates `IndicesArrayToTypedSubarray` to subset all index array types (number[], Uint16Array, and Uint32Array), not just number[] arrays.

In the future, we should just export the full indices buffer once as a single buffer view, then create accessors per subset.