### PR TITLE
Adding dispose for player

### DIFF
--- a/packages/dev/lottiePlayer/src/localPlayer.ts
+++ b/packages/dev/lottiePlayer/src/localPlayer.ts
@@ -104,6 +104,11 @@ export class LocalPlayer {
             this._input.container.removeChild(this._canvas);
         }
 
+        if (this._animationController) {
+            this._animationController.dispose();
+            this._animationController = null;
+        }
+
         this._canvas = null;
 
         this._disposed = true;

--- a/packages/dev/lottiePlayer/src/messageTypes.ts
+++ b/packages/dev/lottiePlayer/src/messageTypes.ts
@@ -78,6 +78,13 @@ export type WorkerLoadedMessage = {
     payload: WorkerLoadedMessagePayload;
 };
 
+export type DisposeMessage = {
+    /** The type of the message */
+    type: "dispose";
+    /** The payload of the message */
+    payload: DisposeMessagePayload;
+};
+
 /** Payload for the "animationUrl" message type. */
 export type AnimationUrlMessagePayload = {
     /** The URL of the animation to be loaded. */
@@ -123,10 +130,13 @@ export type WorkerLoadedMessagePayload = {
     error?: string;
 };
 
+/** Payload for the "dispose" message type */
+export type DisposeMessagePayload = {};
+
 /**
  * Valid message types that can be sent between the main thread and the worker.
  */
-export type MessageType = "animationUrl" | "animationSize" | "startAnimation" | "containerResize" | "preWarm" | "workerLoaded";
+export type MessageType = "animationUrl" | "animationSize" | "startAnimation" | "containerResize" | "preWarm" | "workerLoaded" | "dispose";
 
 /**
  * Valid payload types that can be sent between the main thread and the worker.
@@ -137,4 +147,5 @@ export type MessagePayload =
     | StartAnimationMessagePayload
     | ContainerResizeMessagePayload
     | PreWarmMessagePayload
-    | WorkerLoadedMessagePayload;
+    | WorkerLoadedMessagePayload
+    | DisposeMessagePayload;

--- a/packages/dev/lottiePlayer/src/rendering/animationController.ts
+++ b/packages/dev/lottiePlayer/src/rendering/animationController.ts
@@ -207,7 +207,10 @@ export class AnimationController {
      */
     public dispose(): void {
         this.stopAnimation();
-        this._engine.getRenderingCanvas()?.remove();
+        const canvas = this._engine.getRenderingCanvas();
+        if (canvas && canvas.remove) {
+            canvas.remove();
+        }
         this._engine.dispose();
         this._renderingManager.dispose();
         this._spritePacker.texture.dispose();

--- a/packages/dev/lottiePlayer/src/rendering/animationController.ts
+++ b/packages/dev/lottiePlayer/src/rendering/animationController.ts
@@ -207,10 +207,13 @@ export class AnimationController {
      */
     public dispose(): void {
         this.stopAnimation();
+
+        // Offscreen canvas do not have .remove() as it doesn't inherit from Element
         const canvas = this._engine.getRenderingCanvas();
         if (canvas && canvas.remove) {
             canvas.remove();
         }
+
         this._engine.dispose();
         this._renderingManager.dispose();
         this._spritePacker.texture.dispose();

--- a/packages/dev/lottiePlayer/src/worker.ts
+++ b/packages/dev/lottiePlayer/src/worker.ts
@@ -134,7 +134,7 @@ onmessage = async function (evt) {
         case "dispose": {
             // Clean up resources
             if (Controller) {
-                Controller.dispose(); // If your AnimationController has a dispose method
+                Controller.dispose();
                 Controller = null;
             }
 

--- a/packages/dev/lottiePlayer/src/worker.ts
+++ b/packages/dev/lottiePlayer/src/worker.ts
@@ -131,6 +131,24 @@ onmessage = async function (evt) {
             Controller.setScale(scaleFactor);
             break;
         }
+        case "dispose": {
+            // Clean up resources
+            if (Controller) {
+                Controller.dispose(); // If your AnimationController has a dispose method
+                Controller = null;
+            }
+
+            if (RawAnimation) {
+                RawAnimation = null;
+            }
+
+            // Clean up any other resources
+            GetRawAnimationDataAsync = null;
+            DefaultConfiguration = null;
+            AnimationControllerClass = null;
+            AnimationPromises = null;
+            break;
+        }
         default:
             return;
     }

--- a/packages/dev/lottiePlayer/src/worker.ts
+++ b/packages/dev/lottiePlayer/src/worker.ts
@@ -132,7 +132,6 @@ onmessage = async function (evt) {
             break;
         }
         case "dispose": {
-            // Clean up resources
             if (Controller) {
                 Controller.dispose();
                 Controller = null;
@@ -142,7 +141,6 @@ onmessage = async function (evt) {
                 RawAnimation = null;
             }
 
-            // Clean up any other resources
             GetRawAnimationDataAsync = null;
             DefaultConfiguration = null;
             AnimationControllerClass = null;


### PR DESCRIPTION
Both Player and LocalPlayer were not calling AnimationController.dispose when they were getting disposed, which would not dispose the engine and all internal resources. This addresses this issue.