### PR TITLE
FrameGraph: multi-valued task properties

### DIFF
--- a/packages/dev/core/src/FrameGraph/Tasks/Texture/clearTextureTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Texture/clearTextureTask.ts
@@ -1,7 +1,8 @@
-import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass } from "core/index";
+import type { FrameGraph, FrameGraphTextureHandle, FrameGraphRenderPass, FrameGraphMultiValueType } from "core/index";
 import { Color4, TmpColors } from "../../../Maths/math.color";
 import { FrameGraphTask } from "../../frameGraphTask";
 import { backbufferColorTextureHandle } from "../../frameGraphTypes";
+import { FrameGraphTaskMultiProperty } from "../../frameGraph.decorators";
 
 /**
  * Task used to clear a texture.
@@ -35,7 +36,13 @@ export class FrameGraphClearTextureTask extends FrameGraphTask {
     /**
      * The value to use to clear the stencil buffer (default: 0).
      */
+    @FrameGraphTaskMultiProperty()
     public stencilValue = 0;
+
+    /**
+     * Multi value version of stencilValue.
+     */
+    public stencilValueMulti: FrameGraphMultiValueType<number>;
 
     /**
      * The color texture to clear.

--- a/packages/dev/core/src/FrameGraph/frameGraph.decorators.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraph.decorators.ts
@@ -1,0 +1,131 @@
+import type { FrameGraphTask } from "core/index";
+
+interface IFrameGraphEvaluate {
+    evaluate: () => boolean;
+}
+
+/**
+ * Interface used to evaluate a property in a multi values task property.
+ */
+export interface IFrameGraphEvaluateProperty<T> extends IFrameGraphEvaluate {
+    /**
+     * The value to use if evaluate() returns true.
+     */
+    value: T;
+}
+
+/**
+ * An array of IFrameGraphEvaluateProperty.
+ */
+export type FrameGraphMultiValueType<T> = Array<IFrameGraphEvaluateProperty<T>>;
+
+/** @internal */
+export class FrameGraphTaskProperty<T> {
+    private _multi?: FrameGraphMultiValueType<T>;
+    private _value: T;
+
+    constructor(
+        private _task: FrameGraphTask,
+        defaultValue: T,
+        private _setter?: (oldValue: T) => void
+    ) {
+        _task.multiProperties.push(this);
+        (this._value as any) = defaultValue;
+    }
+
+    public evaluate(): void {
+        if (this._multi === undefined) {
+            return;
+        }
+        for (const entry of this._multi) {
+            if (entry.evaluate()) {
+                const oldValue = this._value;
+                this._value = entry.value;
+                if (oldValue !== this._value && this._setter) {
+                    this._setter.call(this._task, oldValue);
+                }
+                return;
+            }
+        }
+    }
+
+    public get multi(): FrameGraphMultiValueType<T> {
+        if (this._multi === undefined) {
+            this._multi = [];
+        }
+        return this._multi;
+    }
+
+    public set multi(value: FrameGraphMultiValueType<T>) {
+        this._multi = value;
+    }
+
+    public get value(): T {
+        return this._value;
+    }
+
+    public set value(value: T) {
+        this._multi = undefined;
+        this._value = value;
+    }
+}
+
+/**
+ * Decorator to create a multi-value property for a frame graph task.
+ * @param setterName Optional name of the setter to call when the property changes.
+ * @returns Internal use only.
+ */
+export function FrameGraphTaskMultiProperty(setterName?: string) {
+    return (target: any, propertyKey: string) => {
+        const propertyObjectName = propertyKey + "Prop";
+
+        Object.defineProperty(target, propertyKey, {
+            get: function (this: FrameGraphTask) {
+                const prop = (this as any)[propertyObjectName];
+                return prop && prop.evaluateMulti ? prop.value : prop;
+            },
+            set: function (this: FrameGraphTask, value: any) {
+                const prop = (this as any)[propertyObjectName];
+                let oldValue: any;
+                if (prop && prop.evaluateMulti) {
+                    oldValue = prop.value;
+                    this.multiProperties.splice(this.multiProperties.indexOf(prop), 1);
+                } else {
+                    oldValue = prop;
+                }
+                if (oldValue === value) {
+                    return;
+                }
+                (this as any)[propertyObjectName] = value;
+                if (setterName) {
+                    (this as any)[setterName].call(this, oldValue);
+                }
+            },
+            enumerable: true,
+            configurable: true,
+        });
+
+        Object.defineProperty(target, propertyKey + "Multi", {
+            get: function (this: FrameGraphTask) {
+                let prop = (this as any)[propertyObjectName] as FrameGraphTaskProperty<any>;
+                if (!prop || !prop.evaluate) {
+                    prop = new FrameGraphTaskProperty<any>(this, prop, setterName ? (this as any)[setterName] : undefined);
+                    (this as any)[propertyObjectName] = prop;
+                }
+
+                return prop.multi;
+            },
+            set: function (this: FrameGraphTask, value: FrameGraphMultiValueType<any>) {
+                let prop = (this as any)[propertyObjectName] as FrameGraphTaskProperty<any>;
+                if (!prop || !prop.evaluate) {
+                    prop = new FrameGraphTaskProperty<any>(this, prop, setterName ? (this as any)[setterName] : undefined);
+                    (this as any)[propertyObjectName] = prop;
+                }
+
+                prop.multi = value;
+            },
+            enumerable: true,
+            configurable: true,
+        });
+    };
+}

--- a/packages/dev/core/src/FrameGraph/frameGraph.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraph.ts
@@ -204,6 +204,18 @@ export class FrameGraph implements IDisposable {
     }
 
     /**
+     * Evaluates the multi-valued properties of all tasks in the frame graph.
+     */
+    public evaluateMultiValuedProperties(): void {
+        for (const task of this._tasks) {
+            if (task.available && !task.available()) {
+                continue;
+            }
+            task.evaluateMultiValuedProperties();
+        }
+    }
+
+    /**
      * Builds the frame graph.
      * This method should be called after all tasks have been added to the frame graph (FrameGraph.addTask) and before the graph is executed (FrameGraph.execute).
      */
@@ -211,7 +223,13 @@ export class FrameGraph implements IDisposable {
         this.textureManager._releaseTextures(false);
 
         try {
+            this.evaluateMultiValuedProperties();
+
             for (const task of this._tasks) {
+                if (task.available && !task.available()) {
+                    continue;
+                }
+
                 task._reset();
 
                 this._currentProcessedTask = task;
@@ -256,6 +274,9 @@ export class FrameGraph implements IDisposable {
                 () => {
                     let ready = this._renderContext._isReady();
                     for (const task of this._tasks) {
+                        if (task.available && !task.available()) {
+                            continue;
+                        }
                         const taskIsReady = task.isReady();
                         if (!taskIsReady && !firstNotReadyTask) {
                             firstNotReadyTask = task;
@@ -306,6 +327,10 @@ export class FrameGraph implements IDisposable {
         this.textureManager._updateHistoryTextures();
 
         for (const task of this._tasks) {
+            if (task.available && !task.available()) {
+                continue;
+            }
+
             const passes = task._getPasses();
 
             for (const pass of passes) {

--- a/packages/dev/core/src/FrameGraph/index.ts
+++ b/packages/dev/core/src/FrameGraph/index.ts
@@ -44,6 +44,7 @@ export * from "./Tasks/Rendering/shadowGeneratorTask";
 export * from "./Tasks/Rendering/taaObjectRendererTask";
 export * from "./Tasks/Rendering/utilityLayerRendererTask";
 
+export * from "./frameGraph.decorators";
 export * from "./frameGraph";
 export * from "./frameGraphContext";
 export * from "./frameGraphObjectList";


### PR DESCRIPTION
This is a PoC, intended to gather feedback on this feature (is it useful? How can it best be implemented? etc.).

Feature
---------------------------------
Currently, properties in tasks are simple properties, such as `public numCascades: number;` in the `FrameGraphCascadedShadowGeneratorTask` class.

The idea is to be able to set a value for a property based on a condition. Of course, we could do this in user code:
```typescript
if (shadowQuality === "low") shadowGenTask.numCascades = 2;
if (shadowQuality === "middle") shadowGenTask.numCascades = 3;
if (shadowQuality === "high") shadowGenTask.numCascades = 4;
```
This is a bit tedious, and the code can quickly become cluttered with numerous conditions if the frame graph has a high degree of variability (some parts of the graph can depend on the engine type, others on **globalQuality**, **shadowQuality**, ... parameters, etc.).

In this PoC, I suggest adding an additional variable `numCascadesMulti`, which allows you to define the property as follows:
```typescript
shadowGenTask.numCascadesMulti = [
    { value: 2, evaluate: () => shadowQuality === "low" },
    { value: 3, evaluate: () => shadowQuality === "middle" },
    { value: 4, evaluate: () => shadowQuality === "high" },
];
```
When the graph is built, all **multi** properties of all tasks are parsed and evaluated: the first entry that returns **true** will set its value as the property value.

In this way, the variations are closely linked to the property and are clearly part of the graph itself, rather than additional code.

In addition, a new property `public available?: () => boolean;` has been added to the task class: if the property is defined and the function returns **false**, everything behaves as if the task were not in the task list: it will neither be built nor executed.

Example of use
--------------------------------
Let's imagine that we want to display volumetric lighting only if the **globalQuality** parameter is set to “high”:

Without the PR:
```typescript
const renderTask = new BABYLON.FrameGraphObjectRendererTask("renderScene", ...);
const imageProcessing = new BABYLON.FrameGraphImageProcessingTask("imgProcessing", ...);

if (globalQuality === "high") {
    const volumLightingTask = new FrameGraphVolumetricLighting("volumLighting", ...);

    volumLightingTask.sourceTexture = renderTask.outputTexture;
    imageProcessing.sourceTexture = volumLightingTask.outputTexture;
} else {
    imageProcessing.sourceTexture = renderTask.outputTexture;
}
```

With the PR:
```typescript
const renderTask = new BABYLON.FrameGraphObjectRendererTask("renderScene", ...);
const volumLightingTask = new FrameGraphVolumetricLighting("volumLighting", ...);

volumLightingTask.available = () => globalQuality === "high";
volumLightingTask.sourceTexture = renderTask.outputTexture;

const imageProcessing = new BABYLON.FrameGraphImageProcessingTask("imgProcessing", ...);

imageProcessing.sourceTextureMulti = [
    { value: volumLightingTask.outputTexture, evaluate: () => globalQuality === "high" },
    { value: renderTask.outputTexture, evaluate: () => globalQuality !== "high" }
];
```

When you change the value of **globalQuality**, in the first case, you must reset the frame graph and re-execute the function that creates it. In the second case, you just need to execute `frameGraph.build()`. Furthermore, I think the code is more readable in the second case, and even more so if additional conditions are added to the code.

Implementation
--------------------------------
You must use a decorator to indicate that a property must have a corresponding “multi” property:
```typescript
@FrameGraphTaskMultiProperty("_numCascadesSetter")
public numCascades = CascadedShadowGenerator.DEFAULT_CASCADES_COUNT;
```

The decorator creates the `numCascadesMulti` property. However, in order for the property to be available in IntelliSense, I had to declare it in the class:
```typescript
public numCascadesMulti: FrameGraphMultiValueType<number>;
```
I don't know if there's a way to make it available via IntelliSense without having to add this declaration...

The generator can take an additional parameter, which is the name of the “setter” function, a function that will be called when the property changes (in case you need to execute additional code when this happens):
```typescript
protected _numCascadesSetter(_oldValue: number) {
    this._setupShadowGenerator();
}
```

Note that there are no breaking changes, `numCascades` still exists, and if you assign a value to it, this value takes precedence over what you might have assigned to `numCascadesMulti`: the setter for `numCascades` deletes the `FrameGraphTaskProperty` instance created when `numCascadesMulti` was first accessed.
