### PR TITLE
Inspector v2: New pane tab list

### DIFF
--- a/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
@@ -155,7 +155,7 @@ export const GizmoToolbar: FunctionComponent<{ scene: Scene; entity: unknown; gi
                                         onClick: toggleCoordinatesMode,
                                     }}
                                     size="small"
-                                    appearance="secondary"
+                                    appearance="transparent"
                                     shape="rounded"
                                     icon={coordinatesMode === GizmoCoordinatesMode.Local ? <CubeRegular /> : <GlobeRegular />}
                                 ></SplitButton>

--- a/packages/dev/inspector-v2/src/components/theme.tsx
+++ b/packages/dev/inspector-v2/src/components/theme.tsx
@@ -1,0 +1,17 @@
+import type { FluentProviderProps } from "@fluentui/react-components";
+import type { FunctionComponent } from "react";
+
+import { FluentProvider } from "@fluentui/react-components";
+import { useThemeMode } from "../hooks/themeHooks";
+import { DarkTheme, LightTheme } from "../themes/babylonTheme";
+
+export const Theme: FunctionComponent<FluentProviderProps & { invert?: boolean }> = (props) => {
+    const { invert = false, ...rest } = props;
+    const { isDarkMode } = useThemeMode();
+
+    return (
+        <FluentProvider theme={isDarkMode !== invert ? DarkTheme : LightTheme} {...rest}>
+            {props.children}
+        </FluentProvider>
+    );
+};

--- a/packages/dev/inspector-v2/src/hooks/themeHooks.ts
+++ b/packages/dev/inspector-v2/src/hooks/themeHooks.ts
@@ -5,21 +5,25 @@ import { useTernaryDarkMode } from "usehooks-ts";
 const ThemeModeStorageKey = `Babylon/Settings/ThemeMode`;
 
 /**
- * Custom hook to manage the theme mode (light/dark/auto).
- * @param modeOverride If specified, any previously stored theme mode will be replaced with this mode.
+ * Custom hook to manage the theme mode (system/dark/light).
  * @returns An object containing the theme mode state and helper functions.
  */
-export function useThemeMode(modeOverride?: TernaryDarkMode) {
+export function useThemeMode() {
     const { isDarkMode, ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode({
-        defaultValue: modeOverride,
-        initializeWithValue: !modeOverride,
         localStorageKey: ThemeModeStorageKey,
     });
-    // If a modeOverride is provided, replace any previously stored mode.
-    // Also make sure there is a stored value initially, even before changing the theme.
+    // Make sure there is a stored value initially, even before changing the theme.
     // This way, other usages of this hook will get the correct initial value.
-    if (modeOverride || !localStorage.getItem(ThemeModeStorageKey)) {
-        localStorage.setItem(ThemeModeStorageKey, JSON.stringify(ternaryDarkMode));
+    if (!localStorage.getItem(ThemeModeStorageKey)) {
+        SetThemeMode(ternaryDarkMode);
     }
     return { isDarkMode, themeMode: ternaryDarkMode, setThemeMode: setTernaryDarkMode };
+}
+
+/**
+ * Sets the theme mode.
+ * @param mode The desired theme mode (system/dark/light).
+ */
+export function SetThemeMode(mode: TernaryDarkMode) {
+    localStorage.setItem(ThemeModeStorageKey, JSON.stringify(mode));
 }

--- a/packages/dev/inspector-v2/src/modularTool.tsx
+++ b/packages/dev/inspector-v2/src/modularTool.tsx
@@ -16,7 +16,6 @@ import {
     DialogContent,
     DialogSurface,
     DialogTitle,
-    FluentProvider,
     List,
     ListItem,
     makeStyles,
@@ -29,14 +28,14 @@ import { createRoot } from "react-dom/client";
 
 import { Deferred } from "core/Misc/deferred";
 import { Logger } from "core/Misc/logger";
+import { Theme } from "./components/theme";
 import { ExtensionManagerContext } from "./contexts/extensionManagerContext";
 import { ExtensionManager } from "./extensibility/extensionManager";
-import { useThemeMode } from "./hooks/themeHooks";
+import { SetThemeMode } from "./hooks/themeHooks";
 import { ServiceContainer } from "./modularity/serviceContainer";
 import { ExtensionListServiceDefinition } from "./services/extensionsListService";
 import { MakeShellServiceDefinition, RootComponentServiceIdentity } from "./services/shellService";
 import { ThemeSelectorServiceDefinition } from "./services/themeSelectorService";
-import { DarkTheme, LightTheme } from "./themes/babylonTheme";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
@@ -99,11 +98,13 @@ export type ModularToolOptions = {
  */
 export function MakeModularTool(options: ModularToolOptions): IDisposable {
     const { containerElement, serviceDefinitions, themeMode, showThemeSelector = true, extensionFeeds = [] } = options;
+    if (themeMode) {
+        SetThemeMode(themeMode);
+    }
 
     const modularToolRootComponent: FunctionComponent = () => {
         const classes = useStyles();
         const [extensionManagerContext, setExtensionManagerContext] = useState<ExtensionManagerContext>();
-        const { isDarkMode } = useThemeMode(themeMode);
         const [requiredExtensions, setRequiredExtensions] = useState<string[]>();
         const [requiredExtensionsDeferred, setRequiredExtensionsDeferred] = useState<Deferred<boolean>>();
         const [extensionInstallError, setExtensionInstallError] = useState<InstallFailedInfo>();
@@ -221,7 +222,7 @@ export function MakeModularTool(options: ModularToolOptions): IDisposable {
 
         return (
             <ExtensionManagerContext.Provider value={extensionManagerContext}>
-                <FluentProvider className={classes.app} theme={isDarkMode ? DarkTheme : LightTheme}>
+                <Theme className={classes.app}>
                     <>
                         <Dialog open={!!requiredExtensions} modalType="alert">
                             <DialogSurface>
@@ -273,7 +274,7 @@ export function MakeModularTool(options: ModularToolOptions): IDisposable {
                             <Content />
                         </Suspense>
                     </>
-                </FluentProvider>
+                </Theme>
             </ExtensionManagerContext.Provider>
         );
     };

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -4,7 +4,7 @@ import type { ComponentType, FunctionComponent } from "react";
 import type { IService, ServiceDefinition } from "../modularity/serviceDefinition";
 
 import { useResizeHandle } from "@fluentui-contrib/react-resize-handle";
-import { Button, Divider, Toolbar as FluentToolbar, makeStyles, Subtitle1, Tab, tokens, ToolbarRadioButton, Tooltip } from "@fluentui/react-components";
+import { Button, Divider, Toolbar as FluentToolbar, makeStyles, Subtitle2Stronger, tokens, ToolbarRadioButton, Tooltip } from "@fluentui/react-components";
 import { PanelLeftContractRegular, PanelLeftExpandRegular, PanelRightContractRegular, PanelRightExpandRegular } from "@fluentui/react-icons";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 
@@ -292,15 +292,19 @@ const useStyles = makeStyles({
         flexDirection: "column",
         justifyContent: "center",
         backgroundColor: tokens.colorNeutralBackgroundInverted,
-        height: "44px",
+        height: "36px",
     },
     paneHeaderText: {
         marginLeft: tokens.spacingHorizontalM,
         color: tokens.colorNeutralForegroundInverted,
     },
-    headerDivider: {
+    paneDivider: {
         flex: "0 0 auto",
         marginTop: tokens.spacingVerticalM,
+        margin: "0",
+        minHeight: tokens.spacingVerticalM,
+        cursor: "ns-resize",
+        alignItems: "end",
     },
     tabToolbar: {
         padding: 0,
@@ -349,7 +353,7 @@ const PaneHeader: FunctionComponent<{ title?: string }> = ({ title }) => {
 
     return (
         <div className={classes.paneHeaderDiv}>
-            <Subtitle1 className={classes.paneHeaderText}>{title}</Subtitle1>
+            <Subtitle2Stronger className={classes.paneHeaderText}>{title}</Subtitle2Stronger>
         </div>
     );
 };
@@ -673,13 +677,7 @@ function usePane(
                                 </div>
 
                                 {/* If we have both top and bottom panes, show a divider. This divider is also the resizer for the bottom pane. */}
-                                {topPanes.length > 0 && bottomPanes.length > 0 && (
-                                    <Divider
-                                        ref={paneVerticalResizeHandleRef}
-                                        className={classes.headerDivider}
-                                        style={{ margin: "0", minHeight: tokens.spacingVerticalM, cursor: "ns-resize" }}
-                                    />
-                                )}
+                                {topPanes.length > 0 && bottomPanes.length > 0 && <Divider ref={paneVerticalResizeHandleRef} className={classes.paneDivider} />}
 
                                 {/* Render the bottom pane tablist. */}
                                 {bottomPanes.length > 1 && (

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -4,7 +4,7 @@ import type { ComponentType, FunctionComponent } from "react";
 import type { IService, ServiceDefinition } from "../modularity/serviceDefinition";
 
 import { useResizeHandle } from "@fluentui-contrib/react-resize-handle";
-import { Button, Divider, Toolbar as FluentToolbar, makeStyles, Subtitle2Stronger, tokens, ToolbarRadioButton, Tooltip } from "@fluentui/react-components";
+import { Button, Divider, Toolbar as FluentToolbar, makeStyles, mergeClasses, Subtitle2Stronger, tokens, ToolbarRadioButton, Tooltip } from "@fluentui/react-components";
 import { PanelLeftContractRegular, PanelLeftExpandRegular, PanelRightContractRegular, PanelRightExpandRegular } from "@fluentui/react-icons";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 
@@ -219,6 +219,7 @@ const useStyles = makeStyles({
         display: "flex",
         flexDirection: "row",
         flex: "0 0 auto",
+        height: "36px",
         backgroundColor: tokens.colorNeutralBackground2,
     },
     bar: {
@@ -316,6 +317,9 @@ const useStyles = makeStyles({
         justifyContent: "center",
         borderTopLeftRadius: tokens.borderRadiusMedium,
         borderTopRightRadius: tokens.borderRadiusMedium,
+    },
+    unselectedTab: {
+        backgroundColor: "transparent",
     },
     tabRadioButton: {
         backgroundColor: "transparent",
@@ -447,6 +451,8 @@ const SidePaneTab: FunctionComponent<{ alignment: "left" | "right"; id: string; 
     const useTeachingMoment = useMemo(() => MakePopoverTeachingMoment(`Pane/${alignment}/${title ?? id}`), [title, id]);
     const teachingMoment = useTeachingMoment(suppressTeachingMoment);
 
+    const tabClass = mergeClasses(classes.tab, isSelected ? undefined : classes.unselectedTab);
+
     return (
         <>
             <TeachingMoment
@@ -455,7 +461,7 @@ const SidePaneTab: FunctionComponent<{ alignment: "left" | "right"; id: string; 
                 title={title ?? "Extension"}
                 description={`The "${title ?? id}" extension can be accessed here.`}
             />
-            <Theme className={classes.tab} invert={isSelected}>
+            <Theme className={tabClass} invert={isSelected}>
                 <ToolbarRadioButton
                     ref={teachingMoment.targetRef}
                     appearance="transparent"
@@ -594,7 +600,7 @@ function usePane(
                                                     title={entry.title}
                                                     icon={entry.icon}
                                                     suppressTeachingMoment={entry.suppressTeachingMoment}
-                                                    isSelected={isSelected}
+                                                    isSelected={isSelected && !collapsed}
                                                 />
                                             );
                                         })}
@@ -605,7 +611,11 @@ function usePane(
                             {/* When the toolbar mode is "full", we add an extra button that allows the side panes to be collapsed. */}
                             {toolbarMode === "full" && (
                                 <>
-                                    <Divider vertical inset />
+                                    {paneComponents.length > 1 && (
+                                        <>
+                                            <Divider vertical inset style={{ minHeight: 0 }} />{" "}
+                                        </>
+                                    )}
                                     <Tooltip content={collapsed ? "Show Side Pane" : "Hide Side Pane"} relationship="label">
                                         <Button className={classes.paneCollapseButton} appearance="subtle" icon={expandCollapseIcon} onClick={onExpandCollapseClick} />
                                     </Tooltip>

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -324,7 +324,7 @@ const useStyles = makeStyles({
     tabRadioButton: {
         backgroundColor: "transparent",
     },
-    tabIcon: {
+    selectedTabIcon: {
         color: tokens.colorNeutralForeground1,
     },
     resizer: {
@@ -469,7 +469,7 @@ const SidePaneTab: FunctionComponent<{ alignment: "left" | "right"; id: string; 
                     name="selectedTab"
                     value={id}
                     icon={{
-                        className: classes.tabIcon,
+                        className: isSelected ? classes.selectedTabIcon : undefined,
                         children: <Icon />,
                     }}
                 />

--- a/packages/dev/inspector-v2/src/services/themeSelectorService.tsx
+++ b/packages/dev/inspector-v2/src/services/themeSelectorService.tsx
@@ -52,7 +52,7 @@ export const ThemeSelectorServiceDefinition: ServiceDefinition<[], [IShellServic
                                         menuButton={triggerProps}
                                         primaryActionButton={{ onClick: toggleTheme }}
                                         size="small"
-                                        appearance="secondary"
+                                        appearance="transparent"
                                         shape="circular"
                                         icon={isDarkMode ? <WeatherSunnyRegular /> : <WeatherMoonRegular />}
                                     ></SplitButton>


### PR DESCRIPTION
This PR reworks the side pane tabs.

- Factored out a <Theme> component that wraps the Fluent ThemeProvider, reads from local storage for the theme mode, and allows the theme to be inverted.
- Used this <Theme> component for the main theme as well as inverted themes for the pane header and the selected pane tab.
- Reduced the height of the toolbar (and therefore pane tabs).
- Changed the toolbar split buttons to not have the outline since it looks awkward with the reduced height toolbar.
- Swapped out the pane tab implementation from TabList to Toolbar + ToolbarRadioButton to give a look and feel that is a little closer to Inspector v1.
- Reduced the height and font size for the pane header (to match the toolbar).
- Fixed a bug where a useMemo dependency list was missing the pane tab lists, which are now more dynamic with the theme inversion.

<img width="867" height="211" alt="image" src="https://github.com/user-attachments/assets/0f389cc5-a400-4d8e-80d6-02dfda0c1869" />
