### PR TITLE
Add support for hand tracking microgestures

### DIFF
--- a/packages/dev/core/src/XR/motionController/index.ts
+++ b/packages/dev/core/src/XR/motionController/index.ts
@@ -5,5 +5,6 @@ export * from "./webXRGenericMotionController";
 export * from "./webXRMicrosoftMixedRealityController";
 export * from "./webXRMotionControllerManager";
 export * from "./webXROculusTouchMotionController";
+export * from "./webXROculusHandController";
 export * from "./webXRHTCViveMotionController";
 export * from "./webXRProfiledMotionController";

--- a/packages/dev/core/src/XR/motionController/webXRMotionControllerManager.ts
+++ b/packages/dev/core/src/XR/motionController/webXRMotionControllerManager.ts
@@ -82,6 +82,7 @@ export class WebXRMotionControllerManager {
         this.RegisterFallbacksForProfileId("samsung-odyssey", ["generic-touchpad"]);
         this.RegisterFallbacksForProfileId("valve-index", ["generic-trigger-squeeze-touchpad-thumbstick"]);
         this.RegisterFallbacksForProfileId("generic-hand-select", ["generic-trigger"]);
+        this.RegisterFallbacksForProfileId("oculus-hand", ["generic-trigger"]);
     }
 
     /**

--- a/packages/dev/core/src/XR/motionController/webXROculusHandController.ts
+++ b/packages/dev/core/src/XR/motionController/webXROculusHandController.ts
@@ -1,0 +1,258 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { IMotionControllerLayoutMap, IMinimalMotionControllerObject, MotionControllerHandedness } from "./webXRAbstractMotionController";
+import { WebXRAbstractMotionController } from "./webXRAbstractMotionController";
+import type { Scene } from "../../scene";
+import type { AbstractMesh } from "../../Meshes/abstractMesh";
+import { WebXRMotionControllerManager } from "./webXRMotionControllerManager";
+
+/**
+ * Oculus hand controller class that supports microgestures
+ */
+export class WebXROculusHandController extends WebXRAbstractMotionController {
+    public profileId = "oculus-hand";
+
+    /**
+     * Create a new hand controller object, without loading a controller model
+     * @param scene the scene to use to create this controller
+     * @param gamepadObject the corresponding gamepad object
+     * @param handedness the handedness of the controller
+     */
+    constructor(scene: Scene, gamepadObject: IMinimalMotionControllerObject, handedness: MotionControllerHandedness) {
+        // Don't load the controller model - for now, hands have no real model.
+        super(scene, OculusHandProfile[handedness], gamepadObject, handedness, true);
+    }
+
+    protected _getFilenameAndPath(): { filename: string; path: string } {
+        return {
+            filename: "generic.babylon",
+            path: "https://controllers.babylonjs.com/generic/",
+        };
+    }
+
+    protected _getModelLoadingConstraints(): boolean {
+        return true;
+    }
+
+    protected _processLoadedModel(_meshes: AbstractMesh[]): void {
+        // no-op
+    }
+
+    protected _setRootMesh(meshes: AbstractMesh[]): void {
+        // no-op
+    }
+
+    protected _updateModel(): void {
+        // no-op
+    }
+}
+
+// register the profiles
+WebXRMotionControllerManager.RegisterController("oculus-hand", (xrInput: XRInputSource, scene: Scene) => {
+    return new WebXROculusHandController(scene, <any>xrInput.gamepad, xrInput.handedness);
+});
+
+// https://github.com/immersive-web/webxr-input-profiles/blob/main/packages/registry/profiles/oculus/oculus-hand.json
+const OculusHandProfile: IMotionControllerLayoutMap = {
+    left: {
+        selectComponentId: "xr-standard-trigger",
+        components: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "xr-standard-trigger": {
+                type: "trigger",
+                gamepadIndices: {
+                    button: 0,
+                },
+                rootNodeName: "xr-standard-trigger",
+                visualResponses: {},
+            },
+            menu: {
+                type: "button",
+                gamepadIndices: {
+                    button: 4,
+                },
+                rootNodeName: "menu",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-left": {
+                type: "button",
+                gamepadIndices: {
+                    button: 5,
+                },
+                rootNodeName: "swipe-left",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-right": {
+                type: "button",
+                gamepadIndices: {
+                    button: 6,
+                },
+                rootNodeName: "swipe-right",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-forward": {
+                type: "button",
+                gamepadIndices: {
+                    button: 7,
+                },
+                rootNodeName: "swipe-forward",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-backward": {
+                type: "button",
+                gamepadIndices: {
+                    button: 8,
+                },
+                rootNodeName: "swipe-backward",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "tap-thumb": {
+                type: "button",
+                gamepadIndices: {
+                    button: 9,
+                },
+                rootNodeName: "tap-thumb",
+                visualResponses: {},
+            },
+        },
+        gamepadMapping: "xr-standard",
+        rootNodeName: "oculus-hand-left",
+        assetPath: "left.glb",
+    },
+    right: {
+        selectComponentId: "xr-standard-trigger",
+        components: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "xr-standard-trigger": {
+                type: "trigger",
+                gamepadIndices: {
+                    button: 0,
+                },
+                rootNodeName: "xr-standard-trigger",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-left": {
+                type: "button",
+                gamepadIndices: {
+                    button: 5,
+                },
+                rootNodeName: "swipe-left",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-right": {
+                type: "button",
+                gamepadIndices: {
+                    button: 6,
+                },
+                rootNodeName: "swipe-right",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-forward": {
+                type: "button",
+                gamepadIndices: {
+                    button: 7,
+                },
+                rootNodeName: "swipe-forward",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-backward": {
+                type: "button",
+                gamepadIndices: {
+                    button: 8,
+                },
+                rootNodeName: "swipe-backward",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "tap-thumb": {
+                type: "button",
+                gamepadIndices: {
+                    button: 9,
+                },
+                rootNodeName: "tap-thumb",
+                visualResponses: {},
+            },
+        },
+        gamepadMapping: "xr-standard",
+        rootNodeName: "oculus-hand-right",
+        assetPath: "right.glb",
+    },
+    none: {
+        selectComponentId: "xr-standard-trigger",
+        components: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "xr-standard-trigger": {
+                type: "trigger",
+                gamepadIndices: {
+                    button: 0,
+                },
+                rootNodeName: "xr-standard-trigger",
+                visualResponses: {},
+            },
+            menu: {
+                type: "button",
+                gamepadIndices: {
+                    button: 4,
+                },
+                rootNodeName: "menu",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-left": {
+                type: "button",
+                gamepadIndices: {
+                    button: 5,
+                },
+                rootNodeName: "swipe-left",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-right": {
+                type: "button",
+                gamepadIndices: {
+                    button: 6,
+                },
+                rootNodeName: "swipe-right",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-forward": {
+                type: "button",
+                gamepadIndices: {
+                    button: 7,
+                },
+                rootNodeName: "swipe-forward",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "swipe-backward": {
+                type: "button",
+                gamepadIndices: {
+                    button: 8,
+                },
+                rootNodeName: "swipe-backward",
+                visualResponses: {},
+            },
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            "tap-thumb": {
+                type: "button",
+                gamepadIndices: {
+                    button: 9,
+                },
+                rootNodeName: "tap-thumb",
+                visualResponses: {},
+            },
+        },
+        gamepadMapping: "xr-standard",
+        rootNodeName: "oculus-hand-none",
+        assetPath: "none.glb",
+    },
+};


### PR DESCRIPTION
This pull request adds the support for hand tracking microgestures, a Meta OpenXR extension - compatible with Quest 2/Pro/3/3S - that adds five boolean inputs per hand (thumb tap + D-pad–like swipes).

`WebXROculusHandController` has been created starting from `WebXRGenericHandController` as base and mapping the input profile with the`oculus-hand` profile: https://github.com/immersive-web/webxr-input-profiles/pull/274/files.

___

### Behaviour
As today, all the input controller profiles are retrieved from the WebXR controller [repository](https://immersive-web.github.io/webxr-input-profiles/packages/viewer/dist), unfortunately, the `oculus-hand` controller is missing. I made the PR https://github.com/immersive-web/webxr-input-profiles/pull/278 to add it, but i don't know if/when it will be approved.

**As-is**
1. Starting a WebXR session with a compatible Quest device, `xrController.inputSource.profiles` is correctly populated with `oculus-hand` profile:

   ```ts
   ['oculus-hand', 'generic-hand', 'generic-hand-select', 'generic-trigger']
   ```

3. All input controller profiles are retrieved from:
   https://immersive-web.github.io/webxr-input-profiles/packages/viewer/dist/profiles/profilesList.json

   (but `oclus-hand` is missing).

4. Get `generic-hand` because it is the first available profile:
    https://immersive-web.github.io/webxr-input-profiles/packages/viewer/dist/profiles/generic-hand/profile.json

5. Map `generic-hand`.

**To-be (after pull request is merged)**
1. The user create an XR experience disabling the online controller repository (see "Considerations" below):

```ts
scene.createDefaultXRExperienceAsync({
        inputOptions: {
            disableOnlineControllerRepository: true
        }
 })
```

2. Starting a WebXR session with a compatible Quest device, `xrController.inputSource.profiles` is correctly populated with `oculus-hand` profile:

```ts
['oculus-hand', 'generic-hand', 'generic-hand-select', 'generic-trigger']
```

3. The `oculus-hand` profile is retrieved from Babylon.js itself (local).
___
### Note
Forcing the input profile:

```ts
scene.createDefaultXRExperienceAsync({
        inputOptions: {
            forceInputProfile: 'oculus-hand'
        }
 })
```
is not a valid option because in any case the `generic-hand` profile will be retrieved.
___

### Test
Tested with Oculus Quest 3. 
Playground (valid after PR build): https://playground.babylonjs.com/#F41V6N#2275.
___

### Considerations

When the `oculus-hand` profile will be added to online repository, it shouldn't introduce regressions because the `oculus-hand` it will be retrieved  and consumed automatically. The `oculus-hand` profile is 1:1 mapping with `generic-hand` profile with the adding of specific swipe components (`menu` - only left hand, `swipe-left`, `swipe-right`, `swipe-forward`, `swipe-backward`, `tap-thumb`).

___

### Discussion
Forum link: https://forum.babylonjs.com/t/hand-tracking-microgestures/60860.
