### PR TITLE
Inspector v2: When used in Playground, drive the inspector theme from the Playground theme

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -70,6 +70,8 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                 } else {
                     inspectorV2Module.ShowInspector(this._scene, {
                         embedMode: true,
+                        showThemeSelector: false,
+                        themeMode: Utilities.ReadStringFromStore("theme", "Light") === "Dark" ? "dark" : "light",
                     });
                 }
             } else {


### PR DESCRIPTION
When Playground shows inspector v2, with this change it:
1. Hides the independent theme selector button
2. Forces the theme to the Playgrounds theme

This way, the light/dark theme is consistent across Playground (the code editor and inspector).