### PR TITLE
Inspector v2: Feedback button and persistent fps counter

### DIFF
--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -14,6 +14,7 @@ import { DefaultInspectorExtensionFeed } from "./extensibility/defaultInspectorE
 import { MakeModularTool } from "./modularTool";
 import { GizmoServiceDefinition } from "./services/gizmoService";
 import { GizmoToolbarServiceDefinition } from "./services/gizmoToolbarService";
+import { MiniStatsServiceDefinition } from "./services/miniStatsService";
 import { DebugServiceDefinition } from "./services/panes/debugService";
 import { AnimationGroupPropertiesServiceDefinition } from "./services/panes/properties/animationGroupPropertiesService";
 import { AnimationPropertiesServiceDefinition } from "./services/panes/properties/animationPropertiesService";
@@ -57,6 +58,7 @@ import { PickingServiceDefinition } from "./services/pickingService";
 import { SceneContextIdentity } from "./services/sceneContext";
 import { SelectionServiceDefinition } from "./services/selectionService";
 import { ShellServiceIdentity } from "./services/shellService";
+import { UserFeedbackServiceDefinition } from "./services/userFeedbackService";
 
 let CurrentInspectorToken: Nullable<IDisposable> = null;
 
@@ -253,6 +255,12 @@ function _ShowInspector(scene: Nullable<Scene>, options: Partial<IInspectorOptio
 
             // Allows picking objects from the scene to select them.
             PickingServiceDefinition,
+
+            // Adds entry points for user feedback on Inspector v2 (probably eventually will be removed).
+            UserFeedbackServiceDefinition,
+
+            // Adds always present "mini stats" (like fps) to the toolbar, etc.
+            MiniStatsServiceDefinition,
 
             // Additional services passed in to the Inspector.
             ...(options.serviceDefinitions ?? []),

--- a/packages/dev/inspector-v2/src/services/miniStatsService.tsx
+++ b/packages/dev/inspector-v2/src/services/miniStatsService.tsx
@@ -1,0 +1,38 @@
+import type { ServiceDefinition } from "../modularity/serviceDefinition";
+import type { ISceneContext } from "./sceneContext";
+import type { IShellService } from "./shellService";
+
+import { Badge, makeStyles, tokens } from "@fluentui/react-components";
+
+import { useObservableState } from "../hooks/observableHooks";
+import { SceneContextIdentity } from "./sceneContext";
+import { ShellServiceIdentity } from "./shellService";
+
+const useStyles = makeStyles({
+    badge: {
+        margin: tokens.spacingHorizontalXXS,
+        fontFamily: "monospace",
+    },
+});
+
+export const MiniStatsServiceDefinition: ServiceDefinition<[], [ISceneContext, IShellService]> = {
+    friendlyName: "Mini Stats",
+    consumes: [SceneContextIdentity, ShellServiceIdentity],
+    factory: (sceneContext, shellService) => {
+        shellService.addToolbarItem({
+            key: "Mini Stats",
+            verticalLocation: "bottom",
+            horizontalLocation: "right",
+            suppressTeachingMoment: true,
+            component: () => {
+                const classes = useStyles();
+
+                const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
+                const engine = scene?.getEngine();
+                const fps = useObservableState(() => (engine ? Math.round(engine.getFps()) : null), engine?.onBeginFrameObservable);
+
+                return fps != null ? <Badge appearance="outline" className={classes.badge}>{`${fps} fps`}</Badge> : null;
+            },
+        });
+    },
+};

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -238,12 +238,14 @@ const useStyles = makeStyles({
     barLeft: {
         marginRight: "auto",
         display: "flex",
+        alignItems: "center",
         flexDirection: "row",
         columnGap: tokens.spacingHorizontalSNudge,
     },
     barRight: {
         marginLeft: "auto",
         display: "flex",
+        alignItems: "center",
         flexDirection: "row-reverse",
         columnGap: tokens.spacingHorizontalSNudge,
     },

--- a/packages/dev/inspector-v2/src/services/userFeedbackService.tsx
+++ b/packages/dev/inspector-v2/src/services/userFeedbackService.tsx
@@ -1,0 +1,30 @@
+import type { ServiceDefinition } from "../modularity/serviceDefinition";
+import type { IShellService } from "./shellService";
+
+import { ShellServiceIdentity } from "./shellService";
+import { Button } from "shared-ui-components/fluent/primitives/button";
+
+import { PersonFeedbackRegular } from "@fluentui/react-icons";
+
+export const UserFeedbackServiceDefinition: ServiceDefinition<[], [IShellService]> = {
+    friendlyName: "User Feedback",
+    consumes: [ShellServiceIdentity],
+    factory: (shellService) => {
+        shellService.addToolbarItem({
+            key: "User Feedback",
+            verticalLocation: "bottom",
+            horizontalLocation: "right",
+            suppressTeachingMoment: true,
+            component: () => {
+                return (
+                    <Button
+                        appearance="subtle"
+                        icon={PersonFeedbackRegular}
+                        title="Give Feedback on Inspector v2"
+                        onClick={() => window.open("https://forum.babylonjs.com/", "_blank")} // TODO: Replace this with a direct link to the announcement post.
+                    />
+                );
+            },
+        });
+    },
+};


### PR DESCRIPTION
This PR adds two small Inspector v2 features:

1. A feedback button. As of this PR it just links to the forum site. Once the announcement is posted, I will update it to link to that post specifically.
2. A persistent frame rate counter.

Both of these are in the bottom right toolbar.

<img width="423" height="156" alt="image" src="https://github.com/user-attachments/assets/dc700eeb-cd12-4382-a5dd-702cb7ac5d21" />
