### PR TITLE
Moving BindLogDepth to pure file

### DIFF
--- a/packages/dev/core/src/Materials/materialHelper.functions.pure.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.pure.ts
@@ -1,0 +1,28 @@
+/** This file must only contain pure code and pure imports */
+
+import type { Camera } from "../Cameras/camera";
+import type { Scene } from "../scene";
+import type { Effect } from "./effect";
+
+// All non-type imports must be pure
+
+import { Constants } from "../Engines/constants";
+import { Logger } from "../Misc/logger";
+
+// All code must be pure
+
+/**
+ * Binds the logarithmic depth information from the scene to the effect for the given defines.
+ * @param defines The generated defines used in the effect
+ * @param effect The effect we are binding the data to
+ * @param scene The scene we are willing to render with logarithmic scale for
+ */
+export function BindLogDepth(defines: any, effect: Effect, scene: Scene): void {
+    if (!defines || defines["LOGARITHMICDEPTH"] || (defines.indexOf && defines.indexOf("LOGARITHMICDEPTH") >= 0)) {
+        const camera = scene.activeCamera as Camera;
+        if (camera.mode === Constants.ORTHOGRAPHIC_CAMERA) {
+            Logger.Error("Logarithmic depth is not compatible with orthographic cameras!", 20);
+        }
+        effect.setFloat("logarithmicDepthConstant", 2.0 / (Math.log(camera.maxZ + 1.0) / Math.LN2));
+    }
+}

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -1,5 +1,4 @@
 import { Logger } from "../Misc/logger";
-import type { Camera } from "../Cameras/camera";
 import type { Scene } from "../scene";
 import type { Effect, IEffectCreationOptions } from "./effect";
 import type { AbstractMesh } from "../Meshes/abstractMesh";
@@ -24,6 +23,9 @@ import { Texture } from "./Textures/texture";
 import type { CubeTexture } from "./Textures/cubeTexture";
 import type { Color3 } from "core/Maths/math.color";
 
+// For backwards compatibility, we export everything from the pure version of this file.
+export * from "./materialHelper.functions.pure";
+
 // Temps
 const TempFogColor: IColor3Like = { r: 0, g: 0, b: 0 };
 const TmpMorphInfluencers = {
@@ -34,22 +36,6 @@ const TmpMorphInfluencers = {
     UV2: false,
     COLOR: false,
 };
-
-/**
- * Binds the logarithmic depth information from the scene to the effect for the given defines.
- * @param defines The generated defines used in the effect
- * @param effect The effect we are binding the data to
- * @param scene The scene we are willing to render with logarithmic scale for
- */
-export function BindLogDepth(defines: any, effect: Effect, scene: Scene): void {
-    if (!defines || defines["LOGARITHMICDEPTH"] || (defines.indexOf && defines.indexOf("LOGARITHMICDEPTH") >= 0)) {
-        const camera = scene.activeCamera as Camera;
-        if (camera.mode === Constants.ORTHOGRAPHIC_CAMERA) {
-            Logger.Error("Logarithmic depth is not compatible with orthographic cameras!", 20);
-        }
-        effect.setFloat("logarithmicDepthConstant", 2.0 / (Math.log(camera.maxZ + 1.0) / Math.LN2));
-    }
-}
 
 /**
  * Binds the fog information from the scene to the effect for the given mesh.

--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -12,7 +12,7 @@ import type { ThinTexture } from "../Materials/Textures/thinTexture";
 import type { Scene } from "../scene";
 import type { ThinEngine } from "../Engines/thinEngine";
 import { Logger } from "../Misc/logger";
-import { BindLogDepth } from "../Materials/materialHelper.functions";
+import { BindLogDepth } from "../Materials/materialHelper.functions.pure";
 import { ShaderLanguage } from "../Materials/shaderLanguage";
 
 /**


### PR DESCRIPTION
materialHelper.functions.ts contains side effect, so any code importing it will also bring all the side effects. This makes that in 2D scenarios where we only use SpriteRenderer.ts, which should be small, are bringing a lot of extra code not needed because SpriteRenderer uses the BindLogDepth function.

Move the BindLogDepth function to a pure version of materialHelper.functions.pure.ts, now when using SpriteRenderer in a simple website, the dependency graph doesn't show any math.vector or math.color imports.

<img width="1850" height="950" alt="MovingToPure" src="https://github.com/user-attachments/assets/a38fb383-4805-4a0e-a1b7-e9ae6b8eaa73" />
