### PR TITLE
Inspector v2: Update Playground webpack config for sharedUiComponents

### DIFF
--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = (env) => {
                     return callback(null, "BABYLON");
                 }
 
-                if (context.includes("inspector-v2")) {
+                if (context.includes("inspector-v2") || context.includes("sharedUiComponents")) {
                     if (/^core\//.test(request)) {
                         return callback(null, "BABYLON");
                     } else if (/^loaders\//.test(request)) {


### PR DESCRIPTION
I noticed that Color and Vector/Quaternion related properties were not displaying correctly in Inspector v2 specifically in Playground. After a little investigation, I realized that imports from core, loaders, etc. were being correctly externalized to BABYLON.* for any code directly in inspector-v2, but not for sharedUiComponents, which means specifically for our shared controls, the Playground app bundle itself was basically getting extra copies of Color*/Vector*/Quaternion classes and the `instanceof` checks were failing (because they were two different classes with the same name/content). This change updates Playground's webpack config to externalize any core, loaders, etc. imports to use BABYLON.*, which fixes the problem.