### PR TITLE
Render normals when no normal attribute

### DIFF
--- a/packages/dev/core/src/Shaders/geometry.fragment.fx
+++ b/packages/dev/core/src/Shaders/geometry.fragment.fx
@@ -93,8 +93,11 @@ void main() {
         #else
             normalOutput = normalize(vec3(vWorldView * vec4(normalW, 0.0)));
         #endif
-    #else
+    #elif defined(HAS_NORMAL_ATTRIBUTE)
         normalOutput = normalize(vNormalV);
+    #elif defined(POSITION)
+        // Derive normal from position
+	    normalOutput = normalize(-cross(dFdx(vPositionW), dFdy(vPositionW)));
     #endif
 
     #ifdef ENCODE_NORMAL

--- a/packages/dev/core/src/ShadersWGSL/geometry.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/geometry.fragment.fx
@@ -95,8 +95,11 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
         #else
             normalOutput = normalize( (mat4x4f(input.vWorldView0, input.vWorldView1, input.vWorldView2, input.vWorldView3) *  vec4f(normalW, 0.0)).xyz);
         #endif
-    #else
+    #elif defined(HAS_NORMAL_ATTRIBUTE)
         normalOutput = normalize(input.vNormalV);
+    #elif defined(POSITION)
+        // Derive normal from position
+	    normalOutput = normalize(-cross(dpdx(input.vPositionW), dpdy(input.vPositionW)));
     #endif
 
     #ifdef ENCODE_NORMAL


### PR DESCRIPTION
After [this recent fix](https://github.com/BabylonJS/Babylon.js/pull/17279), I noticed that meshes without normal attributes render black for the normal output of the geometry buffer.

This PR should fix it. Though, it assumes world-space normals.