### PR TITLE
Up Viz test for native

### DIFF
--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -1918,7 +1918,7 @@
         {
             "title": "Multi cameras and output render target",
             "renderCount": 2,
-            "playgroundId": "#BCYE7J#31",
+            "playgroundId": "#BCYE7J#46",
             "referenceImage": "multiCamerasOutputRenderTarget.png"
         },
         {


### PR DESCRIPTION
This line in test `#31` fives an error when in strict mode on native. I commented the line in `#46`
`renderTarget.renderPassId = undefined;`