### PR TITLE
new feature:Enhanced zoomOnBoundingsInfo with Bounding Box Option, Orthographic Camera Support, and Offset

### DIFF
--- a/packages/dev/core/src/Behaviors/Cameras/framingBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Cameras/framingBehavior.ts
@@ -312,7 +312,7 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
      * @param onAnimationEnd Callback triggered at the end of the framing animation
      * @returns true if the zoom was done
      */
-    public zoomOnBoundingInfo(minimumWorld: Vector3, maximumWorld: Vector3, focusOnOriginXZ: boolean = false, onAnimationEnd: Nullable<() => void> = null): boolean {
+    public zoomOnBoundingInfo(minimumWorld: Vector3, maximumWorld: Vector3, mode: string ="sphere", radiusScaling: number = 1, focusOnOriginXZ: boolean = false, onAnimationEnd: Nullable<() => void> = null): boolean {
         let zoomTarget: Vector3;
 
         if (!this._attachedCamera) {
@@ -350,13 +350,13 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
         // Small delta ensures camera is not always at lower zoom limit.
         let radius = 0;
         if (this._mode === FramingBehavior.FitFrustumSidesMode) {
-            const position = this._calculateLowerRadiusFromModelBoundingSphere(minimumWorld, maximumWorld);
+            const position = this._calculateLowerRadiusFromModelBoundingInfo(minimumWorld, maximumWorld);
             if (this.autoCorrectCameraLimitsAndSensibility) {
                 this._attachedCamera.lowerRadiusLimit = radiusWorld.length() + this._attachedCamera.minZ;
             }
             radius = position;
         } else if (this._mode === FramingBehavior.IgnoreBoundsSizeMode) {
-            radius = this._calculateLowerRadiusFromModelBoundingSphere(minimumWorld, maximumWorld);
+            radius = this._calculateLowerRadiusFromModelBoundingInfo(minimumWorld, maximumWorld);
             if (this.autoCorrectCameraLimitsAndSensibility && this._attachedCamera.lowerRadiusLimit === null) {
                 this._attachedCamera.lowerRadiusLimit = this._attachedCamera.minZ;
             }
@@ -399,14 +399,14 @@ export class FramingBehavior implements Behavior<ArcRotateCamera> {
      * @returns The minimum distance from the primary mesh's center point at which the camera must be kept in order
      *		 to fully enclose the mesh in the viewing frustum.
      */
-    protected _calculateLowerRadiusFromModelBoundingSphere(minimumWorld: Vector3, maximumWorld: Vector3): number {
+    protected _calculateLowerRadiusFromModelBoundingInfo(minimumWorld: Vector3, maximumWorld: Vector3, mode: string = "sphere", radiusScale: number = 1): number {
         const camera = this._attachedCamera;
 
         if (!camera) {
             return 0;
         }
 
-        let distance = camera._calculateLowerRadiusFromModelBoundingSphere(minimumWorld, maximumWorld, this._radiusScale);
+        let distance = camera._calculateLowerRadiusFromModelBoundingInfo(minimumWorld, maximumWorld, mode, radiusScale);
         if (camera.lowerRadiusLimit && this._mode === FramingBehavior.IgnoreBoundsSizeMode) {
             // Don't exceed the requested limit
             distance = distance < camera.lowerRadiusLimit ? camera.lowerRadiusLimit : distance;


### PR DESCRIPTION
My team and I often need to frame an object at the center of the scene. The zoomOnBoundingsInfo function is very useful for this purpose. However, we noticed that it relies on the bounding sphere to calculate the camera distance, which can cause issues for particularly deep meshes.

To address this, I implemented the ability to choose the method used for distance calculation (bounding sphere or bounding box). Another requirement I had was to work with the orthographic camera, so I implemented a similar system within the same modification for convenience.

This is a tool we use internally, and I thought it would be useful to share it with the community. Additionally, I added the ability to set an offset on the radius so that the mesh does not align exactly with the window edges when displayed.