### PR TITLE
Disallow Inspector-v2 in Playground/Sandbox when old Babylon versions are specified, part 2

### DIFF
--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -203,6 +203,7 @@ let checkBabylonVersionAsync = async function () {
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
             globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            return "";
         }
 
         return activeVersion.includes(".") ? activeVersion : "";


### PR DESCRIPTION
I missed a case in the first PR where if the version in Playground is loaded from storage (e.g. the dropdown selection in the toolbar) then it was still trying to use inspector v2. I was only checking the explicit version as a query param. Doh.