### PR TITLE
Fix: use camera world position for floating origin

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2797,10 +2797,10 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     private _floatingOriginOffsetDefault: Vector3 = Vector3.Zero();
     /**
      * @experimental
-     * When floatingOriginMode is enabled, offset is equal to the active camera position. If no active camera or floatingOriginMode is disabled, offset is 0.
+     * When floatingOriginMode is enabled, offset is equal to the active camera position in world space. If no active camera or floatingOriginMode is disabled, offset is 0.
      */
     public get floatingOriginOffset(): Vector3 {
-        return this.floatingOriginMode && this.activeCamera ? this.activeCamera.position : this._floatingOriginOffsetDefault;
+        return this.floatingOriginMode && this.activeCamera ? this.activeCamera.getWorldMatrix().getTranslation() : this._floatingOriginOffsetDefault;
     }
 
     /**


### PR DESCRIPTION
Rationale: the previous version did not work when the camera had a parent

Test with https://playground.babylonjs.com/#N2CSHB

see: https://forum.babylonjs.com/t/floating-origin-breaks-rendering-when-camera-has-a-parent/60951/3