### PR TITLE
Revert "Exclude atmosphere visual tests on mac+firefox"

### DIFF
--- a/packages/tools/tests/test/playwright/performance.test.ts
+++ b/packages/tools/tests/test/playwright/performance.test.ts
@@ -96,12 +96,7 @@ export const performanceTests = async (engineType = "webgl2", testFileName = "co
             const re = new RegExp(regex, "i");
             return re.test(test.title);
         });
-        return !(
-            externallyExcluded ||
-            test.excludeFromAutomaticTesting ||
-            (test.excludedEngines && test.excludedEngines.includes(engineType)) ||
-            (test.excludedSystems && test.excludedSystems.includes(process.env.BROWSERSTACK_BROWSER))
-        );
+        return !(externallyExcluded || test.excludeFromAutomaticTesting || (test.excludedEngines && test.excludedEngines.includes(engineType)));
     });
 
     function log(msg: any, title?: string) {
@@ -185,13 +180,9 @@ export const performanceTests = async (engineType = "webgl2", testFileName = "co
         if (testCase.excludeFromAutomaticTesting) {
             continue;
         }
-        if (testCase.excludedSystems && testCase.excludedSystems.includes(process.env.BROWSERSTACK_BROWSER)) {
-            continue;
-        }
         if (testCase.excludedEngines && testCase.excludedEngines.indexOf(engineType) !== -1) {
             continue;
         }
-
         test(testCase.title, async ({ browser }) => {
             //defensive
             testResults = {};

--- a/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
+++ b/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
@@ -43,12 +43,7 @@ export const evaluatePlaywrightVisTests = async (
             const re = new RegExp(regex, "i");
             return re.test(test.title);
         });
-        return !(
-            externallyExcluded ||
-            test.excludeFromAutomaticTesting ||
-            (test.excludedEngines && test.excludedEngines.includes(engineType)) ||
-            (test.excludedSystems && test.excludedSystems.includes(process.env.BROWSERSTACK_BROWSER))
-        );
+        return !(externallyExcluded || test.excludeFromAutomaticTesting || (test.excludedEngines && test.excludedEngines.includes(engineType)));
     });
 
     function log(msg: any, title?: string) {
@@ -115,9 +110,6 @@ export const evaluatePlaywrightVisTests = async (
 
     for (const testCase of tests) {
         if (testCase.excludeFromAutomaticTesting) {
-            continue;
-        }
-        if (testCase.excludedSystems && testCase.excludedSystems.includes(process.env.BROWSERSTACK_BROWSER)) {
             continue;
         }
         if (testCase.excludedEngines && testCase.excludedEngines.indexOf(engineType) !== -1) {

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -2837,7 +2837,6 @@
             "playgroundId": "#VO1Z0C#14",
             "referenceImage": "atmosphere-day.png",
             "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"],
             "renderCount": 2
         },
         {
@@ -2845,7 +2844,6 @@
             "playgroundId": "#VO1Z0C#10",
             "referenceImage": "atmosphere-day.png",
             "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"],
             "renderCount": 2
         },
         {
@@ -2853,7 +2851,6 @@
             "playgroundId": "#VO1Z0C#15",
             "referenceImage": "atmosphere-sunset.png",
             "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"],
             "renderCount": 2
         },
         {
@@ -2861,7 +2858,6 @@
             "playgroundId": "#VO1Z0C#11",
             "referenceImage": "atmosphere-sunset.png",
             "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"],
             "renderCount": 2
         },
         {
@@ -2869,7 +2865,6 @@
             "playgroundId": "#VO1Z0C#13",
             "referenceImage": "atmosphere-night.png",
             "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"],
             "renderCount": 2
         },
         {
@@ -2877,15 +2872,13 @@
             "playgroundId": "#VO1Z0C#12",
             "referenceImage": "atmosphere-night.png",
             "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"],
             "renderCount": 2
         },
         {
             "title": "Atmosphere Space View",
             "playgroundId": "#VO1Z0C#6",
             "referenceImage": "atmosphere-space-view.png",
-            "excludedEngines": ["webgl1", "webgpu"],
-            "excludedSystems": ["playwright-firefox@latest:OSX Sonoma"]
+            "excludedEngines": ["webgl1", "webgpu"]
         },
         {
             "title": "OpenPBR IBL Reflectance with IOR",

--- a/packages/tools/tests/test/visualization/visualization.utils.ts
+++ b/packages/tools/tests/test/visualization/visualization.utils.ts
@@ -50,12 +50,7 @@ export const evaluateTests = async (engineType = "webgl2", testFileName = "confi
             const re = new RegExp(regex, "i");
             return re.test(test.title);
         });
-        return !(
-            externallyExcluded ||
-            test.excludeFromAutomaticTesting ||
-            (test.excludedEngines && test.excludedEngines.includes(engineType)) ||
-            (test.excludedSystems && test.excludedSystems.includes(process.env.BROWSERSTACK_BROWSER))
-        );
+        return !(externallyExcluded || test.excludeFromAutomaticTesting || (test.excludedEngines && test.excludedEngines.includes(engineType)));
     });
 
     // 2% error rate


### PR DESCRIPTION
Reverts BabylonJS/Babylon.js#17291

The visualization test config filter added for the atmosphere visualization tests on macOS/Firefox is not needed anymore since updating playwright in #17295 also fixes the atmosphere visualization tests.