### PR TITLE
Fix Smart Filter Debugger Build: set @dev/core "type"="module" to fix module resolution issue

### DIFF
--- a/packages/dev/core/package.json
+++ b/packages/dev/core/package.json
@@ -6,6 +6,7 @@
     "esnext": "dist/index",
     "types": "dist/index",
     "private": true,
+    "type": "module",
     "files": [
         "dist",
         "src"


### PR DESCRIPTION
This is affecting the build with certain versions of node.