### PR TITLE
Inspector v2: Fix Scene Explorer max depth of 10

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -22,6 +22,7 @@ import {
     tokens,
     Tooltip,
     TreeItemLayout,
+    treeItemLevelToken,
 } from "@fluentui/react-components";
 import { ArrowExpandAllRegular, createFluentIcon, FilterRegular, GlobeRegular } from "@fluentui/react-icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -455,6 +456,7 @@ const EntityTreeItem: FunctionComponent<{
                     aria-setsize={1}
                     aria-posinset={1}
                     onClick={select}
+                    style={{ [treeItemLevelToken]: entityItem.depth }}
                 >
                     <TreeItemLayout
                         iconBefore={entityItem.icon ? <entityItem.icon entity={entityItem.entity} /> : null}

--- a/packages/dev/inspector-v2/src/services/miniStatsService.tsx
+++ b/packages/dev/inspector-v2/src/services/miniStatsService.tsx
@@ -3,6 +3,7 @@ import type { ISceneContext } from "./sceneContext";
 import type { IShellService } from "./shellService";
 
 import { Badge, makeStyles, tokens } from "@fluentui/react-components";
+import { useCallback } from "react";
 
 import { useObservableState } from "../hooks/observableHooks";
 import { SceneContextIdentity } from "./sceneContext";
@@ -27,9 +28,15 @@ export const MiniStatsServiceDefinition: ServiceDefinition<[], [ISceneContext, I
             component: () => {
                 const classes = useStyles();
 
-                const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
+                const scene = useObservableState(
+                    useCallback(() => sceneContext.currentScene, [sceneContext.currentScene]),
+                    sceneContext.currentSceneObservable
+                );
                 const engine = scene?.getEngine();
-                const fps = useObservableState(() => (engine ? Math.round(engine.getFps()) : null), engine?.onBeginFrameObservable);
+                const fps = useObservableState(
+                    useCallback(() => (engine ? Math.round(engine.getFps()) : null), [engine]),
+                    engine?.onBeginFrameObservable
+                );
 
                 return fps != null ? <Badge appearance="outline" className={classes.badge}>{`${fps} fps`}</Badge> : null;
             },

--- a/packages/dev/inspector-v2/src/services/selectionService.ts
+++ b/packages/dev/inspector-v2/src/services/selectionService.ts
@@ -49,6 +49,9 @@ export const SelectionServiceDefinition: ServiceDefinition<[ISelectionService], 
                     }
                 }
 
+                // Expose the selected entity through a global variable. This is an Inspector v1 feature that people have found useful.
+                (globalThis as any).debugNode = item;
+
                 // Automatically open the properties pane when an entity is selected.
                 if (item && settingsContext.showPropertiesOnEntitySelection) {
                     shellService.sidePanes.find((pane) => pane.key === "Properties")?.select();


### PR DESCRIPTION
This PR has a few fixes for Inspector v2, mostly feedback from the forum:
1. Scene Explorer wonked out once it hit a node that was 10 levels or deeper. Interestingly this is a [documented](https://storybooks.fluentui.dev/react/?path=/docs/components-tree--docs#inline-styling-tree-item-level) as being the default for performance reasons, but there is a way to fix it. I did not notice any impact on perf.
2. Adding a `debugNode` global like Inspector v1 (see https://forum.babylonjs.com/t/scene-debuglayer-copy-last-command-to-clipboard/49796/18 for context).
3. Fix an issue I noticed where there was a missing useCallback in the recent "mini stats" I added that was causing a lot of unnecessary react renders and frequent console errors as a result.