### PR TITLE
Inspector v2: Add Dispose button for any disposable in the properties pane

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -1,5 +1,7 @@
 import type { FunctionComponent } from "react";
 
+import type { IDisposable } from "core/index";
+
 import { useMemo } from "react";
 
 import { TextInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
@@ -7,6 +9,7 @@ import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/
 import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 import { useProperty } from "../../hooks/compoundPropertyHooks";
 import { GetPropertyDescriptor, IsPropertyReadonly } from "../../instrumentation/propertyInstrumentation";
+import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 
 type CommonEntity = {
     readonly id?: number;
@@ -37,6 +40,16 @@ export const CommonGeneralProperties: FunctionComponent<{ commonEntity: CommonEn
                 <StringifiedPropertyLine key="EntityUniqueId" label="Unique ID" description="The unique id of the node." value={commonEntity.uniqueId} />
             )}
             {className !== undefined && <TextPropertyLine key="EntityClassName" label="Class" description="The class of the node." value={className} />}
+        </>
+    );
+};
+
+export const DisposableGeneralProperties: FunctionComponent<{ disposableEntity: IDisposable }> = (props) => {
+    const { disposableEntity } = props;
+
+    return (
+        <>
+            <ButtonLine label="Dispose" onClick={() => disposableEntity.dispose()} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/materials/materialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/materialProperties.tsx
@@ -1,18 +1,19 @@
-import { Material } from "core/Materials/material";
-import { Engine } from "core/Engines/engine";
-import { Constants } from "core/Engines/constants";
 import type { FunctionComponent } from "react";
 
-import { BoundProperty } from "../boundProperty";
 import type { DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";
+
+import { Constants } from "core/Engines/constants";
+import { Engine } from "core/Engines/engine";
+import { Material } from "core/Materials/material";
+import { AlphaModeOptions } from "shared-ui-components/constToOptionsMaps";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
+import { PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { Collapse } from "shared-ui-components/fluent/primitives/collapse";
-import { AlphaModeOptions } from "shared-ui-components/constToOptionsMaps";
 import { useProperty } from "../../../hooks/compoundPropertyHooks";
-import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
-import { PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
+import { BoundProperty } from "../boundProperty";
 
 const OrientationOptions = [
     { label: "Clockwise", value: Material.ClockWiseSideOrientation },
@@ -76,15 +77,15 @@ export const MaterialGeneralProperties: FunctionComponent<{ material: Material }
                 target={material}
                 propertyKey="backFaceCulling"
             />
-            {faceCulling && (
+            <Collapse visible={faceCulling}>
                 <BoundProperty
                     component={SwitchPropertyLine}
-                    label="Culls back faces"
+                    label="Cull Back Faces"
                     description="Culls back faces. If false, front faces are culled."
                     target={material}
                     propertyKey="cullBackFaces"
                 />
-            )}
+            </Collapse>
             <BoundProperty
                 component={NumberDropdownPropertyLine}
                 label="Orientation"
@@ -113,24 +114,24 @@ export const MaterialGeneralProperties: FunctionComponent<{ material: Material }
             <BoundProperty component={SwitchPropertyLine} label="Wireframe" target={material} propertyKey="wireframe" />
             <BoundProperty component={SwitchPropertyLine} label="Point Cloud" target={material} propertyKey="pointsCloud" />
             {pointsCloud && <BoundProperty component={SyncedSliderPropertyLine} label="Point Size" target={material} propertyKey="pointSize" min={0} max={100} step={0.1} />}
-            {isWebGPU && <BoundProperty component={SwitchPropertyLine} label="Use vertex pulling" target={material} propertyKey="useVertexPulling" />}
+            {isWebGPU && <BoundProperty component={SwitchPropertyLine} label="Use Vertex Pulling" target={material} propertyKey="useVertexPulling" />}
             <BoundProperty
                 component={SwitchPropertyLine}
-                label="Support fog"
+                label="Support Fog"
                 target={material}
                 propertyKey="fogEnabled"
                 description="Indicates whether the material supports fog (however, fog must be enabled at the scene level to be effective)."
             />
             <BoundProperty
                 component={SwitchPropertyLine}
-                label="Use logarithmic depth"
+                label="Use Logarithmic Depth"
                 target={material}
                 propertyKey="useLogarithmicDepth"
                 docLink="https://doc.babylonjs.com/features/featuresDeepDive/materials/advanced/logarithmicDepthBuffer"
             />
             <BoundProperty
                 component={SwitchPropertyLine}
-                label="Set vertex output invariant"
+                label="Set Vertex Output Invariant"
                 target={material}
                 propertyKey="setVertexOutputInvariant"
                 description="Setting this property to true will force the shader compiler to disable some optimization to make sure the vertex output is always calculated the same way across different compilation units."

--- a/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/abstractMeshProperties.tsx
@@ -16,7 +16,6 @@ import { CreateLineSystem } from "core/Meshes/Builders/linesBuilder";
 import { InstancedMesh } from "core/Meshes/instancedMesh";
 import { Tools } from "core/Misc/tools";
 import { RenderingManager } from "core/Rendering/renderingManager";
-import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { Collapse } from "shared-ui-components/fluent/primitives/collapse";
 import { BooleanBadgePropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/booleanBadgePropertyLine";
 import { Color3PropertyLine, Color4PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
@@ -62,7 +61,6 @@ export const AbstractMeshGeneralProperties: FunctionComponent<{ mesh: AbstractMe
                     selectionService={selectionService}
                 />
             )}
-            <ButtonLine label="Dispose" onClick={() => mesh.dispose()} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/postProcesses/postProcessProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/postProcesses/postProcessProperties.tsx
@@ -6,7 +6,6 @@ import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propert
 import { CheckboxPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/checkboxPropertyLine";
 import { BoundProperty } from "../boundProperty";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
-import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 
 /**
  * The properties component for a post process.
@@ -23,7 +22,6 @@ export const PostProcessProperties: FunctionComponent<{ postProcess: PostProcess
             <BoundProperty component={CheckboxPropertyLine} label="Pixel Perfect:" target={postProcess} propertyKey="enablePixelPerfectMode" />
             <BoundProperty component={CheckboxPropertyLine} label="Fullscreen Viewport:" target={postProcess} propertyKey="forceFullscreenViewport" />
             <BoundProperty component={SyncedSliderPropertyLine} label="Samples:" target={postProcess} propertyKey="samples" min={1} max={8} step={1} />
-            <ButtonLine label="Dispose" onClick={() => postProcess.dispose()} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/sprites/spriteManagerProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/sprites/spriteManagerProperties.tsx
@@ -5,7 +5,6 @@ import type { ISelectionService } from "../../../services/selectionService";
 
 import { RenderingManager } from "core/Rendering/renderingManager";
 import { AlphaModeOptions } from "shared-ui-components/constToOptionsMaps";
-import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
 import { SpinButtonPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/spinButtonPropertyLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
@@ -24,7 +23,6 @@ export const SpriteManagerGeneralProperties: FunctionComponent<{ spriteManager: 
         <>
             <TextPropertyLine label="Capacity" value={spriteManager.capacity.toString()} />
             <LinkToEntityPropertyLine label="Texture" entity={texture} selectionService={selectionService} />
-            <ButtonLine label="Dispose" onClick={() => spriteManager.dispose()} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/services/panes/properties/commonPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/commonPropertiesService.tsx
@@ -1,9 +1,10 @@
+import type { IDisposable } from "core/index";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { IPropertiesService } from "./propertiesService";
 
 import { Scene } from "core/scene";
 
-import { CommonGeneralProperties } from "../../../components/properties/commonGeneralProperties";
+import { CommonGeneralProperties, DisposableGeneralProperties } from "../../../components/properties/commonGeneralProperties";
 import { PropertiesServiceIdentity } from "./propertiesService";
 
 type CommonEntity = {
@@ -17,7 +18,7 @@ export const CommonPropertiesServiceDefinition: ServiceDefinition<[], [IProperti
     friendlyName: "Common Properties",
     consumes: [PropertiesServiceIdentity],
     factory: (propertiesService) => {
-        const contentRegistration = propertiesService.addSectionContent({
+        const commonContentRegistration = propertiesService.addSectionContent({
             key: "Common Properties",
             predicate: (entity: unknown): entity is CommonEntity => {
                 // Common properties are not useful for the scene.
@@ -36,9 +37,25 @@ export const CommonPropertiesServiceDefinition: ServiceDefinition<[], [IProperti
             ],
         });
 
+        const disposableContentRegistration = propertiesService.addSectionContent({
+            key: "Disposable Properties",
+            predicate: (entity: unknown): entity is IDisposable => {
+                const disposable = entity as Partial<IDisposable>;
+                return typeof disposable.dispose === "function";
+            },
+            content: [
+                {
+                    section: "General",
+                    order: 100000,
+                    component: ({ context }) => <DisposableGeneralProperties disposableEntity={context} />,
+                },
+            ],
+        });
+
         return {
             dispose: () => {
-                contentRegistration.dispose();
+                commonContentRegistration.dispose();
+                disposableContentRegistration.dispose();
             },
         };
     },


### PR DESCRIPTION
This is in response to https://forum.babylonjs.com/t/introducing-inspector-v2/60937/54

Instead of selectively adding a Dispose button in the properties pane for some entities, we now add a Dispose button to the bottom of the General section for any entity that implements `IDisposable` (e.g. has a `dispose` function).

Also a tiny bit of cleanup from a recent PR that uses `Collapse` instead of conditionally rendering a component, and uses Title Case for property labels.