### PR TITLE
Update baseSlider.ts to send target/currentTarget to onValueChangedObservable 

### DIFF
--- a/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
@@ -341,5 +341,3 @@ export class BaseSlider extends Control {
         super._onCanvasBlur();
     }
 }
-
-


### PR DESCRIPTION
Added target and currentTarget properties to slider onValueChangedObservable.

Test with this playground: https://playground.babylonjs.com/?snapshot=refs%2Fpull%2F17323%2Fmerge#UBZNMP%230

See this forum post for more details: https://forum.babylonjs.com/t/obtain-gui-component-within-onvaluechangedobservable-on-slider-and-colorpicker/61045/6