### PR TITLE
Add support for instances in FloatingOriginMode

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -2170,6 +2170,12 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                     }
                 }
                 world.copyToArray(instanceStorage.instancesData, offset);
+
+                // Apply floatingOriginOffset to underlying data sent to buffer
+                instanceStorage.instancesData[offset + 12] -= this._scene.floatingOriginOffset.x;
+                instanceStorage.instancesData[offset + 13] -= this._scene.floatingOriginOffset.y;
+                instanceStorage.instancesData[offset + 14] -= this._scene.floatingOriginOffset.z;
+
                 offset += 16;
                 instancesCount++;
             }
@@ -2199,6 +2205,11 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
                             instance._previousWorldMatrix.copyFrom(matrix);
                         }
                     }
+
+                    // Apply floatingOriginOffset to underlying data sent to buffer
+                    instanceStorage.instancesData[offset + 12] -= this._scene.floatingOriginOffset.x;
+                    instanceStorage.instancesData[offset + 13] -= this._scene.floatingOriginOffset.y;
+                    instanceStorage.instancesData[offset + 14] -= this._scene.floatingOriginOffset.z;
 
                     offset += 16;
                     instancesCount++;

--- a/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
+++ b/packages/dev/core/src/Rendering/boundingBoxRenderer.ts
@@ -653,8 +653,13 @@ export class BoundingBoxRenderer implements ISceneComponent {
 
             m[10] = diff._z; // Scale Z
             m[11] = median._z; // Translate Z
-            TempMatrix.multiplyToArray(boundingBox.getWorldMatrix(), matrices, instancesCount * 16);
 
+            const offset = instancesCount * 16;
+            TempMatrix.multiplyToArray(boundingBox.getWorldMatrix(), matrices, offset);
+
+            matrices[offset + 12] -= this.scene.floatingOriginOffset.x;
+            matrices[offset + 13] -= this.scene.floatingOriginOffset.y;
+            matrices[offset + 14] -= this.scene.floatingOriginOffset.z;
             instancesCount++;
         }
 

--- a/packages/dev/core/src/Rendering/edgesRenderer.ts
+++ b/packages/dev/core/src/Rendering/edgesRenderer.ts
@@ -990,6 +990,9 @@ export class EdgesRenderer implements IEdgesRenderer {
 
                     for (let i = 0; i < instanceCount; ++i) {
                         this.customInstances.data[i].copyToArray(instanceStorage.instancesData, offset);
+                        instanceStorage.instancesData[offset + 12] -= scene.floatingOriginOffset.x;
+                        instanceStorage.instancesData[offset + 13] -= scene.floatingOriginOffset.y;
+                        instanceStorage.instancesData[offset + 14] -= scene.floatingOriginOffset.z;
                         offset += 16;
                     }
 


### PR DESCRIPTION
Instances are positioned by combining world0, world1, world2, and world3 attributes, vs using the standard world mat4 uniform. We thus need to do special offset to the buffer data to ensure the instances are positioned properly.

I experimented with a couple approaches and this was the one that had least perf impact and simplest code (compared to overriding prototype of buffer / vertex buffer in order to achieve this behavior) 

Both boundingBoxRenderer and edgesRenderer also support instances, so they needed offset logic as well.

Tested with the below playground snippets
thin instances: /#V1JE4Z#1 
instances: /#PB1NS6#264
boundingbox rendering: /#NRNVQA#4
edges rendering: /#7BY3TM