### PR TITLE
Smart Filter Editor: fix scrollbar to prevent frequent canvas resizes

### DIFF
--- a/packages/tools/smartFiltersEditorControl/src/assets/styles/main.scss
+++ b/packages/tools/smartFiltersEditorControl/src/assets/styles/main.scss
@@ -76,12 +76,13 @@
 
         grid-template-columns: 100%;
         height: 100%;
-        overflow-y: auto;
+        overflow: hidden;
     }
 
     #propertyTab {
         grid-row: 1;
         grid-column: 1;
+        overflow: auto;
     }
 
     .button {


### PR DESCRIPTION
The preview was included in the scroll region, unlike the other editors, so when it got a vertical scrollbar, that changed the width of the preview which caused the engine to resize.  Now SFE behaves like the other editors, and the preview doesn't scroll off screen and isn't affected by the scrollbar.