### PR TITLE
Inspector v2: Update to the latest fluent virtualizer (bug fix + react 19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2710,22 +2710,22 @@
             "license": "MIT"
         },
         "node_modules/@fluentui-contrib/react-virtualizer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-0.3.0.tgz",
-            "integrity": "sha512-ALLvbTiraehvcsm/VrtrxnLJqF9QQ6+YZgupcYGKTC8WWxlnX9loUi9pWoNBlHoB96nYKhDWfmY0Bxi7Jbs32w==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-0.5.3.tgz",
+            "integrity": "sha512-wjkC6/PcMbELb0rQAD2h4il5dSuzoi1tvv86NyT3JLqJsNm/qCV4i0YAYL9TejKuwl/6E8zg5pXk1fl5vJz7LA==",
             "license": "MIT",
             "dependencies": {
+                "@fluentui/react-jsx-runtime": "^9.0.29",
                 "@fluentui/react-utilities": "^9.16.0",
                 "@griffel/react": "^1.5.14",
-                "@swc/helpers": "~0.5.11",
-                "jsonc-eslint-parser": "2.4.0"
+                "@swc/helpers": "~0.5.11"
             },
             "peerDependencies": {
                 "@fluentui/react-shared-contexts": ">=9.7.2 <10.0.0",
-                "@types/react": ">=16.8.0 <19.0.0",
-                "@types/react-dom": ">=16.9.0 <19.0.0",
-                "react": ">=16.8.0 <19.0.0",
-                "react-dom": ">=16.8.0 <19.0.0"
+                "@types/react": ">=16.8.0 <20.0.0",
+                "@types/react-dom": ">=16.9.0 <20.0.0",
+                "react": ">=16.8.0 <20.0.0",
+                "react-dom": ">=16.8.0 <20.0.0"
             }
         },
         "node_modules/@fluentui/keyboard-keys": {
@@ -9846,6 +9846,7 @@
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+            "devOptional": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -9867,6 +9868,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -13870,6 +13872,7 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -13938,6 +13941,7 @@
             "version": "9.6.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "dev": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -18598,24 +18602,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonc-eslint-parser": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
-            "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.5.0",
-                "eslint-visitor-keys": "^3.0.0",
-                "espree": "^9.0.0",
-                "semver": "^7.3.5"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ota-meshi"
             }
         },
         "node_modules/jsonc-parser": {
@@ -28328,7 +28314,7 @@
                 "@dev/loaders": "1.0.0",
                 "@dev/materials": "^1.0.0",
                 "@dev/serializers": "1.0.0",
-                "@fluentui-contrib/react-virtualizer": "^0.3.0",
+                "@fluentui-contrib/react-virtualizer": "^0.5.3",
                 "@fluentui/react-components": "^9.70.0",
                 "@fluentui/react-icons": "^2.0.310",
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",
@@ -28626,7 +28612,7 @@
                 "@babylonjs/loaders": "^8.0.0",
                 "@babylonjs/materials": "^8.0.0",
                 "@babylonjs/serializers": "^8.0.0",
-                "@fluentui-contrib/react-virtualizer": "^0.3.0",
+                "@fluentui-contrib/react-virtualizer": "^0.5.3",
                 "@fluentui/react-components": "^9.70.0",
                 "@fluentui/react-icons": "^2.0.310",
                 "react": ">=16.14.0 <20.0.0",

--- a/packages/dev/inspector-v2/package.json
+++ b/packages/dev/inspector-v2/package.json
@@ -22,7 +22,7 @@
         "@dev/loaders": "1.0.0",
         "@dev/materials": "^1.0.0",
         "@dev/serializers": "1.0.0",
-        "@fluentui-contrib/react-virtualizer": "^0.3.0",
+        "@fluentui-contrib/react-virtualizer": "^0.5.3",
         "@fluentui/react-components": "^9.70.0",
         "@fluentui/react-icons": "^2.0.310",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",

--- a/packages/public/@babylonjs/inspector-v2/package.json
+++ b/packages/public/@babylonjs/inspector-v2/package.json
@@ -28,7 +28,7 @@
         "@babylonjs/loaders": "^8.0.0",
         "@babylonjs/materials": "^8.0.0",
         "@babylonjs/serializers": "^8.0.0",
-        "@fluentui-contrib/react-virtualizer": "^0.3.0",
+        "@fluentui-contrib/react-virtualizer": "^0.5.3",
         "@fluentui/react-components": "^9.70.0",
         "@fluentui/react-icons": "^2.0.310",
         "react": ">=16.14.0 <20.0.0",


### PR DESCRIPTION
This PR updates the Fluent virtualizer package to the latest, which includes a fix for a [regression](https://github.com/microsoft/fluentui-contrib/issues/526) and supports React 19 (from the [forum](https://forum.babylonjs.com/t/introducing-inspector-v2/60937/11)).