### PR TITLE
FloatingOrigin: fix returned eyePos offset

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -9,8 +9,8 @@ import type { ISmartArrayLike } from "./Misc/smartArray";
 import { SmartArrayNoDuplicate, SmartArray } from "./Misc/smartArray";
 import { StringDictionary } from "./Misc/stringDictionary";
 import { Tags } from "./Misc/tags";
-import type { Vector2, Vector4 } from "./Maths/math.vector";
-import { Vector3, Matrix, TmpVectors } from "./Maths/math.vector";
+import type { Vector2 } from "./Maths/math.vector";
+import { Vector3, Vector4, Matrix, TmpVectors } from "./Maths/math.vector";
 import type { IParticleSystem } from "./Particles/IParticleSystem";
 import { ImageProcessingConfiguration } from "./Materials/imageProcessingConfiguration";
 import { UniformBuffer } from "./Materials/uniformBuffer";
@@ -240,6 +240,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
     private _clearColor: Color4 = new Color4(0.2, 0.2, 0.3, 1.0);
 
+    private _tempVect4 = new Vector4();
     /**
      * Observable triggered when the performance priority is changed
      */
@@ -1239,7 +1240,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         const invertNormal = this.useRightHandedSystem === (this._mirroredCameraPosition != null);
 
         const offset = this.floatingOriginOffset;
-        const eyePos = TmpVectors.Vector4[0].set(eyePosition.x, eyePosition.y, eyePosition.z, invertNormal ? -1 : 1);
+        const eyePos = this._tempVect4.set(eyePosition.x, eyePosition.y, eyePosition.z, invertNormal ? -1 : 1);
         const offsetEyePos = eyePos.subtractFromFloatsToRef(offset.x, offset.y, offset.z, 0, TmpVectors.Vector4[1]);
 
         if (effect) {


### PR DESCRIPTION
My change yesterday updated how offset was applied (to improve perf) but accidentally returned the offset eyePos instead of the non-offset eyePos, causing visual inconsistency in floatingoriginmode. 

Side note: the atmosphere visual tests didn't catch this, maybe because the color is too similar? Something to tackle in another PR