### PR TITLE
[Playground] Fixes for editor v2

### DIFF
--- a/packages/tools/playground/src/scss/editor.scss
+++ b/packages/tools/playground/src/scss/editor.scss
@@ -1080,3 +1080,7 @@
 .editor-widget {
     z-index: 1 !important;
 }
+
+.parameter-hints-widget {
+    overflow-y: auto;
+}


### PR DESCRIPTION
1. CSS fix for function parameters overflow
2. Change order of execution for the runner when we have external dependencies that are referenced in code from global namespace. The only external dep that relies on the existence of an Engine is Sound, so everything else can come first and then patch the engine for Sound if that's a dependency afterwards