### PR TITLE
bug: do not attempt to update removed xr anchors

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.ts
@@ -5,7 +5,6 @@ import { Matrix, Vector3, Quaternion } from "../../Maths/math.vector";
 import type { TransformNode } from "../../Meshes/transformNode";
 import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
 import type { IWebXRHitResult } from "./WebXRHitTest";
-import { Tools } from "../../Misc/tools";
 
 /**
  * Configuration options of the anchor system


### PR DESCRIPTION
Fixes issue where warning 'Anchor could not be updated' was being generated for just removed anchors.

Changes

- added check for removed anchors by checking for invalid index (line 347)
- removed `try-catch` as the only reason it would catch is when an anchor has been removed, which we are now handling
- removed `toRemove` array to simplify anchor removal
