### PR TITLE
Standard material: Fix wrong normal when in right handed mode

### DIFF
--- a/packages/dev/core/src/Shaders/default.fragment.fx
+++ b/packages/dev/core/src/Shaders/default.fragment.fx
@@ -122,7 +122,7 @@ void main(void) {
 #ifdef NORMAL
 	vec3 normalW = normalize(vNormalW);
 #else
-	vec3 normalW = normalize(-cross(dFdx(vPositionW), dFdy(vPositionW)));
+	vec3 normalW = normalize(cross(dFdx(vPositionW), dFdy(vPositionW))) * vEyePosition.w;
 #endif
 
 #include<bumpFragment>

--- a/packages/dev/core/src/ShadersWGSL/default.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/default.fragment.fx
@@ -113,7 +113,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 #ifdef NORMAL
 	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
 #else
-	var normalW: vec3f = normalize(-cross(dpdx(fragmentInputs.vPositionW), dpdy(fragmentInputs.vPositionW)));
+	var normalW: vec3f = normalize(cross(dpdx(fragmentInputs.vPositionW), dpdy(fragmentInputs.vPositionW))) *  scene.vEyePosition.w;
 #endif
 
 #include<bumpFragment>


### PR DESCRIPTION
See https://forum.babylonjs.com/t/default-lighting-normals-inverted-for-standard-material-in-right-handed-system/61168