### PR TITLE
[FloatingOrigin] Web GPU Fix

### DIFF
--- a/packages/dev/core/src/Materials/floatingOriginMatrixOverrides.ts
+++ b/packages/dev/core/src/Materials/floatingOriginMatrixOverrides.ts
@@ -120,12 +120,13 @@ function OffsetWorldViewProjectionToRef(
 }
 
 function GetOffsetMatrix(uniformName: string, mat: IMatrixLike): IMatrixLike {
-    TempFinalMat.updateFlag = mat.updateFlag;
     const scene = FloatingOriginCurrentScene.getScene();
     // Early out for scenes that don't have floatingOriginMode enabled
-    if (!scene) {
+    // Effect.setMatrix will call pipelineContext.setMatrix. In WebGPU, this will in turn call ubo.updateMatrix. To avoid double offset, early out if mat is TempFinalMat
+    if (!scene || TempFinalMat === mat) {
         return mat;
     }
+    TempFinalMat.updateFlag = mat.updateFlag;
     const offset = scene.floatingOriginOffset;
     switch (uniformName) {
         case "world":


### PR DESCRIPTION
in FloatingOriginMode, we override effect.setMatrix to apply an offset. This in turn calls pipelineContext.setMatrix, which in webGPUPipelineContext will call ubo.updateMatrix

previously, this would apply offset again and cause incorrect positioning. The fix is to avoid double offset by existing early if the passed in matrix is === the most recently offset Temp matrix. To avoid cases where TempFinalMat happens to be equal values, I also move the updateFlag set to after the early out check.

