### PR TITLE
[Playground] Editor v2: Snippet session state and bug fixes

### DIFF
--- a/packages/tools/playground/src/tools/localSession.ts
+++ b/packages/tools/playground/src/tools/localSession.ts
@@ -2,7 +2,7 @@
 import { Logger } from "@dev/core";
 import type { GlobalState } from "../globalState";
 import { PackSnippetData } from "./snippet";
-import type { V2Manifest } from "./snippet";
+import type { V2Manifest, ExtraSnippetOptions } from "./snippet";
 import { Utilities } from "./utilities";
 
 declare let JSZip: any;
@@ -198,10 +198,10 @@ export function ReadLastLocal(globalState: GlobalState): string | undefined {
     const bundle = LoadBundleForToken(token);
     return bundle.lastLocal;
 }
-export function WriteLastLocal(globalState: GlobalState) {
+export function WriteLastLocal(globalState: GlobalState, extraSnippetOptions: ExtraSnippetOptions = {}) {
     const token = GetDefaultToken(globalState);
     const bundle = LoadBundleForToken(token);
-    bundle.lastLocal = PackSnippetData(globalState);
+    bundle.lastLocal = PackSnippetData(globalState, extraSnippetOptions);
     StoreBundleForToken(token, bundle);
 }
 


### PR DESCRIPTION
1. Snippet session state.
- This is on automatically and mirrors some of what VS Code does. IMO it is a good default behavior that shouldn't need to be behind a config flag because if you're working on a PG and have 5 of the files open and refresh the page, you want all those 5 files open still, and to jump back to the active file where the cursor was on your last edit - that's what this PR does.

2. Error handling logic for older Playgrounds
- This was a bit of a doozy. Older JS engines were quite flexible with a lot of things around variable assignment and scoping, same with the eval JIT JS compiler. Not the case in ES modules, but we do get nice consistent errors when these things happen. This is addressing two issue I saw through examples in the PG:
    - Undefined variables being accessed from RHS. This is like having the line `path = [1,2,3];`. In modern JS, you need to write `var`, `let` or `const` otherwise the compiler will throw. That error is exactly what we can catch and iteratively assign global variables so that it *is* accessible and spits a warning out in the console. Not a pretty solution but don't think there is one.
    - `this` accessing closure or global namespace, I understand people's confusion and frustration with JS from 10 years ago when these sorts of things are allowed to happen:
    ```js
      var scene = new BABYLON.Scene(engine);

	// Camera
    camera = new BABYLON.FreeCamera("camera1", new BABYLON.Vector3(0, 0, -10), this.scene);
    // We get a double-whammy here - no variable declaration and accessing `this` which doesn't exist without caller context.
    ```
    - Solution to bind a calling context of a proxy and map the result and known babylon "instance globals" just to stop the runtime from complaining, but not as a feature.