### PR TITLE
Fix vscode search exclusion of dist folders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,9 @@
         "**/*.compute.ts": true,
         "**/*.block.ts": true
     },
+    "search.exclude": {
+        "**/dist": true
+    },
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },


### PR DESCRIPTION
You can still search them by turning off "Use Exclude Settings and Ignore Files" in the UI if you want to search the .js output