### PR TITLE
PBRMetallicRoughnessMaterial: Fix wrong lighting when two sided lighting enabled

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -5768,4 +5768,3 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 }
 
 RegisterClass("BABYLON.Mesh", Mesh);
-


### PR DESCRIPTION
See https://forum.babylonjs.com/t/wrong-normals-used-for-double-sided-pbr-material-in-right-handed-system/61226