### PR TITLE
Atmosphere addon fixes for floating origin

### DIFF
--- a/packages/dev/addons/src/atmosphere/atmosphere.ts
+++ b/packages/dev/addons/src/atmosphere/atmosphere.ts
@@ -137,12 +137,12 @@ export class Atmosphere implements IDisposable {
     /**
      * Called before the LUTs are rendered for this camera. This happens after the per-camera UBO update.
      */
-    public readonly onBeforeRenderLutsForCameraObservable = new Observable<void>();
+    public readonly onBeforeRenderLutsForCameraObservable = new Observable<Camera>();
 
     /**
      * Called after the LUTs were rendered.
      */
-    public readonly onAfterRenderLutsForCameraObservable = new Observable<void>();
+    public readonly onAfterRenderLutsForCameraObservable = new Observable<Camera>();
 
     /**
      * If provided, this is the depth texture used for composition passes.
@@ -734,7 +734,7 @@ export class Atmosphere implements IDisposable {
         // Before rendering, make sure the per-camera variables have been updated.
         this._onBeforeCameraRenderObserver = scene.onBeforeCameraRenderObservable.add((x) => {
             this._updatePerCameraVariables(x);
-            this._renderLutsForCamera();
+            this._renderLutsForCamera(x);
         });
 
         {
@@ -1207,8 +1207,9 @@ export class Atmosphere implements IDisposable {
     /**
      * Renders the lookup tables, some of which can vary per-camera.
      * It is expected that updatePerCameraVariables was previously called.
+     * @param camera - The camera to render the LUTs for.
      */
-    private _renderLutsForCamera(): void {
+    private _renderLutsForCamera(camera: Camera): void {
         {
             this.onBeforeLightVariablesUpdateObservable.notifyObservers();
 
@@ -1228,7 +1229,7 @@ export class Atmosphere implements IDisposable {
         // Render the LUTs.
         const isEnabled = this.isEnabled();
         {
-            this.onBeforeRenderLutsForCameraObservable.notifyObservers();
+            this.onBeforeRenderLutsForCameraObservable.notifyObservers(camera);
 
             // After UBO update we can render the global LUTs which use some of these values on the GPU.
             // TODO: Could break out update and UBOs to global vs. per-camera.
@@ -1254,7 +1255,7 @@ export class Atmosphere implements IDisposable {
                 }
             }
 
-            this.onAfterRenderLutsForCameraObservable.notifyObservers();
+            this.onAfterRenderLutsForCameraObservable.notifyObservers(camera);
         }
     }
 

--- a/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
@@ -152,6 +152,9 @@ export class AtmospherePBRMaterialPlugin extends MaterialPluginBase {
             this._atmosphere.bindUniformBufferToEffect(effect);
         }
 
+        // Need the offset to apply which will take a world space position and convert it to a global space position in the atmosphere.
+        // If floating origin mode is enabled, that offset is the floating origin offset.
+        // If not, it's an offset up the Y-axis by the planet radius.
         uniformBuffer.updateVector3(
             OriginOffsetUniformName,
             scene.floatingOriginMode

--- a/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
+++ b/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
@@ -11,6 +11,7 @@ import type { IColor3Like, IColor4Like, IVector2Like, IVector3Like } from "core/
 import type { Nullable } from "core/types";
 import { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 import { Sample2DRgbaToRef } from "./sampling";
+import { Vector3Dot } from "core/Maths/math.vector.functions";
 import "./Shaders/diffuseSkyIrradiance.fragment";
 import "./Shaders/fullscreenTriangle.vertex";
 
@@ -161,7 +162,7 @@ export class DiffuseSkyIrradianceLut {
             return result;
         }
 
-        const cosAngleLightToZenith = directionToLight.x * cameraGeocentricNormal.x + directionToLight.y * cameraGeocentricNormal.y + directionToLight.z * cameraGeocentricNormal.z;
+        const cosAngleLightToZenith = Vector3Dot(directionToLight, cameraGeocentricNormal);
         ComputeLutUVToRef(properties, radius, cosAngleLightToZenith, UvTemp);
         Sample2DRgbaToRef(UvTemp.x, UvTemp.y, LutWidthPx, LutHeightPx, this._lutData, Color4Temp, FromHalfFloat);
 

--- a/packages/dev/addons/src/atmosphere/transmittanceLut.ts
+++ b/packages/dev/addons/src/atmosphere/transmittanceLut.ts
@@ -13,6 +13,7 @@ import type { Nullable } from "core/types";
 import { Observable } from "core/Misc/observable";
 import { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 import { Sample2DRgbaToRef } from "./sampling";
+import { Vector3Dot } from "core/Maths/math.vector.functions";
 import "./Shaders/fullscreenTriangle.vertex";
 import "./Shaders/transmittance.fragment";
 
@@ -162,8 +163,7 @@ export class TransmittanceLut {
      */
     public getTransmittedColorToRef<T extends IColor3Like>(directionToLight: IVector3Like, pointRadius: number, pointGeocentricNormal: IVector3Like, result: T): T {
         if (this._lutData[0] !== undefined) {
-            const cosAngleLightToZenith =
-                directionToLight.x * pointGeocentricNormal.x + directionToLight.y * pointGeocentricNormal.y + directionToLight.z * pointGeocentricNormal.z;
+            const cosAngleLightToZenith = Vector3Dot(directionToLight, pointGeocentricNormal);
             SampleLutToRef(this._atmosphere.physicalProperties, this._lutData, pointRadius, cosAngleLightToZenith, Color4Temp);
             result.r = Color4Temp.r;
             result.g = Color4Temp.g;


### PR DESCRIPTION
- Ensure atmosphere parameters get computed correctly when floating origin is enabled, assuming planet center is 0,0,0 in world space.
- Use common dot product helper
- **NOTE:** Minor breaking change to API; Include `Camera` as parameter to some existing observables that were previously `Observable<void>`.