### PR TITLE
Throw error on invalid sound source

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -221,6 +221,8 @@ class _WebAudioStreamingSoundInstance extends _StreamingSoundInstance implements
             this._initFromUrls(sound._source);
         } else if (sound._source instanceof HTMLMediaElement) {
             this._initFromMediaElement(sound._source);
+        } else {
+            throw new Error(`Invalid streaming sound source (${sound._source}).`);
         }
     }
 


### PR DESCRIPTION
Giving a streaming sound an invalid sounds source causes sound creation to fail silently. See https://playground.babylonjs.com/#C584K5 for an example.

This change makes streaming sound creation throw an error when given an invalid sound source.