### PR TITLE
Normalize particle direction in shader for billboardmode_stretchedlocal

### DIFF
--- a/packages/dev/core/src/Shaders/particles.vertex.fx
+++ b/packages/dev/core/src/Shaders/particles.vertex.fx
@@ -68,7 +68,7 @@ vec3 rotateAlign(vec3 toCamera, vec3 rotatedCorner) {
 	vec3 row2 = vec3(normalizedToCamera.x, normalizedToCamera.y, normalizedToCamera.z);
 
 #ifdef BILLBOARDSTRETCHED_LOCAL
-	vec3 row1 = direction;
+	vec3 row1 = normalize(direction);
 #else
 	vec3 crossProduct = normalize(cross(normalizedToCamera, normalizedCrossDirToCamera));
 	vec3 row1 = vec3(crossProduct.x, crossProduct.y, crossProduct.z);

--- a/packages/dev/core/src/ShadersWGSL/particles.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/particles.vertex.fx
@@ -68,7 +68,7 @@ fn rotateAlign(toCamera: vec3f, rotatedCorner: vec3f) -> vec3f {
 	var row2: vec3f =  vec3f(normalizedToCamera.x, normalizedToCamera.y, normalizedToCamera.z);
 
 #ifdef BILLBOARDSTRETCHED_LOCAL
-	var row1: vec3f = vertexInputs.direction;
+	var row1: vec3f = normalize(vertexInputs.direction);
 #else
 	var crossProduct: vec3f = normalize(cross(normalizedToCamera, normalizedCrossDirToCamera));
 	var row1: vec3f =  vec3f(crossProduct.x, crossProduct.y, crossProduct.z);


### PR DESCRIPTION
See this playground using stretched_local https://playground.babylonjs.com/?inspectorv2=true#0K3AQ2#3677 where the direction is not pre-normalized and causes unexpected super stretched particles 

This prevents against assuming pre-normalized direction 