### PR TITLE
Add ignoreBody filter for IRaycastQuery

### DIFF
--- a/packages/dev/core/src/Physics/physicsRaycastResult.ts
+++ b/packages/dev/core/src/Physics/physicsRaycastResult.ts
@@ -1,5 +1,6 @@
 import { Vector3 } from "../Maths/math.vector";
 import { CastingResult } from "./castingResult";
+import type { PhysicsBody } from "./v2/physicsBody";
 
 /**
  * Interface for query parameters in the raycast function.
@@ -12,6 +13,8 @@ export interface IRaycastQuery {
     collideWith?: number;
     /** Should trigger collisions be considered in the query? */
     shouldHitTriggers?: boolean;
+    /** Ignores the body passed if it is in the query */
+    ignoreBody?: PhysicsBody;
 }
 
 /**

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -2119,7 +2119,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
 
         result.reset(from, to);
 
-        const bodyToIgnore = [BigInt(0)];
+        const bodyToIgnore = query?.ignoreBody ? [BigInt(query.ignoreBody._pluginData.hpBodyId[0])] : [BigInt(0)];
         const hkQuery = [this._bVecToV3(from), this._bVecToV3(to), [queryMembership, queryCollideWith], shouldHitTriggers, bodyToIgnore];
         this._hknp.HP_World_CastRayWithCollector(this.world, this._queryCollector, hkQuery);
 


### PR DESCRIPTION
Forum post: https://forum.babylonjs.com/t/ignorebody-query-flag-for-iraycastquery/61276

This is mainly copied from the `shapeCast` function.

For future reference, are forum posts needed for feature requests with PRs like this, or only for issues?