### PR TITLE
Use the scaled Light intensity for the Atmosphere

### DIFF
--- a/packages/dev/addons/src/atmosphere/atmosphere.ts
+++ b/packages/dev/addons/src/atmosphere/atmosphere.ts
@@ -1334,7 +1334,7 @@ export class Atmosphere implements IDisposable {
         ubo.updateVector3("minMultiScattering", this._minimumMultiScattering);
         ubo.updateFloat("diffuseSkyIrradianceIntensity", this._diffuseSkyIrradianceIntensity);
         ubo.updateVector3("cameraPositionGlobal", cameraAtmosphereVariables.cameraPositionGlobal);
-        ubo.updateFloat("lightIntensity", this.lights[0].intensity);
+        ubo.updateFloat("lightIntensity", this.lights[0].getScaledIntensity());
         ubo.updateVector3("clampedCameraPositionGlobal", cameraAtmosphereVariables.clampedCameraPositionGlobal);
         ubo.updateFloat("aerialPerspectiveIntensity", this._aerialPerspectiveIntensity);
         ubo.updateVector3("cameraGeocentricNormal", cameraAtmosphereVariables.cameraGeocentricNormal);


### PR DESCRIPTION
In physically based scenes, one may specify DirectionalLight parameters for angular radius and an intensity in luminance or illuminance, depending on the intensityMode. To properly leverage this for the atmosphere, we need to read the scaled intensity instead.