### PR TITLE
math.vector.functions cleanup and additions

### DIFF
--- a/packages/dev/core/src/Maths/math.vector.functions.ts
+++ b/packages/dev/core/src/Maths/math.vector.functions.ts
@@ -1,8 +1,7 @@
 import { Clamp } from "./math.scalar.functions";
 import type { DeepImmutable } from "../types";
-import type { IVector2Like, IVector3Like } from "./math.like";
+import type { IQuaternionLike, IVector2Like, IVector3Like, IVector4Like } from "./math.like";
 import { Quaternion, Vector3 } from "./math.vector";
-import type { Vector4 } from "./math.vector";
 
 /**
  * Creates a string representation of the IVector2Like
@@ -20,10 +19,9 @@ export function Vector2ToFixed(vector: IVector2Like, decimalCount: number): stri
  * @param b defines the second vector
  * @returns the dot product
  */
-export function Vector3Dot<T extends IVector3Like, U extends IVector3Like>(a: DeepImmutable<T>, b: DeepImmutable<U>) {
+export function Vector3Dot(a: DeepImmutable<IVector3Like>, b: DeepImmutable<IVector3Like>): number {
     return a.x * b.x + a.y * b.y + a.z * b.z;
 }
-
 /**
  * Sets the given floats into the result.
  * @param x defines the x coordinate
@@ -46,7 +44,7 @@ export function Vector3FromFloatsToRef<T extends IVector3Like>(x: number, y: num
  * @param result defines the target vector
  * @returns the scaled vector
  */
-export function Vector3ScaleToRef<T extends IVector3Like, ResultT extends IVector3Like>(a: DeepImmutable<T>, scale: number, result: ResultT): ResultT {
+export function Vector3ScaleToRef<T extends IVector3Like>(a: DeepImmutable<IVector3Like>, scale: number, result: T): T {
     result.x = a.x * scale;
     result.y = a.y * scale;
     result.z = a.z * scale;
@@ -54,22 +52,45 @@ export function Vector3ScaleToRef<T extends IVector3Like, ResultT extends IVecto
 }
 
 /**
- * Creates a string representation of the Vector3
- * @param vector defines the Vector3 to stringify
- * @param decimalCount defines the number of decimals to use
- * @returns a string with the Vector3 coordinates.
+ * Scales the current vector values in place by a factor
+ * @param vector defines the vector to scale
+ * @param scale defines the scale factor
+ * @returns the input scaled vector
  */
-export function Vector3ToFixed(vector: Vector3, decimalCount: number): string {
-    return `{X: ${vector._x.toFixed(decimalCount)} Y: ${vector._y.toFixed(decimalCount)} Z: ${vector._z.toFixed(decimalCount)}}`;
+export function Vector3ScaleInPlace<T extends IVector3Like>(vector: T, scale: number): T {
+    vector.x *= scale;
+    vector.y *= scale;
+    vector.z *= scale;
+    return vector;
 }
 
 /**
- * Creates a string representation of the Vector4
- * @param vector defines the Vector4 to stringify
+ * Creates a string representation of the IVector3Like
+ * @param vector defines the IVector3Like to stringify
  * @param decimalCount defines the number of decimals to use
- * @returns a string with the Vector4 coordinates.
+ * @returns a string with the IVector3Like coordinates.
  */
-export function Vector4ToFixed(vector: Vector4, decimalCount: number): string {
+export function Vector3ToFixed(vector: DeepImmutable<IVector3Like>, decimalCount: number): string {
+    return `{X: ${vector.x.toFixed(decimalCount)} Y: ${vector.y.toFixed(decimalCount)} Z: ${vector.z.toFixed(decimalCount)}}`;
+}
+
+/**
+ * Computes the dot product of two IVector4Like objects
+ * @param a defines the first vector
+ * @param b defines the second vector
+ * @returns the dot product
+ */
+export function Vector4Dot(a: DeepImmutable<IVector4Like>, b: DeepImmutable<IVector4Like>): number {
+    return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+/**
+ * Creates a string representation of the IVector4Like
+ * @param vector defines the IVector4Like to stringify
+ * @param decimalCount defines the number of decimals to use
+ * @returns a string with the IVector4Like coordinates.
+ */
+export function Vector4ToFixed(vector: DeepImmutable<IVector4Like>, decimalCount: number): string {
     return `{X: ${vector.x.toFixed(decimalCount)} Y: ${vector.y.toFixed(decimalCount)} Z: ${vector.z.toFixed(decimalCount)} W: ${vector.w.toFixed(decimalCount)}}`;
 }
 
@@ -79,8 +100,8 @@ export function Vector4ToFixed(vector: Vector4, decimalCount: number): string {
  * @param q2 defines the second quaternion
  * @returns the angle in radians between the two quaternions
  */
-export function GetAngleBetweenQuaternions(q1: DeepImmutable<Quaternion>, q2: DeepImmutable<Quaternion>): number {
-    return Math.acos(Clamp(Quaternion.Dot(q1, q2))) * 2;
+export function GetAngleBetweenQuaternions(q1: DeepImmutable<IQuaternionLike>, q2: DeepImmutable<IQuaternionLike>): number {
+    return Math.acos(Clamp(Vector4Dot(q1, q2))) * 2;
 }
 
 /**


### PR DESCRIPTION
* Remove unnecessary usages of generic types on some params
* Add and use a new `Vector4Dot` in place of static `Quaternion.Dot`
* Add `Vector3ScaleInPlace`
* Use `IQuaternionLike`, `IVector3Like`, and `IVector4Like` interfaces for params instead of `Quaternion`, `Vector3`, and `Vector4`