### PR TITLE
Inspector: Add glTF export option for Draco

### DIFF
--- a/packages/dev/inspector-v2/src/components/tools/exportTools.tsx
+++ b/packages/dev/inspector-v2/src/components/tools/exportTools.tsx
@@ -111,6 +111,7 @@ interface IGltfExportOptionsState {
     exportSkyboxes: boolean;
     exportCameras: boolean;
     exportLights: boolean;
+    dracoCompression: boolean;
 }
 
 export const ExportGltfTools = MakeLazyComponent(async () => {
@@ -124,6 +125,7 @@ export const ExportGltfTools = MakeLazyComponent(async () => {
             exportSkyboxes: false,
             exportCameras: false,
             exportLights: false,
+            dracoCompression: false,
         });
 
         const exportGLTF = useCallback(async () => {
@@ -164,7 +166,10 @@ export const ExportGltfTools = MakeLazyComponent(async () => {
             };
 
             try {
-                const glb = await GLTF2Export.GLBAsync(props.scene, "scene", { shouldExportNode: (node) => shouldExport(node) });
+                const glb = await GLTF2Export.GLBAsync(props.scene, "scene", {
+                    meshCompressionMethod: gltfExportOptions.dracoCompression ? "Draco" : undefined,
+                    shouldExportNode: (node) => shouldExport(node),
+                });
                 glb.downloadFiles();
             } catch (reason) {
                 Logger.Error(`Failed to export GLB: ${reason}`);
@@ -202,6 +207,13 @@ export const ExportGltfTools = MakeLazyComponent(async () => {
                     description="Whether to export lights in the scene."
                     value={gltfExportOptions.exportLights}
                     onChange={(checked: boolean) => setGltfExportOptions({ ...gltfExportOptions, exportLights: checked })}
+                />
+                <SwitchPropertyLine
+                    key="GLTFDracoCompression"
+                    label="Draco Compression"
+                    description="Whether to apply Draco compression to geometry."
+                    value={gltfExportOptions.dracoCompression}
+                    onChange={(checked: boolean) => setGltfExportOptions({ ...gltfExportOptions, dracoCompression: checked })}
                 />
                 <ButtonLine label="Export to GLB" icon={ArrowDownloadRegular} onClick={exportGLTF} disabled={isExportingGltf} />
             </>

--- a/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
@@ -54,6 +54,7 @@ interface IGlbExportOptions {
     exportSkyboxes: boolean;
     exportCameras: boolean;
     exportLights: boolean;
+    dracoCompression: boolean;
 }
 
 export class ToolsTabComponent extends PaneComponent {
@@ -63,7 +64,7 @@ export class ToolsTabComponent extends PaneComponent {
     private _gifOptions = { width: 512, frequency: 200 };
     private _useWidthHeight = false;
     private _isExportingGltf = false;
-    private _gltfExportOptions: IGlbExportOptions = { exportDisabledNodes: false, exportSkyboxes: false, exportCameras: false, exportLights: false };
+    private _gltfExportOptions: IGlbExportOptions = { exportDisabledNodes: false, exportSkyboxes: false, exportCameras: false, exportLights: false, dracoCompression: false };
     private _gifWorkerBlob: Blob;
     private _gifRecorder: any;
     private _previousRenderingScale: number;
@@ -303,7 +304,10 @@ export class ToolsTabComponent extends PaneComponent {
             return true;
         };
 
-        GLTF2Export.GLBAsync(scene, "scene", { shouldExportNode: (node) => shouldExport(node) })
+        GLTF2Export.GLBAsync(scene, "scene", {
+            meshCompressionMethod: this._gltfExportOptions.dracoCompression ? "Draco" : undefined,
+            shouldExportNode: (node) => shouldExport(node),
+        })
             // eslint-disable-next-line github/no-then
             .then((glb: GLTFData) => {
                 this._isExportingGltf = false;
@@ -532,6 +536,11 @@ export class ToolsTabComponent extends PaneComponent {
                                 label="Export Lights"
                                 isSelected={() => this._gltfExportOptions.exportLights}
                                 onSelect={(value) => (this._gltfExportOptions.exportLights = value)}
+                            />
+                            <CheckBoxLineComponent
+                                label="Draco Compression"
+                                isSelected={() => this._gltfExportOptions.dracoCompression}
+                                onSelect={(value) => (this._gltfExportOptions.dracoCompression = value)}
                             />
                             <ButtonLineComponent label="Export to GLB" onClick={() => this.exportGLTF()} />
                         </>


### PR DESCRIPTION
From https://forum.babylonjs.com/t/implement-draco-compressed-glb-export-option-in-sandbox-inspector/52129. Because why not?! :)