### PR TITLE
[FloatingOrigin] Add support for Sprites

### DIFF
--- a/packages/dev/core/src/Sprites/spriteRenderer.ts
+++ b/packages/dev/core/src/Sprites/spriteRenderer.ts
@@ -344,6 +344,7 @@ export class SpriteRenderer {
 
         let offset = 0;
         let noSprite = true;
+        const floatingOriginOffset = this._scene?.floatingOriginOffset || Vector3.ZeroReadOnly;
         for (let index = 0; index < max; index++) {
             const sprite = sprites[index];
             if (!sprite || !sprite.isVisible) {
@@ -354,11 +355,11 @@ export class SpriteRenderer {
             sprite._animate(deltaTime);
             const baseSize = this.texture.getBaseSize(); // This could be change by the user inside the animate callback (like onAnimationEnd)
 
-            this._appendSpriteVertex(offset++, sprite, 0, 0, baseSize, useRightHandedSystem, customSpriteUpdate);
+            this._appendSpriteVertex(offset++, sprite, 0, 0, baseSize, useRightHandedSystem, customSpriteUpdate, floatingOriginOffset);
             if (!this._useInstancing) {
-                this._appendSpriteVertex(offset++, sprite, 1, 0, baseSize, useRightHandedSystem, customSpriteUpdate);
-                this._appendSpriteVertex(offset++, sprite, 1, 1, baseSize, useRightHandedSystem, customSpriteUpdate);
-                this._appendSpriteVertex(offset++, sprite, 0, 1, baseSize, useRightHandedSystem, customSpriteUpdate);
+                this._appendSpriteVertex(offset++, sprite, 1, 0, baseSize, useRightHandedSystem, customSpriteUpdate, floatingOriginOffset);
+                this._appendSpriteVertex(offset++, sprite, 1, 1, baseSize, useRightHandedSystem, customSpriteUpdate, floatingOriginOffset);
+                this._appendSpriteVertex(offset++, sprite, 0, 1, baseSize, useRightHandedSystem, customSpriteUpdate, floatingOriginOffset);
             }
         }
 
@@ -447,7 +448,8 @@ export class SpriteRenderer {
         offsetY: number,
         baseSize: ISize,
         useRightHandedSystem: boolean,
-        customSpriteUpdate: Nullable<(sprite: ThinSprite, baseSize: ISize) => void>
+        customSpriteUpdate: Nullable<(sprite: ThinSprite, baseSize: ISize) => void>,
+        floatingOriginOffset: Vector3
     ): void {
         let arrayOffset = index * this._vertexBufferSize;
 
@@ -479,7 +481,6 @@ export class SpriteRenderer {
         }
 
         // Positions
-        const floatingOriginOffset = this._scene?.floatingOriginOffset || Vector3.ZeroReadOnly;
         this._vertexData[arrayOffset] = sprite.position.x - floatingOriginOffset.x;
         this._vertexData[arrayOffset + 1] = sprite.position.y - floatingOriginOffset.y;
         this._vertexData[arrayOffset + 2] = sprite.position.z - floatingOriginOffset.z;


### PR DESCRIPTION
Offset sprites position in vertex buffer data (as sprites.vertex shader doesn't use world matrix)

https://playground.babylonjs.com/?snapshot=refs/pull/17406/merge#P3E9YP#287 