### PR TITLE
Add WebXR light estimation intensity factor

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRLightEstimation.ts
+++ b/packages/dev/core/src/XR/features/WebXRLightEstimation.ts
@@ -45,6 +45,10 @@ export interface IWebXRLightEstimationOptions {
      */
     createDirectionalLightSource?: boolean;
     /**
+     * The scale factor to multiply the intensity of the directional light by. Defaults to 1.0.
+     */
+    directionalLightIntensityFactor?: number;
+    /**
      * Define the format to be used for the light estimation texture.
      */
     reflectionFormat?: XRReflectionFormat;
@@ -133,6 +137,11 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
     public directionalLight: Nullable<DirectionalLight> = null;
 
     /**
+     * The scale factor to multiply the intensity of the directional light by. Defaults to 1.0.
+     */
+    public directionalLightIntensityFactor: number = 1.0;
+
+    /**
      * This observable will notify when the reflection cube map is updated.
      */
     public onReflectionCubeMapUpdatedObservable: Observable<BaseTexture> = new Observable();
@@ -159,6 +168,8 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
             this.directionalLight.intensity = 0;
             this.directionalLight.falloffType = LightConstants.FALLOFF_GLTF;
         }
+
+        this.directionalLightIntensityFactor = this.options.directionalLightIntensityFactor ?? 1.0;
 
         this._hdrFilter = new HDRFiltering(this._xrSessionManager.scene.getEngine() as ThinEngine);
 
@@ -390,7 +401,7 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
                 // set the values after calculating them
                 if (this.directionalLight) {
                     this.directionalLight.direction.copyFrom(this._lightDirection);
-                    this.directionalLight.intensity = Math.min(this._intensity, 1.0);
+                    this.directionalLight.intensity = Math.min(this._intensity, 1.0) * this.directionalLightIntensityFactor;
                     this.directionalLight.diffuse.copyFrom(this._lightColor);
                 }
             }


### PR DESCRIPTION
The WebXR light estimation directional light's intensity is set directly from the intensity returned by the device's XR implementation, which is too light or dark for some applications.

This change adds a `directionalLightIntensityFactor` setting to the `WebXRLightEstimation` feature to adjust the directional light's as needed.