### PR TITLE
Fix WebXR pick bug

### DIFF
--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -128,6 +128,11 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
         scene.onDisposeObservable.addOnce(() => {
             this.dispose();
         });
+
+        this.onXRSessionEnded.add(() => {
+            // Set the scene's pointer camera to null to stop the XR camera being used for picking.
+            scene.cameraToUseForPointers = null;
+        });
     }
 
     /**


### PR DESCRIPTION
After exiting a WebXR session, mesh picks fail because the scene continues using the XR camera for picking, even though the active camera is set back to the scene's flatscreen camera.

This change fixes the issue by resetting the scene's picking camera when the WebXR session ends.