### PR TITLE
[FloatingOrigin] Add support for node material blocks

### DIFF
--- a/packages/dev/core/src/Materials/floatingOriginMatrixOverrides.ts
+++ b/packages/dev/core/src/Materials/floatingOriginMatrixOverrides.ts
@@ -157,19 +157,19 @@ function GetOffsetMatrix(uniformName: string, mat: IMatrixLike): IMatrixLike {
             // Node material blocks uniforms are formatted u_BlockName, with trailing numbers if there are multiple blocks of the same name
             // Check u_ first so that we can early out for non-node material uniforms
             if (uniformName.startsWith("u_")) {
-                if (uniformName.includes("WorldViewProjection")) {
+                if (uniformName.startsWith("u_WorldViewProjection")) {
                     return OffsetWorldViewProjectionToRef(offset, mat, scene.getTransformMatrix(), scene.getViewMatrix(), scene.getProjectionMatrix(), TempFinalMat);
                 }
-                if (uniformName.includes("ViewProjection")) {
+                if (uniformName.startsWith("u_ViewProjection")) {
                     return OffsetViewProjectionToRef(offset, scene.getViewMatrix(), scene.getProjectionMatrix(), TempFinalMat);
                 }
-                if (uniformName.includes("WorldView")) {
+                if (uniformName.startsWith("u_WorldView")) {
                     return OffsetWorldViewToRef(offset, mat, scene.getViewMatrix(), TempFinalMat);
                 }
-                if (uniformName.includes("World")) {
+                if (uniformName.startsWith("u_World")) {
                     return OffsetWorldToRef(offset, mat, TempFinalMat);
                 }
-                if (uniformName.includes("View")) {
+                if (uniformName.startsWith("u_View")) {
                     return OffsetViewToRef(offset, mat, TempFinalMat);
                 }
             }


### PR DESCRIPTION
NodeMaterials have slightly different uniform names, using u_BlockNameX

<img width="394" height="187" alt="image" src="https://github.com/user-attachments/assets/cf254e65-e78e-4c63-b5a1-dfc7ef18d2cf" />

Note in future if we optimize node material blocks to use same uniform name if same block is used, we can replace includes with === u_Foo

Tested with /#D8AK3Z#130 and /#D8AK3Z#129
See forum post https://forum.babylonjs.com/t/large-world-rendering-has-issues-with-nme-specular-lighting/61375/3