### PR TITLE
WebGPU: Fix updating compressed textures

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -1391,4 +1391,3 @@ export class WebGPUTextureManager {
         this._deferredReleaseTextures.length = 0;
     }
 }
-


### PR DESCRIPTION
See https://forum.babylonjs.com/t/compressed-textures-array-doesnt-work-with-webgpu/61410.