### PR TITLE
Inspector v2: Prevent double inspectors, actually track inspector dispose tokens, and make sure AnimationGroup.dispose fires observable

### DIFF
--- a/packages/dev/core/src/Animations/animationGroup.ts
+++ b/packages/dev/core/src/Animations/animationGroup.ts
@@ -907,11 +907,7 @@ export class AnimationGroup implements IDisposable {
         this._animatables.length = 0;
 
         // Remove from scene
-        const index = this._scene.animationGroups.indexOf(this);
-
-        if (index > -1) {
-            this._scene.animationGroups.splice(index, 1);
-        }
+        this._scene.removeAnimationGroup(this);
 
         if (this._parentContainer) {
             const index = this._parentContainer.animationGroups.indexOf(this);

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -99,6 +99,8 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
         InspectorTokens.delete(scene);
     }
 
+    InspectorTokens.set(scene, inspectorToken);
+
     const disposeActions: (() => void)[] = [];
 
     const canvasContainerDisplay = parentElement.style.display;

--- a/packages/tools/sandbox/src/globalState.ts
+++ b/packages/tools/sandbox/src/globalState.ts
@@ -42,36 +42,40 @@ export class GlobalState {
     }
 
     public showDebugLayer() {
-        this.isDebugLayerEnabled = true;
-        if (this.currentScene) {
-            if (this._isInspectorV2ModeRequested && !this._isInspectorV2ModeEnabled) {
-                alert("Inspector v2 is only supported with the latest version of Babylon.js at this time. Falling back to Inspector V1.");
-            }
+        if (!this.isDebugLayerEnabled) {
+            this.isDebugLayerEnabled = true;
+            if (this.currentScene) {
+                if (this._isInspectorV2ModeRequested && !this._isInspectorV2ModeEnabled) {
+                    alert("Inspector v2 is only supported with the latest version of Babylon.js at this time. Falling back to Inspector V1.");
+                }
 
-            if (!this._isInspectorV2ModeEnabled) {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                this.currentScene.debugLayer.show();
-            } else {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                (async () => {
-                    const inspectorV2Module = await ImportInspectorV2();
-                    inspectorV2Module.Inspector.Show(this.currentScene, {});
-                })();
+                if (!this._isInspectorV2ModeEnabled) {
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    this.currentScene.debugLayer.show();
+                } else {
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    (async () => {
+                        const inspectorV2Module = await ImportInspectorV2();
+                        inspectorV2Module.Inspector.Show(this.currentScene, {});
+                    })();
+                }
             }
         }
     }
 
     public hideDebugLayer() {
-        this.isDebugLayerEnabled = false;
-        if (this.currentScene) {
-            if (!this._isInspectorV2ModeEnabled) {
-                this.currentScene.debugLayer.hide();
-            } else {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                (async () => {
-                    const inspectorV2Module = await ImportInspectorV2();
-                    inspectorV2Module.Inspector.Hide();
-                })();
+        if (this.isDebugLayerEnabled) {
+            this.isDebugLayerEnabled = false;
+            if (this.currentScene) {
+                if (!this._isInspectorV2ModeEnabled) {
+                    this.currentScene.debugLayer.hide();
+                } else {
+                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                    (async () => {
+                        const inspectorV2Module = await ImportInspectorV2();
+                        inspectorV2Module.Inspector.Hide();
+                    })();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR has 3 fixes addressing 2 bugs reported by users:
1. Add a guard in Sandbox to make a call to show inspector a no-op if it is already shown.
2. Actually track the inspector dispose tokens in Inspector v2 (it has a map, but somehow the final iteration of my earlier changes did not actually add the inspector dispose tokens to the map 🤦🏻‍♂️).
3. Fix a bug in AnimationGroup that is unrelated to Inspector v2 but that is one place where you can see the bug. Specifically, the AnimationGroup dispose function just removes the AnimationGroup from the scene, it does not call the removeAnimationGroup function and therefore the associated observable does not actually fire. In Inspector v2, this means it stays in scene explorer even after being disposed.