### PR TITLE
Fix 2D GUI jitter on high DPI screens

### DIFF
--- a/packages/dev/gui/src/2D/controls/control.ts
+++ b/packages/dev/gui/src/2D/controls/control.ts
@@ -1974,12 +1974,6 @@ export class Control implements IAnimatable, IFocusableControl {
 
         this._computeAlignment(this._tempPaddingMeasure, context);
 
-        // Convert to int values
-        // this._currentMeasure.left = this._currentMeasure.left | 0;
-        // this._currentMeasure.top = this._currentMeasure.top | 0;
-        // this._currentMeasure.width = this._currentMeasure.width | 0;
-        // this._currentMeasure.height = this._currentMeasure.height | 0;
-
         // Let children add more features
         this._additionalProcessing(this._tempPaddingMeasure, context);
 

--- a/packages/dev/gui/src/2D/controls/rectangle.ts
+++ b/packages/dev/gui/src/2D/controls/rectangle.ts
@@ -181,18 +181,6 @@ export class Rectangle extends Container {
                     this._currentMeasure.width - this._thickness,
                     this._currentMeasure.height - this._thickness
                 );
-                // eslint-disable-next-line no-console
-                console.log(
-                    "strokeRect - ",
-                    "left: ",
-                    this._currentMeasure.left + this._thickness / 2,
-                    "top: ",
-                    this._currentMeasure.top + this._thickness / 2,
-                    "width: ",
-                    this._currentMeasure.width - this._thickness,
-                    "height: ",
-                    this._currentMeasure.height - this._thickness
-                );
             }
         }
 


### PR DESCRIPTION
On high DPI screens, we can see fractional pixels in the logical (CSS) pixel space. For example, consider a 150x150 pixel screen at 150% scaling - the logical pixel space will be 100x100.  Note that pointer events happen at the granularity of the physical display, but the position is in the logical space, so the mouse moves by 2/3 of a unit at a time.  If we continue truncating fractional values, we lose information which leads to intermittent off-by-one issues and jitter.

In this playground, you can see the jitter when dragging from a point on the screen up and left before the fix, with no jitter after the fix: https://playground.babylonjs.com/#9V23FW#3