### PR TITLE
Fixed using instanced VAT in ShaderMaterial

### DIFF
--- a/packages/dev/core/src/Materials/shaderMaterial.ts
+++ b/packages/dev/core/src/Materials/shaderMaterial.ts
@@ -29,7 +29,6 @@ import {
     BindLogDepth,
     BindMorphTargetParameters,
     BindSceneUniformBuffer,
-    PrepareAttributesForBakedVertexAnimation,
     PrepareDefinesAndAttributesForMorphTargets,
     PushAttributesForInstances,
 } from "./materialHelper.functions";


### PR DESCRIPTION
This PR resolves the issue https://forum.babylonjs.com/t/missing-doc-for-gpupicker-in-v8-31-3/61295/8

I noticed that `PrepareAttributesForBakedVertexAnimation` does not function correctly in `ShaderMaterial`. The reason is as follows:

https://github.com/BabylonJS/Babylon.js/blob/master/packages/dev/core/src/Materials/materialHelper.functions.ts#L415
```
const enabled = defines["BAKED_VERTEX_ANIMATION_TEXTURE"] && defines["INSTANCES"];

if (enabled) {
    attribs.push("bakedVertexAnimationSettingsInstanced");
}
```

`PrepareAttributesForBakedVertexAnimation` checks whether `BAKED_VERTEX_ANIMATION_TEXTURE` and `INSTANCES` exist in the defines to determine whether to add the `bakedVertexAnimationSettingsInstanced` attribute to the list.

However, `ShaderMaterial` stores the define list as a sequence of `“#define DEFINENAME”` entries, causing it to fail this test.

<img width="847" height="379" alt="image" src="https://github.com/user-attachments/assets/36c2d576-334e-4486-8786-d92f8637f7d0" />
This is what it actually looks like when executed on the `ShaderMaterial` in the Edge debugger.

Therefore, I specialized this logic to suit `ShaderMaterial`.

This approach was chosen based on the observation that specialization had already been performed in the logic for assigning Bone's Define and Attribute within `ShaderMaterial`.