### PR TITLE
Inspector v2: Back compat for contextMenu v1 option

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -628,7 +628,7 @@ const EntityTreeItem: FunctionComponent<{
 
 export const SceneExplorer: FunctionComponent<{
     sections: readonly SceneExplorerSection<EntityBase>[];
-    commandProviders: readonly SceneExplorerCommandProvider<EntityBase>[];
+    entityCommandProviders: readonly SceneExplorerCommandProvider<EntityBase>[];
     sectionCommandProviders: readonly SceneExplorerCommandProvider<string, "contextMenu">[];
     scene: Scene;
     selectedEntity?: unknown;
@@ -636,7 +636,7 @@ export const SceneExplorer: FunctionComponent<{
 }> = (props) => {
     const classes = useStyles();
 
-    const { sections, commandProviders, sectionCommandProviders, scene, selectedEntity } = props;
+    const { sections, entityCommandProviders, sectionCommandProviders, scene, selectedEntity } = props;
 
     const [openItems, setOpenItems] = useState(new Set<TreeItemValue>());
     const [sceneVersion, setSceneVersion] = useState(0);
@@ -969,7 +969,7 @@ export const SceneExplorer: FunctionComponent<{
                                     isSelected={selectedEntity === item.entity}
                                     select={() => setSelectedEntity?.(item.entity)}
                                     isFiltering={!!itemsFilter}
-                                    commandProviders={commandProviders}
+                                    commandProviders={entityCommandProviders}
                                     expandAll={() => expandAll(item)}
                                     collapseAll={() => collapseAll(item)}
                                 />

--- a/packages/dev/inspector-v2/src/legacy/inspector.tsx
+++ b/packages/dev/inspector-v2/src/legacy/inspector.tsx
@@ -147,7 +147,7 @@ export function ConvertOptions(v1Options: Partial<InspectorV1Options>): Partial<
             factory: (sceneExplorerService) => {
                 const sceneExplorerCommandRegistrations = explorerExtensibility.flatMap((command) =>
                     command.entries.map((entry) =>
-                        sceneExplorerService.addCommand({
+                        sceneExplorerService.addEntityCommand({
                             predicate: (entity): entity is EntityBase => command.predicate(entity),
                             getCommand: (entity) => {
                                 return {

--- a/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
@@ -53,7 +53,7 @@ export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISc
             getEntityRemovedObservables: () => [scene.onAnimationGroupRemovedObservable],
         });
 
-        const animationPlayPauseCommandRegistration = sceneExplorerService.addCommand({
+        const animationPlayPauseCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown) => entity instanceof AnimationGroup,
             order: DefaultCommandsOrder.AnimationGroupPlay,
             getCommand: (animationGroup) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -49,7 +49,7 @@ export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
             getEntityRemovedObservables: () => [scene.onFrameGraphRemovedObservable],
         });
 
-        const activeFrameGraphCommandRegistration = sceneExplorerService.addCommand({
+        const activeFrameGraphCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown) => entity instanceof FrameGraph,
             order: DefaultCommandsOrder.FrameGraphPlay,
             getCommand: (frameGraph) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -100,7 +100,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             getEntityMovedObservables: () => [nodeMovedObservable],
         });
 
-        const abstractMeshBoundingBoxCommandRegistration = sceneExplorerService.addCommand({
+        const abstractMeshBoundingBoxCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown): entity is AbstractMesh => entity instanceof AbstractMesh && entity.getTotalVertices() > 0,
             order: DefaultCommandsOrder.MeshBoundingBox,
             getCommand: (mesh) => {
@@ -130,7 +130,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             },
         });
 
-        const abstractMeshVisibilityCommandRegistration = sceneExplorerService.addCommand({
+        const abstractMeshVisibilityCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown): entity is AbstractMesh => entity instanceof AbstractMesh && entity.getTotalVertices() > 0,
             order: DefaultCommandsOrder.MeshVisibility,
             getCommand: (mesh) => {
@@ -160,7 +160,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             },
         });
 
-        const activeCameraCommandRegistration = sceneExplorerService.addCommand({
+        const activeCameraCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown) => entity instanceof Camera,
             order: DefaultCommandsOrder.CameraActive,
             getCommand: (camera) => {
@@ -194,7 +194,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
         });
 
         function addGizmoCommand<NodeT extends Node>(nodeClass: abstract new (...args: any[]) => NodeT, getGizmoRef: (node: NodeT) => IDisposable) {
-            return sceneExplorerService.addCommand({
+            return sceneExplorerService.addEntityCommand({
                 predicate: (entity: unknown): entity is NodeT => entity instanceof nodeClass,
                 order: DefaultCommandsOrder.GizmoActive,
                 getCommand: (node) => {
@@ -236,7 +236,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
 
         const cameraGizmoCommandRegistration = addGizmoCommand(Camera, gizmoService.getCameraGizmo.bind(gizmoService));
 
-        const lightEnabledCommandRegistration = sceneExplorerService.addCommand({
+        const lightEnabledCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown): entity is Light => entity instanceof Light,
             order: DefaultCommandsOrder.LightActive,
             getCommand: (light) => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
@@ -31,7 +31,7 @@ export interface ISceneExplorerService extends IService<typeof SceneExplorerServ
      * Adds a new command (e.g. "Delete", "Rename", etc.) that can be executed on entities in the scene explorer.
      * @param command A description of the command to add.
      */
-    addCommand<T extends EntityBase>(command: SceneExplorerCommandProvider<T>): IDisposable;
+    addEntityCommand<T extends EntityBase>(command: SceneExplorerCommandProvider<T>): IDisposable;
 
     /**
      * Adds a new command that can be executed on sections in the scene explorer.
@@ -49,7 +49,7 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
     consumes: [SceneContextIdentity, ShellServiceIdentity, SelectionServiceIdentity],
     factory: (sceneContext, shellService, selectionService) => {
         const sectionsCollection = new ObservableCollection<SceneExplorerSection<EntityBase>>();
-        const commandsCollection = new ObservableCollection<SceneExplorerCommandProvider<EntityBase>>();
+        const entityCommandsCollection = new ObservableCollection<SceneExplorerCommandProvider<EntityBase>>();
         const sectionCommandsCollection = new ObservableCollection<SceneExplorerCommandProvider<string, "contextMenu">>();
 
         const registration = shellService.addSidePane({
@@ -61,7 +61,7 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
             suppressTeachingMoment: true,
             content: () => {
                 const sections = useOrderedObservableCollection(sectionsCollection);
-                const commands = useOrderedObservableCollection(commandsCollection);
+                const entityCommands = useOrderedObservableCollection(entityCommandsCollection);
                 const sectionCommands = useOrderedObservableCollection(sectionCommandsCollection);
                 const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
                 const entity = useObservableState(() => selectionService.selectedEntity, selectionService.onSelectedEntityChanged);
@@ -71,7 +71,7 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
                         {scene && (
                             <SceneExplorer
                                 sections={sections}
-                                commandProviders={commands}
+                                entityCommandProviders={entityCommands}
                                 sectionCommandProviders={sectionCommands}
                                 scene={scene}
                                 selectedEntity={entity}
@@ -85,7 +85,7 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
 
         return {
             addSection: (section) => sectionsCollection.add(section as SceneExplorerSection<EntityBase>),
-            addCommand: (command) => commandsCollection.add(command as SceneExplorerCommandProvider<EntityBase>),
+            addEntityCommand: (command) => entityCommandsCollection.add(command as SceneExplorerCommandProvider<EntityBase>),
             addSectionCommand: (command) => sectionCommandsCollection.add(command as unknown as SceneExplorerCommandProvider<string, "contextMenu">),
             dispose: () => registration.dispose(),
         };

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -52,7 +52,7 @@ export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISce
             getEntityRemovedObservables: () => [scene.onSpriteManagerRemovedObservable],
         });
 
-        const spritePlayStopCommandRegistration = sceneExplorerService.addCommand({
+        const spritePlayStopCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown) => entity instanceof Sprite,
             order: DefaultCommandsOrder.SpritePlay,
             getCommand: (sprite) => {


### PR DESCRIPTION
Prior to this PR, Inspector v2 supports scene explorer commands on entities only (individual meshes, transform nodes, textures, materials, etc.) but not on sections (Nodes, Textures, Materials, etc.). This PR renames `addCommand` to `addEntityCommand` and then adds an `addSectionCommand`. This re-uses all the existing Inspector v2 scene explorer command infrastructure, just with different constraints (for now, section commands are context menu only for simplicity).

With this in place, the Inspector v1 `contextMenu` option is simply adding section commands of type "action" with no icon.
<img width="361" height="324" alt="image" src="https://github.com/user-attachments/assets/c2f68041-534c-44e8-9062-71d5cc9ac8e3" />
