### PR TITLE
GeospatialCamera flyToPoint will calculate new center

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
@@ -84,12 +84,9 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
     }
 
     public override onDoubleTap(type: string): void {
-        const scene = this.camera.getScene();
-        const pickResult = scene.pick(scene.pointerX, scene.pointerY, this.camera.pickPredicate);
-
-        if (pickResult.hit && pickResult.pickedPoint) {
-            const newRadius = this.camera.radius * 0.5; // Zoom to 50% of current distance
-            void this.camera.flyToAsync(undefined, undefined, newRadius, pickResult.pickedPoint);
+        const pickResult = this.camera._scene.pick(this.camera._scene.pointerX, this.camera._scene.pointerY, this.camera.pickPredicate);
+        if (pickResult.pickedPoint) {
+            void this.camera.flyToPointAsync(pickResult.pickedPoint);
         }
     }
 


### PR DESCRIPTION
DoubleTap to zoom was assuming the pickedPoint was the new center which is not correct. This change exposes a new flyToPoint function which internally calculates the new center (using same logic as zoomToCursor) and flies towards new point by the given radius scale%

#17451 