### PR TITLE
Fix: Prevent convertToFlatShadedMesh from mutating original indices

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -3426,7 +3426,7 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 
     private _convertToUnIndexedMesh(flattenNormals: boolean = false): Mesh {
         const kinds = this.getVerticesDataKinds().filter((kind) => !this.getVertexBuffer(kind)?.getIsInstanced());
-        const indices = this.getIndices()!;
+        const indices = this.getIndices(false, true)!;
         const data: { [kind: string]: FloatArray } = {};
 
         const separateVertices = (data: FloatArray, size: number): Float32Array => {


### PR DESCRIPTION
- Changed getIndices() to getIndices(false, true) to force array copy
- Prevents mutation of shared vertex data indices array
- Fixes issue preventing vertexData reuse across multiple meshes
- Also fixes the same bug in convertToUnIndexedMesh()

Forum discussion: https://forum.babylonjs.com/t/mesh-converttoflatshadedmesh-mutates-vertex-indices/61473