### PR TITLE
Silence webpack performance warnings/hints

### DIFF
--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -240,6 +240,9 @@ export const commonDevWebpackConfiguration = (
               }
             : undefined,
         plugins,
+        performance: {
+            hints: false,
+        },
     };
 };
 
@@ -367,6 +370,9 @@ export const commonUMDWebpackConfiguration = (options: {
                 includeCSS: true,
                 mode: options.mode || "development",
             }),
+        },
+        performance: {
+            hints: false,
         },
         ...options.extendedWebpackConfig,
     } as Configuration;


### PR DESCRIPTION
Turns off webpack warnings like:
```
WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
```