### PR TITLE
Fix monaco-editor sourcemap errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
                 "lerna": "^9.0.1",
                 "mini-css-extract-plugin": "~2.6.0",
                 "nx": "^18.0.4",
+                "patch-package": "^8.0.1",
                 "prettier": "^3.0.3",
                 "rimraf": "~6.0.1",
                 "ts-jest": "~29.1.0",
@@ -14403,6 +14404,13 @@
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
         },
+        "node_modules/dompurify": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+            "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+            "dev": true,
+            "license": "(MPL-2.0 OR Apache-2.0)"
+        },
         "node_modules/domutils": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -16188,6 +16196,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "micromatch": "^4.0.2"
             }
         },
         "node_modules/flat": {
@@ -20187,6 +20205,26 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
+        "node_modules/json-stable-stringify": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -20237,6 +20275,16 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true,
+            "license": "Public Domain",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/jsonparse": {
@@ -20317,6 +20365,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.11"
             }
         },
         "node_modules/kleur": {
@@ -21780,6 +21838,19 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/marked": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+            "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -22527,12 +22598,14 @@
             }
         },
         "node_modules/monaco-editor": {
-            "version": "0.53.0",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.53.0.tgz",
-            "integrity": "sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==",
+            "version": "0.54.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
+            "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/trusted-types": "^1.0.6"
+                "dompurify": "3.1.7",
+                "marked": "14.0.0"
             }
         },
         "node_modules/monaco-editor-webpack-plugin": {
@@ -22547,12 +22620,6 @@
                 "monaco-editor": ">= 0.31.0",
                 "webpack": "^4.5.0 || 5.x"
             }
-        },
-        "node_modules/monaco-editor/node_modules/@types/trusted-types": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-            "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-            "dev": true
         },
         "node_modules/mrmime": {
             "version": "2.0.1",
@@ -24836,6 +24903,92 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/patch-package": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+            "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^4.1.2",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^10.0.0",
+                "json-stable-stringify": "^1.0.2",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.6",
+                "open": "^7.4.2",
+                "semver": "^7.5.3",
+                "slash": "^2.0.0",
+                "tmp": "^0.2.4",
+                "yaml": "^2.2.2"
+            },
+            "bin": {
+                "patch-package": "index.js"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">5"
+            }
+        },
+        "node_modules/patch-package/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/patch-package/node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/patch-package/node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/patch-package/node_modules/slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/path-exists": {
@@ -32236,7 +32389,7 @@
                 "file-loader": "^6.2.0",
                 "html-webpack-plugin": "^5.4.0",
                 "mini-css-extract-plugin": "^2.4.3",
-                "monaco-editor": "^0.53.0",
+                "monaco-editor": "^0.54.0",
                 "monaco-editor-webpack-plugin": "^7.1.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "lerna": "^9.0.1",
         "mini-css-extract-plugin": "~2.6.0",
         "nx": "^18.0.4",
+        "patch-package": "^8.0.1",
         "prettier": "^3.0.3",
         "rimraf": "~6.0.1",
         "ts-jest": "~29.1.0",
@@ -61,6 +62,7 @@
         "packages/**/*"
     ],
     "scripts": {
+        "postinstall": "patch-package",
         "build:dev": "npm run build:assets && npm run build:source && npm run build:declaration -w @tools/babylon-server",
         "build:lts": "npm run build:assets && npm run build:source:lts",
         "build:source": "tsc -b ./tsconfig.devpackages.json",

--- a/packages/tools/playground/package.json
+++ b/packages/tools/playground/package.json
@@ -27,7 +27,7 @@
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.4.0",
         "mini-css-extract-plugin": "^2.4.3",
-        "monaco-editor": "^0.53.0",
+        "monaco-editor": "^0.54.0",
         "monaco-editor-webpack-plugin": "^7.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/patches/monaco-editor+0.54.0.patch
+++ b/patches/monaco-editor+0.54.0.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/monaco-editor/esm/vs/base/browser/dompurify/dompurify.js b/node_modules/monaco-editor/esm/vs/base/browser/dompurify/dompurify.js
+index af10243..b06a048 100644
+--- a/node_modules/monaco-editor/esm/vs/base/browser/dompurify/dompurify.js
++++ b/node_modules/monaco-editor/esm/vs/base/browser/dompurify/dompurify.js
+@@ -1551,4 +1551,3 @@ function createDOMPurify() {
+ var purify = createDOMPurify();
+ 
+ export { purify as default };
+-//# sourceMappingURL=purify.es.mjs.map
+\ No newline at end of file
+diff --git a/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js b/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js
+index b7b6ecc..ea54625 100644
+--- a/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js
++++ b/node_modules/monaco-editor/esm/vs/base/common/marked/marked.js
+@@ -2479,4 +2479,3 @@ const parser = _Parser.parse;
+ const lexer = _Lexer.lex;
+ 
+ export { _Hooks as Hooks, _Lexer as Lexer, Marked, _Parser as Parser, _Renderer as Renderer, _TextRenderer as TextRenderer, _Tokenizer as Tokenizer, _defaults as defaults, _getDefaults as getDefaults, lexer, marked, options, parse, parseInline, parser, setOptions, use, walkTokens };
+-//# sourceMappingURL=marked.esm.js.map


### PR DESCRIPTION
With the new playground, the monaco editor package has errors due to missing sourcemaps. There is no fix for this in the upstream monaco-editor package repo, yet, so this change fixes the issue using patch-package to remove the sourcemap directives from the monaco-editor package after `npm install`.

See https://github.com/microsoft/monaco-editor/issues/4712.