### PR TITLE
Inspector v2: Back compat for Inspector.MarkLineContainerTitleForHighlighting

### DIFF
--- a/packages/dev/inspector-v2/src/legacy/debugLayer.ts
+++ b/packages/dev/inspector-v2/src/legacy/debugLayer.ts
@@ -24,6 +24,7 @@ class DebugLayerEx extends DebugLayer {
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     override async show(config?: IInspectorOptions): Promise<DebugLayer> {
+        // If a custom inspector URL is not provided, default to a lazy dynamic import of the inspector module.
         if (!config?.inspectorURL) {
             this.BJSINSPECTOR = await LazyInspectorModule.value;
         }

--- a/packages/dev/inspector-v2/src/legacy/propertiesSectionMapping.ts
+++ b/packages/dev/inspector-v2/src/legacy/propertiesSectionMapping.ts
@@ -1,0 +1,139 @@
+// Mappings for Inspector v1 property section names to Inspector v2 section names.
+export const LegacyPropertiesSectionMapping = {
+    // Common sections
+    ["GENERAL"]: "General",
+    ["CUSTOM"]: "Custom",
+    ["COMMANDS"]: "Commands",
+    ["DEBUG"]: "Debug",
+    ["ADVANCED"]: "Advanced",
+    ["PROPERTIES"]: "Properties",
+
+    // Transform sections
+    ["TRANSFORMATIONS"]: "Transform",
+    ["TRANSFORMS"]: "Transform",
+    ["TRANSFORM"]: "Transform",
+
+    // Animation sections
+    ["ANIMATION"]: "Animation",
+    ["ANIMATION RANGES"]: "Animation Ranges",
+    ["ANIMATIONS"]: "Animation",
+    ["ANIMATION GENERAL CONTROL"]: "Animation Control",
+    ["CONTROLS"]: "Control",
+    ["INFOS"]: "Info",
+
+    // Camera sections
+    ["COLLISIONS"]: "Collision",
+    ["LIMITS"]: "Limits",
+    ["BEHAVIORS"]: "Behaviors",
+
+    // Material sections
+    ["TRANSPARENCY"]: "Transparency",
+    ["STENCIL"]: "Stencil",
+    ["STENCIL - FRONT"]: "Stencil Front",
+    ["STENCIL - BACK"]: "Stencil Back",
+    ["TEXTURES"]: "Textures",
+    ["LIGHTING & COLORS"]: "Lighting & Colors",
+    ["LEVELS"]: "Levels",
+    ["NORMAL MAP"]: "Normal Map",
+    ["RENDERING"]: "Rendering",
+    ["CHANNELS"]: "Channels",
+
+    // PBR Material sections
+    ["METALLIC WORKFLOW"]: "Metallic Workflow",
+    ["CLEAR COAT"]: "Clear Coat",
+    ["IRIDESCENCE"]: "Iridescence",
+    ["ANISOTROPIC"]: "Anisotropic",
+    ["SHEEN"]: "Sheen",
+    ["SUBSURFACE"]: "Subsurface",
+
+    // OpenPBR Material sections
+    ["BASE"]: "Base",
+    ["SPECULAR"]: "Specular",
+    ["COAT"]: "Coat",
+    ["FUZZ"]: "Fuzz",
+    ["EMISSION"]: "Emission",
+    ["THIN FILM"]: "Thin Film",
+    ["GEOMETRY"]: "Geometry",
+
+    // Sky Material
+    ["SKY"]: "Sky",
+
+    // Multi Material
+    ["CHILDREN"]: "Children",
+
+    // Mesh sections
+    ["DISPLAY"]: "Display",
+    ["DISPLAY OPTIONS"]: "Display Options",
+    ["NODE GEOMETRY"]: "Node Geometry",
+    ["MORPH TARGETS"]: "Morph Targets",
+    ["PHYSICS"]: "Physics",
+    ["OCCLUSIONS"]: "Occlusions",
+    ["EDGE RENDERING"]: "Edge Rendering",
+    ["OUTLINE & OVERLAY"]: "Outlines & Overlays",
+
+    // Light sections
+    ["SETUP"]: "Setup",
+    ["SHADOWS"]: "Shadows",
+    ["SHADOW GENERATOR"]: "Shadow Generator",
+
+    // Particle System sections
+    ["NODE PARTICLE EDITOR"]: "Node Particle Editor",
+    ["FILE"]: "File",
+    ["SNIPPET"]: "Snippet",
+    ["ATTRACTORS"]: "Attractors",
+    ["IMPOSTORS"]: "Impostors",
+    ["EMITTER"]: "Emitter",
+    ["SIZE"]: "Size",
+    ["LIFETIME"]: "Lifetime",
+    ["COLORS"]: "Color",
+    ["ROTATION"]: "Rotation",
+    ["SPRITESHEET"]: "Spritesheet",
+
+    // Sprite sections
+    ["CELLS"]: "Cells",
+    ["CELL"]: "Cell",
+    ["SCALE"]: "Scale",
+
+    // Post Process sections
+    ["CONFIGURATION"]: "Configuration",
+    ["BLOOM"]: "Bloom",
+    ["CHROMATIC ABERRATION"]: "Chromatic Aberration",
+    ["DEPTH OF FIELD"]: "Depth of Field",
+    ["FXAA"]: "FXAA",
+    ["GLOW LAYER"]: "Glow Layer",
+    ["GRAIN"]: "Grain",
+    ["IMAGE PROCESSING"]: "Image Processing",
+    ["SHARPEN"]: "Sharpen",
+    ["OPTIONS"]: "Options",
+    ["SSAO"]: "SSAO",
+    ["Denoiser"]: "Denoiser",
+    ["SSR"]: "SSR",
+    ["Voxel Shadows"]: "Voxel Shadows",
+    ["Screenspace Shadows"]: "Screenspace Shadows",
+    ["Automatic thickness computation"]: "Automatic Thickness Computation",
+    ["Blur"]: "Blur",
+    ["Attenuations"]: "Attenuations",
+    ["Color space"]: "Color Space",
+
+    // Scene sections
+    ["RENDERING MODE"]: "Rendering",
+    ["ENVIRONMENT"]: "Environment",
+    ["MATERIAL IMAGE PROCESSING"]: "Material Image Processing",
+
+    // Texture sections
+    ["PREVIEW"]: "Preview",
+    ["ADVANCED TEXTURE PROPERTIES"]: "Advanced Texture Properties",
+
+    // Frame Graph sections
+    ["TASKS"]: "Tasks",
+
+    // Metadata
+    ["METADATA"]: "Metadata",
+    ["XMP METADATA"]: "XMP Metadata",
+
+    // Variants
+    ["VARIANTS"]: "Variants",
+
+    // Node Material
+    ["INPUTS"]: "Inputs",
+} as const;


### PR DESCRIPTION
This PR adds support for `Inspector.MarkLineContainerTitleForHighlighting` and `Inspector.MarkMultipleLineContainerTitlesForHighlighting`.
- Add a prop to `Accordion` to allow highlighting sections. Similar to v1, the other sections are collapsed.
- Add a prop for an imperative ref for the `ExtensibleAccordion` that provides an interface for triggering the highlighting in the contained `Accordion`. Similar to v1, the highlighting state is cleared when a different entity is selected.
- Add a `highlightSections` function to the `IPropertiesService` that calls into the highlighting interface on the `ExtensibleAccordion`.
- Implement `Inspector.MarkMultipleLineContainerTitlesForHighlighting` by providing a service that consumes the `IPropertiesService` and calls `highlightSections`. There is also a giant mapping of Inspector v1 property section names to Inspector v2 property section names (thank you GitHub Copilot Chat 😁).

https://github.com/user-attachments/assets/0aad1986-3b99-4767-952b-335b7a58e3e5