### PR TITLE
Node material: Fix properties not being parsed correctly

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2345,7 +2345,13 @@ export class NodeMaterial extends NodeMaterialBase {
             this.clear();
         }
 
+        const id = this.id;
+        const uniqueId = this.uniqueId;
+
         SerializationHelper.ParseProperties(source, this, this.getScene(), rootUrl);
+
+        this.id = id;
+        this.uniqueId = uniqueId;
 
         const map: { [key: number]: NodeMaterialBlock } = {};
 
@@ -2460,11 +2466,13 @@ export class NodeMaterial extends NodeMaterialBase {
         const serializationObject = this.serialize();
 
         const clone = SerializationHelper.Clone(() => new NodeMaterial(name, this.getScene(), this.options), this);
-        clone.id = name;
-        clone.name = name;
 
         clone.parseSerializedObject(serializationObject);
+
+        clone.id = name;
+        clone.name = name;
         clone._buildId = this._buildId;
+
         clone.build(false, !shareEffect);
 
         return clone;
@@ -2539,10 +2547,12 @@ export class NodeMaterial extends NodeMaterialBase {
         options?: Partial<INodeMaterialOptions>
     ): Promise<NodeMaterial> {
         const material = targetMaterial ?? new NodeMaterial(name, scene, options);
+        const finalName = material.name;
 
         const data = await scene._loadFileAsync(url);
         const serializationObject = JSON.parse(data);
         material.parseSerializedObject(serializationObject, rootUrl, undefined, urlRewriter);
+        material.name = finalName; // in case it was changed during parse
         if (!skipBuild) {
             material.build();
         }


### PR DESCRIPTION
I think this is a better fix than #17498 => even with the PR, there are still some properties that are not parsed correctly (**comment**, **ignoreAlpha** and **maxSimultaneousLights**).

In #17098, my mistake was to add `SerializationHelper.ParseProperties(source, this, this.getScene(), rootUrl);` in `loadFromSerialization` and not in `parseSerializedObject`: when we call `parseSerializedObject` directly, the fix was not in effect.

What do you think?