### PR TITLE
Revert to old arcrotatecamera behavior where alpha/beta does not scale inertialLimit by speed

### DIFF
--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1042,9 +1042,6 @@ export class ArcRotateCamera extends TargetCamera {
         this.inputs.checkInputs();
         let hasUserInteractions = false;
 
-        const inertialPanningLimit = this.speed * this._panningEpsilon;
-        const inertialRotationLimit = this.speed * this._rotationEpsilon;
-
         // Inertia
         if (this.inertialAlphaOffset !== 0 || this.inertialBetaOffset !== 0 || this.inertialRadiusOffset !== 0) {
             hasUserInteractions = true;
@@ -1064,13 +1061,13 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialAlphaOffset *= this.inertia;
             this.inertialBetaOffset *= this.inertia;
             this.inertialRadiusOffset *= this.inertia;
-            if (Math.abs(this.inertialAlphaOffset) < inertialRotationLimit) {
+            if (Math.abs(this.inertialAlphaOffset) < this._rotationEpsilon) {
                 this.inertialAlphaOffset = 0;
             }
-            if (Math.abs(this.inertialBetaOffset) < inertialRotationLimit) {
+            if (Math.abs(this.inertialBetaOffset) < this._rotationEpsilon) {
                 this.inertialBetaOffset = 0;
             }
-            if (Math.abs(this.inertialRadiusOffset) < inertialRotationLimit) {
+            if (Math.abs(this.inertialRadiusOffset) < this.speed * this._rotationEpsilon) {
                 this.inertialRadiusOffset = 0;
             }
         }
@@ -1116,6 +1113,7 @@ export class ArcRotateCamera extends TargetCamera {
             this.inertialPanningX *= this.panningInertia;
             this.inertialPanningY *= this.panningInertia;
 
+            const inertialPanningLimit = this.speed * this._panningEpsilon;
             if (Math.abs(this.inertialPanningX) < inertialPanningLimit) {
                 this.inertialPanningX = 0;
             }


### PR DESCRIPTION
[This PR ](https://github.com/BabylonJS/Babylon.js/commit/1808908d802449319b8b7f3ee8a6ca2931bbcf4a#diff-058148631353bb90134f4cecf195b8ea72bfc7c791d70de6015e331aa381ff51) exposed overrideable rotationEpsilon and panningEpsilon to enable modifying these values on a per-frame basis (so that they can be scaled based on frame rate). However the change also modified the check for alpha/beta to be speed*epsilon to match what radius check did (which was treated as a bug fix)). However this changed behavior of alpha/beta movement on the camera.

This PR moves us back to the old alpha/beta behavior. The plan is to address confusion around camera limits / movement behavior all at once when addressing framerate-independent inertia at the camera level, vs causing an intermediate change in behavior now.