### PR TITLE
Fix: Node drop position accuracy

### DIFF
--- a/packages/tools/nodeParticleEditor/src/graphEditor.tsx
+++ b/packages/tools/nodeParticleEditor/src/graphEditor.tsx
@@ -451,7 +451,11 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         const data = event.dataTransfer.getData("babylonjs-particle-node");
 
         const container = this._diagramContainerRef.current!;
-        this.emitNewBlock(data, event.clientX - container.offsetLeft, event.clientY - container.offsetTop);
+        const rect = container.getBoundingClientRect();
+        const targetX = event.clientX - rect.left;
+        const targetY = event.clientY - rect.top;
+
+        this.emitNewBlock(data, targetX, targetY);
     }
 
     handlePopUp = () => {


### PR DESCRIPTION
Fixed incorrect node positioning when dropping nodes onto the canvas. Replaced `offsetLeft/offsetTop` with `getBoundingClientRect().left/top` in `dropNewBlock` method to accurately calculate drop coordinates, accounting for all parent positioning, transforms, and nested containers.

**Issue demonstration:** https://soullnik.github.io/npe-guide/