### PR TITLE
ThinEngine: Replace window with globalThis

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -4615,7 +4615,7 @@ export class ThinEngine extends AbstractEngine {
                 const tempcanvas = AbstractEngine._CreateCanvas(1, 1);
                 const gl = tempcanvas.getContext("webgl") || (tempcanvas as any).getContext("experimental-webgl");
 
-                this._IsSupported = gl != null && !!window.WebGLRenderingContext;
+                this._IsSupported = gl != null && !!globalThis.WebGLRenderingContext;
             } catch (e) {
                 this._IsSupported = false;
             }


### PR DESCRIPTION
Fixes `ThinEngine.IsSupported` incorrectly returning false in worker contexts, from https://forum.babylonjs.com/t/issue-with-recent-dumptools-changes-in-web-worker-context/61638. 