### PR TITLE
Fixes invalid import path @babylonjs/core/Lights/Clustered.js

### DIFF
--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -19,7 +19,7 @@ import {
 } from "@fluentui/react-icons";
 
 import { Camera } from "core/Cameras/camera";
-import { ClusteredLightContainer } from "core/Lights/Clustered";
+import { ClusteredLightContainer } from "core/Lights/Clustered/clusteredLightContainer";
 import { Light } from "core/Lights/light";
 import { AbstractMesh } from "core/Meshes/abstractMesh";
 import { TransformNode } from "core/Meshes/transformNode";


### PR DESCRIPTION
Fixes invalid import path @babylonjs/core/Lights/Clustered.js in the inspector-v2 package introduced in #17520. This is the same class of bug as the Meshes.js issue fixed in #17282.

The Problem

When importing from a directory barrel (e.g., core/Lights/Clustered), the build tooling's pathTransform appends .js to create @babylonjs/core/Lights/Clustered.js. However, Clustered is a directory with an index.js, not a standalone file, causing module resolution to fail for consumers.

The Fix

Changed the import to reference the specific file directly:

```
-import { ClusteredLightContainer } from "core/Lights/Clustered";
+import { ClusteredLightContainer } from "core/Lights/Clustered/clusteredLightContainer";
```