### PR TITLE
Inspector v2: Export ConvertOptions

### DIFF
--- a/packages/dev/inspector-v2/src/index.ts
+++ b/packages/dev/inspector-v2/src/index.ts
@@ -40,7 +40,7 @@ export * from "./services/settingsContext";
 export type { IShellService, ToolbarItemDefinition, SidePaneDefinition, CentralContentDefinition } from "./services/shellService";
 export { ShellServiceIdentity } from "./services/shellService";
 export * from "./inspector";
-export { Inspector } from "./legacy/inspector";
+export { ConvertOptions, Inspector } from "./legacy/inspector";
 export { AttachDebugLayer, DetachDebugLayer } from "./legacy/debugLayer";
 
 // Export the shared primitive UI controls that can be used for extending the inspector.

--- a/packages/dev/inspector-v2/src/legacy/inspector.tsx
+++ b/packages/dev/inspector-v2/src/legacy/inspector.tsx
@@ -41,6 +41,11 @@ type PropertyChangedEvent = {
     allowNullValue?: boolean;
 };
 
+/**
+ * Converts Inspector v1 options to Inspector v2 options.
+ * @param v1Options Inspector v1 options.
+ * @returns Inspector v2 options.
+ */
 export function ConvertOptions(v1Options: Partial<InspectorV1Options>): Partial<InspectorV2Options> {
     // Options not currently handled:
     // • enablePopup: Do users care about this one?


### PR DESCRIPTION
`ConvertOptions` is a helper function that converts Inspector v1 options to Inspector v2 options. It is mostly used internally for the `Inspector` class that exists for back compat. However, it is also used in Playground. Since I'm changing Playground to consume the Inspector v2 umd bundle, the `ConvertOptions` function needs to be exported and visible from the umd bundle. This just adds a doc comment and adds it to the top level exports.