### PR TITLE
Inspector v2: Fix bug where all SceneExplorer sections can't be collapsed when an item is selected

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -852,7 +852,7 @@ export const SceneExplorer: FunctionComponent<{
 
     const selectEntity = useCallback(
         (selectedEntity: unknown) => {
-            const entity = selectedEntity as EntityBase;
+            const entity = selectedEntity as Nullable<EntityBase>;
             if (entity && entity.uniqueId != undefined) {
                 const parentStack = getParentStack(entity);
                 if (parentStack.length > 0) {
@@ -879,11 +879,9 @@ export const SceneExplorer: FunctionComponent<{
     }, [selectedEntity, selectEntity]);
 
     useEffect(() => {
-        // If there are no open items, then it should mean scene explorer has only just mounted, so we should select the already selected entity.
-        if (openItems.size === 0) {
-            selectEntity(selectedEntity);
-        }
-    }, [openItems, selectEntity, selectedEntity]);
+        // When the component first mounts, select the currently selected entity to ensure it is visible.
+        selectEntity(selectedEntity);
+    }, []);
 
     // We need to wait for a render to complete before we can scroll to the item, hence the isScrollToPending.
     useEffect(() => {


### PR DESCRIPTION
This is to address a bug reported on the forum: https://forum.babylonjs.com/t/introducing-inspector-v2/60937/105

SceneExplorer selects the currently selected entity when it is first mounted. The logic for this is wrong and makes it so that if you try to collapse all top level sections of SceneExplorer, it will trigger re-selecting and showing the currently selected item, which re-expands the collapsed section. The intent is to just have this happen when the component is first mounted. This can just be in a useEffect with no dependencies, so I'm not sure why I didn't do it this way to start. 🤷🏻‍♂️