### PR TITLE
Make sure Inspector v2 theme matches Playground theme

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -35,7 +35,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
     private _downloadManager: DownloadManager;
     private _inspectorFallback: boolean = false;
     private readonly _inspectorV2ModulePromise: Promise<InspectorV2Module | undefined>;
-    private inspectorV2Token: Nullable<IDisposable> = null;
+    private _inspectorV2Token: Nullable<IDisposable> = null;
 
     /**
      * Create the rendering component.
@@ -105,7 +105,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             }
 
             const isInspectorV1Enabled = this._scene.debugLayer.openedPanes !== 0;
-            const isInspectorV2Enabled = !!this.inspectorV2Token;
+            const isInspectorV2Enabled = !!this._inspectorV2Token;
             const isInspectorEnabled = isInspectorV1Enabled || isInspectorV2Enabled;
 
             const searchParams = new URLSearchParams(window.location.search);
@@ -134,8 +134,8 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
             }
 
             if (isInspectorV2Enabled && (!isInspectorV2ModeEnabled || action === "disable")) {
-                this.inspectorV2Token?.dispose();
-                this.inspectorV2Token = null;
+                this._inspectorV2Token?.dispose();
+                this._inspectorV2Token = null;
             }
 
             if (!isInspectorV1Enabled && !isInspectorV2ModeEnabled && action === "enable") {
@@ -154,6 +154,13 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
         this.props.globalState.onFullcreenRequiredObservable.add(() => {
             this._engine?.switchFullscreen(false);
+        });
+
+        this.props.globalState.onThemeChangedObservable.add(() => {
+            if (this._inspectorV2Token) {
+                this._inspectorV2Token.dispose();
+                this._showInspectorV2Async();
+            }
         });
 
         window.addEventListener("resize", () => {
@@ -189,7 +196,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
                     showThemeSelector: false,
                     themeMode: Utilities.ReadStringFromStore("theme", "Light") === "Dark" ? "dark" : "light",
                 } as const;
-                this.inspectorV2Token = inspectorV2Module.ShowInspector(this._scene, options);
+                this._inspectorV2Token = inspectorV2Module.ShowInspector(this._scene, options);
             }
         }
     }
@@ -230,13 +237,13 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
 
         this.props.globalState.onErrorObservable.notifyObservers(null);
 
-        const displayInspector = this.inspectorV2Token || this._scene?.debugLayer.isVisible();
+        const displayInspector = this._inspectorV2Token || this._scene?.debugLayer.isVisible();
 
         const webgpuPromise = WebGPUEngine ? WebGPUEngine.IsSupportedAsync : Promise.resolve(false);
         const webGPUSupported = await webgpuPromise;
 
-        this.inspectorV2Token?.dispose();
-        this.inspectorV2Token = null;
+        this._inspectorV2Token?.dispose();
+        this._inspectorV2Token = null;
 
         let useWebGPU = location.search.indexOf("webgpu") !== -1 && webGPUSupported;
         let forceWebGL1 = false;


### PR DESCRIPTION
Before the Playground "Editor v2" changes, when the Playground theme would change, Inspector would get reloaded. This no longer happens, which on the one hand is nice, but also means the theme of Inspector v2 does not stay in sync with the theme in Playground. For now the easy fix for this is to just hide and re-show Inspector v2 when the Playground theme changes. I don't think people do this super often, so losing your current Inspector state when swapping the theme shouldn't be too disruptive. What would be better would be to programmatically tell Inspector v2 to change its theme dynamically, but this would be more challenging with the current Playground architecture since we'd need version dependent conditional code (e.g. different Inspector v2 APIs being available depending on the version). I don't think this approach would scale at all. We should note that this is another signal for the value of a newer Playground architecture where we simply rely on dynamic imports and whole site snapshots for versioning, which would make handling this trivial.