### PR TITLE
Fix sandbox pan behavior when zoomed close to a large model

### DIFF
--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -26,7 +26,6 @@ import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import type { AbstractEngine } from "core/Engines/abstractEngine";
 import { setOpenGLOrientationForUV, useOpenGLOrientationForUV } from "core/Compat/compatibilityOptions";
 import { ImageProcessingConfiguration } from "core/Materials/imageProcessingConfiguration";
-import { Epsilon } from "core/Maths/math.constants";
 
 function GetFileExtension(str: string): string {
     return str.split(".").pop() || "";
@@ -317,13 +316,13 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
 
         this._scene.executeWhenReady(() => {
             this._engine.runRenderLoop(() => {
+                // NOTE: this logic to adjust camera parameters based on radius is copied in viewer.ts.
+                // Please keep them in sync.
                 // Adapt the camera sensibility based on the distance to the object
                 camera.panningSensibility = 5000 / camera.radius;
-
-                // Ensure the panning epsilon is always small enough (no bigger than a 10th of the smallest amount
-                // of movement the user can cause) so that even when the panningSensibility is very high and the
-                // user pans very slowly, we can still get inertia during the pan without it being clamped to 0 too quickly.
-                camera._panningEpsilon = Math.min(Epsilon, 1 / camera.panningSensibility / 10);
+                // Update the camera speed based on the camera's distance from the target.
+                // TODO: This makes mouse wheel zooming behave well, but makes mouse based rotation a bit worse.
+                camera.speed = camera.radius * 0.2;
                 this._scene.render();
             });
         });

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -2752,6 +2752,9 @@ export class Viewer implements IDisposable {
                     this._sceneMutated = false;
                     this._scene.render();
 
+                    // NOTE: this logic to adjust camera parameters based on radius is copied in renderingZone.tsx (for sandbox).
+                    // Please keep them in sync.
+
                     // Update the camera panning sensitivity based on the camera's distance from the target.
                     this._camera.panningSensibility = 5000 / this._camera.radius;
 


### PR DESCRIPTION
When zoomed in close to a model, the sandbox code will increase the panning sensitivity so that small mouse motions don't result in large unexpected camera movement. However, if you get very close to a model, the check to see if the inertia should be clamped to zero would start clamping all slow user movement to zero.  Then when the user moved slightly faster, all of a sudden it wouldn't hit the clamp, and it would feel like it sped up unexpectedly all of a sudden.

With this fix, we do the same thing that viewer does - scale the speed parameter as well with radius, so that the clamp gets smaller when close up to the model.