### PR TITLE
Prep for webgpu support (atmosphere add-on)

### DIFF
--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereFragmentDeclaration.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereFragmentDeclaration.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 uniform vec3 peakRayleighScattering;
 uniform float planetRadius;

--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereFunctions.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereFunctions.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 // Portions from https://github.com/sebh/UnrealEngineSkyAtmosphere
 // MIT License

--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereUboDeclaration.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereUboDeclaration.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 layout(std140, column_major) uniform;
 

--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereVertexDeclaration.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereVertexDeclaration.fx
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 uniform mat4 inverseViewProjectionWithoutTranslation;

--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/depthFunctions.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/depthFunctions.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 // Assumes infinite far plane (camera.maxZ = 0), forward depth (non-reversed).
 float reconstructDistanceFromCameraPlane(float depth, float cameraNearPlane) {

--- a/packages/dev/addons/src/atmosphere/Shaders/aerialPerspective.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/aerialPerspective.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 #define RENDER_CAMERA_VOLUME
 

--- a/packages/dev/addons/src/atmosphere/Shaders/compositeAerialPerspective.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/compositeAerialPerspective.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 precision highp float;
 precision highp sampler2D;

--- a/packages/dev/addons/src/atmosphere/Shaders/compositeGlobeAtmosphere.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/compositeGlobeAtmosphere.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 #define SAMPLE_SKY_VIEW_LUT
 #if USE_SKY_VIEW_LUT

--- a/packages/dev/addons/src/atmosphere/Shaders/compositeSky.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/compositeSky.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 #define SAMPLE_SKY_VIEW_LUT
 #if USE_SKY_VIEW_LUT

--- a/packages/dev/addons/src/atmosphere/Shaders/diffuseSkyIrradiance.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/diffuseSkyIrradiance.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 precision highp float;
 

--- a/packages/dev/addons/src/atmosphere/Shaders/fullscreenTriangle.vertex.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/fullscreenTriangle.vertex.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 precision highp float;
 

--- a/packages/dev/addons/src/atmosphere/Shaders/multiScattering.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/multiScattering.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 #define RENDER_MULTI_SCATTERING
 #define COMPUTE_MULTI_SCATTERING

--- a/packages/dev/addons/src/atmosphere/Shaders/skyView.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/skyView.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 #define RENDER_SKY_VIEW
 

--- a/packages/dev/addons/src/atmosphere/Shaders/transmittance.fragment.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/transmittance.fragment.fx
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 #define RENDER_TRANSMITTANCE
 #define EXCLUDE_RAY_MARCHING_FUNCTIONS

--- a/packages/dev/addons/src/atmosphere/atmosphere.ts
+++ b/packages/dev/addons/src/atmosphere/atmosphere.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { AbstractEngine } from "core/Engines/abstractEngine";
 import { AtmospherePBRMaterialPlugin } from "./atmospherePBRMaterialPlugin";

--- a/packages/dev/addons/src/atmosphere/atmosphereOptions.ts
+++ b/packages/dev/addons/src/atmosphere/atmosphereOptions.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { AtmospherePhysicalProperties } from "./atmospherePhysicalProperties";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";

--- a/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { Atmosphere } from "./atmosphere";
 import type { BaseTexture } from "core/Materials/Textures/baseTexture";

--- a/packages/dev/addons/src/atmosphere/atmospherePerCameraVariables.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePerCameraVariables.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { Camera } from "core/Cameras/camera";
 import type { IMatrixLike, IVector3Like, IVector4Like } from "core/Maths/math.like";

--- a/packages/dev/addons/src/atmosphere/atmospherePhysicalProperties.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePhysicalProperties.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { IAtmospherePhysicalPropertiesOptions } from "./atmospherePhysicalPropertiesOptions";
 import { Observable } from "core/Misc/observable";

--- a/packages/dev/addons/src/atmosphere/atmospherePhysicalPropertiesOptions.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePhysicalPropertiesOptions.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { Vector3 } from "core/Maths/math.vector";
 

--- a/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
+++ b/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { Atmosphere } from "./atmosphere";
 import type { AtmospherePhysicalProperties } from "./atmospherePhysicalProperties";

--- a/packages/dev/addons/src/atmosphere/index.ts
+++ b/packages/dev/addons/src/atmosphere/index.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 export * from "./atmosphere";
 export * from "./atmosphereOptions";

--- a/packages/dev/addons/src/atmosphere/sampling.ts
+++ b/packages/dev/addons/src/atmosphere/sampling.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import { Clamp } from "core/Maths/math.scalar.functions";
 import type { IColor4Like } from "core/Maths/math.like";

--- a/packages/dev/addons/src/atmosphere/transmittanceLut.ts
+++ b/packages/dev/addons/src/atmosphere/transmittanceLut.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
 import type { Atmosphere } from "./atmosphere";
 import type { AtmospherePhysicalProperties } from "./atmospherePhysicalProperties";

--- a/packages/dev/addons/test/unit/atmosphere/sampling.test.ts
+++ b/packages/dev/addons/test/unit/atmosphere/sampling.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
-// MIT License
+// Licensed under the MIT License.
 
-import { Sample2DRgbaToRef } from "../../sampling";
+import { Sample2DRgbaToRef } from "../../../src/atmosphere/sampling";
 import type { IColor4Like } from "core/Maths/math.like";
 
 const Black = { r: 0, g: 0, b: 0, a: 1.0 };
@@ -50,10 +50,10 @@ describe("textureSampler", () => {
         (expect(result) as any).toBeApproxColor4Like(White);
     });
     test("testVertical3x3", () => {
-        const testData2x2 = new Float32Array([Black, Black, White, White, White, White, White, White, White].flatMap((x) => [x.r, x.g, x.b, x.a]));
+        const testData3x3 = new Float32Array([Black, Black, White, White, White, White, White, White, White].flatMap((x) => [x.r, x.g, x.b, x.a]));
 
         const result = { r: 0, g: 0, b: 0, a: 0 };
-        Sample2DRgbaToRef(0.33333333333, 0.33333333333, 3, 3, testData2x2, result, (value) => value);
+        Sample2DRgbaToRef(0.33333333333, 0.33333333333, 3, 3, testData3x3, result, (value) => value);
         (expect(result) as any).toBeApproxColor4Like(Grey);
     });
     test("testHorizontal2x2", () => {


### PR DESCRIPTION
* Refactoring shader code uniform locations and apply inlining where needed.
* Using defines for more precise control of what's included per Effect.
* Header cleanup and move tests out of /src.