### PR TITLE
GUI: Fix Line layout bug when a connectedControl has a higher zIndex

### DIFF
--- a/packages/dev/gui/src/2D/controls/line.ts
+++ b/packages/dev/gui/src/2D/controls/line.ts
@@ -47,7 +47,8 @@ export class Line extends Control {
     }
 
     public set connectedControl(value: Control) {
-        if (this._connectedControl === value) {
+        // Don't allow circular references, and no-op if the same control is assigned
+        if (this._connectedControl === value || (value instanceof Line && value._connectedControl === (this as Control))) {
             return;
         }
 
@@ -209,6 +210,14 @@ export class Line extends Control {
         // Width / Height
         this._currentMeasure.width = Math.abs(this._x1.getValue(this._host) - this._effectiveX2) + this._lineWidth;
         this._currentMeasure.height = Math.abs(this._y1.getValue(this._host) - this._effectiveY2) + this._lineWidth;
+    }
+
+    public override _layout(parentMeasure: Measure, context: ICanvasRenderingContext): boolean {
+        if (this._connectedControl) {
+            // If we have a connected control, we need to let it layout first so we can ensure our layout math uses its latest position
+            this._connectedControl._layout(parentMeasure, context);
+        }
+        return super._layout(parentMeasure, context);
     }
 
     protected override _computeAlignment(parentMeasure: Measure): void {


### PR DESCRIPTION
The Line layout code depends on the connectedControl's centerX and centerY to be up to date, but if the connectedControl had a higher zIndex, it would do its layout work after the Line control, so the Line control would be working with stale data during the Control._clip() call which is part of Control._render().  That stale data meant it would clip to using the stale location information of the connectedControl, leading to the bug demonstrated in this playground: https://playground.babylonjs.com/#5SVAQB#3

With this change, Line will ensure the connectedControl has done its layout work before it does its own layout math.  This ensures the clipping is calculated correctly regardless of zIndex.