### PR TITLE
Fix static sound `stop()` throwing error in some cases

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -434,7 +434,12 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
         this._setState(SoundState.Paused);
         this._enginePauseTime += this.engine.currentTime - this._enginePlayTime;
 
-        this._sourceNode?.stop();
+        if (this._state === SoundState.Started) {
+            this._sourceNode?.stop();
+        } else {
+            this.engine.stateChangedObservable.removeCallback(this._onEngineStateChanged);
+        }
+
         this._deinitSourceNode();
     }
 
@@ -451,8 +456,10 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
             return;
         }
 
-        const engineStopTime = this.engine.currentTime + (options.waitTime ?? 0);
-        this._sourceNode?.stop(engineStopTime);
+        if (this._state === SoundState.Started) {
+            const engineStopTime = this.engine.currentTime + (options.waitTime ?? 0);
+            this._sourceNode?.stop(engineStopTime);
+        }
 
         if (options.waitTime === undefined || options.waitTime <= 0) {
             this._setState(SoundState.Stopped);

--- a/packages/tools/tests/test/audioV2/staticSound.stop.test.ts
+++ b/packages/tools/tests/test/audioV2/staticSound.stop.test.ts
@@ -1,0 +1,29 @@
+import { InitAudioV2Tests } from "./utils/audioV2.utils";
+
+import { expect, test } from "@playwright/test";
+
+InitAudioV2Tests();
+
+test.describe("StaticSound stop", () => {
+    test("Stop should not throw error if not playing", async ({ page }) => {
+        test.setTimeout(0);
+
+        const result = await page.evaluate(async () => {
+            const audioEngine = await AudioV2Test.CreateAudioEngineAsync("Realtime");
+            await ((audioEngine as any)._audioContext as AudioContext).suspend();
+
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { autoplay: true, loop: true });
+
+            let error = null;
+            try {
+                sound.stop();
+            } catch (e) {
+                error = (e as Error).message;
+            }
+
+            return error;
+        });
+
+        expect(result).toBe(null);
+    });
+});


### PR DESCRIPTION
When a static sound is created with `autoplay` and `loop` turned on, but the audio engine is suspended, calling `stop()` on it throws a WebAudio error because the underlying source node is not playing.

This change fixes the issue by making sure the sound has actually started playing before calling `stop` on the underlying WebAudio source node.