### PR TITLE
GPUPicker: Added support for bones, morph targets, and VAT

### DIFF
--- a/packages/dev/core/src/Shaders/picking.vertex.fx
+++ b/packages/dev/core/src/Shaders/picking.vertex.fx
@@ -20,13 +20,14 @@ flat varying float vMeshID;
 #endif
 
 void main(void) {
-    
+
+    vec3 positionUpdated = position;
 #include<morphTargetsVertexGlobal>
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>
-    vec4 worldPos = finalWorld * vec4(position, 1.0);
+    vec4 worldPos = finalWorld * vec4(positionUpdated, 1.0);
 	gl_Position = viewProjection * worldPos;
 
 #if defined(INSTANCES)

--- a/packages/dev/core/src/ShadersWGSL/picking.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/picking.vertex.fx
@@ -22,12 +22,13 @@ flat varying vMeshID: f32;
 @vertex
 fn main(input : VertexInputs) -> FragmentInputs {
     
+    var positionUpdated: vec3f = input.position;
 #include<morphTargetsVertexGlobal>
 #include<morphTargetsVertex>[0..maxSimultaneousMorphTargets]
 #include<instancesVertex>
 #include<bonesVertex>
 #include<bakedVertexAnimation>
-    var worldPos: vec4f = finalWorld * vec4f(input.position, 1.0);
+    var worldPos: vec4f = finalWorld * vec4f(positionUpdated, 1.0);
 	vertexOutputs.position = uniforms.viewProjection * worldPos;
 
 #if defined(INSTANCES)


### PR DESCRIPTION
Due to issues with the shader, Bone, Morph Targets and VAT have not been functioning.