### PR TITLE
Meshes: Fix wrong normals after calling updateFacetData

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -2391,7 +2391,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
         }
         const positions = this.getVerticesData(VertexBuffer.PositionKind);
         const indices = this.getIndices();
-        const normals = this.getVerticesData(VertexBuffer.NormalKind);
+        const normals = this.getVerticesData(VertexBuffer.NormalKind)?.slice();
         const bInfo = this.getBoundingInfo();
 
         if (data.facetDepthSort && !data.facetDepthSortEnabled) {


### PR DESCRIPTION
See https://forum.babylonjs.com/t/mesh-updatefacetdata-breaks-smooth-shading-after-gltf-glb-export-faceted-look-on-rounded-meshes/61944

The problem is that calling `updateFacetData` updates the normal array on the CPU side, but not the GPU buffer. So the mesh looks fine in the Playground, but after exporting/importing it, it no longer does, because when exporting, we use the CPU-side array.

I don't think `updateFacetData` was designed to modify a mesh's normal array (I don't see why we would do that?), so I simply cloned the array before calling `VertexData.ComputeNormals` (which is the function that updates the normals).