### PR TITLE
Added extra guards to Area Lights defines to avoid shader compilation. 

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -53,7 +53,7 @@
                 preInfo = computeHemisphericPreLightingInfo(light{X}.vLightData, viewDirectionW, normalW);
             #elif defined(DIRLIGHT{X})
                 preInfo = computeDirectionalPreLightingInfo(light{X}.vLightData, viewDirectionW, normalW);
-            #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 preInfo = computeAreaPreLightingInfo(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, roughness);
             #endif
 
@@ -106,7 +106,7 @@
 
             // Simulates Light radius for diffuse and spec term
             // clear coat is using a dedicated roughness
-            #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X})
+            #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 preInfo.roughness = roughness;
             #else
                 preInfo.roughness = adjustRoughnessFromLightProperties(roughness, light{X}.vLightSpecular.a, preInfo.lightDistance);
@@ -125,7 +125,7 @@
 
             #ifdef HEMILIGHT{X}
                 info.diffuse = computeHemisphericDiffuseLighting(preInfo, diffuse{X}.rgb, light{X}.vLightGround);
-            #elif defined(AREALIGHT{X})
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 info.diffuse = computeAreaDiffuseLighting(preInfo, diffuse{X}.rgb);
             #elif defined(SS_TRANSLUCENCY)
                 #ifndef SS_TRANSLUCENCY_LEGACY
@@ -140,7 +140,7 @@
 
             // Specular contribution
             #ifdef SPECULARTERM
-                #if AREALIGHT{X}
+                #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                     info.specular = computeAreaSpecularLighting(preInfo, light{X}.vLightSpecular.rgb, clearcoatOut.specularEnvironmentR0, reflectivityOut.colorReflectanceF90);
                 #else
                     // For OpenPBR, we use the F82 specular model for metallic materials and mix with the
@@ -234,7 +234,7 @@
                 info = computeHemisphericLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, light{X}.vLightGround, glossiness);
             #elif defined(POINTLIGHT{X}) || defined(DIRLIGHT{X})
                 info = computeLighting(viewDirectionW, normalW, light{X}.vLightData, diffuse{X}.rgb, light{X}.vLightSpecular.rgb, diffuse{X}.a, glossiness);
-            #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 info = computeAreaLighting(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.rgb, light{X}.vLightHeight.rgb, diffuse{X}.rgb, light{X}.vLightSpecular.rgb,
                 #ifdef AREALIGHTNOROUGHTNESS
                     0.5

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightUboDeclaration.fx
@@ -16,7 +16,7 @@
 			vec2 vSliceData;
 			vec2 vSliceRanges[CLUSTLIGHT_SLICES];
 		#endif
-		#if defined(AREALIGHT{X})
+		#if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 			vec4 vLightWidth;
 			vec4 vLightHeight;
 		#endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightVxFragmentDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightVxFragmentDeclaration.fx
@@ -32,7 +32,7 @@
 	#elif defined(HEMILIGHT{X})
 		uniform vec3 vLightGround{X};
 	#endif
-	#if defined(AREALIGHT{X})
+	#if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 		uniform vec4 vLightWidth{X};
 		uniform vec4 vLightHeight{X};
 	#endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightVxUboDeclaration.fx
@@ -16,7 +16,7 @@
 			vec2 vSliceData;
 			vec2 vSliceRanges[CLUSTLIGHT_SLICES];
 		#endif
-		#if defined(AREALIGHT{X})
+		#if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 			vec4 vLightWidth;
 			vec4 vLightHeight;
 		#endif

--- a/packages/dev/core/src/Shaders/ShadersInclude/openpbrDirectLighting.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/openpbrDirectLighting.fx
@@ -15,7 +15,7 @@
     // Diffuse Lobe
     #ifdef HEMILIGHT{X}
         slab_diffuse = computeHemisphericDiffuseLighting(preInfo{X}, lightColor{X}.rgb, light{X}.vLightGround);
-    #elif defined(AREALIGHT{X})
+    #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_diffuse = computeAreaDiffuseLighting(preInfo{X}, lightColor{X}.rgb);
     #else
         slab_diffuse = computeDiffuseLighting(preInfo{X}, lightColor{X}.rgb);
@@ -37,7 +37,7 @@
     #endif
 
     // Specular Lobe
-    #if AREALIGHT{X}
+    #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_glossy = computeAreaSpecularLighting(preInfo{X}, light{X}.vLightSpecular.rgb, baseConductorReflectance.F0, baseConductorReflectance.F90);
     #else
         {
@@ -66,7 +66,7 @@
     #endif
 
     // Metal Lobe
-    #if AREALIGHT{X}
+    #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_metal = computeAreaSpecularLighting(preInfo{X}, light{X}.vLightSpecular.rgb, baseConductorReflectance.F0, baseConductorReflectance.F90);
     #else
         {
@@ -99,7 +99,7 @@
     #endif
 
     // Coat Lobe
-    #if AREALIGHT{X}
+    #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_coat = computeAreaSpecularLighting(preInfoCoat{X}, light{X}.vLightSpecular.rgb, coatReflectance.F0, coatReflectance.F90);
     #else
         {

--- a/packages/dev/core/src/Shaders/ShadersInclude/openpbrDirectLightingInit.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/openpbrDirectLightingInit.fx
@@ -23,7 +23,7 @@
         #elif defined(DIRLIGHT{X})
             preInfo{X} = computeDirectionalPreLightingInfo(light{X}.vLightData, viewDirectionW, normalW);
             preInfoCoat{X} = computeDirectionalPreLightingInfo(light{X}.vLightData, viewDirectionW, coatNormalW);
-        #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+        #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
             preInfo{X} = computeAreaPreLightingInfo(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, specular_roughness);
             preInfoCoat{X} = computeAreaPreLightingInfo(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, coatNormalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, coat_roughness);
         #endif
@@ -80,7 +80,7 @@
 
         // Simulates Light radius for diffuse and spec term
         // clear coat is using a dedicated roughness
-        #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X})
+        #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
             preInfo{X}.roughness = specular_roughness;
             preInfoCoat{X}.roughness = coat_roughness;
         #else

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -53,7 +53,7 @@
                 preInfo = computeHemisphericPreLightingInfo(light{X}.vLightData, viewDirectionW, normalW);
             #elif defined(DIRLIGHT{X})
                 preInfo = computeDirectionalPreLightingInfo(light{X}.vLightData, viewDirectionW, normalW);
-            #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 preInfo = computeAreaPreLightingInfo(areaLightsLTC1Sampler, areaLightsLTC1SamplerSampler, areaLightsLTC2Sampler, areaLightsLTC2SamplerSampler, viewDirectionW, normalW, fragmentInputs.vPositionW, light{X}.vLightData.xyz, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, roughness);
             #endif
 
@@ -106,7 +106,7 @@
 
             // Simulates Light radius for diffuse and spec term
             // clear coat is using a dedicated roughness
-            #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X})
+            #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 preInfo.roughness = roughness;
             #else
                 preInfo.roughness = adjustRoughnessFromLightProperties(roughness, light{X}.vLightSpecular.a, preInfo.lightDistance);
@@ -125,7 +125,7 @@
 
             #ifdef HEMILIGHT{X}
                 info.diffuse = computeHemisphericDiffuseLighting(preInfo, diffuse{X}.rgb, light{X}.vLightGround);
-            #elif defined(AREALIGHT{X})
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 info.diffuse = computeAreaDiffuseLighting(preInfo, diffuse{X}.rgb);
             #elif defined(SS_TRANSLUCENCY)
                 #ifndef SS_TRANSLUCENCY_LEGACY
@@ -140,7 +140,7 @@
 
             // Specular contribution
             #ifdef SPECULARTERM
-                #if AREALIGHT{X}
+                #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                     info.specular = computeAreaSpecularLighting(preInfo, light{X}.vLightSpecular.rgb, clearcoatOut.specularEnvironmentR0, reflectivityOut.colorReflectanceF90);
                 #else
                     // For OpenPBR, we use the F82 specular model for metallic materials and mix with the

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightUboDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightUboDeclaration.fx
@@ -15,7 +15,7 @@
 			vSliceData: vec2f,
 			vSliceRanges: array<vec4f, CLUSTLIGHT_SLICES>,
 		#endif
-		#if defined(AREALIGHT{X})
+		#if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 			vLightWidth: vec4f,
 			vLightHeight: vec4f,
 		#endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightVxFragmentDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightVxFragmentDeclaration.fx
@@ -32,7 +32,7 @@
 	#elif defined(HEMILIGHT{X})
 		uniform vLightGround{X}: vec3f;
 	#endif
-	#if defined(AREALIGHT{X})
+	#if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 		uniform vLightWidth{X}: vec4f;
 		uniform vLightHeight{X}: vec4f;
 	#endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightVxUboDeclaration.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightVxUboDeclaration.fx
@@ -15,7 +15,7 @@
 			vSliceData: vec2f,
 			vSliceRanges: array<vec4f, CLUSTLIGHT_SLICES>,
 		#endif
-		#if defined(AREALIGHT{X})
+		#if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
 			vLightWidth: vec4f,
 			vLightHeight: vec4f,
 		#endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/openpbrDirectLighting.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/openpbrDirectLighting.fx
@@ -17,7 +17,7 @@
     // Diffuse Lobe
     #ifdef HEMILIGHT{X}
         slab_diffuse = computeHemisphericDiffuseLighting(preInfo{X}, lightColor{X}.rgb, light{X}.vLightGround);
-    #elif defined(AREALIGHT{X})
+    #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_diffuse = computeAreaDiffuseLighting(preInfo{X}, lightColor{X}.rgb);
     #else
         slab_diffuse = computeDiffuseLighting(preInfo{X}, lightColor{X}.rgb);
@@ -39,7 +39,7 @@
     #endif
 
     // Specular Lobe
-    #if AREALIGHT{X}
+    #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_glossy = computeAreaSpecularLighting(preInfo{X}, light{X}.vLightSpecular.rgb, baseConductorReflectance.F0, baseConductorReflectance.F90);
     #else
         {
@@ -68,7 +68,7 @@
     #endif
 
     // Metal Lobe
-    #if AREALIGHT{X}
+    #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_metal = computeAreaSpecularLighting(preInfo{X}, light{X}.vLightSpecular.rgb, baseConductorReflectance.F0, baseConductorReflectance.F90);
     #else
         {
@@ -99,7 +99,7 @@
     #endif
 
     // Coat Lobe
-    #if AREALIGHT{X}
+    #if defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
         slab_coat = computeAreaSpecularLighting(preInfoCoat{X}, light{X}.vLightSpecular.rgb, coatReflectance.F0, coatReflectance.F90);
     #else
         {

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/openpbrDirectLightingInit.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/openpbrDirectLightingInit.fx
@@ -23,7 +23,7 @@
         #elif defined(DIRLIGHT{X})
             preInfo{X} = computeDirectionalPreLightingInfo(light{X}.vLightData, viewDirectionW, normalW);
             preInfoCoat{X} = computeDirectionalPreLightingInfo(light{X}.vLightData, viewDirectionW, coatNormalW);
-        #elif defined(AREALIGHT{X}) && defined(AREALIGHTSUPPORTED)
+        #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
             preInfo{X} = computeAreaPreLightingInfo(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, normalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, specular_roughness);
             preInfoCoat{X} = computeAreaPreLightingInfo(areaLightsLTC1Sampler, areaLightsLTC2Sampler, viewDirectionW, coatNormalW, vPositionW, light{X}.vLightData, light{X}.vLightWidth.xyz, light{X}.vLightHeight.xyz, coat_roughness);
         #endif
@@ -80,7 +80,7 @@
 
         // Simulates Light radius for diffuse and spec term
         // clear coat is using a dedicated roughness
-        #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X})
+        #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
             preInfo{X}.roughness = specular_roughness;
             preInfoCoat{X}.roughness = coat_roughness;
         #else


### PR DESCRIPTION
Added extra guards against area lights defines to avoid shader compilation errors. This is related to a user reported issue on the forum and a proposed fix by @Popov72 . 

Forum issue: https://forum.babylonjs.com/t/shader-fails-to-compile-due-to-unresolved-identifier-arealightsltc1sampler/61955/5