### PR TITLE
Fixed defines where area lights and hemi lights need to checked together

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -106,7 +106,9 @@
 
             // Simulates Light radius for diffuse and spec term
             // clear coat is using a dedicated roughness
-            #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
+            #if defined(HEMILIGHT{X})
+                preInfo.roughness = roughness;
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 preInfo.roughness = roughness;
             #else
                 preInfo.roughness = adjustRoughnessFromLightProperties(roughness, light{X}.vLightSpecular.a, preInfo.lightDistance);

--- a/packages/dev/core/src/Shaders/ShadersInclude/openpbrDirectLightingInit.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/openpbrDirectLightingInit.fx
@@ -80,7 +80,10 @@
 
         // Simulates Light radius for diffuse and spec term
         // clear coat is using a dedicated roughness
-        #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
+        #if defined(HEMILIGHT{X})
+            preInfo{X}.roughness = specular_roughness;
+            preInfoCoat{X}.roughness = coat_roughness;
+        #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
             preInfo{X}.roughness = specular_roughness;
             preInfoCoat{X}.roughness = coat_roughness;
         #else

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -106,7 +106,9 @@
 
             // Simulates Light radius for diffuse and spec term
             // clear coat is using a dedicated roughness
-            #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
+            #if defined(HEMILIGHT{X})
+                preInfo.roughness = roughness;
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 preInfo.roughness = roughness;
             #else
                 preInfo.roughness = adjustRoughnessFromLightProperties(roughness, light{X}.vLightSpecular.a, preInfo.lightDistance);
@@ -125,7 +127,7 @@
 
             #ifdef HEMILIGHT{X}
                 info.diffuse = computeHemisphericDiffuseLighting(preInfo, diffuse{X}.rgb, light{X}.vLightGround);
-            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
+            #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
                 info.diffuse = computeAreaDiffuseLighting(preInfo, diffuse{X}.rgb);
             #elif defined(SS_TRANSLUCENCY)
                 #ifndef SS_TRANSLUCENCY_LEGACY

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/openpbrDirectLightingInit.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/openpbrDirectLightingInit.fx
@@ -80,7 +80,10 @@
 
         // Simulates Light radius for diffuse and spec term
         // clear coat is using a dedicated roughness
-        #if defined(HEMILIGHT{X}) || defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
+        #if defined(HEMILIGHT{X})
+            preInfo{X}.roughness = specular_roughness;
+            preInfoCoat{X}.roughness = coat_roughness;
+        #elif defined(AREALIGHT{X}) && defined(AREALIGHTUSED) && defined(AREALIGHTSUPPORTED)
             preInfo{X}.roughness = specular_roughness;
             preInfoCoat{X}.roughness = coat_roughness;
         #else


### PR DESCRIPTION
Quick fix for changes in area lights defines not to break  hemispheric light. Fixes bug introduced by PR #17596 