### PR TITLE
Inspector v2: Improve overlay mode

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -472,6 +472,15 @@ export default tseslint.config(
                     format: ["strictCamelCase", "snake_case", "UPPER_CASE"],
                     leadingUnderscore: "allow",
                 },
+                // Allow CSS selector patterns in object literals (e.g., "> *", "&:hover", ":first-child")
+                {
+                    selector: "objectLiteralProperty",
+                    format: null,
+                    filter: {
+                        regex: "^[>&:.*#\\[]",
+                        match: true,
+                    },
+                },
                 {
                     selector: "enumMember",
                     format: ["StrictPascalCase", "UPPER_CASE"],

--- a/packages/dev/inspector-v2/src/components/extensibleAccordion.tsx
+++ b/packages/dev/inspector-v2/src/components/extensibleAccordion.tsx
@@ -54,7 +54,6 @@ export type DynamicAccordionSectionContent<ContextT> = Readonly<{
     component: ComponentType<{ context: ContextT }>;
 }>;
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     rootDiv: {
         flex: 1,

--- a/packages/dev/inspector-v2/src/components/properties/propertiesPane.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/propertiesPane.tsx
@@ -2,7 +2,6 @@ import { Body1Strong, makeStyles, tokens } from "@fluentui/react-components";
 
 import { ExtensibleAccordion } from "../extensibleAccordion";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     placeholderDiv: {
         padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -274,7 +274,6 @@ function useCommandContextMenuState(commands: readonly SceneExplorerCommand<"con
     return [checkedContextMenuItems, onContextMenuCheckedValueChange, contextMenuItems] as const;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     rootDiv: {
         flex: 1,

--- a/packages/dev/inspector-v2/src/components/teachingMoment.tsx
+++ b/packages/dev/inspector-v2/src/components/teachingMoment.tsx
@@ -3,7 +3,6 @@ import type { MakePopoverTeachingMoment } from "../hooks/teachingMomentHooks";
 
 import { makeStyles, TeachingPopover, TeachingPopoverBody, TeachingPopoverHeader, TeachingPopoverSurface } from "@fluentui/react-components";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     extensionTeachingPopover: {
         maxWidth: "320px",

--- a/packages/dev/inspector-v2/src/components/textureEditor/tools.tsx
+++ b/packages/dev/inspector-v2/src/components/textureEditor/tools.tsx
@@ -98,8 +98,6 @@ export const ToolBar: FunctionComponent<ToolBarProps> = (props) => {
             <Divider />
             <div className={classes.toolsSection}>
                 {tools.map((tool, index) => {
-                    // eslint-disable-next-line @typescript-eslint/naming-convention
-                    const IconComponent = tool.icon;
                     return (
                         <Tooltip key={index} content={tool.name} relationship="label" positioning="after">
                             <ToggleButton
@@ -107,7 +105,7 @@ export const ToolBar: FunctionComponent<ToolBarProps> = (props) => {
                                 appearance="subtle"
                                 checked={index === activeToolIndex}
                                 onClick={() => handleToolClick(index)}
-                                icon={<IconComponent />}
+                                icon={<tool.icon />}
                             />
                         </Tooltip>
                     );

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -1,5 +1,6 @@
 import type { IDisposable, Scene } from "core/scene";
 import type { Nullable } from "core/types";
+import type { WeaklyTypedServiceDefinition } from "./modularity/serviceContainer";
 import type { ServiceDefinition } from "./modularity/serviceDefinition";
 import type { ModularToolOptions } from "./modularTool";
 import type { ISceneContext } from "./services/sceneContext";
@@ -61,7 +62,12 @@ import { ShellServiceIdentity } from "./services/shellService";
 import { TextureEditorServiceDefinition } from "./services/textureEditor/textureEditorService";
 import { UserFeedbackServiceDefinition } from "./services/userFeedbackService";
 
-export type InspectorOptions = Omit<ModularToolOptions, "toolbarMode"> & { autoResizeEngine?: boolean };
+type LayoutMode = "inline" | "overlay";
+
+export type InspectorOptions = Omit<ModularToolOptions, "toolbarMode"> & {
+    autoResizeEngine?: boolean;
+    layoutMode?: LayoutMode;
+};
 
 // TODO: The key should probably be the Canvas, because we only want to show one inspector instance per canvas.
 //       If it is called for a different scene that is rendering to the same canvas, then we should probably
@@ -97,6 +103,7 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
     // Set default options.
     options = {
         autoResizeEngine: true,
+        layoutMode: "overlay",
         ...options,
     };
 
@@ -106,14 +113,28 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
         let parentElement = options.containerElement ?? null;
         // If a container element was not found, find an appropriate one above the engine's rendering canvas.
         if (!parentElement) {
-            parentElement = scene.getEngine().getRenderingCanvas()?.parentElement ?? null;
+            const renderingCanvas = scene.getEngine().getRenderingCanvas();
+            parentElement = renderingCanvas;
             while (parentElement) {
                 const rootNode = parentElement.getRootNode();
                 // TODO: Right now we never parent the inspector within a ShadowRoot because we need to do more work to get FluentProvider to work correctly in this context.
-                if (!(rootNode instanceof ShadowRoot)) {
+                if (rootNode instanceof ShadowRoot) {
+                    // If we are in a ShadowRoot, continue up the tree.
+                    parentElement = rootNode.host.parentElement;
+                } else {
+                    // Found the closest ancestor that is not in a ShadowRoot.
                     break;
                 }
-                parentElement = rootNode.host.parentElement;
+            }
+
+            if (renderingCanvas && parentElement === renderingCanvas) {
+                // If we were not in a ShadowRoot, then the direct parent of the rendering canvas is the container.
+                parentElement = renderingCanvas.parentElement;
+            }
+
+            if (!parentElement) {
+                // If we still haven't found a parent element, default to document.body.
+                parentElement = document.body;
             }
         }
 
@@ -151,43 +172,69 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
             }
         });
 
-        // Remove all the existing children from the parent element.
-        const canvasContainerDisplay = parentElement.style.display;
-        const canvasContainerChildren = [...parentElement.childNodes];
-        parentElement.replaceChildren();
+        // This array will contain all the default Inspector service definitions.
+        const serviceDefinitions: WeaklyTypedServiceDefinition[] = [];
 
-        disposeActions.push(async () => {
-            // When the ModularTool token is disposed, it unmounts the react element, which asynchronously
-            // removes all children from the parentElement. We need to wait for that to complete before
-            // re-adding the canvas children back to the parentElement.
-            await new Promise((resolve) => setTimeout(resolve));
-            parentElement.replaceChildren(...canvasContainerChildren);
+        // Create a container element for the inspector UI.
+        // This element will become the root React node, so it must be a new empty node
+        // since React will completely take over its contents.
+        const containerElement = document.createElement("div");
+        containerElement.id = "babylon-inspector-container";
+        containerElement.style.position = "absolute";
+        containerElement.style.inset = "0";
+        containerElement.style.display = "flex";
+        // For "overlay" layout mode, we let pointer events pass through the inspector container.
+        // Pointer events are re-enabled specifically for toolbars, side panes, and central content elements.
+        containerElement.style.pointerEvents = "none";
+
+        // When the layoutMode is "inline", we will re-parent the child nodes of the parentElement under the containerElement.
+        if (options.layoutMode === "inline") {
+            // Remove all the existing children from the parent element.
+            const canvasContainerDisplay = parentElement.style.display;
+            const canvasContainerChildren = [...parentElement.childNodes];
+            parentElement.replaceChildren();
+
+            disposeActions.push(async () => {
+                // When the ModularTool token is disposed, it unmounts the react element, which asynchronously
+                // removes all children from the parentElement. We need to wait for that to complete before
+                // re-adding the canvas children back to the parentElement.
+                await new Promise((resolve) => setTimeout(resolve));
+                parentElement.replaceChildren(...canvasContainerChildren);
+            });
+
+            // This service is responsible for injecting the passed in canvas as the "central content" of the shell UI (the main area between the side panes and toolbars).
+            const canvasInjectorServiceDefinition: ServiceDefinition<[], [IShellService]> = {
+                friendlyName: "Canvas Injector",
+                consumes: [ShellServiceIdentity],
+                factory: (shellService) => {
+                    const registration = shellService.addCentralContent({
+                        key: "Canvas Injector",
+                        component: () => {
+                            const canvasContainerRef = useRef<HTMLDivElement>(null);
+                            useEffect(() => {
+                                canvasContainerRef.current?.replaceChildren(...canvasContainerChildren);
+                            }, []);
+
+                            return <div ref={canvasContainerRef} style={{ display: canvasContainerDisplay, position: "absolute", inset: "0" }} />;
+                        },
+                    });
+
+                    return {
+                        dispose: () => {
+                            registration.dispose();
+                        },
+                    };
+                },
+            };
+
+            serviceDefinitions.push(canvasInjectorServiceDefinition);
+        }
+
+        // Now it is safe to append the container element to the parent.
+        parentElement.appendChild(containerElement);
+        disposeActions.push(() => {
+            parentElement.removeChild(containerElement);
         });
-
-        // This service is responsible for injecting the passed in canvas as the "central content" of the shell UI (the main area between the side panes and toolbars).
-        const canvasInjectorServiceDefinition: ServiceDefinition<[], [IShellService]> = {
-            friendlyName: "Canvas Injector",
-            consumes: [ShellServiceIdentity],
-            factory: (shellService) => {
-                const registration = shellService.addCentralContent({
-                    key: "Canvas Injector",
-                    component: () => {
-                        const canvasContainerRef = useRef<HTMLDivElement>(null);
-                        useEffect(() => {
-                            canvasContainerRef.current?.replaceChildren(...canvasContainerChildren);
-                        }, []);
-
-                        return <div ref={canvasContainerRef} style={{ display: canvasContainerDisplay, width: "100%", height: "100%" }} />;
-                    },
-                });
-
-                return {
-                    dispose: () => {
-                        registration.dispose();
-                    },
-                };
-            },
-        };
 
         // This service exposes the scene that was passed into Inspector through ISceneContext, which is used by other services that may be used in other contexts outside of Inspector.
         const sceneContextServiceDefinition: ServiceDefinition<[ISceneContext], []> = {
@@ -200,95 +247,95 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
                 };
             },
         };
+        serviceDefinitions.push(sceneContextServiceDefinition);
 
         if (options.autoResizeEngine) {
             const observer = scene.onBeforeRenderObservable.add(() => scene.getEngine().resize());
             disposeActions.push(() => observer.remove());
         }
 
+        serviceDefinitions.push(
+            // Helps with managing gizmos and a shared utility layer.
+            GizmoServiceDefinition,
+
+            // Scene explorer tab and related services.
+            SceneExplorerServiceDefinition,
+            NodeExplorerServiceDefinition,
+            SkeletonExplorerServiceDefinition,
+            MaterialExplorerServiceDefinition,
+            TextureExplorerServiceDefinition,
+            PostProcessExplorerServiceDefinition,
+            RenderingPipelineExplorerServiceDefinition,
+            EffectLayerExplorerServiceDefinition,
+            ParticleSystemExplorerServiceDefinition,
+            SpriteManagerExplorerServiceDefinition,
+            AnimationGroupExplorerServiceDefinition,
+            GuiExplorerServiceDefinition,
+            FrameGraphExplorerServiceDefinition,
+            AtmosphereExplorerServiceDefinition,
+
+            // Properties pane tab and related services.
+            ScenePropertiesServiceDefinition,
+            PropertiesServiceDefinition,
+            TexturePropertiesServiceDefinition,
+            CommonPropertiesServiceDefinition,
+            TransformPropertiesServiceDefinition,
+            AnimationPropertiesServiceDefinition,
+            NodePropertiesServiceDefinition,
+            PhysicsPropertiesServiceDefinition,
+            SkeletonPropertiesServiceDefinition,
+            MaterialPropertiesServiceDefinition,
+            LightPropertiesServiceDefinition,
+            SpritePropertiesServiceDefinition,
+            ParticleSystemPropertiesServiceDefinition,
+            CameraPropertiesServiceDefinition,
+            PostProcessPropertiesServiceDefinition,
+            RenderingPipelinePropertiesServiceDefinition,
+            EffectLayerPropertiesServiceDefinition,
+            FrameGraphPropertiesServiceDefinition,
+            AnimationGroupPropertiesServiceDefinition,
+            MetadataPropertiesServiceDefinition,
+            AtmospherePropertiesServiceDefinition,
+
+            // Texture editor and related services.
+            TextureEditorServiceDefinition,
+
+            // Debug pane tab and related services.
+            DebugServiceDefinition,
+
+            // Stats pane tab and related services.
+            StatsServiceDefinition,
+
+            // Tools pane tab and related services.
+            ToolsServiceDefinition,
+
+            // Settings pane tab and related services.
+            SettingsServiceDefinition,
+
+            // Tracks entity selection state (e.g. which Mesh or Material or other entity is currently selected in scene explorer and bound to the properties pane, etc.).
+            SelectionServiceDefinition,
+
+            // Gizmos for manipulating objects in the scene.
+            GizmoToolbarServiceDefinition,
+
+            // Allows picking objects from the scene to select them.
+            PickingServiceDefinition,
+
+            // Adds entry points for user feedback on Inspector v2 (probably eventually will be removed).
+            UserFeedbackServiceDefinition,
+
+            // Adds always present "mini stats" (like fps) to the toolbar, etc.
+            MiniStatsServiceDefinition,
+
+            // Legacy service to support custom inspectable properties on objects.
+            LegacyInspectableObjectPropertiesServiceDefinition
+        );
+
         const modularTool = MakeModularTool({
-            containerElement: parentElement,
+            containerElement,
             serviceDefinitions: [
-                // Injects the canvas the scene is rendering to into the central "content" area of the shell UI.
-                canvasInjectorServiceDefinition,
-
-                // Provides access to the scene in a generic way (other tools might provide a scene in a different way).
-                sceneContextServiceDefinition,
-
-                // Helps with managing gizmos and a shared utility layer.
-                GizmoServiceDefinition,
-
-                // Scene explorer tab and related services.
-                SceneExplorerServiceDefinition,
-                NodeExplorerServiceDefinition,
-                SkeletonExplorerServiceDefinition,
-                MaterialExplorerServiceDefinition,
-                TextureExplorerServiceDefinition,
-                PostProcessExplorerServiceDefinition,
-                RenderingPipelineExplorerServiceDefinition,
-                EffectLayerExplorerServiceDefinition,
-                ParticleSystemExplorerServiceDefinition,
-                SpriteManagerExplorerServiceDefinition,
-                AnimationGroupExplorerServiceDefinition,
-                GuiExplorerServiceDefinition,
-                FrameGraphExplorerServiceDefinition,
-                AtmosphereExplorerServiceDefinition,
-
-                // Properties pane tab and related services.
-                ScenePropertiesServiceDefinition,
-                PropertiesServiceDefinition,
-                TexturePropertiesServiceDefinition,
-                CommonPropertiesServiceDefinition,
-                TransformPropertiesServiceDefinition,
-                AnimationPropertiesServiceDefinition,
-                NodePropertiesServiceDefinition,
-                PhysicsPropertiesServiceDefinition,
-                SkeletonPropertiesServiceDefinition,
-                MaterialPropertiesServiceDefinition,
-                LightPropertiesServiceDefinition,
-                SpritePropertiesServiceDefinition,
-                ParticleSystemPropertiesServiceDefinition,
-                CameraPropertiesServiceDefinition,
-                PostProcessPropertiesServiceDefinition,
-                RenderingPipelinePropertiesServiceDefinition,
-                EffectLayerPropertiesServiceDefinition,
-                FrameGraphPropertiesServiceDefinition,
-                AnimationGroupPropertiesServiceDefinition,
-                MetadataPropertiesServiceDefinition,
-                AtmospherePropertiesServiceDefinition,
-
-                // Texture editor and related services.
-                TextureEditorServiceDefinition,
-
-                // Debug pane tab and related services.
-                DebugServiceDefinition,
-
-                // Stats pane tab and related services.
-                StatsServiceDefinition,
-
-                // Tools pane tab and related services.
-                ToolsServiceDefinition,
-
-                // Settings pane tab and related services.
-                SettingsServiceDefinition,
-
-                // Tracks entity selection state (e.g. which Mesh or Material or other entity is currently selected in scene explorer and bound to the properties pane, etc.).
-                SelectionServiceDefinition,
-
-                // Gizmos for manipulating objects in the scene.
-                GizmoToolbarServiceDefinition,
-
-                // Allows picking objects from the scene to select them.
-                PickingServiceDefinition,
-
-                // Adds entry points for user feedback on Inspector v2 (probably eventually will be removed).
-                UserFeedbackServiceDefinition,
-
-                // Adds always present "mini stats" (like fps) to the toolbar, etc.
-                MiniStatsServiceDefinition,
-
-                // Legacy service to support custom inspectable properties on objects.
-                LegacyInspectableObjectPropertiesServiceDefinition,
+                // Default Inspector services.
+                ...serviceDefinitions,
 
                 // Additional services passed in to the Inspector.
                 ...(options.serviceDefinitions ?? []),
@@ -296,7 +343,6 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
             themeMode: options.themeMode,
             showThemeSelector: options.showThemeSelector,
             extensionFeeds: [DefaultInspectorExtensionFeed, ...(options.extensionFeeds ?? [])],
-            layoutMode: options.layoutMode,
             toolbarMode: "compact",
             sidePaneRemapper: options.sidePaneRemapper,
         });

--- a/packages/dev/inspector-v2/src/modularTool.tsx
+++ b/packages/dev/inspector-v2/src/modularTool.tsx
@@ -36,13 +36,13 @@ import { ServiceContainer } from "./modularity/serviceContainer";
 import { MakeShellServiceDefinition, RootComponentServiceIdentity } from "./services/shellService";
 import { ThemeSelectorServiceDefinition } from "./services/themeSelectorService";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     app: {
         colorScheme: "light dark",
         flexGrow: 1,
         display: "flex",
         flexDirection: "column",
+        backgroundColor: tokens.colorTransparentBackground,
     },
     spinner: {
         flexGrow: 1,

--- a/packages/dev/inspector-v2/src/services/creationToolsService.tsx
+++ b/packages/dev/inspector-v2/src/services/creationToolsService.tsx
@@ -9,7 +9,6 @@ import { FormNewRegular } from "@fluentui/react-icons";
 import { SceneContextIdentity } from "./sceneContext";
 import { useObservableState } from "../hooks/observableHooks";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     section: {
         display: "flex",

--- a/packages/dev/inspector-v2/src/services/extensionsListService.tsx
+++ b/packages/dev/inspector-v2/src/services/extensionsListService.tsx
@@ -61,7 +61,6 @@ import { useExtensionManager } from "../contexts/extensionManagerContext";
 import { MakePopoverTeachingMoment } from "../hooks/teachingMomentHooks";
 import { ShellServiceIdentity } from "./shellService";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     extensionButton: {},
     extensionsDialogSurface: {
@@ -183,7 +182,6 @@ function usePeopleMetadata(people?: readonly (string | PersonMetadata | undefine
     return peopleMetadataEx.filter(Boolean);
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useTeachingMoment = MakePopoverTeachingMoment("Extensions");
 
 const WebResource: FunctionComponent<{ url: string; urlDisplay?: string; icon: JSX.Element; label: string }> = (props) => {

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -245,8 +245,6 @@ export interface IShellService extends IService<typeof ShellServiceIdentity> {
 
 type ToolbarMode = "full" | "compact";
 
-type LayoutMode = "inline" | "overlay";
-
 /**
  * Options for configuring the shell service.
  */
@@ -285,25 +283,21 @@ export type ShellServiceOptions = {
      * @returns The new location for the side pane.
      */
     sidePaneRemapper?: (sidePane: Readonly<SidePaneDefinition>) => Nullable<{ horizontalLocation: HorizontalLocation; verticalLocation: VerticalLocation }>;
-
-    /**
-     * Determines whether the side panes and toolbars are displayed inline with the central content, or overlayed on top of it.
-     */
-    layoutMode?: LayoutMode;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const useStyles = makeStyles({
     mainView: {
         flex: 1,
         display: "flex",
         flexDirection: "column",
         overflow: "hidden",
+        backgroundColor: tokens.colorTransparentBackground,
     },
     verticallyCentralContent: {
         flexGrow: 1,
         display: "flex",
         overflow: "hidden",
+        backgroundColor: tokens.colorTransparentBackground,
     },
     barDiv: {
         display: "flex",
@@ -311,6 +305,7 @@ const useStyles = makeStyles({
         flex: "0 0 auto",
         height: "36px",
         backgroundColor: tokens.colorNeutralBackground2,
+        pointerEvents: "auto",
     },
     bar: {
         display: "flex",
@@ -378,16 +373,7 @@ const useStyles = makeStyles({
         overflowX: "hidden",
         overflowY: "hidden",
         zIndex: 1,
-    },
-    paneContainerOverlay: {
-        position: "absolute",
-        height: "100%",
-    },
-    paneContainerOverlayLeft: {
-        left: 0,
-    },
-    paneContainerOverlayRight: {
-        right: 0,
+        pointerEvents: "auto",
     },
     paneContent: {
         display: "flex",
@@ -457,6 +443,10 @@ const useStyles = makeStyles({
         flexGrow: 1,
         display: "flex",
         overflow: "hidden",
+        backgroundColor: tokens.colorTransparentBackground,
+        "> *": {
+            pointerEvents: "auto",
+        },
     },
     expandButtonContainer: {
         position: "absolute",
@@ -675,7 +665,6 @@ const SidePaneTab: FunctionComponent<
 // In "full" mode, the returned tab list is later injected into the toolbar.
 function usePane(
     location: HorizontalLocation,
-    layoutMode: LayoutMode,
     defaultWidth: number,
     minWidth: number,
     sidePanes: SidePaneDefinition[],
@@ -1048,15 +1037,7 @@ function usePane(
             <>
                 {/* If there is no window state, then we are docked, so render the resizable div and the collapse container. */}
                 {!isChildWindowOpen && (
-                    <div
-                        ref={paneContainerRef}
-                        className={mergeClasses(
-                            classes.paneContainer,
-                            layoutMode === "inline"
-                                ? undefined
-                                : mergeClasses(classes.paneContainerOverlay, location === "left" ? classes.paneContainerOverlayLeft : classes.paneContainerOverlayRight)
-                        )}
-                    >
+                    <div ref={paneContainerRef} className={classes.paneContainer}>
                         {(topPanes.length > 0 || bottomPanes.length > 0) && (
                             <div className={`${classes.pane} ${location === "left" ? classes.paneLeft : classes.paneRight}`}>
                                 <Collapse orientation="horizontal" visible={!collapsed}>
@@ -1095,7 +1076,6 @@ export function MakeShellServiceDefinition({
     rightPaneMinWidth = 350,
     toolbarMode = "full",
     sidePaneRemapper = undefined,
-    layoutMode = "inline",
 }: ShellServiceOptions = {}): ServiceDefinition<[IShellService, IRootComponentService], []> {
     return {
         friendlyName: "MainView",
@@ -1291,7 +1271,6 @@ export function MakeShellServiceDefinition({
 
                 const [leftPaneTabList, leftPane, leftPaneCollapsed, setLeftPaneCollapsed, leftPaneUndocked, setLeftPaneUndocked] = usePane(
                     "left",
-                    layoutMode,
                     leftPaneDefaultWidth,
                     leftPaneMinWidth,
                     coercedSidePanes,
@@ -1309,7 +1288,6 @@ export function MakeShellServiceDefinition({
 
                 const [rightPaneTabList, rightPane, rightPaneCollapsed, setRightPaneCollapsed, rightPaneUndocked, setRightPaneUndocked] = usePane(
                     "right",
-                    layoutMode,
                     rightPaneDefaultWidth,
                     rightPaneMinWidth,
                     coercedSidePanes,
@@ -1367,14 +1345,14 @@ export function MakeShellServiceDefinition({
                                 ))}
                                 {toolbarMode === "compact" && (
                                     <>
-                                        <FluentFade visible={leftPaneCollapsed} delay={50}>
+                                        <FluentFade visible={leftPaneCollapsed} delay={50} duration={100} unmountOnExit>
                                             <div className={mergeClasses(classes.expandButtonContainer, classes.expandButtonContainerLeft)}>
                                                 <Tooltip content="Show Side Pane" relationship="label">
                                                     <Button className={classes.expandButton} icon={<PanelLeftExpandRegular />} onClick={() => setLeftPaneCollapsed(false)} />
                                                 </Tooltip>
                                             </div>
                                         </FluentFade>
-                                        <FluentFade visible={rightPaneCollapsed} delay={50}>
+                                        <FluentFade visible={rightPaneCollapsed} delay={50} duration={100} unmountOnExit>
                                             <div className={mergeClasses(classes.expandButtonContainer, classes.expandButtonContainerRight)}>
                                                 <Tooltip content="Show Side Pane" relationship="label">
                                                     <Button className={classes.expandButton} icon={<PanelRightExpandRegular />} onClick={() => setRightPaneCollapsed(false)} />

--- a/packages/dev/inspector-v2/src/themes/babylonTheme.ts
+++ b/packages/dev/inspector-v2/src/themes/babylonTheme.ts
@@ -1,12 +1,11 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
 import type { BrandVariants, Theme } from "@fluentui/react-components";
 
 import { createDarkTheme, createLightTheme } from "@fluentui/react-components";
 
 // Generated from https://react.fluentui.dev/?path=/docs/theme-theme-designer--docs
 // Key color: #3A94FC
-const babylonRamp: BrandVariants = {
+/* eslint-disable @typescript-eslint/naming-convention */
+const BabylonRamp: BrandVariants = {
     10: "#020305",
     20: "#121721",
     30: "#1A263A",
@@ -24,11 +23,12 @@ const babylonRamp: BrandVariants = {
     150: "#AFC9FF",
     160: "#C6D8FF",
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export const LightTheme: Theme = {
-    ...createLightTheme(babylonRamp),
+    ...createLightTheme(BabylonRamp),
 };
 
 export const DarkTheme: Theme = {
-    ...createDarkTheme(babylonRamp),
+    ...createDarkTheme(BabylonRamp),
 };


### PR DESCRIPTION
The main change in this PR is to improve "overlay" mode in Inspector v2. Previously, Inspector v2 would always rehost targeted canvas element (or some ancestor when the canvas is inside a shadow root), regardless of "inline" mode or "overlay" mode. The difference was just whether the side panes would "overlay" the canvas or not. This can be problematic when the host app needs the dom to not change, such as when using an html custom element that has setup/teardown logic when the element is connected/disconnected (the Babylon Viewer is one example). With this change, Inspector v2 will no longer re-host the canvas element in "overlay" mode, and instead finds and appropriate ancestor element where it is injected "on top" of the canvas. This is more like what Inspector v1 did for overlay mode as well. However, since Inspector v2 does rely on a container element for the side panes and toolbars, the "central content" area needs to be visually transparent and also allow pointer input to pass through it to the canvas below. So the main two changes are:
- Central content area is visually transparent and allows pointer input to pass through.
- Improved logic for determining a parent element where the inspector v2 UI is attached.
- Move "overlay" mode logic from ShellService to instead be specific to the Inspector layer.
- The "canvas injector" service is now conditional, and only used when re-hosting the canvas for "inline" mode (it is not needed for "overlay" mode since we are not modifying the dom for the host app).

FYI @coryboyle

Also included some other small fixes:
- Added an ESLint rule to not enforce object property naming conventions for names that look like css selectors (e.g. in css in js, like React styles).
- Removed now unnecessary ESLint rule suppression comments.
- Fixed a bug where the side pane expand buttons were still in the dom when the side panes were already expanded, just visually hidden. Otherwise, those invisible buttons still block input to the canvas.