### PR TITLE
[NPE] Clone reference values when migrating

### DIFF
--- a/packages/dev/core/src/Particles/Node/Blocks/particleSourceTextureBlock.ts
+++ b/packages/dev/core/src/Particles/Node/Blocks/particleSourceTextureBlock.ts
@@ -170,7 +170,7 @@ export class ParticleTextureSourceBlock extends NodeParticleBlock {
                             height: size.height,
                             data: new Uint8ClampedArray(data),
                         };
-                        //texture.dispose();
+                        texture.dispose();
                         resolve(this._cachedData);
                     })
                     // eslint-disable-next-line github/no-then


### PR DESCRIPTION
When migrating a particle system all values were passed from the old system to the new system. For value types that is fine as they get copied, but for references like Vector3 or Color4, the same reference was used in both systems. This PR clones any reference type to avoid having any object shared between the old system and the created new system.