### PR TITLE
SFE: Replace react-contextmenu dependency w fluent contextMenu from sharedUi 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33733,8 +33733,7 @@
                 "@dev/core": "^1.0.0",
                 "@dev/shared-ui-components": "^1.0.0",
                 "@dev/smart-filters": "^1.0.0",
-                "@dev/smart-filters-blocks": "^1.0.0",
-                "react-contextmenu": "RaananW/react-contextmenu#4cb92c957ebff7aee6fc3b0ace61bc143a7373f2"
+                "@dev/smart-filters-blocks": "^1.0.0"
             },
             "peerDependencies": {
                 "@babylonjs/core": "^8.0.1",

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/fluentToolWrapper.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/fluentToolWrapper.tsx
@@ -24,6 +24,11 @@ export type ToolHostProps = {
      * Name of the tool displayed in the UX
      */
     toolName: string;
+
+    /**
+     * Override the qsp detection for fluent
+     */
+    useFluent?: boolean;
 };
 
 export const ToolContext = createContext({ useFluent: false as boolean, disableCopy: false as boolean, toolName: "" as string, size: undefined as UiSize | undefined } as const);
@@ -36,7 +41,8 @@ export const ToolContext = createContext({ useFluent: false as boolean, disableC
  */
 export const FluentToolWrapper: FunctionComponent<PropsWithChildren<ToolHostProps>> = (props) => {
     const url = new URL(window.location.href);
-    const useFluent = url.searchParams.has("newUX") || url.hash.includes("newUX");
+    const useFluentFromUrl = url.searchParams.has("newUX") || url.hash.includes("newUX");
+    const useFluent = props.useFluent ?? useFluentFromUrl;
     const contextValue = {
         useFluent,
         disableCopy: !!props.disableCopy,

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/button.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/button.tsx
@@ -1,11 +1,12 @@
 import { Button as FluentButton } from "@fluentui/react-components";
+import type { MouseEvent } from "react";
 import { forwardRef, useContext } from "react";
 import type { FluentIcon } from "@fluentui/react-icons";
 import type { BasePrimitiveProps } from "./primitive";
 import { ToolContext } from "../hoc/fluentToolWrapper";
 
 export type ButtonProps = BasePrimitiveProps & {
-    onClick?: () => void;
+    onClick?: (e?: MouseEvent<HTMLButtonElement>) => void;
     icon?: FluentIcon;
     appearance?: "subtle" | "transparent" | "primary";
     label?: string;

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/contextMenu.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/contextMenu.tsx
@@ -1,0 +1,204 @@
+import type { ReactElement, ReactNode } from "react";
+import { forwardRef, useState } from "react";
+import { Menu, MenuTrigger, MenuPopover, MenuList, MenuItem, MenuDivider, MenuGroup, MenuGroupHeader, makeStyles, tokens } from "@fluentui/react-components";
+import type { MenuProps as FluentMenuProps } from "@fluentui/react-components";
+import type { FluentIcon } from "@fluentui/react-icons";
+import { Button } from "shared-ui-components/fluent/primitives/button";
+import type { BasePrimitiveProps } from "./primitive";
+
+const useStyles = makeStyles({
+    menuPopover: {
+        minWidth: "160px",
+    },
+    menuItem: {
+        cursor: "pointer",
+    },
+    menuItemIcon: {
+        color: tokens.colorNeutralForeground2,
+    },
+});
+
+/**
+ * Represents a single menu item in the context menu.
+ */
+export type ContextMenuItemProps = {
+    /**
+     * Unique key for the menu item.
+     */
+    key: string;
+    /**
+     * The text label displayed for the menu item.
+     */
+    label: string;
+    /**
+     * Optional icon to display alongside the menu item.
+     */
+    icon?: FluentIcon;
+    /**
+     * Called when the menu item is clicked.
+     */
+    onClick?: () => void;
+    /**
+     * Whether the menu item is disabled.
+     */
+    disabled?: boolean;
+    /**
+     * Optional secondary text displayed alongside the label.
+     */
+    secondaryContent?: string;
+};
+
+/**
+ * Represents a divider in the context menu.
+ */
+export type ContextMenuDividerProps = {
+    /**
+     * Unique key for the divider.
+     */
+    key: string;
+    /**
+     * Indicates this is a divider item.
+     */
+    type: "divider";
+};
+
+/**
+ * Represents a group of menu items with an optional header.
+ */
+export type ContextMenuGroupProps = {
+    /**
+     * Unique key for the group.
+     */
+    key: string;
+    /**
+     * Indicates this is a group item.
+     */
+    type: "group";
+    /**
+     * Optional header text for the group.
+     */
+    header?: string;
+    /**
+     * The menu items within the group.
+     */
+    items: ContextMenuItem[];
+};
+
+/**
+ * Union type representing all possible menu items.
+ */
+export type ContextMenuItem = ContextMenuItemProps | ContextMenuDividerProps | ContextMenuGroupProps;
+
+type ContextMenuWithIconProps = {
+    /**
+     * Icon to use as the trigger button.
+     */
+    icon: FluentIcon;
+    trigger?: never;
+};
+
+type ContextMenuWithTriggerProps = {
+    icon?: never;
+    /**
+     * Custom trigger element for opening the menu.
+     */
+    trigger: ReactElement;
+};
+
+export type ContextMenuProps = BasePrimitiveProps &
+    (ContextMenuWithIconProps | ContextMenuWithTriggerProps) & {
+        /**
+         * Array of menu items to display.
+         */
+        items: ContextMenuItem[];
+        /**
+         * Positioning of the menu relative to the trigger.
+         */
+        positioning?: FluentMenuProps["positioning"];
+        /**
+         * Called when the menu open state changes.
+         */
+        onOpenChange?: (open: boolean) => void;
+    };
+
+const IsDivider = (item: ContextMenuItem): item is ContextMenuDividerProps => {
+    return "type" in item && item.type === "divider";
+};
+
+const IsGroup = (item: ContextMenuItem): item is ContextMenuGroupProps => {
+    return "type" in item && item.type === "group";
+};
+
+const RenderMenuItem = (item: ContextMenuItemProps, classes: ReturnType<typeof useStyles>) => {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    const Icon = item.icon;
+    return (
+        <MenuItem
+            key={item.key}
+            className={classes.menuItem}
+            icon={Icon ? <Icon className={classes.menuItemIcon} /> : undefined}
+            onClick={item.onClick}
+            disabled={item.disabled}
+            secondaryContent={item.secondaryContent}
+        >
+            {item.label}
+        </MenuItem>
+    );
+};
+
+const RenderMenuItems = (items: ContextMenuItem[], classes: ReturnType<typeof useStyles>): ReactNode[] => {
+    return items.map((item) => {
+        if (IsDivider(item)) {
+            return <MenuDivider key={item.key} />;
+        }
+
+        if (IsGroup(item)) {
+            return (
+                <MenuGroup key={item.key}>
+                    {item.header && <MenuGroupHeader>{item.header}</MenuGroupHeader>}
+                    {RenderMenuItems(item.items, classes)}
+                </MenuGroup>
+            );
+        }
+
+        return RenderMenuItem(item, classes);
+    });
+};
+
+/**
+ * A wrapper around Fluent UI's Menu component providing a simplified API for context menus.
+ * Supports menu items with icons, dividers, and grouped items.
+ */
+export const ContextMenu = forwardRef<HTMLButtonElement, ContextMenuProps>((props, ref) => {
+    const { items, onOpenChange, disabled } = props;
+    const [open, setOpen] = useState(false);
+    const classes = useStyles();
+
+    const handleOpenChange = (_: unknown, data: { open: boolean }) => {
+        setOpen(data.open);
+        onOpenChange?.(data.open);
+    };
+
+    return (
+        <Menu openOnContext open={open} onOpenChange={handleOpenChange}>
+            <MenuTrigger disableButtonEnhancement>
+                {props.trigger ?? (
+                    <Button
+                        ref={ref}
+                        icon={props.icon}
+                        onClick={(e) => {
+                            e?.stopPropagation();
+                            setOpen(true);
+                        }}
+                        disabled={disabled}
+                    />
+                )}
+            </MenuTrigger>
+            <MenuPopover className={classes.menuPopover}>
+                <MenuList>{RenderMenuItems(items, classes)}</MenuList>
+            </MenuPopover>
+        </Menu>
+    );
+});
+
+ContextMenu.displayName = "ContextMenu";

--- a/packages/tools/smartFiltersEditorControl/package.json
+++ b/packages/tools/smartFiltersEditorControl/package.json
@@ -34,7 +34,6 @@
         "@dev/smart-filters": "^1.0.0",
         "@dev/smart-filters-blocks": "^1.0.0",
         "@dev/core": "^1.0.0",
-        "@dev/shared-ui-components": "^1.0.0",
-        "react-contextmenu": "RaananW/react-contextmenu#4cb92c957ebff7aee6fc3b0ace61bc143a7373f2"
+        "@dev/shared-ui-components": "^1.0.0"
     }
 }

--- a/packages/tools/smartFiltersEditorControl/src/components/nodeList/nodeListComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/components/nodeList/nodeListComponent.tsx
@@ -3,7 +3,7 @@ import * as react from "react";
 import type { Nullable } from "core/types";
 import type { Observer } from "core/Misc/observable";
 import { Tools } from "core/Misc/tools.js";
-import { ContextMenu, MenuItem } from "react-contextmenu";
+import type { ContextMenuItem } from "shared-ui-components/fluent/primitives/contextMenu";
 
 import type { GlobalState } from "../../globalState";
 import { LineContainerComponent } from "../../sharedComponents/lineContainerComponent.js";
@@ -108,7 +108,7 @@ export class NodeListComponent extends react.Component<INodeListComponentProps, 
                     return <DraggableBlockLineComponent key={GetBlockKey(block.blockType, block.namespace)} block={block} />;
                 });
 
-            let contextMenu: JSX.Element | undefined = undefined;
+            let contextMenuItems: ContextMenuItem[] | undefined = undefined;
 
             if (key === CustomBlocksNamespace) {
                 const line = (
@@ -128,25 +128,22 @@ export class NodeListComponent extends react.Component<INodeListComponentProps, 
 
                 if (this.props.globalState.clearCustomBlocks) {
                     const clearCustomBlocks = this.props.globalState.clearCustomBlocks;
-                    contextMenu = (
-                        <ContextMenu id={"contextmenu#" + key} className="context-menu">
-                            <MenuItem
-                                key="Remove_All_Custom_Blocks"
-                                onClick={() => {
-                                    clearCustomBlocks();
-                                    this.forceUpdate();
-                                }}
-                            >
-                                Remove All Custom Blocks
-                            </MenuItem>
-                        </ContextMenu>
-                    );
+                    contextMenuItems = [
+                        {
+                            key: "Remove_All_Custom_Blocks",
+                            label: "Remove All Custom Blocks",
+                            onClick: () => {
+                                clearCustomBlocks();
+                                this.forceUpdate();
+                            },
+                        },
+                    ];
                 }
             }
 
             if (blockList.length) {
                 blockMenu.push(
-                    <LineContainerComponent key={key + " blocks"} title={key.replace("__", ": ").replace("_", " ")} closed={false} contextMenu={contextMenu}>
+                    <LineContainerComponent key={key + " blocks"} title={key.replace("__", ": ").replace("_", " ")} closed={false} contextMenuItems={contextMenuItems}>
                         {blockList}
                     </LineContainerComponent>
                 );

--- a/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/sharedComponents/lineContainerComponent.tsx
@@ -1,13 +1,15 @@
 import { DataStorage } from "core/Misc/dataStorage.js";
 import * as react from "react";
 import downArrow from "../assets/imgs/downArrow.svg";
-import { ContextMenuTrigger } from "react-contextmenu";
+import type { ContextMenuItem } from "shared-ui-components/fluent/primitives/contextMenu";
+import { ContextMenu } from "shared-ui-components/fluent/primitives/contextMenu";
+import { FluentToolWrapper } from "shared-ui-components/fluent/hoc/fluentToolWrapper";
 
 interface ILineContainerComponentProps {
     title: string;
     children: any[] | any;
     closed?: boolean;
-    contextMenu?: JSX.Element;
+    contextMenuItems?: ContextMenuItem[];
 }
 
 export class LineContainerComponent extends react.Component<ILineContainerComponentProps, { isExpanded: boolean }> {
@@ -37,13 +39,11 @@ export class LineContainerComponent extends react.Component<ILineContainerCompon
                 </div>
             </div>
         );
-
-        if (this.props.contextMenu) {
+        if (this.props.contextMenuItems && this.props.contextMenuItems.length > 0) {
             return (
-                <ContextMenuTrigger id={this.props.contextMenu.props.id}>
-                    {this.props.contextMenu}
-                    {header}
-                </ContextMenuTrigger>
+                <FluentToolWrapper toolName="Smart Filter Editor" useFluent>
+                    <ContextMenu trigger={header} items={this.props.contextMenuItems} />
+                </FluentToolWrapper>
             );
         } else {
             return header;


### PR DESCRIPTION
- create a shared contextMenu component using fluent's menu component
- replace usage of react-contextMenu with the new shared components in SFE
<img width="281" height="48" alt="image" src="https://github.com/user-attachments/assets/f4928cb4-f98a-4091-ada8-6eb04c619c7d" />
