### PR TITLE
Fix Inspector v2 layout regression in Playground and Sandbox

### DIFF
--- a/packages/tools/playground/src/scss/main.scss
+++ b/packages/tools/playground/src/scss/main.scss
@@ -76,6 +76,10 @@
     }
 }
 
+.canvasZone {
+    position: relative;
+}
+
 @media screen and (max-width: 1140px) {
     #pg-root {
         grid-template-rows: 40px calc(100% - 75px) 35px;

--- a/packages/tools/sandbox/src/scss/renderingZone.scss
+++ b/packages/tools/sandbox/src/scss/renderingZone.scss
@@ -1,5 +1,6 @@
 #canvasZone {
     display: block;
+    position: relative;
     padding: 0;
     margin: 0;
     overflow: hidden;


### PR DESCRIPTION
#17603 reworked the Inspector v2 overlay mode, and part of this included creating a new container element, and not mutating the canvas parent element, since it can have other children, so mutating it can break the host app. However, as it currently is, Inspector v2 will not render correctly when the parent element has its css `position` set to `static` (the default), which is what is happening in Playground and Sandbox right now. As a quick fix for this regression, I'm simply setting `position` to `relative` for both Playground and Sandbox, and I need to investigate more if there is a robust way to make the layout correct without mutating the parent container element.