### PR TITLE
TAA: Fix crash when using materials that don't support plugins

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/taaMaterialManager.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/Pipelines/taaMaterialManager.ts
@@ -169,8 +169,11 @@ export class TAAMaterialManager {
         }
     }
 
-    private _getPlugin(material: Material): TAAJitterMaterialPlugin {
-        let plugin = material.pluginManager?.getPlugin<TAAJitterMaterialPlugin>(TAAJitterMaterialPlugin.Name);
+    private _getPlugin(material: Material): Nullable<TAAJitterMaterialPlugin> {
+        if (!material.pluginManager) {
+            return null;
+        }
+        let plugin = material.pluginManager.getPlugin<TAAJitterMaterialPlugin>(TAAJitterMaterialPlugin.Name);
         if (!plugin) {
             plugin = new TAAJitterMaterialPlugin(material);
         }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/error-using-taa-and-rotationgizmo/61995