### PR TITLE
Light: Add a flag to not add the light to the scene at creation time

### DIFF
--- a/packages/dev/core/src/Lights/areaLight.ts
+++ b/packages/dev/core/src/Lights/areaLight.ts
@@ -79,9 +79,10 @@ export abstract class AreaLight extends Light {
      * @param name The friendly name of the light
      * @param position The position of the area light.
      * @param scene The scene the light belongs to
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, position: Vector3, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, position: Vector3, scene?: Scene, dontAddToScene?: boolean) {
+        super(name, scene, dontAddToScene);
         this.position = position;
 
         if (!this._scene._ltcTextures) {

--- a/packages/dev/core/src/Lights/directionalLight.ts
+++ b/packages/dev/core/src/Lights/directionalLight.ts
@@ -134,9 +134,10 @@ export class DirectionalLight extends ShadowLight {
      * @param name The friendly name of the light
      * @param direction The direction of the light
      * @param scene The scene the light belongs to
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, direction: Vector3, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, direction: Vector3, scene?: Scene, dontAddToScene?: boolean) {
+        super(name, scene, dontAddToScene);
         this.position = direction.scale(-1.0);
         this.direction = direction;
     }

--- a/packages/dev/core/src/Lights/hemisphericLight.ts
+++ b/packages/dev/core/src/Lights/hemisphericLight.ts
@@ -39,9 +39,10 @@ export class HemisphericLight extends Light {
      * @param name The friendly name of the light
      * @param direction The direction of the light reflection
      * @param scene The scene the light belongs to
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, direction: Vector3, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, direction: Vector3, scene?: Scene, dontAddToScene?: boolean) {
+        super(name, scene, dontAddToScene);
         this.direction = direction || Vector3.Up();
     }
 

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -379,17 +379,22 @@ export abstract class Light extends Node implements ISortableLight {
      * Documentation : https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction
      * @param name The friendly name of the light
      * @param scene The scene the light belongs too
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, scene?: Scene) {
+    constructor(name: string, scene?: Scene, dontAddToScene?: boolean) {
         super(name, scene, false);
-        this.getScene().addLight(this);
+        if (!dontAddToScene) {
+            this.getScene().addLight(this);
+        }
         this._uniformBuffer = new UniformBuffer(this.getScene().getEngine(), undefined, undefined, name);
         this._buildUniformLayout();
 
         this.includedOnlyMeshes = [] as AbstractMesh[];
         this.excludedMeshes = [] as AbstractMesh[];
 
-        this._resyncMeshes();
+        if (!dontAddToScene) {
+            this._resyncMeshes();
+        }
     }
 
     protected abstract _buildUniformLayout(): void;

--- a/packages/dev/core/src/Lights/pointLight.ts
+++ b/packages/dev/core/src/Lights/pointLight.ts
@@ -76,9 +76,10 @@ export class PointLight extends ShadowLight {
      * @param name The light friendly name
      * @param position The position of the point light in the scene
      * @param scene The scene the lights belongs to
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, position: Vector3, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, position: Vector3, scene?: Scene, dontAddToScene?: boolean) {
+        super(name, scene, dontAddToScene);
         this.position = position;
     }
 

--- a/packages/dev/core/src/Lights/rectAreaLight.ts
+++ b/packages/dev/core/src/Lights/rectAreaLight.ts
@@ -58,9 +58,10 @@ export class RectAreaLight extends AreaLight {
      * @param width The width of the area light.
      * @param height The height of the area light.
      * @param scene The scene the light belongs to
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, position: Vector3, width: number, height: number, scene?: Scene) {
-        super(name, position, scene);
+    constructor(name: string, position: Vector3, width: number, height: number, scene?: Scene, dontAddToScene?: boolean) {
+        super(name, position, scene, dontAddToScene);
         this._width = new Vector3(width, 0, 0);
         this._height = new Vector3(0, height, 0);
         this._pointTransformedPosition = Vector3.Zero();

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -259,9 +259,10 @@ export class SpotLight extends ShadowLight {
      * @param angle The cone angle of the light in Radians
      * @param exponent The light decay speed with the distance from the emission spot
      * @param scene The scene the lights belongs to
+     * @param dontAddToScene True to not add the light to the scene
      */
-    constructor(name: string, position: Vector3, direction: Vector3, angle: number, exponent: number, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, position: Vector3, direction: Vector3, angle: number, exponent: number, scene?: Scene, dontAddToScene?: boolean) {
+        super(name, scene, dontAddToScene);
 
         this.position = position;
         this.direction = direction;

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2978,8 +2978,9 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             if (!toRemove.parent) {
                 toRemove._removeFromSceneRootNodes();
             }
+
+            this.onLightRemovedObservable.notifyObservers(toRemove);
         }
-        this.onLightRemovedObservable.notifyObservers(toRemove);
         return index;
     }
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/adding-lights-to-a-scene-does-not-scale/62029

It dramatically improves creation of lights for use in a clustered light container if you set this new flag to **true** when creating the light.