### PR TITLE
[GeospatialCamera] Rework center/radius calc after zoom to point

### DIFF
--- a/packages/dev/core/src/Cameras/geospatialCamera.ts
+++ b/packages/dev/core/src/Cameras/geospatialCamera.ts
@@ -391,7 +391,7 @@ export class GeospatialCamera extends Camera {
             return newRadius;
         }
 
-        // Move the camera position along the center->target ray by the raw zoom delta
+        // Move the camera position towards targetPoint by distanceToTarget
         directionToTarget.scaleInPlace(distance / distanceToTarget);
         const newPosition = this._position.addToRef(directionToTarget, TmpVectors.Vector3[1]);
 


### PR DESCRIPTION
The old method moved the center directly toward the target and then renormalized, which could cause drift when the camera isn't looking straight down. The new method moves the camera along the actual ray to the zoom target, projects that movement onto the look direction to correctly update radius, then reconstructs the center from the camera's new position. This is geometrically more accurate for zoomToCursor when camera is pitched.