### PR TITLE
Fix npe package dependencies

### DIFF
--- a/packages/public/@babylonjs/node-particle-editor/package.json
+++ b/packages/public/@babylonjs/node-particle-editor/package.json
@@ -18,14 +18,13 @@
         "clean": "rimraf dist"
     },
     "peerDependencies": {
-        "@babylonjs/core": "^8.0.0",
+        "@babylonjs/core": "^8.0.0"
+    },
+    "devDependencies": {
         "@dev/shared-ui-components": "1.0.0",
         "@tools/node-particle-editor": "1.0.0",
         "@types/react": ">=16.7.3",
-        "@types/react-dom": ">=16.0.9"
-    },
-    "devDependencies": {
-        "@babylonjs/core": "^8.45.1",
+        "@types/react-dom": ">=16.0.9",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
     },


### PR DESCRIPTION
There was a regression in a recent change that results in errors when you try to `npm install @babylonjs/node-particle-editor`:

https://github.com/BabylonJS/Babylon.js/pull/17554/changes#diff-de4836ec4c38608ff991f28e6ba1b5b832e793e9fa6c96108ab1c7dadd8f4d6cR22

Two devDependencies were added to peerDependencies instead, and these are internal packages within our monorepo, so they cannot be resolved when installing the public package. This PR moves those two dependencies to devDependencies, and also cleans up some other incorrect (though non-breaking) dependency issues.