### PR TITLE
Engine: Fix crash when debug marker functions are not defined

### DIFF
--- a/packages/dev/core/src/Engines/Extensions/engine.debugging.ts
+++ b/packages/dev/core/src/Engines/Extensions/engine.debugging.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { AbstractEngine } from "../../Engines/abstractEngine";
 
+/**
+ * Note that users may not import this file, so each time we want to call one of them, we must check if it exists.
+ * @internal
+ */
+
 declare module "../../Engines/abstractEngine" {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     export interface AbstractEngine {

--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/volumetricLightingTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/volumetricLightingTask.ts
@@ -49,7 +49,7 @@ export class FrameGraphVolumetricLightingTask extends FrameGraphTask {
 
     /**
      * The lighting volume texture (optional).
-     * If not provided, a new texture will be created, which the same size, format and type as targetTexture.
+     * If not provided, a new texture will be created, with the same size, format and type as targetTexture.
      * This is the texture that will store the volumetric lighting information, before being blended to targetTexture.
      */
     public lightingVolumeTexture?: FrameGraphTextureHandle;
@@ -204,7 +204,7 @@ export class FrameGraphVolumetricLightingTask extends FrameGraphTask {
         return "FrameGraphVolumetricLightingTask";
     }
 
-    public override record(skipCreationOfDisabledPasses = false) {
+    public record(skipCreationOfDisabledPasses = false) {
         if (this.targetTexture === undefined || this.depthTexture === undefined || this.camera === undefined || this.lightingVolumeMesh === undefined || this.light === undefined) {
             throw new Error(`FrameGraphVolumetricLightingTask "${this.name}": targetTexture, depthTexture, camera, lightingVolumeMesh and light are required`);
         }

--- a/packages/dev/core/src/FrameGraph/frameGraphContext.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphContext.ts
@@ -61,14 +61,14 @@ export class FrameGraphContext {
      * @param name The name of the debug group
      */
     public pushDebugGroup(name: string) {
-        this.enableDebugMarkers && this._engine._debugPushGroup(name);
+        this.enableDebugMarkers && this._engine._debugPushGroup?.(name);
     }
 
     /**
      * Pops a debug group from the engine's debug stack.
      */
     public popDebugGroup() {
-        this.enableDebugMarkers && this._engine._debugPopGroup();
+        this.enableDebugMarkers && this._engine._debugPopGroup?.();
     }
 
     /**
@@ -76,7 +76,7 @@ export class FrameGraphContext {
      * @param text The text of the debug marker
      */
     public insertDebugMarker(text: string) {
-        this.enableDebugMarkers && this._engine._debugInsertMarker(text);
+        this.enableDebugMarkers && this._engine._debugInsertMarker?.(text);
     }
 
     /**

--- a/packages/dev/core/src/FrameGraph/frameGraphTask.ts
+++ b/packages/dev/core/src/FrameGraph/frameGraphTask.ts
@@ -231,7 +231,7 @@ export abstract class FrameGraphTask {
         this.onBeforeTaskExecute.notifyObservers(this);
 
         if (!this._disableDebugMarkers) {
-            this._frameGraph.engine._debugPushGroup(`${this.getClassName()} (${this.name})`);
+            this._frameGraph.engine._debugPushGroup?.(`${this.getClassName()} (${this.name})`);
         }
 
         for (const pass of passes) {
@@ -239,7 +239,7 @@ export abstract class FrameGraphTask {
         }
 
         if (!this._disableDebugMarkers) {
-            this._frameGraph.engine._debugPopGroup();
+            this._frameGraph.engine._debugPopGroup?.();
         }
 
         this.onAfterTaskExecute.notifyObservers(this);
@@ -248,7 +248,7 @@ export abstract class FrameGraphTask {
     /** @internal */
     public _initializePasses() {
         if (!this._disableDebugMarkers) {
-            this._frameGraph.engine._debugPushGroup(`${this.getClassName()} (${this.name})`);
+            this._frameGraph.engine._debugPushGroup?.(`${this.getClassName()} (${this.name})`);
         }
 
         for (const pass of this._passes) {
@@ -260,7 +260,7 @@ export abstract class FrameGraphTask {
         }
 
         if (!this._disableDebugMarkers) {
-            this._frameGraph.engine._debugPopGroup();
+            this._frameGraph.engine._debugPopGroup?.();
         }
     }
 

--- a/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/cascadedShadowGenerator.ts
@@ -902,7 +902,7 @@ export class CascadedShadowGenerator extends ShadowGenerator {
             this._currentSceneUBO = this._scene.getSceneUniformBuffer();
             if (engine._enableGPUDebugMarkers) {
                 engine.restoreDefaultFramebuffer();
-                engine._debugPushGroup(`Cascaded shadow map generation for pass id ${engine.currentRenderPassId}`);
+                engine._debugPushGroup?.(`Cascaded shadow map generation for pass id ${engine.currentRenderPassId}`);
             }
             if (this._breaksAreDirty) {
                 this._splitFrustum();

--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -1049,7 +1049,7 @@ export class ShadowGenerator implements IShadowGenerator {
             this._currentSceneUBO = this._scene.getSceneUniformBuffer();
             if (engine._enableGPUDebugMarkers) {
                 engine.restoreDefaultFramebuffer();
-                engine._debugPushGroup(`Shadow map generation for pass id ${engine.currentRenderPassId}`);
+                engine._debugPushGroup?.(`Shadow map generation for pass id ${engine.currentRenderPassId}`);
             }
         });
 
@@ -1083,7 +1083,7 @@ export class ShadowGenerator implements IShadowGenerator {
                 engine.setColorWrite(true);
             }
             if (!this.useBlurExponentialShadowMap && !this.useBlurCloseExponentialShadowMap) {
-                engine._debugPopGroup();
+                engine._debugPopGroup?.();
                 return;
             }
             const shadowMap = this.getShadowMapForRendering();
@@ -1094,7 +1094,7 @@ export class ShadowGenerator implements IShadowGenerator {
             }
 
             if (engine._enableGPUDebugMarkers) {
-                engine._debugPopGroup();
+                engine._debugPopGroup?.();
             }
         });
 

--- a/packages/dev/core/src/Lights/lightingVolume.ts
+++ b/packages/dev/core/src/Lights/lightingVolume.ts
@@ -220,7 +220,7 @@ export class LightingVolume {
 
             if (this._engine._enableGPUDebugMarkers) {
                 this._engine.restoreDefaultFramebuffer();
-                this._engine._debugPushGroup(`Update lighting volume (${this._name})`);
+                this._engine._debugPushGroup?.(`Update lighting volume (${this._name})`);
             }
 
             if (this._needUpdateGeometry()) {
@@ -228,21 +228,21 @@ export class LightingVolume {
 
                 const dispatchSize = Math.ceil((this._tesselation + 1) / 32);
 
-                this._engine._debugPushGroup(`Update vertices of other planes`);
+                this._engine._debugPushGroup?.(`Update vertices of other planes`);
                 this._cs2!.dispatch(dispatchSize, 1, 1);
-                this._engine._debugPopGroup();
+                this._engine._debugPopGroup?.();
             } else {
                 this._fullUpdateUBO();
             }
 
             const dispatchSize = Math.ceil((this._tesselation + 1) / 8);
 
-            this._engine._debugPushGroup(`Update vertices of far plane`);
+            this._engine._debugPushGroup?.(`Update vertices of far plane`);
             this._cs!.dispatch(dispatchSize, dispatchSize, 1);
-            this._engine._debugPopGroup();
+            this._engine._debugPopGroup?.();
 
             if (this._engine._enableGPUDebugMarkers) {
-                this._engine._debugPopGroup();
+                this._engine._debugPopGroup?.();
             }
 
             this._firstUpdate = false;

--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.ts
@@ -730,7 +730,7 @@ export class ProceduralTexture extends Texture {
 
         if (engine._enableGPUDebugMarkers) {
             engine.restoreDefaultFramebuffer();
-            engine._debugPushGroup(`procedural texture generation for ${this.name}`);
+            engine._debugPushGroup?.(`procedural texture generation for ${this.name}`);
         }
 
         const viewPort = engine.currentViewport;
@@ -796,7 +796,7 @@ export class ProceduralTexture extends Texture {
         }
 
         if (engine._enableGPUDebugMarkers) {
-            engine._debugPopGroup();
+            engine._debugPopGroup?.();
         }
 
         if (this.onGenerated) {

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.ts
@@ -703,11 +703,11 @@ export class RenderTargetTexture extends Texture implements IRenderTargetTexture
                 }
             }
 
-            engine._debugPushGroup(`Render to ${this.name} (face #${this._currentFaceIndex} layer #${this._currentLayer})`);
+            engine._debugPushGroup?.(`Render to ${this.name} (face #${this._currentFaceIndex} layer #${this._currentLayer})`);
         });
 
         this._onAfterRenderingManagerRenderObserver = this._objectRenderer.onAfterRenderingManagerRenderObservable.add(() => {
-            engine._debugPopGroup();
+            engine._debugPopGroup?.();
 
             // After Camera Draw
             if (!this._disableEngineStages) {

--- a/packages/dev/core/src/Misc/minMaxReducer.ts
+++ b/packages/dev/core/src/Misc/minMaxReducer.ts
@@ -154,7 +154,7 @@ export class MinMaxReducer {
 
         this._onAfterUnbindObserver = this._sourceTexture.onAfterUnbindObservable.add(() => {
             const engine = this._camera.getScene().getEngine();
-            engine._debugPushGroup(`min max reduction`);
+            engine._debugPushGroup?.(`min max reduction`);
             this._reductionSteps![0].activate(this._camera);
             this._postProcessManager.directRender(
                 this._reductionSteps!,
@@ -166,7 +166,7 @@ export class MinMaxReducer {
                 this._reductionSteps.length - 1
             );
             engine.unBindFramebuffer(this._reductionSteps![this._reductionSteps.length - 1].inputTexture, false);
-            engine._debugPopGroup();
+            engine._debugPopGroup?.();
         });
 
         this._activated = true;

--- a/packages/dev/core/src/Probes/reflectionProbe.ts
+++ b/packages/dev/core/src/Probes/reflectionProbe.ts
@@ -192,7 +192,7 @@ export class ReflectionProbe {
             this._currentSceneUBO = scene.getSceneUniformBuffer();
             if (engine._enableGPUDebugMarkers) {
                 engine.restoreDefaultFramebuffer();
-                engine._debugPushGroup(`reflection probe generation for ${name}`);
+                engine._debugPushGroup?.(`reflection probe generation for ${name}`);
             }
             currentApplyByPostProcess = this._scene.imageProcessingConfiguration.applyByPostProcess;
             if (linearSpace) {
@@ -209,7 +209,7 @@ export class ReflectionProbe {
             }
             scene.updateTransformMatrix(true);
             if (engine._enableGPUDebugMarkers) {
-                engine._debugPopGroup();
+                engine._debugPopGroup?.();
             }
         });
     }

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -178,13 +178,13 @@ export class DepthRenderer {
         this._depthMap.onBeforeBindObservable.add(() => {
             if (engine._enableGPUDebugMarkers) {
                 engine.restoreDefaultFramebuffer();
-                engine._debugPushGroup(`Depth renderer`);
+                engine._debugPushGroup?.(`Depth renderer`);
             }
         });
 
         this._depthMap.onAfterUnbindObservable.add(() => {
             if (engine._enableGPUDebugMarkers) {
-                engine._debugPopGroup();
+                engine._debugPopGroup?.();
             }
         });
 


### PR DESCRIPTION
The debug marker functions may not be defined, because it's an optional engine extension. So, we must check if they exist before calling them.