### PR TITLE
Do not attempt fallback when audio parameter `setValueCurveAtTime` fails

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/components/webAudioParameterComponent.ts
@@ -87,9 +87,7 @@ export class _WebAudioParameterComponent {
             this._param.setValueCurveAtTime(_GetAudioParamCurveValues(shape, Number.isFinite(this._param.value) ? this._param.value : 0, value), startTime, duration);
             this._rampEndTime = startTime + duration;
         } catch (e) {
-            Logger.Warn(`Audio parameter ramping failed. Setting value without ramping: ${(e as Error).message}`);
-            this._param.value = value;
-            this._rampEndTime = startTime;
+            Logger.Warn(`Audio parameter ramping failed: ${(e as Error).message}`);
         }
     }
 }


### PR DESCRIPTION
Firefox does not always cancel audio parameter curves when `cancelScheduledValues(0)` is called, which causes `setValueCurveAtTime` to throw an error. This happens rarely and a fallback is in place to set the volume without ramping, but that also fails on Firefox.

This change removes the fallback and only logs a warning in the rare case when Firefox throws an error.

For future reference, this PG repros the issue fairly consistently:
https://playground.babylonjs.com/#P1FP6L