### PR TITLE
[NPE] Migrating attractors

### DIFF
--- a/packages/dev/core/src/Particles/baseParticleSystem.ts
+++ b/packages/dev/core/src/Particles/baseParticleSystem.ts
@@ -889,6 +889,13 @@ export class BaseParticleSystem implements IClipPlanesHolder {
         throw new Error("Method not implemented.");
     }
 
+    /**
+     * Creates a Cone Emitter for the particle system (emits from the cone to the particle position)
+     * @param radius The radius of the cone to emit from
+     * @param angle The base angle of the cone
+     * @param direction1 Particles are emitted between the direction1 and direction2 from within the cone
+     * @param direction2 Particles are emitted between the direction1 and direction2 from within the cone
+     */
     public createDirectedConeEmitter(radius = 1, angle = Math.PI / 4, direction1 = new Vector3(0, 1.0, 0), direction2 = new Vector3(0, 1.0, 0)): ConeDirectedParticleEmitter {
         throw new Error("Method not implemented.");
     }

--- a/packages/dev/core/src/Particles/particleSystem.ts
+++ b/packages/dev/core/src/Particles/particleSystem.ts
@@ -218,6 +218,10 @@ export class ParticleSystem extends ThinParticleSystem {
         }
     }
 
+    /**
+     * Starts the particle system and begins to emit
+     * @param delay defines the delay in milliseconds before starting the system (this.startDelay by default)
+     */
     public override start(delay = this.startDelay): void {
         if (!this.canStart()) {
             return;
@@ -309,6 +313,14 @@ export class ParticleSystem extends ThinParticleSystem {
         return particleEmitter;
     }
 
+    /**
+     * Creates a Cone Emitter for the particle system (emits from the cone to the particle position)
+     * @param radius The radius of the cone to emit from
+     * @param angle The base angle of the cone
+     * @param direction1 Particles are emitted between the direction1 and direction2 from within the cone
+     * @param direction2 Particles are emitted between the direction1 and direction2 from within the cone
+     * @returns the emitter
+     */
     public override createDirectedConeEmitter(
         radius = 1,
         angle = Math.PI / 4,

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -495,6 +495,9 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
         return this._indexBuffer;
     }
 
+    /**
+     * Gets or sets a texture used to add random noise to particle positions
+     */
     public override get noiseTexture() {
         return this._noiseTexture;
     }
@@ -759,6 +762,10 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
         // Do nothing
     };
 
+    /**
+     * Serializes the particle system to a JSON object.
+     * @param _serializeTexture Whether to serialize the texture information
+     */
     serialize(_serializeTexture: boolean) {
         throw new Error("Method not implemented.");
     }
@@ -831,6 +838,9 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
         }
     }
 
+    /**
+     * The amount of time the particle system is running (depends of the overall update speed).
+     */
     public override get targetStopDuration(): number {
         return this._targetStopDuration;
     }
@@ -1571,7 +1581,6 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
      */
     public start(delay = this.startDelay): void {
         if (!this.targetStopDuration && this._hasTargetStopDurationDependantGradient()) {
-            // eslint-disable-next-line no-throw-literal
             throw "Particle system started with a targetStopDuration dependant gradient (eg. startSizeGradients) but no targetStopDuration set";
         }
         if (delay) {

--- a/packages/tools/nodeParticleEditor/src/graphSystem/registerToDisplayLedger.ts
+++ b/packages/tools/nodeParticleEditor/src/graphSystem/registerToDisplayLedger.ts
@@ -11,6 +11,9 @@ import { TeleportInDisplayManager } from "./display/teleportInDisplayManager";
 import { ConditionDisplayManager } from "./display/conditionDisplayManager";
 import { TriggerDisplayManager } from "./display/triggerDisplayManager";
 
+/**
+ * Registers all display managers to the display ledger
+ */
 export const RegisterToDisplayManagers = () => {
     DisplayLedger.RegisteredControls["ParticleInputBlock"] = InputDisplayManager;
     DisplayLedger.RegisteredControls["ParticleTextureSourceBlock"] = TextureDisplayManager;
@@ -36,6 +39,7 @@ export const RegisterToDisplayManagers = () => {
     DisplayLedger.RegisteredControls["BasicPositionUpdateBlock"] = UpdateDisplayManager;
     DisplayLedger.RegisteredControls["BasicSpriteUpdateBlock"] = UpdateDisplayManager;
     DisplayLedger.RegisteredControls["BasicColorUpdateBlock"] = UpdateDisplayManager;
+    DisplayLedger.RegisteredControls["UpdateAttractorBlock"] = UpdateDisplayManager;
     DisplayLedger.RegisteredControls["UpdateFlowMapBlock"] = UpdateDisplayManager;
     DisplayLedger.RegisteredControls["UpdateNoiseBlock"] = UpdateDisplayManager;
     DisplayLedger.RegisteredControls["UpdateRemapBlock"] = UpdateDisplayManager;


### PR DESCRIPTION
Adds attractors to the migration tool.
Adds some missing docs for the linter.

PG to test: #DEZ79M#72
<img width="1578" height="1254" alt="image" src="https://github.com/user-attachments/assets/3deea5a4-55c4-4973-8dd0-7901bfff70c3" />
