### PR TITLE
Inspector v2: Add support for launching node editors (legacy path)

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/commonGeneralProperties.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent } from "react";
 
 import type { IDisposable } from "core/index";
 
+import { DeleteRegular } from "@fluentui/react-icons";
 import { useMemo } from "react";
 
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
@@ -63,7 +64,7 @@ export const DisposableGeneralProperties: FunctionComponent<{ disposableEntity: 
 
     return (
         <>
-            <ButtonLine label="Dispose" onClick={() => disposableEntity.dispose()} />
+            <ButtonLine label="Dispose" icon={DeleteRegular} onClick={() => disposableEntity.dispose()} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/frameGraph/frameGraphProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/frameGraph/frameGraphProperties.tsx
@@ -2,11 +2,13 @@ import type { FrameGraph } from "core/index";
 
 import type { FunctionComponent } from "react";
 
-import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
+import { EditRegular, PlayRegular } from "@fluentui/react-icons";
+
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
+import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
-import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 
 export const FrameGraphTaskProperties: FunctionComponent<{ frameGraph: FrameGraph }> = (props) => {
     const { frameGraph } = props;
@@ -35,11 +37,19 @@ export const FrameGraphGeneralProperties: FunctionComponent<{ frameGraph: FrameG
                 target={frameGraph}
                 propertyKey="optimizeTextureAllocation"
             ></BoundProperty>
-            {isSceneFrameGraph !== frameGraph && <ButtonLine onClick={() => (frameGraph.scene.frameGraph = frameGraph)} label="Set as scene's frame graph" />}
+            {isSceneFrameGraph !== frameGraph && <ButtonLine onClick={() => (frameGraph.scene.frameGraph = frameGraph)} label="Make Active" icon={PlayRegular} />}
             <ButtonLine
                 label="Edit Graph"
-                onClick={() => {
-                    void frameGraph.getLinkedNodeRenderGraph()!.edit({ nodeRenderGraphEditorConfig: { hostScene: frameGraph.scene } });
+                icon={EditRegular}
+                onClick={async () => {
+                    const renderGraph = frameGraph.getLinkedNodeRenderGraph();
+                    if (renderGraph) {
+                        // TODO: Figure out how to get all the various build steps to work with this.
+                        //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+                        // const { NodeRenderGraphEditor } = await import("node-render-graph-editor/nodeRenderGraphEditor");
+                        // NodeRenderGraphEditor.Show({ nodeRenderGraph: renderGraph, hostScene: frameGraph.scene });
+                        await renderGraph.edit({ nodeRenderGraphEditorConfig: { hostScene: frameGraph.scene } });
+                    }
                 }}
             ></ButtonLine>
         </>

--- a/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
@@ -1,0 +1,30 @@
+import type { FunctionComponent } from "react";
+
+import type { NodeMaterial } from "core/index";
+
+import { EditRegular } from "@fluentui/react-icons";
+
+import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
+import { BoundProperty } from "../boundProperty";
+
+export const NodeMaterialGeneralProperties: FunctionComponent<{ material: NodeMaterial }> = (props) => {
+    const { material } = props;
+
+    return (
+        <>
+            <BoundProperty component={SwitchPropertyLine} label="Ignore Alpha" target={material} propertyKey="ignoreAlpha" />
+            <ButtonLine
+                label="Edit"
+                icon={EditRegular}
+                onClick={async () => {
+                    // TODO: Figure out how to get all the various build steps to work with this.
+                    //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+                    // const { NodeEditor } = await import("node-editor/nodeEditor");
+                    // NodeEditor.Show({ nodeMaterial: material });
+                    await material.edit();
+                }}
+            ></ButtonLine>
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/properties/nodes/meshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/meshProperties.tsx
@@ -1,12 +1,38 @@
 import type { FunctionComponent } from "react";
 
-import type { Mesh } from "core/index";
+import type { Mesh, NodeGeometry } from "core/index";
+
+import { EditRegular } from "@fluentui/react-icons";
 
 import { Constants } from "core/Engines/constants";
-
-import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
+import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
+import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { BoundProperty } from "../boundProperty";
+
+export const MeshGeneralProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {
+    const { mesh } = props;
+
+    const nodeGeometry = mesh._internalMetadata?.nodeGeometry as NodeGeometry | undefined;
+
+    return (
+        <>
+            {nodeGeometry && (
+                <ButtonLine
+                    label="Edit"
+                    icon={EditRegular}
+                    onClick={async () => {
+                        // TODO: Figure out how to get all the various build steps to work with this.
+                        //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+                        // const { NodeGeometryEditor } = await import("node-geometry-editor/nodeGeometryEditor");
+                        // NodeGeometryEditor.Show({ nodeGeometry: nodeGeometry, hostScene: mesh.getScene() });
+                        await nodeGeometry.edit({ nodeGeometryEditorConfig: { hostScene: mesh.getScene() } });
+                    }}
+                />
+            )}
+        </>
+    );
+};
 
 export const MeshDisplayProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {
     const { mesh } = props;

--- a/packages/dev/inspector-v2/src/components/properties/particles/attractorList.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/particles/attractorList.tsx
@@ -84,12 +84,12 @@ export const AttractorList: FunctionComponent<AttractorListProps> = (props) => {
         <>
             {items.length > 0 && (
                 <>
-                    <Color3PropertyLine label="Attractor debug color" value={impostorColor} onChange={setImpostorColor} />
-                    <SyncedSliderPropertyLine label="Attractor debug size" value={impostorScale} onChange={setImpostorScale} min={0} max={10} step={0.1} />
+                    <Color3PropertyLine label="Attractor Debug Color" value={impostorColor} onChange={setImpostorColor} />
+                    <SyncedSliderPropertyLine label="Attractor Debug Size" value={impostorScale} onChange={setImpostorScale} min={0} max={10} step={0.1} />
                 </>
             )}
             <List
-                addButtonLabel={`Add new attractor`}
+                addButtonLabel={`Add New Attractor`}
                 items={items}
                 onDelete={(item, _index) => system.removeAttractor(item.data)}
                 onAdd={(item) => system.addAttractor(item?.data ?? new Attractor())}

--- a/packages/dev/inspector-v2/src/components/properties/particles/particleSystemProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/particles/particleSystemProperties.tsx
@@ -4,6 +4,9 @@ import type { Attractor } from "core/Particles/attractor";
 import type { FunctionComponent } from "react";
 import type { ISelectionService } from "../../../services/selectionService";
 
+import { ArrowDownloadRegular, CloudArrowDownRegular, CloudArrowUpRegular, EditRegular, EyeRegular, PlayRegular, StopRegular } from "@fluentui/react-icons";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
 import { Color3 } from "core/Maths/math.color";
 import { Vector3 } from "core/Maths/math.vector";
 import { BoxParticleEmitter } from "core/Particles/EmitterTypes/boxParticleEmitter";
@@ -13,9 +16,10 @@ import { HemisphericParticleEmitter } from "core/Particles/EmitterTypes/hemisphe
 import { MeshParticleEmitter } from "core/Particles/EmitterTypes/meshParticleEmitter";
 import { PointParticleEmitter } from "core/Particles/EmitterTypes/pointParticleEmitter";
 import { SphereParticleEmitter } from "core/Particles/EmitterTypes/sphereParticleEmitter";
-import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { Deferred } from "core/Misc/deferred";
 import { Tools } from "core/Misc/tools";
+import { ConvertToNodeParticleSystemSetAsync } from "core/Particles/Node/nodeParticleSystemSet.helper";
 import { ParticleHelper } from "core/Particles/particleHelper";
 import { ParticleSystem } from "core/Particles/particleSystem";
 import { BlendModeOptions, ParticleBillboardModeOptions } from "shared-ui-components/constToOptionsMaps";
@@ -179,7 +183,9 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
         request.send();
     }, [applyParticleSystemJsonToSystem, scene, system]);
 
-    const saveToSnippetServer = useCallback(() => {
+    const saveToSnippetServer = useCallback(async () => {
+        const deferred = new Deferred<void>();
+
         // Serialize once and post as snippet payload.
         const content = JSON.stringify(system.serialize(true));
 
@@ -190,6 +196,7 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
             }
 
             if (xmlHttp.status !== 200) {
+                deferred.reject();
                 alert("Unable to save your particle system");
                 return;
             }
@@ -208,8 +215,10 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
 
                 PersistSnippetId(system.snippetId);
 
+                deferred.resolve();
                 alert("Particle system saved with ID: " + system.snippetId + " (the id was also saved to your clipboard)");
             } catch (e) {
+                deferred.reject(e);
                 alert("Unable to save your particle system: " + e);
             }
         };
@@ -227,6 +236,8 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
         };
 
         xmlHttp.send(JSON.stringify(dataToSend));
+
+        await deferred.promise;
     }, [system]);
 
     return (
@@ -246,10 +257,23 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
             <BoundProperty component={NumberInputPropertyLine} label="Update Speed" target={system} propertyKey="updateSpeed" min={0} step={0.01} />
 
             <ButtonLine
-                label={system.isNodeGenerated ? "Edit in Node Particle Editor (coming soon)" : "View in Node Particle Editor (coming soon)"}
-                disabled={true}
-                onClick={() => {
-                    // Hook up once Node Particle Editor UX is wired.
+                label={system.isNodeGenerated ? "Edit" : "View"}
+                icon={system.isNodeGenerated ? EditRegular : EyeRegular}
+                onClick={async () => {
+                    const scene = system.getScene();
+                    if (!scene) {
+                        return;
+                    }
+
+                    const systemSet = system.source ? system.source : await ConvertToNodeParticleSystemSetAsync("source", [system]);
+
+                    if (systemSet) {
+                        // TODO: Figure out how to get all the various build steps to work with this.
+                        //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+                        // const { NodeParticleEditor } = await import("node-particle-editor/nodeParticleEditor");
+                        // NodeParticleEditor.Show({ nodeParticleSet: systemSet, hostScene: scene, backgroundColor: scene.clearColor });
+                        await systemSet.editAsync({ nodeEditorConfig: { backgroundColor: scene.clearColor } });
+                    }
                 }}
             />
 
@@ -258,6 +282,7 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
             ) : isAlive ? (
                 <ButtonLine
                     label="Stop"
+                    icon={StopRegular}
                     onClick={() => {
                         setStopRequested(true);
                         system.stop();
@@ -266,6 +291,7 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
             ) : (
                 <ButtonLine
                     label="Start"
+                    icon={PlayRegular}
                     onClick={() => {
                         setStopRequested(false);
                         system.start();
@@ -276,7 +302,7 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
             {!system.isNodeGenerated && (
                 <>
                     <FileUploadLine
-                        label="Load from file"
+                        label="Load from File"
                         accept=".json"
                         onClick={(files) => {
                             if (files.length === 0) {
@@ -302,7 +328,8 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
                     />
 
                     <ButtonLine
-                        label="Save to file"
+                        label="Save to File"
+                        icon={ArrowDownloadRegular}
                         onClick={() => {
                             // Download serialization as a JSON file.
                             const data = JSON.stringify(system.serialize(true), null, 2);
@@ -313,8 +340,8 @@ export const ParticleSystemGeneralProperties: FunctionComponent<{ particleSystem
                     />
 
                     {snippetId && <TextPropertyLine label="Snippet ID" value={snippetId} />}
-                    <ButtonLine label="Load from snippet server" onClick={loadFromSnippetServer} />
-                    <ButtonLine label="Save to snippet server" onClick={saveToSnippetServer} />
+                    <ButtonLine label="Load from Snippet Server" onClick={loadFromSnippetServer} icon={CloudArrowUpRegular} />
+                    <ButtonLine label="Save to Snippet Server" onClick={saveToSnippetServer} icon={CloudArrowDownRegular} />
                 </>
             )}
         </>

--- a/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
@@ -5,13 +5,24 @@ import type { IPropertiesService } from "./propertiesService";
 
 import { Material } from "core/Materials/material";
 import { MultiMaterial } from "core/Materials/multiMaterial";
-import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
+import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { OpenPBRMaterial } from "core/Materials/PBR/openpbrMaterial";
+import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { SkyMaterial } from "materials/sky/skyMaterial";
 import { MaterialGeneralProperties, MaterialStencilProperties, MaterialTransparencyProperties } from "../../../components/properties/materials/materialProperties";
 import { MultiMaterialChildrenProperties } from "../../../components/properties/materials/multiMaterialProperties";
+import { NodeMaterialGeneralProperties } from "../../../components/properties/materials/nodeMaterialProperties";
 import { NormalMapProperties } from "../../../components/properties/materials/normalMapProperties";
+import {
+    OpenPBRMaterialBaseProperties,
+    OpenPBRMaterialCoatProperties,
+    OpenPBRMaterialEmissionProperties,
+    OpenPBRMaterialFuzzProperties,
+    OpenPBRMaterialGeometryProperties,
+    OpenPBRMaterialSpecularProperties,
+    OpenPBRMaterialThinFilmProperties,
+} from "../../../components/properties/materials/openpbrMaterialProperties";
 import {
     PBRBaseMaterialAdvancedProperties,
     PBRBaseMaterialAnisotropicProperties,
@@ -28,15 +39,6 @@ import {
     PBRBaseMaterialSubSurfaceProperties,
     PBRBaseMaterialTransparencyProperties,
 } from "../../../components/properties/materials/pbrBaseMaterialProperties";
-import {
-    OpenPBRMaterialBaseProperties,
-    OpenPBRMaterialCoatProperties,
-    OpenPBRMaterialEmissionProperties,
-    OpenPBRMaterialFuzzProperties,
-    OpenPBRMaterialGeometryProperties,
-    OpenPBRMaterialSpecularProperties,
-    OpenPBRMaterialThinFilmProperties,
-} from "../../../components/properties/materials/openpbrMaterialProperties";
 import { SkyMaterialProperties } from "../../../components/properties/materials/skyMaterialProperties";
 import {
     StandardMaterialGeneralProperties,
@@ -238,6 +240,17 @@ export const MaterialPropertiesServiceDefinition: ServiceDefinition<[], [IProper
             ],
         });
 
+        const nodeMaterialContentRegistration = propertiesService.addSectionContent({
+            key: "Node Material Properties",
+            predicate: (entity: unknown) => entity instanceof NodeMaterial,
+            content: [
+                {
+                    section: "General",
+                    component: ({ context }) => <NodeMaterialGeneralProperties material={context} />,
+                },
+            ],
+        });
+
         return {
             dispose: () => {
                 pbrMaterialPropertyChangedObserver.remove();
@@ -247,6 +260,7 @@ export const MaterialPropertiesServiceDefinition: ServiceDefinition<[], [IProper
                 openPBRMaterialPropertiesRegistration.dispose();
                 skyMaterialRegistration.dispose();
                 multiMaterialContentRegistration.dispose();
+                nodeMaterialContentRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
@@ -3,6 +3,7 @@ import type { ISelectionService } from "../../selectionService";
 import type { IPropertiesService } from "./propertiesService";
 
 import { AbstractMesh } from "core/Meshes/abstractMesh";
+import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
 import { Mesh } from "core/Meshes/mesh";
 import { Node } from "core/node";
 import {
@@ -14,12 +15,11 @@ import {
     AbstractMeshOcclusionsProperties,
     AbstractMeshOutlineOverlayProperties,
 } from "../../../components/properties/nodes/abstractMeshProperties";
-import { MeshDisplayProperties } from "../../../components/properties/nodes/meshProperties";
 import { GaussianSplattingDisplayProperties } from "../../../components/properties/nodes/gaussianSplattingProperties";
+import { MeshDisplayProperties, MeshGeneralProperties } from "../../../components/properties/nodes/meshProperties";
 import { NodeGeneralProperties } from "../../../components/properties/nodes/nodeProperties";
 import { SelectionServiceIdentity } from "../../selectionService";
 import { PropertiesServiceIdentity } from "./propertiesService";
-import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
 
 export const NodePropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, ISelectionService]> = {
     friendlyName: "Mesh Properties",
@@ -76,6 +76,10 @@ export const NodePropertiesServiceDefinition: ServiceDefinition<[], [IProperties
             key: "Mesh Properties",
             predicate: (entity: unknown): entity is Mesh => entity instanceof Mesh && entity.getTotalVertices() > 0,
             content: [
+                {
+                    section: "General",
+                    component: ({ context }) => <MeshGeneralProperties mesh={context} />,
+                },
                 {
                     section: "Display",
                     component: ({ context }) => <MeshDisplayProperties mesh={context} />,

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -26,7 +26,13 @@ import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { MultiMaterial } from "core/Materials/multiMaterial";
 import { Texture } from "core/Materials/Textures/texture";
-import { ShowInspector } from "../../src";
+
+// TODO: Get this working automatically without requiring an explicit import. Inspector v2 should dynamically import these when needed.
+//       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+import "node-editor/legacy/legacy";
+import "node-geometry-editor/legacy/legacy";
+import "node-particle-editor/legacy/legacy";
+import "node-render-graph-editor/legacy/legacy";
 
 // Register scene loader plugins.
 registerBuiltInLoaders();

--- a/packages/dev/inspector-v2/webpack.config.js
+++ b/packages/dev/inspector-v2/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = (env) => {
         ),
 
         resolve: {
-            extensions: [".ts", ".tsx", ".js", ".jsx"],
+            extensions: [".ts", ".tsx", ".js", ".jsx", ".svg", ".scss"],
             alias: {
                 addons: path.resolve("../../dev/addons/dist"),
                 core: path.resolve("../../dev/core/dist"),
@@ -30,13 +30,23 @@ module.exports = (env) => {
                 "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
                 "inspector-v2": path.resolve("./src"),
                 serializers: path.resolve("../../dev/serializers/dist"),
+                "node-editor": path.resolve("../../tools/nodeEditor/dist"),
+                "node-geometry-editor": path.resolve("../../tools/nodeGeometryEditor/dist"),
+                "node-particle-editor": path.resolve("../../tools/nodeParticleEditor/dist"),
+                "node-render-graph-editor": path.resolve("../../tools/nodeRenderGraphEditor/dist"),
             },
         },
 
         module: {
             rules: webpackTools.getRules({
                 sideEffects: true,
-                includeCSS: false,
+                includeCSS: true,
+                extraRules: [
+                    {
+                        test: /\.svg$/,
+                        type: "asset/inline",
+                    },
+                ],
                 enableFastRefresh: !production,
                 tsOptions: {
                     configFile: "tsconfig.build.json",

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/button.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/button.tsx
@@ -1,12 +1,12 @@
-import { Button as FluentButton } from "@fluentui/react-components";
+import { Button as FluentButton, Spinner } from "@fluentui/react-components";
 import type { MouseEvent } from "react";
-import { forwardRef, useContext } from "react";
+import { forwardRef, useCallback, useContext, useState } from "react";
 import type { FluentIcon } from "@fluentui/react-icons";
 import type { BasePrimitiveProps } from "./primitive";
 import { ToolContext } from "../hoc/fluentToolWrapper";
 
 export type ButtonProps = BasePrimitiveProps & {
-    onClick?: (e?: MouseEvent<HTMLButtonElement>) => void;
+    onClick?: (e?: MouseEvent<HTMLButtonElement>) => unknown | Promise<unknown>;
     icon?: FluentIcon;
     appearance?: "subtle" | "transparent" | "primary";
     label?: string;
@@ -15,9 +15,34 @@ export type ButtonProps = BasePrimitiveProps & {
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     const { size } = useContext(ToolContext);
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { icon: Icon, label, ...buttonProps } = props;
+    const { icon: Icon, label, onClick, disabled, ...buttonProps } = props;
+
+    const [isOnClickBusy, setIsOnClickBusy] = useState(false);
+    const handleOnClick = useCallback(
+        async (e: MouseEvent<HTMLButtonElement>) => {
+            const result = onClick?.();
+            if (result instanceof Promise) {
+                setIsOnClickBusy(true);
+                try {
+                    await result;
+                } finally {
+                    setIsOnClickBusy(false);
+                }
+            }
+        },
+        [onClick]
+    );
+
     return (
-        <FluentButton ref={ref} iconPosition="after" {...buttonProps} size={size} icon={Icon && <Icon />}>
+        <FluentButton
+            ref={ref}
+            iconPosition="after"
+            {...buttonProps}
+            size={size}
+            icon={isOnClickBusy ? <Spinner size="extra-tiny" /> : Icon && <Icon />}
+            onClick={handleOnClick}
+            disabled={disabled || isOnClickBusy}
+        >
             {label && props.label}
         </FluentButton>
     );


### PR DESCRIPTION
Tried to get this to work without the legacy path in [this PR](https://github.com/BabylonJS/Babylon.js/pull/17646), but couldn't get it to work. Need to revisit post 9.0 or if I get time. For now, we will rely on the legacy path, which means users will need to know they have to npm install the various node editor packages and explicitly import the legacy file with the needed side effects.