### PR TITLE
[GSplat] Fix vertex count in sorting worker

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -1834,4 +1834,3 @@ export class GaussianSplattingMesh extends Mesh {
         return new Vector2(width, height);
     }
 }
-


### PR DESCRIPTION
It seems to me that `vertexCountPadded` was 4 times the number of vertices, leading to wasteful evaluation of projected positions.

This needs a second pair of eyes to look at it though, as I am not an expert in the codebase.