### PR TITLE
Viewer: Add support for querying hotspots when multiple models are loaded

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -753,7 +753,6 @@ type ModelInternal = Model & {
 };
 
 /**
- * @experimental
  * Provides an experience for viewing a single 3D model.
  * @remarks
  * The Viewer is not tied to a specific UI framework and can be used with Babylon.js in a browser or with Babylon Native.
@@ -2524,22 +2523,30 @@ export class Viewer implements IDisposable {
     }
 
     /**
-     * Return world and canvas coordinates of an hot spot
-     * @param query mesh index and surface information to query the hot spot positions
-     * @param result Query a Hot Spot and does the conversion for Babylon Hot spot to a more generic HotSpotPositions, without Vector types
-     * @returns true if hotspot found
+     * Return world and canvas coordinates of an hot spot.
+     * @param query mesh index and surface information to query the hot spot positions.
+     * @param result Query a Hot Spot and does the conversion for Babylon Hot spot to a more generic HotSpotPositions, without Vector types.
+     * @returns true if hotspot found.
      */
     public getHotSpotToRef(query: Readonly<ViewerHotSpotQuery>, result: ViewerHotSpotResult): boolean {
-        return this._activeModel?.getHotSpotToRef(query, result) ?? false;
+        return this._getHotSpotToRef(
+            this._loadedModels.flatMap((model) => model.assetContainer.meshes),
+            query,
+            result
+        );
     }
 
-    protected _getHotSpotToRef(assetContainer: Nullable<AssetContainer>, query: Readonly<ViewerHotSpotQuery>, result: ViewerHotSpotResult): boolean {
+    protected _getHotSpotToRef(
+        ...args: [...([assetContainer: Nullable<AssetContainer>] | [meshes: Nullable<AbstractMesh[]>]), query: Readonly<ViewerHotSpotQuery>, result: ViewerHotSpotResult]
+    ): boolean {
+        const [meshesOrAssetContainer, query, result] = args;
+        const meshes = Array.isArray(meshesOrAssetContainer) ? meshesOrAssetContainer : meshesOrAssetContainer?.meshes;
         const worldNormal = this._tempVectors[2];
         const worldPos = this._tempVectors[1];
         const screenPos = this._tempVectors[0];
 
         if (query.type === "surface") {
-            const mesh = assetContainer?.meshes[query.meshIndex];
+            const mesh = meshes?.[query.meshIndex];
             if (!mesh) {
                 return false;
             }
@@ -2574,10 +2581,10 @@ export class Viewer implements IDisposable {
     }
 
     /**
-     * Get hotspot world and screen values from a named hotspot
-     * @param name slot of the hot spot
-     * @param result resulting world and screen positions
-     * @returns world position, world normal and screen space coordinates
+     * Get hotspot world and screen values from a named hotspot.
+     * @param name slot of the hot spot.
+     * @param result resulting world and screen positions.
+     * @returns world position, world normal and screen space coordinates.
      */
     public queryHotSpot(name: string, result: ViewerHotSpotResult): boolean {
         return this._queryHotSpot(name, result) != null;

--- a/packages/tools/viewer/src/viewerElement.ts
+++ b/packages/tools/viewer/src/viewerElement.ts
@@ -143,7 +143,6 @@ export interface ViewerElement {
 }
 
 /**
- * @experimental
  * Base class for the viewer custom element.
  */
 export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends LitElement {
@@ -152,7 +151,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     private _viewerDetails?: Readonly<ViewerDetails & { viewer: ViewerClass }>;
 
     /**
-     * @experimental
      * Creates an instance of a ViewerElement subclass.
      * @param _viewerClass The Viewer subclass to use when creating the Viewer instance.
      * @param _options The options to use when creating the Viewer and binding it to the specified canvas.
@@ -794,7 +792,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     public hotSpots: Record<string, HotSpot> = this._options.hotSpots ?? {};
 
     /**
-     * @experimental
      * True if the viewer has any hotspots.
      */
     protected get _hasHotSpots(): boolean {
@@ -815,7 +812,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * True if the loaded model has any animations.
      */
     protected get _hasAnimations(): boolean {
@@ -1024,7 +1020,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Renders the progress bar.
      * @returns The template result for the progress bar.
      */
@@ -1045,7 +1040,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Renders the toolbar.
      * @returns The template result for the toolbar.
      */
@@ -1150,7 +1144,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Renders the reload button.
      * @returns The template result for the reload button.
      */
@@ -1167,7 +1160,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Renders UI elements that overlay the viewer.
      * Override this method to provide additional rendering for the component.
      * @returns TemplateResult The rendered template result.
@@ -1183,7 +1175,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Dispatches a custom event.
      * @param type The type of the event.
      * @param event A function that creates the event.
@@ -1193,7 +1184,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Handles changes to the selected animation.
      * @param event The change event.
      */
@@ -1203,7 +1193,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Handles changes to the animation speed.
      * @param event The change event.
      */
@@ -1213,7 +1202,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Handles changes to the animation timeline.
      * @param event The change event.
      */
@@ -1228,7 +1216,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Handles pointer down events on the animation timeline.
      * @param event The pointer down event.
      */
@@ -1241,7 +1228,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Handles changes to the selected material variant.
      * @param event The change event.
      */
@@ -1251,7 +1237,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Handles changes to the hot spot list.
      * @param event The change event.
      */
@@ -1453,7 +1438,6 @@ export abstract class ViewerElement<ViewerClass extends Viewer = Viewer> extends
     }
 
     /**
-     * @experimental
      * Creates a viewer for the specified canvas.
      * @param canvas The canvas to create the viewer for.
      * @param options The options to use for the viewer.

--- a/packages/tools/viewer/src/viewerFactory.ts
+++ b/packages/tools/viewer/src/viewerFactory.ts
@@ -39,7 +39,6 @@ export function GetDefaultEngine(): NonNullable<CanvasViewerOptions["engine"]> {
 }
 
 /**
- * @experimental
  * Creates a Viewer instance that is bound to an HTML canvas.
  * @remarks
  * This function can be shared across multiple UI integrations (e.g. Web Components, React, etc.).

--- a/packages/tools/viewer/test/apps/web/index.html
+++ b/packages/tools/viewer/test/apps/web/index.html
@@ -316,18 +316,20 @@
                 }
             };
 
-            let isInspectorVisible = false;
+            let inspectorToken = null;
             globalThis.onToggleInspector = async () => {
-                const { Inspector } = await import("inspector/inspector");
+                const { ShowInspector } = await import("inspector-v2/inspector");
                 console.log("toggle inspector");
-                if (isInspectorVisible) {
-                    Inspector.Hide();
+                if (inspectorToken) {
+                    inspectorToken.dispose();
+                    inspectorToken = null;
                 } else {
                     console.log(viewerDetails != null);
                     console.log(viewerDetails?.scene != null);
-                    Inspector.Show(viewerDetails.scene, {});
+                    inspectorToken = ShowInspector(viewerDetails.scene, {
+                        // containerElement: document.body,
+                    });
                 }
-                isInspectorVisible = !isInspectorVisible;
             };
 
             let isTopContentVisible = false;


### PR DESCRIPTION
The main change here is to add the ability to query hotspots when multiple models are simultaneously loaded through the protected interface.
- Change the protected `_getHotSpotToRef` function to accept either an `AssetContainer` (former API) or a `AbstractMesh[]`.
- Change the public `getHotSpotToRef` to call `_getHotSpotToRef` function with `this._loadedModels.flatMap((model) => model.assetContainer.meshes)` instead of `this._activeModel.assetContainer.meshes`.

This is backward compatible from an API and behavior standpoint. The API is a superset, and if you only load one model the flat index is the same as the index into the single model.

Some other small changes included in this PR:
- Removed all the `@experimental` flags on the doc comments. The low level `Viewer` and the protected API are stable enough, and we have several users heavily invested in these layers, so we aren't going to change them in a breaking way going forward.
- Switched the test app to use Inspector v2.