### PR TITLE
[glTF Exporter] Fix double subset of indices with non-zero verticesStart

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -1340,7 +1340,7 @@ export class GLTFExporter {
         state: ExporterState,
         primitive: IMeshPrimitive
     ): void {
-        let indicesToExport: Nullable<Uint32Array | Uint16Array> = null;
+        let indicesToExport = null;
 
         primitive.mode = GetPrimitiveMode(fillMode);
 


### PR DESCRIPTION
Fixes https://forum.babylonjs.com/t/exporting-to-gltf-in-new-version-causing-an-error-on-importing-from-blender/62030/4. When offset !== 0, indices were being subsected twice: once to generate the newIndices, and again while calling IndicesArrayToTypedSubarray.