### PR TITLE
[NPE] Issues with remap block

### DIFF
--- a/packages/dev/core/src/Particles/Node/Blocks/index.ts
+++ b/packages/dev/core/src/Particles/Node/Blocks/index.ts
@@ -18,6 +18,7 @@ export * from "./Update/basicColorUpdateBlock";
 export * from "./Update/updateSpriteCellIndexBlock";
 export * from "./Update/updateFlowMapBlock";
 export * from "./Update/updateNoiseBlock";
+export * from "./Update/updateRemapBlock";
 export * from "./Update/updateAttractorBlock";
 export * from "./Update/alignAngleBlock";
 export * from "./Emitters/index";

--- a/packages/tools/nodeParticleEditor/src/blockTools.ts
+++ b/packages/tools/nodeParticleEditor/src/blockTools.ts
@@ -31,6 +31,7 @@ import { BasicSpriteUpdateBlock } from "core/Particles/Node/Blocks/Update/basicS
 import { UpdateSpriteCellIndexBlock } from "core/Particles/Node/Blocks/Update/updateSpriteCellIndexBlock";
 import { UpdateFlowMapBlock } from "core/Particles/Node/Blocks/Update/updateFlowMapBlock";
 import { UpdateNoiseBlock } from "core/Particles/Node/Blocks/Update/updateNoiseBlock";
+import { UpdateRemapBlock } from "core/Particles/Node/Blocks/Update/updateRemapBlock";
 import { ParticleConditionBlock, ParticleConditionBlockTests } from "core/Particles/Node/Blocks/Conditions/particleConditionBlock";
 import { CreateParticleBlock } from "core/Particles/Node/Blocks/Emitters/createParticleBlock";
 import { BoxShapeBlock } from "core/Particles/Node/Blocks/Emitters/boxShapeBlock";
@@ -157,6 +158,8 @@ export class BlockTools {
                 return new UpdateNoiseBlock("Update noise");
             case "UpdateAttractorBlock":
                 return new UpdateAttractorBlock("Update attractor");
+            case "UpdateRemapBlock":
+                return new UpdateRemapBlock("Update remap");
             case "SystemBlock":
                 return new SystemBlock("System");
             case "TextureBlock":


### PR DESCRIPTION
Remap was missing from index.ts and BlockTools, so it could be created programatically by code, but not by using the editor.