### PR TITLE
Change ES version to match the usage of String.replaceAll()

### DIFF
--- a/packages/dev/buildTools/tsconfig.build.json
+++ b/packages/dev/buildTools/tsconfig.build.json
@@ -2,7 +2,8 @@
     "extends": "../../../tsconfig.build.json",
 
     "compilerOptions": {
-        "target": "es2017",
+        "target": "es2021",
+        "lib": ["es2021"],
         "module": "CommonJS",
         "outDir": "./dist",
         "rootDir": "./src",

--- a/packages/dev/buildTools/tsconfig.json
+++ b/packages/dev/buildTools/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../../tsconfig.json",
 
     "compilerOptions": {
-        "target": "es2017",
+        "target": "es2021",
+        "lib": ["es2021"],
         "module": "esnext",
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true


### PR DESCRIPTION
File `packages/dev/buildTools/src/packageMapping.ts` use the `replaceAll()` method of strings on multiple occasions. 
The `replaceAll()` method was introduced in JavaScript 2021 ([source](https://www.w3schools.com/jsref/jsref_string_replaceall.asp)). This is incompatible with the version of JavaScript specified in TypeScript config (ES2017).

There are two possible options: **(A)** Upgrade tsconfig to use ES2021 or **(B)** modify `packageMapping.ts` to polyfill `replaceAll()`. This PR implements **(A)**, feel free to suggest **(B)** instead.