### PR TITLE
Inspector v2: Node Material input properties

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
@@ -1,12 +1,33 @@
 import type { FunctionComponent } from "react";
 
-import type { NodeMaterial } from "core/index";
+import type { GradientBlock, InputBlock, NodeMaterial } from "core/index";
 
+import { makeStyles, Subtitle2, tokens } from "@fluentui/react-components";
 import { EditRegular } from "@fluentui/react-icons";
+import { Fragment, useCallback } from "react";
 
+import { GradientBlockColorStep } from "core/Materials/Node/Blocks/gradientBlock";
+import { NodeMaterialBlockConnectionPointTypes } from "core/Materials/Node/Enums/nodeMaterialBlockConnectionPointTypes";
+import { Color3 } from "core/Maths/math.color";
+import { Color3Gradient } from "core/Misc/gradients";
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
+import { Color3GradientList } from "shared-ui-components/fluent/hoc/gradientList";
+import { Color3PropertyLine, Color4PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
+import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
+import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
+import { Vector2PropertyLine, Vector3PropertyLine, Vector4PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
+import { MessageBar } from "shared-ui-components/fluent/primitives/messageBar";
+import { useProperty } from "../../../hooks/compoundPropertyHooks";
+import { useObservableState } from "../../../hooks/observableHooks";
+import { GroupBy } from "../../../misc/arrayUtils";
 import { BoundProperty } from "../boundProperty";
+
+const useStyles = makeStyles({
+    subsection: {
+        marginTop: tokens.spacingVerticalM,
+    },
+});
 
 export const NodeMaterialGeneralProperties: FunctionComponent<{ material: NodeMaterial }> = (props) => {
     const { material } = props;
@@ -25,6 +46,141 @@ export const NodeMaterialGeneralProperties: FunctionComponent<{ material: NodeMa
                     await material.edit();
                 }}
             ></ButtonLine>
+        </>
+    );
+};
+
+// A modified InputBlock type where the value is `NonNullable<unknown>` instead of `any` so it works correctly with BoundProperty.
+type SafeInputBlock = Omit<InputBlock, "value"> & { value: NonNullable<unknown> };
+
+const InputBlockPropertyLine: FunctionComponent<{ block: SafeInputBlock }> = (props) => {
+    const { block } = props;
+
+    // We need to re-evaluate this outer component when type/isBoolean/min/max change since that determines what type of property line we render.
+    const type = useProperty(block, "type");
+    const isBoolean = useProperty(block, "isBoolean");
+    const min = useProperty(block, "min");
+    const max = useProperty(block, "max");
+
+    const commonProps = {
+        label: block.name,
+        target: block,
+        propertyKey: "value",
+    } as const;
+
+    if (type === NodeMaterialBlockConnectionPointTypes.Float) {
+        if (isBoolean) {
+            return <BoundProperty key={`${block.uniqueId} (Switch)`} component={SwitchPropertyLine} {...commonProps} />;
+        } else {
+            const hasMinMax = !isNaN(min) && !isNaN(max) && min !== max;
+            if (hasMinMax) {
+                return <BoundProperty key={`${block.uniqueId} (Slider)`} component={SyncedSliderPropertyLine} {...commonProps} min={min} max={max} step={(max - min) / 100.0} />;
+            } else {
+                return <BoundProperty key={`${block.uniqueId} (Number)`} component={NumberInputPropertyLine} {...commonProps} />;
+            }
+        }
+    } else if (type === NodeMaterialBlockConnectionPointTypes.Color3) {
+        return <BoundProperty key={`${block.uniqueId} (Color3)`} component={Color3PropertyLine} {...commonProps} />;
+    } else if (type === NodeMaterialBlockConnectionPointTypes.Color4) {
+        return <BoundProperty key={`${block.uniqueId} (Color4)`} component={Color4PropertyLine} {...commonProps} />;
+    } else if (type === NodeMaterialBlockConnectionPointTypes.Vector2) {
+        return <BoundProperty key={`${block.uniqueId} (Vector2)`} component={Vector2PropertyLine} {...commonProps} />;
+    } else if (type === NodeMaterialBlockConnectionPointTypes.Vector3) {
+        return <BoundProperty key={`${block.uniqueId} (Vector3)`} component={Vector3PropertyLine} {...commonProps} />;
+    } else if (type === NodeMaterialBlockConnectionPointTypes.Vector4) {
+        return <BoundProperty key={`${block.uniqueId} (Vector4)`} component={Vector4PropertyLine} {...commonProps} />;
+    } else {
+        return null;
+    }
+};
+
+const GradientBlockPropertyLine: FunctionComponent<{ material: NodeMaterial; block: GradientBlock }> = (props) => {
+    const { material, block } = props;
+
+    const gradients = useObservableState(
+        useCallback(() => block.colorSteps.map((step) => new Color3Gradient(step.step, step.color)), [block.colorSteps]),
+        block.onValueChangedObservable
+    );
+
+    return (
+        <Color3GradientList
+            label="step"
+            gradients={gradients}
+            addGradient={(gradient) => {
+                block.colorSteps.push(gradient ? new GradientBlockColorStep(gradient.gradient, gradient.color) : new GradientBlockColorStep(1.0, Color3.White()));
+                block.colorStepsUpdated();
+                material.build();
+            }}
+            removeGradient={(_, index) => {
+                block.colorSteps.splice(index, 1);
+                block.colorStepsUpdated();
+                material.build();
+            }}
+            onChange={(gradient, index) => {
+                block.colorSteps[index].step = gradient.gradient;
+                block.colorSteps[index].color = gradient.color;
+                block.colorStepsUpdated();
+                material.build();
+            }}
+        />
+    );
+};
+
+export const NodeMaterialInputProperties: FunctionComponent<{ material: NodeMaterial }> = (props) => {
+    const { material } = props;
+
+    const classes = useStyles();
+
+    const inputBlocks = useObservableState(
+        useCallback(() => {
+            const inspectorVisibleInputBlocks = material
+                .getInputBlocks()
+                .filter((block) => block.visibleInInspector)
+                .map((block) => block as SafeInputBlock);
+            const groupedInputBlocks = GroupBy(inspectorVisibleInputBlocks, (block) => block.groupInInspector);
+            return groupedInputBlocks.sort((a, b) => a.key.localeCompare(b.key));
+        }, [material]),
+        material.onBuildObservable,
+        material.onBuildErrorObservable
+    );
+
+    const gradientBlocks = useObservableState(
+        useCallback(
+            () => material.attachedBlocks.filter((block) => block.visibleInInspector && block.getClassName() === "GradientBlock").map((block) => block as GradientBlock),
+            [material]
+        ),
+        material.onBuildObservable,
+        material.onBuildErrorObservable
+    );
+
+    return (
+        <>
+            {inputBlocks.length === 0 && gradientBlocks.length === 0 ? (
+                <MessageBar
+                    key="no-visible-input-blocks"
+                    intent="info"
+                    title="No Visible Input Blocks"
+                    message="To see input blocks, mark them as visibleInInspector."
+                    docLink="https://doc.babylonjs.com/features/featuresDeepDive/materials/node_material/nodeMaterial/#adding-blocks"
+                />
+            ) : (
+                <>
+                    {inputBlocks.map((group) => (
+                        <Fragment key={`${group.key || "default"} (Group)`}>
+                            {group.key && <Subtitle2 className={classes.subsection}>{group.key}</Subtitle2>}
+                            {group.items.map((block) => (
+                                <InputBlockPropertyLine key={block.uniqueId} block={block} />
+                            ))}
+                        </Fragment>
+                    ))}
+                    {gradientBlocks.map((block) => (
+                        <Fragment key={`${block.uniqueId} (Gradient)`}>
+                            <Subtitle2 className={classes.subsection}>{block.name}</Subtitle2>
+                            <GradientBlockPropertyLine material={material} block={block} />
+                        </Fragment>
+                    ))}
+                </>
+            )}
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/misc/arrayUtils.ts
+++ b/packages/dev/inspector-v2/src/misc/arrayUtils.ts
@@ -1,0 +1,13 @@
+export function GroupBy<T, K>(items: T[], getKey: (item: T) => K): { key: K; items: T[] }[] {
+    const map = items.reduce((map, item) => {
+        const key = getKey(item);
+        let group = map.get(key);
+        if (!group) {
+            map.set(key, (group = []));
+        }
+        group.push(item);
+        return map;
+    }, new Map<K, T[]>());
+
+    return Array.from(map, ([key, items]) => ({ key, items }));
+}

--- a/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/materialPropertiesService.tsx
@@ -12,7 +12,7 @@ import { StandardMaterial } from "core/Materials/standardMaterial";
 import { SkyMaterial } from "materials/sky/skyMaterial";
 import { MaterialGeneralProperties, MaterialStencilProperties, MaterialTransparencyProperties } from "../../../components/properties/materials/materialProperties";
 import { MultiMaterialChildrenProperties } from "../../../components/properties/materials/multiMaterialProperties";
-import { NodeMaterialGeneralProperties } from "../../../components/properties/materials/nodeMaterialProperties";
+import { NodeMaterialGeneralProperties, NodeMaterialInputProperties } from "../../../components/properties/materials/nodeMaterialProperties";
 import { NormalMapProperties } from "../../../components/properties/materials/normalMapProperties";
 import {
     OpenPBRMaterialBaseProperties,
@@ -247,6 +247,10 @@ export const MaterialPropertiesServiceDefinition: ServiceDefinition<[], [IProper
                 {
                     section: "General",
                     component: ({ context }) => <NodeMaterialGeneralProperties material={context} />,
+                },
+                {
+                    section: "Inputs",
+                    component: ({ context }) => <NodeMaterialInputProperties material={context} />,
                 },
             ],
         });

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -24,6 +24,7 @@ import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { MultiMaterial } from "core/Materials/multiMaterial";
+import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { Texture } from "core/Materials/Textures/texture";
 import { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
 import { Button } from "gui/2D/controls/button";
@@ -158,6 +159,8 @@ function createTestMetadata() {
 function createMaterials() {
     const multiMaterial = new MultiMaterial("multi", scene);
     multiMaterial.subMaterials.push(...scene.materials);
+
+    NodeMaterial.ParseFromSnippetAsync("9RX8AG#4", scene);
 }
 
 function createGaussianSplatting() {

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/gradientList.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/gradientList.tsx
@@ -1,5 +1,7 @@
 import type { FunctionComponent } from "react";
 
+import { useMemo } from "react";
+
 import { List } from "../primitives/list";
 import { Color3GradientComponent, Color4GradientComponent, FactorGradientComponent } from "../primitives/gradient";
 import { Color3Gradient, ColorGradient as Color4Gradient, FactorGradient } from "core/Misc/gradients";
@@ -11,8 +13,8 @@ type GradientListProps<T extends FactorGradient | Color3Gradient | Color4Gradien
     label: string;
     gradients: Nullable<Array<T>>;
     addGradient: (step?: T) => void;
-    removeGradient: (step: T) => void;
-    onChange: (newGradient: T) => void;
+    removeGradient: (step: T, index: number) => void;
+    onChange: (newGradient: T, index: number) => void;
 };
 
 // Convert gradients to LineList items and sort by gradient value
@@ -28,13 +30,13 @@ function GradientsToListItems<T extends IValueGradient>(gradients: Nullable<Arra
 export const FactorGradientList: FunctionComponent<GradientListProps<FactorGradient>> = (props) => {
     FactorGradientList.displayName = "FactorGradientList";
     const { gradients } = props;
-    const items = GradientsToListItems<FactorGradient>(gradients);
+    const items = useMemo(() => GradientsToListItems<FactorGradient>(gradients), [gradients]);
     return (
         <List
             key="Factor"
             addButtonLabel={items.length > 0 ? `Add new ${props.label}` : `Use ${props.label}s`}
             items={items}
-            onDelete={(item) => props.removeGradient(item.data)}
+            onDelete={(item, index) => props.removeGradient(item.data, index)}
             onAdd={() => {
                 if (items.length === 0) {
                     props.addGradient(); // Default
@@ -42,7 +44,7 @@ export const FactorGradientList: FunctionComponent<GradientListProps<FactorGradi
                     props.addGradient(new FactorGradient(1, 1, 1));
                 }
             }}
-            renderItem={(item) => {
+            renderItem={(item, index) => {
                 return (
                     <FactorGradientComponent
                         value={item.data}
@@ -50,7 +52,7 @@ export const FactorGradientList: FunctionComponent<GradientListProps<FactorGradi
                             item.data.gradient = newGradient.gradient;
                             item.data.factor1 = newGradient.factor1;
                             item.data.factor2 = newGradient.factor2;
-                            props.onChange(newGradient);
+                            props.onChange(newGradient, index);
                         }}
                     />
                 );
@@ -62,13 +64,13 @@ export const FactorGradientList: FunctionComponent<GradientListProps<FactorGradi
 export const Color3GradientList: FunctionComponent<GradientListProps<Color3Gradient>> = (props) => {
     Color3GradientList.displayName = "Color3GradientList";
     const { gradients } = props;
-    const items = GradientsToListItems<Color3Gradient>(gradients);
+    const items = useMemo(() => GradientsToListItems<Color3Gradient>(gradients), [gradients]);
     return (
         <List
             key="Color3"
             addButtonLabel={items.length > 0 ? `Add new ${props.label}` : `Use ${props.label}s`}
             items={items}
-            onDelete={(item) => props.removeGradient(item.data)}
+            onDelete={(item, index) => props.removeGradient(item.data, index)}
             onAdd={() => {
                 if (items.length === 0) {
                     props.addGradient(); // Default
@@ -76,14 +78,14 @@ export const Color3GradientList: FunctionComponent<GradientListProps<Color3Gradi
                     props.addGradient(new Color3Gradient(1, Color3.White()));
                 }
             }}
-            renderItem={(item) => {
+            renderItem={(item, index) => {
                 return (
                     <Color3GradientComponent
                         value={item.data}
                         onChange={(newGradient: Color3Gradient) => {
                             item.data.gradient = newGradient.gradient;
                             item.data.color = newGradient.color;
-                            props.onChange(newGradient);
+                            props.onChange(newGradient, index);
                         }}
                     />
                 );
@@ -95,13 +97,13 @@ export const Color3GradientList: FunctionComponent<GradientListProps<Color3Gradi
 export const Color4GradientList: FunctionComponent<GradientListProps<Color4Gradient>> = (props) => {
     Color4GradientList.displayName = "Color4GradientList";
     const { gradients } = props;
-    const items = GradientsToListItems<Color4Gradient>(gradients);
+    const items = useMemo(() => GradientsToListItems<Color4Gradient>(gradients), [gradients]);
     return (
         <List
             key="Color4"
             addButtonLabel={items.length > 0 ? `Add new ${props.label}` : `Use ${props.label}s`}
             items={items}
-            onDelete={(item) => props.removeGradient(item.data)}
+            onDelete={(item, index) => props.removeGradient(item.data, index)}
             onAdd={() => {
                 if (items.length === 0) {
                     props.addGradient(); // Default
@@ -109,7 +111,7 @@ export const Color4GradientList: FunctionComponent<GradientListProps<Color4Gradi
                     props.addGradient(new Color4Gradient(1, new Color4(1, 1, 1, 1), new Color4(1, 1, 1, 1)));
                 }
             }}
-            renderItem={(item) => {
+            renderItem={(item, index) => {
                 return (
                     <Color4GradientComponent
                         value={item.data}
@@ -117,7 +119,7 @@ export const Color4GradientList: FunctionComponent<GradientListProps<Color4Gradi
                             item.data.gradient = newGradient.gradient;
                             item.data.color1 = newGradient.color1;
                             item.data.color2 = newGradient.color2;
-                            props.onChange(newGradient);
+                            props.onChange(newGradient, index);
                         }}
                     />
                 );

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/list.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/list.tsx
@@ -1,7 +1,10 @@
-import { CopyRegular, DeleteRegular } from "@fluentui/react-icons";
-import type { ReactNode, ReactElement } from "react";
-import { ButtonLine } from "../hoc/buttonLine";
+import type { ReactElement, ReactNode } from "react";
+
 import { Body1Strong, makeStyles, tokens } from "@fluentui/react-components";
+import { AddRegular, CopyRegular, DeleteRegular } from "@fluentui/react-icons";
+import { useMemo } from "react";
+
+import { ButtonLine } from "../hoc/buttonLine";
 
 const useListStyles = makeStyles({
     item: {
@@ -59,23 +62,23 @@ export function List<T>(props: ListProps<T>): ReactElement {
     const { items, renderItem, onDelete, onAdd, addButtonLabel = "Add new item" } = props;
     const classes = useListStyles();
 
+    const sortedItems = useMemo(() => [...items].sort((a, b) => a.sortBy - b.sortBy), [items]);
+
     return (
         <div>
-            <ButtonLine label={addButtonLabel} onClick={() => props.onAdd()} />
+            <ButtonLine label={addButtonLabel} icon={AddRegular} onClick={() => props.onAdd()} />
 
             <div className={classes.list}>
-                {items
-                    .sort((a, b) => a.sortBy - b.sortBy)
-                    .map((item: ListItem<T>, index: number) => (
-                        <div key={item.id} className={classes.item}>
-                            <Body1Strong className={classes.itemId}>#{index}</Body1Strong>
-                            <div className={classes.itemContent}>{renderItem(item, index)}</div>
-                            <div className={classes.iconContainer}>
-                                <CopyRegular onClick={() => onAdd(item)} />
-                                <DeleteRegular onClick={() => onDelete(item, index)} />
-                            </div>
+                {sortedItems.map((item: ListItem<T>, index: number) => (
+                    <div key={item.id} className={classes.item}>
+                        <Body1Strong className={classes.itemId}>#{index}</Body1Strong>
+                        <div className={classes.itemContent}>{renderItem(item, items.indexOf(sortedItems[index]))}</div>
+                        <div className={classes.iconContainer}>
+                            <CopyRegular onClick={() => onAdd(item)} />
+                            <DeleteRegular onClick={() => onDelete(item, items.indexOf(sortedItems[index]))} />
                         </div>
-                    ))}
+                    </div>
+                ))}
             </div>
         </div>
     );


### PR DESCRIPTION
This PR adds support for `InputBock`s in the properties of a `NodeMaterial`.
- Updated `List` to pass through the original (before sorting) index of the item being removed or rendered. This makes it much easier to manage updates to the source list (unsorted).
- Plumbed through the index passing in the various gradient list components.
- Added various property lines for a NodeMaterial's InputBlocks as well as GradientBlocks (similar to inspector v1).

<img width="341" height="479" alt="image" src="https://github.com/user-attachments/assets/4099f1e5-d8cf-4820-ad23-f54b03e35c48" />

<img width="334" height="139" alt="image" src="https://github.com/user-attachments/assets/a0b61d65-c382-4e6a-ae77-4d3b334eb337" />
