### PR TITLE
fix(ImageProcessingBlock): use 1.0 for alpha when vec3 input with convertInputToLinearSpace

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts
@@ -176,8 +176,7 @@ export class ImageProcessingBlock extends NodeMaterialBlock {
 
         if (color.connectedPoint?.isConnected) {
             const isVec4Input =
-                color.connectedPoint.type === NodeMaterialBlockConnectionPointTypes.Color4 ||
-                color.connectedPoint.type === NodeMaterialBlockConnectionPointTypes.Vector4;
+                color.connectedPoint.type === NodeMaterialBlockConnectionPointTypes.Color4 || color.connectedPoint.type === NodeMaterialBlockConnectionPointTypes.Vector4;
             // For vec3 inputs (Color3/Vector3), use 1.0 for alpha since they have no .a component
             const alpha = isVec4Input ? `${color.associatedVariableName}.a` : "1.0";
 


### PR DESCRIPTION
## Summary
- Fix shader error when `ImageProcessingBlock` receives vec3 input (Color3/Vector3) with `convertInputToLinearSpace=true`
- The generated shader code incorrectly accessed `.a` on vec3, causing GLSL error: `'a' : vector field selection out of range`
- Use `1.0` for alpha when input is vec3, use actual `.a` component when input is vec4

## Regression from v6
This worked correctly in **BabylonJS 6.x**. The v6 implementation modified `.rgb` in-place without reconstructing the vec4:

```typescript
// v6.45.0 - worked correctly
state.compilationString += `${output.associatedVariableName}.rgb = toLinearSpace(${color.associatedVariableName}.rgb);\n`;
```

See: [v6.45.0 imageProcessingBlock.ts](https://github.com/BabylonJS/Babylon.js/blob/6.45.0/packages/dev/core/src/Materials/Node/Blocks/Fragment/imageProcessingBlock.ts#L120-L179)

The v8 implementation changed to reconstruct the vec4, but incorrectly accesses `.a` on vec3 inputs:
```typescript
// v8.x - broken for vec3 inputs
state.compilationString += `${output.associatedVariableName} = vec4(toLinearSpace(${color.associatedVariableName}.rgb), ${color.associatedVariableName}.a);\n`;
```

## Bug Details
When using `ImageProcessingBlock` in a Node Material with:
- Input connected to a `Color3` or `Vector3` output
- `convertInputToLinearSpace` set to `true`

The shader compilation fails with:
```
FRAGMENT SHADER ERROR: 0:354: 'a' : vector field selection out of range
```

## Fix
Determine alpha based on input type:
- vec4 inputs (Color4/Vector4): use `${color.associatedVariableName}.a`
- vec3 inputs (Color3/Vector3): use `1.0`
