### PR TITLE
ConvertCubeMapTextureToSphericalPolynomial: Fix wrong calculated polynomials

### DIFF
--- a/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
+++ b/packages/dev/core/src/Misc/HighDynamicRange/cubemapToSphericalPolynomial.ts
@@ -76,10 +76,6 @@ export class CubeMapToSphericalPolynomialTools {
         const gammaSpace = texture.gammaSpace;
         // Always read as RGBA.
         const format = Constants.TEXTUREFORMAT_RGBA;
-        let type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
-        if (texture.textureType == Constants.TEXTURETYPE_FLOAT || texture.textureType == Constants.TEXTURETYPE_HALF_FLOAT) {
-            type = Constants.TEXTURETYPE_FLOAT;
-        }
 
         return new Promise((resolve) => {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises, github/no-then
@@ -93,7 +89,7 @@ export class CubeMapToSphericalPolynomialTools {
                     front,
                     back,
                     format,
-                    type,
+                    type: left instanceof Float32Array ? Constants.TEXTURETYPE_FLOAT : Constants.TEXTURETYPE_UNSIGNED_BYTE,
                     gammaSpace,
                 };
 


### PR DESCRIPTION
See https://forum.babylonjs.com/t/incorrect-diffuse-irradiance-spherical-harmonics-when-using-r11g11b10f-format/62126

Note that `ConvertCubeMapTextureToSphericalPolynomial` with the **r11g11b10f** texture format does not work in WebGPU, because we would have to convert this format to float “by hand,” and the `readPixels` code does not do this. We chose to keep `readPixels` simple, as this would involve adding conversion code for all supported formats (except byte, half float, and float formats). To be supported in WebGPU, I think we should perform the conversion from cube map to spherical polynomial in a shader.