### PR TITLE
Add apply torque physics v2

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -436,6 +436,7 @@ export interface IPhysicsEnginePluginV2 {
     applyImpulse(body: PhysicsBody, impulse: Vector3, location: Vector3, instanceIndex?: number): void;
     applyAngularImpulse(body: PhysicsBody, angularImpulse: Vector3, instanceIndex?: number): void;
     applyForce(body: PhysicsBody, force: Vector3, location: Vector3, instanceIndex?: number): void;
+    applyTorque(body: PhysicsBody, torque: Vector3, instanceIndex?: number): void;
     setAngularVelocity(body: PhysicsBody, angVel: Vector3, instanceIndex?: number): void;
     getAngularVelocityToRef(body: PhysicsBody, angVel: Vector3, instanceIndex?: number): void;
     getBodyGeometry(body: PhysicsBody): object;

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -1137,6 +1137,20 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
     }
 
     /**
+     * Applies a torque to a physics body.
+     * @param body - The physics body to apply the torque to.
+     * @param torque - The torque vector.
+     * @param instanceIndex - The index of the instance to apply the torque to. If not specified, the torque will be applied to all instances.
+     *
+     * This method is useful for applying a torque to a physics body.
+     * This can be used to simulate rotational forces such as motors, angular momentum, and rotational dynamics.
+     */
+    public applyTorque(body: PhysicsBody, torque: Vector3, instanceIndex?: number): void {
+        torque.scaleToRef(this.getTimeStep(), this._tmpVec3[0]);
+        this.applyAngularImpulse(body, this._tmpVec3[0], instanceIndex);
+    }
+
+    /**
      * Sets the angular velocity of a physics body.
      *
      * @param body - The physics body to set the angular velocity of.

--- a/packages/dev/core/src/Physics/v2/physicsBody.ts
+++ b/packages/dev/core/src/Physics/v2/physicsBody.ts
@@ -481,6 +481,19 @@ export class PhysicsBody {
     }
 
     /**
+     * Applies a torque to the physics body.
+     *
+     * @param torque The torque vector.
+     * @param instanceIndex For a instanced body, the instance to where the torque should be applied. If not specified, the torque is applied to all instances.
+     *
+     * This method is useful for applying a torque to a physics body, which can be used to simulate rotational forces such as motors,
+     * angular momentum, and rotational dynamics. This can be used to create realistic physics simulations in a game or other application.
+     */
+    public applyTorque(torque: Vector3, instanceIndex?: number): void {
+        this._physicsPlugin.applyTorque(this, torque, instanceIndex);
+    }
+
+    /**
      * Applies a force to the physics object.
      *
      * @param force The force vector.

--- a/packages/dev/core/src/Physics/v2/physicsEngineComponent.ts
+++ b/packages/dev/core/src/Physics/v2/physicsEngineComponent.ts
@@ -36,6 +36,12 @@ declare module "../../Meshes/transformNode" {
          */
         applyAngularImpulse(angularImpulse: Vector3): TransformNode;
 
+        /** Apply a physic torque to the mesh
+         * @param torque defines the torque to apply
+         * @returns the current mesh
+         */
+        applyTorque(torque: Vector3): TransformNode;
+
         /** @internal */
         _disposePhysicsObserver: Nullable<Observer<Node>>;
     }
@@ -103,5 +109,19 @@ TransformNode.prototype.applyAngularImpulse = function (angularImpulse: Vector3)
         throw new Error("No Physics Body for TransformNode");
     }
     this.physicsBody.applyAngularImpulse(angularImpulse);
+    return this;
+};
+
+/**
+ * Apply a physic torque to the mesh
+ * @param torque defines the torque to apply
+ * @returns the current mesh
+ * @see https://doc.babylonjs.com/features/featuresDeepDive/physics/usingPhysicsEngine
+ */
+TransformNode.prototype.applyTorque = function (torque: Vector3): TransformNode {
+    if (!this.physicsBody) {
+        throw new Error("No Physics Body for TransformNode");
+    }
+    this.physicsBody.applyTorque(torque);
     return this;
 };


### PR DESCRIPTION
Hey there, I noticed PhysicsV2 exposes `applyAngularImpulse`, but there is no time-dependent counterpart (like `applyForce` is to `applyImpulse`). 

So I made this small PR with copilot to implement an `applyTorque` methods that scales the angular impulse by the physics engine's timestep. I implemented it in the same places `applyForce` is implemented.