### PR TITLE
Fix ClusteredLightContainer proxy mesh belonging to wrong scene

### DIFF
--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -245,7 +245,7 @@ export class ClusteredLightContainer extends Light {
         this._proxyMaterial.alphaMode = Constants.ALPHA_ADD;
         this._proxyMaterial.sideOrientation = Constants.MATERIAL_CounterClockWiseSideOrientation;
 
-        this._proxyMesh = CreatePlane("ProxyMesh", { size: 2 });
+        this._proxyMesh = CreatePlane("ProxyMesh", { size: 2 }, this._scene);
         // Make sure it doesn't render for the default scene
         this._scene.removeMesh(this._proxyMesh);
         this._proxyMesh.material = this._proxyMaterial;


### PR DESCRIPTION
Hey there, I found a small bug in `ClusteredLightContainer`.

Basically, the `_proxyMesh` is created with `CreatePlane` without specifying the `scene` parameter. This will automatically pick the latest created scene.

The issue is that the `_proxyMesh` is supposed to be removed from the scene right away with `this._scene.removeMesh`. But `this._scene` might not be the same scene as the one used to create the plane:

If I create a 1st scene, then a 2nd scene, then create a `ClusteredLightContainer` for the 1st scene, the `_proxyMesh`  will be created in the 2nd scene instead of the 1st, and will not be removed! 

This can lead to visual bugs that I was not able to repro on the PG. However I captured it using SpectorJS:

[capture 16_50_57.json](https://github.com/user-attachments/files/24838302/capture.16_50_57.json)

Here, you can see the `_proxyMesh` for a first scene drawing itself as a red horizontal strip in my second scene, which should never happen: 

<img width="1919" height="932" alt="image" src="https://github.com/user-attachments/assets/23df8acd-1065-476d-970f-9ed671484cb6" />

I also tweaked this PG to log the meshes in the 2nd scene to confirm the `_proxyMesh` is indeed present:

https://playground.babylonjs.com/#P3E9YP#309

And with this PR, it works as expected: https://playground.babylonjs.com/?snapshot=refs/pull/17722/merge#P3E9YP#309

In the end the fix is quite simple: set the `scene` argument in `CreatePlane`. It fixed the red strip issue on my end anyway