### PR TITLE
Adding network wait for interaction sandbox tests to assure models load

### DIFF
--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -50,6 +50,7 @@ test("dropping an image to the sandbox", async ({ page }) => {
     // wait for #babylonjsLoadingDiv to be hidden
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "hidden" });
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "detached" });
+    await page.waitForLoadState("networkidle");
     // check snapshot of the page
     await expect(page).toHaveScreenshot({ maxDiffPixels: 3000 });
 });
@@ -65,6 +66,7 @@ test("loading a model using query parameters", async ({ page }) => {
     // wait for #babylonjsLoadingDiv to be hidden
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "hidden" });
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "detached" });
+    await page.waitForLoadState("networkidle");
     // check snapshot of the page
     await expect(page).toHaveScreenshot({ maxDiffPixels: 3000 });
 });
@@ -81,6 +83,7 @@ test("inspector is opened when clicking on the button", async ({ page }) => {
     // wait for #babylonjsLoadingDiv to be hidden
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "hidden" });
     await page.waitForSelector("#babylonjsLoadingDiv", { state: "detached" });
+    await page.waitForLoadState("networkidle");
 
     // click the "Inspector" button
     await page.getByTitle("Display inspector").click();


### PR DESCRIPTION
On tests that load content for the sandbox, add a wait for networkidle to make sure we take the screenshot when all content has finished loading and rendering.