### PR TITLE
[GeospatialCamera] Add GeospatialClippingBehavior and fix scrollwheel zoom limit

### DIFF
--- a/packages/dev/core/src/Behaviors/Cameras/geospatialClippingBehavior.ts
+++ b/packages/dev/core/src/Behaviors/Cameras/geospatialClippingBehavior.ts
@@ -1,0 +1,94 @@
+import type { Behavior } from "../../Behaviors/behavior";
+import type { GeospatialCamera } from "../../Cameras/geospatialCamera";
+import type { Nullable } from "../../types";
+import type { Observer } from "../../Misc/observable";
+import type { Scene } from "../../scene";
+
+/**
+ * The GeospatialClippingBehavior automatically adjusts the near and far clip planes of a GeospatialCamera
+ * based on altitude and viewing angle to optimize depth buffer precision for geospatial applications.
+ *
+ * When viewing from high altitudes looking down, a larger near plane can be used.
+ * When viewing horizontally at ground level, a smaller near plane is needed to avoid clipping nearby terrain.
+ * The far plane is calculated based on the visible horizon distance.
+ */
+export class GeospatialClippingBehavior implements Behavior<GeospatialCamera> {
+    /**
+     * Gets the name of the behavior.
+     */
+    public get name(): string {
+        return "GeospatialClipping";
+    }
+
+    private _attachedCamera: Nullable<GeospatialCamera> = null;
+    private _onBeforeRenderObserver: Nullable<Observer<Scene>> = null;
+
+    /**
+     * Gets the attached camera.
+     */
+    public get attachedNode(): Nullable<GeospatialCamera> {
+        return this._attachedCamera;
+    }
+
+    /**
+     * Initializes the behavior.
+     */
+    public init(): void {
+        // Do nothing
+    }
+
+    /**
+     * Attaches the behavior to its geospatial camera.
+     * @param camera Defines the camera to attach the behavior to
+     */
+    public attach(camera: GeospatialCamera): void {
+        this._attachedCamera = camera;
+        const scene = camera.getScene();
+
+        this._onBeforeRenderObserver = scene.onBeforeRenderObservable.add(() => {
+            this._updateCameraClipPlanes();
+        });
+    }
+
+    /**
+     * Detaches the behavior from its current geospatial camera.
+     */
+    public detach(): void {
+        if (this._attachedCamera) {
+            const scene = this._attachedCamera.getScene();
+            if (this._onBeforeRenderObserver) {
+                scene.onBeforeRenderObservable.remove(this._onBeforeRenderObserver);
+                this._onBeforeRenderObserver = null;
+            }
+        }
+        this._attachedCamera = null;
+    }
+
+    /**
+     * Updates the camera's near and far clip planes based on altitude and viewing angle.
+     */
+    private _updateCameraClipPlanes(): void {
+        const camera = this._attachedCamera;
+        if (!camera) {
+            return;
+        }
+
+        const planetRadius = camera.limits.planetRadius;
+        const altitude = Math.max(1, camera.radius);
+        const pitch = camera.pitch; // 0 = looking down, π/2 = looking at horizon
+
+        // Near plane calculation:
+        // - When looking down (pitch ≈ 0): nearest visible point is roughly at altitude distance
+        // - When looking at horizon (pitch ≈ π/2): nearby terrain can be much closer
+
+        // Use pitch to blend between a small near (for horizontal view) and altitude-based near (for top-down)
+        const pitchFactor = Math.sin(pitch); // 0 when looking down, 1 at horizon
+        const minNearHorizontal = 1; // When looking horizontally, need small near plane
+        const minNearVertical = Math.max(1, altitude * 0.01); // When looking down, can use larger near
+        camera.minZ = minNearHorizontal + (minNearVertical - minNearHorizontal) * (1 - pitchFactor);
+
+        // Far plane: see to the horizon and beyond
+        const horizonDist = Math.sqrt(2 * planetRadius * altitude + altitude * altitude);
+        camera.maxZ = horizonDist + planetRadius * 0.1;
+    }
+}

--- a/packages/dev/core/src/Behaviors/Cameras/index.ts
+++ b/packages/dev/core/src/Behaviors/Cameras/index.ts
@@ -1,3 +1,5 @@
 export * from "./autoRotationBehavior";
 export * from "./bouncingBehavior";
 export * from "./framingBehavior";
+export * from "./interpolatingBehavior";
+export * from "./geospatialClippingBehavior";

--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
@@ -83,7 +83,8 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
                     // Scale zoom by distance to picked point
                     const distanceToPoint = this.camera.position.subtract(pickResult.pickedPoint).length();
                     const zoomDistance = pinchDelta * distanceToPoint * 0.005;
-                    this.camera.zoomToPoint(pickResult.pickedPoint, zoomDistance);
+                    const clampedZoom = this.camera.limits.clampZoomDistance(zoomDistance, this.camera.radius, distanceToPoint);
+                    this.camera.zoomToPoint(pickResult.pickedPoint, clampedZoom);
                     return;
                 }
             }
@@ -91,7 +92,8 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
 
         // Fallback: scale zoom by camera radius along lookat vector
         const zoomDistance = pinchDelta * this.camera.radius * 0.005;
-        this.camera.zoomAlongLookAt(zoomDistance);
+        const clampedZoom = this.camera.limits.clampZoomDistance(zoomDistance, this.camera.radius);
+        this.camera.zoomAlongLookAt(clampedZoom);
     }
 
     /**

--- a/packages/dev/core/src/Cameras/Limits/geospatialLimits.ts
+++ b/packages/dev/core/src/Cameras/Limits/geospatialLimits.ts
@@ -4,7 +4,7 @@ import { Epsilon } from "../../Maths/math.constants";
  */
 export class GeospatialLimits {
     private _planetRadius: number;
-    private _radiusMin: number = Epsilon;
+    private _radiusMin: number = 10;
     private _radiusMax: number = Infinity;
 
     /** Gets the minimum pitch angle (angle from horizon) -- 0 means looking straight down at planet */
@@ -65,5 +65,24 @@ export class GeospatialLimits {
     /** Sets the planet radius and updates the radius limits to maintain current altitude */
     public set planetRadius(value: number) {
         this._planetRadius = value;
+    }
+
+    /**
+     * Clamps a zoom distance to respect the radius limits.
+     * @param zoomDistance The requested zoom distance (positive = zoom in, negative = zoom out)
+     * @param currentRadius The current camera radius
+     * @param distanceToTarget Optional distance to the zoom target point (used for zoom-in clamping)
+     * @returns The clamped zoom distance
+     */
+    public clampZoomDistance(zoomDistance: number, currentRadius: number, distanceToTarget?: number): number {
+        if (zoomDistance > 0) {
+            // Zooming IN - don't zoom past the surface or below radiusMin
+            const maxZoomIn = (distanceToTarget ?? currentRadius) - this._radiusMin;
+            return Math.min(zoomDistance, Math.max(0, maxZoomIn));
+        } else {
+            // Zooming OUT - don't exceed radiusMax
+            const maxZoomOut = this._radiusMax - currentRadius;
+            return Math.max(zoomDistance, -Math.max(0, maxZoomOut));
+        }
     }
 }

--- a/packages/dev/core/src/Cameras/geospatialCamera.ts
+++ b/packages/dev/core/src/Cameras/geospatialCamera.ts
@@ -433,21 +433,8 @@ export class GeospatialCamera extends Camera {
             return 0;
         }
 
-        if (zoomDelta > 0) {
-            // Zooming IN - respect radiusMin as distance to surface
-            if (pickedPoint) {
-                const pickDistance = Vector3Distance(this._position, pickedPoint);
-                // Don't zoom past the picked surface point + radiusMin
-                const maxZoomToSurface = pickDistance - this.limits.radiusMin;
-                return Math.min(zoomDelta, Math.max(0, maxZoomToSurface));
-            }
-
-            return zoomDelta;
-        } else {
-            // Zooming OUT - respect radiusMax
-            const maxZoomOut = this.limits.radiusMax - this._radius;
-            return Math.max(zoomDelta, -Math.max(0, maxZoomOut));
-        }
+        const distanceToTarget = pickedPoint ? Vector3Distance(this._position, pickedPoint) : undefined;
+        return this.limits.clampZoomDistance(zoomDelta, this._radius, distanceToTarget);
     }
 
     public zoomToPoint(targetPoint: DeepImmutable<IVector3Like>, distance: number) {

--- a/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
+++ b/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
@@ -62,6 +62,7 @@ export class GeospatialCameraMovement extends CameraMovement {
         this.rotationInertia = 0;
         this.rotationXSpeed = Math.PI / 500; // Move 1/500th of a half circle per pixel
         this.rotationYSpeed = Math.PI / 500; // Move 1/500th of a half circle per pixel
+        this.zoomSpeed = 2; // Base zoom speed; actual speed is scaled based on altitude
     }
 
     public startDrag(pointerX: number, pointerY: number) {


### PR DESCRIPTION
- Can attach clippingbehavior to automatically adjust min and max Z to take into account planetradius and cameras location from surface
- Fix bug where touchzoom let you zoom out further than scroll
- Minor limit changes to improve default movement behavior