### PR TITLE
Fix issue with srgb in sandbox

### DIFF
--- a/packages/dev/core/src/Engines/thinEngine.ts
+++ b/packages/dev/core/src/Engines/thinEngine.ts
@@ -93,8 +93,9 @@ export interface EngineOptions extends AbstractEngineOptions, WebGLContextAttrib
     failIfMajorPerformanceCaveat?: boolean;
 
     /**
-     * If sRGB Buffer support is not set during construction, use this value to force a specific state
-     * This is added due to an issue when processing textures in chrome/edge/firefox
+     * If sRGB buffer support is not set during construction, use this value to force a specific state
+     * This was originally added to mitigate an issue when processing textures in chrome/edge/firefox.
+     * The browser issue has since been fixed. This option remains for backward compatibility.
      * This will not influence NativeEngine and WebGPUEngine which set the behavior to true during construction.
      */
     forceSRGBBufferSupportState?: boolean;

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -86,7 +86,6 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
                 premultipliedAlpha: false,
                 preserveDrawingBuffer: true,
                 antialias: antialias,
-                forceSRGBBufferSupportState: this.props.globalState.commerceMode,
             });
         }
 


### PR DESCRIPTION
Fix issue when viewing [TextureLinearInterpolationTest](https://github.com/KhronosGroup/glTF-Sample-Models/tree/main/2.0/TextureLinearInterpolationTest) in the sandbox.

[Direct link](https://sandbox.babylonjs.com/?asset=https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/refs/heads/main/2.0/TextureLinearInterpolationTest/glTF/TextureLinearInterpolationTest.gltf)