### PR TITLE
Make inspector v1 package forward compatible with Babylon 9

### DIFF
--- a/packages/public/@babylonjs/inspector/package.json
+++ b/packages/public/@babylonjs/inspector/package.json
@@ -23,13 +23,13 @@
         "@fortawesome/free-solid-svg-icons": "^6.0.0"
     },
     "peerDependencies": {
-        "@babylonjs/addons": "^8.0.0",
-        "@babylonjs/core": "^8.0.0",
-        "@babylonjs/gui": "^8.0.0",
-        "@babylonjs/gui-editor": "^8.0.0",
-        "@babylonjs/loaders": "^8.0.0",
-        "@babylonjs/materials": "^8.0.0",
-        "@babylonjs/serializers": "^8.0.0",
+        "@babylonjs/addons": "^8.0.0 || ^9.0.0",
+        "@babylonjs/core": "^8.0.0 || ^9.0.0",
+        "@babylonjs/gui": "^8.0.0 || ^9.0.0",
+        "@babylonjs/gui-editor": "^8.0.0 || ^9.0.0",
+        "@babylonjs/loaders": "^8.0.0 || ^9.0.0",
+        "@babylonjs/materials": "^8.0.0 || ^9.0.0",
+        "@babylonjs/serializers": "^8.0.0 || ^9.0.0",
         "@types/react": ">=16.7.3",
         "@types/react-dom": ">=16.0.9"
     },


### PR DESCRIPTION
Because we plan to stop publishing Inspector v1 npm packages prior to the 9.0 release, we will publish some final Inspector v1 packages that are forward compatible with 9.0. This will mean that while Inspector v2 is still very new, if anyone needs to use Inspector v1 with their project using Babylon 9, they still can (without npm errors or force installing a package that claims to be incompatible). This is just a simple step to help ease the transition to v2 as much as we can.