### PR TITLE
Fix file size error threshold

### DIFF
--- a/.build/flags.json
+++ b/.build/flags.json
@@ -1,3 +1,3 @@
 {
-    "errorThreshold": 2.5
+    "errorThreshold": 1.2
 }


### PR DESCRIPTION
This was probably supposed to be temporarily set to 2.5. Changing it back to 1.2 so the CI fails as expected when the file size increase is more than 20%.

NB: was changed to 2.5 in PR https://github.com/BabylonJS/Babylon.js/pull/15600.