### PR TITLE
Fix Inspector v2 regression in Playground

### DIFF
--- a/packages/dev/inspector-v2/src/components/tools/import/gltfLoaderOptionsTool.tsx
+++ b/packages/dev/inspector-v2/src/components/tools/import/gltfLoaderOptionsTool.tsx
@@ -26,7 +26,6 @@ export const GLTFLoaderOptionsTool: FunctionComponent<{
         <PropertyLine
             label="Loader Options"
             expandByDefault={false}
-            indentExpandedContent={true}
             expandedContent={
                 <>
                     <BoundProperty component={SwitchPropertyLine} label="Always compute bounding box" target={loaderOptions} propertyKey="alwaysComputeBoundingBox" />
@@ -68,7 +67,6 @@ export const GLTFExtensionOptionsTool: FunctionComponent<{
         <PropertyLine
             label="Extension Options"
             expandByDefault={false}
-            indentExpandedContent={true}
             expandedContent={
                 <>
                     {Object.entries(extensionOptions).map(([extensionName, options]) => {

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/propertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/propertyLine.tsx
@@ -55,8 +55,6 @@ const usePropertyLineStyles = makeStyles({
     },
     expandedContentDiv: {
         overflow: "hidden",
-    },
-    expandedContentDivIndented: {
         paddingLeft: tokens.spacingHorizontalM,
     },
     checkbox: {
@@ -112,7 +110,7 @@ type NonNullableProperty = {
     ignoreNullable?: false;
 };
 
-// Only expect optional expandByDefault or indentExpandedContent prop if expandedContent is defined
+// Only expect optional expandByDefault prop if expandedContent is defined
 type ExpandableProperty = {
     /**
      * If supplied, an 'expand' icon will be shown which, when clicked, renders this component within the property line.
@@ -123,11 +121,6 @@ type ExpandableProperty = {
      * If true, the expanded content will be shown by default.
      */
     expandByDefault?: boolean;
-
-    /**
-     * If true, the expanded content will be indented to the right.
-     */
-    indentExpandedContent?: boolean;
 };
 
 // If expanded content is undefined, don't expect expandByDefault prop
@@ -218,7 +211,7 @@ export const PropertyLine = forwardRef<HTMLDivElement, PropsWithChildren<Propert
             </div>
             {expandedContent && (
                 <Collapse visible={!!expanded}>
-                    <div className={mergeClasses(classes.expandedContentDiv, props.indentExpandedContent ? classes.expandedContentDivIndented : undefined)}>{expandedContent}</div>
+                    <div className={classes.expandedContentDiv}>{expandedContent}</div>
                 </Collapse>
             )}
         </LineContainer>

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/messageBar.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/messageBar.tsx
@@ -18,14 +18,14 @@ type MessageBarProps = {
 };
 export const MessageBar: FunctionComponent<MessageBarProps> = (props) => {
     MessageBar.displayName = "MessageBar";
-    const { message, title: header, intent, docLink } = props;
+    const { message, title, intent, docLink } = props;
     const classes = useClasses();
 
     return (
         <div className={classes.container}>
             <FluentMessageBar intent={intent} layout="multiline">
                 <MessageBarBody>
-                    {header && <MessageBarTitle>{header}</MessageBarTitle>}
+                    {title && <MessageBarTitle>{title}</MessageBarTitle>}
                     {message}
                     {docLink && (
                         <>

--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 // Version
 var Versions = {
     Latest: [
@@ -6,13 +5,6 @@ var Versions = {
         { url: "https://preview.babylonjs.com/babylon.js", instantResolve: false },
         { url: "https://preview.babylonjs.com/gui/babylon.gui.min.js", instantResolve: false },
         { url: "https://preview.babylonjs.com/addons/babylonjs.addons.min.js", instantResolve: false, minVersion: "7.32.4" },
-        // Allow an "inspectorv1" query param to force loading Inspector v1.
-        ...(window.location.search.toLocaleLowerCase().includes("inspectorv1")
-            ? [{ url: "https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js", instantResolve: true }]
-            : [
-                  { url: "https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js", instantResolve: true, maxVersion: "8.40.0" },
-                  { url: "https://preview.babylonjs.com/inspector/babylon.inspector-v2.bundle.js", instantResolve: true, minVersion: "8.40.1" },
-              ]),
         { url: "https://preview.babylonjs.com/nodeEditor/babylon.nodeEditor.js", instantResolve: true },
         { url: "https://preview.babylonjs.com/nodeGeometryEditor/babylon.nodeGeometryEditor.js", instantResolve: true },
         { url: "https://preview.babylonjs.com/nodeRenderGraphEditor/babylon.nodeRenderGraphEditor.js", instantResolve: true },
@@ -23,6 +15,13 @@ var Versions = {
         { url: "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js", instantResolve: true },
         { url: "https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js", instantResolve: true },
         { url: "https://preview.babylonjs.com/accessibility/babylon.accessibility.js", instantResolve: true },
+        // Allow an "inspectorv1" query param to force loading Inspector v1.
+        ...(window.location.search.toLocaleLowerCase().includes("inspectorv1")
+            ? [{ url: "https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js", instantResolve: true }]
+            : [
+                  { url: "https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js", instantResolve: true, maxVersion: "8.40.0" },
+                  { url: "https://preview.babylonjs.com/inspector/babylon.inspector-v2.bundle.js", instantResolve: true, minVersion: "8.40.1" },
+              ]),
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/f43ab677b4bca0a6ab77132d3f785be300382760/ClonerSystem/src/babylonx.cloner.js", instantResolve: true },
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js", instantResolve: true },
     ],
@@ -30,8 +29,6 @@ var Versions = {
         { url: `//${window.location.hostname}:1337/babylon.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/gui/babylon.gui.min.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/addons/babylonjs.addons.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/inspector/babylon.inspector.bundle.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/nodeEditor/babylon.nodeEditor.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/nodeGeometryEditor/babylon.nodeGeometryEditor.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/nodeRenderGraphEditor/babylon.nodeRenderGraphEditor.js`, instantResolve: false },
@@ -42,6 +39,8 @@ var Versions = {
         { url: `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/serializers/babylonjs.serializers.min.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/accessibility/babylon.accessibility.js`, instantResolve: false },
+        // { url: `//${window.location.hostname}:1337/inspector/babylon.inspector.bundle.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:1337/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/f43ab677b4bca0a6ab77132d3f785be300382760/ClonerSystem/src/babylonx.cloner.js", instantResolve: false },
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js", instantResolve: false },
     ],

--- a/packages/tools/sandbox/public/index.js
+++ b/packages/tools/sandbox/public/index.js
@@ -63,6 +63,7 @@ const Versions = {
         { url: `//${window.location.hostname}:1337/serializers/babylonjs.serializers.min.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/materialsLibrary/babylonjs.materials.min.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/gui/babylon.gui.min.js`, instantResolve: false },
+        // { url: `//${window.location.hostname}:1337/inspector/babylon.inspector.bundle.js`, instantResolve: false },
         { url: `//${window.location.hostname}:1337/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
     ],
 };


### PR DESCRIPTION
In the recent change #17739, all the gltf tools are always on services, which means they are now statically imported instead of dynamically imported (through an extension), and they include module scoped code that uses things from the loaders package:
```ts
const AnimationStartModeOptions: DropdownOption<number>[] = [
    { label: "None", value: GLTFLoaderAnimationStartMode.NONE },
    { label: "First", value: GLTFLoaderAnimationStartMode.FIRST },
    { label: "All", value: GLTFLoaderAnimationStartMode.ALL },
];
```
This means in the Playground where we use independent core/loaders/etc bundles, and we manually manage the load order (no tooling to help with the dependency graph), the loaders bundle must be explicitly loaded before the inspector v2 bundle, which was not how it was configured. This PR mostly is just fixing the order. It was already correct for Sandbox.

This PR also includes a few really small changes that were supposed to be in a different PR but somehow got lost. They are small, so I'm just tacking them on.