### PR TITLE
Fix: Remove enforced undefined for MSC_TRANSCODER

### DIFF
--- a/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
+++ b/packages/tools/ktx2Decoder/src/Transcoders/mscTranscoder.ts
@@ -55,7 +55,7 @@ export class MSCTranscoder extends Transcoder {
         )
             // eslint-disable-next-line github/no-then
             .then(async (wasmBinary) => {
-                if (MSCTranscoder.JSModule && typeof MSC_TRANSCODER === "undefined") {
+                if (MSCTranscoder.JSModule) {
                     // this must be set on the global scope for the MSC transcoder to work. Mainly due to back-compat with the old way of loading the MSC transcoder.
                     (globalThis as any).MSC_TRANSCODER = MSCTranscoder.JSModule;
                 } else {


### PR DESCRIPTION
Please see the forum thread: https://forum.babylonjs.com/t/how-to-inject-babylonjs-ktx2decoder-into-babylon/62160/6

When using local CDN `ktx2decoder` files, we have to do a hacky workaround of unsetting `globalThis. MSC_TRANSCODER` otherwise the check `typeof MSC_TRANSCODER === "undefined"` will reject the local files and instead fetch from the CDN.

The source code works as is when using the npm package `@babylonjs/ktx2decoder`, since it does not set `globalThis. MSC_TRANSCODER` like importing `msc_basis_transcoder.js` as a local file does. This fix should allow both methods (`@babylonjs/ktx2decoder` and local CDN files) to work.
