### PR TITLE
Geometry: Fix copy of instanced buffers

### DIFF
--- a/packages/dev/core/src/Meshes/geometry.ts
+++ b/packages/dev/core/src/Meshes/geometry.ts
@@ -1061,10 +1061,8 @@ export class Geometry implements IGetSetVerticesData {
                 let bufferDataByteSize = 0;
                 if (bufferData instanceof Array) {
                     bufferDataByteSize = bufferData.length * 4;
-                } else if (bufferData instanceof ArrayBuffer) {
-                    bufferDataByteSize = bufferData.byteLength;
                 } else {
-                    bufferDataByteSize = bufferData.buffer.byteLength;
+                    bufferDataByteSize = bufferData.byteLength;
                 }
                 numElements = bufferDataByteSize / byteStride;
             }


### PR DESCRIPTION
See https://forum.babylonjs.com/t/thin-instances-cloning-without-clone-makegeometryunique-will-render-transparent/62266

Note that we do our best to calculate a number of instances, because we don't have this information in the geometry class.