### PR TITLE
Gaussian Splatting Part Visibility Support

### DIFF
--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
@@ -153,6 +153,7 @@ export class GaussianSplattingMaterial extends PushMaterial {
         "alpha",
         "depthValues",
         "partWorld",
+        "partVisibility",
     ];
     private _sourceMesh: GaussianSplattingMesh | null = null;
     /**
@@ -356,11 +357,19 @@ export class GaussianSplattingMaterial extends PushMaterial {
             // Bind part indices texture, if the
             if (gsMesh.partIndicesTexture) {
                 effect.setTexture("partIndicesTexture", gsMesh.partIndicesTexture);
+                // Bind part world matrices
                 const partWorldData = new Float32Array(gsMesh.partCount * 16);
                 for (let i = 0; i < gsMesh.partCount; i++) {
                     gsMesh.getWorldMatrixForPart(i).toArray(partWorldData, i * 16);
                 }
                 effect.setMatrices("partWorld", partWorldData);
+
+                // Bind part visibility data
+                const partVisibilityData: number[] = [];
+                for (let i = 0; i < gsMesh.partCount; i++) {
+                    partVisibilityData.push(gsMesh.partVisibility[i] ?? 1.0);
+                }
+                effect.setArray("partVisibility", partVisibilityData);
             }
         }
     }

--- a/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
+++ b/packages/dev/core/src/Shaders/gaussianSplatting.vertex.fx
@@ -20,6 +20,7 @@ uniform float alpha;
 
 #if IS_COMPOUND
 uniform mat4 partWorld[MAX_PART_COUNT];
+uniform float partVisibility[MAX_PART_COUNT];
 #endif
 
 uniform sampler2D covariancesATexture;
@@ -74,6 +75,11 @@ void main () {
 #endif
 
     vColor.w *= alpha;
+
+#if IS_COMPOUND
+    // Apply part visibility (0.0 to 1.0) to alpha
+    vColor.w *= partVisibility[splat.partIndex];
+#endif
 
     gl_Position = gaussianSplatting(position.xy, worldPos.xyz, vec2(1.,1.), covA, covB, splatWorld, view, projection);
 

--- a/packages/dev/core/src/ShadersWGSL/gaussianSplatting.vertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/gaussianSplatting.vertex.fx
@@ -23,6 +23,7 @@ uniform alpha: f32;
 
 #if IS_COMPOUND
 uniform partWorld: array<mat4x4<f32>, MAX_PART_COUNT>;
+uniform partVisibility: array<f32, MAX_PART_COUNT>;
 #endif
 
 // textures
@@ -76,6 +77,11 @@ fn main(input : VertexInputs) -> FragmentInputs {
     vertexOutputs.vColor = vec4f(splat.color.xyz + computeSH(splat, eyeToSplatLocalSpace), splat.color.w * uniforms.alpha);
 #else
     vertexOutputs.vColor = vec4f(splat.color.xyz, splat.color.w * uniforms.alpha);
+#endif
+
+#if IS_COMPOUND
+    // Apply part visibility (0.0 to 1.0) to alpha
+    vertexOutputs.vColor.w *= uniforms.partVisibility[splat.partIndex];
 #endif
 
     vertexOutputs.position = gaussianSplatting(input.position.xy, worldPos.xyz, vec2f(1.0, 1.0), covA, covB, splatWorld, scene.view, scene.projection, uniforms.focal, uniforms.invViewport, uniforms.kernelSize);


### PR DESCRIPTION
Allow toggling visibility and setting transparency of a part of a compound splat