### PR TITLE
Fix legacy `Sound` loop bug

### DIFF
--- a/packages/dev/core/src/Audio/sound.ts
+++ b/packages/dev/core/src/Audio/sound.ts
@@ -37,17 +37,6 @@ const TmpStopOptions: IStaticSoundStopOptions = {
     waitTime: 0,
 };
 
-function ResetTmpPlayOptions() {
-    TmpPlayOptions.duration = 0;
-    TmpPlayOptions.startOffset = 0;
-    TmpPlayOptions.waitTime = 0;
-
-    TmpPlayOptions.loop = undefined;
-    TmpPlayOptions.loopStart = undefined;
-    TmpPlayOptions.loopEnd = undefined;
-    TmpPlayOptions.volume = undefined;
-}
-
 function D2r(degrees: number): number {
     return (degrees * Math.PI) / 180;
 }
@@ -739,10 +728,13 @@ export class Sound {
             }
 
             try {
-                ResetTmpPlayOptions();
                 TmpPlayOptions.duration = length || 0;
                 TmpPlayOptions.startOffset = offset !== undefined ? offset || this._optionsV2.startOffset! : this._optionsV2.startOffset!;
                 TmpPlayOptions.waitTime = time || 0;
+                TmpPlayOptions.loop = undefined;
+                TmpPlayOptions.loopStart = undefined;
+                TmpPlayOptions.loopEnd = undefined;
+                TmpPlayOptions.volume = undefined;
 
                 if (audioEngine?.unlocked) {
                     this._soundV2.play(TmpPlayOptions);


### PR DESCRIPTION
The static temp play options object being sent from the old sound implementation to the new v2 audio engine implementation is not being reset, so the options from one sound are being carried over to other sound's `play` function calls.

This change fixes the issue by resetting the necessary play options on the static object.