### PR TITLE
Export UniqueIdGenerator to fix umd

### DIFF
--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -79,6 +79,7 @@ export * from "./asyncLock";
 export * from "./bitArray";
 export * from "./urlTools";
 export * from "./lazy";
+export * from "./uniqueIdGenerator";
 
 // RGBDTextureTools
 export * from "../Shaders/rgbdDecode.fragment";


### PR DESCRIPTION
`UniqueIdGenerator` is not exported, which means it is not exposed through the umd bundle, and Inspector v2 now relies on it. This fixes a crash in Playground when using Inspector v2 with an entity type that does not have a `uniqueId` (such as Sounds or legacy custom nodes).