### PR TITLE
Skip sceneWithInspector.ts in umd bundle tests for now

### DIFF
--- a/packages/tools/tests/build.js
+++ b/packages/tools/tests/build.js
@@ -2,9 +2,15 @@
 
 const fs = require("fs");
 const path = require("path");
+const chalk = require("chalk");
 const { execSync } = require("child_process");
 
 const files = fs.readdirSync(path.join(__dirname, "src"));
 files.forEach((file) => {
-    execSync(`webpack --env entry=${path.basename(file, ".ts")}`, { stdio: "inherit" });
+    // TODO: Figure out why WebPack uses so much memory when bundling sceneWithInspector.js
+    if (file !== "sceneWithInspector.ts") {
+        console.log();
+        console.log(chalk.bold(chalk.blue(`===== Building ${file} =====`)));
+        execSync(`webpack --env entry=${path.basename(file, ".ts")}`, { stdio: "inherit" });
+    }
 });


### PR DESCRIPTION
This bundle test is causing node out of memory issues on the build agents, so disabling for now. We'll investigate more later, but right now we need to be able to enable the other umd bundle tests for core, etc.