### PR TITLE
[InspectorV2] Add morphTargets section to mesh properties

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/nodes/meshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/meshProperties.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent } from "react";
 
-import type { Mesh, NodeGeometry } from "core/index";
+import type { Mesh, MorphTarget, NodeGeometry } from "core/index";
 
 import { EditRegular } from "@fluentui/react-icons";
 
@@ -60,6 +60,44 @@ export const MeshDisplayProperties: FunctionComponent<{ mesh: Mesh }> = (props) 
                     { value: Constants.MATERIAL_CounterClockWiseSideOrientation, label: "CounterClockwise" },
                 ]}
             />
+        </>
+    );
+};
+
+export const MeshMorphTargetsProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {
+    const { mesh } = props;
+
+    if (!mesh.morphTargetManager) {
+        return null;
+    }
+
+    const morphTargets: MorphTarget[] = [];
+    for (let index = 0; index < mesh.morphTargetManager.numTargets; index++) {
+        const target = mesh.morphTargetManager.getTarget(index);
+        if (target.hasPositions) {
+            morphTargets.push(target);
+        }
+    }
+
+    if (morphTargets.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {morphTargets.map((target, index) => (
+                <BoundProperty
+                    key={index}
+                    component={SyncedSliderPropertyLine}
+                    label={target.name || `Target ${index}`}
+                    description={`Influence of morph target "${target.name || `Target ${index}`}"`}
+                    target={target}
+                    propertyKey="influence"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                />
+            ))}
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/nodePropertiesService.tsx
@@ -16,7 +16,7 @@ import {
     AbstractMeshOutlineOverlayProperties,
 } from "../../../components/properties/nodes/abstractMeshProperties";
 import { GaussianSplattingDisplayProperties } from "../../../components/properties/nodes/gaussianSplattingProperties";
-import { MeshDisplayProperties, MeshGeneralProperties } from "../../../components/properties/nodes/meshProperties";
+import { MeshDisplayProperties, MeshGeneralProperties, MeshMorphTargetsProperties } from "../../../components/properties/nodes/meshProperties";
 import { NodeGeneralProperties } from "../../../components/properties/nodes/nodeProperties";
 import { SelectionServiceIdentity } from "../../selectionService";
 import { PropertiesServiceIdentity } from "./propertiesService";
@@ -83,6 +83,10 @@ export const NodePropertiesServiceDefinition: ServiceDefinition<[], [IProperties
                 {
                     section: "Display",
                     component: ({ context }) => <MeshDisplayProperties mesh={context} />,
+                },
+                {
+                    section: "Morph Targets",
+                    component: ({ context }) => <MeshMorphTargetsProperties mesh={context} />,
                 },
             ],
         });


### PR DESCRIPTION
This section was missing from mesh properties
<img width="218" height="107" alt="image" src="https://github.com/user-attachments/assets/86a4e1f7-af18-47d8-a4b9-481d7825c460" />