### PR TITLE
Feature: Inspector drag to reparent

### DIFF
--- a/packages/dev/inspector-v2/package.json
+++ b/packages/dev/inspector-v2/package.json
@@ -22,7 +22,6 @@
         "@dev/loaders": "1.0.0",
         "@dev/materials": "1.0.0",
         "@dev/serializers": "1.0.0",
-        "@dnd-kit/core": "^6.3.1",
         "@fluentui-contrib/react-virtualizer": "^0.5.3",
         "@fluentui/react-components": "^9.70.0",
         "@fluentui/react-icons": "^2.0.310",

--- a/packages/dev/inspector-v2/src/components/scene/dragDropProviders/reorderDragProvider.ts
+++ b/packages/dev/inspector-v2/src/components/scene/dragDropProviders/reorderDragProvider.ts
@@ -1,0 +1,177 @@
+import type { Node } from "core/node";
+import type { TransformNode } from "core/Meshes/transformNode";
+
+import type { DragDropProvider } from "../sceneExplorerDragDrop";
+
+/**
+ * Internal drop data for node sibling ordering provider.
+ */
+type DropData =
+    | { action: "reparent"; newParent: Node }
+    | { action: "reorder"; newParent: Node | null; position: "before" | "after"; referenceNode: Node };
+
+/**
+ * Creates a drag-drop provider for Babylon.js Nodes that supports both reparenting and sibling ordering.
+ * - Drop in middle zone (70%): reparent under target
+ * - Drop in top zone (15%): insert before target as sibling
+ * - Drop in bottom zone (15%): insert after target as sibling
+ *
+ * This provider handles all the Babylon.js-specific logic internally:
+ * - Uses `setParent` for TransformNodes to preserve world transform
+ * - Directly manipulates the internal `_children` array and `rootNodes` array
+ * - Updates `_sceneRootNodesIndex` for root-level nodes
+ *
+ * @param isSiblingReorderDisabled - Optional function that returns true to disable sibling reordering
+ *        (edge zones) and only allow reparenting. Called on each drag evaluation. Useful when the tree
+ *        is sorted alphabetically, making manual ordering meaningless.
+ * @returns A DragDropProvider for Node reparenting and sibling ordering
+ *
+ * @example
+ * ```typescript
+ * // Enable sibling reordering
+ * sceneExplorerService.dragDropProvider = createReorderDragProvider();
+ *
+ * // Disable sibling reordering when sorted alphabetically
+ * sceneExplorerService.dragDropProvider = createReorderDragProvider(
+ *     () => sceneExplorerService.isSorted
+ * );
+ * ```
+ */
+export function createReorderDragProvider(isSiblingReorderDisabled?: () => boolean): DragDropProvider<Node, DropData> {
+
+    return {
+        canDrag: () => true,
+
+        evaluateDrop: (dragged, target, pointerY, targetRect) => {
+            // Cycle detection - can't drop onto self or descendant
+            if (target === dragged || target.isDescendantOf(dragged)) {
+                return { canDrop: false };
+            }
+
+            // If sibling reorder is disabled, always reparent
+            if (isSiblingReorderDisabled?.()) {
+                return {
+                    canDrop: true,
+                    visual: { type: "border" },
+                    dropData: { action: "reparent", newParent: target },
+                };
+            }
+
+            // Calculate relative position within target
+            const relativeY = (pointerY - targetRect.top) / targetRect.height;
+
+            if (relativeY < 0.15) {
+                // Top zone: insert before target
+                return {
+                    canDrop: true,
+                    visual: { type: "edge", edge: "top" },
+                    dropData: {
+                        action: "reorder",
+                        newParent: target.parent,
+                        position: "before",
+                        referenceNode: target,
+                    },
+                };
+            } else if (relativeY > 0.85) {
+                // Bottom zone: insert after target
+                return {
+                    canDrop: true,
+                    visual: { type: "edge", edge: "bottom" },
+                    dropData: {
+                        action: "reorder",
+                        newParent: target.parent,
+                        position: "after",
+                        referenceNode: target,
+                    },
+                };
+            } else {
+                // Middle zone: reparent under target
+                return {
+                    canDrop: true,
+                    visual: { type: "border" },
+                    dropData: { action: "reparent", newParent: target },
+                };
+            }
+        },
+
+        onDrop: (dragged, _target, dropData) => {
+            if (dropData.action === "reparent") {
+                // Simple reparenting
+                if (dragged.parent !== dropData.newParent) {
+                    setNodeParent(dragged, dropData.newParent);
+                }
+            } else {
+                // Sibling reordering
+                const { newParent, position, referenceNode } = dropData;
+
+                // First, reparent if needed
+                if (dragged.parent !== newParent) {
+                    setNodeParent(dragged, newParent);
+                }
+
+                // Then, reorder within siblings
+                const siblings = getChildrenArray(newParent, dragged);
+
+                if (siblings) {
+                    const draggedIndex = siblings.indexOf(dragged);
+                    const referenceIndex = siblings.indexOf(referenceNode);
+
+                    if (draggedIndex !== -1 && referenceIndex !== -1 && draggedIndex !== referenceIndex) {
+                        // Remove from current position
+                        siblings.splice(draggedIndex, 1);
+
+                        // Calculate insertion index (adjust if dragged was before reference)
+                        let insertIndex = draggedIndex < referenceIndex ? referenceIndex - 1 : referenceIndex;
+                        if (position === "after") {
+                            insertIndex++;
+                        }
+
+                        // Insert at new position
+                        siblings.splice(insertIndex, 0, dragged);
+
+                        // Update root node indices if at root level
+                        if (!newParent) {
+                            updateRootNodeIndices(siblings);
+                        }
+                    }
+                }
+            }
+        },
+    };
+}
+
+/**
+ * Sets a node's parent, using setParent for TransformNodes to preserve world transform.
+ */
+function setNodeParent(node: Node, parent: Node | null): void {
+    // Check if node has setParent method (TransformNode and subclasses)
+    if ("setParent" in node && typeof (node as TransformNode).setParent === "function") {
+        (node as TransformNode).setParent(parent);
+    } else {
+        node.parent = parent;
+    }
+}
+
+/**
+ * Gets the mutable children array for a parent node, or the scene's rootNodes for root-level.
+ */
+function getChildrenArray(parent: Node | null, node: Node): Node[] | null {
+    if (parent) {
+        // Access internal _children array
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (parent as any)._children as Node[] | null;
+    } else {
+        // Root level - use scene's rootNodes
+        return node.getScene().rootNodes;
+    }
+}
+
+/**
+ * Updates the cached _sceneRootNodesIndex for all root nodes after reordering.
+ */
+function updateRootNodeIndices(rootNodes: Node[]): void {
+    rootNodes.forEach((node, index) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (node as any)._nodeDataStorage._sceneRootNodesIndex = index;
+    });
+}

--- a/packages/dev/inspector-v2/src/components/scene/dragDropProviders/reparentDragProvider.ts
+++ b/packages/dev/inspector-v2/src/components/scene/dragDropProviders/reparentDragProvider.ts
@@ -1,0 +1,50 @@
+import type { DragDropProvider } from "../sceneExplorerDragDrop";
+
+/**
+ * Internal drop data for reparent-only provider.
+ */
+type DropData<T> = {
+    newParent: T;
+};
+
+/**
+ * Creates a simple drag-drop provider that only supports reparenting.
+ * Dropping anywhere on a target makes the target the new parent.
+ * Shows a border visual around the drop target.
+ *
+ * @param setParent - Function to set an entity's parent
+ * @param isDescendantOf - Function to check if an entity is a descendant of another
+ * @returns A DragDropProvider for reparenting
+ *
+ * @example
+ * ```typescript
+ * const provider = createReparentDragProvider<Node>(
+ *     (node, parent) => (node as TransformNode).setParent(parent),
+ *     (node, ancestor) => node.isDescendantOf(ancestor)
+ * );
+ * ```
+ */
+export function createReparentDragProvider<T>(
+    setParent: (entity: T, newParent: T | null) => void,
+    isDescendantOf: (entity: T, potentialAncestor: T) => boolean
+): DragDropProvider<T, DropData<T>> {
+    return {
+        canDrag: () => true,
+
+        evaluateDrop: (dragged, target) => {
+            // Cycle detection - can't drop onto self or descendant
+            if (target === dragged || isDescendantOf(target, dragged)) {
+                return { canDrop: false };
+            }
+            return {
+                canDrop: true,
+                visual: { type: "border" },
+                dropData: { newParent: target },
+            };
+        },
+
+        onDrop: (dragged, _target, { newParent }) => {
+            setParent(dragged, newParent);
+        },
+    };
+}

--- a/packages/dev/inspector-v2/src/index.ts
+++ b/packages/dev/inspector-v2/src/index.ts
@@ -2,7 +2,9 @@
 export * from "./components/properties/boundProperty";
 export * from "./components/properties/linkToEntityPropertyLine";
 export type { EntityBase, EntityDisplayInfo, SceneExplorerCommand, SceneExplorerCommandProvider, SceneExplorerSection } from "./components/scene/sceneExplorer";
-export type { DragDropConfig, DropPosition, SceneExplorerDragDropEvent } from "./components/scene/sceneExplorerDragDrop";
+export type { DragDropProvider, DropEvaluation, DropVisual } from "./components/scene/sceneExplorerDragDrop";
+export { createReparentDragProvider } from "./components/scene/dragDropProviders/reparentDragProvider";
+export { createReorderDragProvider } from "./components/scene/dragDropProviders/reorderDragProvider";
 export * from "./components/extensibleAccordion";
 export { SidePaneContainer } from "./components/pane";
 export * from "./components/theme";

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -1,6 +1,7 @@
 import type { IDisposable, Node, Nullable } from "core/index";
-import type { DropPosition } from "../../../components/scene/sceneExplorerDragDrop";
 import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
+
+import { createReorderDragProvider } from "../../../components/scene/dragDropProviders/reorderDragProvider";
 import type { IGizmoService } from "../../gizmoService";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
@@ -131,73 +132,10 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                 scene.onLightRemovedObservable,
             ],
             getEntityMovedObservables: () => [nodeMovedObservable],
-            dragDropConfig: {
-                // Note: service-level canDrag is checked separately in useSceneExplorerDragDrop
-                canDrag: () => true,
-                canDrop: (draggedNode: Node, targetNode: Node, dropPosition: DropPosition) => {
-                    // Determine the effective new parent for cycle detection
-                    const effectiveNewParent = dropPosition === "inside" ? targetNode : targetNode.parent;
-
-                    // Check if dropping would create a cycle (dropping onto self or any descendant)
-                    if (effectiveNewParent) {
-                        return !(targetNode === draggedNode || targetNode.isDescendantOf(draggedNode));
-                    }
-                    return true;
-                },
-
-                onDrop: (draggedNode: Node, targetNode: Node, dropPosition: DropPosition) => {
-                    // Compute the new parent from the resolved target/position
-                    const newParent = dropPosition === "inside" ? targetNode : targetNode.parent;
-
-                    // Only re-parent if the parent is actually changing
-                    if (draggedNode.parent !== newParent) {
-                        if (draggedNode instanceof TransformNode) {
-                            // setParent preserves the world position/rotation/scale
-                            draggedNode.setParent(newParent);
-                        } else {
-                            // Fallback for non-TransformNode nodes
-                            draggedNode.parent = newParent;
-                        }
-                    }
-
-                    // Handle sibling ordering for before/after positions
-                    if (dropPosition !== "inside") {
-                        // Get the actual internal siblings array (not a copy)
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        const siblings: Node[] | null = newParent ? (newParent as any)._children : draggedNode.getScene().rootNodes;
-
-                        if (siblings) {
-                            const draggedIndex = siblings.indexOf(draggedNode);
-                            const targetIndex = siblings.indexOf(targetNode);
-
-                            if (draggedIndex !== -1 && targetIndex !== -1 && draggedIndex !== targetIndex) {
-                                // Remove from current position
-                                siblings.splice(draggedIndex, 1);
-                                // Calculate new index (adjust if dragged was before target)
-                                let insertIndex = draggedIndex < targetIndex ? targetIndex - 1 : targetIndex;
-                                if (dropPosition === "after") {
-                                    insertIndex++;
-                                }
-                                // Insert at new position
-                                siblings.splice(insertIndex, 0, draggedNode);
-
-                                // For root nodes, update the _sceneRootNodesIndex for all affected nodes
-                                // since Babylon.js uses this index for fast removal via swap-and-pop
-                                if (!newParent) {
-                                    for (let i = 0; i < siblings.length; i++) {
-                                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                        (siblings[i] as any)._nodeDataStorage._sceneRootNodesIndex = i;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Notify observers that the node was moved
-                    nodeMovedObservable.notifyObservers(draggedNode);
-                },
-            },
         });
+
+        // Set the default drag-drop provider for reparenting and reordering nodes
+        sceneExplorerService.dragDropProvider = createReorderDragProvider(() => sceneExplorerService.isSorted);
 
         const abstractMeshBoundingBoxCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown): entity is AbstractMesh => entity instanceof AbstractMesh && entity.getTotalVertices() > 0,

--- a/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
@@ -1,7 +1,7 @@
-import type { IDisposable } from "core/index";
+import type { IDisposable, IReadonlyObservable } from "core/index";
 
 import type { EntityBase, SceneExplorerCommandProvider, SceneExplorerSection } from "../../../components/scene/sceneExplorer";
-import type { DropPosition, SceneExplorerDragDropEvent } from "../../../components/scene/sceneExplorerDragDrop";
+import type { DragDropProvider } from "../../../components/scene/sceneExplorerDragDrop";
 import type { IService, ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISelectionService } from "../../selectionService";
@@ -16,6 +16,8 @@ import { ObservableCollection } from "../../../misc/observableCollection";
 import { SceneContextIdentity } from "../../sceneContext";
 import { SelectionServiceIdentity } from "../../selectionService";
 import { ShellServiceIdentity } from "../../shellService";
+
+const IsSortedLocalStorageKey = "Babylon.js:Inspector:SceneExplorer:IsSorted";
 
 export const SceneExplorerServiceIdentity = Symbol("SceneExplorer");
 
@@ -42,32 +44,19 @@ export interface ISceneExplorerService extends IService<typeof SceneExplorerServ
     addSectionCommand<T extends string>(command: SceneExplorerCommandProvider<T, "contextMenu">): IDisposable;
 
     /**
-     * Enables or disables drag-to-reparent functionality for Node entities in the scene explorer.
-     * When enabled, users can drag nodes and drop them onto other nodes to change the parent-child relationship.
+     * Optional drag-drop provider. Set to `undefined` to disable drag-drop entirely.
      */
-    enableDragToReparent: boolean;
+    dragDropProvider: DragDropProvider<EntityBase, unknown> | undefined;
 
     /**
-     * Callback invoked when a drag-drop operation occurs.
-     * Consumers can use this to intercept or customize the drop behavior.
-     * Call `event.preventDefault()` to cancel the default reparenting behavior.
+     * Whether the scene explorer is currently sorted alphabetically.
      */
-    onDrop: ((event: SceneExplorerDragDropEvent) => void) | undefined;
+    readonly isSorted: boolean;
 
     /**
-     * Optional callback to determine if a node can be dragged.
-     * Return false to prevent dragging a specific node.
-     * If not set, all nodes are draggable.
+     * Observable that fires when the sorted state changes.
      */
-    canDrag: ((entity: EntityBase) => boolean) | undefined;
-
-    /**
-     * Optional callback to determine if a drop operation is valid.
-     * Return false to prevent dropping the dragged entity onto the target at the given position.
-     * Built-in cycle detection is always applied; this callback adds additional validation.
-     * If not set, all drops that pass cycle detection are allowed.
-     */
-    canDrop: ((draggedEntity: EntityBase, targetEntity: EntityBase, dropPosition: DropPosition) => boolean) | undefined;
+    readonly onIsSortedChanged: IReadonlyObservable<boolean>;
 }
 
 /**
@@ -82,12 +71,20 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
         const entityCommandsCollection = new ObservableCollection<SceneExplorerCommandProvider<unknown>>();
         const sectionCommandsCollection = new ObservableCollection<SceneExplorerCommandProvider<string, "contextMenu">>();
 
-        let dragToReparentEnabled = true;
-        const dragToReparentObservable = new Observable<void>();
+        let dragDropProviderOverride: DragDropProvider<EntityBase, unknown> | undefined = undefined;
+        const dragDropProviderObservable = new Observable<void>();
 
-        let onDropCallback: ((event: SceneExplorerDragDropEvent) => void) | undefined = undefined;
-        let canDragCallback: ((entity: EntityBase) => boolean) | undefined = undefined;
-        let canDropCallback: ((draggedEntity: EntityBase, targetEntity: EntityBase, dropPosition: DropPosition) => boolean) | undefined = undefined;
+        // Initialize isSorted from localStorage
+        let isSortedValue = false;
+        try {
+            const stored = localStorage.getItem(IsSortedLocalStorageKey);
+            if (stored !== null) {
+                isSortedValue = JSON.parse(stored);
+            }
+        } catch {
+            // Ignore localStorage errors
+        }
+        const isSortedObservable = new Observable<boolean>();
 
         const registration = shellService.addSidePane({
             key: "Scene Explorer",
@@ -102,7 +99,8 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
                 const sectionCommands = useOrderedObservableCollection(sectionCommandsCollection);
                 const scene = useObservableState(() => sceneContext.currentScene, sceneContext.currentSceneObservable);
                 const entity = useObservableState(() => selectionService.selectedEntity, selectionService.onSelectedEntityChanged);
-                const enableDragToReparent = useObservableState(() => dragToReparentEnabled, dragToReparentObservable);
+                const dragDropProvider = useObservableState(() => dragDropProviderOverride, dragDropProviderObservable);
+                const isSorted = useObservableState(() => isSortedValue, isSortedObservable);
 
                 return (
                     <>
@@ -114,10 +112,17 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
                                 scene={scene}
                                 selectedEntity={entity}
                                 setSelectedEntity={(entity) => (selectionService.selectedEntity = entity)}
-                                enableDragToReparent={enableDragToReparent}
-                                onDrop={onDropCallback}
-                                canDrag={canDragCallback}
-                                canDrop={canDropCallback}
+                                dragDropProvider={dragDropProvider}
+                                isSorted={isSorted}
+                                setIsSorted={(value) => {
+                                    isSortedValue = value;
+                                    try {
+                                        localStorage.setItem(IsSortedLocalStorageKey, JSON.stringify(value));
+                                    } catch {
+                                        // Ignore localStorage errors
+                                    }
+                                    isSortedObservable.notifyObservers(value);
+                                }}
                             />
                         )}
                     </>
@@ -129,35 +134,22 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
             addSection: (section) => sectionsCollection.add(section as SceneExplorerSection<unknown>),
             addEntityCommand: (command) => entityCommandsCollection.add(command as SceneExplorerCommandProvider<unknown>),
             addSectionCommand: (command) => sectionCommandsCollection.add(command as unknown as SceneExplorerCommandProvider<string, "contextMenu">),
-            get enableDragToReparent() {
-                return dragToReparentEnabled;
+            get dragDropProvider() {
+                return dragDropProviderOverride;
             },
-            set enableDragToReparent(value: boolean) {
-                if (dragToReparentEnabled !== value) {
-                    dragToReparentEnabled = value;
-                    dragToReparentObservable.notifyObservers();
+            set dragDropProvider(value: DragDropProvider<EntityBase, unknown> | undefined) {
+                if (dragDropProviderOverride !== value) {
+                    dragDropProviderOverride = value;
+                    dragDropProviderObservable.notifyObservers();
                 }
             },
-            get onDrop() {
-                return onDropCallback;
+            get isSorted() {
+                return isSortedValue;
             },
-            set onDrop(value: ((event: SceneExplorerDragDropEvent) => void) | undefined) {
-                onDropCallback = value;
-            },
-            get canDrag() {
-                return canDragCallback;
-            },
-            set canDrag(value: ((entity: EntityBase) => boolean) | undefined) {
-                canDragCallback = value;
-            },
-            get canDrop() {
-                return canDropCallback;
-            },
-            set canDrop(value: ((draggedEntity: EntityBase, targetEntity: EntityBase, dropPosition: DropPosition) => boolean) | undefined) {
-                canDropCallback = value;
-            },
+            onIsSortedChanged: isSortedObservable,
             dispose: () => {
-                dragToReparentObservable.clear();
+                dragDropProviderObservable.clear();
+                isSortedObservable.clear();
                 registration.dispose();
             },
         };


### PR DESCRIPTION
Adds drag-and-drop reparenting and sibling order support to the Scene Explorer in Inspector v2.
Behavior can be configured or disabled via the SceneExplorerService

Also includes a fix for entity parent value

https://github.com/user-attachments/assets/78403ff3-f777-40af-8dd8-3dd48fb04e02

