### PR TITLE
[InspectorV2] Fix tooltip errors

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
@@ -1,25 +1,24 @@
 import type { Nullable } from "core/index";
 
-import type { ReactElement, Ref } from "react";
-import { forwardRef, cloneElement, isValidElement } from "react";
+import type { ReactElement } from "react";
+import { forwardRef } from "react";
 
 import { Tooltip as FluentTooltip } from "@fluentui/react-components";
 
 export type TooltipProps = { content?: Nullable<string>; children: ReactElement };
 
-export const Tooltip = forwardRef<HTMLElement, TooltipProps>((props, ref) => {
+// forwardRef wrapper to avoid "function components cannot be given refs" warning
+// FluentTooltip handles ref forwarding to children internally via applyTriggerPropsToChildren
+export const Tooltip = forwardRef<HTMLElement, TooltipProps>((props, _ref) => {
     const { content, children } = props;
 
-    // Clone children to pass ref through
-    const childWithRef = isValidElement(children) ? cloneElement(children, { ref } as { ref: Ref<HTMLElement> }) : children;
-
     if (!content) {
-        return childWithRef;
+        return children;
     }
 
     return (
         <FluentTooltip relationship="description" content={content}>
-            {childWithRef}
+            {children}
         </FluentTooltip>
     );
 });


### PR DESCRIPTION
Fixes error

`Check the render method of `MenuTrigger`. Error Component Stack
    at Tooltip (d:\Repos\Babylon.js\packages\dev\sharedUiComponents\src\fluent\primitives\tooltip.tsx:10:1)
    at MenuTrigger (d:\Repos\Babylon.js\node_modules\@fluentui\react-menu\lib\components\MenuTrigger\MenuTrigger.js:8:1)
    at Provider (d:\Repos\Babylon.js\node_modules\@fluentui\react-menu\node_modules\@fluentui\react-context-selector\lib\createContext.js:7:1)
    at Menu (d:\Repos\Babylon.js\node_modules\@fluentui\react-menu\lib\components\Menu\Menu.js:8:1)
    at DockMenu (d:\Repos\Babylon.js\packages\dev\inspector-v2\src\services\shellService.tsx:476:1)
    at div (<anonymous>)
    at SidePaneTab (d:\Repos\Babylon.js\packages\dev\inspector-v2\src\services\shellService.tsx:627:1)
    at div (<anonymous>)`