### PR TITLE
Check for valid material in transparency helper

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_materials_transmission.ts
@@ -171,6 +171,9 @@ class TransmissionHelper {
         // internal properties are not setup yet, like _sourceMesh (needed when doing mesh.material below)
         Tools.SetImmediate(() => {
             if (mesh.material) {
+                if (!this._loader.isMatchingMaterialType(mesh.material)) {
+                    return;
+                }
                 const adapter = this._loader._getOrCreateMaterialAdapter(mesh.material);
                 if (adapter.transmissionWeight > 0) {
                     adapter.refractionBackgroundTexture = this._opaqueRenderTarget;
@@ -212,6 +215,9 @@ class TransmissionHelper {
         const transparentIdx = this._transparentMeshesCache.indexOf(mesh);
         const opaqueIdx = this._opaqueMeshesCache.indexOf(mesh);
 
+        if (!this._loader.isMatchingMaterialType(mesh.material)) {
+            return;
+        }
         // If the material is transparent, make sure that it's added to the transparent list and removed from the opaque list
         const adapter = mesh.material ? this._loader._getOrCreateMaterialAdapter(mesh.material) : null;
         const useTransmission = adapter ? adapter.transmissionWeight > 0 : false;
@@ -289,6 +295,9 @@ class TransmissionHelper {
 
         for (const mesh of this._transparentMeshesCache) {
             if (mesh.material) {
+                if (!this._loader.isMatchingMaterialType(mesh.material)) {
+                    return;
+                }
                 const adapter = this._loader._getOrCreateMaterialAdapter(mesh.material);
                 if (adapter.transmissionWeight > 0) {
                     adapter.refractionBackgroundTexture = this._opaqueRenderTarget;

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -234,6 +234,18 @@ export class GLTFLoader implements IGLTFLoader {
     public _pbrMaterialImpl: Nullable<Readonly<PBRMaterialImplementation>> | false = null;
 
     /**
+     * Test if the given material is of the same type as the one used by the loader
+     * @param material The material to test
+     * @returns true if the material is of the same type, false otherwise
+     */
+    public isMatchingMaterialType(material: Nullable<Material>): boolean {
+        if (material && this._pbrMaterialImpl) {
+            return material instanceof this._pbrMaterialImpl.materialClass;
+        }
+        return false;
+    }
+
+    /**
      * The default glTF sampler.
      */
     public static readonly DefaultSampler: ISampler = { index: -1 };


### PR DESCRIPTION
Okay, this fixes a bug reported here:
https://forum.babylonjs.com/t/regression-in-8-47-2-typeerror-cannot-read-properties-of-undefined-reading-isrefractionenabled-in-babylonjs-loaders/62253/11

The issue is that the TransparencyHelper, created from within the `KHR_materials_transmission` extension can be called for any material type but the TransparencyHelper tries to use the loader's material adapter to check for transmission props. A material adapter is then created for the material, even if the material type doesn't match. This, of course, leads to problems.

Currently, the material adapter supports only `PBRMaterial` and `OpenPBRMaterial` but the bigger issue is that it only supports **one** of them at a time. If you load a glTF with OpenPBR support and then create a PBRMaterial later, the TransparencyHelper will try to use the OpenPBR material loading adapter...

This PR just checks if the incoming material is the same type as the one loaded with the glTF loader. If it's not, it ignores it.