### PR TITLE
[InspectorV2] Fix bug where you cannot reexport env after dragging/dropping a new env texture

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
@@ -202,7 +202,7 @@ export const SceneShadowsProperties: FunctionComponent<{ scene: Scene }> = (prop
     return (
         <>
             <ButtonLine
-                label={"Normalize scene"}
+                label={"Normalize Scene"}
                 onClick={() => {
                     for (const mesh of scene.meshes) {
                         mesh.normalizeToUnitCube(true);
@@ -271,7 +271,7 @@ export const SceneRenderingProperties: FunctionComponent<{ scene: Scene; selecti
             />
 
             {scene.environmentTexture && (
-                <LinkPropertyLine label="Env. texture" value={scene.environmentTexture.name} onLink={() => (selectionService.selectedEntity = scene.environmentTexture)} />
+                <LinkPropertyLine label="Env. Texture" value={scene.environmentTexture.name} onLink={() => (selectionService.selectedEntity = scene.environmentTexture)} />
             )}
 
             <FileUploadLine

--- a/packages/dev/inspector-v2/src/components/tools/exportTools.tsx
+++ b/packages/dev/inspector-v2/src/components/tools/exportTools.tsx
@@ -68,14 +68,14 @@ export const ExportBabylonTools: FunctionComponent<{ scene: Scene }> = ({ scene 
             Logger.Error(error);
             alert(error);
         }
-    }, [environmentTexture, babylonExportOptions]);
+    }, [scene, environmentTexture, babylonExportOptions]);
 
     return (
         <>
             <ButtonLine label="Export to Babylon" icon={ArrowDownloadRegular} onClick={exportBabylon} />
             {!scene.getEngine().premultipliedAlpha && environmentTexture && environmentTexture._prefiltered && scene.activeCamera && (
                 <>
-                    <ButtonLine label="Generate .env texture" icon={ArrowDownloadRegular} onClick={createEnvTexture} />
+                    <ButtonLine label="Generate .env Texture" icon={ArrowDownloadRegular} onClick={createEnvTexture} />
                     {environmentTexture.irradianceTexture && (
                         <SwitchPropertyLine
                             key="iblDiffuse"


### PR DESCRIPTION
See this forum post 
https://forum.babylonjs.com/t/sandbox-env-export-only-works-one-time/62306