### PR TITLE
[NPE] Fixing emitter and rendering group

### DIFF
--- a/packages/dev/core/src/Particles/Node/Blocks/systemBlock.ts
+++ b/packages/dev/core/src/Particles/Node/Blocks/systemBlock.ts
@@ -1,5 +1,4 @@
 import type { Nullable } from "core/types";
-import type { Vector3 } from "core/Maths/math.vector";
 import type { AbstractMesh } from "core/Meshes/abstractMesh";
 import type { ParticleSystem } from "core/Particles/particleSystem";
 import type { NodeParticleConnectionPoint } from "core/Particles/Node/nodeParticleBlockConnectionPoint";
@@ -9,7 +8,7 @@ import type { ParticleGradientValueBlock } from "./particleGradientValueBlock";
 import { Constants } from "../../../Engines/constants";
 import { editableInPropertyPage, PropertyTypeForEdition } from "core/Decorators/nodeDecorator";
 import { RegisterClass } from "core/Misc/typeStore";
-import { Vector2 } from "core/Maths/math.vector";
+import { Vector2, Vector3 } from "core/Maths/math.vector";
 import { Color3, Color4 } from "core/Maths/math.color";
 import { BaseParticleSystem } from "core/Particles/baseParticleSystem";
 import { NodeParticleBlock } from "core/Particles/Node/nodeParticleBlock";
@@ -137,7 +136,7 @@ export class SystemBlock extends NodeParticleBlock {
     /**
      * Gets or sets the emitter for the particle system.
      */
-    public emitter: Nullable<AbstractMesh | Vector3> = null;
+    public emitter: Nullable<AbstractMesh | Vector3> = Vector3.Zero();
 
     /**
      * Create a new SystemBlock
@@ -267,7 +266,9 @@ export class SystemBlock extends NodeParticleBlock {
         particleSystem.isLocal = this.isLocal;
         particleSystem.disposeOnStop = this.disposeOnStop;
         particleSystem.renderingGroupId = this.renderingGroupId;
-        particleSystem.emitter = this.emitter;
+        if (this.emitter) {
+            particleSystem.emitter = this.emitter;
+        }
 
         // Apply custom shader if defined
         if (this.customShader) {

--- a/packages/dev/core/src/Particles/Node/nodeParticleSystemSet.helper.ts
+++ b/packages/dev/core/src/Particles/Node/nodeParticleSystemSet.helper.ts
@@ -1033,7 +1033,12 @@ function _SystemBlockGroup(updateParticleOutput: NodeParticleConnectionPoint, ol
     newSystem.isLocal = oldSystem.isLocal;
     newSystem.disposeOnStop = oldSystem.disposeOnStop;
     newSystem.renderingGroupId = oldSystem.renderingGroupId;
-    newSystem.emitter = oldSystem.emitter;
+    const emitter = oldSystem.emitter;
+    if (emitter instanceof Vector3) {
+        newSystem.emitter = emitter.clone();
+    } else {
+        newSystem.emitter = emitter;
+    }
 
     _SystemCustomShader(oldSystem, newSystem);
     _SystemEmitRateValue(oldSystem.getEmitRateGradients(), oldSystem.targetStopDuration, oldSystem.emitRate, newSystem, context);


### PR DESCRIPTION
- Removes emitterPosition from the systemBlock as it is not needed.
- Handles emitter migration correctly.
- Adds migration for rendering group

PG to test: #A97UQ6#4
<img width="1547" height="496" alt="image" src="https://github.com/user-attachments/assets/ee2b4619-1784-47cf-86e5-2a82520e1662" />
