### PR TITLE
WebGPU: Fix wrong color space conversion when loading images

### DIFF
--- a/packages/dev/core/src/Misc/environmentTextureTools.ts
+++ b/packages/dev/core/src/Misc/environmentTextureTools.ts
@@ -868,7 +868,7 @@ async function _UploadLevelsAsync(
 
             if (engine._features.forceBitmapOverHTMLImageElement) {
                 // eslint-disable-next-line github/no-then
-                promise = engine.createImageBitmap(blob, { premultiplyAlpha: "none" }).then(async (img) => {
+                promise = engine.createImageBitmap(blob, { premultiplyAlpha: "none", colorSpaceConversion: "none" }).then(async (img) => {
                     return await _OnImageReadyAsync(img, engine, expandTexture, rgbdPostProcess, url, face, i, generateNonLODTextures, lodTextures, cubeRtt, texture);
                 });
             } else {

--- a/packages/dev/core/src/Misc/fileTools.ts
+++ b/packages/dev/core/src/Misc/fileTools.ts
@@ -253,7 +253,7 @@ export const LoadImage = (
             url,
             (data) => {
                 engine
-                    .createImageBitmap(new Blob([data], { type: mimeType }), { premultiplyAlpha: "none", ...imageBitmapOptions })
+                    .createImageBitmap(new Blob([data], { type: mimeType }), { premultiplyAlpha: "none", colorSpaceConversion: "none", ...imageBitmapOptions })
                     // eslint-disable-next-line github/no-then
                     .then((imgBmp) => {
                         onLoad(imgBmp);


### PR DESCRIPTION
https://playground.babylonjs.com/?webgpu#R7BB7Y

WebGPU:
<img width="428" height="428" alt="image" src="https://github.com/user-attachments/assets/6e993e09-6d10-4967-b145-6711a9e8fde3" />

WebGL:
<img width="428" height="428" alt="image" src="https://github.com/user-attachments/assets/54beac23-eb9c-43e9-b137-9e04ab8441de" />

