### PR TITLE
Inspector v2: Fix texture preview/editor cube map gamma and face orientation bugs + transparency checkerboard

### DIFF
--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -396,9 +396,17 @@ async function ReadPixelsUsingRTT(texture: BaseTexture, width: number, height: n
  * @param height the target height of the result, which does not have to match the source texture height
  * @param face if the texture has multiple faces, the face index to use for the source
  * @param lod if the texture has multiple LODs, the lod index to use for the source
+ * @param forceRTT if true, forces the use of the RTT path for reading pixels (useful for cube maps to ensure correct orientation and gamma)
  * @returns the 8-bit texture data
  */
-export async function GetTextureDataAsync(texture: BaseTexture, width?: number, height?: number, face: number = 0, lod: number = 0): Promise<Uint8Array> {
+export async function GetTextureDataAsync(
+    texture: BaseTexture,
+    width?: number,
+    height?: number,
+    face: number = 0,
+    lod: number = 0,
+    forceRTT: boolean = false
+): Promise<Uint8Array> {
     await WhenTextureReadyAsync(texture);
 
     const { width: textureWidth, height: textureHeight } = texture.getSize();
@@ -406,8 +414,9 @@ export async function GetTextureDataAsync(texture: BaseTexture, width?: number, 
     const targetHeight = height ?? textureHeight;
 
     // If the internal texture format is compressed, we cannot read the pixels directly.
-    // Or, if we're resizing the texture, we need to use a render target texture.
-    if (IsCompressedTextureFormat(texture.textureFormat) || targetWidth !== textureWidth || targetHeight !== textureHeight) {
+    // If we're resizing the texture, we need to use a render target texture.
+    // forceRTT can be used to ensure correct orientation and gamma for cube maps.
+    if (forceRTT || IsCompressedTextureFormat(texture.textureFormat) || targetWidth !== textureWidth || targetHeight !== textureHeight) {
         return await ReadPixelsUsingRTT(texture, targetWidth, targetHeight, face, lod);
     }
 

--- a/packages/dev/inspector-v2/src/components/textureEditor/canvasManager.ts
+++ b/packages/dev/inspector-v2/src/components/textureEditor/canvasManager.ts
@@ -513,15 +513,10 @@ export class TextureCanvasManager {
 
     public async grabOriginalTexture() {
         // Grab image data from original texture and paint it onto the context of a DynamicTexture
-        this.setSize(this._originalTexture.getSize());
-        const data = await ApplyChannelsToTextureDataAsync(
-            this._originalTexture,
-            this._size.width,
-            this._size.height,
-            this._face,
-            { R: true, G: true, B: true, A: true },
-            this._mipLevel
-        );
+        const size = this._originalTexture.getSize();
+        // Fetch texture data BEFORE setting size (which clears the canvas) to avoid flicker
+        const data = await ApplyChannelsToTextureDataAsync(this._originalTexture, size.width, size.height, this._face, { R: true, G: true, B: true, A: true }, this._mipLevel);
+        this.setSize(size);
         this._imageData = data;
         this.paintPixelsOnCanvas(data, this._2DCanvas);
         this._3DCanvasTexture.update();
@@ -628,6 +623,7 @@ export class TextureCanvasManager {
     }
 
     public async resize(newSize: ISize) {
+        // Fetch texture data BEFORE setting size (which clears the canvas) to avoid flicker
         const data = await ApplyChannelsToTextureDataAsync(this._originalTexture, newSize.width, newSize.height, this._face, { R: true, G: true, B: true, A: true });
         this.setSize(newSize);
         this.paintPixelsOnCanvas(data, this._2DCanvas);

--- a/packages/dev/inspector-v2/src/misc/textureTools.ts
+++ b/packages/dev/inspector-v2/src/misc/textureTools.ts
@@ -42,7 +42,8 @@ export async function ApplyChannelsToTextureDataAsync(
     channels: TextureChannelsToDisplay,
     lod: number = 0
 ): Promise<Uint8Array> {
-    const data = await GetTextureDataAsync(texture, width, height, face, lod);
+    // For cube maps, force RTT path to ensure correct face orientation and gamma correction
+    const data = await GetTextureDataAsync(texture, width, height, face, lod, texture.isCube);
 
     if (!channels.R || !channels.G || !channels.B || !channels.A) {
         for (let i = 0; i < width * height * 4; i += 4) {


### PR DESCRIPTION
This PR is mainly to address an issue reported on the forum: https://forum.babylonjs.com/t/inconsistent-display-of-cubetexture-thumbnails-between-inspectorv2-and-inspectorv1/62347/3

The issue is that Inspector v2 reads the whole texture, and this goes down a different code path in `GetTextureDataAsync` from textureToo.ts. Specifically, when reading a subset of the texture, it uses an RTT with a shader that does uv swizzling and gamma correction, but for the full texture it just reads the raw texture data.

- Add an optional parameter to `GetTextureDataAsync` to force reading the texture with the RTT path. I assume directly reading the texture is more performant, so I don't want to make it always use the RTT path, and I don't want to do any post processing of the image data, otherwise I expect it could regress perf for many scenarios.
- In Inspector v2, pass true for that new arg for cube textures.

That also fixes the same bug in Texture Editor since they rely on the same shared logic for reading textures.

Since I was touching this code, I also fixed a couple other issues:
- Show the checkerboard only behind the texture itself, not the texture container. Otherwise it is misleading and makes it seem like the texture is larger with transparency on the sides.
- Use outline instead of border to ensure the checkered background is not visible near the borders of the control.
- Don't clear the canvas before we have finished reading the pixels of a new face (when switching faces), otherwise you briefly see the checkered background so it looks like it flickers. Fixed this in both Texture Preview and Texture Editor.