### PR TITLE
[NPE] Supporting procedural textures in the texture preview

### DIFF
--- a/packages/dev/core/src/Particles/Node/Blocks/particleSourceTextureBlock.ts
+++ b/packages/dev/core/src/Particles/Node/Blocks/particleSourceTextureBlock.ts
@@ -168,7 +168,7 @@ export class ParticleTextureSourceBlock extends NodeParticleBlock {
                         this._cachedData = {
                             width: size.width,
                             height: size.height,
-                            data: data as Uint8ClampedArray,
+                            data: new Uint8ClampedArray(data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)),
                         };
                         resolve(this._cachedData);
                     })

--- a/packages/tools/nodeParticleEditor/src/graphSystem/display/textureDisplayManager.ts
+++ b/packages/tools/nodeParticleEditor/src/graphSystem/display/textureDisplayManager.ts
@@ -74,17 +74,7 @@ export class TextureDisplayManager implements IDisplayManager {
         const ctx = this._previewCanvas.getContext("2d");
 
         if (ctx) {
-            let imageData: ImageData;
-
-            try {
-                // The most common scenario is that the data is already a Uint8ClampedArray with a compatible ArrayBuffer
-                imageData = new ImageData(data as Uint8ClampedArray<ArrayBuffer>, width, height);
-            } catch {
-                // Fallback: create a copy with a fresh ArrayBuffer if the original buffer was not compatible
-                const dataCopy = new Uint8ClampedArray(data);
-                imageData = new ImageData(dataCopy, width, height);
-            }
-
+            const imageData = new ImageData(data as Uint8ClampedArray<ArrayBuffer>, width, height);
             ctx.putImageData(imageData, 0, 0);
             return this._previewCanvas.toDataURL("image/png");
         }


### PR DESCRIPTION
Supports previewing procedural textures like noise in the texture block (just the first frame, not animated):

PG to test: #R1JWLA#151
<img width="1184" height="958" alt="image" src="https://github.com/user-attachments/assets/2cd45c66-d028-4e7a-bfb4-ec478c028196" />
