### PR TITLE
[InspectorV2] Create new NodeMaterial should use default template

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
@@ -43,7 +43,7 @@ export const NodeMaterialGeneralProperties: FunctionComponent<{ material: NodeMa
                     //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
                     // const { NodeEditor } = await import("node-editor/nodeEditor");
                     // NodeEditor.Show({ nodeMaterial: material });
-                    await material.edit();
+                    await material.edit({ nodeEditorConfig: { backgroundColor: material.getScene().clearColor } });
                 }}
             ></ButtonLine>
         </>

--- a/packages/dev/inspector-v2/src/extensions/quickCreate/materials.tsx
+++ b/packages/dev/inspector-v2/src/extensions/quickCreate/materials.tsx
@@ -39,6 +39,7 @@ export const MaterialsContent: FunctionComponent<MaterialsContentProps> = ({ sce
             }
         } else {
             const nodeMaterial = new NodeMaterial(nodeMaterialName, scene);
+            nodeMaterial.setToDefault();
             nodeMaterial.build();
         }
     };


### PR DESCRIPTION

Before: <img width="752" height="648" alt="image" src="https://github.com/user-attachments/assets/36a0e628-7a73-4972-bd74-9e93984bd440" />
After: <img width="752" height="648" alt="image" src="https://github.com/user-attachments/assets/a2c3b6ab-4760-459f-a888-f503d0ffff8c" />