### PR TITLE
Export KTX2 Worker functions

### DIFF
--- a/packages/dev/core/src/Misc/index.ts
+++ b/packages/dev/core/src/Misc/index.ts
@@ -80,6 +80,7 @@ export * from "./bitArray";
 export * from "./urlTools";
 export * from "./lazy";
 export * from "./uniqueIdGenerator";
+export { workerFunction as KTX2WorkerFunction, initializeWebWorker as KTX2InitializeWebWorker } from "./khronosTextureContainer2Worker";
 
 // RGBDTextureTools
 export * from "../Shaders/rgbdDecode.fragment";


### PR DESCRIPTION
Please refer to the [forum post](https://forum.babylonjs.com/t/request-to-expose-2-babylon-ktx-functions/62353)

This PR aims to expose the KTX2 functions `workerFunction()` and `initializeWebWorker()` on the global `BABYLON` object
