### PR TITLE
ensure joint tracking spheres are created in same scene as the XR session

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -914,7 +914,8 @@ export class WebXRHandTracking extends WebXRAbstractFeature {
         }
 
         if (!this._handResources.jointMeshes) {
-            this._originalMesh = this._originalMesh || this.options.jointMeshes?.sourceMesh || CreateIcoSphere("jointParent", WebXRHandTracking._ICOSPHERE_PARAMS);
+            this._originalMesh =
+                this._originalMesh || this.options.jointMeshes?.sourceMesh || CreateIcoSphere("jointParent", WebXRHandTracking._ICOSPHERE_PARAMS, this._xrSessionManager.scene);
             this._originalMesh.isVisible = false;
 
             this._handResources.jointMeshes = WebXRHandTracking._GenerateTrackedJointMeshes(this.options, this._originalMesh);


### PR DESCRIPTION
Fix for https://forum.babylonjs.com/t/handconstraintbehavior-not-updating-position-to-follow-hand-tracking/62370