### PR TITLE
Fix an issue with static in old versions

### DIFF
--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -45,6 +45,21 @@ module.exports = (env) => {
                 includeCSS: true,
                 extraRules: [
                     {
+                        test: /\.m?js$/,
+                        include: /node_modules[\\/]+monaco-editor/,
+                        use: {
+                            loader: "ts-loader",
+                            options: {
+                                transpileOnly: true,
+                                compilerOptions: {
+                                    allowJs: true,
+                                    target: "ES2015",
+                                    module: "ESNext",
+                                },
+                            },
+                        },
+                    },
+                    {
                         test: /\.ttf$/,
                         type: "asset/resource",
                     },


### PR DESCRIPTION
Details here:

https://github.com/BabylonJS/Babylon.js/pull/17750

This only fixes one of the issues: untranspiled es2022+ syntax
static syntax -> Add transpile target to webpack for monaco-editor