### PR TITLE
Trying a different Monaco fix

### DIFF
--- a/packages/tools/playground/src/custom.d.ts
+++ b/packages/tools/playground/src/custom.d.ts
@@ -20,3 +20,8 @@ declare module "monaco-editor/esm/vs/editor/common/services/languageFeatures" {
     const SuggestAdapter: any;
     export type SuggestAdapter = any;
 }
+
+declare module "monaco-editor/esm/vs/base/common/color.js" {
+    export const Color: any;
+    export const HSLA: any;
+}

--- a/packages/tools/playground/src/tools/monaco/compat/defaultDocumentColorsComputer.ts
+++ b/packages/tools/playground/src/tools/monaco/compat/defaultDocumentColorsComputer.ts
@@ -1,0 +1,161 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* eslint-disable */
+
+/**
+ * A compatibility implementation of the default document colors computer from Monaco Editor.
+ * The core Monaco Editor (vs in github) introduced negative lookbehind in regexes which cannot be
+ * parsed by older JS engines -> immediate breakage.
+ * Here is the offending commit: https://github.com/microsoft/vscode/commit/24c0ff16c250f2b39eea8cebd661be2375f61ba5#diff-65ea4cbbc9e4e800a953089c267ad5523c197f193da57a1d30c2163e1df5c9d7
+ *
+ * This file is a copy of the original implementation with the offending regexes replaced.
+ */
+import { Color, HSLA } from "monaco-editor/esm/vs/base/common/color.js";
+import type { IPosition, IRange } from "monaco-editor/esm/vs/editor/editor.api";
+
+export interface IDocumentColorComputerTarget {
+    getValue(): string;
+    positionAt(offset: number): IPosition;
+    findMatches(regex: RegExp): RegExpMatchArray[];
+}
+
+function _parseCaptureGroups(captureGroups: IterableIterator<string>) {
+    const values = [];
+    for (const captureGroup of captureGroups) {
+        const parsedNumber = Number(captureGroup);
+        if (parsedNumber || (parsedNumber === 0 && captureGroup.replace(/\s/g, "") !== "")) {
+            values.push(parsedNumber);
+        }
+    }
+    return values;
+}
+
+function _toIColor(r: number, g: number, b: number, a: number): any {
+    return {
+        red: r / 255,
+        blue: b / 255,
+        green: g / 255,
+        alpha: a,
+    };
+}
+
+function _findRange(model: IDocumentColorComputerTarget, match: RegExpMatchArray): IRange | undefined {
+    const index = match.index;
+    const length = match[0].length;
+    if (index === undefined) {
+        return;
+    }
+    const startPosition = model.positionAt(index);
+    const range: IRange = {
+        startLineNumber: startPosition.lineNumber,
+        startColumn: startPosition.column,
+        endLineNumber: startPosition.lineNumber,
+        endColumn: startPosition.column + length,
+    };
+    return range;
+}
+
+function _findHexColorInformation(range: IRange | undefined, hexValue: string) {
+    if (!range) {
+        return;
+    }
+    const parsedHexColor = Color.Format.CSS.parseHex(hexValue);
+    if (!parsedHexColor) {
+        return;
+    }
+    return {
+        range: range,
+        color: _toIColor(parsedHexColor.rgba.r, parsedHexColor.rgba.g, parsedHexColor.rgba.b, parsedHexColor.rgba.a),
+    };
+}
+
+function _findRGBColorInformation(range: IRange | undefined, matches: RegExpMatchArray[], isAlpha: boolean) {
+    if (!range || matches.length !== 1) {
+        return;
+    }
+    const match = matches[0]!;
+    const captureGroups = match.values();
+    const parsedRegex = _parseCaptureGroups(captureGroups);
+    return {
+        range: range,
+        color: _toIColor(parsedRegex[0], parsedRegex[1], parsedRegex[2], isAlpha ? parsedRegex[3] : 1),
+    };
+}
+
+function _findHSLColorInformation(range: IRange | undefined, matches: RegExpMatchArray[], isAlpha: boolean) {
+    if (!range || matches.length !== 1) {
+        return;
+    }
+    const match = matches[0]!;
+    const captureGroups = match.values();
+    const parsedRegex = _parseCaptureGroups(captureGroups);
+    const colorEquivalent = new Color(new HSLA(parsedRegex[0], parsedRegex[1] / 100, parsedRegex[2] / 100, isAlpha ? parsedRegex[3] : 1));
+    return {
+        range: range,
+        color: _toIColor(colorEquivalent.rgba.r, colorEquivalent.rgba.g, colorEquivalent.rgba.b, colorEquivalent.rgba.a),
+    };
+}
+
+function _findMatches(model: IDocumentColorComputerTarget | string, regex: RegExp): RegExpMatchArray[] {
+    if (typeof model === "string") {
+        return [...model.matchAll(regex)];
+    } else {
+        return model.findMatches(regex);
+    }
+}
+
+function computeColors(model: IDocumentColorComputerTarget): any[] {
+    const result: any[] = [];
+    // Early validation for RGB and HSL
+    const initialValidationRegex = /\b(rgb|rgba|hsl|hsla)(\([0-9\s,.\%]*\))|\s+(#)([A-Fa-f0-9]{6})\b|\s+(#)([A-Fa-f0-9]{8})\b|^(#)([A-Fa-f0-9]{6})\b|^(#)([A-Fa-f0-9]{8})\b/gm;
+    const initialValidationMatches = _findMatches(model, initialValidationRegex);
+
+    // Potential colors have been found, validate the parameters
+    if (initialValidationMatches.length > 0) {
+        for (const initialMatch of initialValidationMatches) {
+            const initialCaptureGroups = initialMatch.filter((captureGroup) => captureGroup !== undefined);
+            const colorScheme = initialCaptureGroups[1];
+            const colorParameters = initialCaptureGroups[2];
+            if (!colorParameters) {
+                continue;
+            }
+            let colorInformation;
+            if (colorScheme === "rgb") {
+                const regexParameters =
+                    /^\(\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*\)$/gm;
+                colorInformation = _findRGBColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), false);
+            } else if (colorScheme === "rgba") {
+                const regexParameters =
+                    /^\(\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\s*,\s*(0[.][0-9]+|[.][0-9]+|[01][.]|[01])\s*\)$/gm;
+                colorInformation = _findRGBColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), true);
+            } else if (colorScheme === "hsl") {
+                const regexParameters = /^\(\s*(36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])\s*,\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*,\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*\)$/gm;
+                colorInformation = _findHSLColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), false);
+            } else if (colorScheme === "hsla") {
+                const regexParameters =
+                    /^\(\s*(36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])\s*,\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*,\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*,\s*(0[.][0-9]+|[.][0-9]+|[01][.]|[01])\s*\)$/gm;
+                colorInformation = _findHSLColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), true);
+            } else if (colorScheme === "#") {
+                colorInformation = _findHexColorInformation(_findRange(model, initialMatch), colorScheme + colorParameters);
+            }
+            if (colorInformation) {
+                result.push(colorInformation);
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Returns an array of all default document colors in the provided document
+ */
+export function computeDefaultDocumentColors(model: IDocumentColorComputerTarget): any[] {
+    if (!model || typeof model.getValue !== "function" || typeof model.positionAt !== "function") {
+        // Unknown caller!
+        return [];
+    }
+    return computeColors(model);
+}

--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -28,6 +28,14 @@ module.exports = (env) => {
                     filename: "[name].[contenthash].worker.js",
                     monacoEditorPath: path.resolve("../../../node_modules/monaco-editor"),
                 }),
+                // Override Monaco's defaultDocumentColorsComputer with a compatible version
+                // that doesn't use negative lookbehind regex (unsupported in older Safari).
+                // Using NormalModuleReplacementPlugin instead of resolve.alias to avoid
+                // circular resolution loops that cause CI timeouts.
+                new (require("webpack").NormalModuleReplacementPlugin)(
+                    /defaultDocumentColorsComputer\.js$/,
+                    path.resolve(__dirname, "src/tools/monaco/compat/defaultDocumentColorsComputer.ts")
+                ),
             ]
         ),
         resolve: {


### PR DESCRIPTION
This is an attempt to fix the issue with a regex in the latest Monaco that doesn't work in old Safari versions. The original fix works locally but hangs the CI. This fix also works locally, running this PR to see the CI results.

Still missing testing in an old Safari device.

Original work from @simonedevit and @knervous 