### PR TITLE
Inspector v2: Fix regression in hiding properties

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
@@ -220,6 +220,12 @@ export const AccordionSectionItem: FunctionComponent<PropsWithChildren<Accordion
     const accordionCtx = useContext(AccordionContext);
     const itemState = useAccordionSectionItemState(props);
     const [ctrlMode, setCtrlMode] = useState(false);
+    const ctrlPressed = useKeyState("Control");
+    const [mouseOver, setMouseOver] = useState(false);
+
+    useEffect(() => {
+        setCtrlMode(ctrlPressed && mouseOver);
+    }, [ctrlPressed, mouseOver]);
 
     // If static item or no context, just render children
     if (staticItem || !accordionCtx || !itemState) {
@@ -241,13 +247,6 @@ export const AccordionSectionItem: FunctionComponent<PropsWithChildren<Accordion
 
     const pinnedContainer = isPinned ? pinnedContainerRef.current : null;
     const showControls = inEditMode || ctrlMode;
-
-    const ctrlPressed = useKeyState("Control");
-    const [mouseOver, setMouseOver] = useState(false);
-
-    useEffect(() => {
-        setCtrlMode(ctrlPressed && mouseOver);
-    }, [ctrlPressed, mouseOver]);
 
     const itemElement = (
         <div


### PR DESCRIPTION
I accidentally introduced this regression in this change: https://github.com/BabylonJS/Babylon.js/pull/17837/changes#diff-32574963ca707d3b7e62b1335228d1e7ea3a9544fde6c98411bb7d4d3e55676dR245-R250

This added hooks for robustly observing keyboard state, but the hooks replaced event handlers that were *after* some early returns, which makes them conditional, which breaks "the rule of hooks" (breaks React internal state).

This fix just moves the hooks above the early returns.