### PR TITLE
Fix Bounding Box Renderer did not work when EffectLayer was enabled

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -5019,7 +5019,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
                 const boundingBoxRenderer = (this as any).getBoundingBoxRenderer?.() as Nullable<BoundingBoxRenderer>;
 
                 if (boundingBoxRenderer && !currentBoundingBoxMeshList) {
-                    // Saves the current bounding box mesh list (potentially built by the call to _evaluateActiveMeshes above), which will be reset/updated when processing this target
+                    // Saves the current bounding box mesh list (potentially built by the call to _evaluateActiveMeshes above), which can be reset/updated during the loop below
                     currentBoundingBoxMeshList = boundingBoxRenderer.renderList.length > 0 ? boundingBoxRenderer.renderList.data.slice() : [];
                     currentBoundingBoxMeshList.length = boundingBoxRenderer.renderList.length;
                 }


### PR DESCRIPTION
Once this PR is merged, the next PG should appear as shown in the image.

https://playground.babylonjs.com/#LA850M#36
<img width="976" height="1018" alt="image" src="https://github.com/user-attachments/assets/98ebf819-e25b-48be-9b8b-b6a10b99d146" />


Fixes the issue mentioned in #17861 where the BoundingBoxRenderer does not work when an Effect Layer is enabled.

The root cause is as follows:

Effect Layer renders the Scene to a render target through an ObjectRenderer in the _cameraDrawRenderTargetStage. During this process, the ObjectRenderer calls _beforeEvaluateActiveMeshStage, which clears the BoundingBoxRenderer's renderList.

In fact, the same issue also occurs when rendering render targets, and there is already evidence that it has been addressed.

If you look at the code right above the code I modified, you can see that after collecting the render targets and performing the rendering, it saves the BoundingBoxRenderer's renderList and then restores it afterward.

```typescript
const boundingBoxRenderer = (this as any).getBoundingBoxRenderer?.() as Nullable<BoundingBoxRenderer>;

let currentBoundingBoxMeshList: Array<BoundingBox> | undefined;

for (let renderIndex = 0; renderIndex < this._renderTargets.length; renderIndex++) {
    const renderTarget = this._renderTargets.data[renderIndex];
    if (renderTarget._shouldRender()) {
        this._renderId++;
        const hasSpecialRenderTargetCamera = renderTarget.activeCamera && renderTarget.activeCamera !== this.activeCamera;
        if (boundingBoxRenderer && !currentBoundingBoxMeshList) {
            // Saves the current bounding box mesh list (potentially built by the call to _evaluateActiveMeshes above), which will be reset/updated when processing this target
            currentBoundingBoxMeshList = boundingBoxRenderer.renderList.length > 0 ? boundingBoxRenderer.renderList.data.slice() : [];
            currentBoundingBoxMeshList.length = boundingBoxRenderer.renderList.length;
        }
        renderTarget.render(<boolean>hasSpecialRenderTargetCamera, this.dumpNextRenderTargets);
        needRebind = true;
    }
}
if (boundingBoxRenderer && currentBoundingBoxMeshList) {
    boundingBoxRenderer.renderList.data = currentBoundingBoxMeshList;
    boundingBoxRenderer.renderList.length = currentBoundingBoxMeshList.length;
}
```

Therefore, I applied the same approach and modified the code so that the renderList is restored even after the Effect Layer's ObjectRenderer has executed.