### PR TITLE
Add .webp which is already supported to inspector v2 material textures

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/materials/openpbrMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/openpbrMaterialProperties.tsx
@@ -36,7 +36,7 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Base Weight" target={material} propertyKey="baseWeight" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Base Weight"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.baseWeightTexture = texture));
@@ -46,7 +46,7 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={Color3PropertyLine} label="Base Color" target={material} propertyKey="baseColor" isLinearMode />
             <FileUploadLine
                 label="Base Color"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.baseColorTexture = texture));
@@ -56,7 +56,7 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Base Metalness" target={material} propertyKey="baseMetalness" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Base Metalness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.baseMetalnessTexture = texture));
@@ -66,7 +66,7 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Base Diffuse Roughness" target={material} propertyKey="baseDiffuseRoughness" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Base Diffuse Roughness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.baseDiffuseRoughnessTexture = texture));
@@ -90,7 +90,7 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Specular Weight" target={material} propertyKey="specularWeight" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Specular Weight"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.specularWeightTexture = texture));
@@ -100,7 +100,7 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
             <BoundProperty component={Color3PropertyLine} label="Specular Color" target={material} propertyKey="specularColor" isLinearMode />
             <FileUploadLine
                 label="Specular Color"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.specularColorTexture = texture));
@@ -110,7 +110,7 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Specular Roughness" target={material} propertyKey="specularRoughness" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Specular Roughness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.specularRoughnessTexture = texture));
@@ -128,7 +128,7 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
             />
             <FileUploadLine
                 label="Specular Roughness Anisotropy"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.specularRoughnessAnisotropyTexture = texture));
@@ -148,7 +148,7 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
             <BoundProperty component={SyncedSliderPropertyLine} label="Transmission Weight" target={material} propertyKey="transmissionWeight" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Transmission Weight"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.transmissionWeightTexture = texture));
@@ -158,7 +158,7 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
             <BoundProperty component={Color3PropertyLine} label="Transmission Color" target={material} propertyKey="transmissionColor" isLinearMode />
             <FileUploadLine
                 label="Transmission Color"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.transmissionColorTexture = texture));
@@ -168,7 +168,7 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
             <BoundProperty component={SyncedSliderPropertyLine} label="Transmission Depth" target={material} propertyKey="transmissionDepth" min={0} step={0.01} />
             <FileUploadLine
                 label="Transmission Depth"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.transmissionDepthTexture = texture));
@@ -178,7 +178,7 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
             <BoundProperty component={Color3PropertyLine} label="Transmission Scatter" target={material} propertyKey="transmissionScatter" isLinearMode />
             <FileUploadLine
                 label="Transmission Scatter"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.transmissionScatterTexture = texture));
@@ -214,7 +214,7 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
             />
             <FileUploadLine
                 label="Transmission Dispersion Scale"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.transmissionDispersionScaleTexture = texture));
@@ -238,7 +238,7 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Coat Weight" target={material} propertyKey="coatWeight" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Coat Weight"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.coatWeightTexture = texture));
@@ -248,7 +248,7 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={Color3PropertyLine} label="Coat Color" target={material} propertyKey="coatColor" isLinearMode />
             <FileUploadLine
                 label="Coat Color"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.coatColorTexture = texture));
@@ -258,7 +258,7 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Coat Roughness" target={material} propertyKey="coatRoughness" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Coat Roughness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.coatRoughnessTexture = texture));
@@ -276,7 +276,7 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
             />
             <FileUploadLine
                 label="Coat Roughness Anisotropy"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.coatRoughnessAnisotropyTexture = texture));
@@ -287,7 +287,7 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Coat Darkening" target={material} propertyKey="coatDarkening" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Coat Darkening"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.coatDarkeningTexture = texture));
@@ -311,7 +311,7 @@ export const OpenPBRMaterialFuzzProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Fuzz Weight" target={material} propertyKey="fuzzWeight" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Fuzz Weight"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.fuzzWeightTexture = texture));
@@ -321,7 +321,7 @@ export const OpenPBRMaterialFuzzProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={Color3PropertyLine} label="Fuzz Color" target={material} propertyKey="fuzzColor" isLinearMode />
             <FileUploadLine
                 label="Fuzz Color"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.fuzzColorTexture = texture));
@@ -331,7 +331,7 @@ export const OpenPBRMaterialFuzzProperties: FunctionComponent<{ material: OpenPB
             <BoundProperty component={SyncedSliderPropertyLine} label="Fuzz Roughness" target={material} propertyKey="fuzzRoughness" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Fuzz Roughness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.fuzzRoughnessTexture = texture));
@@ -356,7 +356,7 @@ export const OpenPBRMaterialEmissionProperties: FunctionComponent<{ material: Op
             <BoundProperty component={Color3PropertyLine} label="Emission Color" target={material} propertyKey="emissionColor" isLinearMode />
             <FileUploadLine
                 label="Emission Color"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.emissionColorTexture = texture));
@@ -381,7 +381,7 @@ export const OpenPBRMaterialThinFilmProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Thin Film Weight" target={material} propertyKey="thinFilmWeight" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Thin Film Weight"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.thinFilmWeightTexture = texture));
@@ -391,7 +391,7 @@ export const OpenPBRMaterialThinFilmProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Thin Film Thickness" target={material} propertyKey="thinFilmThickness" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Thin Film Thickness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.thinFilmThicknessTexture = texture));
@@ -416,7 +416,7 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Opacity" target={material} propertyKey="geometryOpacity" min={0} max={1} step={0.01} />
             <FileUploadLine
                 label="Geometry Opacity"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.geometryOpacityTexture = texture));
@@ -425,7 +425,7 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
             />
             <FileUploadLine
                 label="Geometry Normal"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.geometryNormalTexture = texture));
@@ -435,7 +435,7 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Tangent Angle" target={material} propertyKey="geometryTangentAngle" min={0} max={Math.PI} step={0.01} />
             <FileUploadLine
                 label="Geometry Tangent"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.geometryTangentTexture = texture));
@@ -453,7 +453,7 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
             />
             <FileUploadLine
                 label="Geometry Coat Normal"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.geometryCoatNormalTexture = texture));
@@ -462,7 +462,7 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
             />
             <FileUploadLine
                 label="Geometry Coat Tangent"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.geometryCoatTangentTexture = texture));
@@ -472,7 +472,7 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
             <BoundProperty component={SyncedSliderPropertyLine} label="Geometry Thickness" target={material} propertyKey="geometryThickness" min={0} step={0.1} />
             <FileUploadLine
                 label="Geometry Thickness"
-                accept=".jpg, .png, .tga, .dds, .env, .exr"
+                accept=".jpg, .png, .webp, .tga, .dds, .env, .exr"
                 onClick={(files) => {
                     if (files.length > 0) {
                         UpdateTexture(files[0], material, (texture) => (material.geometryThicknessTexture = texture));


### PR DESCRIPTION
These file formats are already supported by the inspector, just that they won't show when uploading (unless explicitly changing to show all files in the OS file picker).