### PR TITLE
Playground: disable type checking in ts-loader

### DIFF
--- a/packages/tools/playground/package.json
+++ b/packages/tools/playground/package.json
@@ -6,6 +6,7 @@
         "build": "webpack",
         "build:declaration": "build-tools -c pud --config ./config.json",
         "build:deployment": "npm run clean && webpack --env mode=production",
+        "typecheck": "tsc -p tsconfig.build.json --noEmit",
         "serve": "webpack serve",
         "serve:prod": "webpack serve --env mode=production",
         "serve:https": "webpack serve --env mode=development --server-type https --host ::",

--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -77,6 +77,7 @@ module.exports = (env) => {
                     },
                 ],
                 tsOptions: {
+                    transpileOnly: true,
                     compilerOptions: {
                         rootDir: "../../",
                     },


### PR DESCRIPTION
- Disable type checking for ts-loader. Otherwise it type checks all TypeScript code in the bundle, which I believe includes Monaco and other dependencies.
- Add a script that typechecks the Playground code directly with tsc. This uses very little memory and only takes a few seconds to run. It can be added to the build pipeline steps to make sure we still typecheck the Playground code itself.