### PR TITLE
Replace regex that is breaking our `test:escheck` script

### DIFF
--- a/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
+++ b/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
@@ -125,9 +125,9 @@ export class DiffuseSkyIrradianceLut {
                 // Replace the CUSTOM_IRRADIANCE_FILTERING placeholder with call to integrateForIrradiance.
                 const includeStore = useWebGPU ? ShaderStore.IncludesShadersStoreWGSL : ShaderStore.IncludesShadersStore;
                 let patchedInclude = includeStore["hdrFilteringFunctions"];
-                patchedInclude = patchedInclude.replace(/(?<!#ifdef\s|#ifndef\s)CUSTOM_IRRADIANCE_FILTERING_INPUT/g, "");
+                patchedInclude = patchedInclude.replace(/^(?!.*#(?:ifdef|ifndef)\s).*CUSTOM_IRRADIANCE_FILTERING_INPUT/gm, "");
                 patchedInclude = patchedInclude.replace(
-                    /(?<!#ifdef\s|#ifndef\s)CUSTOM_IRRADIANCE_FILTERING_FUNCTION/g,
+                    /^(?!.*#(?:ifdef|ifndef)\s).*CUSTOM_IRRADIANCE_FILTERING_FUNCTION/gm,
                     useWebGPU ? "var c = integrateForIrradiance(n, Ls, vec3f(0., filteringInfo.x, 0.));" : "vec3 c = integrateForIrradiance(n, Ls, vec3(0., filteringInfo.x, 0.));"
                 );
 


### PR DESCRIPTION
The current regex uses negative lookbehind with alternation and variable-width patterns, which is not valid in Safari/JavaScriptCore.

This change replaces the regex with a valid negative lookahead anchored at the start of each line.

Fixes issue introduced by PR https://github.com/BabylonJS/Babylon.js/pull/17855.