### PR TITLE
Simplify placeholder regex further

### DIFF
--- a/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
+++ b/packages/dev/addons/src/atmosphere/diffuseSkyIrradianceLut.ts
@@ -124,7 +124,7 @@ export class DiffuseSkyIrradianceLut {
 
                 // Replace the CUSTOM_IRRADIANCE_FILTERING_INPUT and CUSTOM_IRRADIANCE_FILTERING_FUNCTION placeholders.
                 // Note, the regex replacements look for lines that *only* contain these placeholder strings.
-                // Since buildShaders removes trailing/leading whitespace, the placeholders are expected to be on lines by themselves.
+                // Since buildShaders removes leading whitespace, the placeholders are expected to start at the beginning of the line.
                 const includeStore = useWebGPU ? ShaderStore.IncludesShadersStoreWGSL : ShaderStore.IncludesShadersStore;
                 let patchedInclude = includeStore["hdrFilteringFunctions"];
                 patchedInclude = patchedInclude.replace(/^CUSTOM_IRRADIANCE_FILTERING_INPUT\s*$/gm, "");


### PR DESCRIPTION
The placeholders being searched for are on lines by themselves. That allows us to further simplify the regex. Now it will search for the placeholders that begin (and end) a line.

Validated with `npm run test:escheck` on the umd build.