### PR TITLE
[EngineInstrumentation] Fix double-count bug

### DIFF
--- a/packages/dev/core/src/Instrumentation/engineInstrumentation.ts
+++ b/packages/dev/core/src/Instrumentation/engineInstrumentation.ts
@@ -79,7 +79,8 @@ export class EngineInstrumentation implements IDisposable {
             });
 
             this._onAfterShaderCompilationObserver = this.engine.onAfterShaderCompilationObservable.add(() => {
-                this._shaderCompilationTime.endMonitoring();
+                this._shaderCompilationTime.endMonitoring(false);
+                this._shaderCompilationTime.endFrame();
             });
         } else {
             this.engine.onBeforeShaderCompilationObservable.remove(this._onBeforeShaderCompilationObserver);


### PR DESCRIPTION
The shaderCompilationTimeCounter would call `fetchNewFrame()`, which increments count, both before and after shader compilation. This should fix it. See playground for repro of the issue: https://playground.babylonjs.com/#F7C6DP#10