### PR TITLE
[InspectorV2] Incorporate copy button into the 'edit' mode used for pinning/hiding

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/propertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/propertyLine.tsx
@@ -152,7 +152,7 @@ export type PropertyLineProps<ValueT> = BasePropertyLineProps &
  */
 export const PropertyLine = forwardRef<HTMLDivElement, PropsWithChildren<PropertyLineProps<any>>>((props, ref) => {
     PropertyLine.displayName = "PropertyLine";
-    const { disableCopy, size } = useContext(ToolContext);
+    const { size } = useContext(ToolContext);
     const classes = usePropertyLineStyles();
     const { label, uniqueId, onCopy, expandedContent, children, nullable, ignoreNullable } = props;
 
@@ -226,11 +226,7 @@ export const PropertyLine = forwardRef<HTMLDivElement, PropsWithChildren<Propert
                         </Tooltip>
                     )}
                     <div className={classes.childWrapper}>{processedChildren}</div>
-                    {onCopy && !disableCopy && (
-                        <Tooltip content="Copy to Clipboard">
-                            <Button className={classes.copy} appearance="transparent" icon={size === "small" ? Copy16Regular : CopyRegular} onClick={handleCopy} />
-                        </Tooltip>
-                    )}
+                    {onCopy && <CopyButton onCopy={handleCopy} />}
                 </div>
             </div>
             {expandedContent && (
@@ -277,6 +273,26 @@ export const LineContainer = forwardRef<HTMLDivElement, PropsWithChildren<HTMLPr
         </AccordionSectionItem>
     );
 });
+
+/**
+ * Copy button that reads ToolContext at its own position in the tree.
+ * This allows AccordionSectionItem's ToolContext.Provider override (e.g. ctrl+hover) to control visibility.
+ * @returns The copy button element.
+ */
+const CopyButton: FunctionComponent<{ onCopy: () => void }> = ({ onCopy }) => {
+    const { disableCopy, size } = useContext(ToolContext);
+    const classes = usePropertyLineStyles();
+
+    if (disableCopy) {
+        return null;
+    }
+
+    return (
+        <Tooltip content="Copy to Clipboard">
+            <Button className={classes.copy} appearance="transparent" icon={size === "small" ? Copy16Regular : CopyRegular} onClick={onCopy} />
+        </Tooltip>
+    );
+};
 
 export const PlaceholderPropertyLine: FunctionComponent<PrimitiveProps<any> & PropertyLineProps<any>> = (props) => {
     return (

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
@@ -229,6 +229,12 @@ export const AccordionSectionItem: FunctionComponent<PropsWithChildren<Accordion
         setCtrlMode(ctrlPressed && mouseOver);
     }, [ctrlPressed, mouseOver]);
 
+    // Override disableCopy so copy buttons appear when ctrl+hovering on this item or when edit mode is active
+    const parentToolContext = useContext(ToolContext);
+    const editMode = accordionCtx?.state.editMode ?? false;
+    const showCopy = ctrlMode || editMode;
+    const itemToolContext = useMemo(() => (showCopy ? { ...parentToolContext, disableCopy: false } : parentToolContext), [parentToolContext, showCopy]);
+
     // If static item or no context, just render children
     if (staticItem || !accordionCtx || !itemState) {
         return <>{children}</>;
@@ -251,29 +257,31 @@ export const AccordionSectionItem: FunctionComponent<PropsWithChildren<Accordion
     const showControls = inEditMode || ctrlMode;
 
     const itemElement = (
-        <div
-            className={classes.sectionItemContainer}
-            style={isPinned ? { order: pinnedIndex } : undefined}
-            onMouseMove={() => setMouseOver(true)}
-            onMouseLeave={() => setMouseOver(false)}
-        >
-            {showControls && (
-                <div className={classes.sectionItemButtons}>
-                    {features.hiding && (
-                        <Button title={isHidden ? "Unhide" : "Hide"} icon={isHidden ? EyeOffRegular : EyeFilled} appearance="transparent" onClick={actions.toggleHidden} />
-                    )}
-                    {features.pinning && (
-                        <>
-                            <Button title={isPinned ? "Unpin" : "Pin"} icon={isPinned ? PinFilled : PinRegular} appearance="transparent" onClick={actions.togglePinned} />
-                            {isPinned && <Button icon={ArrowCircleUpRegular} appearance="transparent" disabled={!canMoveUp} onClick={actions.movePinnedUp} />}
-                        </>
-                    )}
-                </div>
-            )}
-            <AccordionItemDepthContext.Provider value={true}>
-                <div className={classes.sectionItemContent}>{children}</div>
-            </AccordionItemDepthContext.Provider>
-        </div>
+        <ToolContext.Provider value={itemToolContext}>
+            <div
+                className={classes.sectionItemContainer}
+                style={isPinned ? { order: pinnedIndex } : undefined}
+                onMouseMove={() => setMouseOver(true)}
+                onMouseLeave={() => setMouseOver(false)}
+            >
+                {showControls && (
+                    <div className={classes.sectionItemButtons}>
+                        {features.hiding && (
+                            <Button title={isHidden ? "Unhide" : "Hide"} icon={isHidden ? EyeOffRegular : EyeFilled} appearance="transparent" onClick={actions.toggleHidden} />
+                        )}
+                        {features.pinning && (
+                            <>
+                                <Button title={isPinned ? "Unpin" : "Pin"} icon={isPinned ? PinFilled : PinRegular} appearance="transparent" onClick={actions.togglePinned} />
+                                {isPinned && <Button icon={ArrowCircleUpRegular} appearance="transparent" disabled={!canMoveUp} onClick={actions.movePinnedUp} />}
+                            </>
+                        )}
+                    </div>
+                )}
+                <AccordionItemDepthContext.Provider value={true}>
+                    <div className={classes.sectionItemContent}>{children}</div>
+                </AccordionItemDepthContext.Provider>
+            </div>
+        </ToolContext.Provider>
     );
 
     return pinnedContainer ? <Portal mountNode={pinnedContainer}>{itemElement}</Portal> : itemElement;


### PR DESCRIPTION
This creates a more consistent UX so even if disableCopy is true, the copy button is still accessible in edit mode or ctrl mode 