### PR TITLE
Inspector v2: Scene Explorer entity commands for associated tool (e.g. NME, NGE, GUI Editor, etc.)

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/frameGraph/frameGraphProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/frameGraph/frameGraphProperties.tsx
@@ -7,6 +7,7 @@ import { EditRegular, PlayRegular } from "@fluentui/react-icons";
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 import { useProperty } from "../../../hooks/compoundPropertyHooks";
+import { EditNodeRenderGraph } from "../../../misc/nodeRenderGraphEditor";
 import { BoundProperty } from "../boundProperty";
 
 export const FrameGraphTaskProperties: FunctionComponent<{ frameGraph: FrameGraph }> = (props) => {
@@ -48,19 +49,7 @@ export const FrameGraphGeneralProperties: FunctionComponent<{ frameGraph: FrameG
                 propertyKey="optimizeTextureAllocation"
             ></BoundProperty>
             {isSceneFrameGraph !== frameGraph && <ButtonLine onClick={() => (frameGraph.scene.frameGraph = frameGraph)} label="Make Active" icon={PlayRegular} />}
-            {renderGraph && (
-                <ButtonLine
-                    label="Edit Graph"
-                    icon={EditRegular}
-                    onClick={async () => {
-                        // TODO: Figure out how to get all the various build steps to work with this.
-                        //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
-                        // const { NodeRenderGraphEditor } = await import("node-render-graph-editor/nodeRenderGraphEditor");
-                        // NodeRenderGraphEditor.Show({ nodeRenderGraph: renderGraph, hostScene: frameGraph.scene });
-                        await renderGraph.edit({ nodeRenderGraphEditorConfig: { hostScene: frameGraph.scene } });
-                    }}
-                ></ButtonLine>
-            )}
+            {renderGraph && <ButtonLine label="Edit Graph" icon={EditRegular} onClick={async () => await EditNodeRenderGraph(renderGraph)}></ButtonLine>}
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/nodeMaterialProperties.tsx
@@ -22,6 +22,7 @@ import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { useObservableState } from "../../../hooks/observableHooks";
 import { GroupBy } from "../../../misc/arrayUtils";
 import { BoundProperty } from "../boundProperty";
+import { EditNodeMaterial } from "../../../misc/nodeMaterialEditor";
 
 const useStyles = makeStyles({
     subsection: {
@@ -35,17 +36,7 @@ export const NodeMaterialGeneralProperties: FunctionComponent<{ material: NodeMa
     return (
         <>
             <BoundProperty component={SwitchPropertyLine} label="Ignore Alpha" target={material} propertyKey="ignoreAlpha" />
-            <ButtonLine
-                label="Edit"
-                icon={EditRegular}
-                onClick={async () => {
-                    // TODO: Figure out how to get all the various build steps to work with this.
-                    //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
-                    // const { NodeEditor } = await import("node-editor/nodeEditor");
-                    // NodeEditor.Show({ nodeMaterial: material });
-                    await material.edit({ nodeEditorConfig: { backgroundColor: material.getScene().clearColor } });
-                }}
-            ></ButtonLine>
+            <ButtonLine label="Edit" icon={EditRegular} onClick={async () => await EditNodeMaterial(material)}></ButtonLine>
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/components/properties/nodes/meshProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/nodes/meshProperties.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent } from "react";
 
-import type { Mesh, MorphTarget, NodeGeometry } from "core/index";
+import type { Mesh, MorphTarget } from "core/index";
 
 import { EditRegular } from "@fluentui/react-icons";
 
@@ -8,30 +8,15 @@ import { Constants } from "core/Engines/constants";
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
+import { EditNodeGeometry, GetNodeGeometry } from "../../../misc/nodeGeometryEditor";
 import { BoundProperty } from "../boundProperty";
 
 export const MeshGeneralProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {
     const { mesh } = props;
 
-    const nodeGeometry = mesh._internalMetadata?.nodeGeometry as NodeGeometry | undefined;
+    const nodeGeometry = GetNodeGeometry(mesh);
 
-    return (
-        <>
-            {nodeGeometry && (
-                <ButtonLine
-                    label="Edit"
-                    icon={EditRegular}
-                    onClick={async () => {
-                        // TODO: Figure out how to get all the various build steps to work with this.
-                        //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
-                        // const { NodeGeometryEditor } = await import("node-geometry-editor/nodeGeometryEditor");
-                        // NodeGeometryEditor.Show({ nodeGeometry: nodeGeometry, hostScene: mesh.getScene() });
-                        await nodeGeometry.edit({ nodeGeometryEditorConfig: { hostScene: mesh.getScene() } });
-                    }}
-                />
-            )}
-        </>
-    );
+    return <>{nodeGeometry && <ButtonLine label="Edit" icon={EditRegular} onClick={async () => await EditNodeGeometry(nodeGeometry, mesh.getScene())} />}</>;
 };
 
 export const MeshDisplayProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {

--- a/packages/dev/inspector-v2/src/components/properties/particles/systemProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/particles/systemProperties.tsx
@@ -1,21 +1,22 @@
-import type { FunctionComponent } from "react";
 import type { GPUParticleSystem } from "core/Particles/gpuParticleSystem";
+import type { FunctionComponent } from "react";
 import type { ISelectionService } from "../../../services/selectionService";
+
 import { EditRegular, EyeRegular } from "@fluentui/react-icons";
 
 import { ParticleSystem } from "core/Particles/particleSystem";
-import { ConvertToNodeParticleSystemSetAsync } from "core/Particles/Node/nodeParticleSystemSet.helper";
 import { BlendModeOptions, ParticleBillboardModeOptions } from "shared-ui-components/constToOptionsMaps";
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
+import { TextureSelectorPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/entitySelectorPropertyLine";
 import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
-import { TextureSelectorPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/entitySelectorPropertyLine";
 import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { useObservableState } from "../../../hooks/observableHooks";
+import { EditParticleSystem } from "../../../misc/nodeParticleEditor";
 import { BoundProperty } from "../boundProperty";
 
 /**
@@ -76,17 +77,7 @@ export const ParticleSystemSystemProperties: FunctionComponent<{ particleSystem:
                     uniqueId="View/Edit"
                     label={isNodeGenerated ? "Edit" : "View as Node-Based Particle System"}
                     icon={isNodeGenerated ? EditRegular : EyeRegular}
-                    onClick={async () => {
-                        const scene = system.getScene();
-                        if (!scene) {
-                            return;
-                        }
-
-                        const systemSet = isNodeGenerated ? system.source : await ConvertToNodeParticleSystemSetAsync("source", [system]);
-                        if (systemSet) {
-                            await systemSet.editAsync({ nodeEditorConfig: { backgroundColor: scene.clearColor, disposeOnClose: !isNodeGenerated } });
-                        }
-                    }}
+                    onClick={async () => await EditParticleSystem(system)}
                 />
             )}
         </>

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -187,7 +187,7 @@ type ActionCommand = {
     /**
      * The function that executes the command.
      */
-    execute(): void;
+    execute(): unknown | Promise<unknown>;
 };
 
 type ToggleCommand = {

--- a/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
+++ b/packages/dev/inspector-v2/src/components/stats/statsPane.tsx
@@ -3,9 +3,10 @@ import type { Scene } from "core/index";
 import { makeStyles, tokens } from "@fluentui/react-components";
 
 import { AbstractEngine } from "core/Engines/abstractEngine";
-import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { StringifiedPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/stringifiedPropertyLine";
+import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
 import { useObservableState } from "../../hooks/observableHooks";
+import { usePollingObservable } from "../../hooks/pollingHooks";
 import { ExtensibleAccordion } from "../extensibleAccordion";
 import { SidePaneContainer } from "../pane";
 
@@ -21,7 +22,8 @@ export const StatsPane: typeof ExtensibleAccordion<Scene> = (props) => {
 
     const scene = props.context;
     const engine = scene.getEngine();
-    const fps = useObservableState(() => Math.round(engine.getFps()), engine.onBeginFrameObservable);
+    const pollingObservable = usePollingObservable(250);
+    const fps = useObservableState(() => Math.round(engine.getFps()), pollingObservable);
 
     return (
         <>

--- a/packages/dev/inspector-v2/src/misc/nodeGeometryEditor.ts
+++ b/packages/dev/inspector-v2/src/misc/nodeGeometryEditor.ts
@@ -1,0 +1,13 @@
+import type { Mesh, NodeGeometry, Nullable, Scene } from "core/index";
+
+export function GetNodeGeometry(mesh: Mesh): Nullable<NodeGeometry> {
+    return (mesh._internalMetadata?.nodeGeometry as NodeGeometry | undefined) ?? null;
+}
+
+export async function EditNodeGeometry(nodeGeometry: NodeGeometry, hostScene: Scene) {
+    // TODO: Figure out how to get all the various build steps to work with this.
+    //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+    // const { NodeGeometryEditor } = await import("node-geometry-editor/nodeGeometryEditor");
+    // NodeGeometryEditor.Show({ nodeGeometry: nodeGeometry, hostScene: mesh.getScene() });
+    await nodeGeometry.edit({ nodeGeometryEditorConfig: { hostScene } });
+}

--- a/packages/dev/inspector-v2/src/misc/nodeMaterialEditor.ts
+++ b/packages/dev/inspector-v2/src/misc/nodeMaterialEditor.ts
@@ -1,0 +1,9 @@
+import type { NodeMaterial } from "core/index";
+
+export async function EditNodeMaterial(material: NodeMaterial) {
+    // TODO: Figure out how to get all the various build steps to work with this.
+    //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+    // const { NodeEditor } = await import("node-editor/nodeEditor");
+    // NodeEditor.Show({ nodeMaterial: material });
+    await material.edit({ nodeEditorConfig: { backgroundColor: material.getScene().clearColor } });
+}

--- a/packages/dev/inspector-v2/src/misc/nodeParticleEditor.ts
+++ b/packages/dev/inspector-v2/src/misc/nodeParticleEditor.ts
@@ -1,0 +1,17 @@
+import type { ParticleSystem } from "core/index";
+
+import { ConvertToNodeParticleSystemSetAsync } from "core/Particles/Node/nodeParticleSystemSet.helper";
+
+export async function EditParticleSystem(particleSystem: ParticleSystem) {
+    // TODO: Figure out how to get all the various build steps to work with this.
+    //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+    // const { NodeParticleEditor } = await import("node-particle-editor/nodeParticleEditor");
+    // NodeParticleEditor.Show({ nodeParticleSet: NodeParticleSystemSet });
+    const scene = particleSystem.getScene();
+    if (scene) {
+        const systemSet = particleSystem.isNodeGenerated ? particleSystem.source : await ConvertToNodeParticleSystemSetAsync("source", [particleSystem]);
+        if (systemSet) {
+            await systemSet.editAsync({ nodeEditorConfig: { backgroundColor: scene.clearColor, disposeOnClose: !particleSystem.isNodeGenerated } });
+        }
+    }
+}

--- a/packages/dev/inspector-v2/src/misc/nodeRenderGraphEditor.ts
+++ b/packages/dev/inspector-v2/src/misc/nodeRenderGraphEditor.ts
@@ -1,0 +1,9 @@
+import type { NodeRenderGraph } from "core/index";
+
+export async function EditNodeRenderGraph(nodeRenderGraph: NodeRenderGraph) {
+    // TODO: Figure out how to get all the various build steps to work with this.
+    //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
+    // const { NodeRenderGraphEditor } = await import("node-render-graph-editor/nodeRenderGraphEditor");
+    // NodeRenderGraphEditor.Show({ nodeRenderGraph: renderGraph, hostScene: frameGraph.scene });
+    await nodeRenderGraph.edit({ nodeRenderGraphEditorConfig: { backgroundColor: nodeRenderGraph.getScene().clearColor, hostScene: nodeRenderGraph.getScene() } });
+}

--- a/packages/dev/inspector-v2/src/services/miniStatsService.tsx
+++ b/packages/dev/inspector-v2/src/services/miniStatsService.tsx
@@ -6,6 +6,7 @@ import { Badge, makeStyles, tokens } from "@fluentui/react-components";
 import { useCallback } from "react";
 
 import { useObservableState } from "../hooks/observableHooks";
+import { usePollingObservable } from "../hooks/pollingHooks";
 import { SceneContextIdentity } from "./sceneContext";
 import { ShellServiceIdentity } from "./shellService";
 
@@ -33,9 +34,10 @@ export const MiniStatsServiceDefinition: ServiceDefinition<[], [ISceneContext, I
                     sceneContext.currentSceneObservable
                 );
                 const engine = scene?.getEngine();
+                const pollingObservable = usePollingObservable(250);
                 const fps = useObservableState(
                     useCallback(() => (engine ? Math.round(engine.getFps()) : null), [engine]),
-                    engine?.onBeginFrameObservable
+                    pollingObservable
                 );
 
                 return fps != null ? <Badge appearance="outline" className={classes.badge}>{`${fps} fps`}</Badge> : null;

--- a/packages/dev/inspector-v2/src/services/panes/scene/defaultSectionsMetadata.ts
+++ b/packages/dev/inspector-v2/src/services/panes/scene/defaultSectionsMetadata.ts
@@ -26,5 +26,9 @@ export const enum DefaultCommandsOrder {
     GuiHighlight = 1000,
     MeshVisibility = 1100,
     GuiVisibility = 1100,
+    EditNodeMaterial = 1100,
+    EditParticleSystem = 1100,
+    EditNodeGeometry = 1100,
+    EditNodeRenderGraph = 1100,
     Dispose = 10000,
 }

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -2,11 +2,12 @@ import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
-import { FrameRegular, PlayFilled, PlayRegular } from "@fluentui/react-icons";
+import { EditRegular, FrameRegular, PlayFilled, PlayRegular } from "@fluentui/react-icons";
 
 import { FrameGraph } from "core/FrameGraph/frameGraph";
 import { Observable } from "core/Misc/observable";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { EditNodeRenderGraph } from "../../../misc/nodeRenderGraphEditor";
 import { SceneContextIdentity } from "../../sceneContext";
 import { DefaultCommandsOrder, DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
@@ -79,10 +80,31 @@ export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
             },
         });
 
+        const editNodeRenderGraphCommandRegistration = sceneExplorerService.addEntityCommand({
+            predicate: (entity: unknown): entity is FrameGraph => entity instanceof FrameGraph && !!entity.getLinkedNodeRenderGraph(),
+            order: DefaultCommandsOrder.EditNodeRenderGraph,
+            getCommand: (frameGraph) => {
+                const renderGraph = frameGraph.getLinkedNodeRenderGraph();
+
+                return {
+                    type: "action",
+                    displayName: "Edit Graph",
+                    icon: () => <EditRegular />,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    execute: async () => {
+                        if (renderGraph) {
+                            await EditNodeRenderGraph(renderGraph);
+                        }
+                    },
+                };
+            },
+        });
+
         return {
             dispose: () => {
                 sectionRegistration.dispose();
                 activeFrameGraphCommandRegistration.dispose();
+                editNodeRenderGraphCommandRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -3,7 +3,7 @@ import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
-import { AppGenericRegular, BorderNoneRegular, BorderOutsideRegular, EyeOffRegular, EyeRegular, RectangleLandscapeRegular } from "@fluentui/react-icons";
+import { AppGenericRegular, BorderNoneRegular, BorderOutsideRegular, EditRegular, EyeOffRegular, EyeRegular, RectangleLandscapeRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc/observable";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
@@ -103,6 +103,23 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
             getEntityRemovedObservables: () => [guiEntityRemovedObservable],
         });
 
+        const editGuiCommandRegistration = sceneExplorerService.addEntityCommand({
+            predicate: (entity: unknown): entity is AdvancedDynamicTexture => IsAdvancedDynamicTexture(entity),
+            order: DefaultCommandsOrder.EditNodeMaterial,
+            getCommand: (texture) => {
+                return {
+                    type: "action",
+                    displayName: "Edit in GUI Editor",
+                    icon: () => <EditRegular />,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    execute: async () => {
+                        const { GUIEditor } = await import("gui-editor/guiEditor");
+                        await GUIEditor.Show({ liveGuiTexture: texture });
+                    },
+                };
+            },
+        });
+
         const highlightControlCommandRegistration = sceneExplorerService.addEntityCommand({
             predicate: (entity: unknown): entity is Control => IsControl(entity),
             order: DefaultCommandsOrder.GuiHighlight,
@@ -159,6 +176,7 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
                 textureAddedObserver.remove();
                 textureRemovedObserver.remove();
                 sectionRegistration.dispose();
+                editGuiCommandRegistration.dispose();
                 highlightControlCommandRegistration.dispose();
                 controlVisibilityCommandRegistration.dispose();
             },

--- a/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
@@ -2,11 +2,15 @@ import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
+import { EditRegular } from "@fluentui/react-icons";
+
+import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { Observable } from "core/Misc/observable";
 import { MaterialIcon } from "shared-ui-components/fluent/icons";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { EditNodeMaterial } from "../../../misc/nodeMaterialEditor";
 import { SceneContextIdentity } from "../../sceneContext";
-import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
+import { DefaultCommandsOrder, DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
@@ -47,9 +51,24 @@ export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
             getEntityRemovedObservables: () => [scene.onMaterialRemovedObservable],
         });
 
+        const editNodeMaterialCommandRegistration = sceneExplorerService.addEntityCommand({
+            predicate: (entity) => entity instanceof NodeMaterial,
+            order: DefaultCommandsOrder.EditNodeMaterial,
+            getCommand: (nodeMaterial) => {
+                return {
+                    type: "action",
+                    displayName: "Edit in Node Material Editor",
+                    icon: () => <EditRegular />,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    execute: async () => await EditNodeMaterial(nodeMaterial),
+                };
+            },
+        });
+
         return {
             dispose: () => {
                 sectionRegistration.dispose();
+                editNodeMaterialCommandRegistration.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
@@ -2,12 +2,14 @@ import type { ServiceDefinition } from "../../../modularity/serviceDefinition";
 import type { ISceneContext } from "../../sceneContext";
 import type { ISceneExplorerService } from "./sceneExplorerService";
 
-import { DropRegular } from "@fluentui/react-icons";
+import { DropRegular, EditRegular } from "@fluentui/react-icons";
 
 import { Observable } from "core/Misc/observable";
+import { ParticleSystem } from "core/Particles/particleSystem";
 import { InterceptProperty } from "../../../instrumentation/propertyInstrumentation";
+import { EditParticleSystem } from "../../../misc/nodeParticleEditor";
 import { SceneContextIdentity } from "../../sceneContext";
-import { DefaultSectionsOrder } from "./defaultSectionsMetadata";
+import { DefaultCommandsOrder, DefaultSectionsOrder } from "./defaultSectionsMetadata";
 import { SceneExplorerServiceIdentity } from "./sceneExplorerService";
 
 export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext]> = {
@@ -48,9 +50,24 @@ export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISc
             getEntityRemovedObservables: () => [scene.onParticleSystemRemovedObservable],
         });
 
+        const editParticleSystemCommandRegistration = sceneExplorerService.addEntityCommand({
+            predicate: (entity): entity is ParticleSystem => entity instanceof ParticleSystem && entity.isNodeGenerated,
+            order: DefaultCommandsOrder.EditParticleSystem,
+            getCommand: (particleSystem) => {
+                return {
+                    type: "action",
+                    displayName: "Edit in Node Particle System Editor",
+                    icon: () => <EditRegular />,
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
+                    execute: async () => await EditParticleSystem(particleSystem),
+                };
+            },
+        });
+
         return {
             dispose: () => {
                 sectionRegistration.dispose();
+                editParticleSystemCommandRegistration.dispose();
             },
         };
     },


### PR DESCRIPTION
This PR mostly just adds Scene Explorer commands for editing entities in their associated tool: NME, NGE, NPE, NRGE, and GUI Editor. I added new files with helpers for launching each of the editors that is used from both the properties pane buttons and scene explorer commands.

<img width="520" height="283" alt="image" src="https://github.com/user-attachments/assets/8de6908b-6a04-4b5d-8e12-aef8e0121469" />

I also included a couple other tiny changes where we just poll for FPS from engine every 250ms rather than every frame as this is the only thing I could find happening on a per frame basis in the default Inspector state, so I want to see if this helps with https://forum.babylonjs.com/t/introducing-inspector-v2/60937/149