### PR TITLE
Enable copy/paste in playground on mobile

### DIFF
--- a/packages/tools/playground/src/tools/monaco/editor/editorHost.ts
+++ b/packages/tools/playground/src/tools/monaco/editor/editorHost.ts
@@ -34,7 +34,6 @@ export class EditorHost {
             selectionHighlight: false,
             readOnly: false,
             theme: Utilities.ReadStringFromStore("theme", "Light") === "Dark" ? "vs-dark" : "vs-light",
-            contextmenu: false,
             folding: true,
             showFoldingControls: "always",
             fontSize: parseInt(Utilities.ReadStringFromStore("font-size", "14")),


### PR DESCRIPTION
Use the default 'true' for contextMenu rather than specifying false

<img width="179" height="196" alt="image" src="https://github.com/user-attachments/assets/bc51eae2-2611-426d-93b9-aeed3555d33c" />
