### PR TITLE
Inspector v2: Reduce perf overhead in default idle state

### DIFF
--- a/packages/dev/inspector-v2/src/services/panes/properties/propertiesService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/properties/propertiesService.tsx
@@ -83,6 +83,7 @@ export const PropertiesServiceDefinition: ServiceDefinition<[IPropertiesService]
             verticalLocation: "top",
             order: 100,
             suppressTeachingMoment: true,
+            keepMounted: true,
             content: () => {
                 const sections = useOrderedObservableCollection(sectionsCollection);
                 const sectionContent = useObservableCollection(sectionContentCollection);

--- a/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.tsx
@@ -59,6 +59,7 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
             horizontalLocation: "left",
             verticalLocation: "top",
             suppressTeachingMoment: true,
+            keepMounted: true,
             content: () => {
                 const sections = useOrderedObservableCollection(sectionsCollection);
                 const entityCommands = useOrderedObservableCollection(entityCommandsCollection);

--- a/packages/dev/inspector-v2/src/services/shellService.tsx
+++ b/packages/dev/inspector-v2/src/services/shellService.tsx
@@ -180,6 +180,12 @@ export type SidePaneDefinition = {
      * Teaching moments are more helpful for dynamically added panes, possibly from extensions.
      */
     suppressTeachingMoment?: boolean;
+
+    /**
+     * Keep the pane mounted even when it is not visible. This is useful if you don't want the
+     * user to lose the complex visual state when switching between tabs.
+     */
+    keepMounted?: boolean;
 };
 
 type RegisteredSidePane = {
@@ -1017,13 +1023,15 @@ function usePane(
                             <>
                                 <PaneHeader id={topSelectedTab.key} title={topSelectedTab.title} dockOptions={validTopDockOptions} />
                                 {/* Render all panes to retain their state even when they are not selected, but only display the selected pane. */}
-                                {topPanes.map((pane) => (
-                                    <div key={pane.key} className={mergeClasses(classes.paneContent, pane.key !== topSelectedTab.key ? classes.unselectedPane : undefined)}>
-                                        <ErrorBoundary name={pane.title}>
-                                            <pane.content />
-                                        </ErrorBoundary>
-                                    </div>
-                                ))}
+                                {topPanes
+                                    .filter((pane) => pane.key === topSelectedTab.key || pane.keepMounted)
+                                    .map((pane) => (
+                                        <div key={pane.key} className={mergeClasses(classes.paneContent, pane.key !== topSelectedTab.key ? classes.unselectedPane : undefined)}>
+                                            <ErrorBoundary name={pane.title}>
+                                                <pane.content />
+                                            </ErrorBoundary>
+                                        </div>
+                                    ))}
                             </>
                         )}
                     </div>
@@ -1050,13 +1058,15 @@ function usePane(
                             <>
                                 <PaneHeader id={bottomSelectedTab.key} title={bottomSelectedTab.title} dockOptions={validBottomDockOptions} />
                                 {/* Render all panes to retain their state even when they are not selected, but only display the selected pane. */}
-                                {bottomPanes.map((pane) => (
-                                    <div key={pane.key} className={mergeClasses(classes.paneContent, pane.key !== bottomSelectedTab.key ? classes.unselectedPane : undefined)}>
-                                        <ErrorBoundary name={pane.title}>
-                                            <pane.content />
-                                        </ErrorBoundary>
-                                    </div>
-                                ))}
+                                {bottomPanes
+                                    .filter((pane) => pane.key === bottomSelectedTab.key || pane.keepMounted)
+                                    .map((pane) => (
+                                        <div key={pane.key} className={mergeClasses(classes.paneContent, pane.key !== bottomSelectedTab.key ? classes.unselectedPane : undefined)}>
+                                            <ErrorBoundary name={pane.title}>
+                                                <pane.content />
+                                            </ErrorBoundary>
+                                        </div>
+                                    ))}
                             </>
                         )}
                     </div>


### PR DESCRIPTION
In response to some of the forum discussion on Inspector v2 perf overhead (https://forum.babylonjs.com/t/introducing-inspector-v2/60937/152), I did some more investigation and found a couple more things that have a small amount of overhead:

1. The stats pane (including the Performance Viewer) instantiates several instances of `SceneInstrumentation`, plus register with other per-frame observables. This adds some per-frame overhead.
2. The debug pane hooks a bunch of `Scene` properties. Since we don't have observables for these, it hooks the properties through our property instrumentation helpers, which replaces the original property with a new one to create a "synthetic" observable when the property setter is called, but this also means replacing the getter, which adds one more layer in the call stack. From what I can see, this one is extremely tiny overhead, but it is non-zero.

In the default idle Inspector v2 state (where neither the stats pane nor the debug pane are visible), you still pay the perf overhead for them. This is because Inspector v2 keeps all panes mounted so they don't lose their state when switching between tabs. This is particularly useful for Scene Explorer and Properties, but less useful for the other panes (since there isn't a lot of user effort that goes into getting the other panes into a particular visual state). Given this, the change I'm making in this PR is to make the stay-mounted-when-not-visible behavior opt-in, and Scene Explorer and Properties are the only panes that opt in. This means in the default/idle state, there are no hooked observables or properties that are touched on a per-frame bases.

With these changes, plus these two:
https://github.com/BabylonJS/Babylon.js/pull/17893/changes#diff-2e00c9c08d421d1d47f3292f08211caf984e42d948b70b4ed633597411bf36abR25-R26
https://github.com/BabylonJS/Babylon.js/pull/17893/changes#diff-ce43142078840ddae7d6a16fc2f50227432422fb7eeedb65577281a0fd1dc2e5R37-R40

I see no measurable difference in frame rate even with the `--disable-gpu-vsync --disable-frame-rate-limit` Chrome settings that @Popov72 mentioned in the forum thread.