### PR TITLE
Inspector v2: Fix es6 package and other bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27043,6 +27043,7 @@
                 "@dev/build-tools": "^1.0.0",
                 "@dev/inspector": "1.0.0",
                 "@rollup/plugin-alias": "^5.1.0",
+                "@rollup/plugin-commonjs": "^26.0.1",
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-typescript": "^11.1.6",
                 "chalk": "^5.3.0",

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -1075,7 +1075,7 @@ export const SceneExplorer: FunctionComponent<{
     const selectEntity = useCallback(
         (selectedEntity: unknown) => {
             const entity = selectedEntity as Nullable<EntityBase>;
-            if (entity && entity.uniqueId != undefined) {
+            if (entity && GetEntityId(entity) != undefined) {
                 const parentStack = getParentStack(entity);
                 if (parentStack.length > 0) {
                     const newOpenItems = new Set<TreeItemValue>(openItems);
@@ -1204,7 +1204,7 @@ export const SceneExplorer: FunctionComponent<{
 
                             return (
                                 <EntityTreeItem
-                                    key={item.entity.uniqueId}
+                                    key={GetEntityId(item.entity)}
                                     scene={scene}
                                     entityItem={item}
                                     isSelected={selectedEntity === item.entity}

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -12,7 +12,8 @@ import { Engine } from "core/Engines/engine";
 import { ImportMeshAsync, LoadAssetContainerAsync } from "core/Loading/sceneLoader";
 import { ParticleHelper } from "core/Particles/particleHelper";
 import { Vector3 } from "core/Maths/math.vector";
-import { PhysicsAggregate, PhysicsMotionType, PhysicsShapeType } from "core/Physics/v2";
+import type { PhysicsMotionType, PhysicsShapeType } from "core/Physics/v2";
+import { PhysicsAggregate } from "core/Physics/v2/physicsAggregate";
 import { HavokPlugin } from "core/Physics/v2/Plugins/havokPlugin";
 import { Scene } from "core/scene";
 import { registerBuiltInLoaders } from "loaders/dynamic";
@@ -28,10 +29,9 @@ import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { Texture } from "core/Materials/Textures/texture";
 import { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
 import { Button } from "gui/2D/controls/button";
-import "core/Audio/audioSceneComponent";
-import "core/Audio/audioEngine";
 import { Sound } from "core/Audio/sound";
 import { ShowInspector } from "../../src/inspector";
+// import "../../src/legacy/legacy";
 
 // TODO: Get this working automatically without requiring an explicit import. Inspector v2 should dynamically import these when needed.
 //       See the initial attempt here: https://github.com/BabylonJS/Babylon.js/pull/17646
@@ -189,7 +189,10 @@ function createGui() {
     advancedTexture.addControl(button);
 }
 
-function createSound() {
+async function createSound() {
+    await import("core/Audio/audioSceneComponent");
+    await import("core/Audio/audioEngine");
+
     const sound = new Sound("Music", "https://playground.babylonjs.com/sounds/violons11.wav", scene, null, {
         loop: true,
         autoplay: false,
@@ -246,3 +249,4 @@ function createSound() {
 })();
 
 ShowInspector(scene);
+// scene.debugLayer.show();

--- a/packages/public/@babylonjs/inspector-v2/package.json
+++ b/packages/public/@babylonjs/inspector-v2/package.json
@@ -39,6 +39,7 @@
         "@dev/build-tools": "^1.0.0",
         "@dev/inspector": "1.0.0",
         "@rollup/plugin-alias": "^5.1.0",
+        "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.6",
         "chalk": "^5.3.0",

--- a/packages/public/@babylonjs/inspector-v2/rollup.config.lib.mjs
+++ b/packages/public/@babylonjs/inspector-v2/rollup.config.lib.mjs
@@ -1,6 +1,7 @@
 import typescript from "@rollup/plugin-typescript";
 import { dts } from "rollup-plugin-dts";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 import alias from "@rollup/plugin-alias";
 import path from "path";
 
@@ -45,13 +46,9 @@ const jsConfig = {
         }),
         typescript({ tsconfig: "tsconfig.build.lib.json" }),
         nodeResolve({ mainFields: ["browser", "module", "main"] }),
+        commonjs(),
     ],
     onwarn(warning, warn) {
-        // Ignore warning over "this" being undefined in ES when converting gif.js from UMD to ES.
-        if (warning.code === "THIS_IS_UNDEFINED" && warning.loc && warning.loc.file && warning.loc.file.endsWith("node_modules/gif.js.optimized/dist/gif.js")) {
-            return;
-        }
-
         // Treat all other warnings as errors.
         throw new Error(warning.message);
     },


### PR DESCRIPTION
This PR has three Inspector v2 bug fixes:
1. When we added gif capture support, we didn't get the es6 bundler settings correct. We silenced a warning that was actually legit. The correct fix is to use a bundler plugin that effectively converts a consumed umd bundle (the external gif lib) to esm. Without this, you get a runtime error and the tools pane doesn't work.
2. Scene Explorer tries to read `scene.mainSoundTrack.soundCollection`, but `scene.mainSoundTrack` is `undefined` unless the audioSceneComponent is imported and its side effects assigns a value to `scene.mainSoundTrack`. This means without the side effect, you actually just get a crash. Now the code is conditional, and hooks the `scene._mainSoundTrack` property to see when it becomes valid (or changes).
3. Scene Explorer had a couple direct references to `entity.uniqueId` instead of `GetEntityId(entity)`, which in the case of "synthetic unique ids" (like for `Sound`), would return undefined, which results in an error in the console and can break tree virtualization.