### PR TITLE
Prevents joint meshes from appearing before hand tracking is active

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRHandTracking.ts
+++ b/packages/dev/core/src/XR/features/WebXRHandTracking.ts
@@ -584,10 +584,10 @@ export class WebXRHandTracking extends WebXRAbstractFeature {
     private static _GenerateTrackedJointMeshes(options: IWebXRHandTrackingOptions, originalMesh: AbstractMesh): { left: AbstractMesh[]; right: AbstractMesh[] } {
         const meshes: { left: AbstractMesh[]; right: AbstractMesh[] } = { left: [], right: [] };
 
+        originalMesh.isVisible = !!options.jointMeshes?.keepOriginalVisible;
         for (const handedness of ["left", "right"] as const) {
             const h = handedness as "left" | "right";
             const trackedMeshes: AbstractMesh[] = [];
-            originalMesh.isVisible = !!options.jointMeshes?.keepOriginalVisible;
             for (let i = 0; i < HandJointReferenceArray.length; i++) {
                 let newInstance: AbstractMesh;
                 if (originalMesh instanceof Mesh) {


### PR DESCRIPTION
This PR fixes a visual glitch where a ghost icosphere (joint meshes) appears at the scene origin when entering an immersive session using only controllers (no hand tracking). 

Joint meshes are created as soon as `WebXRHandTracking` feature is attached. If hand tracking is not active yet, those meshes can remain visible until a hand is created and `updateFromXRFrame` applies the correct visibility. This fix makes the joint meshes invisible immediately on creation, preventing them from appear at the scene origin before hand tracking becomes active.

@matthargett, do you see any issues with this approach?

Additionally, the original mesh visibility has been restored.

### Alternative

If we decide not to adopt this fix, users can avoid the ghost joint meshes by explicitly setting:

```tsx
jointMeshes: { 
   invisible: true
}
```

during the creation of the default experience (`invisible` is set to false by default).

---

Forum: https://forum.babylonjs.com/t/request-for-minimal-working-vr-controller-v2-physics/62103/5