### PR TITLE
[Fix] Update gaussianSplattingMaterial

### DIFF
--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
@@ -683,4 +683,3 @@ export class GaussianSplattingMaterial extends PushMaterial {
 }
 
 RegisterClass("BABYLON.GaussianSplattingMaterial", GaussianSplattingMaterial);
-


### PR DESCRIPTION
Set GaussianSplattingMaxPart to 128 instead of 256 so Mac can compile shaders.