### PR TITLE
Inspector v2: Fix child window on Firefox (and other non-chromium browsers)

### DIFF
--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -12,7 +12,7 @@ import { Engine } from "core/Engines/engine";
 import { ImportMeshAsync, LoadAssetContainerAsync } from "core/Loading/sceneLoader";
 import { ParticleHelper } from "core/Particles/particleHelper";
 import { Vector3 } from "core/Maths/math.vector";
-import type { PhysicsMotionType, PhysicsShapeType } from "core/Physics/v2";
+import { PhysicsMotionType, PhysicsShapeType } from "core/Physics/v2/IPhysicsEnginePlugin";
 import { PhysicsAggregate } from "core/Physics/v2/physicsAggregate";
 import { HavokPlugin } from "core/Physics/v2/Plugins/havokPlugin";
 import { Scene } from "core/scene";

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/childWindow.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/childWindow.tsx
@@ -190,22 +190,9 @@ export const ChildWindow: FunctionComponent<PropsWithChildren<ChildWindowProps>>
             body.style.display = "flex";
             body.style.overflow = "hidden";
 
-            const applyWindowState = () => {
-                // Setup the window state, including creating a Fluent/Griffel "renderer" for managing runtime styles/classes in the child window.
-                setWindowState({ mountNode: body, renderer: createDOMRenderer(childWindow.document) });
-                onOpenChange?.(true);
-            };
-
-            // Once the child window document is ready, setup the window state which will trigger another effect that renders into the child window.
-            if (childWindow.document.readyState === "complete") {
-                applyWindowState();
-            } else {
-                const onChildWindowLoad = () => {
-                    applyWindowState();
-                };
-                childWindow.addEventListener("load", onChildWindowLoad, { once: true });
-                disposeActions.push(() => childWindow.removeEventListener("load", onChildWindowLoad));
-            }
+            // Setup the window state, including creating a Fluent/Griffel "renderer" for managing runtime styles/classes in the child window.
+            setWindowState({ mountNode: body, renderer: createDOMRenderer(childWindow.document) });
+            onOpenChange?.(true);
 
             // When the child window is closed for any reason, transition back to a closed state.
             const onChildWindowUnload = () => {


### PR DESCRIPTION
This change fixes child windows on Firefox (and probably other non-Chromium browsers). https://forum.babylonjs.com/t/introducing-inspector-v2/60937/157

The fix is simply to remove some unnecessary code. Previously we were trying to wait for `document.readyState === "complete"`, but this is not correct and not needed. You would do this if you were actually loading a url in the child window and needing to wait for it to load, but in our case we are creating a child window and directly rendering content to it from the client side. So waiting for `document.readyState === "complete"` is not necessary, and in fact doesn't even work on some browsers (like Firefox), where the readyState is "uninitialized" and stays in that state until a page is loaded. So simply remove this code fixes the issue. Tested in Edge, Chrome, Firefox, Opera, and Safari.

Also included one tiny fix for a regression in the Inspector v2 test app (type only import when in fact the enum is needed at runtime).