### PR TITLE
Textures: Fix parsing of texture

### DIFF
--- a/packages/dev/core/src/Materials/Textures/texture.ts
+++ b/packages/dev/core/src/Materials/Textures/texture.ts
@@ -1102,7 +1102,7 @@ export class Texture extends BaseTexture {
                             },
                         };
 
-                        // name and url are the same to ensure caching happens from the actual base64 string
+                        // use the base64 string as the texture name for caching; the actual payload comes from options.buffer
                         texture = Texture.CreateFromBase64String("", parsedTexture.base64String, scene, options);
 
                         // prettier name to fit with the loaded data


### PR DESCRIPTION
See https://forum.babylonjs.com/t/texture-parse-not-parsing-usesrgbbuffer-flag/62473

The `creationFlags` and `useSRGBBuffer` properties were not correctly parsed.