### PR TITLE
[NPE] Changing overflow to wrap

### DIFF
--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphFrame.module.scss
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphFrame.module.scss
@@ -32,9 +32,9 @@
 }
 
 .frame-comment-span {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
 }
 
 .selected.frame-box-border {

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.module.scss
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.module.scss
@@ -104,14 +104,12 @@
 
 .comments {
     position: absolute;
-    top: -50px;
+    bottom: calc(100% + 5px);
     width: 200px;
-    height: 45px;
-    overflow: hidden;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
     font-style: italic;
     opacity: 0.8;
-    display: grid;
-    align-items: flex-end;
     pointer-events: none;
 }
 


### PR DESCRIPTION
The documentation for NGE says that comments must wrap instead of overflow, so updating NPE block and frame comments to behave the same way.

<img width="815" height="645" alt="image" src="https://github.com/user-attachments/assets/62e4b4cd-08e2-4c25-8af8-22b51359bb5f" />
