### PR TITLE
[InspectorV2] Fix spinbutton regression and precision bug

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
@@ -94,10 +94,17 @@ export const SpinButton = forwardRef<HTMLInputElement, SpinButtonProps>((props, 
         }
     };
 
-    // Strip the unit suffix (e.g. " deg") from the raw input value before evaluating expressions.
+    // Strip the unit suffix (e.g. "deg" or " deg") from the raw input value before evaluating expressions.
     const stripUnit = (val: string): string => {
-        if (props.unit && val.endsWith(" " + props.unit)) {
-            return val.slice(0, -(props.unit.length + 1));
+        if (!props.unit) {
+            return val;
+        }
+
+        const regex = new RegExp("\\s*" + props.unit + "$");
+        const match = val.match(regex);
+
+        if (match) {
+            return val.slice(0, -match[0].length);
         }
         return val;
     };


### PR DESCRIPTION
- Fix bug where the step precision was overwriting the value precision -- now even if step is '1', if user enters '4.5' and then uses the step button, it will go to 5.5
- If user enters a value in spin button that is greater than the defined precision, the underlying value will be persisted and when you copy the value (using copy property) you will still get precise value (even if displayvalue caps to 4)
- Fix bug where a spinbutton with a unit ('rad' or 'deg') would cause submission to revert value to prevously committed value (needed to remove the unit when doing the evaluation logic)

<img width="1203" height="348" alt="image" src="https://github.com/user-attachments/assets/9687b65b-a460-4f66-a5ef-48e8d2a9ad97" />

