### PR TITLE
[Graph tools] Fixing one pixel bug in nodes rendering

### DIFF
--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.module.scss
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.module.scss
@@ -32,12 +32,10 @@
     grid-column: 1;
     position: relative;
     border: 4px solid black;
-    border-top-right-radius: 7px;
-    border-top-left-radius: 7px;
+    border-top-right-radius: 8px;
+    border-top-left-radius: 8px;
     background: black;
     color: white;
-    transform: scaleX(1.01) translateY(-0.5px);
-    transform-origin: center;
     display: grid;
     grid-template-columns: auto 1fr auto;
     grid-template-rows: 100%;


### PR DESCRIPTION
After spending hours taking screenshots of nodes for documentation, I realized that the nodes borders are off by one pixel:

<img width="74" height="361" alt="image" src="https://github.com/user-attachments/assets/8dc0bae0-4f75-41f5-9629-3b271bd70893" />

Updated the css to fix this because I can't unsee it now:

<img width="131" height="377" alt="image" src="https://github.com/user-attachments/assets/66fd4141-7aaf-4a66-a300-30973fa665e7" />
