### PR TITLE
WebGPU: Fix crash when using SSAO with materials using needDepthPrePass

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/depthPrePass.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/depthPrePass.fx
@@ -1,4 +1,6 @@
 #ifdef DEPTHPREPASS
+#if !defined(PREPASS) && !defined(ORDER_INDEPENDENT_TRANSPARENCY)
 	fragmentOutputs.color =  vec4f(0., 0., 0., 1.0);
+#endif
 	return fragmentOutputs;
 #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/wgsl-error-when-using-webgpu-pbr-and-ssao2-rendering-pipeline/62543