### PR TITLE
[NPE] Fixing number math block

### DIFF
--- a/packages/dev/core/src/Particles/Node/Blocks/particleNumberMathBlock.ts
+++ b/packages/dev/core/src/Particles/Node/Blocks/particleNumberMathBlock.ts
@@ -66,6 +66,8 @@ export class ParticleNumberMathBlock extends NodeParticleBlock {
             NodeParticleBlockConnectionPointTypes.Vector2Gradient,
             NodeParticleBlockConnectionPointTypes.Vector3Gradient,
             NodeParticleBlockConnectionPointTypes.Color4Gradient,
+            NodeParticleBlockConnectionPointTypes.System,
+            NodeParticleBlockConnectionPointTypes.Undefined,
         ] as const;
 
         this.left.excludedConnectionPointTypes.push(...excludedConnectionPointTypes);


### PR DESCRIPTION
NumberMath should only allow Int and Float, but currently allows any type of block as input. Fixing this bug.