### PR TITLE
WebGPU: Fix crash when enabling reflection fresnel and falloff in the background material

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/background.fragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/background.fragment.fx
@@ -296,7 +296,7 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
         reflectionAmount *= planarReflectionFresnel;
 
         #ifdef REFLECTIONFALLOFF
-            var reflectionDistanceFalloff: f32 = 1.0 - saturate(length(vPositionW.xyz - uniforms.vBackgroundCenter) * uniforms.vReflectionControl.w);
+            var reflectionDistanceFalloff: f32 = 1.0 - saturate(length(fragmentInputs.vPositionW.xyz - uniforms.vBackgroundCenter) * uniforms.vReflectionControl.w);
             reflectionDistanceFalloff *= reflectionDistanceFalloff;
             reflectionAmount *= reflectionDistanceFalloff;
         #endif


### PR DESCRIPTION
See https://forum.babylonjs.com/t/webgpu-with-createdefaultenvironment-and-groundmirrorfalloffdistance-causes-crash/62549