### PR TITLE
NullEngine: createTexture: added buffer to internal texture

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.ts
+++ b/packages/dev/core/src/Engines/nullEngine.ts
@@ -723,6 +723,7 @@ export class NullEngine extends Engine {
         if (format) {
             texture.format = format;
         }
+        // Store buffer to support export/serialization and other operations.
         if (buffer) {
             texture._buffer = buffer;
         }


### PR DESCRIPTION
This PR ensures that the buffer provided in the NullEngine.createTexture function is correctly assigned to the internalTexture.

This change enables the `GLTF2Export` to include textures when running in a `NullEngine` env.
This is resolving issues where textures were missing in exported files.

Related discussion: 
* https://forum.babylonjs.com/t/nullengine-glb-export-with-textures-workaround/62541