### PR TITLE
Inspector v2: Call registerBuiltInLoaders in quick create

### DIFF
--- a/packages/dev/inspector-v2/src/extensions/quickCreate/meshes.tsx
+++ b/packages/dev/inspector-v2/src/extensions/quickCreate/meshes.tsx
@@ -11,6 +11,9 @@ import { CheckboxPropertyLine } from "shared-ui-components/fluent/hoc/propertyLi
 import type { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
 import { QuickCreateSection, QuickCreateRow, QuickCreateItem } from "./quickCreateLayout";
 import type { ISelectionService } from "../../services/selectionService";
+import { registerBuiltInLoaders } from "loaders/dynamic";
+
+registerBuiltInLoaders();
 
 const SetCamera = function (scene: Scene) {
     const camera = scene.activeCamera as ArcRotateCamera;


### PR DESCRIPTION
The Quick Create extension does not call `registerBuiltInLoaders` (or otherwise bring in any of the scene loaders, like glb), so unless the host app is already bringing these in, importing a model will fail.

https://forum.babylonjs.com/t/introducing-inspector-v2/60937/168