### PR TITLE
[InspectorV2] Fix console warn from duplicate labels 

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/hoc/fileUploadLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/fileUploadLine.tsx
@@ -18,7 +18,7 @@ export const FileUploadLine: FunctionComponent<FileUploadLineProps> = ({ onClick
     FileUploadLine.displayName = "FileUploadLine";
 
     return (
-        <LineContainer uniqueId={label}>
+        <LineContainer uniqueId={`${label}_upload`} label={label}>
             <UploadButton onUpload={onClick} accept={accept} label={label} {...buttonProps} />
         </LineContainer>
     );


### PR DESCRIPTION
Fix many cases where fileuploadline and propertyline have same label
<img width="1248" height="452" alt="image" src="https://github.com/user-attachments/assets/849a6c11-af0e-4952-afd8-9d6c44770e72" />
