### PR TITLE
[PG] Phantom files in some scenarios

### DIFF
--- a/packages/tools/playground/src/tools/monaco/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monaco/monacoManager.ts
@@ -171,7 +171,7 @@ export class MonacoManager {
                 try {
                     const lastLocal = JSON.parse(lastLocalJson) as SnippetData;
                     if (lastLocal.sessionData) {
-                        const validFiles = new Set(Object.keys(this.globalState.files || {}));
+                        const validFiles = new Set(Object.keys(this.globalState.files ?? {}));
                         const filteredOpenFiles = lastLocal.sessionData.openFiles.filter((f) => validFiles.has(f));
                         if (filteredOpenFiles.length > 0) {
                             this.globalState.openEditors = filteredOpenFiles;


### PR DESCRIPTION
When testing PG and Particles I found that in some scenarios you could get file tabs for files that don't exist.

Repro steps:

1. Open a playground you own that has 2+ files (e.g. index.ts and helper.ts)
2. Open both file tabs
3. Type something in the editor — wait at least 500ms for the debounced WriteLastLocal to fire (this saves openEditors: ["index.ts", "helper.ts"] to localStorage under your snippet token)
4. Delete helper.ts — this does NOT trigger WriteLastLocal since file deletion isn't a text edit
5. Save the playground — creates a new revision with only index.ts, but localStorage still has the stale 2-file session
6. Reload the page
7. The new revision loads with 1 file, but ReadLastLocal restores the stale openEditors → a phantom helper.ts tab appears that doesn't correspond to any file in the snippet

Fix: instead of using the sessionData files as is, get the set of files from globalState.files (the ones that came from the snippet), and validate which files actually exist. Same check for the cursorPosition.