### PR TITLE
Fix clusteredLighting bug when setting depthSlices to a value below initial value

### DIFF
--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -184,9 +184,9 @@ export class ClusteredLightContainer extends Light {
         this._uniformBuffer = new UniformBuffer(this.getEngine(), undefined, undefined, this.name);
         this._buildUniformLayout();
 
-        // CLUSTLIGHT_SLICES is a shader define that sizes the vSliceRanges UBO array.
+        // CLUSTLIGHT_SLICES is a shader define that sizes the vSliceRanges array in the UBO.
         // Materials must recompile when depthSlices changes so the shader layout matches the rebuilt UBO.
-        // Otherwise if you try to change depthSlices to a value that is smaller than the initial depthSlices, buffer is too small and rendering fails
+        // Otherwise, if depthSlices is reduced, the rebuilt UBO can be smaller than what the previously compiled shader expects, causing rendering to fail.
         this._markMeshesAsLightDirty();
     }
 


### PR DESCRIPTION
### Problem

Setting `ClusteredLightContainer.depthSlices` to a value **smaller** than the initial default causes the scene to go completely black. You can repro with https://playground.babylonjs.com/#6JYGXW#1 

### Root Cause

The `depthSlices` setter correctly rebuilds the light's uniform buffer (UBO) with the new array size, but it never notifies materials that their shaders need to be recompiled, so the old shader would be used against a UBO rebuilt for a different number of slices.

### Fix

Add `this._markMeshesAsLightDirty()` to the `depthSlices` setter. This triggers the standard dirty-flag chain:

1. `_markMeshesAsLightDirty()` → sets `_areLightsDirty = true` on every affected submesh's material defines
2. Next frame, `isReadyForSubMesh()` → calls `PrepareDefinesForLights()` (which normally early-returns when lights aren't dirty)
3. `PrepareDefinesForLights()` → calls `light.prepareLightSpecificDefines()` 
4. `prepareLightSpecificDefines()` → sets `defines["CLUSTLIGHT_SLICES"] = this._depthSlices` (the new value)
5. Material detects the define changed → recompiles shader with correct array size → UBO and shader are back in sync

(AI-written human-edited PR description)

Before
<img width="620" height="665" alt="image" src="https://github.com/user-attachments/assets/deb4f4ff-8bd2-456e-bfb5-f113181a200e" />

After
<img width="625" height="641" alt="image" src="https://github.com/user-attachments/assets/cb06a404-31e3-4779-b88a-55f7368fd8c5" />
