### PR TITLE
Slider UI fix: pointer inputs not adjusted for adaptive scaling

### DIFF
--- a/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
@@ -285,11 +285,9 @@ export class BaseSlider extends Control {
      * @internal
      */
     protected _updateValueFromPointer(x: number, y: number): void {
-        if (this.rotation != 0) {
-            this._invertTransformMatrix.transformCoordinates(x, y, this._transformedPosition);
-            x = this._transformedPosition.x;
-            y = this._transformedPosition.y;
-        }
+        this._invertTransformMatrix.transformCoordinates(x, y, this._transformedPosition);
+        x = this._transformedPosition.x;
+        y = this._transformedPosition.y;
 
         let value: number;
         if (this._isVertical) {

--- a/packages/dev/gui/src/2D/controls/sliders/imageScrollBar.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/imageScrollBar.ts
@@ -252,11 +252,9 @@ export class ImageScrollBar extends BaseSlider {
      * @internal
      */
     protected override _updateValueFromPointer(x: number, y: number): void {
-        if (this.rotation != 0) {
-            this._invertTransformMatrix.transformCoordinates(x, y, this._transformedPosition);
-            x = this._transformedPosition.x;
-            y = this._transformedPosition.y;
-        }
+        this._invertTransformMatrix.transformCoordinates(x, y, this._transformedPosition);
+        x = this._transformedPosition.x;
+        y = this._transformedPosition.y;
 
         const sign = this._invertScrollDirection ? -1 : 1;
 

--- a/packages/dev/gui/src/2D/controls/sliders/scrollBar.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/scrollBar.ts
@@ -142,11 +142,9 @@ export class ScrollBar extends BaseSlider {
      * @internal
      */
     protected override _updateValueFromPointer(x: number, y: number): void {
-        if (this.rotation != 0) {
-            this._invertTransformMatrix.transformCoordinates(x, y, this._transformedPosition);
-            x = this._transformedPosition.x;
-            y = this._transformedPosition.y;
-        }
+        this._invertTransformMatrix.transformCoordinates(x, y, this._transformedPosition);
+        x = this._transformedPosition.x;
+        y = this._transformedPosition.y;
 
         const sign = this._invertScrollDirection ? -1 : 1;
 


### PR DESCRIPTION
With adaptive scaling active, transformCoordinates is required to bring pointer inputs into the correct slider space. Otherwise input pointer may be significantly off / remapped from visuals.

Fix: always transform pointer coordinates