### PR TITLE
Fix css selector in node editor tools

### DIFF
--- a/packages/tools/nodeEditor/src/main.scss
+++ b/packages/tools/nodeEditor/src/main.scss
@@ -10,7 +10,7 @@
         overflow: hidden;
     }
 
-    .wait-screen {
+    & ~ .wait-screen {
         display: grid;
         justify-content: center;
         align-content: center;

--- a/packages/tools/nodeGeometryEditor/src/main.scss
+++ b/packages/tools/nodeGeometryEditor/src/main.scss
@@ -11,7 +11,7 @@
         overflow: hidden;
     }
 
-    .wait-screen {
+    & ~ .wait-screen {
         display: grid;
         justify-content: center;
         align-content: center;

--- a/packages/tools/nodeParticleEditor/src/main.scss
+++ b/packages/tools/nodeParticleEditor/src/main.scss
@@ -11,7 +11,7 @@
         overflow: hidden;
     }
 
-    .wait-screen {
+    & ~ .wait-screen {
         display: grid;
         justify-content: center;
         align-content: center;

--- a/packages/tools/nodeRenderGraphEditor/src/main.scss
+++ b/packages/tools/nodeRenderGraphEditor/src/main.scss
@@ -11,7 +11,7 @@
         overflow: hidden;
     }
 
-    .wait-screen {
+    & ~ .wait-screen {
         display: grid;
         justify-content: center;
         align-content: center;


### PR DESCRIPTION
All the node editors have a high level jsx structure that looks roughly like this:

```tsx
<SplitContainer id="node-editor-graph-root" ... />
<div className="wait-screen hidden">Processing...please wait</div>
```

And they all have scss that looks roughly like this:

```css
#node-editor-graph-root {
  .wait-screen { ... }
}
```

So structurally, the "root" element and the wait screen div are *siblings*, but the css is setup to have the wait screen element be a child of the "root" element. This means the css doesn't get applied. The result is that this div is both visible and makes the window overflow and get a scrollbar:
<img width="1095" height="96" alt="image" src="https://github.com/user-attachments/assets/b927faa9-82c4-425a-a467-3a9d99887787" />

I believe this only works in Playground/Sandbox because we have a lot of global css with not very unique names, and GUI Editor has a `.wait-screen` at the top level of its css, so I'm guessing this is the one getting applied. But making the scss correct for the node editors (changing the selector to be a sibling instead of a child) fixes the issue when using node editors standalone.
