### PR TITLE
Inspector v2: Fix Quick Create extension install regression

### DIFF
--- a/packages/dev/inspector-v2/src/extensions/quickCreate/meshes.tsx
+++ b/packages/dev/inspector-v2/src/extensions/quickCreate/meshes.tsx
@@ -14,6 +14,8 @@ import type { ISelectionService } from "../../services/selectionService";
 import { registerBuiltInLoaders } from "loaders/dynamic";
 import { GetRegisteredSceneLoaderPluginMetadata } from "core/Loading/sceneLoader";
 
+registerBuiltInLoaders();
+
 const SetCamera = function (scene: Scene) {
     const camera = scene.activeCamera as ArcRotateCamera;
     if (camera && camera.radius !== undefined) {
@@ -413,7 +415,6 @@ export const MeshesContent: FunctionComponent<{ scene: Scene; selectionService: 
             <QuickCreateRow>
                 <Button
                     onClick={() => {
-                        registerBuiltInLoaders();
                         fileInputRef.current?.click();
                     }}
                     label="Import Mesh"
@@ -424,7 +425,6 @@ export const MeshesContent: FunctionComponent<{ scene: Scene; selectionService: 
                         <Button
                             appearance="primary"
                             onClick={() => {
-                                registerBuiltInLoaders();
                                 fileInputRef.current?.click();
                             }}
                             label="Import"


### PR DESCRIPTION
In a recent [PR ](https://github.com/BabylonJS/Babylon.js/pull/17954) I added a call to `registerBuiltInLoaders` to the Quick Create extension so that any of our supported model types can be loaded from Quick Create even if the host app hasn't explicitly setup scene loader plugins. This works fine in the Inspector v2 test app, but causes the Quick Create extension to fail to install in the Playground. This happens because Playground uses the umd bundles, and `registerBuiltInLoaders` is in `dynamic.ts` which was not exported from `index.ts` and therefore not included in the loaders umd bundle. The reason `dynamic.ts` is not exported from `index.ts` was because:

1. It would make no sense to import it `registerBuiltInLoaders` from `index.ts` (e.g. from `"@babylonjs/loaders"`) because importing anything from `index.ts` will trigger all the side effects which would cause all the loaders to be pulled in statically which means `registerBuiltInLoaders` (which is for dynamically pulling in loaders) would do nothing.
2. For basically the same reason, `registerBuiltInLoaders` is pointless in umd because everything is bundled into a single js file, so all the loaders js code has already been downloaded and parsed.

That said, excluding it from `index.ts` means there is a missing API from umd, which means the consumer (in this case the Quick Create extension) has to write different code for umd vs es6, which we never want to be the case. I think then the only solution is to export `dynamic.ts` from `index.ts`. This might result in some incorrect usage, but it will also be addressed by the side effects workstream, so it's our best bet for the time being.