### PR TITLE
Inspector v2: Types support in Playground

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -325,7 +325,7 @@
             "label": "Playground Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": ["CDN Serve and watch (Dev)", "Watch Inspector v2"],
+            "dependsOn": ["CDN Serve and watch (Dev)"],
             "runOptions": {
                 "instanceLimit": 1
             },
@@ -379,7 +379,7 @@
             "label": "Sandbox Serve (Dev)",
             "type": "shell",
             "command": "npm",
-            "dependsOn": ["CDN Serve and watch (Dev)", "Watch Inspector v2"],
+            "dependsOn": ["CDN Serve and watch (Dev)"],
             "runOptions": {
                 "instanceLimit": 1
             },

--- a/packages/tools/playground/src/tools/monaco/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monaco/monacoManager.ts
@@ -557,6 +557,7 @@ export class MonacoManager {
             "https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.d.ts",
             "https://preview.babylonjs.com/serializers/babylonjs.serializers.d.ts",
             "https://preview.babylonjs.com/inspector/babylon.inspector.d.ts",
+            "https://preview.babylonjs.com/inspector/babylon.inspector-v2.d.ts",
             "https://preview.babylonjs.com/accessibility/babylon.accessibility.d.ts",
             "https://preview.babylonjs.com/addons/babylonjs.addons.d.ts",
             "https://preview.babylonjs.com/glTF2Interface/babylon.glTF2Interface.d.ts",


### PR DESCRIPTION
Adding the Inspector v2 umd d.ts to the list for the Monaco editor in Playground.

Also removing the now unneeded VS code task dependency for Playground/Sandbox on the Inspector v2 watch task since Inspector v2 is now consumed from umd in Playground/Sandbox.