### PR TITLE
FrameGraph: Fix undo/redo in NRGE

### DIFF
--- a/packages/dev/gui/src/2D/FrameGraph/guiTask.ts
+++ b/packages/dev/gui/src/2D/FrameGraph/guiTask.ts
@@ -49,7 +49,7 @@ export class FrameGraphGUITask extends FrameGraphTask {
                 throw new Error(`AdvancedDynamicTexture "${name}": the texture must have been created with the useStandalone property set to true`);
             }
         } else {
-            adt = AdvancedDynamicTexture.CreateFullscreenUI(name, undefined, { useStandalone: true });
+            adt = AdvancedDynamicTexture.CreateFullscreenUI(name, undefined, { useStandalone: true, scene: frameGraph.scene });
         }
         this._adt = adt;
 

--- a/packages/dev/gui/src/2D/FrameGraph/renderGraphGUIBlock.ts
+++ b/packages/dev/gui/src/2D/FrameGraph/renderGraphGUIBlock.ts
@@ -48,6 +48,7 @@ export class NodeRenderGraphGUIBlock extends NodeRenderGraphBlock {
 
         this._gui = AdvancedDynamicTexture.CreateFullscreenUI(this.name, undefined, {
             useStandalone: true,
+            scene,
         });
         this._frameGraphTask = new FrameGraphGUITask(this.name, frameGraph, this._gui);
     }

--- a/packages/tools/nodeRenderGraphEditor/src/components/preview/previewManager.ts
+++ b/packages/tools/nodeRenderGraphEditor/src/components/preview/previewManager.ts
@@ -592,6 +592,7 @@ export class PreviewManager {
         this._globalState.onResetRequiredObservable.remove(this._onResetRequiredObserver);
         this._globalState.onLightUpdated.remove(this._onLightUpdatedObserver);
 
+        this._scene.frameGraph = null;
         this._nodeRenderGraph?.dispose();
 
         this._scene.dispose();


### PR DESCRIPTION
See https://forum.babylonjs.com/t/ctrl-z-in-frame-graph-brokes-playground-demo/62620

It also fixes the GUI button disappearing in the example PG when we undo a change (though, for this to work, the GUI button must be created in `nrg.onBeforeBuildObservable` or in `nrg.onBuildObservable`, see http://playground.babylonjs.com/#JWKDME#213).