### PR TITLE
Remove aggregate.body.disableSync from XR Controllers

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerPhysics.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPhysics.ts
@@ -145,7 +145,6 @@ export class WebXRControllerPhysics extends WebXRAbstractFeature {
                         );
 
                         aggregate.body.setMotionType(PhysicsMotionType.ANIMATED);
-                        aggregate.body.disableSync = true;
 
                         const controllerMesh = xrController.grip || xrController.pointer;
                         this._controllers[xrController.uniqueId] = {
@@ -241,7 +240,6 @@ export class WebXRControllerPhysics extends WebXRAbstractFeature {
         );
 
         aggregate.body.setMotionType(PhysicsMotionType.ANIMATED);
-        aggregate.body.disableSync = true;
 
         this._controllers[xrController.uniqueId] = {
             xrController,


### PR DESCRIPTION
Removes

```ts
aggregate.body.disableSync = true;
```

It was introduced in an attempt to improve performance. It works well on emulators but break on real devices.


Can be tested in this playground: https://playground.babylonjs.com/#YN4F0X#1

CC: @docEdub 