### PR TITLE
Inspector: Fix depth peeling renderer being instantiated when we enable inspector v2

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneProperties.tsx
@@ -366,4 +366,3 @@ export const SceneRenderingProperties: FunctionComponent<{ scene: Scene; selecti
         </>
     );
 };
-


### PR DESCRIPTION
When we open Inspector v2, all these textures appear under Textures/:
<img width="348" height="758" alt="image" src="https://github.com/user-attachments/assets/347b7888-7f9b-4b55-92fd-62faa6cb4b2b" />

That's because accessing `scene.depthPeelingRenderer` creates an instance of the renderer, which in turn creates the textures.