### PR TITLE
Inspector v2: Allow metadata stringify even with functions

### DIFF
--- a/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/gizmoToolbar.tsx
@@ -67,7 +67,7 @@ export const GizmoToolbar: FunctionComponent<{ gizmoService: IGizmoService; scen
             const value = data.checkedItems[0];
             gizmoService.gizmoCamera = value === "-1" ? null : (cameras.find((camera) => camera.uniqueId.toString() === value) ?? null);
         },
-        [gizmoService]
+        [gizmoService, cameras]
     );
 
     return (
@@ -109,7 +109,7 @@ export const GizmoToolbar: FunctionComponent<{ gizmoService: IGizmoService; scen
                     </MenuPopover>
                 </Menu>
             </Collapse>
-            <Collapse visible={!!gizmoMode} orientation="horizontal">
+            <Collapse visible={!!gizmoMode && !!cameras && cameras.length > 1} orientation="horizontal">
                 <Menu positioning="below-end" checkedValues={{ cameraGizmo: [cameraGizmo?.uniqueId.toString() ?? "-1"] }} onCheckedValueChange={onCameraGizmoChange}>
                     <MenuTrigger disableButtonEnhancement={true}>
                         {(triggerProps: MenuButtonProps) => (
@@ -131,12 +131,11 @@ export const GizmoToolbar: FunctionComponent<{ gizmoService: IGizmoService; scen
                             <MenuItemRadio name="cameraGizmo" value={"-1"}>
                                 Automatic
                             </MenuItemRadio>
-                            {sceneContext.currentScene &&
-                                sceneContext.currentScene.activeCameras?.map((camera, index) => (
-                                    <MenuItemRadio key={camera.uniqueId} name="cameraGizmo" value={camera.uniqueId.toString()}>
-                                        {camera.name}
-                                    </MenuItemRadio>
-                                ))}
+                            {cameras?.map((camera) => (
+                                <MenuItemRadio key={camera.uniqueId} name="cameraGizmo" value={camera.uniqueId.toString()}>
+                                    {camera.name}
+                                </MenuItemRadio>
+                            ))}
                         </MenuList>
                     </MenuPopover>
                 </Menu>

--- a/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
@@ -84,9 +84,12 @@ function StringifyMetadata(metadata: unknown, format: boolean) {
     }
 
     if (metadata) {
-        if (ObjectCanSafelyStringify(metadata)) {
+        // Try JSON.stringify even for objects with functions — it safely omits
+        // function-valued and undefined properties. Only fall back to String()
+        // for cases that actually throw (e.g. circular references).
+        try {
             return JSON.stringify(metadata, undefined, format ? PrettyJSONIndent : undefined);
-        } else {
+        } catch {
             return String(metadata);
         }
     }


### PR DESCRIPTION
Inspector v1 classifies metadata objects as `json` if it can be stringified *without any loss* e.g. (functions), otherwise as `object`, but it still calls `JSON.stringify` regardless. Inspector v2 did not call `JSON.stringify` if the object was classified as `object` instead of `json`, which was an unintentional change in behavior. This PR fixes that.

Additionally, I included a few small fixes for the camera selector in the gizmo toolbar, including hiding it entirely when there is only one active camera.