### PR TITLE
Playground: Show strikethrough for deprecated types/functions/etc. in JS

### DIFF
--- a/packages/tools/playground/src/tools/monaco/ts/tsPipeline.ts
+++ b/packages/tools/playground/src/tools/monaco/ts/tsPipeline.ts
@@ -6,7 +6,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
  *
  */
 
-const TsOptions: typescript.CompilerOptions = {
+const TsOptions = {
     allowJs: true,
     allowSyntheticDefaultImports: true,
     esModuleInterop: true,
@@ -31,16 +31,29 @@ const TsOptions: typescript.CompilerOptions = {
     jsx: typescript.JsxEmit.ReactJSX,
     jsxFactory: "JSXAlone.createElement",
     lib: ["es2020", "dom", "dom.iterable"],
-};
+} as const satisfies typescript.CompilerOptions;
 
-const JsOptions: typescript.CompilerOptions = {
+const JsOptions = {
     ...TsOptions,
-    checkJs: false,
+    checkJs: true,
     noImplicitAny: false,
     allowJs: true,
     jsxFactory: "JSXAlone.createElement",
     jsx: typescript.JsxEmit.ReactJSX,
-};
+} as const satisfies typescript.CompilerOptions;
+
+const TsDiagnosticsOptions = {
+    noSemanticValidation: false,
+    noSyntaxValidation: false,
+    noSuggestionDiagnostics: false,
+} as const satisfies typescript.DiagnosticsOptions;
+
+const JsDiagnosticsOptions = {
+    noSemanticValidation: true,
+    noSyntaxValidation: false,
+    noSuggestionDiagnostics: false,
+} as const satisfies typescript.DiagnosticsOptions;
+
 /**
  *
  */
@@ -95,11 +108,8 @@ declare module "*.fx"   { const content: string; export default content; }`;
             ...JsOptions,
             paths: { ...this._paths },
         });
-        typescript.typescriptDefaults.setDiagnosticsOptions({
-            noSemanticValidation: false,
-            noSyntaxValidation: false,
-            noSuggestionDiagnostics: false,
-        });
+        typescript.typescriptDefaults.setDiagnosticsOptions(TsDiagnosticsOptions);
+        typescript.javascriptDefaults.setDiagnosticsOptions(JsDiagnosticsOptions);
     }
 
     addForwarder(raw: string, canonical: string) {
@@ -160,17 +170,9 @@ declare module "*.fx"   { const content: string; export default content; }`;
         const ts = typescript;
 
         // Force worker restart to pick up all models
-        ts.typescriptDefaults.setDiagnosticsOptions({
-            noSemanticValidation: false,
-            noSyntaxValidation: false,
-            noSuggestionDiagnostics: false,
-        });
+        ts.typescriptDefaults.setDiagnosticsOptions(TsDiagnosticsOptions);
 
-        ts.javascriptDefaults.setDiagnosticsOptions({
-            noSemanticValidation: false,
-            noSyntaxValidation: false,
-            noSuggestionDiagnostics: false,
-        });
+        ts.javascriptDefaults.setDiagnosticsOptions(JsDiagnosticsOptions);
     }
     private _workspaceDecls?: { ts: monaco.IDisposable; js: monaco.IDisposable };
 


### PR DESCRIPTION
When the language is set to JS, intellisense will show a strikethrough for deprecated entries. However, in the actual code, for JS only deprecated types/functions do not get a strikethrough. From what I can tell:

1. Deprecated types/functions used to be shown with some custom code analysis (codeAnalysisService.ts, `setTagCandidates`) running in a service worker. This worked for both JS and TS, and showed up with red squigglies.
2. When the "[Playground v2](https://github.com/BabylonJS/Babylon.js/pull/17175)" changes were merged, Monaco was updated, and the custom code analysis code was no longer needed since the newer Monaco natively supports showing deprecated types/functions. This shows up with a strikethrough.
3. In that same PR, the TypeScript compiler options for JS include `checkJs: false`. This means no checking at all is done, including for deprecated types/functions.

So effectively, we lost the ability to see deprecated types/functions in JS code with #17175.

The change here is to:
1. Set `checkJs: true` for JS.
2. Set `noSemanticValidation: true` for JS. (In one case it was previously `false`, but as far as I can tell that does nothing when `checkJs: false`)

With this combination, as far as I can tell the checking should still be pretty minimal for JS, but it will show the strikethrough for deprecated types/functions. If we find this adds noise to JS that we don't want, we can suppress individual diagnostic codes with the `diagnosticCodesToIgnore` option.

As a separate follow up, we should look closer at codeAnalysisService.ts as I think there is some dead code here since we no longer have the service worker. Maybe @knervous can help here?

<img width="1015" height="354" alt="image" src="https://github.com/user-attachments/assets/ddf470bc-0095-4158-aa7f-78202c97ae7c" />
