### PR TITLE
Fix error in mesh subdivide: glDrawElements: Insufficient buffer size.

### DIFF
--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -5893,4 +5893,3 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
 }
 
 RegisterClass("BABYLON.Mesh", Mesh);
-


### PR DESCRIPTION
When subdividing a mesh, it can in some cases (depending on the number of subdivisions & mesh size) cause the webgl error GL_INVALID_OPERATION: glDrawElements: Insufficient buffer size. This also causes a complete crash in webgpu mode, with a similar error.

This is caused by the startIndex + indexCount being larger than the index buffer. In this case the last submesh needs to be smaller than the rest, as the total number of indices may not perfectly divide into the subdivision size.

In mesh.subdivide, the code is already present for the last iteration, to set the indexCount to the remaining correct size, however it's based on the current index vs count, which may not be correct, due to the subdivision size being adjusted above to ensure it's a multiple of 3.

This change modifies it so that it's based off the offset & subdivision size, relative to the total indices.