### PR TITLE
Mark edge renderer line shader as non-serializable

### DIFF
--- a/packages/dev/core/src/Rendering/edgesRenderer.ts
+++ b/packages/dev/core/src/Rendering/edgesRenderer.ts
@@ -272,6 +272,7 @@ export class EdgesRenderer implements IEdgesRenderer {
             shader.disableDepthWrite = true;
             shader.backFaceCulling = false;
             shader.checkReadyOnEveryCall = scene.getEngine().isWebGPU;
+            shader.doNotSerialize = true;
 
             scene._edgeRenderLineShader = shader;
 


### PR DESCRIPTION
## Description

The internal `ShaderMaterial` created by `EdgesRenderer._GetShader()` was being included in scene serialization. Its options contain `extraInitializationsAsync` (a function), which causes `structuredClone()` to throw a `DataCloneError` when the serialized result is cloned.

**Fix:** Set `lineShader.doNotSerialize = true`, following the established pattern used by `BoundingBoxRenderer` and `LinesMesh` for their internal shaders.

## Reproduction

[Playground](https://playground.babylonjs.com/#R6IV57) — open console to see error.

## Forum Reference

https://forum.babylonjs.com/t/function-included-in-serialized-result-after-enableedgesrendering/62575