### PR TITLE
[NPE] Fix contrast on color4 block

### DIFF
--- a/packages/tools/nodeParticleEditor/src/graphSystem/display/inputDisplayManager.ts
+++ b/packages/tools/nodeParticleEditor/src/graphSystem/display/inputDisplayManager.ts
@@ -157,9 +157,11 @@ export class InputDisplayManager implements IDisplayManager {
                 case NodeParticleBlockConnectionPointTypes.Color4: {
                     const col4Value = inputBlock.value as Color4;
                     value = `(${col4Value.r.toFixed(2)}, ${col4Value.g.toFixed(2)}, ${col4Value.b.toFixed(2)}, ${col4Value.a.toFixed(2)})`;
-                    // Use black or white text for readability based on color brightness
-                    const desaturated = (col4Value.r + col4Value.g + col4Value.b) / 3;
-                    contentArea.style.color = 1 - Math.round(desaturated) ? "white" : "black";
+                    // Use black or white text for readability based on perceived luminance
+                    const luminance = 0.3 * col4Value.r + 0.59 * col4Value.g + 0.11 * col4Value.b;
+                    const effectiveLuminance = luminance * col4Value.a + (1 - col4Value.a);
+                    const isDarkBackground = effectiveLuminance < 0.5;
+                    contentArea.style.color = isDarkBackground ? "white" : "black";
                     break;
                 }
             }


### PR DESCRIPTION
In NPE, the text of the color4 block is always white, and the background of the block depends on the color the user selects, so if the user selects color white, the text is invisible.

These changes the color of the text so the color is white or black depending how close the background is to white or black, so the text will go the opposite way to make sure there is always contrast.