### PR TITLE
Inspector: Push updated metadata to react state

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
@@ -2,7 +2,7 @@ import type { FunctionComponent } from "react";
 
 import { Body1, Button, makeStyles, tokens, Tooltip } from "@fluentui/react-components";
 import { ArrowUndoRegular, BracesDismiss16Regular, BracesRegular, SaveRegular } from "@fluentui/react-icons";
-import { useContext, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
 import { ToolContext } from "shared-ui-components/fluent/hoc/fluentToolWrapper";
@@ -175,6 +175,10 @@ export const MetadataProperties: FunctionComponent<{ entity: IMetadataContainer 
     const isReadonly = canPreventObjectCorruption && preventObjectCorruption;
 
     const [editedMetadata, setEditedMetadata] = useState(stringifiedMetadata);
+    useEffect(() => {
+        setEditedMetadata(stringifiedMetadata);
+    }, [stringifiedMetadata]);
+
     const isEditedMetadataJSON = useMemo(() => IsParsable(editedMetadata), [editedMetadata]);
     const unformattedEditedMetadata = useMemo(() => Restringify(editedMetadata, false), [editedMetadata]);
 


### PR DESCRIPTION
The metadata properties was missing code that pushes updated metadata into the transient used in the component since it can edit the metadata without committing it. The bug manifests in two ways:
1. If the metadata updates at runtime, it won't immediately update in the properties pane.
2. If you select a new entity, the new entity's metadata typically won't show. https://forum.babylonjs.com/t/bug-in-inspector-v2-metadata/62626/8