### PR TITLE
Add motor stiffness and damping methods to physics constraints

### DIFF
--- a/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
+++ b/packages/dev/core/src/Physics/v2/IPhysicsEnginePlugin.ts
@@ -488,6 +488,10 @@ export interface IPhysicsEnginePluginV2 {
     getAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     setAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, maxForce: number): void;
     getAxisMotorMaxForce(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
+    setAxisMotorStiffness(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, stiffness: number): void;
+    getAxisMotorStiffness(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
+    setAxisMotorDamping(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, damping: number): void;
+    getAxisMotorDamping(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number>;
     disposeConstraint(constraint: PhysicsConstraint): void;
     getBodiesUsingConstraint(constraint: PhysicsConstraint): ConstrainedBodyPair[];
 

--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -2413,6 +2413,8 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
 
     /**
      * Sets the target of an axis motor of a constraint.
+     * Uses the explicit position/velocity target functions as recommended by the Havok API,
+     * which ensures correct behavior with non-default constraint frames (custom axisA/perpAxisA).
      *
      * @param constraint - The constraint to set the axis motor target of.
      * @param axis - The axis of the constraint to set the motor target of.
@@ -2421,12 +2423,21 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      */
     public setAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, target: number): void {
         for (const jointId of constraint._pluginData) {
-            this._hknp.HP_Constraint_SetAxisMotorTarget(jointId, this._constraintAxisToNative(axis), target);
+            const nativeAxis = this._constraintAxisToNative(axis);
+            const motorType = this._hknp.HP_Constraint_GetAxisMotorType(jointId, nativeAxis)[1];
+            if (motorType === this._hknp.ConstraintMotorType.POSITION) {
+                this._hknp.HP_Constraint_SetAxisMotorPositionTarget(jointId, nativeAxis, target);
+            } else if (motorType === this._hknp.ConstraintMotorType.VELOCITY) {
+                this._hknp.HP_Constraint_SetAxisMotorVelocityTarget(jointId, nativeAxis, target);
+            } else {
+                this._hknp.HP_Constraint_SetAxisMotorTarget(jointId, nativeAxis, target);
+            }
         }
     }
 
     /**
      * Gets the target of the motor of the given axis of the given constraint.
+     * Uses the explicit position/velocity target functions as recommended by the Havok API.
      *
      * @param constraint - The constraint to get the motor target from.
      * @param axis - The axis of the constraint to get the motor target from.
@@ -2436,7 +2447,14 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
     public getAxisMotorTarget(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
         const firstId = constraint._pluginData && constraint._pluginData[0];
         if (firstId) {
-            return this._hknp.HP_Constraint_GetAxisMotorTarget(constraint._pluginData, this._constraintAxisToNative(axis))[1];
+            const nativeAxis = this._constraintAxisToNative(axis);
+            const motorType = this._hknp.HP_Constraint_GetAxisMotorType(firstId, nativeAxis)[1];
+            if (motorType === this._hknp.ConstraintMotorType.POSITION) {
+                return this._hknp.HP_Constraint_GetAxisMotorPositionTarget(firstId, nativeAxis)[1];
+            } else if (motorType === this._hknp.ConstraintMotorType.VELOCITY) {
+                return this._hknp.HP_Constraint_GetAxisMotorVelocityTarget(firstId, nativeAxis)[1];
+            }
+            return this._hknp.HP_Constraint_GetAxisMotorTarget(firstId, nativeAxis)[1];
         }
         return null;
     }
@@ -2466,6 +2484,60 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
         const firstId = constraint._pluginData && constraint._pluginData[0];
         if (firstId) {
             return this._hknp.HP_Constraint_GetAxisMotorMaxForce(firstId, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
+    }
+
+    /**
+     * Sets the stiffness of the motor of the given constraint axis.
+     * This is used for spring-type motors to control position targeting strength.
+     * @param constraint - The constraint to set the motor stiffness for.
+     * @param axis - The axis of the constraint to set the motor stiffness for.
+     * @param stiffness - The stiffness value for the motor.
+     */
+    public setAxisMotorStiffness(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, stiffness: number): void {
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMotorStiffness(jointId, this._constraintAxisToNative(axis), stiffness);
+        }
+    }
+
+    /**
+     * Gets the stiffness of the motor of the given constraint axis.
+     * @param constraint - The constraint to get the motor stiffness from.
+     * @param axis - The axis of the constraint to get the motor stiffness from.
+     * @returns The stiffness of the motor, or null if the constraint hasn't been initialized yet.
+     */
+    public getAxisMotorStiffness(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisMotorStiffness(firstId, this._constraintAxisToNative(axis))[1];
+        }
+        return null;
+    }
+
+    /**
+     * Sets the damping of the motor of the given constraint axis.
+     * This is used for spring-type motors to control velocity targeting damping.
+     * @param constraint - The constraint to set the motor damping for.
+     * @param axis - The axis of the constraint to set the motor damping for.
+     * @param damping - The damping value for the motor.
+     */
+    public setAxisMotorDamping(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis, damping: number): void {
+        for (const jointId of constraint._pluginData) {
+            this._hknp.HP_Constraint_SetAxisMotorDamping(jointId, this._constraintAxisToNative(axis), damping);
+        }
+    }
+
+    /**
+     * Gets the damping of the motor of the given constraint axis.
+     * @param constraint - The constraint to get the motor damping from.
+     * @param axis - The axis of the constraint to get the motor damping from.
+     * @returns The damping of the motor, or null if the constraint hasn't been initialized yet.
+     */
+    public getAxisMotorDamping(constraint: PhysicsConstraint, axis: PhysicsConstraintAxis): Nullable<number> {
+        const firstId = constraint._pluginData && constraint._pluginData[0];
+        if (firstId) {
+            return this._hknp.HP_Constraint_GetAxisMotorDamping(firstId, this._constraintAxisToNative(axis))[1];
         }
         return null;
     }

--- a/packages/dev/core/src/Physics/v2/physicsConstraint.ts
+++ b/packages/dev/core/src/Physics/v2/physicsConstraint.ts
@@ -323,6 +323,44 @@ export class Physics6DoFConstraint extends PhysicsConstraint {
     public getAxisMotorMaxForce(axis: PhysicsConstraintAxis): Nullable<number> {
         return this._physicsPlugin.getAxisMotorMaxForce(this, axis);
     }
+
+    /**
+     * Sets the stiffness of the motor of the given axis of the constraint.
+     * This is used for spring-type motors to control position targeting strength.
+     * @param axis - The axis of the constraint.
+     * @param stiffness - The stiffness value for the motor.
+     */
+    public setAxisMotorStiffness(axis: PhysicsConstraintAxis, stiffness: number): void {
+        this._physicsPlugin.setAxisMotorStiffness(this, axis, stiffness);
+    }
+
+    /**
+     * Gets the stiffness of the motor of the given axis of the constraint.
+     * @param axis - The axis of the constraint.
+     * @returns The stiffness of the motor, or null if the constraint hasn't been initialized yet.
+     */
+    public getAxisMotorStiffness(axis: PhysicsConstraintAxis): Nullable<number> {
+        return this._physicsPlugin.getAxisMotorStiffness(this, axis);
+    }
+
+    /**
+     * Sets the damping of the motor of the given axis of the constraint.
+     * This is used for spring-type motors to control velocity targeting damping.
+     * @param axis - The axis of the constraint.
+     * @param damping - The damping value for the motor.
+     */
+    public setAxisMotorDamping(axis: PhysicsConstraintAxis, damping: number): void {
+        this._physicsPlugin.setAxisMotorDamping(this, axis, damping);
+    }
+
+    /**
+     * Gets the damping of the motor of the given axis of the constraint.
+     * @param axis - The axis of the constraint.
+     * @returns The damping of the motor, or null if the constraint hasn't been initialized yet.
+     */
+    public getAxisMotorDamping(axis: PhysicsConstraintAxis): Nullable<number> {
+        return this._physicsPlugin.getAxisMotorDamping(this, axis);
+    }
 }
 
 /**


### PR DESCRIPTION
Addressing https://forum.babylonjs.com/t/physics-motor-joints-with-position-mode-cant-use-a-custom-rotation-axis/62657

Root Cause The Havok WASM API has separate position and velocity target functions for constraint motors, and the Havok type declarations explicitly recommend using them:

HP_Constraint_SetAxisMotorTarget — *"The precise meaning of target depends on the type of the constraint motor. Consider using the more explicit position/velocity target functions."*

Babylon.js was only using the generic HP_Constraint_SetAxisMotorTarget, which doesn't properly handle position motors with non-default constraint frames (i.e., custom axisA/perpAxisA). The Havok API provides these specific functions that Babylon.js wasn't using:

HP_Constraint_SetAxisMotorPositionTarget / GetAxisMotorPositionTarget HP_Constraint_SetAxisMotorVelocityTarget / GetAxisMotorVelocityTarget HP_Constraint_SetAxisMotorStiffness / GetAxisMotorStiffness HP_Constraint_SetAxisMotorDamping / GetAxisMotorDamping Changes Made (3 files)
1. havokPlugin.ts
setAxisMotorTarget: Now queries the motor type first, then calls SetAxisMotorPositionTarget for POSITION motors and SetAxisMotorVelocityTarget for VELOCITY motors, falling back to the generic function for other types. getAxisMotorTarget: Same type-specific dispatch, plus fixed a bug where it passed constraint._pluginData (the full array) instead of firstId (the first element) to the Havok getter. Added setAxisMotorStiffness, getAxisMotorStiffness, setAxisMotorDamping, getAxisMotorDamping — these expose Havok's spring motor parameters that were previously inaccessible.
2. IPhysicsEnginePlugin.ts
Added setAxisMotorStiffness, getAxisMotorStiffness, setAxisMotorDamping, getAxisMotorDamping to the IPhysicsEnginePluginV2 interface.
3. physicsConstraint.ts
Added public setAxisMotorStiffness, getAxisMotorStiffness, setAxisMotorDamping, getAxisMotorDamping methods on Physics6DoFConstraint.