### PR TITLE
fix: gltf export dropping animations on meshless nodes in right-handed scenes

### DIFF
--- a/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFExporter.ts
@@ -874,25 +874,27 @@ export class GLTFExporter {
         const rootNodesLH = new Array<Node>();
         const rootNoopNodesRH = new Array<Node>();
 
-        // Collect root nodes targeted by animation groups so we don't remove them as noop nodes.
-        let animationTargetNodes: Set<Node> | undefined;
+        // Collect root nodes targeted by animation groups so we preserve them during noop removal.
+        let animGroupTargets: Set<Node> | undefined;
         if (this._options.removeNoopRootNodes && !this._options.includeCoordinateSystemConversionNodes) {
             for (const animationGroup of this._babylonScene.animationGroups) {
                 for (const targetedAnimation of animationGroup.targetedAnimations) {
                     const target = targetedAnimation.target;
                     if (target instanceof TransformNode && !target.parent) {
-                        (animationTargetNodes ??= new Set()).add(target);
+                        (animGroupTargets ??= new Set()).add(target);
                     }
                 }
             }
         }
 
         for (const rootNode of this._babylonScene.rootNodes) {
+            const animations = rootNode.animations;
+            const hasAnimations = (!!animations && animations.length > 0) || animGroupTargets?.has(rootNode);
             if (
                 this._options.removeNoopRootNodes &&
                 !this._options.includeCoordinateSystemConversionNodes &&
                 IsNoopNode(rootNode, this._babylonScene.useRightHandedSystem) &&
-                !animationTargetNodes?.has(rootNode)
+                !hasAnimations
             ) {
                 rootNoopNodesRH.push(...rootNode.getChildren());
             } else if (this._babylonScene.useRightHandedSystem) {

--- a/packages/dev/serializers/test/integration/glTFSerializer.test.ts
+++ b/packages/dev/serializers/test/integration/glTFSerializer.test.ts
@@ -581,7 +581,30 @@ describe("Babylon glTF Serializer", () => {
             expect(assertionData.scenes).toHaveLength(1);
             expect(assertionData.scenes[0].nodes).toHaveLength(2);
         });
-        it("should export animation group targeting a meshless node in a right-handed scene", async () => {
+        it("should export node animations targeting a meshless root node in a right-handed scene", async () => {
+            const assertionData = await page.evaluate(async () => {
+                window.scene!.useRightHandedSystem = true;
+                const node = new BABYLON.TransformNode("animTarget", window.scene!);
+
+                const animation = new BABYLON.Animation("posAnim", "position", 30, BABYLON.Animation.ANIMATIONTYPE_VECTOR3, BABYLON.Animation.ANIMATIONLOOPMODE_CYCLE);
+                animation.setKeys([
+                    { frame: 0, value: new BABYLON.Vector3(0, 0, 0) },
+                    { frame: 30, value: new BABYLON.Vector3(1, 1, 1) },
+                ]);
+                node.animations.push(animation);
+
+                const glTFData = await BABYLON.GLTF2Export.GLTFAsync(window.scene!, "test");
+                const jsonString = glTFData.files["test.gltf"] as string;
+                return JSON.parse(jsonString);
+            });
+            expect(assertionData.nodes).toHaveLength(1);
+            expect(assertionData.nodes[0].name).toEqual("animTarget");
+            expect(assertionData.animations).toHaveLength(1);
+            expect(assertionData.animations[0].channels).toHaveLength(1);
+            expect(assertionData.animations[0].channels[0].target.node).toEqual(0);
+            expect(assertionData.animations[0].channels[0].target.path).toEqual("translation");
+        });
+        it("should export animation group targeting a meshless root node in a right-handed scene", async () => {
             const assertionData = await page.evaluate(async () => {
                 window.scene!.useRightHandedSystem = true;
                 const node = new BABYLON.TransformNode("animTarget", window.scene!);


### PR DESCRIPTION
Root TransformNodes with identity transforms and no geometry were being
removed as "noop" nodes during export, even when targeted by animation
groups. This caused animations to silently disappear in right-handed
scenes (where these nodes don't carry a handedness-conversion transform).

Skip noop removal for any root node that is an animation group target.

## Summary
Fix: glTF exporter no longer strips root nodes that are animation group targets during noop node removal
In right-handed scenes, meshless root TransformNodes with identity transforms were classified as "noop" and removed, causing their animations to be silently dropped
In left-handed scenes this didn't surface because those nodes typically carry a handedness-conversion transform, so they weren't considered noop

## Test plan
Added integration test: export an animation group targeting a meshless TransformNode in a right-handed scene, verify the node and animation channel appear in the output
Verified test fails without the fix (nodes is undefined) and passes with it