### PR TITLE
inspector-v2: Add option for global override of GLTF loader options.

### DIFF
--- a/packages/dev/inspector-v2/src/components/tools/import/gltfLoaderOptionsTool.tsx
+++ b/packages/dev/inspector-v2/src/components/tools/import/gltfLoaderOptionsTool.tsx
@@ -4,7 +4,7 @@ import type { DropdownOption } from "shared-ui-components/fluent/primitives/drop
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
-import type { GLTFExtensionOptionsType, GLTFLoaderOptionsType } from "../../../services/panes/tools/import/gltfLoaderOptionsService";
+import type { GlobalOverrideSettingsType, GLTFExtensionOptionsType, GLTFLoaderOptionsType } from "../../../services/panes/tools/import/gltfLoaderOptionsService";
 import { PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
 import { BoundProperty } from "../../properties/boundProperty";
 
@@ -21,42 +21,51 @@ const CoordinateSystemModeOptions: DropdownOption<number>[] = [
 
 export const GLTFLoaderOptionsTool: FunctionComponent<{
     loaderOptions: GLTFLoaderOptionsType;
-}> = ({ loaderOptions }) => {
+    overrideSettings: GlobalOverrideSettingsType;
+}> = ({ loaderOptions, overrideSettings }) => {
     return (
-        <PropertyLine
-            label="Loader Options"
-            expandByDefault={false}
-            expandedContent={
-                <>
-                    <BoundProperty component={SwitchPropertyLine} label="Always compute bounding box" target={loaderOptions} propertyKey="alwaysComputeBoundingBox" />
-                    <BoundProperty component={SwitchPropertyLine} label="Always compute skeleton root node" target={loaderOptions} propertyKey="alwaysComputeSkeletonRootNode" />
-                    <BoundProperty
-                        component={NumberDropdownPropertyLine}
-                        label="Animation start mode"
-                        options={AnimationStartModeOptions}
-                        target={loaderOptions}
-                        propertyKey="animationStartMode"
-                    />
-                    <BoundProperty component={SwitchPropertyLine} label="Capture performance counters" target={loaderOptions} propertyKey="capturePerformanceCounters" />
-                    <BoundProperty component={SwitchPropertyLine} label="Compile materials" target={loaderOptions} propertyKey="compileMaterials" />
-                    <BoundProperty component={SwitchPropertyLine} label="Compile shadow generators" target={loaderOptions} propertyKey="compileShadowGenerators" />
-                    <BoundProperty
-                        component={NumberDropdownPropertyLine}
-                        label="Coordinate system"
-                        options={CoordinateSystemModeOptions}
-                        target={loaderOptions}
-                        propertyKey="coordinateSystemMode"
-                    />
-                    <BoundProperty component={SwitchPropertyLine} label="Create instances" target={loaderOptions} propertyKey="createInstances" />
-                    <BoundProperty component={SwitchPropertyLine} label="Enable logging" target={loaderOptions} propertyKey="loggingEnabled" />
-                    <BoundProperty component={SwitchPropertyLine} label="Load all materials" target={loaderOptions} propertyKey="loadAllMaterials" />
-                    <BoundProperty component={SyncedSliderPropertyLine} label="Target FPS" target={loaderOptions} propertyKey="targetFps" min={1} max={120} step={1} />
-                    <BoundProperty component={SwitchPropertyLine} label="Transparency as coverage" target={loaderOptions} propertyKey="transparencyAsCoverage" />
-                    <BoundProperty component={SwitchPropertyLine} label="Use clip plane" target={loaderOptions} propertyKey="useClipPlane" />
-                    <BoundProperty component={SwitchPropertyLine} label="Use sRGB buffers" target={loaderOptions} propertyKey="useSRGBBuffers" />
-                </>
-            }
-        />
+        <>
+            <BoundProperty component={SwitchPropertyLine} label="Override loader options globally" target={overrideSettings} propertyKey="enabled" />
+            <PropertyLine
+                label="Loader Options"
+                expandByDefault={false}
+                expandedContent={
+                    <>
+                        <BoundProperty component={SwitchPropertyLine} label="Always compute bounding box" target={loaderOptions} propertyKey="alwaysComputeBoundingBox" />
+                        <BoundProperty
+                            component={SwitchPropertyLine}
+                            label="Always compute skeleton root node"
+                            target={loaderOptions}
+                            propertyKey="alwaysComputeSkeletonRootNode"
+                        />
+                        <BoundProperty
+                            component={NumberDropdownPropertyLine}
+                            label="Animation start mode"
+                            options={AnimationStartModeOptions}
+                            target={loaderOptions}
+                            propertyKey="animationStartMode"
+                        />
+                        <BoundProperty component={SwitchPropertyLine} label="Capture performance counters" target={loaderOptions} propertyKey="capturePerformanceCounters" />
+                        <BoundProperty component={SwitchPropertyLine} label="Compile materials" target={loaderOptions} propertyKey="compileMaterials" />
+                        <BoundProperty component={SwitchPropertyLine} label="Compile shadow generators" target={loaderOptions} propertyKey="compileShadowGenerators" />
+                        <BoundProperty
+                            component={NumberDropdownPropertyLine}
+                            label="Coordinate system"
+                            options={CoordinateSystemModeOptions}
+                            target={loaderOptions}
+                            propertyKey="coordinateSystemMode"
+                        />
+                        <BoundProperty component={SwitchPropertyLine} label="Create instances" target={loaderOptions} propertyKey="createInstances" />
+                        <BoundProperty component={SwitchPropertyLine} label="Enable logging" target={loaderOptions} propertyKey="loggingEnabled" />
+                        <BoundProperty component={SwitchPropertyLine} label="Load all materials" target={loaderOptions} propertyKey="loadAllMaterials" />
+                        <BoundProperty component={SyncedSliderPropertyLine} label="Target FPS" target={loaderOptions} propertyKey="targetFps" min={1} max={120} step={1} />
+                        <BoundProperty component={SwitchPropertyLine} label="Transparency as coverage" target={loaderOptions} propertyKey="transparencyAsCoverage" />
+                        <BoundProperty component={SwitchPropertyLine} label="Use clip plane" target={loaderOptions} propertyKey="useClipPlane" />
+                        <BoundProperty component={SwitchPropertyLine} label="Use sRGB buffers" target={loaderOptions} propertyKey="useSRGBBuffers" />
+                    </>
+                }
+            />
+        </>
     );
 };
 

--- a/packages/dev/inspector-v2/src/services/panes/tools/import/gltfLoaderOptionsService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/tools/import/gltfLoaderOptionsService.tsx
@@ -11,6 +11,11 @@ import { ToolsServiceIdentity } from "../../toolsService";
 
 export const GLTFLoaderServiceIdentity = Symbol("GLTFLoaderService");
 
+// Controls whether the inspector globally overrides GLTF loader options on every load.
+// Defaults to false to avoid interfering with per-load options set by application code.
+export const GlobalOverrideSettings = { enabled: false };
+export type GlobalOverrideSettingsType = typeof GlobalOverrideSettings;
+
 // Options exposed in Inspector includes all the properties from the default loader options (GLTFLoaderDefaultOptions)
 // plus some options that only exist directly on the GLTFFileLoader class itself.
 const CurrentLoaderOptions = Object.assign(
@@ -68,7 +73,11 @@ export const GLTFLoaderOptionsServiceDefinition: ServiceDefinition<[], [IToolsSe
             if (plugin.name === "gltf") {
                 const loader = plugin as GLTFFileLoader;
 
-                // Apply loader settings
+                // Only apply loader settings when global override is explicitly enabled.
+                // When disabled (default), per-load options set by application code are preserved.
+                if (!GlobalOverrideSettings.enabled) {
+                    return;
+                }
                 Object.assign(loader, CurrentLoaderOptions);
 
                 // Subscribe to extension loading
@@ -90,7 +99,7 @@ export const GLTFLoaderOptionsServiceDefinition: ServiceDefinition<[], [IToolsSe
                 return (
                     <>
                         <MessageBar intent="info" message="Reload the file for changes to take effect" />
-                        <GLTFLoaderOptionsTool loaderOptions={CurrentLoaderOptions} />
+                        <GLTFLoaderOptionsTool loaderOptions={CurrentLoaderOptions} overrideSettings={GlobalOverrideSettings} />
                         <GLTFExtensionOptionsTool extensionOptions={CurrentExtensionOptions} />
                     </>
                 );


### PR DESCRIPTION
fix #18042 