### PR TITLE
Inspector: Use "Unnamed" for unnamed entities in scene explorer

### DIFF
--- a/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/animationGroupExplorerService.tsx
@@ -37,7 +37,7 @@ export const AnimationGroupExplorerServiceDefinition: ServiceDefinition<[], [ISc
 
                 return {
                     get name() {
-                        return namedEntity.name;
+                        return namedEntity.name || "Unnamed AnimationGroup";
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/atmosphereExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/atmosphereExplorerService.tsx
@@ -32,7 +32,7 @@ export const AtmosphereExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
 
                 return {
                     get name() {
-                        return atmosphere.name;
+                        return atmosphere.name || `Unnamed ${atmosphere.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/effectLayersExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/effectLayersExplorerService.tsx
@@ -32,7 +32,7 @@ export const EffectLayerExplorerServiceDefinition: ServiceDefinition<[], [IScene
 
                 return {
                     get name() {
-                        return effectLayer.name;
+                        return effectLayer.name || `Unnamed ${effectLayer.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/frameGraphExplorerService.tsx
@@ -34,7 +34,7 @@ export const FrameGraphExplorerServiceDefinition: ServiceDefinition<[], [ISceneE
 
                 return {
                     get name() {
-                        return frameGraph.name;
+                        return frameGraph.name || `Unnamed ${frameGraph.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -87,9 +87,9 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
                 return {
                     get name() {
                         if (IsAdvancedDynamicTexture(entity)) {
-                            return entity.name;
+                            return entity.name || `Unnamed ${entity.getClassName()}`;
                         } else {
-                            return `${entity.name ?? "No name"} [${entity.getClassName()}]`;
+                            return `${entity.name || "Unnamed"} [${entity.getClassName()}]`;
                         }
                     },
                     onChange: onChangeObservable,

--- a/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/materialExplorerService.tsx
@@ -35,7 +35,7 @@ export const MaterialExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
 
                 return {
                     get name() {
-                        return material.name;
+                        return material.name || `Unnamed ${material.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -100,7 +100,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
 
                 return {
                     get name() {
-                        return node.name;
+                        return node.name || `Unnamed ${node.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/particleSystemExplorerService.tsx
@@ -34,7 +34,7 @@ export const ParticleSystemExplorerServiceDefinition: ServiceDefinition<[], [ISc
 
                 return {
                     get name() {
-                        return particleSystem.name;
+                        return particleSystem.name || `Unnamed ${particleSystem.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/postProcessExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/postProcessExplorerService.tsx
@@ -32,7 +32,7 @@ export const PostProcessExplorerServiceDefinition: ServiceDefinition<[], [IScene
 
                 return {
                     get name() {
-                        return postProcess.name;
+                        return postProcess.name || `Unnamed ${postProcess.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/renderingPipelinesExplorerService.tsx
@@ -27,8 +27,7 @@ export const RenderingPipelineExplorerServiceDefinition: ServiceDefinition<[], [
             getEntityDisplayInfo: (pipeline) => {
                 return {
                     get name() {
-                        const typeName = pipeline.getClassName();
-                        return `${pipeline.name} (${typeName})`;
+                        return `${pipeline.name || "Unnamed"} [${pipeline.getClassName()}]`;
                     },
                 };
             },

--- a/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/skeletonExplorerService.tsx
@@ -40,7 +40,7 @@ export const SkeletonExplorerServiceDefinition: ServiceDefinition<[], [ISceneExp
 
                 return {
                     get name() {
-                        return skeletonOrBone.name;
+                        return skeletonOrBone.name || `Unnamed ${skeletonOrBone.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/soundExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/soundExplorerService.tsx
@@ -63,7 +63,7 @@ export const SoundExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplor
 
                 return {
                     get name() {
-                        return sound.name;
+                        return sound.name || `Unnamed ${sound.getClassName()}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {

--- a/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/spriteManagerExplorerService.tsx
@@ -38,7 +38,7 @@ export const SpriteManagerExplorerServiceDefinition: ServiceDefinition<[], [ISce
 
                 return {
                     get name() {
-                        return spriteEntity.name;
+                        return spriteEntity.name || `Unnamed ${spriteEntity instanceof Sprite ? spriteEntity.getClassName() : "SpriteManager"}`;
                     },
                     onChange: onChangeObservable,
                     dispose: () => {


### PR DESCRIPTION
This addresses two issues:
1. If you create an entity (like a `Material`) and don't pass the *required* name (e.g. from JS), then `name` is undefined and it causes an unhandled error in scene explorer. This is a case of incorrectly using the Babylon.js API, but we've found this is a common misuse in Playground, so let's not crash Inspector when it happens.
2. If you create an entity with an empty name (`""`), instead of seeing a blank line you will see something like "Unnamed PBRMaterial".