### PR TITLE
Fix setAndStartTimer: onAborted and onEnded both firing, missing data arg, onTick on terminal tick

### DIFF
--- a/packages/dev/core/src/Misc/timer.ts
+++ b/packages/dev/core/src/Misc/timer.ts
@@ -110,15 +110,17 @@ export function setAndStartTimer<T = any>(options: ITimerOptions<T>): Nullable<O
                 completeRate: timer / options.timeout,
                 payload,
             };
-            options.onTick && options.onTick(data);
-            if (options.breakCondition && options.breakCondition()) {
+            if (options.breakCondition && options.breakCondition(data)) {
                 options.contextObservable.remove(observer);
                 options.onAborted && options.onAborted(data);
+                return;
             }
             if (timer >= options.timeout) {
                 options.contextObservable.remove(observer);
                 options.onEnded && options.onEnded(data);
+                return;
             }
+            options.onTick && options.onTick(data);
         },
         options.observableParameters.mask,
         options.observableParameters.insertFirst,

--- a/packages/dev/core/test/unit/Misc/babylon.timer.test.ts
+++ b/packages/dev/core/test/unit/Misc/babylon.timer.test.ts
@@ -1,0 +1,202 @@
+import { Observable } from "core/Misc/observable";
+import { setAndStartTimer } from "core/Misc/timer";
+
+describe("setAndStartTimer", () => {
+    it("calls onEnded when timeout is reached", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let endedCalled = false;
+        let abortedCalled = false;
+
+        setAndStartTimer({
+            timeout: 100,
+            contextObservable: observable,
+            onEnded: () => {
+                endedCalled = true;
+            },
+            onAborted: () => {
+                abortedCalled = true;
+            },
+        });
+
+        jest.advanceTimersByTime(150);
+        observable.notifyObservers();
+
+        expect(endedCalled).toBe(true);
+        expect(abortedCalled).toBe(false);
+
+        jest.useRealTimers();
+    });
+
+    it("calls onAborted when breakCondition is met, not onEnded", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let endedCalled = false;
+        let abortedCalled = false;
+
+        setAndStartTimer({
+            timeout: 100,
+            contextObservable: observable,
+            breakCondition: () => true,
+            onEnded: () => {
+                endedCalled = true;
+            },
+            onAborted: () => {
+                abortedCalled = true;
+            },
+        });
+
+        observable.notifyObservers();
+
+        expect(abortedCalled).toBe(true);
+        expect(endedCalled).toBe(false);
+
+        jest.useRealTimers();
+    });
+
+    it("does not call onEnded when breakCondition fires at the same tick as timeout", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let endedCalled = false;
+        let abortedCalled = false;
+
+        setAndStartTimer({
+            timeout: 100,
+            contextObservable: observable,
+            breakCondition: () => true,
+            onEnded: () => {
+                endedCalled = true;
+            },
+            onAborted: () => {
+                abortedCalled = true;
+            },
+        });
+
+        // Advance past the timeout so both conditions would be true simultaneously
+        jest.advanceTimersByTime(200);
+        observable.notifyObservers();
+
+        expect(abortedCalled).toBe(true);
+        expect(endedCalled).toBe(false);
+
+        jest.useRealTimers();
+    });
+
+    it("passes data to breakCondition", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let receivedData: any = null;
+
+        setAndStartTimer({
+            timeout: 1000,
+            contextObservable: observable,
+            breakCondition: (data) => {
+                receivedData = data;
+                return true;
+            },
+        });
+
+        observable.notifyObservers();
+
+        expect(receivedData).not.toBeNull();
+        expect(typeof receivedData.startTime).toBe("number");
+        expect(typeof receivedData.deltaTime).toBe("number");
+        expect(typeof receivedData.completeRate).toBe("number");
+
+        jest.useRealTimers();
+    });
+
+    it("does not call onTick when timer ends", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let tickCalled = false;
+        let endedCalled = false;
+
+        setAndStartTimer({
+            timeout: 100,
+            contextObservable: observable,
+            onTick: () => {
+                tickCalled = true;
+            },
+            onEnded: () => {
+                endedCalled = true;
+            },
+        });
+
+        jest.advanceTimersByTime(150);
+        observable.notifyObservers();
+
+        expect(endedCalled).toBe(true);
+        expect(tickCalled).toBe(false);
+
+        jest.useRealTimers();
+    });
+
+    it("calls onTick on intermediate ticks before timeout", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let tickCount = 0;
+        let endedCalled = false;
+
+        setAndStartTimer({
+            timeout: 200,
+            contextObservable: observable,
+            onTick: () => {
+                tickCount++;
+            },
+            onEnded: () => {
+                endedCalled = true;
+            },
+        });
+
+        // First tick at 50ms - should call onTick
+        jest.advanceTimersByTime(50);
+        observable.notifyObservers();
+        expect(tickCount).toBe(1);
+        expect(endedCalled).toBe(false);
+
+        // Second tick at 100ms - should call onTick
+        jest.advanceTimersByTime(50);
+        observable.notifyObservers();
+        expect(tickCount).toBe(2);
+        expect(endedCalled).toBe(false);
+
+        // Third tick at 250ms - should call onEnded, not onTick
+        jest.advanceTimersByTime(150);
+        observable.notifyObservers();
+        expect(tickCount).toBe(2);
+        expect(endedCalled).toBe(true);
+
+        jest.useRealTimers();
+    });
+
+    it("stops firing after timeout is reached", () => {
+        jest.useFakeTimers();
+
+        const observable = new Observable<void>();
+        let endedCount = 0;
+
+        setAndStartTimer({
+            timeout: 100,
+            contextObservable: observable,
+            onEnded: () => {
+                endedCount++;
+            },
+        });
+
+        jest.advanceTimersByTime(150);
+        observable.notifyObservers();
+        observable.notifyObservers();
+        observable.notifyObservers();
+
+        expect(endedCount).toBe(1);
+
+        jest.useRealTimers();
+    });
+});


### PR DESCRIPTION
## Problem

`setAndStartTimer` in `packages/dev/core/src/Misc/timer.ts` has three bugs, all inconsistent with the `AdvancedTimer` class in the same file:

### 1. Both `onAborted` and `onEnded` fire in the same tick

When `breakCondition` returns `true` at the same tick that `timer >= timeout`, both callbacks fire. The JSDoc explicitly states:

> *"An optional break condition that will stop the times prematurely. In this case **onEnded will not be triggered!**"*

**Before:**
```typescript
if (options.breakCondition && options.breakCondition()) {
    options.contextObservable.remove(observer);
    options.onAborted && options.onAborted(data);
}
if (timer >= options.timeout) {          // still executes after abort!
    options.contextObservable.remove(observer);
    options.onEnded && options.onEnded(data);
}
```

### 2. `breakCondition` called without `data`

The `data` object is constructed but not passed to `breakCondition()`. `AdvancedTimer` correctly calls `this._breakCondition(data)`.

### 3. `onTick` fires on terminal ticks

`onTick` was called before the abort/timeout checks, so it fired even on the tick that ended the timer. `AdvancedTimer` only calls `onEachCountObservable` on intermediate ticks.

## Fix

```typescript
if (options.breakCondition && options.breakCondition(data)) {
    options.contextObservable.remove(observer);
    options.onAborted && options.onAborted(data);
    return;  // prevents onEnded from firing
}
if (timer >= options.timeout) {
    options.contextObservable.remove(observer);
    options.onEnded && options.onEnded(data);
    return;
}
options.onTick && options.onTick(data);  // only on intermediate ticks
```

## Tests

Added `packages/dev/core/test/unit/Misc/babylon.timer.test.ts` with 7 tests covering:
- Normal timeout → `onEnded` fires, `onAborted` does not
- Break condition → `onAborted` fires, `onEnded` does not
- Break condition at timeout → only `onAborted` fires (the core bug)
- `breakCondition` receives `data`
- `onTick` does not fire on the terminal tick
- `onTick` fires on intermediate ticks
- Observer is removed after timeout (no double-fire)