### PR TITLE
Add mirror behavior on scaling gizmo

### DIFF
--- a/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
+++ b/packages/dev/core/src/Gizmos/boundingBoxGizmo.ts
@@ -545,9 +545,9 @@ export class BoundingBoxGizmo extends Gizmo implements IBoundingBoxGizmo {
                     scaleBoxesDragBehavior.moveAttached = false;
                     let totalRelativeDragDistance = 0;
                     let previousScale = 0;
-                    let initialAnchorCenter = new Vector3();
-                    let initialBoxPosition = new Vector3();
-                    let initialMeshAbsolutePosition = new Vector3();
+                    const initialAnchorCenter = new Vector3();
+                    const initialBoxPosition = new Vector3();
+                    const initialMeshAbsolutePosition = new Vector3();
                     box.addBehavior(scaleBoxesDragBehavior);
                     scaleBoxesDragBehavior.onDragObservable.add((event) => {
                         this.onScaleBoxDragObservable.notifyObservers({ dragOperation: DragOperation.Scaling, dragAxis: new Vector3(i - 1, j - 1, k - 1) });


### PR DESCRIPTION
This PR adds a new behavior on scaling gizmos. When pressing ctrl on windows or alt on mac, the scaling will be mirrored around the center point. This is a follow up to this forum conversation: 

https://forum.babylonjs.com/t/boundingboxgizmo-with-adaptive-scalepivot-based-on-ctrl-opt-key/62454

Note: there is a (small I think) performance cost to support retroactive mirroring where the user can (un)press the hotkey anytime while scaling.

Question: I left a TODO, I don't really under the implementation of `incrementalSnap` and would need some pointer on how to adapt in this case. I've tried Claude on it but I'm not convinced by the suggestion.

_This is my first PR, I've tried to go through the docs to do things properly, but let me know if I missed something. Also I gotta tell you folks that running prod playground snippets locally to test things is absolutely amazing for a first time contributor like me :)_

Edit: I'm testing using playground #SG9ZZB - http://localhost:1338/#SG9ZZB