### PR TITLE
Add eslint rule to catch downlevelIteration errors in UMD builds

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -704,5 +704,28 @@ export default tseslint.config(
         rules: {
             "babylonjs/no-directory-barrel-imports": "error",
         },
+    },
+
+    // ===========================================
+    // UMD ES5 downlevel iteration guard
+    // These dev packages are compiled into UMD bundles targeting ES5
+    // without --downlevelIteration. for...of and spread on non-array
+    // iterables (Set, Map, generators, etc.) silently produce broken
+    // code. This rule catches those patterns at lint time.
+    // ===========================================
+    {
+        files: [
+            "packages/dev/core/src/**/*.ts",
+            "packages/dev/gui/src/**/*.ts",
+            "packages/dev/loaders/src/**/*.ts",
+            "packages/dev/materials/src/**/*.ts",
+            "packages/dev/serializers/src/**/*.ts",
+            "packages/dev/postProcesses/src/**/*.ts",
+            "packages/dev/proceduralTextures/src/**/*.ts",
+            "packages/dev/addons/src/**/*.ts",
+        ],
+        rules: {
+            "babylonjs/no-downlevel-iteration": "error",
+        },
     }
 );

--- a/packages/tools/eslintBabylonPlugin/src/index.ts
+++ b/packages/tools/eslintBabylonPlugin/src/index.ts
@@ -610,6 +610,104 @@ const plugin: IPlugin = {
                 };
             },
         },
+        "no-downlevel-iteration": {
+            meta: {
+                type: "problem",
+                docs: {
+                    description: "Disallow for...of loops and spread syntax on non-array iterables that break in the UMD build (ES5 target) without --downlevelIteration",
+                },
+                messages: {
+                    forOfNonArray:
+                        'for...of over a non-array iterable ({{typeName}}) will not work in the UMD build (ES5 target) without --downlevelIteration. Convert to an array first, e.g. "for (const x of Array.from(iterable))".',
+                    spreadNonArray:
+                        'Spreading a non-array iterable ({{typeName}}) will not work in the UMD build (ES5 target) without --downlevelIteration. Convert to an array first, e.g. "[...Array.from(iterable)]".',
+                },
+            },
+            create(context: eslint.Rule.RuleContext) {
+                // Access type-checker from typescript-eslint parser services
+                const parserServices = (context.sourceCode as any).parserServices;
+                if (!parserServices?.esTreeNodeToTSNodeMap || !parserServices?.program) {
+                    return {};
+                }
+
+                const checker: ts.TypeChecker = parserServices.program.getTypeChecker();
+
+                function isSafeForDownlevelIteration(type: ts.Type): boolean {
+                    // any/unknown - can't determine, assume safe
+                    if (type.getFlags() & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) {
+                        return true;
+                    }
+
+                    // String types - downlevel for-of uses index access which works (surrogate pairs aside)
+                    if (type.getFlags() & ts.TypeFlags.StringLike) {
+                        return true;
+                    }
+
+                    // Array types (Array<T>, T[], ReadonlyArray<T>)
+                    if (checker.isArrayType(type)) {
+                        return true;
+                    }
+
+                    // Tuple types ([T, U, ...])
+                    if (checker.isTupleType(type)) {
+                        return true;
+                    }
+
+                    // Union types - all members must be safe
+                    if (type.isUnion()) {
+                        return type.types.every((t) => isSafeForDownlevelIteration(t));
+                    }
+
+                    // Intersection types - if any member is safe, the whole type is safe
+                    if (type.isIntersection()) {
+                        return type.types.some((t) => isSafeForDownlevelIteration(t));
+                    }
+
+                    // Types with numeric index signature + length (covers TypedArrays, NodeList, HTMLCollection, arguments)
+                    // The downlevel for-of emit uses .length and [i] which works for these
+                    const numberIndexType = type.getNumberIndexType();
+                    if (numberIndexType && type.getProperty("length")) {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                function checkExpression(esTreeNode: ESTree.Expression, messageId: string) {
+                    try {
+                        const tsNode = parserServices.esTreeNodeToTSNodeMap.get(esTreeNode);
+                        if (!tsNode) {
+                            return;
+                        }
+
+                        const type = checker.getTypeAtLocation(tsNode);
+                        if (!isSafeForDownlevelIteration(type)) {
+                            context.report({
+                                node: esTreeNode,
+                                messageId,
+                                data: {
+                                    typeName: checker.typeToString(type),
+                                },
+                            });
+                        }
+                    } catch {
+                        // If type checking fails for any reason, don't report
+                    }
+                }
+
+                return {
+                    ForOfStatement(node: ESTree.ForOfStatement & eslint.Rule.NodeParentExtension) {
+                        checkExpression(node.right, "forOfNonArray");
+                    },
+                    SpreadElement(node: ESTree.SpreadElement & eslint.Rule.NodeParentExtension) {
+                        const parent = (node as any).parent;
+                        if (parent?.type === "ArrayExpression" || parent?.type === "CallExpression" || parent?.type === "NewExpression") {
+                            checkExpression(node.argument, "spreadNonArray");
+                        }
+                    },
+                };
+            },
+        },
         "require-context-save-before-apply-states": {
             meta: {
                 type: "problem",


### PR DESCRIPTION
Adds a new 'babylonjs/no-downlevel-iteration' eslint rule that flags for...of loops and spread syntax on non-array iterables (Set, Map, generators, etc.) in source files that feed into UMD bundles targeting ES5.

Without --downlevelIteration, TypeScript compiles for...of to a .length/[i] loop which silently breaks on non-array iterables. This rule catches those patterns at lint time so developers don't have to wait for the CI UMD build to discover them.

The rule uses type information from typescript-eslint to distinguish:
- Safe: arrays, tuples, strings, types with numeric index + length (TypedArrays, NodeList)
- Unsafe: Set, Map, IterableIterator, generators, custom iterables

Applied to packages compiled into UMD ES5: core, gui, loaders, materials, serializers, postProcesses, proceduralTextures, addons.