### PR TITLE
Inspector v2: Fix section flickering when filtering

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.tsx
@@ -13,7 +13,6 @@ import {
     SearchBox,
     Subtitle2Stronger,
     makeStyles,
-    mergeClasses,
     tokens,
 } from "@fluentui/react-components";
 import { ArrowCircleUpRegular, CheckmarkFilled, EditRegular, EyeFilled, EyeOffRegular, FilterRegular, PinFilled, PinRegular } from "@fluentui/react-icons";


### PR DESCRIPTION
In a #17866, `AccordionSection`s became conditional based on whether they are empty. However, the Accordion internally keeps track of "registered sections" (the unique id of sections in the Accordion), and making the sections conditional means they can be removed from that collection. When this happens, we get into an oscillating state where each time the Accordion renders, it goes back and forth between showing and hiding the empty sections, and it looks like it is flickering. The fix here is to not make the sections conditional, but rather just make the styling conditional, such that empty sections are not displayed (though they still exist as children of the Accordion).