### PR TITLE
Fix incorrect CDN url for draco wasm js (and possibly other CDN resources)

### DIFF
--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -550,7 +550,11 @@ export class Tools {
             } else if (Tools._CdnVersion) {
                 // If a CDN version is set (injected at build time), rewrite unversioned CDN URLs to versioned ones
                 const versionedBase = `${Tools._DefaultCdnUrl}/v${Tools._CdnVersion}`;
-                scriptUrl = scriptUrl.replace(Tools._DefaultCdnUrl, versionedBase);
+                // Guard against double-versioning if the URL already contains the version prefix
+                // (e.g. when GetBabylonScriptURL is called multiple times on the same URL)
+                if (!scriptUrl.startsWith(versionedBase)) {
+                    scriptUrl = scriptUrl.replace(Tools._DefaultCdnUrl, versionedBase);
+                }
             }
         }
 

--- a/packages/tools/ktx2Decoder/src/transcoder.ts
+++ b/packages/tools/ktx2Decoder/src/transcoder.ts
@@ -35,7 +35,11 @@ export class Transcoder {
                 wasmUrl = wasmUrl.replace(Transcoder._DefaultCdnUrl, baseUrl);
             } else if (Transcoder.CdnVersion) {
                 const versionedBase = `${Transcoder._DefaultCdnUrl}/v${Transcoder.CdnVersion}`;
-                wasmUrl = wasmUrl.replace(Transcoder._DefaultCdnUrl, versionedBase);
+                // Guard against double-versioning if the URL already contains the version prefix
+                // (e.g. when GetWasmUrl is called multiple times on the same URL)
+                if (!wasmUrl.startsWith(versionedBase)) {
+                    wasmUrl = wasmUrl.replace(Transcoder._DefaultCdnUrl, versionedBase);
+                }
             }
         }
         return wasmUrl;


### PR DESCRIPTION
Some tests are failing because they are trying to download CDN resources like this: `https://cdn.babylonjs.com/v8.54.2/v8.54.2/draco_wasm_wrapper.js`. This fails because the version got added twice. This was a regression from #18047.

Here is the AI explanation of the regression, which is correct:

```
  Yes, this is a regression from PR #18047. The root cause is that the Draco wasm wrapper URL gets
  double-processed through GetBabylonScriptURL.

  The double-processing path

   1. dracoCodec.ts:118 — URL is processed a first time: url: urlNeeded ? 
  Tools.GetBabylonScriptURL(configuration.wasmUrl, true) : "",

   https://cdn.babylonjs.com/draco_wasm_wrapper.js → https://cdn.babylonjs.com/v8.54.2/draco_wasm_wrapper.js
   2. dracoCodec.ts:148 — When numWorkers = 0, the already-rewritten URL is loaded via: await 
  Tools.LoadBabylonScriptAsync(codecInfo.url);
   3. tools.ts:573 — LoadBabylonScriptAsync calls GetBabylonScriptURL again: scriptUrl = 
  Tools.GetBabylonScriptURL(scriptUrl);

   https://cdn.babylonjs.com/v8.54.2/draco_wasm_wrapper.js still starts with https://cdn.babylonjs.com, so the 
  version is prepended again → https://cdn.babylonjs.com/v8.54.2/v8.54.2/draco_wasm_wrapper.js 💥

  Why it didn't break before PR #18047

  Before the PR, GetBabylonScriptURL only rewrote URLs when ScriptBaseUrl was set, which changes the domain (e.g.
  cdn.babylonjs.com → my-cdn.com). After rewriting, the URL no longer starts with _DefaultCdnUrl, making the
  second call a no-op. But the new _CdnVersion logic keeps the same domain, so the startsWith check matches on
  every call.

  Why it only affects numWorkers = 0

  When workers are used, the URL goes to initializeWebWorker (line 137), which doesn't call GetBabylonScriptURL
  again. The LoadBabylonScriptAsync path (line 148) is only taken when there are no workers.
```

And here is the AI explanation for why it didn't fail in the PR build for #18047:

```
● Because _CdnVersion is initialized as "" in source code:

   public static _CdnVersion = "";

  It only gets set to a real version (e.g. "8.54.2") when scripts/updateVersion.js runs during the release
  process, not during PR CI. So during the PR's test run, Tools._CdnVersion was falsy, the else if
  (Tools._CdnVersion) branch never executed, and the double-versioning never triggered.

  The bug only manifests after a version is published and the injected _CdnVersion value is baked into the build.
```