### PR TITLE
WebGPU: Fix volumetric lighting in WebGPU not working on iPhones

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -1187,7 +1187,16 @@ export class WebGPUTextureManager {
             label: `BabylonWebGPUDevice${this._engine.uniqueId}_resolveMSAADepthTexture${msaaTexture.label ? "_" + msaaTexture.label : ""}`,
             colorAttachments: [
                 {
-                    view: outputTexture,
+                    // Note: the WebGPU spec allows passing a GPUTexture directly as the view, but Safari rejects it (non-compliant).
+                    // We explicitly create a GPUTextureView to work around this Safari bug.
+                    view: outputTexture.createView({
+                        format,
+                        dimension: WebGPUConstants.TextureViewDimension.E2d,
+                        baseMipLevel: 0,
+                        mipLevelCount: 1,
+                        arrayLayerCount: 1,
+                        baseArrayLayer: 0,
+                    }),
                     loadOp: WebGPUConstants.LoadOp.Load,
                     storeOp: WebGPUConstants.StoreOp.Store,
                 },

--- a/packages/dev/core/src/ShadersWGSL/lightingVolume.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/lightingVolume.compute.fx
@@ -49,7 +49,7 @@ fn updateFarPlaneVertices(@builtin(global_invocation_id) global_id : vec3u) {
 
 @compute @workgroup_size(32, 1, 1)
 fn updatePlaneVertices(@builtin(global_invocation_id) global_id : vec3u) {
-    _ = shadowMap;
+    _ = textureDimensions(shadowMap);
 
     let uindex = global_id.x;
     let index = f32(uindex);


### PR DESCRIPTION
This is a workaround for iOS 26.3.1 which doesn't implement the spec properly (see comment in code).