### PR TITLE
Update changelog generation script for additional directories and groupings

### DIFF
--- a/scripts/generateChangelog.js
+++ b/scripts/generateChangelog.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const path = require("path");
 const fs = require("fs");
 const exec = require("child_process").exec;
@@ -16,19 +17,35 @@ function runCommand(command) {
     });
 }
 
+// Maps package directory names (under packages/dev/ or packages/tools/) to changelog
+// section headers. Multiple directories can map to the same friendly name and will be
+// grouped into a single section. Directories not listed here are excluded from the changelog.
 const friendlyNames = {
+    // packages/dev (published to npm)
     core: "Core",
     gui: "GUI",
     loaders: "Loaders",
     serializers: "Serializers",
     materials: "Materials",
-    postProcess: "Post-Process",
+    postProcesses: "Post Processes",
     proceduralTextures: "Procedural Textures",
-    inspector: "Inspector",
+    "inspector-v2": "Inspector",
+    addons: "Addons",
+    smartFilters: "Smart Filters",
+    smartFilterBlocks: "Smart Filters",
+    lottiePlayer: "Lottie Player",
+    // packages/tools (published to npm or deployed as public web apps)
     nodeEditor: "Node Editor",
-    guiEditor: "GUI Editor",
+    nodeGeometryEditor: "Node Geometry Editor",
+    nodeParticleEditor: "Node Particle Editor",
+    nodeRenderGraphEditor: "Node Render Graph Editor",
+    guiEditor: "GUI",
     playground: "Playground",
+    sandbox: "Sandbox",
     viewer: "Viewer",
+    "viewer-configurator": "Viewer",
+    smartFiltersEditor: "Smart Filters",
+    smartFiltersEditorControl: "Smart Filters",
 };
 
 const tagNames = {
@@ -174,10 +191,9 @@ async function generateChangelog(nextVersion) {
 function generateVersionMarkdown(versionPackages) {
     let markdown = "";
     const sortedPackages = Object.keys(versionPackages).sort();
-    sortedPackages.forEach((pck) => {
-        const prettyPackage = friendlyNames[pck];
+    sortedPackages.forEach((prettyPackage) => {
         markdown += `\n### ${prettyPackage}\n\n`;
-        versionPackages[pck].forEach((pr) => {
+        versionPackages[prettyPackage].forEach((pr) => {
             if (pr.tags && pr.tags.indexOf(skipChangelogTag) !== -1) {
                 return;
             }
@@ -211,15 +227,18 @@ function generateMarkdown(finalChangelog) {
     versions.forEach((version) => {
         versionChangelog[version] = {};
         finalChangelog[version].forEach((pr) => {
-            // what package was influenced by that change?
+            // Categorize the PR by which packages its changed files belong to.
+            // File paths from the GitHub API look like "packages/{dev|tools}/<package>/...",
+            // so parts[2] extracts the package directory name (e.g. "core", "viewer").
+            // Map to friendly names so that multiple directories sharing the same
+            // friendly name (e.g. smartFilters + smartFilterBlocks → "Smart Filters")
+            // are grouped into a single changelog section.
             const packageInfluenced = pr.files
                 .map((file) => {
                     const parts = file.split("/");
-                    return parts[2];
+                    return friendlyNames[parts[2]];
                 })
-                .filter((pck) => {
-                    return friendlyNames[pck];
-                });
+                .filter(Boolean);
             const packagesSet = new Set(packageInfluenced);
             packagesSet.forEach((pck) => {
                 versionChangelog[version][pck] = versionChangelog[version][pck] || [];


### PR DESCRIPTION
With the recent change #18040, we are relying on our custom changelog generation for the GitHub release notes. However, I noticed that a lot seems to be missing from this changelog, so I looked closer and saw that it appears to be very out of date. It has a mapping of directories to "friendly" (feature) names, and anything not in that list is ignored. So this PR changes two things:
- Update the list of directories to include new packages and tools introduced since last time the changelog generator script was updated.
- Change the logic slightly to allow multiple directories to map to one "friendly" (feature) name. For example, viewer and viewer-configurator both map to the feature "Viewer", and four smart filter related directories map to "Smart Filters". I think this is better for keeping the changelog concise and easy to read, but this is subjective and I'm open to other perspectives.

I tested this locally against the checked in changelog.json (raw PR history for versions) and it looked good to me.