### PR TITLE
Clustered lights: Limit batch size for mobile devices

### DIFF
--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -34,6 +34,7 @@ Node.AddNodeConstructor("Light_Type_5", (name, scene) => {
 });
 
 const DefaultDepthSlices = 16;
+const MobileClusteredLightBatchSize = 8;
 
 /**
  * A special light that renders all its associated spot or point lights using a clustered or forward+ system.
@@ -53,7 +54,7 @@ export class ClusteredLightContainer extends Light {
             }
             // Due to the use of floats we want to limit lights to the precision of floats
             // The reduced precision for mobiles is because some devices (like Samsung Galaxy) report support for R32F but actually create the texture with less precision.
-            return engine.hostInformation.isMobile ? 8 : caps.shaderFloatPrecision;
+            return engine.hostInformation.isMobile ? MobileClusteredLightBatchSize : caps.shaderFloatPrecision;
         } else {
             // WebGL 1 is not supported due to lack of dynamic for loops
             return 0;


### PR DESCRIPTION
Adjust the batch size based on device type, limiting to 8 for mobile devices.