### PR TITLE
Migrate Azure DevOps classic CI/CD pipelines to YAML

### DIFF
--- a/.azure-pipelines/cd-publish.yml
+++ b/.azure-pipelines/cd-publish.yml
@@ -1,0 +1,194 @@
+# =============================================================================
+# Publish Pipeline (Definition ID: 15)
+# Converted from Azure DevOps Classic Pipeline
+#
+# Triggered when .build/config.json is changed on master.
+# Handles versioning, building, publishing to npm, creating GitHub releases,
+# and pushing tags.
+#
+# Secret variables (configure in pipeline UI):
+#   - BASIC_AUTH
+#   - DEPLOYMENT_SERVER
+#   - GitHubPAT
+#   - NPM_TOKEN
+# =============================================================================
+
+trigger:
+    batch: true
+    branches:
+        include:
+            - master
+    paths:
+        include:
+            - .build/config.json
+
+pr: none
+
+pool:
+    vmImage: ubuntu-latest
+
+jobs:
+    - job: PublishToNpm
+      displayName: "Publish to npm"
+      steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 0
+            fetchTags: true
+
+          - task: NodeTool@0
+            displayName: "Use Node 20.x"
+            inputs:
+                versionSpec: "20.x"
+
+          - bash: |
+                git config --global user.email "bot@babylonjs.com"
+                git config --global user.name "Babylon.js Platform"
+                git remote rm origin
+                git remote add origin https://$(GitHubPAT)@github.com/BabylonJS/Babylon.js.git
+                #echo "https://$(GitHubPAT):x-oauth-basic@github.com" >> "$(HOME)/.git-credentials"
+                #git config --global --add url."git@github.com:".insteadOf "https://github.com/"
+                git remote -v
+                git fetch origin
+                git checkout $(Build.SourceBranchName)
+            displayName: "prepare git"
+
+          - bash: npm install
+            displayName: "npm install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - bash: node ./scripts/updateVersion.js $(Build.SourceBranchName)
+            displayName: "run updater"
+            env:
+                GITHUBPAT: $(GitHubPAT)
+
+          - bash: npm install
+            displayName: "Update package-lock.json"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - bash: node ./scripts/tagVersion.js $(Build.SourceBranchName)
+            displayName: "Tag the version"
+            env:
+                GITHUBPAT: $(GitHubPAT)
+
+          - bash: npm run format:fix
+            displayName: "fix formatting"
+            env:
+                GITHUBPAT: $(GitHubPAT)
+
+          - bash: npm run test:unit
+            displayName: "unit tests"
+            retryCountOnTaskFailure: 2
+
+          - bash: npm run build:umd
+            displayName: "npm build umd"
+
+          - bash: npm run build:es6
+            displayName: "npm build es6"
+
+          - bash: echo "//registry.npmjs.org/:_authToken=$(NPM_TOKEN)" > ./.npmrc
+            displayName: "write npmrc"
+
+          - bash: npm publish -ws --access=public
+            displayName: "publish latest stable (master branch)"
+            condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
+
+          - bash: npm publish -ws --tag preview
+            displayName: "publish preview (preview branch)"
+            condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'preview'))
+
+          - bash: git fetch origin
+            displayName: "fetch origin"
+
+          - bash: git merge origin/$(Build.SourceBranchName)
+            displayName: "pull master"
+
+          - bash: git push origin $(Build.SourceBranchName) --tags
+            displayName: "push to git"
+
+          - bash: |
+                npm run prepare-snapshot
+
+                zip -r $(Build.ArtifactStagingDirectory)/cdnSnapshot.zip .snapshot
+            displayName: "prepare snapshot"
+            condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
+
+          - task: GitHubRelease@1
+            displayName: "GitHub release (create)"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "BabylonJS/Babylon.js"
+                action: create
+                target: master
+                tagSource: gitTag
+                assets: "$(Build.ArtifactStagingDirectory)/cdnSnapshot.zip"
+                isDraft: false
+                isPreRelease: false
+                addChangeLog: false
+                releaseNotesFilePath: ".build/release-notes.md"
+
+          - bash: |
+                pv=$(jq -r '.version' ./packages/public/umd/babylonjs/package.json)
+                echo "##vso[task.setvariable variable=PackageVersion]${pv}"
+            displayName: "Get version"
+            continueOnError: true
+
+          - script: |
+                cd .snapshot
+                zip -r ../snapshot.zip *
+                cd ..
+
+                curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+                  -H "Content-Type: multipart/form-data" \
+                  -H "Authorization: $(BASIC_AUTH)" \
+                  -F "path=cdn/master/v$(PackageVersion)" \
+                  -F "storageAccount=babylonsnapshots" \
+                  -F "saveZip=true" \
+                  -F "zip=@snapshot.zip"
+            displayName: "Update snapshot"
+
+          - task: Npm@1
+            displayName: "run build -w @tools/tests"
+            inputs:
+                command: custom
+                customCommand: "run build -w @tools/tests"
+
+          - task: Npm@1
+            displayName: "npm generate modules size"
+            inputs:
+                command: custom
+                customCommand: "run generate-file-size-report -w @tools/tests"
+
+          - script: |
+                # filesize
+                cd packages/tools/tests/dist
+                zip ../../../../fileSize.zip fileSizes.json
+                cd ../../../..
+
+                curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+                  -H "Content-Type: multipart/form-data" \
+                  -H "Authorization: $(BASIC_AUTH)" \
+                  -F "path=cdn/master/v$(PackageVersion)" \
+                  -F "storageAccount=babylonsnapshots" \
+                  -F "zip=@fileSize.zip"
+            displayName: "Update snapshot modules size"
+
+          # DISABLED in classic pipeline:
+          # - script: |
+          #     node ./packages/public/@babylonjs/inspector-v2/prepublish.cjs
+          #     node ./packages/public/umd/babylonjs-inspector-v2/prepublish.cjs
+          #   displayName: 'Run inspector v2 preview script'
+
+          # - script: npm install
+          #   displayName: 'npm install (for @babylonjs/inspector-v2 -> @babylonjs/inspector)'
+
+          # - script: |
+          #     npm publish -w @babylonjs/inspector --tag preview
+          #     npm publish -w babylonjs-inspector --tag preview
+          #   displayName: 'publish inspector v2 preview'

--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -1,0 +1,260 @@
+# =============================================================================
+# CD-Tools Pipeline (Definition ID: 16)
+# Converted from Azure DevOps Classic Pipeline
+#
+# Builds and deploys all tools (Playground, Sandbox, NME, NGE, NRGE,
+# GUI Editor, NPE) to production storage after a successful publish.
+#
+# Triggers:
+#   - Schedule: midnight PST on Tue/Wed/Fri/Sat (daysToBuild: 22)
+#   - Build completion from Publish pipeline (ID: 15)
+#
+# Secret variables (configure in pipeline UI):
+#   - BASIC_AUTH
+#   - DEPLOYMENT_SERVER
+# =============================================================================
+
+trigger: none
+pr: none
+
+schedules:
+    # Midnight PST = 08:00 UTC
+    # daysToBuild 22 = binary 10110 = Tue,Wed,Fri,Sat
+    # (Azure classic uses bit flags: Mon=1,Tue=2,Wed=4,Thu=8,Fri=16,Sat=32,Sun=64)
+    # 22 = 2+4+16 = Tue,Wed,Fri
+    - cron: "0 8 * * 2,3,5"
+      displayName: Scheduled tools deployment
+      branches:
+          include:
+              - master
+      always: false
+
+resources:
+    pipelines:
+        - pipeline: publishPipeline
+          source: "Publish pipeline" # Update with actual pipeline name
+          trigger:
+              branches:
+                  include:
+                      - master
+
+pool:
+    vmImage: ubuntu-latest
+
+jobs:
+    - job: BuildTools
+      displayName: "Build tools"
+      steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 1
+            fetchTags: true
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: Npm@1
+            displayName: "npm install"
+            retryCountOnTaskFailure: 2
+            inputs:
+                command: install
+
+          # DISABLED in classic pipeline:
+          # - task: Npm@1
+          #   displayName: 'npm update-version (for smart filters)'
+          #   inputs:
+          #     command: custom
+          #     customCommand: 'run update-version -w @dev/smart-filters'
+
+          - task: Npm@1
+            displayName: "build dev"
+            inputs:
+                command: custom
+                customCommand: "run build:dev"
+
+          # DISABLED in classic pipeline:
+          # - task: Npm@1
+          #   displayName: 'build smart filters core'
+          #   inputs:
+          #     command: custom
+          #     customCommand: 'run build:source:smart-filters'
+
+          - task: Npm@1
+            displayName: "build playground"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/playground"
+
+          - task: Npm@1
+            displayName: "build sandbox"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/sandbox"
+
+          - task: Npm@1
+            displayName: "build gui editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/gui-editor"
+
+          - task: Npm@1
+            displayName: "build node editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-editor"
+
+          - task: Npm@1
+            displayName: "build node geometry editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-geometry-editor"
+
+          - task: Npm@1
+            displayName: "build node graph editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-render-graph-editor"
+
+          - task: Npm@1
+            displayName: "build node particle editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-particle-editor"
+
+          # DISABLED in classic pipeline:
+          # - task: Npm@1
+          #   displayName: 'build smart filters editor'
+          #   inputs:
+          #     command: custom
+          #     customCommand: 'run build:deployment -w @tools/smart-filters-editor'
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/sandbox"
+                deployPath: "sandbox"
+                storageAccount: "babylontools"
+                displayName: "Sandbox deployment"
+                purgeEndpoint: "babylonjssandbox"
+                purgeProfile: "babylonjssandbox"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/playground"
+                deployPath: "playground"
+                storageAccount: "babylontools"
+                displayName: "Playground deployment"
+                purgeEndpoint: "babylonjsplayground"
+                purgeProfile: "babylonjsplayground"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeEditor"
+                deployPath: "nodeEditor"
+                storageAccount: "babylontools"
+                displayName: "NME deployment"
+                purgeEndpoint: "babylonjsnodeeditor"
+                purgeProfile: "babylonjstools"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeGeometryEditor"
+                deployPath: "nodeGeometryEditor"
+                storageAccount: "babylontools"
+                displayName: "NGE deployment"
+                purgeEndpoint: "node-geometry-editor"
+                purgeProfile: "babylonjstools"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeRenderGraphEditor"
+                deployPath: "nodeRenderGraphEditor"
+                storageAccount: "babylontools"
+                displayName: "NRGE deployment"
+                purgeEndpoint: "node-render-graph-editor"
+                purgeProfile: "babylonjstools"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/guiEditor"
+                deployPath: "guiEditor"
+                storageAccount: "babylontools"
+                displayName: "GUI Editor deployment"
+                purgeEndpoint: "babylonjsguieditor"
+                purgeProfile: "babylonjstools"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeParticleEditor"
+                deployPath: "nodeParticleEditor"
+                storageAccount: "babylontools"
+                displayName: "NPE deployment"
+                purgeEndpoint: "node-particle-editor"
+                purgeProfile: "babylonjstools"
+
+          # DISABLED in classic pipeline:
+          # - script: |
+          #     # sfe
+          #     cd packages/tools/smartFiltersEditor/dist
+          #     zip -r ../../../../dist.zip *
+          #     cd ..
+          #     cd public
+          #     zip -r ../../../../public.zip *
+          #     cd ../../../..
+          #
+          #     curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+          #       -H "Content-Type: multipart/form-data" \
+          #       -H "Authorization: $(BASIC_AUTH)" \
+          #       -F "path=smartFiltersEditor" \
+          #       -F "storageAccount=babylontools" \
+          #       -F "zip=@dist.zip"
+          #     curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+          #       -H "Content-Type: multipart/form-data" \
+          #       -H "Authorization: $(BASIC_AUTH)" \
+          #       -F "path=smartFiltersEditor" \
+          #       -F "storageAccount=babylontools" \
+          #       -F "zip=@public.zip"
+          #
+          #     curl "$(DEPLOYMENT_SERVER)/purgeTest?endpoint=smart-filters-editor&profileName=babylonjstools&wait=true" -i -H "Authorization: $(BASIC_AUTH)"
+          #   displayName: 'SFE deployment'
+
+          # DISABLED in classic pipeline - Azure CLI upload and purge steps:
+          # - task: AzureCLI@2
+          #   displayName: 'Upload tools to storage'
+          #   inputs:
+          #     azureSubscription: 'de3af4a1-32cc-400a-9c3f-3482bc46da6f'
+          #     scriptType: bash
+          #     scriptLocation: inlineScript
+          #     inlineScript: |
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/sandbox" --account-name "babylontools" --source "./packages/tools/sandbox/dist" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/sandbox" --account-name "babylontools" --source "./packages/tools/sandbox/public" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/playground" --account-name "babylontools" --source "./packages/tools/playground/dist" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/playground" --account-name "babylontools" --source "./packages/tools/playground/public" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/nodeEditor" --account-name "babylontools" --source "./packages/tools/nodeEditor/dist" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/nodeEditor" --account-name "babylontools" --source "./packages/tools/nodeEditor/public" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/guiEditor" --account-name "babylontools" --source "./packages/tools/guiEditor/dist" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/guiEditor" --account-name "babylontools" --source "./packages/tools/guiEditor/public" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/nodeGeometryEditor" --account-name "babylontools" --source "./packages/tools/nodeGeometryEditor/dist" --overwrite true
+          #       az storage blob upload-batch --auth-mode login --destination "\$web/nodeGeometryEditor" --account-name "babylontools" --source "./packages/tools/nodeGeometryEditor/public" --overwrite true
+
+          # - task: AzureCLI@2
+          #   displayName: 'Purge cache'
+          #   inputs:
+          #     azureSubscription: 'de3af4a1-32cc-400a-9c3f-3482bc46da6f'
+          #     scriptType: bash
+          #     scriptLocation: inlineScript
+          #     inlineScript: |
+          #       az afd endpoint purge -g babylonMsTools --endpoint-name babylonjsnodeeditor --profile-name babylonjstools --content-paths "/*"
+          #       az afd endpoint purge -g babylonMsTools --endpoint-name babylonjsguieditor --profile-name babylonjstools --content-paths "/*"
+          #       az afd endpoint purge -g babylonMsTools --endpoint-name babylonjsplayground --profile-name babylonjsplayground --content-paths "/*"
+
+          # - task: AzureCLI@2
+          #   displayName: 'Purge cache part 2'
+          #   inputs:
+          #     azureSubscription: 'de3af4a1-32cc-400a-9c3f-3482bc46da6f'
+          #     scriptType: bash
+          #     scriptLocation: inlineScript
+          #     inlineScript: |
+          #       az afd endpoint purge -g babylonMsTools --endpoint-name babylonjssandbox --profile-name babylonjssandbox --content-paths "/*"
+          #       az afd endpoint purge -g babylonMsTools --endpoint-name node-geometry-editor --profile-name babylonjstools --content-paths "/*"

--- a/.azure-pipelines/ci-browser-testing.yml
+++ b/.azure-pipelines/ci-browser-testing.yml
@@ -1,0 +1,166 @@
+# =============================================================================
+# Browser Testing Pipeline (Definition ID: 27)
+# Converted from Azure DevOps Classic Pipeline
+#
+# Scheduled nightly pipeline that runs WebGL2 visualization tests on
+# Webkit, Firefox, and compiles with Google Closure Compiler.
+#
+# Schedule: 1:00 AM PST daily (09:00 UTC)
+#
+# Secret variables (configure in pipeline UI):
+#   - ACCESS_KEY (BrowserStack)
+#   - USERNAME (BrowserStack)
+# =============================================================================
+
+trigger: none
+pr: none
+
+schedules:
+    # 1:00 AM PST = 09:00 UTC, all days (daysToBuild: 31)
+    - cron: "0 9 * * *"
+      displayName: Nightly browser testing
+      branches:
+          include:
+              - master
+      always: false
+
+variables:
+    system.debug: false
+
+pool:
+    vmImage: ubuntu-latest
+
+jobs:
+    # ============================================================================
+    # WEBKIT WEBGL2 TESTS
+    # ============================================================================
+    - job: WebkitWebGL2
+      displayName: "Webkit WebGL2 tests"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - script: npm install
+            displayName: "NPM install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: npm run test:playwright -w @tools/tests -- --project=webgl2
+            displayName: "Run tests (Webkit)"
+            env:
+                CDN_BASE_URL: "https://cdn.babylonjs.com"
+                CI: "true"
+                BROWSER: "BrowserStack"
+                TIMEOUT: "20000"
+                BROWSERSTACK_USERNAME: $(USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(ACCESS_KEY)
+                BROWSERSTACK_BROWSER: "playwright-webkit@latest:OSX Sonoma"
+                EXCLUDE_REGEX_ARRAY: "Picking Visual Test,GUI Input Test,Export GLTF Extension KHR_texture_transform,PBR refraction,Procedural textures playground,GLTF Serializer Morph Target Animation,GLTF Serializer KHR materials clearcoat,Motion Blur"
+                SCREENSHOT_MAX_PIXEL: "6"
+                SCREENSHOT_THRESHOLD: "0.05"
+
+          - task: PublishTestResults@2
+            displayName: "Publish Test Results"
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./packages/tools/tests/junit.xml"
+
+    # ============================================================================
+    # FIREFOX WEBGL2 TESTS
+    # ============================================================================
+    - job: FirefoxWebGL2
+      displayName: "Firefox WebGL2 tests"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - script: npm install
+            displayName: "NPM install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: npm run test:playwright -w @tools/tests -- --project=webgl2
+            displayName: "Run tests (Firefox)"
+            env:
+                CDN_BASE_URL: "https://cdn.babylonjs.com"
+                CI: "true"
+                BROWSER: "BrowserStack"
+                TIMEOUT: "20000"
+                BROWSERSTACK_USERNAME: $(USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(ACCESS_KEY)
+                BROWSERSTACK_BROWSER: "playwright-firefox@latest:OSX Sonoma"
+                EXCLUDE_REGEX_ARRAY: "Procedural textures playground,Normed 16 bits texture formats"
+                SCREENSHOT_THRESHOLD: "0.05"
+                SCREENSHOT_MAX_PIXEL: "5"
+
+          - task: PublishTestResults@2
+            displayName: "Publish Test Results"
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./packages/tools/tests/junit.xml"
+
+    # ============================================================================
+    # COMPILE WITH CLOSURE
+    # Builds UMD with ES2020 target and validates with Google Closure Compiler
+    # ============================================================================
+    - job: ClosureCompile
+      displayName: "Compile with closure"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: JavaToolInstaller@0
+            displayName: "Use Java 21"
+            inputs:
+                versionSpec: "21"
+                jdkArchitectureOption: x64
+                jdkSourceOption: PreInstalled
+
+          - script: |
+                npm install
+                npm i google-closure-compiler
+            displayName: "NPM install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: |
+                sed -i 's/ES5/ES2020/g' ./packages/public/umd/babylonjs/tsconfig.build.json
+                sed -i 's/ES5/ES2020/g' ./packages/public/umd/babylonjs-loaders/tsconfig.build.json
+                sed -i 's/ES5/ES2020/g' ./packages/public/umd/babylonjs-serializers/tsconfig.build.json
+            displayName: "change to ES2020"
+
+          - task: Npm@1
+            displayName: "build"
+            inputs:
+                command: custom
+                customCommand: "run build:umd"
+
+          - script: npx google-closure-compiler --js ./packages/public/umd/babylonjs/babylon.max.js --js_output_file file.out.js
+            displayName: "Test core"
+
+          - script: npx google-closure-compiler --js ./packages/public/umd/babylonjs-loaders/babylonjs.loaders.js --js_output_file loaders.out.js
+            displayName: "Test loaders"
+
+          - script: npx google-closure-compiler --js ./packages/public/umd/babylonjs-serializers/babylonjs.serializers.js --js_output_file serializers.out.js
+            displayName: "Test serializers"

--- a/.azure-pipelines/ci-graph-tools.yml
+++ b/.azure-pipelines/ci-graph-tools.yml
@@ -1,0 +1,170 @@
+# =============================================================================
+# GraphTools-CI Pipeline (Definition ID: 33)
+# Converted from Azure DevOps Classic Pipeline
+#
+# Triggers on PRs that touch graph tool editor files.
+# Builds NME, NGE, NRGE, GUI Editor, NPE, deploys snapshots, and runs
+# Playwright tests.
+#
+# Secret variables (configure in pipeline UI):
+#   - BASIC_AUTH
+#   - DEPLOYMENT_SERVER
+# =============================================================================
+
+trigger: none
+
+pr:
+    branches:
+        include:
+            - master
+    paths:
+        include:
+            - packages/tools/nodeEditor/**/*.*
+            - packages/tools/nodeGeometryEditor/**/*.*
+            - packages/tools/nodeRenderGraphEditor/**/*.*
+            - packages/tools/guiEditor/**/*.*
+            - packages/dev/sharedUiComponents/**/*.*
+            - packages/dev/buildTools/src/webpackTools.ts
+            - "**/*interaction.tools*"
+
+variables:
+    BuildName: $(Build.SourceBranch)
+
+pool:
+    vmImage: ubuntu-latest
+
+jobs:
+    - job: TestTools
+      displayName: "Test tools"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: Npm@1
+            displayName: "npm install"
+            inputs:
+                command: install
+
+          - task: Npm@1
+            displayName: "npm build:dev"
+            inputs:
+                command: custom
+                customCommand: "run build:dev"
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "TOOLS/$(BuildName)"
+                displayName: "Check snapshot existence"
+
+          - task: Npm@1
+            displayName: "npm build nodeEditor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-editor"
+
+          - task: Npm@1
+            displayName: "npm build nodeGeometryEditor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-geometry-editor"
+
+          - task: Npm@1
+            displayName: "npm build nodeRenderGraphEditor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-render-graph-editor"
+
+          - task: Npm@1
+            displayName: "npm build guiEditor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/gui-editor"
+
+          - task: Npm@1
+            displayName: "npm build nodeParticleEditor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/node-particle-editor"
+
+          - template: templates/wait-for-snapshot.yml
+            parameters:
+                displayName: "Wait for Babylon snapshot"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeEditor"
+                deployPath: "TOOLS/$(BuildName)/nodeEditor"
+                displayName: "Deploy NME"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeGeometryEditor"
+                deployPath: "TOOLS/$(BuildName)/nodeGeometryEditor"
+                displayName: "Deploy NGE"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeRenderGraphEditor"
+                deployPath: "TOOLS/$(BuildName)/nodeRenderGraphEditor"
+                displayName: "Deploy NRGE"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/guiEditor"
+                deployPath: "TOOLS/$(BuildName)/guiEditor"
+                displayName: "Deploy GUI Editor"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/nodeParticleEditor"
+                deployPath: "TOOLS/$(BuildName)/nodeParticleEditor"
+                displayName: "Deploy NPE"
+
+          - script: |
+                npx playwright install --with-deps
+                npx playwright test --project=graphTools
+            displayName: "Test tools"
+            env:
+                CI: "true"
+                BROWSER: "Chrome"
+                NME_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeEditor/"
+                NGE_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeGeometryEditor/"
+                NRGE_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeRenderGraphEditor/"
+                GUIEDITOR_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/guiEditor/"
+                SNAPSHOT: "$(BuildName)"
+
+          - template: templates/upload-test-results.yml
+            parameters:
+                deployPath: "TOOLS/$(BuildName)/testResults"
+
+          - task: GitHubComment@0
+            displayName: "Tests failed message"
+            condition: failed()
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Graph tools CI has failed you can find the test results at:
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/testResults/
+
+          - task: GitHubComment@0
+            displayName: "Tests success"
+            condition: succeeded()
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    You have made possible changes to one or more graph tools. To test the snapshots:
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeEditor/
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeGeometryEditor/
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeParticleEditor/
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/nodeRenderGraphEditor/
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/TOOLS/$(BuildName)/guiEditor/

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -1,0 +1,1110 @@
+# =============================================================================
+# CI-Monorepo Pipeline - Babylon.js
+# Converted from Azure DevOps Classic Pipeline (Definition ID: 14)
+#
+# IMPORTANT SETUP NOTES:
+# 1. Secret variables must be configured in the Azure DevOps pipeline UI:
+#    - BASIC_AUTH
+#    - BROWSERSTACK_ACCESS_KEY
+#    - BROWSERSTACK_USERNAME
+#    - DEPLOYMENT_SERVER
+#
+# 2. Fork build settings (allow secrets, require comments for non-team members)
+#    must be configured in the Azure DevOps pipeline settings UI.
+#
+# 3. The GitHubComment tasks use service connection ID
+#    '64b7b35d-c231-434d-a365-b23a07bef5aa'. Ensure this service connection
+#    exists and is authorized for this pipeline.
+#
+# 4. Update the 'resources.pipelines' source names to match your actual
+#    pipeline names in Azure DevOps.
+# =============================================================================
+
+trigger:
+    batch: true
+    branches:
+        include:
+            - master
+    paths:
+        exclude:
+            - .build/config.json
+            - CHANGELOG.md
+
+pr:
+    branches:
+        include:
+            - master
+
+schedules:
+    # Classic pipeline: midnight PST on Mon, Tue, Wed, Fri (daysToBuild: 23)
+    # Cron is in UTC: midnight PST = 08:00 UTC
+    - cron: "0 8 * * 1,2,3,5"
+      displayName: Scheduled build
+      branches:
+          include:
+              - master
+      always: false # Only run if there are changes
+
+resources:
+    pipelines:
+        # Build completion trigger - pipeline ID 15
+        - pipeline: buildCompletionTrigger
+          source: "TODO-Pipeline-15-Name" # Update with actual pipeline name
+          trigger:
+              branches:
+                  include:
+                      - master
+        # Native tests artifact source - pipeline ID 36
+        - pipeline: nativeTestsArtifact
+          source: "TODO-Pipeline-36-Name" # Update with actual pipeline name
+          project: ContinousIntegration
+
+variables:
+    BuildName: $(Build.SourceBranch)
+    BROWSERSTACK_BROWSER: "chrome@143:OSX Sonoma"
+    system.debug: false
+
+pool:
+    vmImage: ubuntu-latest
+
+jobs:
+    # ============================================================================
+    # BUILD JOB
+    # Builds UMD packages, prepares and uploads snapshot, posts PR comments
+    # No dependencies - runs immediately
+    # ============================================================================
+    - job: Build
+      displayName: "Build job"
+      steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 0
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - bash: |
+                git diff --name-status $(git rev-parse origin/master) $(git rev-parse HEAD) | grep -q "what's new.md" && echo "##vso[task.setvariable variable=WhatsNewChanged]true"
+                git diff --name-status $(git rev-parse origin/master) $(git rev-parse HEAD) | grep -q "package.json" && echo "##vso[task.setvariable variable=PackageJsonChanged]true"
+                git diff --name-status $(git rev-parse origin/master) $(git rev-parse HEAD) | grep -q ".build/config.json" && echo "##vso[task.setvariable variable=ConfigJsonChanged]true"
+                git diff --name-status $(git rev-parse origin/master) $(git rev-parse HEAD) | grep -q "smartFilter" && echo "##vso[task.setvariable variable=SmartFiltersChanged]true"
+
+                git diff --name-status $(git rev-parse origin/master) $(git rev-parse HEAD)
+            displayName: "Check git changes"
+            continueOnError: true
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "$(BuildName)"
+
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/delete?path=$(BuildName)" -X POST -H "Authorization: $(BASIC_AUTH)"
+            displayName: "Clear snapshot"
+            condition: and(succeeded(), eq(variables['SNAPSHOTEXISTS'], 'true'), not(eq(variables['Build.SourceBranchName'], 'master')))
+
+          - task: GitHubComment@0
+            displayName: "Tag your PR!"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['SNAPSHOTEXISTS'], 'false'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Please make sure to label your PR with "bug", "new feature" or "breaking change" label(s).
+                    To prevent this PR from going to the changelog marked it with the "skip changelog" label.
+
+          - task: GitHubComment@0
+            displayName: "What's new comment"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['WHATSNEWCHANGED'], 'true'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    There is no need to update the "what's new.md" file. A changelog will be generated using the PR and its tags.
+
+          - task: GitHubComment@0
+            displayName: "Did package.json changed?"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['PACKAGEJSONCHANGED'], 'true'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Reviewer - this PR has made changes to one or more package.json files.
+
+          - task: GitHubComment@0
+            displayName: "Did build directory changed"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['CONFIGJSONCHANGED'], 'true'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Reviewer - this PR has made changes to the build configuration file.
+
+                    *This build will release a new package on npm*
+
+                    If that was unintentional please make sure to revert those changes or close this PR.
+
+          - script: npm install
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - task: Npm@1
+            displayName: "npm build umd"
+            inputs:
+                command: custom
+                customCommand: "run build:umd"
+
+          - task: Npm@1
+            displayName: "npm build smart filters"
+            condition: and(succeeded(), eq(variables['SMARTFILTERSCHANGED'], 'true'))
+            inputs:
+                command: custom
+                customCommand: "run build:source:smart-filters"
+
+          - task: Npm@1
+            displayName: "npm build smart filters editor"
+            condition: and(succeeded(), eq(variables['SMARTFILTERSCHANGED'], 'true'))
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/smart-filters-editor"
+
+          - task: Npm@1
+            displayName: "Prepare snapshot"
+            inputs:
+                command: custom
+                customCommand: "run prepare-snapshot"
+
+          - task: Npm@1
+            displayName: "Test es version of UMD packages"
+            continueOnError: true
+            inputs:
+                command: custom
+                customCommand: "run test:escheck"
+
+          - task: Npm@1
+            displayName: "Test UMD build"
+            inputs:
+                command: custom
+                customCommand: "run build -w babylonjs-testproject"
+
+          - script: |
+                mkdir .snapshot/smartFiltersEditor
+                cp -r packages/tools/smartFiltersEditor/dist/* .snapshot/smartFiltersEditor
+            displayName: "Add Smart Filters Editor to snapshot"
+            condition: and(succeeded(), eq(variables['SMARTFILTERSCHANGED'], 'true'))
+
+          - script: |
+                cd .snapshot
+                zip -r ../snapshot.zip *
+                cd ..
+
+                curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+                  -H "Content-Type: multipart/form-data" \
+                  -H "Authorization: $(BASIC_AUTH)" \
+                  -F "path=$(BuildName)" \
+                  -F "storageAccount=babylonsnapshots" \
+                  -F "saveZip=true" \
+                  -F "zip=@snapshot.zip"
+            displayName: "Upload snapshot"
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['SNAPSHOTEXISTS'], 'false'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Snapshot stored with reference name:
+                    $(BuildName)
+
+                    Test environment:
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/index.html
+
+                    To test a playground add it to the URL, for example:
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/index.html#WGZLGJ#4600
+
+                    Links to test your changes to core in the published versions of the Babylon tools (does not contain changes you made to the tools themselves):
+
+                    https://playground.babylonjs.com/?snapshot=$(BuildName)
+                    https://sandbox.babylonjs.com/?snapshot=$(BuildName)
+                    https://gui.babylonjs.com/?snapshot=$(BuildName)
+                    https://nme.babylonjs.com/?snapshot=$(BuildName)
+
+                    To test the snapshot in the playground with a playground ID add it after the snapshot query string:
+
+                    https://playground.babylonjs.com/?snapshot=$(BuildName)#BCU1XR#0
+
+                    *If you made changes to the sandbox or playground in this PR, additional comments will be generated soon containing links to the dev versions of those tools.*
+
+          - task: GitHubComment@0
+            displayName: "Writing SFE GitHub comment"
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['SMARTFILTERSCHANGED'], 'true'))
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Smart Filters Editor is available to test at:
+                    https://sfe.babylonjs.com/?snapshot=$(BuildName)
+
+    # ============================================================================
+    # ES6
+    # Builds ES6 modules and generates file size reports
+    # No dependencies - runs immediately
+    # ============================================================================
+    - job: ES6
+      displayName: "ES6"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - script: npm install
+            displayName: "npm install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - task: Npm@1
+            displayName: "npm build es6"
+            inputs:
+                command: custom
+                customCommand: "run build:es6"
+
+          - bash: |
+                npx nx run-many --target=prepublishOnly --all
+            displayName: "Make sure es6 packages are ready"
+            continueOnError: true
+
+          - task: Npm@1
+            displayName: "npm build modules size"
+            inputs:
+                command: custom
+                customCommand: "run build -w @tools/tests"
+
+          - task: Npm@1
+            displayName: "npm generate modules size"
+            inputs:
+                command: custom
+                customCommand: "run generate-file-size-report -w @tools/tests"
+
+          - script: |
+                cd packages/tools/tests/dist
+                zip ../../../../snapshot.zip fileSizes.json
+                cd ../../../..
+
+                curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+                  -H "Content-Type: multipart/form-data" \
+                  -H "Authorization: $(BASIC_AUTH)" \
+                  -F "path=$(BuildName)" \
+                  -F "storageAccount=babylonsnapshots" \
+                  -F "zip=@snapshot.zip"
+            displayName: "Upload file size results"
+
+    # ============================================================================
+    # FORMAT, LINT, AND MORE
+    # Checks formatting, linting, and circular dependencies
+    # No dependencies - runs immediately
+    # ============================================================================
+    - job: FormatLint
+      displayName: "Format, Lint, and more"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.17.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.17.1"
+
+          - script: npm install
+            displayName: "npm install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: npx prettier --list-different "./packages/**/src/**/*.{ts,tsx,js,scss}"
+            displayName: "Formatting"
+
+          - script: npx eslint "packages/dev/core/src/**/*.ts" --quiet --format azure-devops
+            displayName: "Linting core"
+            env:
+                NODE_OPTIONS: "--max-old-space-size=8192"
+
+          - script: npx eslint "packages/dev/**/src/**/*.{ts,tsx}" --quiet --ignore-pattern "packages/dev/core/*" --format azure-devops
+            displayName: "Linting dev"
+            env:
+                NODE_OPTIONS: "--max-old-space-size=8192"
+
+          - script: npx eslint "packages/tools/**/src/**/*.{ts,tsx}" --quiet --format azure-devops
+            displayName: "Linting tools"
+            env:
+                NODE_OPTIONS: "--max-old-space-size=8192"
+
+          # DISABLED in classic pipeline:
+          # - task: Npm@1
+          #   displayName: 'Linting'
+          #   inputs:
+          #     command: custom
+          #     customCommand: 'run lint:check -- --format azure-devops'
+
+          - script: npx --yes dpdm -T --no-tree ./packages/dev/core/src/**/*
+            displayName: "Circular dependencies"
+
+    # ============================================================================
+    # TYPEDOC CHECK
+    # Only runs on PRs (not on master branch)
+    # No dependencies - runs immediately
+    # ============================================================================
+    - job: TypeDocCheck
+      displayName: "TypeDoc check"
+      condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+      steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 0
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - script: npm install
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: |
+                git branch
+                git fetch origin "+refs/heads/*:refs/remotes/origin/*"
+                git checkout -B master origin/master
+                git branch
+
+                GIT_CHANGES_COMMAND="git diff $(Build.SourceVersion) --name-only --relative" npm run test:docs
+            displayName: "Run TypeDoc test"
+            continueOnError: true
+            env:
+                CI: "true"
+
+          - task: PublishTestResults@2
+            displayName: "Publish TypeDoc Results"
+            condition: succeededOrFailed()
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./junit.xml"
+
+    # ============================================================================
+    # UNIT TESTS
+    # Depends on: Build
+    # ============================================================================
+    - job: UnitTests
+      displayName: "Unit tests"
+      dependsOn: Build
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: Npm@1
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            inputs:
+                command: install
+
+          - script: npm run test:unit
+            displayName: "unit tests"
+            retryCountOnTaskFailure: 2
+            env:
+                CDN_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)"
+                HEADLESS: "true"
+
+          - task: PublishTestResults@2
+            displayName: "Publish Unit Test Results"
+            condition: succeededOrFailed()
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./junit.xml"
+
+          # DISABLED in classic pipeline - integration tests:
+          # - script: |
+          #     export DISPLAY=:99
+          #     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          #     sleep 3
+          #     npm run test:integration
+          #   displayName: 'integration tests'
+          #   continueOnError: true
+          #   retryCountOnTaskFailure: 4
+          #   env:
+          #     CDN_BASE_URL: 'https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)'
+          #     HEADLESS: 'true'
+
+          # DISABLED in classic pipeline - interaction tests (moved to separate job):
+          # - script: |
+          #     npx playwright install --with-deps
+          #     export CDN_BASE_URL="https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(Build.SourceBranch)"
+          #     export BROWSERSTACK_USERNAME=$(BROWSERSTACK_USERNAME)
+          #     export BROWSERSTACK_ACCESS_KEY=$(BROWSERSTACK_ACCESS_KEY)
+          #     npm run test:interactions
+          #   displayName: 'interaction tests'
+          #   retryCountOnTaskFailure: 2
+          #   env:
+          #     CI: 'true'
+
+    # ============================================================================
+    # INTERACTION TESTS
+    # Depends on: Build
+    # ============================================================================
+    - job: InteractionTests
+      displayName: "Interaction tests"
+      dependsOn: Build
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "$(BuildName)/testResults/interactionplaywright"
+
+          - script: |
+                npm install
+                npx playwright install --with-deps
+            displayName: "npm install && playwright install"
+            retryCountOnTaskFailure: 1
+
+          - script: npm run test:interactions
+            displayName: "run interaction tests"
+            retryCountOnTaskFailure: 1
+            env:
+                CDN_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)"
+                BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+                CI: "true"
+
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/delete?path=$(BuildName)/testResults/interactionplaywright" -X POST -H "Authorization: $(BASIC_AUTH)"
+            displayName: "Delete test results"
+            continueOnError: true
+            condition: eq(variables['SNAPSHOTEXISTS'], 'true')
+
+          - template: templates/upload-test-results.yml
+            parameters:
+                reportDir: "packages/tools/tests/playwright-report"
+                fallbackReportDir: "playwright-report"
+                deployPath: "$(BuildName)/testResults/interactionplaywright"
+                continueOnError: true
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment"
+            continueOnError: true
+            condition: eq(variables['SNAPSHOTEXISTS'], 'false')
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Interaction tests
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/testResults/interactionplaywright/index.html
+
+          - task: PublishTestResults@2
+            displayName: "Publish interaction test results"
+            condition: succeededOrFailed()
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./packages/tools/tests/junit.xml"
+
+    # ============================================================================
+    # VISUALIZATION TESTS - WEBGL1
+    # Depends on: Build
+    # NOTE: All test steps are DISABLED in the classic pipeline.
+    # Only Node setup is enabled; the job is effectively a no-op.
+    # ============================================================================
+    - job: VisualizationWebGL1
+      displayName: "Visualization tests - WebGL1"
+      dependsOn: Build
+      timeoutInMinutes: 40
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          # ALL REMAINING STEPS DISABLED in classic pipeline:
+          # - script: npm install
+          #   displayName: 'npm install'
+          #   env:
+          #     PUPPETEER_PRODUCT: firefox
+
+          # - script: |
+          #     export DISPLAY=:99
+          #     Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          #     sleep 3
+          #     npx jest --selectProjects=visualization --runInBand -i "webgl1"
+          #   displayName: 'visualization tests (FF)'
+          #   continueOnError: true
+          #   env:
+          #     CDN_BASE_URL: 'https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)'
+          #     BROWSER: firefox
+          #     TEST_GPU: desktop
+          #     PUPPETEER_PRODUCT: firefox
+
+          # - script: |
+          #     curl "$(DEPLOYMENT_SERVER)/delete?path=$(BuildName)/testResults/webgl1" -X POST -H "Authorization: $(BASIC_AUTH)"
+          #   displayName: 'Delete test results'
+          #   condition: failed()
+
+          # - script: |
+          #     cd jest-screenshot-report
+          #     zip -r ../file.zip *
+          #     cd ..
+          #     curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+          #       -H "Content-Type: multipart/form-data" \
+          #       -H "Authorization: $(BASIC_AUTH)" \
+          #       -F "path=$(BuildName)/testResults/webgl1" \
+          #       -F "storageAccount=babylonsnapshots" \
+          #       -F "zip=@file.zip"
+          #   displayName: 'Upload test results'
+          #   condition: failed()
+
+          # - task: GitHubComment@0
+          #   displayName: 'Writing GitHub comment'
+          #   condition: failed()
+          #   inputs:
+          #     gitHubConnection: '64b7b35d-c231-434d-a365-b23a07bef5aa'
+          #     repositoryName: '$(Build.Repository.Name)'
+          #     comment: |
+          #       Visualization tests for WebGL 1 have failed. If some tests failed because the snapshots do not match, the report can be found at
+          #
+          #       https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/testResults/webgl1/index.html
+          #
+          #       If tests were successful afterwards, this report might not be available anymore.
+
+    # ============================================================================
+    # VISUALIZATION TESTS - WEBGL 2
+    # Depends on: Build
+    # Runs on BrowserStack
+    # ============================================================================
+    - job: VisualizationWebGL2
+      displayName: "Visualization tests - WebGL 2"
+      dependsOn: Build
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.x"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "$(BuildName)/testResults/webgl2playwright"
+
+          - script: |
+                npm install
+                #npx playwright install
+                #npx playwright install --force chrome
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: npm run test:playwright -w @tools/tests -- --project=webgl2 --project=webgl2-largeWorld
+            displayName: "WebGL2 BStack"
+            env:
+                CDN_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)"
+                CI: "true"
+                EXCLUDE_REGEX_ARRAY: "Procedural textures playground"
+                BROWSER: "BrowserStack"
+                TIMEOUT: "27500"
+                BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/delete?path=$(BuildName)/testResults/webgl2playwright" -X POST -H "Authorization: $(BASIC_AUTH)"
+            displayName: "Delete test results"
+            continueOnError: true
+            condition: eq(variables['SNAPSHOTEXISTS'], 'true')
+
+          - template: templates/upload-test-results.yml
+            parameters:
+                reportDir: "packages/tools/tests/playwright-report"
+                fallbackReportDir: "playwright-report"
+                deployPath: "$(BuildName)/testResults/webgl2playwright"
+                continueOnError: true
+
+          - task: GitHubComment@0
+            displayName: "GitHub WebGL2 comment"
+            condition: eq(variables['SNAPSHOTEXISTS'], 'false')
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    WebGL2 visualization test reporter:
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/testResults/webgl2playwright/index.html
+
+          - task: PublishTestResults@2
+            displayName: "Publish webgl2 test results"
+            condition: succeededOrFailed()
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./packages/tools/tests/junit.xml"
+
+    # ============================================================================
+    # VISUALIZATION TESTS - WEBGPU
+    # Depends on: Build
+    # Runs on BrowserStack
+    # ============================================================================
+    - job: VisualizationWebGPU
+      displayName: "Visualization tests - WebGPU"
+      dependsOn: Build
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.x"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "$(BuildName)/testResults/webgpuplaywright"
+
+          - script: |
+                npm install
+                #npx playwright install --force chrome
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - script: npm run test:playwright -w @tools/tests -- --project=webgpu --project=webgpu-largeWorld
+            displayName: "WebGPU BStack"
+            retryCountOnTaskFailure: 1
+            env:
+                CDN_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)"
+                CI: "true"
+                EXCLUDE_REGEX_ARRAY: "Sample depth texture,Render to 3D RT,apply-all-post-processes"
+                BROWSER: "BrowserStack"
+                TIMEOUT: "27500"
+                BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/delete?path=$(BuildName)/testResults/webgpuplaywright" -X POST -H "Authorization: $(BASIC_AUTH)"
+            displayName: "Delete test results"
+            continueOnError: true
+            condition: eq(variables['SNAPSHOTEXISTS'], 'true')
+
+          - template: templates/upload-test-results.yml
+            parameters:
+                reportDir: "packages/tools/tests/playwright-report"
+                fallbackReportDir: "playwright-report"
+                deployPath: "$(BuildName)/testResults/webgpuplaywright"
+                continueOnError: true
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment"
+            continueOnError: true
+            condition: eq(variables['SNAPSHOTEXISTS'], 'false')
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Visualization tests for WebGPU
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/testResults/webgpuplaywright/index.html
+
+          - task: PublishTestResults@2
+            displayName: "Publish webgpu test results"
+            condition: succeededOrFailed()
+            inputs:
+                testResultsFormat: JUnit
+                testResultsFiles: "./packages/tools/tests/junit.xml"
+
+    # ============================================================================
+    # NATIVE TESTS (EXPERIMENTAL)
+    # Depends on: Build
+    # Runs on Windows agent pool
+    # ============================================================================
+    - job: NativeTests
+      displayName: "Native tests (experimental)"
+      dependsOn: Build
+      timeoutInMinutes: 15
+      pool:
+          vmImage: windows-latest
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: DownloadPipelineArtifact@2
+            displayName: "Download Pipeline Artifact"
+            inputs:
+                source: specific
+                project: "243fb099-542d-4655-b246-4dfd67131bd4"
+                pipeline: 36
+                runVersion: latest
+                runBranch: "refs/heads/master"
+                path: "$(Pipeline.Workspace)"
+
+          - script: |
+                for /f %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere" -property instanceId') do (
+                  reg add HKCU\Software\Microsoft\VisualStudio\Debugger\JIT\{F200A7E7-DEA5-11D0-B854-00A0244A1DE2}\%%i /f /v Disabled /t REG_DWORD /d 1
+                )
+
+                reg query HKCU\Software\Microsoft\VisualStudio\Debugger\JIT\{F200A7E7-DEA5-11D0-B854-00A0244A1DE2} /s
+            displayName: "Disable JIT Debugging for Script"
+
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/snapshotExists?buildNumber=$(BuildName)&fileTocheck=cdnSnapshot.zip" -o ./tmp.json -H "Authorization: $(BASIC_AUTH)"
+                findstr "true" .\tmp.json >nul 2>&1
+                if %errorlevel% equ 0 (
+                   echo snapshot exists
+                ) else (
+                    echo snapshot does not exist
+                )
+
+                curl "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/cdnSnapshot.zip" -o snapshot.zip
+                if errorlevel 1 exit /b %errorlevel%
+
+                set destDir=..\BabylonNativeNightlyUnitTests\RelWithDebInfo\Assets
+                for /f %%i in ('dir /b %destDir%\babylon*') do (
+                  unzip -p snapshot.zip "**%%i" > %destDir%\%%i
+                  if errorlevel 1 exit /b !errorlevel!
+                )
+
+                set destDir=..\BabylonNativeNightlyPlayground\RelWithDebInfo\Scripts
+                for /f %%i in ('dir /b %destDir%\babylon*') do (
+                  unzip -p snapshot.zip "**%%i" > %destDir%\%%i
+                  if errorlevel 1 exit /b !errorlevel!
+                )
+            displayName: "Update scripts from snapshot"
+            retryCountOnTaskFailure: 5
+
+          - script: |
+                cd
+                cd ..\BabylonNativeNightlyUnitTests\RelWithDebInfo
+                UnitTests.exe
+            displayName: "Run unit tests"
+            retryCountOnTaskFailure: 3
+
+          - script: |
+                cd
+                cd ..\BabylonNativeNightlyPlayground\RelWithDebInfo
+                Playground.exe app:///Scripts/validation_native.js
+            displayName: "Run visualization tests"
+            retryCountOnTaskFailure: 3
+
+    # ============================================================================
+    # PERFORMANCE TESTS (EXPERIMENTAL)
+    # Depends on: Build
+    # NOTE: The test step is DISABLED in the classic pipeline.
+    # ============================================================================
+    - job: PerformanceTests
+      displayName: "Performance tests (experimental)"
+      dependsOn: Build
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - script: npm install
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          # DISABLED in classic pipeline:
+          # - script: npm run test:performance
+          #   displayName: 'Run tests'
+          #   continueOnError: true
+          #   env:
+          #     CDN_BASE_URL: 'https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)'
+          #     CI: 'true'
+          #     BROWSER: 'BrowserStack'
+          #     TIMEOUT: '100000'
+          #     BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+          #     BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+
+    # ============================================================================
+    # VIEWER TESTS
+    # No dependencies - runs immediately
+    # ============================================================================
+    - job: ViewerTests
+      displayName: "Viewer tests"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: Npm@1
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+            inputs:
+                command: install
+
+          - task: Npm@1
+            displayName: "npm build"
+            retryCountOnTaskFailure: 1
+            inputs:
+                command: custom
+                customCommand: "run build:dev"
+
+          - script: |
+                (npm run serve -w @tools/viewer &)
+                npx playwright install --with-deps
+                npm run test:playwright -w @tools/tests -- --project=viewer
+            displayName: "run tests"
+            retryCountOnTaskFailure: 1
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+                CI: "true"
+                BROWSER: "Chrome"
+
+    # ============================================================================
+    # VISUALIZATION TESTS - DEVHOST (EXPERIMENTAL)
+    # Depends on: Build, ES6
+    # NOTE: ALL STEPS are DISABLED in the classic pipeline.
+    # The job is kept as a placeholder since Deploy depends on it.
+    # ============================================================================
+    - job: VisualizationDevhost
+      displayName: "Visualization tests - Devhost (experimental)"
+      dependsOn:
+          - Build
+          - ES6
+      steps:
+          - script: echo "All steps in this job are disabled in the classic pipeline"
+            displayName: "Placeholder - all steps disabled"
+
+          # DISABLED in classic pipeline - full step list:
+          # - task: NodeTool@0
+          #   displayName: 'Use Node 22.4.1'
+          #   continueOnError: true
+          #   retryCountOnTaskFailure: 1
+          #   inputs:
+          #     versionSpec: '22.4.1'
+
+          # - script: |
+          #     curl "$(DEPLOYMENT_SERVER)/snapshotExists?buildNumber=$(BuildName)/testResults/devhostplaywright" -o ./tmp.json -H "Authorization: $(BASIC_AUTH)"
+          #     if grep "true" ./tmp.json
+          #     then
+          #        echo "##vso[task.setvariable variable=SnapshotExists]true"
+          #     else
+          #        echo "##vso[task.setvariable variable=SnapshotExists]false"
+          #     fi
+          #   displayName: 'Check if snapshot exists'
+
+          # - script: |
+          #     npm install
+          #     npx playwright install
+          #   displayName: 'npm install && playwright install'
+          #   retryCountOnTaskFailure: 1
+          #   env:
+          #     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
+          #     PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+          # - task: Npm@1
+          #   displayName: 'npm build dev'
+          #   inputs:
+          #     command: custom
+          #     customCommand: 'run build:dev'
+
+          # - script: npm run test:visualization:devhost
+          #   displayName: 'run visual tests'
+          #   continueOnError: true
+          #   retryCountOnTaskFailure: 1
+          #   env:
+          #     CDN_BASE_URL: 'https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)'
+          #     CI: 'true'
+          #     BROWSER: 'Chrome'
+          #     TIMEOUT: '27500'
+          #     BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+          #     BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
+          #     CIWORKERS: '1'
+
+          # - script: |
+          #     curl "$(DEPLOYMENT_SERVER)/delete?path=$(BuildName)/testResults/devhostplaywright" -X POST -H "Authorization: $(BASIC_AUTH)"
+          #   displayName: 'Delete test results'
+          #   continueOnError: true
+          #   condition: eq(variables['SNAPSHOTEXISTS'], 'true')
+
+          # - script: |
+          #     DIR="packages/tools/tests/playwright-report"
+          #     if test -d "$DIR"; then
+          #       cd packages/tools/tests/playwright-report
+          #       zip -r ../../../../file.zip *
+          #       cd ../../../..
+          #     else
+          #       cd playwright-report
+          #       zip -r ../file.zip *
+          #       cd ..
+          #     fi
+          #     curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+          #       -H "Content-Type: multipart/form-data" \
+          #       -H "Authorization: $(BASIC_AUTH)" \
+          #       -F "path=$(BuildName)/testResults/devhostplaywright" \
+          #       -F "storageAccount=babylonsnapshots" \
+          #       -F "zip=@file.zip"
+          #   displayName: 'Upload test results'
+          #   continueOnError: true
+          #   condition: succeededOrFailed()
+
+          # - task: GitHubComment@0
+          #   displayName: 'Writing Devhost comment'
+          #   condition: eq(variables['SNAPSHOTEXISTS'], 'false')
+          #   inputs:
+          #     gitHubConnection: '64b7b35d-c231-434d-a365-b23a07bef5aa'
+          #     repositoryName: '$(Build.Repository.Name)'
+          #     comment: |
+          #       Devhost visualization test reporter:
+          #
+          #       https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/testResults/devhostplaywright/index.html
+
+          # - task: PublishTestResults@2
+          #   displayName: 'Publish Devhost test results'
+          #   condition: succeededOrFailed()
+          #   inputs:
+          #     testResultsFormat: JUnit
+          #     testResultsFiles: './packages/tools/tests/junit.xml'
+
+    # ============================================================================
+    # DEPLOY
+    # Depends on: Build, UnitTests, VisualizationWebGL2, ES6,
+    #             VisualizationWebGPU, InteractionTests, VisualizationDevhost
+    # Only runs on master/preview branch for Manual/ResourceTrigger/Schedule/
+    # BuildCompletion builds
+    # ============================================================================
+    - job: Deploy
+      displayName: "Deploy"
+      dependsOn:
+          - Build
+          - UnitTests
+          - VisualizationWebGL2
+          - ES6
+          - VisualizationWebGPU
+          - InteractionTests
+          - VisualizationDevhost
+      condition: >-
+          and(
+            succeeded(),
+            or(
+              eq(variables['Build.SourceBranchName'], 'master'),
+              eq(variables['Build.SourceBranchName'], 'preview')
+            ),
+            or(
+              eq(variables['Build.Reason'], 'Manual'),
+              eq(variables['Build.Reason'], 'ResourceTrigger'),
+              eq(variables['Build.Reason'], 'Schedule'),
+              eq(variables['Build.Reason'], 'BuildCompletion')
+            )
+          )
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - bash: mkdir download
+            displayName: "Prepare download directory"
+
+          - script: |
+                curl "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/cdnSnapshot.zip" -o snapshot.zip
+
+                curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+                  -H "Content-Type: multipart/form-data" \
+                  -H "Authorization: $(BASIC_AUTH)" \
+                  -F "path=cdn/$(Build.SourceBranchName)" \
+                  -F "storageAccount=babylonsnapshots" \
+                  -F "zip=@snapshot.zip"
+
+                curl "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/fileSizes.json" -o fileSizes.json
+
+                zip ./fileSize.zip fileSizes.json
+
+                curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+                  -H "Content-Type: multipart/form-data" \
+                  -H "Authorization: $(BASIC_AUTH)" \
+                  -F "path=cdn/$(Build.SourceBranchName)" \
+                  -F "storageAccount=babylonsnapshots" \
+                  -F "zip=@fileSize.zip"
+            displayName: "Update CDN"
+
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/purgeTest?endpoint=babylonjscdn&profileName=babylonjscdn&wait=true" -i -H "Authorization: $(BASIC_AUTH)"
+
+                curl "$(DEPLOYMENT_SERVER)/purgeTest?endpoint=babylonjspreviewcdn&profileName=babylonjscdn&wait=true" -i -H "Authorization: $(BASIC_AUTH)"
+            displayName: "Purge CDN"

--- a/.azure-pipelines/ci-playground-sandbox.yml
+++ b/.azure-pipelines/ci-playground-sandbox.yml
@@ -1,0 +1,216 @@
+# =============================================================================
+# Playground-Sandbox-CI Pipeline (Definition ID: 32)
+# Converted from Azure DevOps Classic Pipeline
+#
+# Triggers on PRs that touch playground, sandbox, or inspector-v2 files.
+# Builds and tests both Playground and Sandbox in parallel jobs.
+#
+# Secret variables (configure in pipeline UI):
+#   - BASIC_AUTH
+#   - DEPLOYMENT_SERVER
+# =============================================================================
+
+trigger: none
+
+pr:
+    branches:
+        include:
+            - master
+    paths:
+        include:
+            - packages/tools/playground/**/*.*
+            - packages/tools/sandbox/**/*.*
+            - packages/dev/sharedUiComponents/**/*.*
+            - "**/*playground*"
+            - packages/dev/buildTools/src/webpackTools.ts
+            - "**/*sandbox*"
+            - packages/dev/inspector-v2/**/*.*
+
+variables:
+    BuildName: $(Build.SourceBranch)
+
+pool:
+    vmImage: ubuntu-24.04
+
+jobs:
+    # ============================================================================
+    # PLAYGROUND TESTS
+    # ============================================================================
+    - job: PlaygroundTests
+      displayName: "Playground tests"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: Npm@1
+            displayName: "npm install"
+            inputs:
+                command: install
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "PLAYGROUND/$(BuildName)"
+
+          - task: Npm@1
+            displayName: "npm build:dev"
+            inputs:
+                command: custom
+                customCommand: "run build:dev"
+
+          - task: Npm@1
+            displayName: "npm typecheck playground"
+            inputs:
+                command: custom
+                customCommand: "run typecheck -w @tools/playground"
+
+          - task: Npm@1
+            displayName: "npm build playground"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/playground"
+
+          - template: templates/wait-for-snapshot.yml
+
+          - script: |
+                # Remove scenes/textures from public — not needed for testing
+                rm -rf packages/tools/playground/public/scenes
+                rm -rf packages/tools/playground/public/textures
+            displayName: "Remove scenes and textures from playground public"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/playground"
+                deployPath: "PLAYGROUND/$(BuildName)"
+                displayName: "Deploy playground snapshot"
+
+          - script: |
+                npx playwright install --with-deps
+                npx playwright test --project=playground
+            displayName: "Test playground"
+            env:
+                CI: "true"
+                PLAYGROUND_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/PLAYGROUND/$(BuildName)/"
+                BROWSER: "Chrome"
+                SNAPSHOT: "$(BuildName)"
+
+          - template: templates/upload-test-results.yml
+            parameters:
+                deployPath: "PLAYGROUND/$(BuildName)/testResults"
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment - test or build failed"
+            condition: failed()
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Building or testing the playground has failed.
+
+                    If the tests failed, results can be found here:
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/PLAYGROUND/$(BuildName)/testResults/
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment"
+            condition: succeeded()
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    You have made possible changes to the playground.
+                    You can test the snapshot here:
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/PLAYGROUND/$(BuildName)/
+
+                    The snapshot playground with the CDN snapshot (only when available):
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/PLAYGROUND/$(BuildName)/?snapshot=$(BuildName)
+
+                    Note that neither Babylon scenes nor textures are uploaded to the snapshot directory, so some playgrounds won't work correctly.
+
+    # ============================================================================
+    # SANDBOX TESTS
+    # ============================================================================
+    - job: SandboxTests
+      displayName: "Test sandbox"
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: NodeTool@0
+            displayName: "Use Node 22.4.1"
+            inputs:
+                versionSpec: "22.4.1"
+
+          - task: Npm@1
+            displayName: "npm install"
+            inputs:
+                command: install
+
+          - template: templates/check-snapshot-exists.yml
+            parameters:
+                snapshotPath: "SANDBOX/$(BuildName)"
+
+          - task: Npm@1
+            displayName: "npm build:dev"
+            inputs:
+                command: custom
+                customCommand: "run build:dev"
+
+          - task: Npm@1
+            displayName: "npm build sandbox"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/sandbox"
+
+          - template: templates/wait-for-snapshot.yml
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/sandbox"
+                deployPath: "SANDBOX/$(BuildName)"
+                displayName: "Deploy sandbox snapshot"
+
+          - script: |
+                npx playwright install --with-deps
+                npx playwright test --project=sandbox
+            displayName: "Test sandbox"
+            env:
+                CI: "true"
+                SANDBOX_BASE_URL: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/SANDBOX/$(BuildName)/"
+                BROWSER: "Chrome"
+                SNAPSHOT: "$(BuildName)"
+
+          - template: templates/upload-test-results.yml
+            parameters:
+                deployPath: "SANDBOX/$(BuildName)/testResults"
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment - test or build failed"
+            condition: failed()
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    Building or testing the sandbox has failed.
+
+                    If the tests failed, results can be found here:
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/SANDBOX/$(BuildName)/testResults/
+
+          - task: GitHubComment@0
+            displayName: "Writing GitHub comment"
+            condition: succeeded()
+            inputs:
+                gitHubConnection: "64b7b35d-c231-434d-a365-b23a07bef5aa"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    You have changed file(s) that made possible changes to the sandbox.
+                    You can test the sandbox snapshot here:
+
+                    https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/SANDBOX/$(BuildName)/

--- a/.azure-pipelines/templates/check-snapshot-exists.yml
+++ b/.azure-pipelines/templates/check-snapshot-exists.yml
@@ -1,0 +1,27 @@
+# =============================================================================
+# Template: Check if a snapshot exists on the deployment server
+#
+# Queries the deployment server for a snapshot path and sets a pipeline
+# variable (default: SnapshotExists) to 'true' or 'false'.
+# =============================================================================
+
+parameters:
+    - name: snapshotPath
+      type: string
+    - name: variableName
+      type: string
+      default: "SnapshotExists"
+    - name: displayName
+      type: string
+      default: "Check if snapshot exists"
+
+steps:
+    - script: |
+          curl "$(DEPLOYMENT_SERVER)/snapshotExists?buildNumber=${{ parameters.snapshotPath }}" -o ./tmp.json -H "Authorization: $(BASIC_AUTH)"
+          if grep "true" ./tmp.json
+          then
+             echo "##vso[task.setvariable variable=${{ parameters.variableName }}]true"
+          else
+             echo "##vso[task.setvariable variable=${{ parameters.variableName }}]false"
+          fi
+      displayName: "${{ parameters.displayName }}"

--- a/.azure-pipelines/templates/deploy-tool.yml
+++ b/.azure-pipelines/templates/deploy-tool.yml
@@ -1,0 +1,56 @@
+# =============================================================================
+# Template: Deploy a tool's dist + public directories to the deployment server
+#
+# Zips the dist/ and public/ directories of a tool package, uploads both
+# to the deployment server, and optionally purges a CDN endpoint.
+# =============================================================================
+
+parameters:
+    - name: toolPackageDir
+      type: string # relative path from repo root, e.g. 'packages/tools/playground'
+    - name: deployPath
+      type: string # server path, e.g. 'PLAYGROUND/$(BuildName)' or 'sandbox'
+    - name: storageAccount
+      type: string
+      default: "babylonsnapshots"
+    - name: displayName
+      type: string
+      default: "Deploy tool"
+    - name: purgeEndpoint
+      type: string
+      default: ""
+    - name: purgeProfile
+      type: string
+      default: ""
+
+steps:
+    - script: |
+          cd ${{ parameters.toolPackageDir }}/dist
+          zip -r $(Build.SourcesDirectory)/_deploy_dist.zip *
+          cd $(Build.SourcesDirectory)
+
+          cd ${{ parameters.toolPackageDir }}/public
+          zip -r $(Build.SourcesDirectory)/_deploy_public.zip *
+          cd $(Build.SourcesDirectory)
+
+          curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+            -H "Content-Type: multipart/form-data" \
+            -H "Authorization: $(BASIC_AUTH)" \
+            -F "path=${{ parameters.deployPath }}" \
+            -F "storageAccount=${{ parameters.storageAccount }}" \
+            -F "zip=@_deploy_dist.zip"
+
+          curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+            -H "Content-Type: multipart/form-data" \
+            -H "Authorization: $(BASIC_AUTH)" \
+            -F "path=${{ parameters.deployPath }}" \
+            -F "storageAccount=${{ parameters.storageAccount }}" \
+            -F "zip=@_deploy_public.zip"
+
+          rm -f _deploy_dist.zip _deploy_public.zip
+      displayName: "${{ parameters.displayName }}"
+
+    - ${{ if ne(parameters.purgeEndpoint, '') }}:
+          - script: |
+                curl "$(DEPLOYMENT_SERVER)/purgeTest?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}&wait=true" -i -H "Authorization: $(BASIC_AUTH)"
+            displayName: "Purge CDN (${{ parameters.purgeEndpoint }})"

--- a/.azure-pipelines/templates/upload-test-results.yml
+++ b/.azure-pipelines/templates/upload-test-results.yml
@@ -1,0 +1,58 @@
+# =============================================================================
+# Template: Upload Playwright test results to the deployment server
+#
+# Looks for a playwright-report directory, zips it, and uploads to the
+# deployment server. Supports a fallback directory for cases where the
+# report may be in a different location.
+# =============================================================================
+
+parameters:
+    - name: reportDir
+      type: string
+      default: "playwright-report"
+    - name: fallbackReportDir
+      type: string
+      default: ""
+    - name: deployPath
+      type: string
+    - name: storageAccount
+      type: string
+      default: "babylonsnapshots"
+    - name: displayName
+      type: string
+      default: "Upload test results"
+    - name: condition
+      type: string
+      default: "succeededOrFailed()"
+    - name: continueOnError
+      type: boolean
+      default: false
+
+steps:
+    - script: |
+          REPORT_DIR="${{ parameters.reportDir }}"
+          FALLBACK_DIR="${{ parameters.fallbackReportDir }}"
+
+          if test -d "$REPORT_DIR"; then
+            cd "$REPORT_DIR"
+          elif [ -n "$FALLBACK_DIR" ] && test -d "$FALLBACK_DIR"; then
+            cd "$FALLBACK_DIR"
+          else
+            echo "No report directory found, skipping upload"
+            exit 0
+          fi
+
+          zip -r $(Build.SourcesDirectory)/_test_report.zip *
+          cd $(Build.SourcesDirectory)
+
+          curl $(DEPLOYMENT_SERVER)/upload -i -X POST \
+            -H "Content-Type: multipart/form-data" \
+            -H "Authorization: $(BASIC_AUTH)" \
+            -F "path=${{ parameters.deployPath }}" \
+            -F "storageAccount=${{ parameters.storageAccount }}" \
+            -F "zip=@_test_report.zip"
+
+          rm -f _test_report.zip
+      displayName: "${{ parameters.displayName }}"
+      condition: ${{ parameters.condition }}
+      continueOnError: ${{ parameters.continueOnError }}

--- a/.azure-pipelines/templates/wait-for-snapshot.yml
+++ b/.azure-pipelines/templates/wait-for-snapshot.yml
@@ -1,0 +1,30 @@
+# =============================================================================
+# Template: Wait for a Babylon snapshot to become available
+#
+# Polls a snapshot URL with retries until it's available, or times out.
+# Used by PR pipelines that depend on the main CI snapshot being deployed.
+# =============================================================================
+
+parameters:
+    - name: snapshotUrl
+      type: string
+      default: "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/$(BuildName)/index.html"
+    - name: timeoutMinutes
+      type: number
+      default: 30
+    - name: displayName
+      type: string
+      default: "Wait for Babylon snapshot"
+
+steps:
+    - script: |
+          curl --connect-timeout 5 \
+              --max-time 10 \
+              --retry 500 \
+              --retry-delay 20 \
+              --retry-max-time 1200 \
+              --retry-all-errors \
+              --fail \
+              '${{ parameters.snapshotUrl }}'
+      displayName: "${{ parameters.displayName }}"
+      timeoutInMinutes: ${{ parameters.timeoutMinutes }}


### PR DESCRIPTION
Converts all Azure DevOps classic pipeline definitions to checked-in YAML files and introduces shared templates to reduce duplication.

## Converted Pipelines

| Classic Pipeline | Definition ID | YAML File | 
|---|---|---| 
| CI-Monorepo | 14 | `.azure-pipelines/ci-monorepo.yml` | 
| Playground-Sandbox-CI | 32 | `.azure-pipelines/ci-playground-sandbox.yml` | 
| GraphTools-CI | 33 | `.azure-pipelines/ci-graph-tools.yml` | 
| Browser Testing | 27 | `.azure-pipelines/ci-browser-testing.yml` | 
| Publish Pipeline | 15 | `.azure-pipelines/cd-publish.yml` | 
| CD-Tools | 16 | `.azure-pipelines/cd-tools.yml` |

## Shared Templates

Extracted repeated patterns into reusable step templates under `.azure-pipelines/templates/`:

- **`deploy-tool.yml`** — Zips a tool's `dist/` + `public/` directories, uploads to the deployment server, and optionally purges a CDN endpoint
- **`upload-test-results.yml`** — Zips and uploads a Playwright report directory (with fallback path support)
- **`check-snapshot-exists.yml`** — Queries the deployment server for snapshot existence and sets a pipeline variable
- **`wait-for-snapshot.yml`** — Polls a snapshot URL with retries until it becomes available

## Migration Tracking

TODOs:
- Per-pipeline setup tasks (secret variables, service connections, fork/PR settings)
- Schedule verification (cron expressions mapped from classic `daysToBuild` bitmasks)
- Post-migration cleanup (disabling classic pipelines, removing disabled jobs)
- Remaining work (Pipeline 36 for Native test artifacts)

## What's NOT included

- No classic pipelines are disabled or deleted — this PR only adds the YAML equivalents
- Pipeline secret variables (`BASIC_AUTH`, `DEPLOYMENT_SERVER`, `BROWSERSTACK_*`, `GitHubPAT`, `NPM_TOKEN`, etc.) must be configured in the Azure DevOps pipeline UI before enabling
- `resources.pipelines` source names contain `TODO` placeholders that need to be updated with actual pipeline names
- Steps that were disabled in the classic pipelines are preserved as comments in the YAML for reference