### PR TITLE
Viewer Configurator: Reduce allowed min width

### DIFF
--- a/packages/tools/viewer-configurator/src/App.scss
+++ b/packages/tools/viewer-configurator/src/App.scss
@@ -22,7 +22,7 @@
     z-index: 9999;
 }
 
-@media screen and (max-width: 899px) {
+@media screen and (max-width: 599px) {
     .blocker {
         display: grid;
     }

--- a/packages/tools/viewer-configurator/src/App.tsx
+++ b/packages/tools/viewer-configurator/src/App.tsx
@@ -28,7 +28,7 @@ export const App: FunctionComponent = () => {
                     )}
                 </div>
             </SplitContainer>
-            <div className="blocker">Viewer Configurator needs a horizontal resolution of at least 900px</div>
+            <div className="blocker">Viewer Configurator needs a horizontal resolution of at least 600px</div>
         </>
     );
 };

--- a/packages/tools/viewer-configurator/src/components/configurator/configurator.scss
+++ b/packages/tools/viewer-configurator/src/components/configurator/configurator.scss
@@ -53,10 +53,13 @@
     }
 
     .stickyContainer {
-        position: sticky;
-        top: 0;
         z-index: 100;
         background: $primary-background;
+
+        @media (min-height: 600px) {
+            position: sticky;
+            top: 0;
+        }
     }
 
     .configuratorHeader {


### PR DESCRIPTION
- Reduce the min width from 900px to 600px (before blocking the app).
- Only make the top snippet part of the side pane sticky (out of the scrolling area) if there is enough vertical space. Otherwise, don't make it sticky so it scrolls with the rest of the content. This is needed so we don't have a sticky top part and not enough room for the scrolling part to be useful.