### PR TITLE
Geo cam keyboard fix on mac

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
@@ -12,7 +12,7 @@ import type { AbstractEngine } from "../../Engines/abstractEngine";
 
 /**
  * Manage the keyboard inputs to control the movement of a geospatial camera.
- * Arrow keys + Modifier key (ctrl/alt, cmd/option on mac): rotate
+ * Arrow keys + Modifier key (ctrl/alt/option on mac): rotate
  * Arrow keys alone: pan
  * + / - keys: zoom in/out
  * @see https://doc.babylonjs.com/features/featuresDeepDive/cameras/customizingCameraInputs
@@ -108,17 +108,9 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
 
         this._onKeyboardObserver = this._scene.onKeyboardObservable.add((info) => {
             const evt = info.event;
-            const isArrowKey =
-                this.keysUp.indexOf(evt.keyCode) !== -1 ||
-                this.keysDown.indexOf(evt.keyCode) !== -1 ||
-                this.keysLeft.indexOf(evt.keyCode) !== -1 ||
-                this.keysRight.indexOf(evt.keyCode) !== -1;
-            // Allow metaKey (Cmd on Mac) through for arrow keys so Cmd+Arrow
-            // works as the Mac equivalent of Ctrl+Arrow for rotation.
-            // Block metaKey for other keys to avoid capturing browser shortcuts (e.g., Cmd+=/Cmd+-).
-            if (!evt.metaKey || isArrowKey) {
+            if (!evt.metaKey) {
                 if (info.type === KeyboardEventTypes.KEYDOWN) {
-                    this._modifierPressed = evt.ctrlKey || evt.metaKey || evt.altKey;
+                    this._modifierPressed = evt.ctrlKey || evt.altKey;
 
                     if (
                         this.keysUp.indexOf(evt.keyCode) !== -1 ||


### PR DESCRIPTION
Ctrl+ArrowKey is reserved for mission control on Mac, so it wasn't resulting in rotation in geospatial camera.

This fix adds the 'alt/option' modifier key