### PR TITLE
Volumetric Lighting: Check for support and throw descriptive error

### DIFF
--- a/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/volumetricLightingTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/PostProcesses/volumetricLightingTask.ts
@@ -169,6 +169,12 @@ export class FrameGraphVolumetricLightingTask extends FrameGraphTask {
     constructor(name: string, frameGraph: FrameGraph, enableExtinction = false) {
         super(name, frameGraph);
 
+        if (!FrameGraphVolumetricLightingTask.IsSupported(frameGraph.engine, enableExtinction)) {
+            throw new Error(
+                `FrameGraphVolumetricLightingTask "${name}": the current configuration is not supported. Use FrameGraphVolumetricLightingTask.IsSupported(engine, enableExtinction) to check before creating this task.`
+            );
+        }
+
         this.enableExtinction = enableExtinction;
 
         const isWebGPU = this._frameGraph.engine.isWebGPU;


### PR DESCRIPTION
We already have a `FrameGraphVolumetricLightingTask.IsSupported` check, but if you don't know you need to check this, then eventually we just fail in a WebGPU call that is really hard to diagnose and understand what is going on. This change simply does the IsSupported check in the constructor and throws a descriptive error telling the user what went wrong and how to defend against the error.