### PR TITLE
ImageProcessingMixin: correctly invoke decorator factory

### DIFF
--- a/packages/dev/core/src/Materials/imageProcessing.ts
+++ b/packages/dev/core/src/Materials/imageProcessing.ts
@@ -22,7 +22,7 @@ export function ImageProcessingMixin<Tbase extends ImageProcessingMixinConstruct
             super(...args);
             // Decorators don't work on this annonymous class
             // so I'm setting this up manually.
-            serializeAsImageProcessingConfiguration.call(this, this, "_imageProcessingConfiguration");
+            serializeAsImageProcessingConfiguration()(this, "_imageProcessingConfiguration");
         }
         /**
          * Default configuration related to image processing available in the standard Material.


### PR DESCRIPTION
`serializeAsImageProcessingConfiguration` is a decorator factory — it returns a decorator function. The call chain is:

1. `serializeAsImageProcessingConfiguration(sourceName?)` → returns `(target, propertyKey) => { ... }`
2. The `.call(this, this, "_imageProcessingConfiguration")` invokes the factory with `sourceName = this` (an object, not a string)
3. The returned decorator function is never invoked — it's just a discarded return value

The correct code should be:
```
serializeAsImageProcessingConfiguration()(this, "_imageProcessingConfiguration");
//                                    ^^ call factory to get decorator, THEN invoke decorator
```
Or equivalently:
```
const decorator = serializeAsImageProcessingConfiguration();
decorator(this, "_imageProcessingConfiguration");
```
The result: _imageProcessingConfiguration is NOT registered in the DecoratorInitialStore. When `SerializationHelper.Parse()` processes a `.babylon` file, it doesn't find the property in the store, so the serialized image processing configuration (exposure, contrast, tone mapping, color curves, etc.) is silently ignored. The material falls back to the scene's default image processing configuration.

Before 8.29.0 (commit ca70334958), PBRBaseMaterial had:
```
@serializeAsImageProcessingConfiguration()
protected _imageProcessingConfiguration: ImageProcessingConfiguration;
```
This properly registered the property for serialization/deserialization.

This commit should fix the parse regression since release 8.28.2, and following forum bugs:
- <https://forum.babylonjs.com/t/pbr-imageprocessingconfiguration-parse-regression-after-8-28-2/62831>
- <https://forum.babylonjs.com/t/the-same-pg-and-the-same-texture-produce-different-results-in-different-versions/62829>