### PR TITLE
Skip empty sections in changelog

### DIFF
--- a/scripts/generateChangelog.js
+++ b/scripts/generateChangelog.js
@@ -192,13 +192,17 @@ function generateVersionMarkdown(versionPackages) {
     let markdown = "";
     const sortedPackages = Object.keys(versionPackages).sort();
     sortedPackages.forEach((prettyPackage) => {
-        const visiblePRs = versionPackages[prettyPackage].filter((pr) => !pr.tags || pr.tags.indexOf(skipChangelogTag) === -1);
+        const visiblePRs = versionPackages[prettyPackage].filter((pr) => {
+            const tags = pr.tags ?? [];
+            return tags.indexOf(skipChangelogTag) === -1;
+        });
         if (visiblePRs.length === 0) {
             return;
         }
         markdown += `\n### ${prettyPackage}\n\n`;
         visiblePRs.forEach((pr) => {
-            const tag = pr.tags.find((tag) => {
+            const tags = pr.tags ?? [];
+            const tag = tags.find((tag) => {
                 return tagNames[tag];
             });
             markdown += `- ${pr.title} - ${tag ? `[_${tagNames[tag]}_] ` : ""}by [${pr.author.name}](${pr.author.url}) ([#${


### PR DESCRIPTION
This pull request updates the changelog generation script to improve how pull requests are displayed for each package. Now, if all pull requests for a package are marked to be skipped in the changelog, that package will no longer appear in the generated markdown output.

You can see an example of where it went wrong here (see the empty "Loaders" section): https://github.com/BabylonJS/Babylon.js/releases/tag/8.55.2

Changelog generation improvements:

* Updated `generateVersionMarkdown` in `scripts/generateChangelog.js` to filter out packages with no visible pull requests, so packages with only skipped PRs are omitted from the changelog.