### PR TITLE
[XR] Allow switching pointer selection controller during session

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
+++ b/packages/dev/core/src/XR/features/WebXRControllerPointerSelection.ts
@@ -371,7 +371,7 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
      * @returns the unique id of the attached controller, or an empty string if none is attached
      */
     public get attachedControllerId(): string {
-        return this._attachedController;
+        return this._attachedController || "";
     }
 
     /**
@@ -408,17 +408,10 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
                     break;
                 }
             }
-            // Update preferredHandedness so reconnections respect the new preference
-            (this._options as IWebXRControllerPointerSelectionOptions).preferredHandedness = controllerId;
         } else {
             // Treat as a controller unique id
             if (this._controllers[controllerId]) {
                 targetUniqueId = controllerId;
-                // Update preferredHandedness based on the target controller's handedness
-                const targetData = this._controllers[controllerId];
-                if (targetData.xrController) {
-                    (this._options as IWebXRControllerPointerSelectionOptions).preferredHandedness = targetData.xrController.inputSource.handedness;
-                }
             }
         }
 
@@ -426,13 +419,26 @@ export class WebXRControllerPointerSelection extends WebXRAbstractFeature {
             return false;
         }
 
+        // Update preferredHandedness only after confirming the switch will happen
+        if (controllerId === "left" || controllerId === "right" || controllerId === "none") {
+            (this._options as IWebXRControllerPointerSelectionOptions).preferredHandedness = controllerId;
+        } else {
+            const targetData = this._controllers[targetUniqueId];
+            if (targetData.xrController) {
+                (this._options as IWebXRControllerPointerSelectionOptions).preferredHandedness = targetData.xrController.inputSource.handedness;
+            }
+        }
+
         // Properly finalize pointer state on the previous controller
         const prevControllerData = this._controllers[this._attachedController];
-        if (prevControllerData && prevControllerData.pointerDownTriggered && !prevControllerData.finalPointerUpTriggered) {
-            this._scene.simulatePointerUp(prevControllerData.pick || new PickingInfo(), {
+        if (prevControllerData && prevControllerData.pointerDownTriggered && !prevControllerData.finalPointerUpTriggered && this._scene.isPointerCaptured(prevControllerData.id)) {
+            const pointerEventInit: PointerEventInit = {
                 pointerId: prevControllerData.id,
                 pointerType: "xr",
-            });
+            };
+            this._augmentPointerInit(pointerEventInit, prevControllerData.id, prevControllerData.screenCoordinates);
+            this._scene.simulatePointerUp(prevControllerData.pick || new PickingInfo(), pointerEventInit);
+            prevControllerData.pointerDownTriggered = false;
             prevControllerData.finalPointerUpTriggered = true;
         }
 

--- a/packages/dev/core/test/unit/XR/webXRControllerPointerSelection.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRControllerPointerSelection.test.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment jsdom
+ * @vitest-environment jsdom
  */
 
 import { NullEngine } from "core/Engines";
@@ -27,8 +27,8 @@ function createMockXRInput() {
     return {
         controllers: [],
         xrCamera: {},
-        onControllerAddedObservable: { add: jest.fn(), removeCallback: jest.fn() },
-        onControllerRemovedObservable: { add: jest.fn(), removeCallback: jest.fn() },
+        onControllerAddedObservable: { add: vi.fn(), removeCallback: vi.fn() },
+        onControllerRemovedObservable: { add: vi.fn(), removeCallback: vi.fn() },
     } as any;
 }
 
@@ -86,8 +86,8 @@ describe("WebXRControllerPointerSelection", () => {
         for (const c of controllers) {
             controllersMap[c.uniqueId] = {
                 xrController: createMockController(c.uniqueId, c.handedness),
-                laserPointer: { isVisible: false, material: { alpha: 0 }, dispose: jest.fn() },
-                selectionMesh: { isVisible: false, material: {}, dispose: jest.fn() },
+                laserPointer: { isVisible: false, material: { alpha: 0 }, dispose: vi.fn() },
+                selectionMesh: { isVisible: false, material: {}, dispose: vi.fn() },
                 meshUnderPointer: null,
                 pick: null,
                 tmpRay: {},
@@ -231,14 +231,17 @@ describe("WebXRControllerPointerSelection", () => {
             leftData.pointerDownTriggered = true;
             leftData.finalPointerUpTriggered = false;
 
-            const simulatePointerUpSpy = jest.spyOn(scene, "simulatePointerUp");
+            const simulatePointerUpSpy = vi.spyOn(scene, "simulatePointerUp");
+            const isPointerCapturedSpy = vi.spyOn(scene, "isPointerCaptured").mockReturnValue(true);
 
             feature.setAttachedController("right");
 
             expect(simulatePointerUpSpy).toHaveBeenCalledTimes(1);
+            expect(leftData.pointerDownTriggered).toBe(false);
             expect(leftData.finalPointerUpTriggered).toBe(true);
 
             simulatePointerUpSpy.mockRestore();
+            isPointerCapturedSpy.mockRestore();
         });
 
         it("does not simulate pointer up if no pointer was down on previous controller", () => {
@@ -252,7 +255,7 @@ describe("WebXRControllerPointerSelection", () => {
                 "ctrl-left"
             );
 
-            const simulatePointerUpSpy = jest.spyOn(scene, "simulatePointerUp");
+            const simulatePointerUpSpy = vi.spyOn(scene, "simulatePointerUp");
 
             feature.setAttachedController("right");
 
@@ -266,8 +269,8 @@ describe("WebXRControllerPointerSelection", () => {
         it("returns empty string when no controller is attached", () => {
             const feature = createFeature();
             // No controllers injected, _attachedController is undefined by default
-            // but the getter should handle it
-            expect(feature.attachedControllerId).toBeFalsy();
+            // but the getter returns empty string per the public contract
+            expect(feature.attachedControllerId).toBe("");
         });
 
         it("returns the unique id of the attached controller", () => {


### PR DESCRIPTION
## Description

Resolves #15345

Currently, `preferredHandedness` on `WebXRControllerPointerSelection` is only evaluated when a controller **initializes**. Users can switch hands by clicking (unless `disableSwitchOnClick` is true), but there is **no public API** to programmatically switch the active pointer hand during an XR session.

This PR adds two new public APIs to `WebXRControllerPointerSelection`:

### New APIs

#### `attachedControllerId` (getter)
Returns the unique id of the currently attached (active) controller for pointer selection. When `enablePointerSelectionOnAllControllers` is true, this value is not meaningful since all controllers are active simultaneously.

#### `setAttachedController(controllerId: XRHandedness | string): boolean`
Programmatically switches which controller handles pointer selection during an XR session.

**Parameters:**
- `controllerId` — accepts either:
  - An `XRHandedness` value (`"left"`, `"right"`, `"none"`) to select the first matching controller
  - A controller `uniqueId` string for precise control

**Behavior:**
- When a matching controller is found, any in-progress pointer-down state on the previously active controller is properly resolved (pointer-up is simulated)
- Updates `preferredHandedness` in the options so that controller reconnections (disconnect/reconnect) respect the new preference
- Returns `true` if the active controller was changed, `false` otherwise
- **No-op** when `enablePointerSelectionOnAllControllers` is true (all controllers are active simultaneously in that mode)

### Example Usage

```typescript
// Switch to right hand by handedness
pointerSelection.setAttachedController("right");

// Switch by specific controller unique id
pointerSelection.setAttachedController(someController.uniqueId);

// Check which controller is currently active
console.log(pointerSelection.attachedControllerId);
```

### Tests
Added 12 unit tests covering:
- Switching by handedness and by unique id
- No-op when target is already attached
- No-op when no matching controller exists
- No-op when `enablePointerSelectionOnAllControllers` is true
- `preferredHandedness` persistence on switch (by handedness and by unique id)
- Pointer-up simulation when switching away from a controller with active pointer-down
- `attachedControllerId` getter behavior

### Breaking Changes
None. This is purely additive — two new public members on an existing class.
