### PR TITLE
Support LoadScript in module-type workers

### DIFF
--- a/packages/dev/core/src/Misc/tools.ts
+++ b/packages/dev/core/src/Misc/tools.ts
@@ -623,7 +623,7 @@ export class Tools {
             } catch (e) {
                 // if in a module type worker, importScripts is not available; use import instead
                 if (e instanceof TypeError) {
-                    import(scriptUrl)
+                    import(/* webpackIgnore: true */ scriptUrl)
                         // eslint-disable-next-line github/no-then -- avoiding changing parent function to async at present
                         .then(() => onSuccess?.())
                         // eslint-disable-next-line github/no-then -- avoiding changing parent function to async at present

--- a/packages/dev/core/test/integration/tools.loadScript.test.ts
+++ b/packages/dev/core/test/integration/tools.loadScript.test.ts
@@ -1,0 +1,98 @@
+import { test, expect, type Page } from "@playwright/test";
+import { getGlobalConfig } from "@tools/test-tools";
+
+/**
+ * Integration tests for Tools.LoadScript in web workers.
+ *
+ * Requires the CDN server (babylon-server) to be running on localhost:1337.
+ */
+test.describe("Tools.LoadScript in workers", () => {
+    /**
+     * Helper: creates a worker, waits for it to post a message back, and returns that message.
+     * @param page - Playwright page to create the worker from.
+     * @param workerCode - JavaScript source for the worker.
+     * @param workerType - "classic" or "module".
+     * @returns The message string posted by the worker.
+     */
+    async function runWorker(page: Page, workerCode: string, workerType: "classic" | "module"): Promise<string> {
+        return page.evaluate(
+            async ({ code, type }) => {
+                return new Promise<string>((resolve, reject) => {
+                    const blob = new Blob([code], { type: "text/javascript" });
+                    const blobUrl = URL.createObjectURL(blob);
+                    const worker = new Worker(blobUrl, { type });
+
+                    const timeout = setTimeout(() => {
+                        worker.terminate();
+                        URL.revokeObjectURL(blobUrl);
+                        reject(new Error("Worker timed out"));
+                    }, 15000);
+
+                    worker.onmessage = (e) => {
+                        clearTimeout(timeout);
+                        worker.terminate();
+                        URL.revokeObjectURL(blobUrl);
+                        resolve(e.data as string);
+                    };
+
+                    worker.onerror = (e) => {
+                        clearTimeout(timeout);
+                        worker.terminate();
+                        URL.revokeObjectURL(blobUrl);
+                        reject(new Error("Worker error: " + e.message));
+                    };
+                });
+            },
+            { code: workerCode, type: workerType }
+        );
+    }
+
+    test("succeeds in a classic worker via importScripts", async ({ browser }) => {
+        const page = await browser.newPage();
+        const baseUrl = getGlobalConfig().baseUrl;
+        const babylonUrl = `${baseUrl}/babylon.js`;
+
+        await page.goto(`${baseUrl}/empty.html`, { waitUntil: "load", timeout: 0 });
+
+        // In a classic worker, importScripts is available and LoadScript
+        // should use it directly without needing the import() fallback.
+        const workerCode = `
+            importScripts("${babylonUrl}");
+            self.BABYLON.Tools.LoadScript(
+                "${babylonUrl}",
+                () => self.postMessage("success"),
+                (msg) => self.postMessage("error:" + msg)
+            );
+        `;
+
+        const result = await runWorker(page, workerCode, "classic");
+        expect(result).toBe("success");
+        await page.close();
+    });
+
+    test("succeeds in a module-type worker via import() fallback", async ({ browser }) => {
+        const page = await browser.newPage();
+        const baseUrl = getGlobalConfig().baseUrl;
+        const babylonUrl = `${baseUrl}/babylon.js`;
+
+        await page.goto(`${baseUrl}/empty.html`, { waitUntil: "load", timeout: 0 });
+
+        // In a module worker, importScripts throws TypeError. LoadScript
+        // should fall back to dynamic import() — the code path from PR #18144.
+        const workerCode = `
+            import("${babylonUrl}").then(() => {
+                self.BABYLON.Tools.LoadScript(
+                    "${babylonUrl}",
+                    () => self.postMessage("success"),
+                    (msg) => self.postMessage("error:" + msg)
+                );
+            }).catch((e) => {
+                self.postMessage("import-failed:" + e.message);
+            });
+        `;
+
+        const result = await runWorker(page, workerCode, "module");
+        expect(result).toBe("success");
+        await page.close();
+    });
+});

--- a/packages/dev/core/test/unit/Misc/babylon.tools.loadScript.test.ts
+++ b/packages/dev/core/test/unit/Misc/babylon.tools.loadScript.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Tools } from "core/Misc/tools";
+
+/**
+ * Tests for Tools.LoadScript / _LoadScriptWeb, specifically the module-worker
+ * fallback introduced in PR #18144.
+ *
+ * `importScripts` does not exist in Node, so we stub it globally to simulate
+ * classic and module-type worker environments.
+ */
+describe("Tools.LoadScript — worker paths", () => {
+    const dataUri = "data:text/javascript,export default {}";
+
+    beforeEach(() => {
+        // Ensure we start each test without a global importScripts
+        vi.unstubAllGlobals();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("calls onSuccess when importScripts succeeds (classic worker)", () => {
+        const mockImportScripts = vi.fn();
+        vi.stubGlobal("importScripts", mockImportScripts);
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        Tools.LoadScript("http://example.com/script.js", onSuccess, onError);
+
+        expect(mockImportScripts).toHaveBeenCalledWith("http://example.com/script.js");
+        expect(onSuccess).toHaveBeenCalledOnce();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("falls back to import() on TypeError and calls onSuccess when import resolves (module worker)", async () => {
+        vi.stubGlobal(
+            "importScripts",
+            vi.fn(() => {
+                throw new TypeError("Failed to execute 'importScripts'");
+            })
+        );
+
+        await expect(Tools.LoadScriptAsync(dataUri)).resolves.toBeUndefined();
+    });
+
+    it("falls back to import() on TypeError and calls onError when import rejects (module worker, bad URL)", async () => {
+        vi.stubGlobal(
+            "importScripts",
+            vi.fn(() => {
+                throw new TypeError("Failed to execute 'importScripts'");
+            })
+        );
+
+        await expect(Tools.LoadScriptAsync("data:text/javascript,throw new Error('fail')")).rejects.toThrow();
+    });
+
+    it("calls onError immediately for non-TypeError exceptions", () => {
+        const networkError = new Error("network error");
+        vi.stubGlobal(
+            "importScripts",
+            vi.fn(() => {
+                throw networkError;
+            })
+        );
+
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+
+        Tools.LoadScript("http://example.com/script.js", onSuccess, onError);
+
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledExactlyOnceWith(expect.stringContaining("Unable to load script"), networkError);
+    });
+});


### PR DESCRIPTION
Workers with `type: "module"` cannot use `importScripts`, so this falls back to `import` to allow use of NullEngine (specifically, loading compressed glbs which triggers this LoadScript call) in module workers

Fixes https://forum.babylonjs.com/t/cannot-load-gltf-model-in-a-module-type-web-worker-due-to-importscripts-dependency/62764