### PR TITLE
fix(sandbox): use network-first strategy for versioned Babylon.js resources in service worker

### DIFF
--- a/packages/tools/sandbox/public/sw.js
+++ b/packages/tools/sandbox/public/sw.js
@@ -124,14 +124,17 @@ function isVersionedResource(url) {
 function networkFirst(event, cache) {
     return fetch(event.request)
         .then((networkResponse) => {
-            if (networkResponse.ok) {
-                // Update cache with the fresh response
-                cache.put(event.request, networkResponse.clone());
+            if (networkResponse.ok || networkResponse.type === "opaque") {
+                // Update cache with the fresh response; use waitUntil to
+                // ensure writes complete before the SW is terminated
+                const cacheUpdates = [];
+                cacheUpdates.push(cache.put(event.request, networkResponse.clone()));
                 // Also cache without query string so offline fallback works
                 const url = new URL(event.request.url);
                 if (url.search) {
-                    cache.put(url.origin + url.pathname, networkResponse.clone());
+                    cacheUpdates.push(cache.put(url.origin + url.pathname, networkResponse.clone()));
                 }
+                event.waitUntil(Promise.allSettled(cacheUpdates));
             }
             return networkResponse;
         })
@@ -160,7 +163,7 @@ function staleWhileRevalidate(event, cache) {
         // For external resources, try matching without query string
         const requestUrl = new URL(event.request.url);
         const urlWithoutQuery = requestUrl.origin + requestUrl.pathname;
-        if (requestUrl.search && !requestUrl.hostname.includes(self.location.hostname)) {
+        if (requestUrl.search && requestUrl.origin !== self.location.origin) {
             return cache.match(urlWithoutQuery);
         }
         return null;
@@ -170,8 +173,8 @@ function staleWhileRevalidate(event, cache) {
         // Start network fetch in background (don't await)
         const fetchPromise = fetch(event.request)
             .then((networkResponse) => {
-                // Update cache with fresh version
-                if (networkResponse.ok) {
+                // Update cache with fresh version (including opaque cross-origin responses)
+                if (networkResponse.ok || networkResponse.type === "opaque") {
                     cache.put(event.request, networkResponse.clone());
                 }
                 return networkResponse;


### PR DESCRIPTION
## Problem

The sandbox's service worker was using **stale-while-revalidate** for all requests, including `timestamp.js` and Babylon.js library scripts. This caused the sandbox to persistently serve stale cached versions of the framework even after CDN updates.

### Root cause

1. `timestamp.js?t=<now>` is intercepted by the SW — the exact URL misses the cache, so the SW strips the query string and returns the **pre-cached old** `timestamp.js` immediately
2. The old timestamp causes library URLs to use `?t=<old_value>`, which the SW again matches against stale cached library versions
3. The background fetch updates the cache _after_ the page already loaded with old code
4. Even hard refresh doesn't bypass the service worker — old versions persist

### Fix

Split resources into two categories with different caching strategies:

| Resource type                                                          | Strategy                   | Rationale                                                                         |
| ---------------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------------------------- |
| `timestamp.js`, `preview.babylonjs.com/*`, snapshot CDN, versioned CDN | **Network-first**          | Must always get fresh versions when online; cache only serves as offline fallback |
| App shell, icons, fonts, physics engines                               | **Stale-while-revalidate** | Change infrequently; fast cached loads are fine                                   |

### Changes

- `isVersionedResource()` classifies requests by hostname/path (covers `timestamp.js`, `preview.babylonjs.com`, snapshot CDN, and versioned CDN paths like `cdn.babylonjs.com/v7.x.x/...`)
- `networkFirst()` strategy tries the network first, falls back to cache only on network failure. Also caches responses both with and without query strings for robust offline fallback
- `staleWhileRevalidate()` strategy remains for non-versioned resources (app shell, icons, fonts, physics engines)
- Bumped `CACHE_VERSION` from `v2` to `v3` to force cleanup of stale caches on activate
- PWA offline mode still works — versioned resources are pre-cached during install as a fallback
