### PR TITLE
Make CDN port configurable via CDN_PORT environment variable

### DIFF
--- a/packages/dev/buildTools/src/webpackTools.ts
+++ b/packages/dev/buildTools/src/webpackTools.ts
@@ -189,6 +189,7 @@ export const commonDevWebpackConfiguration = (
         port: number;
         static?: string[];
         showBuildProgress?: boolean;
+        cdnPort?: number | string;
     },
     additionalPlugins?: WebpackPluginInstance[]
 ) => {
@@ -229,6 +230,14 @@ export const commonDevWebpackConfiguration = (
                       progress: devServerConfig.showBuildProgress,
                   },
                   allowedHosts: process.env.ALLOWED_HOSTS ? process.env.ALLOWED_HOSTS.split(",") : undefined,
+                  setupMiddlewares: (middlewares: any[], devServer: any) => {
+                      const cdnPort = devServerConfig.cdnPort || process.env.CDN_PORT || 1337;
+                      devServer.app.get("/cdn-config.js", (_req: any, res: any) => {
+                          res.type("application/javascript");
+                          res.send(`window.__CDN_PORT__ = ${Number(cdnPort)};`);
+                      });
+                      return middlewares;
+                  },
               }
             : undefined,
         output: env.outputFilename

--- a/packages/tools/babylonServer/webpack.config.js
+++ b/packages/tools/babylonServer/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = (env) => {
                 enableLiveReload: env.enableLiveReload,
             },
             {
-                port: env.cdnPort || env.CDN_PORT || 1337,
+                port: env.cdnPort || env.CDN_PORT || process.env.CDN_PORT || 1337,
                 static: ["public", "declarations", "../playground/public"],
                 showBuildProcess: true,
             }

--- a/packages/tools/guiEditor/public/index.html
+++ b/packages/tools/guiEditor/public/index.html
@@ -42,6 +42,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/guiEditor/public/index.js
+++ b/packages/tools/guiEditor/public/index.js
@@ -1,4 +1,5 @@
 /* global BABYLON */
+var cdnPort = window.__CDN_PORT__ || 1337;
 let snippetUrl = "https://snippet.babylonjs.com";
 let currentSnippetToken;
 let previousHash = "";
@@ -36,7 +37,7 @@ let loadScriptAsync = function (url, instantResolve) {
 
 const Versions = {
     dist: ["https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(), "https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/gui/babylon.gui.min.js"],
-    local: [`//${window.location.hostname}:1337/babylon.js`, `//${window.location.hostname}:1337/gui/babylon.gui.min.js`],
+    local: [`//${window.location.hostname}:${cdnPort}/babylon.js`, `//${window.location.hostname}:${cdnPort}/gui/babylon.gui.min.js`],
 };
 
 let loadInSequence = async function (versions, index, resolve) {
@@ -96,7 +97,7 @@ let checkBabylonVersionAsync = function () {
             globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
         }
     });
 };

--- a/packages/tools/nodeEditor/public/index.html
+++ b/packages/tools/nodeEditor/public/index.html
@@ -46,6 +46,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/nodeEditor/public/index.js
+++ b/packages/tools/nodeEditor/public/index.js
@@ -1,4 +1,5 @@
 /* global BABYLON */
+var cdnPort = window.__CDN_PORT__ || 1337;
 let snippetUrl = "https://snippet.babylonjs.com";
 let currentSnippetToken;
 let previousHash = "";
@@ -43,7 +44,7 @@ let loadScriptAsync = function (url, instantResolve) {
 
 const Versions = {
     dist: ["https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(), "https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"],
-    local: [`//${window.location.hostname}:1337/babylon.js`, `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`],
+    local: [`//${window.location.hostname}:${cdnPort}/babylon.js`, `//${window.location.hostname}:${cdnPort}/loaders/babylonjs.loaders.min.js`],
 };
 
 let loadInSequence = async function (versions, index, resolve) {
@@ -98,7 +99,7 @@ let checkBabylonVersionAsync = function () {
             globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
         }
     });
 };

--- a/packages/tools/nodeGeometryEditor/public/index.html
+++ b/packages/tools/nodeGeometryEditor/public/index.html
@@ -46,6 +46,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/nodeGeometryEditor/public/index.js
+++ b/packages/tools/nodeGeometryEditor/public/index.js
@@ -1,4 +1,5 @@
 /* global BABYLON */
+var cdnPort = window.__CDN_PORT__ || 1337;
 let snippetUrl = "https://snippet.babylonjs.com";
 let currentSnippetToken;
 let previousHash = "";
@@ -43,9 +44,9 @@ const Versions = {
         "https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.min.js",
     ],
     local: [
-        `//${window.location.hostname}:1337/babylon.js`,
-        `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`,
-        `//${window.location.hostname}:1337/materialsLibrary/babylonjs.materials.min.js`,
+        `//${window.location.hostname}:${cdnPort}/babylon.js`,
+        `//${window.location.hostname}:${cdnPort}/loaders/babylonjs.loaders.min.js`,
+        `//${window.location.hostname}:${cdnPort}/materialsLibrary/babylonjs.materials.min.js`,
     ],
 };
 
@@ -101,7 +102,7 @@ let checkBabylonVersionAsync = function () {
             globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
         }
     });
 };

--- a/packages/tools/nodeParticleEditor/public/index.html
+++ b/packages/tools/nodeParticleEditor/public/index.html
@@ -46,6 +46,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/nodeParticleEditor/public/index.js
+++ b/packages/tools/nodeParticleEditor/public/index.js
@@ -1,4 +1,5 @@
 /* global BABYLON */
+var cdnPort = window.__CDN_PORT__ || 1337;
 let snippetUrl = "https://snippet.babylonjs.com";
 let currentSnippetToken;
 let previousHash = "";
@@ -44,9 +45,9 @@ const Versions = {
         "https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.min.js",
     ],
     local: [
-        `//${window.location.hostname}:1337/babylon.js`,
-        `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`,
-        `//${window.location.hostname}:1337/materialsLibrary/babylonjs.materials.min.js`,
+        `//${window.location.hostname}:${cdnPort}/babylon.js`,
+        `//${window.location.hostname}:${cdnPort}/loaders/babylonjs.loaders.min.js`,
+        `//${window.location.hostname}:${cdnPort}/materialsLibrary/babylonjs.materials.min.js`,
     ],
 };
 
@@ -102,7 +103,7 @@ let checkBabylonVersionAsync = function () {
             globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
         }
     });
 };

--- a/packages/tools/nodeRenderGraphEditor/public/index.html
+++ b/packages/tools/nodeRenderGraphEditor/public/index.html
@@ -47,6 +47,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/nodeRenderGraphEditor/public/index.js
+++ b/packages/tools/nodeRenderGraphEditor/public/index.js
@@ -1,4 +1,5 @@
 /* global BABYLON */
+var cdnPort = window.__CDN_PORT__ || 1337;
 let snippetUrl = "https://snippet.babylonjs.com";
 let currentSnippetToken;
 let previousHash = "";
@@ -43,7 +44,7 @@ let loadScriptAsync = function (url, instantResolve) {
 
 const Versions = {
     dist: ["https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(), "https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js"],
-    local: [`//${window.location.hostname}:1337/babylon.js`, `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`],
+    local: [`//${window.location.hostname}:${cdnPort}/babylon.js`, `//${window.location.hostname}:${cdnPort}/loaders/babylonjs.loaders.min.js`],
 };
 
 let loadInSequence = async function (versions, index, resolve) {
@@ -98,7 +99,7 @@ let checkBabylonVersionAsync = function () {
             globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
         }
     });
 };

--- a/packages/tools/playground/debug.html
+++ b/packages/tools/playground/debug.html
@@ -61,6 +61,7 @@
     <body>
         <div id="host-element"></div>
 
+        <script src="/cdn-config.js"></script>
         <script src="/index.js"></script>
     </body>
 </html>

--- a/packages/tools/playground/frame.html
+++ b/packages/tools/playground/frame.html
@@ -56,6 +56,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="/cdn-config.js"></script>
         <script src="/index.js"></script>
     </body>
 </html>

--- a/packages/tools/playground/full.html
+++ b/packages/tools/playground/full.html
@@ -56,6 +56,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="/cdn-config.js"></script>
         <script src="/index.js"></script>
     </body>
 </html>

--- a/packages/tools/playground/index.html
+++ b/packages/tools/playground/index.html
@@ -55,6 +55,7 @@
         <script src="https://cdn.babylonjs.com/Oimo.js"></script>
         <script src="https://cdn.babylonjs.com/earcut.min.js"></script>
         <script src="https://assets.babylonjs.com/generated/Assets.js"></script>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -1,4 +1,5 @@
 // Version
+var cdnPort = window.__CDN_PORT__ || 1337;
 var Versions = {
     Latest: [
         { url: "https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(), instantResolve: false },
@@ -26,21 +27,21 @@ var Versions = {
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js", instantResolve: true },
     ],
     local: [
-        { url: `//${window.location.hostname}:1337/babylon.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/gui/babylon.gui.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/addons/babylonjs.addons.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/nodeEditor/babylon.nodeEditor.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/nodeGeometryEditor/babylon.nodeGeometryEditor.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/nodeRenderGraphEditor/babylon.nodeRenderGraphEditor.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/guiEditor/babylon.guiEditor.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/materialsLibrary/babylonjs.materials.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/postProcessesLibrary/babylonjs.postProcess.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/serializers/babylonjs.serializers.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/accessibility/babylon.accessibility.js`, instantResolve: false },
-        // { url: `//${window.location.hostname}:1337/inspector/babylon.inspector.bundle.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/babylon.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/gui/babylon.gui.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/addons/babylonjs.addons.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/nodeEditor/babylon.nodeEditor.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/nodeGeometryEditor/babylon.nodeGeometryEditor.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/nodeRenderGraphEditor/babylon.nodeRenderGraphEditor.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/guiEditor/babylon.guiEditor.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/materialsLibrary/babylonjs.materials.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/postProcessesLibrary/babylonjs.postProcess.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/loaders/babylonjs.loaders.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/serializers/babylonjs.serializers.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/accessibility/babylon.accessibility.js`, instantResolve: false },
+        // { url: `//${window.location.hostname}:${cdnPort}/inspector/babylon.inspector.bundle.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/f43ab677b4bca0a6ab77132d3f785be300382760/ClonerSystem/src/babylonx.cloner.js", instantResolve: false },
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js", instantResolve: false },
     ],
@@ -239,7 +240,7 @@ let checkBabylonVersionAsync = async function () {
             return { version, bundles };
         } else if (activeVersion === "local") {
             // eslint-disable-next-line no-undef
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
             return { version: "", bundles };
         }
 

--- a/packages/tools/playground/src/tools/monaco/monacoManager.ts
+++ b/packages/tools/playground/src/tools/monaco/monacoManager.ts
@@ -583,8 +583,9 @@ export class MonacoManager {
         }
 
         if (location.hostname === "localhost" && location.search.indexOf("dist") === -1) {
+            const cdnPort = (window as any).__CDN_PORT__ || 1337;
             for (let i = 0; i < declarations.length; i++) {
-                declarations[i] = declarations[i].replace("https://preview.babylonjs.com/", "//localhost:1337/");
+                declarations[i] = declarations[i].replace("https://preview.babylonjs.com/", `//localhost:${cdnPort}/`);
             }
         }
 

--- a/packages/tools/playground/test/interactions.playground.test.ts
+++ b/packages/tools/playground/test/interactions.playground.test.ts
@@ -3,7 +3,8 @@ import { getGlobalConfig } from "@tools/test-tools";
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
-const url = (process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.PLAYGROUND_PORT || ":1338")) + snapshot;
+const cdnPort = ":" + (process.env.CDN_PORT || 1337);
+const url = (process.env.PLAYGROUND_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.PLAYGROUND_PORT || ":1338")) + snapshot;
 
 test("Playground is loaded (Desktop)", async ({ page }) => {
     await page.goto(url, {

--- a/packages/tools/sandbox/public/index.html
+++ b/packages/tools/sandbox/public/index.html
@@ -45,6 +45,7 @@
         <script src="https://cdn.babylonjs.com/havok/HavokPhysics_umd.js"></script>
         <script src="https://cdn.babylonjs.com/cannon.js"></script>
         <script src="https://cdn.babylonjs.com/Oimo.js"></script>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/sandbox/public/index.js
+++ b/packages/tools/sandbox/public/index.js
@@ -1,6 +1,7 @@
 /* global BABYLON */
 
 var hostElement = document.getElementById("host-element");
+var cdnPort = window.__CDN_PORT__ || 1337;
 
 const fallbackUrl = "https://snapshots-cvgtc2eugrd3cgfd.z01.azurefd.net/refs/heads/master";
 
@@ -57,14 +58,14 @@ const Versions = {
               ]),
     ],
     local: [
-        { url: `//${window.location.hostname}:1337/babylon.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/addons/babylonjs.addons.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/loaders/babylonjs.loaders.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/serializers/babylonjs.serializers.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/materialsLibrary/babylonjs.materials.min.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/gui/babylon.gui.min.js`, instantResolve: false },
-        // { url: `//${window.location.hostname}:1337/inspector/babylon.inspector.bundle.js`, instantResolve: false },
-        { url: `//${window.location.hostname}:1337/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/babylon.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/addons/babylonjs.addons.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/loaders/babylonjs.loaders.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/serializers/babylonjs.serializers.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/materialsLibrary/babylonjs.materials.min.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/gui/babylon.gui.min.js`, instantResolve: false },
+        // { url: `//${window.location.hostname}:${cdnPort}/inspector/babylon.inspector.bundle.js`, instantResolve: false },
+        { url: `//${window.location.hostname}:${cdnPort}/inspector/babylon.inspector-v2.bundle.js`, instantResolve: false },
     ],
 };
 
@@ -154,7 +155,7 @@ let checkBabylonVersionAsync = function () {
         } else if (version) {
             globalThis.BABYLON.Tools.ScriptBaseUrl = "https://cdn.babylonjs.com/v" + version;
         } else if (activeVersion === "local") {
-            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:1337/`;
+            globalThis.BABYLON.Tools.ScriptBaseUrl = window.location.protocol + `//${window.location.hostname}:${cdnPort}/`;
         }
 
         return { version, bundles: versions.map((v) => v.url) };

--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -9,7 +9,8 @@ test.beforeAll(async () => {
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
-const url = (process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.SANDBOX_PORT || ":1339")) + snapshot;
+const cdnPort = ":" + (process.env.CDN_PORT || 1337);
+const url = (process.env.SANDBOX_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.SANDBOX_PORT || ":1339")) + snapshot;
 
 test("Sandbox is loaded (Desktop)", async ({ page }) => {
     await page.goto(url, {

--- a/packages/tools/testTools/src/index.ts
+++ b/packages/tools/testTools/src/index.ts
@@ -12,7 +12,7 @@ export const getGlobalConfig = (overrideConfig: { root?: string; baseUrl?: strin
     if (overrideConfig.usesDevHost) {
         baseUrl = (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:1338";
     } else {
-        baseUrl = process.env.CDN_BASE_URL || (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:1337";
+        baseUrl = process.env.CDN_BASE_URL || (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:" + (process.env.CDN_PORT || 1337);
     }
 
     return {

--- a/packages/tools/tests/test/playwright/interaction.tools.test.ts
+++ b/packages/tools/tests/test/playwright/interaction.tools.test.ts
@@ -3,10 +3,11 @@ import { test, expect } from "@playwright/test";
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
-const nmeUrl = (process.env.NME_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NME_PORT || ":1340")) + snapshot;
-const ngeUrl = (process.env.NGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NGE_PORT || ":1343")) + snapshot;
-const guiUrl = (process.env.GUIEDITOR_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.GUIEDITOR_PORT || ":1341")) + snapshot;
-const nrgeUrl = (process.env.NRGE_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.NRGE_PORT || ":1344")) + snapshot;
+const cdnPort = ":" + (process.env.CDN_PORT || 1337);
+const nmeUrl = (process.env.NME_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.NME_PORT || ":1340")) + snapshot;
+const ngeUrl = (process.env.NGE_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.NGE_PORT || ":1343")) + snapshot;
+const guiUrl = (process.env.GUIEDITOR_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.GUIEDITOR_PORT || ":1341")) + snapshot;
+const nrgeUrl = (process.env.NRGE_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.NRGE_PORT || ":1344")) + snapshot;
 
 test.beforeAll(async () => {
     // Set timeout for this hook.

--- a/packages/tools/testsMemoryLeaks/src/index.ts
+++ b/packages/tools/testsMemoryLeaks/src/index.ts
@@ -20,7 +20,7 @@ export const getGlobalConfig = (overrideConfig: { root?: string; baseUrl?: strin
     return {
         snippetUrl: "https://snippet.babylonjs.com",
         pgRoot: "https://playground.babylonjs.com",
-        baseUrl: process.env.CDN_BASE_URL || (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:1337",
+        baseUrl: process.env.CDN_BASE_URL || (checkArgs(["--enable-https"], true) ? "https" : "http") + "://localhost:" + (process.env.CDN_PORT || 1337),
         root: "https://cdn.babylonjs.com",
         ...overrideConfig,
     };

--- a/packages/tools/viewer/test/viewer.test.ts
+++ b/packages/tools/viewer/test/viewer.test.ts
@@ -4,8 +4,9 @@ import { ViewerElement } from "viewer/viewerElement";
 
 // if running in the CI we need to use the babylon snapshot when loading the tools
 const snapshot = process.env.SNAPSHOT ? "?snapshot=" + process.env.SNAPSHOT : "";
+const cdnPort = ":" + (process.env.CDN_PORT || 1337);
 const viewerUrl =
-    (process.env.VIEWER_BASE_URL || getGlobalConfig().baseUrl.replace(":1337", process.env.VIEWER_PORT || ":1342")) + "/packages/tools/viewer/test/apps/web/test.html" + snapshot;
+    (process.env.VIEWER_BASE_URL || getGlobalConfig().baseUrl.replace(cdnPort, process.env.VIEWER_PORT || ":1342")) + "/packages/tools/viewer/test/apps/web/test.html" + snapshot;
 
 let pageErrors: Error[];
 let consoleErrors: string[];

--- a/packages/tools/vsm/public/index.html
+++ b/packages/tools/vsm/public/index.html
@@ -32,6 +32,7 @@
 
     <body>
         <div id="host-element"></div>
+        <script src="cdn-config.js"></script>
         <script src="index.js"></script>
     </body>
 </html>

--- a/packages/tools/vsm/public/index.js
+++ b/packages/tools/vsm/public/index.js
@@ -1,4 +1,5 @@
 /* global BABYLON */
+var cdnPort = window.__CDN_PORT__ || 1337;
 let snippetUrl = "https://snippet.babylonjs.com";
 let currentSnippetToken;
 let previousHash = "";
@@ -36,7 +37,7 @@ let loadScriptAsync = function (url, instantResolve) {
 
 const Versions = {
     dist: ["https://preview.babylonjs.com/timestamp.js?t=" + Date.now(), "https://preview.babylonjs.com/babylon.js", "https://preview.babylonjs.com/gui/babylon.gui.min.js"],
-    local: ["//localhost:1337/babylon.js", "//localhost:1337/gui/babylon.gui.min.js"],
+    local: [`//localhost:${cdnPort}/babylon.js`, `//localhost:${cdnPort}/gui/babylon.gui.min.js`],
 };
 
 let loadInSequence = async function (versions, index, resolve) {


### PR DESCRIPTION
The local CDN server (babylonServer) port was hardcoded to `1337` across all tools. While the server itself partially supported `--env cdnPort` / `--env CDN_PORT` webpack flags, the client-side code in every tool's `public/index.js` had the port baked in as a string literal. This meant changing the CDN server port would break all tool frontends.

This PR makes the CDN port fully configurable end-to-end via the `CDN_PORT` environment variable.

## Why

This allows developers to run multiple versions of Babylon.js locally across different repos simultaneously. Without configurable ports, two instances of the CDN server would conflict on port 1337. With this change, each repo can use a different `CDN_PORT` and all tools will automatically connect to the correct CDN server.

### How it works

1. **`commonDevWebpackConfiguration`** now adds a `setupMiddlewares` hook that serves a virtual `/cdn-config.js` endpoint, which returns `window.__CDN_PORT__ = <port>;` based on `process.env.CDN_PORT`.
2. **Every tool's HTML** loads `cdn-config.js` before `index.js`, bridging the server-side env var to the browser.
3. **Every tool's `public/index.js`** reads `window.__CDN_PORT__ || 1337` instead of hardcoding `:1337`.
4. **babylonServer's webpack config** now also reads `process.env.CDN_PORT` (previously only supported webpack `--env` flags).
5. **Test utilities and Playwright test files** use `process.env.CDN_PORT` for constructing base URLs.

### Usage

```powershell
# Default (port 1337, no changes needed)
npm run serve -w @tools/babylon-server

# Custom CDN port
$env:CDN_PORT=8088; npm run serve -w @tools/babylon-server
$env:CDN_PORT=8088; npm run serve -w @tools/playground

# Linux/macOS
CDN_PORT=8088 npm run serve -w @tools/babylon-server
CDN_PORT=8088 npm run serve -w @tools/playground
```

### Backward compatibility

Fully backward compatible. When `CDN_PORT` is not set, everything defaults to `1337`.

### Changed files (28)

- **Infrastructure:** `packages/dev/buildTools/src/webpackTools.ts`, `packages/tools/babylonServer/webpack.config.js`
- **HTML files (11):** Added `<script src="cdn-config.js">` in playground (4 templates), sandbox, guiEditor, nodeEditor, nodeGeometryEditor, nodeRenderGraphEditor, nodeParticleEditor, vsm
- **JS files (8):** Replaced hardcoded `:1337` with `${cdnPort}` variable in all `public/index.js` files
- **TypeScript (1):** `monacoManager.ts` — uses `window.__CDN_PORT__`
- **Test tools (2):** `testTools/src/index.ts`, `testsMemoryLeaks/src/index.ts`
- **Test files (4):** Updated URL construction to use dynamic CDN port