### PR TITLE
Support zoom while rotating for geo camera wheel input

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraMouseWheelInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraMouseWheelInput.ts
@@ -1,6 +1,7 @@
 import type { GeospatialCamera } from "../../Cameras/geospatialCamera";
 import { CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import { BaseCameraMouseWheelInput } from "./BaseCameraMouseWheelInput";
+import type { GeospatialCameraPointersInput } from "./geospatialCameraPointersInput";
 
 /**
  * Manage the mouse wheel inputs to control a geospatial camera.
@@ -11,6 +12,9 @@ export class GeospatialCameraMouseWheelInput extends BaseCameraMouseWheelInput {
      */
     public camera: GeospatialCamera;
 
+    /** When false, wheel zoom is blocked while a pointer rotation button is active. */
+    public allowZoomWhilePointerRotating: boolean = false;
+
     /**
      * Gets the class name of the current input.
      * @returns the class name
@@ -20,7 +24,10 @@ export class GeospatialCameraMouseWheelInput extends BaseCameraMouseWheelInput {
     }
 
     public override checkInputs(): void {
-        this.camera.movement.handleZoom(this._wheelDeltaY, true);
+        if (this.allowZoomWhilePointerRotating || !(this.camera.inputs.attached["pointers"] as GeospatialCameraPointersInput | undefined)?.isRotating) {
+            this.camera.movement.handleZoom(this._wheelDeltaY, true);
+        }
+
         super.checkInputs();
     }
 }

--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
@@ -3,6 +3,7 @@ import type { IPointerEvent } from "../../Events/deviceInputEvents";
 import type { PointerTouch } from "../../Events/pointerEvents";
 import type { Nullable } from "../../types";
 import { OrbitCameraPointersInput } from "./orbitCameraPointersInput";
+import { Vector3Distance } from "../../Maths/math.vector.functions";
 
 /**
  * Geospatial camera inputs can simulate dragging the globe around or tilting the camera around some point on the globe
@@ -38,6 +39,14 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
      */
     public pinchToPanMax: number = 20;
 
+    private _isRotationButtonDown = false;
+    private _isMultiTouchPanning = false;
+
+    /** Returns true if any rotation is active (e.g., mouse rotation or multi-touch pan). */
+    public get isRotating(): boolean {
+        return this._isRotationButtonDown || this._isMultiTouchPanning;
+    }
+
     public override getClassName(): string {
         return "GeospatialCameraPointersInput";
     }
@@ -48,6 +57,10 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
         switch (evt.button) {
             case 0: // Left button - drag/pan globe under cursor
                 this.camera.movement.startDrag(scene.pointerX, scene.pointerY);
+                break;
+            case 1: // Middle button - rotation
+            case 2: // Right button - rotation
+                this._isRotationButtonDown = true;
                 break;
             default:
                 break;
@@ -96,7 +109,7 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
                 const pickResult = scene.pick(canvasX, canvasY, this.camera.movement.pickPredicate);
                 if (pickResult?.pickedPoint) {
                     // Scale zoom by distance to picked point
-                    const distanceToPoint = this.camera.position.subtract(pickResult.pickedPoint).length();
+                    const distanceToPoint = Vector3Distance(this.camera.position, pickResult.pickedPoint);
                     const zoomDistance = pinchDelta * distanceToPoint * 0.005;
                     const clampedZoom = this.camera.limits.clampZoomDistance(zoomDistance, this.camera.radius, distanceToPoint);
                     this.camera.zoomToPoint(pickResult.pickedPoint, clampedZoom);
@@ -119,6 +132,7 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
      */
     protected override _computeMultiTouchPanning(previousMultiTouchPanPosition: Nullable<PointerTouch>, multiTouchPanPosition: Nullable<PointerTouch>): void {
         if (previousMultiTouchPanPosition && multiTouchPanPosition) {
+            this._isMultiTouchPanning = true;
             const moveDeltaX = multiTouchPanPosition.x - previousMultiTouchPanPosition.x;
             const moveDeltaY = multiTouchPanPosition.y - previousMultiTouchPanPosition.y;
             this._handleTilt(moveDeltaX, moveDeltaY);
@@ -147,6 +161,7 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
         if (pinchSquaredDistance === 0 && multiTouchPanPosition === null) {
             this._initialPinchSquaredDistance = 0;
             this._pinchCentroid = null;
+            this._isMultiTouchPanning = false;
             super.onMultiTouch(pointA, pointB, previousPinchSquaredDistance, pinchSquaredDistance, previousMultiTouchPanPosition, multiTouchPanPosition);
             return;
         }
@@ -166,12 +181,16 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
     public override onButtonUp(_evt: IPointerEvent): void {
         this.camera.movement.stopDrag();
         this.camera.movement.activeInput = false;
+        this._isRotationButtonDown = false;
+        this._isMultiTouchPanning = false;
         this._initialPinchSquaredDistance = 0;
         this._pinchCentroid = null;
         super.onButtonUp(_evt);
     }
 
     public override onLostFocus(): void {
+        this._isRotationButtonDown = false;
+        this._isMultiTouchPanning = false;
         this._initialPinchSquaredDistance = 0;
         this._pinchCentroid = null;
         super.onLostFocus();

--- a/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
+++ b/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
@@ -178,9 +178,9 @@ export class GeospatialCameraMovement extends CameraMovement {
             this._panSpeedMultiplier = 1;
         }
 
-        // If a pan drag or rotate is occurring, stop zooming.
+        // If a pan drag is occurring, stop zooming.
         let zoomTargetDistance: number | undefined;
-        if (this.isDragging || this.rotationAccumulatedPixels.lengthSquared() > Epsilon) {
+        if (this.isDragging) {
             this._zoomSpeedMultiplier = 0;
             this._zoomVelocity = 0;
         } else {


### PR DESCRIPTION
This change provides a way to specify if wheel zoom can be used while rotation is active, moving the configuration/control to the specific inputs instead of relying on per-frame rotation delta. (Similar to `multiTouchPanAndZoom` idea on the orbit camera's pointer input.)

For this new property the default is false, which is closest to the current behavior.