### PR TITLE
[DO NOT MERGE] Add version 8.56.2 with updated script URLs to Versions object

### DIFF
--- a/packages/tools/playground/public/index.js
+++ b/packages/tools/playground/public/index.js
@@ -47,9 +47,8 @@ var Versions = {
     "8.56.2": [
         { url: "https://cdn.babylonjs.com/timestamp.js?t=" + Date.now(), instantResolve: false },
         { url: "https://cdn.babylonjs.com/v8.56.2/babylon.js", instantResolve: false },
-        { url: "https://cdn.babylonjs.com/v8.56.2/addons/babylonjs.addons.js", instantResolve: false },
         { url: "https://cdn.babylonjs.com/v8.56.2/gui/babylon.gui.min.js", instantResolve: false },
-        { url: "https://cdn.babylonjs.com/v8.56.2/inspector/babylon.inspector-v2.bundle.js", instantResolve: true },
+        { url: "https://cdn.babylonjs.com/v8.56.2/addons/babylonjs.addons.min.js", instantResolve: false },
         { url: "https://cdn.babylonjs.com/v8.56.2/nodeEditor/babylon.nodeEditor.js", instantResolve: true },
         { url: "https://cdn.babylonjs.com/v8.56.2/nodeGeometryEditor/babylon.nodeGeometryEditor.js", instantResolve: true },
         { url: "https://cdn.babylonjs.com/v8.56.2/nodeRenderGraphEditor/babylon.nodeRenderGraphEditor.js", instantResolve: true },
@@ -60,6 +59,13 @@ var Versions = {
         { url: "https://cdn.babylonjs.com/v8.56.2/loaders/babylonjs.loaders.min.js", instantResolve: true },
         { url: "https://cdn.babylonjs.com/v8.56.2/serializers/babylonjs.serializers.min.js", instantResolve: true },
         { url: "https://cdn.babylonjs.com/v8.56.2/accessibility/babylon.accessibility.js", instantResolve: true },
+        // Allow an "inspectorv1" query param to force loading Inspector v1.
+        ...(window.location.search.toLocaleLowerCase().includes("inspectorv1")
+            ? [{ url: "https://cdn.babylonjs.com/v8.56.2/inspector/babylon.inspector.bundle.js", instantResolve: true }]
+            : [
+                  { url: "https://cdn.babylonjs.com/v8.56.2/inspector/babylon.inspector.bundle.js", instantResolve: true },
+                  { url: "https://cdn.babylonjs.com/v8.56.2/inspector/babylon.inspector-v2.bundle.js", instantResolve: true },
+              ]),
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/f43ab677b4bca0a6ab77132d3f785be300382760/ClonerSystem/src/babylonx.cloner.js", instantResolve: true },
         { url: "https://rawcdn.githack.com/BabylonJS/Extensions/785013ec55b210d12263c91f3f0a2ae70cf0bc8a/CompoundShader/src/babylonx.CompoundShader.js", instantResolve: true },
     ],


### PR DESCRIPTION
This will be merged after release.

Note - we removed the direct support for 5.X, however it can still be referenced using the ?version=??? QSP