### PR TITLE
fix: update public package READMEs with correct URLs and modern examples

### DIFF
--- a/packages/public/@babylonjs/accessibility/readme.md
+++ b/packages/public/@babylonjs/accessibility/readme.md
@@ -1,5 +1,13 @@
-Accessibility es6
-
 # Babylon.js Accessibility
 
-This package handles accessibility. It contains html twin renderer to generate html twins of the scene objects for 3D content in DOM, thus the 3D content is compatible with screen readers and keyboard navigation.
+This package provides accessibility support for Babylon.js scenes. It contains an HTML twin renderer that generates HTML twins of scene objects, making 3D content compatible with screen readers and keyboard navigation.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/core @babylonjs/accessibility
+```
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/@babylonjs/addons/readme.md
+++ b/packages/public/@babylonjs/addons/readme.md
@@ -1,1 +1,13 @@
 # Babylon.js Addons
+
+A collection of addons and extensions for Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/core @babylonjs/addons
+```
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/@babylonjs/core/readme.md
+++ b/packages/public/@babylonjs/core/readme.md
@@ -2,67 +2,59 @@
 
 Getting started? Play directly with the Babylon.js API using our [playground](https://playground.babylonjs.com/). It also contains a lot of samples to learn how to use it.
 
-[![npm version](https://badge.fury.io/js/babylonjs.svg)](https://badge.fury.io/js/babylonjs)
-[![Build Status](https://travis-ci.com/BabylonJS/Babylon.js.svg?branch=master)](https://travis-ci.com/BabylonJS/Babylon.js)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/BabylonJS/Babylon.js.svg)](http://isitmaintained.com/project/BabylonJS/Babylon.js "Average time to resolve an issue")
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/babylonJS/babylon.js.svg)](https://isitmaintained.com/project/babylonJS/babylon.js "Percentage of issues still open")
-[![Build Size](https://img.badgesize.io/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.js.svg?compression=gzip)](https://img.badgesize.io/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.js.svg?compression=gzip)
-[![Twitter](https://img.shields.io/twitter/follow/babylonjs.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=babylonjs)
+[![npm version](https://badge.fury.io/js/%40babylonjs%2Fcore.svg)](https://www.npmjs.com/package/@babylonjs/core)
 
 **Any questions?** Here is our official [forum](https://forum.babylonjs.com/).
 
 ## CDN
 
-To look into our CDN bundled distribution, you can refer to the package [babylonjs](https://www.npmjs.com/package/babylonjs)
+For the UMD bundled distribution, see the [babylonjs](https://www.npmjs.com/package/babylonjs) package.
 
 ## npm
 
-BabylonJS and its modules are published on npm as esNext modules with full typing support. To install, use:
+Babylon.js and its modules are published on npm as ES modules with full typing support. To install, use:
 
 ```text
-npm install @babylonjs/core --save
+npm install @babylonjs/core
 ```
 
-This will allow you to import BabylonJS entirely using:
+This will allow you to import Babylon.js entirely using:
 
 ```javascript
-import * as BABYLON from '@babylonjs/core/Legacy/legacy';
+import * as BABYLON from "@babylonjs/core/Legacy/legacy";
 ```
 
-or individual classes to benefit from enhanced tree shaking using :
+or individual classes to benefit from tree shaking:
 
 ```javascript
-import { Scene } from '@babylonjs/core/scene';
-import { Engine } from '@babylonjs/core/Engines/engine';
+import { Scene } from "@babylonjs/core/scene";
+import { Engine } from "@babylonjs/core/Engines/engine";
 ```
 
-To add a module, install the respective package. A list of extra packages and their installation instructions can be found on the [babylonjs user on npm](https://www.npmjs.com/~babylonjs) scoped on @babylonjs.
+To add a module, install the respective package. A list of extra packages and their installation instructions can be found on the [@babylonjs scope on npm](https://www.npmjs.com/~babylonjs).
 
 ## Usage
 
-See [our ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support):
+See [our ES6 dedicated documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/):
 
 ```javascript
 import { Engine } from "@babylonjs/core/Engines/engine";
 import { Scene } from "@babylonjs/core/scene";
-import { Vector3 } from "@babylonjs/core/Maths/math";
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 import { FreeCamera } from "@babylonjs/core/Cameras/freeCamera";
 import { HemisphericLight } from "@babylonjs/core/Lights/hemisphericLight";
-import { Mesh } from "@babylonjs/core/Meshes/mesh";
+import { CreateSphere } from "@babylonjs/core/Meshes/Builders/sphereBuilder";
+import { CreateGround } from "@babylonjs/core/Meshes/Builders/groundBuilder";
 
-// Side-effects only imports allowing the standard material to be used as default.
+// Side-effect import allowing the standard material to be used as default.
 import "@babylonjs/core/Materials/standardMaterial";
-// Side-effects only imports allowing Mesh to create default shapes (to enhance tree shaking, the construction methods on mesh are not available if the meshbuilder has not been imported).
-import "@babylonjs/core/Meshes/Builders/sphereBuilder";
-import "@babylonjs/core/Meshes/Builders/boxBuilder";
-import "@babylonjs/core/Meshes/Builders/groundBuilder";
 
 const canvas = document.getElementById("renderCanvas") as HTMLCanvasElement;
 const engine = new Engine(canvas);
-var scene = new Scene(engine);
+const scene = new Scene(engine);
 
 // This creates and positions a free camera (non-mesh)
-var camera = new FreeCamera("camera1", new Vector3(0, 5, -10), scene);
+const camera = new FreeCamera("camera1", new Vector3(0, 5, -10), scene);
 
 // This targets the camera to scene origin
 camera.setTarget(Vector3.Zero());
@@ -71,19 +63,19 @@ camera.setTarget(Vector3.Zero());
 camera.attachControl(canvas, true);
 
 // This creates a light, aiming 0,1,0 - to the sky (non-mesh)
-var light = new HemisphericLight("light1", new Vector3(0, 1, 0), scene);
+const light = new HemisphericLight("light1", new Vector3(0, 1, 0), scene);
 
 // Default intensity is 1. Let's dim the light a small amount
 light.intensity = 0.7;
 
-// Our built-in 'sphere' shape. Params: name, subdivs, size, scene
-var sphere = Mesh.CreateSphere("sphere1", 16, 2, scene);
+// Our built-in 'sphere' shape
+const sphere = CreateSphere("sphere1", { segments: 16, diameter: 2 }, scene);
 
 // Move the sphere upward 1/2 its height
-sphere.position.y = 2;
+sphere.position.y = 1;
 
-// Our built-in 'ground' shape. Params: name, width, depth, subdivs, scene
-Mesh.CreateGround("ground1", 6, 6, 2, scene);
+// Our built-in 'ground' shape
+CreateGround("ground1", { width: 6, height: 6, subdivisions: 2 }, scene);
 
 engine.runRenderLoop(() => {
     scene.render();
@@ -102,15 +94,10 @@ Please see the [contribution guidelines](https://github.com/BabylonJS/Babylon.js
 ## Useful links
 
 - Official web site: [www.babylonjs.com](https://www.babylonjs.com/)
-- Online [playground](https://playground.babylonjs.com/) to learn by experimentating
+- Online [playground](https://playground.babylonjs.com/) to learn by experimenting
 - Online [sandbox](https://www.babylonjs.com/sandbox) where you can test your .babylon and glTF scenes with a simple drag'n'drop
-- Online [shader creation tool](https://www.babylonjs.com/cyos/) where you can learn how to create GLSL shaders
-- 3DS Max [exporter](https://github.com/BabylonJS/Exporters/tree/master/3ds%20Max) can be used to generate a .babylon file from 3DS Max
-- Maya [exporter](https://github.com/BabylonJS/Exporters/tree/master/Maya) can be used to generate a .babylon file from 3DS Max
-- Blender [exporter](https://github.com/BabylonJS/Exporters/tree/master/Blender) can be used to generate a .babylon file from Blender 3d
-- Unity 5[ (deprecated) exporter](https://github.com/BabylonJS/Exporters/tree/master/Unity) can be used to export your geometries from Unity 5 scene editor(animations are supported)
 - [glTF Tools](https://github.com/KhronosGroup/glTF#gltf-tools) by KhronosGroup
 
 ## Features
 
-To get a complete list of supported features, please visit our [website](https://www.babylonjs.com/#specifications).
+To get a complete list of supported features, please visit our [website](https://www.babylonjs.com/).

--- a/packages/public/@babylonjs/gui-editor/readme.md
+++ b/packages/public/@babylonjs/gui-editor/readme.md
@@ -1,15 +1,13 @@
-Gui Editor es6
+# Babylon.js GUI Editor
 
-# Babylon.js Gui Editor
+The GUI Editor is a visual tool for creating and modifying GUI layouts for Babylon.js scenes.
 
-An extension to easily allow users to create and modify GUI for scenes.
+## Installation
 
-## Usage
-Currently available for local development by selecting "Launch GUI Editor (Chrome)"
+To install using npm:
 
-## Current Supported Features
+```bash
+npm install @babylonjs/gui-editor
+```
 
-- Launch GUI editor in local dev mode.
-- Drag and drop GUI elements onto a canvas.
-- Select and move individual GUI elements.
-- Modify properties of selected GUI elements.
+For more information, see the [GUI Editor documentation](https://doc.babylonjs.com/toolsAndResources/guiEditor/).

--- a/packages/public/@babylonjs/gui/readme.md
+++ b/packages/public/@babylonjs/gui/readme.md
@@ -1,31 +1,32 @@
-Babylon.js GUI module
-=====================
+# Babylon.js GUI Module
 
-For usage documentation please visit https://doc.babylonjs.com/overviews/gui
+For usage documentation please visit the [GUI documentation](https://doc.babylonjs.com/features/featuresDeepDive/gui/).
 
-# Installation instructions
+## Installation
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save @babylonjs/core @babylonjs/gui
-```
-
-# How to use
-
-Afterwards it can be imported to your project using:
-
-```
-import { AdvancedDynamicTexture } from '@babylonjs/gui/2D';
+```bash
+npm install @babylonjs/core @babylonjs/gui
 ```
 
-And used as usual:
+## Usage
 
-```
-// Some awesome code
-// Creates the post process
-let postProcess = new AdvancedDynamicTexture("adt", 128, 128, scene);
-// Some more awesome code
+Import and use in your project:
+
+```javascript
+import { AdvancedDynamicTexture } from "@babylonjs/gui/2D";
+import { TextBlock } from "@babylonjs/gui/2D/controls/textBlock";
+
+// Create a fullscreen UI
+const ui = AdvancedDynamicTexture.CreateFullscreenUI("ui");
+
+// Add a text block
+const text = new TextBlock();
+text.text = "Hello Babylon.js!";
+text.color = "white";
+text.fontSize = 24;
+ui.addControl(text);
 ```
 
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support).
+For more information, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).

--- a/packages/public/@babylonjs/inspector/readme.md
+++ b/packages/public/@babylonjs/inspector/readme.md
@@ -1,26 +1,25 @@
-# Babylon.js inspector module
+# Babylon.js Inspector (Legacy)
 
-For usage documentation please visit https://doc.babylonjs.com/how_to/debug_layer.
+> **Note:** This is the legacy inspector. For the new inspector, use the [`@babylonjs/inspector`](https://www.npmjs.com/package/@babylonjs/inspector) package (published from `inspector-v2`). See the [Inspector v2 documentation](https://doc.babylonjs.com/toolsAndResources/inspectorv2/).
 
-# Installation instructions
+For usage documentation on the legacy inspector, see the [legacy inspector documentation](https://doc.babylonjs.com/legacy/inspector/).
 
-To install using npm :
+## Installation
 
-```shell
-npm install @babylonjs/core @babylonjs/inspector
+To install using npm:
+
+```bash
+npm install @babylonjs/core @babylonjs/inspector-legacy
 ```
 
-# How to use
-
-Afterwards it can be imported to your project using:
+## Usage
 
 ```javascript
 import "@babylonjs/core/Debug/debugLayer";
-import "@babylonjs/inspector";
+import "@babylonjs/inspector-legacy";
+
+// ...
+scene.debugLayer.show();
 ```
 
-The first line will ensure you can access the property debugLayer of the scene while the second will ensure the inspector can be used within your scene.
-
-This is a great example where code splitting or conditional loading could be used to ensure you are not delivering the inspector if not part of your final app.
-
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support).
+For more information, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).

--- a/packages/public/@babylonjs/ktx2decoder/readme.md
+++ b/packages/public/@babylonjs/ktx2decoder/readme.md
@@ -1,1 +1,13 @@
 # Babylon.js KTX2 Decoder Module
+
+This package provides KTX2 texture decoding support for Babylon.js. It includes all the decoders and their corresponding WASM files.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/ktx2decoder
+```
+
+For detailed setup and usage, including worker configuration, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).

--- a/packages/public/@babylonjs/materials/readme.md
+++ b/packages/public/@babylonjs/materials/readme.md
@@ -1,30 +1,23 @@
-Babylon.js Materials Library
-=====================
+# Babylon.js Materials Library
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "materials library".
+For usage documentation please visit the [materials library documentation](https://doc.babylonjs.com/toolsAndResources/assetLibraries/materialsLibrary/).
 
-# Installation instructions
+## Installation
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save @babylonjs/core @babylonjs/materials
-```
-
-# How to use
-
-Afterwards it can be imported to your project using:
-
-```
-import { GridMaterial } from '@babylonjs/materials/Grid';
+```bash
+npm install @babylonjs/core @babylonjs/materials
 ```
 
-And used as usual:
+## Usage
 
-```
-// Some awesome code
-let gridMaterial = new GridMaterial("gridMaterial", scene);
-// Some more awesome code
+Import and use in your project:
+
+```javascript
+import { GridMaterial } from "@babylonjs/materials/grid";
+
+const gridMaterial = new GridMaterial("gridMaterial", scene);
 ```
 
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support).
+For more information, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).

--- a/packages/public/@babylonjs/node-editor/readme.md
+++ b/packages/public/@babylonjs/node-editor/readme.md
@@ -1,1 +1,13 @@
-Node Editor es6
+# Babylon.js Node Material Editor
+
+The Node Material Editor is a visual tool for creating and editing Node Materials in Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/node-editor
+```
+
+For more information, see the [Node Material documentation](https://doc.babylonjs.com/features/featuresDeepDive/materials/node_material/).

--- a/packages/public/@babylonjs/node-geometry-editor/readme.md
+++ b/packages/public/@babylonjs/node-geometry-editor/readme.md
@@ -1,1 +1,13 @@
-Node Geometry Editor es6
+# Babylon.js Node Geometry Editor
+
+The Node Geometry Editor is a visual tool for creating and editing procedural geometry using a node-based graph in Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/node-geometry-editor
+```
+
+For more information, see the [Node Geometry documentation](https://doc.babylonjs.com/features/featuresDeepDive/mesh/nodeGeometry/).

--- a/packages/public/@babylonjs/node-particle-editor/readme.md
+++ b/packages/public/@babylonjs/node-particle-editor/readme.md
@@ -1,1 +1,13 @@
-Node Particle Editor es6
+# Babylon.js Node Particle Editor
+
+The Node Particle Editor is a visual tool for creating and editing particle systems using a node-based graph in Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/node-particle-editor
+```
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/@babylonjs/node-render-graph-editor/readme.md
+++ b/packages/public/@babylonjs/node-render-graph-editor/readme.md
@@ -1,1 +1,13 @@
-Node Render Graph Editor es6
+# Babylon.js Node Render Graph Editor
+
+The Node Render Graph Editor is a visual tool for creating and editing render graphs using a node-based graph in Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/node-render-graph-editor
+```
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/@babylonjs/post-processes/readme.md
+++ b/packages/public/@babylonjs/post-processes/readme.md
@@ -1,31 +1,23 @@
-Babylon.js Post Processes Library
-=====================
+# Babylon.js Post Processes Library
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "post process library".
+For usage documentation please visit the [post process library documentation](https://doc.babylonjs.com/toolsAndResources/assetLibraries/postProcessLibrary/).
 
-# Installation instructions
+## Installation
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save @babylonjs/core @babylonjs/post-processes
-```
-
-# How to use
-
-Afterwards it can be imported to your project using:
-
-```
-import { AsciiArtPostProcess } from '@babylonjs/post-processes/asciiArt';
+```bash
+npm install @babylonjs/core @babylonjs/post-processes
 ```
 
-And used as usual:
+## Usage
 
-```
-// Some awesome code
-// Creates the post process
-let postProcess = new AsciiArtPostProcess("AsciiArt", camera);
-// Some more awesome code
+Import and use in your project:
+
+```javascript
+import { AsciiArtPostProcess } from "@babylonjs/post-processes/asciiArt";
+
+const postProcess = new AsciiArtPostProcess("AsciiArt", camera);
 ```
 
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support).
+For more information, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).

--- a/packages/public/@babylonjs/procedural-textures/readme.md
+++ b/packages/public/@babylonjs/procedural-textures/readme.md
@@ -1,34 +1,27 @@
-Babylon.js Procedural Textures Library
-=====================
+# Babylon.js Procedural Textures Library
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "procedural textures library".
+For usage documentation please visit the [procedural textures library documentation](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/).
 
-# Installation instructions
+## Installation
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save @babylonjs/core @babylonjs/procedural-textures
-```
-
-# How to use
-
-Afterwards it can be imported to your project using:
-
-```
-import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial';
-import { FireProceduralTexture } from '@babylonjs/procedural-textures/fireProceduralTexture';
+```bash
+npm install @babylonjs/core @babylonjs/procedural-textures
 ```
 
-And used as usual:
+## Usage
 
-```
-// Some awesome code
-var fireMaterial = new StandardMaterial("fontainSculptur2", scene);
-var fireTexture = new FireProceduralTexture("fire", 256, scene);
+Import and use in your project:
+
+```javascript
+import { StandardMaterial } from "@babylonjs/core/Materials/standardMaterial";
+import { FireProceduralTexture } from "@babylonjs/procedural-textures/fireProceduralTexture";
+
+const fireMaterial = new StandardMaterial("fireMaterial", scene);
+const fireTexture = new FireProceduralTexture("fire", 256, scene);
 fireMaterial.diffuseTexture = fireTexture;
 fireMaterial.opacityTexture = fireTexture;
-// Some more awesome code
 ```
 
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support).
+For more information, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/).

--- a/packages/public/@babylonjs/serializers/readme.md
+++ b/packages/public/@babylonjs/serializers/readme.md
@@ -1,29 +1,23 @@
-Babylon.js Serializers
-=====================
+# Babylon.js Serializers
 
-# Installation instructions
+## Installation
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save @babylonjs/core @babylonjs/serializers
-```
-
-# How to use
-
-Afterwards it can be imported to your project using:
-
-```
-import { GLTF2Export } from '@babylonjs/serializers/glTF';
+```bash
+npm install @babylonjs/core @babylonjs/serializers
 ```
 
-And used as usual:
+## Usage
 
-```
+Import and use in your project:
+
+```javascript
+import { GLTF2Export } from "@babylonjs/serializers/glTF";
+
 GLTF2Export.GLTFAsync(scene, "fileName").then((gltf) => {
     gltf.downloadFiles();
 });
 ```
 
-For more information you can have a look at our [ES6 dedicated documentation](https://doc.babylonjs.com/features/es6_support) and the [gltf exporter documentation](https://doc.babylonjs.com/extensions/gltfexporter).
-
+For more information, see the [ES6 support documentation](https://doc.babylonjs.com/setup/frameworkPackages/es6Support/) and the [glTF exporter documentation](https://doc.babylonjs.com/features/featuresDeepDive/Exporters/glTFExporter/).

--- a/packages/public/@babylonjs/ui-controls/readme.md
+++ b/packages/public/@babylonjs/ui-controls/readme.md
@@ -1,1 +1,13 @@
-UI controls es6
+# Babylon.js UI Controls
+
+A collection of UI controls for Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install @babylonjs/ui-controls
+```
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/umd/babylonjs-accessibility/readme.md
+++ b/packages/public/umd/babylonjs-accessibility/readme.md
@@ -1,5 +1,13 @@
-Accessibility
-
 # Babylon.js Accessibility
 
-This package handles accessibility. It contains html twin renderer to generate html twins of the scene objects for 3D content in DOM, thus the 3D content is compatible with screen readers and keyboard navigation.
+> We recommend using the [ES6 package `@babylonjs/accessibility`](https://www.npmjs.com/package/@babylonjs/accessibility) for new projects.
+
+This package provides accessibility support for Babylon.js scenes. It contains an HTML twin renderer that generates HTML twins of scene objects, making 3D content compatible with screen readers and keyboard navigation.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install babylonjs babylonjs-accessibility
+```

--- a/packages/public/umd/babylonjs-addons/readme.md
+++ b/packages/public/umd/babylonjs-addons/readme.md
@@ -1,1 +1,13 @@
 # Babylon.js Addons Library
+
+> We recommend using the [ES6 package `@babylonjs/addons`](https://www.npmjs.com/package/@babylonjs/addons) for new projects.
+
+A collection of addons and extensions for Babylon.js.
+
+## Installation
+
+To install using npm:
+
+```bash
+npm install babylonjs babylonjs-addons
+```

--- a/packages/public/umd/babylonjs-gui-editor/readme.md
+++ b/packages/public/umd/babylonjs-gui-editor/readme.md
@@ -1,1 +1,7 @@
-Gui Editor
+# Babylon.js GUI Editor
+
+> We recommend using the [ES6 package `@babylonjs/gui-editor`](https://www.npmjs.com/package/@babylonjs/gui-editor) for new projects.
+
+The GUI Editor is a visual tool for creating and modifying GUI layouts for Babylon.js scenes.
+
+For more information, see the [GUI Editor documentation](https://doc.babylonjs.com/toolsAndResources/guiEditor/).

--- a/packages/public/umd/babylonjs-gui/readme.md
+++ b/packages/public/umd/babylonjs-gui/readme.md
@@ -1,43 +1,39 @@
-Babylon.js GUI module
-=====================
+# Babylon.js GUI Module
 
-For usage documentation please visit https://doc.babylonjs.com/overviews/gui
+> We recommend using the [ES6 package `@babylonjs/gui`](https://www.npmjs.com/package/@babylonjs/gui) for new projects.
 
-# Installation instructions
+For usage documentation please visit the [GUI documentation](https://doc.babylonjs.com/features/featuresDeepDive/gui/).
 
-## CDN
+## Installation
+
+### CDN
 
 > ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 Compiled js files (minified and source) are offered on our public CDN here:
 
-* https://preview.babylonjs.com/gui/babylon.gui.js
-* https://preview.babylonjs.com/gui/babylon.gui.min.js
+- https://preview.babylonjs.com/gui/babylon.gui.js
+- https://preview.babylonjs.com/gui/babylon.gui.min.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save babylonjs babylonjs-gui
+```bash
+npm install babylonjs babylonjs-gui
 ```
 
 If using TypeScript, the typing needs to be added to tsconfig.json:
 
-```
-    ....
+```json
     "types": [
         "babylonjs",
-        "babylonjs-gui",
-        "otherImportsYouMightNeed"
-    ],
-    ....
+        "babylonjs-gui"
+    ]
 ```
 
 Afterwards it can be imported to the project using:
 
+```javascript
+import * as GUI from "babylonjs-gui";
 ```
-import * as GUI from 'babylonjs-gui';
-```
-
-Using webpack to package your project will use the minified js file.

--- a/packages/public/umd/babylonjs-inspector/readme.md
+++ b/packages/public/umd/babylonjs-inspector/readme.md
@@ -1,36 +1,32 @@
-Babylon.js inspector module
-=====================
+# Babylon.js Inspector (Legacy)
 
-For usage documentation please visit https://doc.babylonjs.com/how_to/debug_layer.
+> **Note:** This is the legacy inspector. For the new inspector, use the [`babylonjs-inspector`](https://www.npmjs.com/package/babylonjs-inspector) package (inspector v2), or the ES6 [`@babylonjs/inspector`](https://www.npmjs.com/package/@babylonjs/inspector). See the [Inspector v2 documentation](https://doc.babylonjs.com/toolsAndResources/inspectorv2/).
 
-# Installation instructions
+For usage documentation on the legacy inspector, see the [legacy inspector documentation](https://doc.babylonjs.com/legacy/inspector/).
 
-The inspector will be **automatically** (async) loaded when starting the debug layer, if not already included. So technically, nothing needs to be done!
+## Installation
 
-If you wish however to use a different version of the inspector or host it on your own, follow these instructions:
+The inspector will be **automatically** (async) loaded when starting the debug layer, if not already included.
 
-## CDN
+### CDN
 
 > ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 The latest compiled js file is offered on our public CDN here:
 
-* https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js
+- https://preview.babylonjs.com/inspector/babylon.inspector.bundle.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
+```bash
+npm install babylonjs babylonjs-inspector
 ```
-npm install --save babylonjs babylonjs-inspector
-```
+
 Afterwards it can be imported to the project using:
 
+```javascript
+import * as BABYLON from "babylonjs";
+import "babylonjs-inspector";
 ```
-import * as BABYLON from 'babylonjs';
-import 'babylonjs-inspector';
-```
-
-This will create a global INSPECTOR variable that will be used bay BabylonJS
-
-Webpack is supported.

--- a/packages/public/umd/babylonjs-loaders/readme.md
+++ b/packages/public/umd/babylonjs-loaders/readme.md
@@ -1,46 +1,42 @@
-Babylon.js Loaders module
-=====================
+# Babylon.js Loaders Module
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "loaders".
+> We recommend using the [ES6 package `@babylonjs/loaders`](https://www.npmjs.com/package/@babylonjs/loaders) for new projects.
 
-# Installation instructions
+For usage documentation please visit the [loaders documentation](https://doc.babylonjs.com/features/featuresDeepDive/importers/loadingFileTypes/).
 
-## CDN
+## Installation
+
+### CDN
 
 > ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 Compiled js files (minified and source) are offered on our public CDN here:
 
-* https://preview.babylonjs.com/loaders/babylonjs.loaders.js
-* https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js
+- https://preview.babylonjs.com/loaders/babylonjs.loaders.js
+- https://preview.babylonjs.com/loaders/babylonjs.loaders.min.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save babylonjs babylonjs-loaders
+```bash
+npm install babylonjs babylonjs-loaders
 ```
 
 If using TypeScript, the typing needs to be added to tsconfig.json:
 
-```
-    ....
+```json
     "types": [
         "babylonjs",
-        "babylonjs-loaders",
-        ""
-    ],
-    ....
+        "babylonjs-loaders"
+    ]
 ```
 
 Afterwards it can be imported to the project using:
 
-```
-import * as BABYLON from 'babylonjs';
-import 'babylonjs-loaders';
+```javascript
+import * as BABYLON from "babylonjs";
+import "babylonjs-loaders";
 ```
 
 This will extend Babylon's namespace with the loaders available.
-
-Using webpack to package your project will use the minified js file.

--- a/packages/public/umd/babylonjs-materials/readme.md
+++ b/packages/public/umd/babylonjs-materials/readme.md
@@ -1,53 +1,43 @@
-Babylon.js Materials Library
-=====================
+# Babylon.js Materials Library
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "materials library".
+> We recommend using the [ES6 package `@babylonjs/materials`](https://www.npmjs.com/package/@babylonjs/materials) for new projects.
 
-# Installation instructions
+For usage documentation please visit the [materials library documentation](https://doc.babylonjs.com/toolsAndResources/assetLibraries/materialsLibrary/).
 
-## CDN
+## Installation
+
+### CDN
 
 > ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 Compiled js files (minified and source) are offered on our public CDN here:
 
-* https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js
-* https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.min.js
+- https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.js
+- https://preview.babylonjs.com/materialsLibrary/babylonjs.materials.min.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save babylonjs babylonjs-materials
+```bash
+npm install babylonjs babylonjs-materials
 ```
 
 If using TypeScript, the typing needs to be added to tsconfig.json:
 
-```
-    ....
+```json
     "types": [
         "babylonjs",
-        "babylonjs-materials",
-        "oneMoreDependencyThatIReallyNeed"
-    ],
-    ....
+        "babylonjs-materials"
+    ]
 ```
 
 Afterwards it can be imported to the project using:
 
-```
-import * as BABYLON from 'babylonjs';
-import 'babylonjs-materials';
-```
+```javascript
+import * as BABYLON from "babylonjs";
+import "babylonjs-materials";
 
-This will extend Babylon's namespace with the materials available:
-
-```
-// Some awesome code
-let skyMaterial = new BABYLON.SkyMaterial("skyMaterial", scene);
+const skyMaterial = new BABYLON.SkyMaterial("skyMaterial", scene);
 skyMaterial.backFaceCulling = false;
-// Some more awesome code
 ```
-
-Using webpack to package your project will use the minified js file.

--- a/packages/public/umd/babylonjs-node-editor/readme.md
+++ b/packages/public/umd/babylonjs-node-editor/readme.md
@@ -1,1 +1,7 @@
-Node Editor
+# Babylon.js Node Material Editor
+
+> We recommend using the [ES6 package `@babylonjs/node-editor`](https://www.npmjs.com/package/@babylonjs/node-editor) for new projects.
+
+The Node Material Editor is a visual tool for creating and editing Node Materials in Babylon.js.
+
+For more information, see the [Node Material documentation](https://doc.babylonjs.com/features/featuresDeepDive/materials/node_material/).

--- a/packages/public/umd/babylonjs-node-geometry-editor/readme.md
+++ b/packages/public/umd/babylonjs-node-geometry-editor/readme.md
@@ -1,1 +1,7 @@
-Node Geometry Editor
+# Babylon.js Node Geometry Editor
+
+> We recommend using the [ES6 package `@babylonjs/node-geometry-editor`](https://www.npmjs.com/package/@babylonjs/node-geometry-editor) for new projects.
+
+The Node Geometry Editor is a visual tool for creating and editing procedural geometry using a node-based graph in Babylon.js.
+
+For more information, see the [Node Geometry documentation](https://doc.babylonjs.com/features/featuresDeepDive/mesh/nodeGeometry/).

--- a/packages/public/umd/babylonjs-node-particle-editor/readme.md
+++ b/packages/public/umd/babylonjs-node-particle-editor/readme.md
@@ -1,1 +1,7 @@
-Node Particle Editor
+# Babylon.js Node Particle Editor
+
+> We recommend using the [ES6 package `@babylonjs/node-particle-editor`](https://www.npmjs.com/package/@babylonjs/node-particle-editor) for new projects.
+
+The Node Particle Editor is a visual tool for creating and editing particle systems using a node-based graph in Babylon.js.
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/umd/babylonjs-node-render-graph-editor/readme.md
+++ b/packages/public/umd/babylonjs-node-render-graph-editor/readme.md
@@ -1,1 +1,7 @@
-Node Render Graph Editor
+# Babylon.js Node Render Graph Editor
+
+> We recommend using the [ES6 package `@babylonjs/node-render-graph-editor`](https://www.npmjs.com/package/@babylonjs/node-render-graph-editor) for new projects.
+
+The Node Render Graph Editor is a visual tool for creating and editing render graphs using a node-based graph in Babylon.js.
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/umd/babylonjs-post-process/readme.md
+++ b/packages/public/umd/babylonjs-post-process/readme.md
@@ -1,53 +1,42 @@
-Babylon.js Post Processes Library
-=====================
+# Babylon.js Post Processes Library
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "post process library".
+> We recommend using the [ES6 package `@babylonjs/post-processes`](https://www.npmjs.com/package/@babylonjs/post-processes) for new projects.
 
-# Installation instructions
+For usage documentation please visit the [post process library documentation](https://doc.babylonjs.com/toolsAndResources/assetLibraries/postProcessLibrary/).
 
-## CDN
+## Installation
+
+### CDN
 
 > ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 Compiled js files (minified and source) are offered on our public CDN here:
 
-* https://preview.babylonjs.com/postProcessesLibrary/babylonjs.postProcess.js
-* https://preview.babylonjs.com/postProcessesLibrary/babylonjs.postProcess.min.js
+- https://preview.babylonjs.com/postProcessesLibrary/babylonjs.postProcess.js
+- https://preview.babylonjs.com/postProcessesLibrary/babylonjs.postProcess.min.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save babylonjs babylonjs-post-process
+```bash
+npm install babylonjs babylonjs-post-process
 ```
 
 If using TypeScript, the typing needs to be added to tsconfig.json:
 
-```
-    ....
+```json
     "types": [
         "babylonjs",
-        "babylonjs-post-process",
-        "oneMoreDependencyThatIReallyNeed"
-    ],
-    ....
+        "babylonjs-post-process"
+    ]
 ```
 
 Afterwards it can be imported to the project using:
 
-```
-import * as BABYLON from 'babylonjs';
-import 'babylonjs-post-process';
-```
+```javascript
+import * as BABYLON from "babylonjs";
+import "babylonjs-post-process";
 
-This will extend Babylon's namespace with the post processes available:
-
+const postProcess = new BABYLON.AsciiArtPostProcess("AsciiArt", camera);
 ```
-// Some awesome code
-// Creates the post process
-let postProcess = new BABYLON.AsciiArtPostProcess("AsciiArt", camera);
-// Some more awesome code
-```
-
-Using webpack to package your project will use the minified js file.

--- a/packages/public/umd/babylonjs-procedural-textures/readme.md
+++ b/packages/public/umd/babylonjs-procedural-textures/readme.md
@@ -1,55 +1,45 @@
-Babylon.js Procedural Textures Library
-=====================
+# Babylon.js Procedural Textures Library
 
-For usage documentation please visit https://doc.babylonjs.com/extensions and choose "procedural textures library".
+> We recommend using the [ES6 package `@babylonjs/procedural-textures`](https://www.npmjs.com/package/@babylonjs/procedural-textures) for new projects.
 
-# Installation instructions
+For usage documentation please visit the [procedural textures library documentation](https://doc.babylonjs.com/toolsAndResources/assetLibraries/proceduralTexturesLibrary/).
 
-## CDN
+## Installation
+
+### CDN
 
 > ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 Compiled js files (minified and source) are offered on our public CDN here:
 
-* https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.js
-* https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js
+- https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.js
+- https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save babylonjs babylonjs-procedural-textures
+```bash
+npm install babylonjs babylonjs-procedural-textures
 ```
 
 If using TypeScript, the typing needs to be added to tsconfig.json:
 
-```
-    ....
+```json
     "types": [
         "babylonjs",
-        "babylonjs-procedural-textures",
-        "oneMoreDependencyThatIReallyNeed"
-    ],
-    ....
+        "babylonjs-procedural-textures"
+    ]
 ```
 
 Afterwards it can be imported to the project using:
 
-```
-import * as BABYLON from 'babylonjs';
-import 'babylonjs-procedural-textures';
-```
+```javascript
+import * as BABYLON from "babylonjs";
+import "babylonjs-procedural-textures";
 
-This will extend Babylon's namespace with the procedural textures available:
-
-```
-// Some awesome code
-var fireMaterial = new BABYLON.StandardMaterial("fontainSculptur2", scene);
-var fireTexture = new BABYLON.FireProceduralTexture("fire", 256, scene);
+const fireMaterial = new BABYLON.StandardMaterial("fireMaterial", scene);
+const fireTexture = new BABYLON.FireProceduralTexture("fire", 256, scene);
 fireMaterial.diffuseTexture = fireTexture;
 fireMaterial.opacityTexture = fireTexture;
-// Some more awesome code
 ```
-
-Using webpack to package your project will use the minified js file.

--- a/packages/public/umd/babylonjs-serializers/readme.md
+++ b/packages/public/umd/babylonjs-serializers/readme.md
@@ -1,42 +1,42 @@
-Babylon.js Serializers
-=====================
+# Babylon.js Serializers
 
-# Installation instructions
+> We recommend using the [ES6 package `@babylonjs/serializers`](https://www.npmjs.com/package/@babylonjs/serializers) for new projects.
 
-## CDN
+## Installation
+
+### CDN
+
+> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
 
 Compiled js files (minified and source) are offered on our public CDN here:
 
-* https://preview.babylonjs.com/serializers/babylonjs.serializers.js
-* https://preview.babylonjs.com/proceduralTexturesLibrary/babylonjs.serializers.min.js
+- https://preview.babylonjs.com/serializers/babylonjs.serializers.js
+- https://preview.babylonjs.com/serializers/babylonjs.serializers.min.js
 
-## NPM
+### NPM
 
-To install using npm :
+To install using npm:
 
-```
-npm install --save babylonjs babylonjs-serializers
+```bash
+npm install babylonjs babylonjs-serializers
 ```
 
 If using TypeScript, the typing needs to be added to tsconfig.json:
 
-```
-    ....
+```json
     "types": [
         "babylonjs",
-        "babylonjs-serializers",
-        "oneMoreDependencyThatIReallyNeed"
-    ],
-    ....
+        "babylonjs-serializers"
+    ]
 ```
 
 Afterwards it can be imported to the project using:
 
-```
-import * as BABYLON from 'babylonjs';
-import from 'babylonjs-serializers';
+```javascript
+import * as BABYLON from "babylonjs";
+import "babylonjs-serializers";
 ```
 
-This will extend Babylon's namespace with the serializers currently available.
+This will extend Babylon's namespace with the serializers available.
 
-Using webpack to package your project will use the minified js file.
+For more information, see the [glTF exporter documentation](https://doc.babylonjs.com/features/featuresDeepDive/Exporters/glTFExporter/).

--- a/packages/public/umd/babylonjs-ui-controls/readme.md
+++ b/packages/public/umd/babylonjs-ui-controls/readme.md
@@ -1,1 +1,7 @@
-UI controls
+# Babylon.js UI Controls
+
+> We recommend using the [ES6 package `@babylonjs/ui-controls`](https://www.npmjs.com/package/@babylonjs/ui-controls) for new projects.
+
+A collection of UI controls for Babylon.js.
+
+For more information, see the [Babylon.js documentation](https://doc.babylonjs.com).

--- a/packages/public/umd/babylonjs/readme.md
+++ b/packages/public/umd/babylonjs/readme.md
@@ -1,45 +1,38 @@
 # Babylon.js
 
-* We recommend using the [Core ES6-supported version](https://www.npmjs.com/package/@babylonjs/core);
+> We recommend using the [ES6 package `@babylonjs/core`](https://www.npmjs.com/package/@babylonjs/core) for new projects. This UMD package is provided for compatibility.
 
 Getting started? Play directly with the Babylon.js API using our [playground](https://playground.babylonjs.com/). It also contains a lot of samples to learn how to use it.
 
 [![npm version](https://badge.fury.io/js/babylonjs.svg)](https://badge.fury.io/js/babylonjs)
-[![Build Status](https://dev.azure.com/babylonjs/ContinousIntegration/_apis/build/status/CI?branchName=master)](https://dev.azure.com/babylonjs/ContinousIntegration/_build/latest?definitionId=1&branchName=master)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/BabylonJS/Babylon.js.svg)](http://isitmaintained.com/project/BabylonJS/Babylon.js "Average time to resolve an issue")
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/babylonJS/babylon.js.svg)](https://isitmaintained.com/project/babylonJS/babylon.js "Percentage of issues still open")
-[![Build Size](https://img.badgesize.io/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.js.svg?compression=gzip)](https://img.badgesize.io/BabylonJS/Babylon.js/master/dist/preview%20release/babylon.js.svg?compression=gzip)
-[![Twitter](https://img.shields.io/twitter/follow/babylonjs.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=babylonjs)
 
 **Any questions?** Here is our official [forum](https://forum.babylonjs.com/).
 
 ## CDN
 
+> ⚠️ WARNING: The CDN should not be used in production environments. The purpose of our CDN is to serve Babylon packages to users learning how to use the platform or running small experiments. Once you've built an application and are ready to share it with the world at large, you should serve all packages from your own CDN.
+
 - <https://cdn.babylonjs.com/babylon.js>
 - <https://cdn.babylonjs.com/babylon.max.js>
 
-For the preview release, use the following URLs:
-
-- <https://preview.babylonjs.com/babylon.js>
-- <https://preview.babylonjs.com/babylon.max.js>
 ## npm
 
-BabylonJS and its modules are published on npm with full typing support. To install, use:
+Babylon.js and its modules are published on npm with full typing support. To install, use:
 
 ```text
-npm install babylonjs --save
+npm install babylonjs
 ```
 
-This will allow you to import BabylonJS entirely using:
+This will allow you to import Babylon.js entirely using:
 
 ```javascript
-import * as BABYLON from 'babylonjs';
+import * as BABYLON from "babylonjs";
 ```
 
 or individual classes using:
 
 ```javascript
-import { Scene, Engine } from 'babylonjs';
+import { Scene, Engine } from "babylonjs";
 ```
 
 If using TypeScript, don't forget to add 'babylonjs' to 'types' in `tsconfig.json`:
@@ -60,39 +53,30 @@ To add a module, install the respective package. A list of extra packages and th
 See [Getting Started](https://doc.babylonjs.com/start):
 
 ```javascript
-// Get the canvas DOM element
-var canvas = document.getElementById('renderCanvas');
-// Load the 3D engine
-var engine = new BABYLON.Engine(canvas, true, {preserveDrawingBuffer: true, stencil: true});
-// CreateScene function that creates and return the scene
-var createScene = function(){
-    // Create a basic BJS Scene object
-    var scene = new BABYLON.Scene(engine);
-    // Create a FreeCamera, and set its position to {x: 0, y: 5, z: -10}
-    var camera = new BABYLON.FreeCamera('camera1', new BABYLON.Vector3(0, 5, -10), scene);
-    // Target the camera to scene origin
+const canvas = document.getElementById("renderCanvas");
+const engine = new BABYLON.Engine(canvas, true, { preserveDrawingBuffer: true, stencil: true });
+
+const createScene = () => {
+    const scene = new BABYLON.Scene(engine);
+    const camera = new BABYLON.FreeCamera("camera1", new BABYLON.Vector3(0, 5, -10), scene);
     camera.setTarget(BABYLON.Vector3.Zero());
-    // Attach the camera to the canvas
     camera.attachControl(canvas, false);
-    // Create a basic light, aiming 0, 1, 0 - meaning, to the sky
-    var light = new BABYLON.HemisphericLight('light1', new BABYLON.Vector3(0, 1, 0), scene);
-    // Create a built-in "sphere" shape; its constructor takes 6 params: name, segment, diameter, scene, updatable, sideOrientation
-    var sphere = BABYLON.Mesh.CreateSphere('sphere1', 16, 2, scene, false, BABYLON.Mesh.FRONTSIDE);
-    // Move the sphere upward 1/2 of its height
+
+    const light = new BABYLON.HemisphericLight("light1", new BABYLON.Vector3(0, 1, 0), scene);
+
+    const sphere = BABYLON.MeshBuilder.CreateSphere("sphere1", { segments: 16, diameter: 2 }, scene);
     sphere.position.y = 1;
-    // Create a built-in "ground" shape; its constructor takes 6 params : name, width, height, subdivision, scene, updatable
-    var ground = BABYLON.Mesh.CreateGround('ground1', 6, 6, 2, scene, false);
-    // Return the created scene
+
+    BABYLON.MeshBuilder.CreateGround("ground1", { width: 6, height: 6, subdivisions: 2 }, scene);
+
     return scene;
-}
-// call the createScene function
-var scene = createScene();
-// run the render loop
-engine.runRenderLoop(function(){
+};
+
+const scene = createScene();
+engine.runRenderLoop(() => {
     scene.render();
 });
-// the canvas/window resize event handler
-window.addEventListener('resize', function(){
+window.addEventListener("resize", () => {
     engine.resize();
 });
 ```
@@ -104,21 +88,15 @@ window.addEventListener('resize', function(){
 
 ## Contributing
 
-Please see the [Contributing Guidelines](./contributing.md).
+Please see the [Contributing Guidelines](https://github.com/BabylonJS/Babylon.js/blob/master/contributing.md).
 
 ## Useful links
 
 - Official web site: [www.babylonjs.com](https://www.babylonjs.com/)
-- Online [playground](https://playground.babylonjs.com/) to learn by experimentating
+- Online [playground](https://playground.babylonjs.com/) to learn by experimenting
 - Online [sandbox](https://www.babylonjs.com/sandbox) where you can test your .babylon and glTF scenes with a simple drag'n'drop
-- Online [shader creation tool](https://www.babylonjs.com/cyos/) where you can learn how to create GLSL shaders
-- 3DS Max [exporter](https://github.com/BabylonJS/Exporters/tree/master/3ds%20Max) can be used to generate a .babylon file from 3DS Max
-- Maya [exporter](https://github.com/BabylonJS/Exporters/tree/master/Maya) can be used to generate a .babylon file from Maya
-- Blender [exporter](https://github.com/BabylonJS/Exporters/tree/master/Blender) can be used to generate a .babylon file from Blender 3d
-- Unity 5[ (deprecated) exporter](https://github.com/BabylonJS/Exporters/tree/master/Unity) can be used to export your geometries from Unity 5 scene editor(animations are supported)
 - [glTF Tools](https://github.com/KhronosGroup/glTF#gltf-tools) by KhronosGroup
 
 ## Features
 
 To get a complete list of supported features, please visit [Babylon.js website](https://www.babylonjs.com/).
-


### PR DESCRIPTION
## Description

Updates all public package README files (both `@babylonjs/*` ES6 and `babylonjs-*` UMD) to fix outdated content.

### Changes

**Broken URL fixes (404s):**
- `doc.babylonjs.com/overviews/gui` -> `doc.babylonjs.com/features/featuresDeepDive/gui/`
- `doc.babylonjs.com/how_to/debug_layer` -> `doc.babylonjs.com/legacy/inspector/` + `inspectorv2/`
- `doc.babylonjs.com/extensions/gltfexporter` -> `doc.babylonjs.com/features/featuresDeepDive/Exporters/glTFExporter/`
- `doc.babylonjs.com/extensions` -> correct per-library URLs under `toolsAndResources/assetLibraries/`

**Outdated URL fixes (redirects):**
- `doc.babylonjs.com/features/es6_support` -> `doc.babylonjs.com/setup/frameworkPackages/es6Support/`

**`@babylonjs/core` overhaul:**
- Removed broken badges (Travis CI, isitmaintained.com, badgesize.io, Twitter)
- Updated npm badge to point to `@babylonjs/core` instead of `babylonjs`
- Replaced deprecated `Mesh.CreateSphere`/`Mesh.CreateGround` with modern `CreateSphere`/`CreateGround`
- Fixed `Vector3` import path (`Maths/math` -> `Maths/math.vector`)
- Removed dead links to deprecated exporters (3DS Max, Maya, Blender, Unity) and CYOS

**Empty/minimal READMEs filled in (13 packages):**
`accessibility`, `addons`, `gui-editor`, `ktx2decoder`, `node-editor`, `node-geometry-editor`, `node-particle-editor`, `node-render-graph-editor`, `ui-controls` (both ES6 and UMD variants)

**Inspector legacy:**
- Updated both ES6 and UMD inspector READMEs to mark as legacy with links to inspector v2

**UMD packages:**
- Added ES6 package recommendation to all UMD READMEs
- Fixed syntax error in serializers README (`import from` -> proper import)
- Fixed wrong CDN path in serializers README
- Modernized code examples (`var` -> `const`, `Mesh.Create*` -> `MeshBuilder`)

### No changes needed
`viewer`, `inspector-v2`, `loaders`, `lottiePlayer`, `smart-filters`, `smart-filters-blocks`, `test-tools`, `shared-ui-components` - already up to date.
