### PR TITLE
Playground: Log warning if string too big to be stored to local store

### DIFF
--- a/packages/tools/playground/src/tools/utilities.ts
+++ b/packages/tools/playground/src/tools/utilities.ts
@@ -1,4 +1,5 @@
 import type { GlobalState } from "../globalState";
+import { Logger } from "@dev/core";
 
 // One-shot session flag for user-initiated engine reloads.
 const ManualEngineSwitchReloadStorageKey = "playground-manual-engine-switch-reload";


### PR DESCRIPTION
Trapping the error prevents some PGs not being run by Monaco.

