### PR TITLE
fix(buildTools): fix regex that replaces external type references with 'any' in declaration generation

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -180,9 +180,16 @@ function GetModuleDeclaration(
         if (!devPackageName) {
             if (externalName) {
                 if (externalName === "@fortawesome" || externalName === "@fluentui" || externalName === "@recast-navigation") {
-                    // replace with any
-                    const matchRegex = new RegExp(`([ <])(${alias}[^,;\n>) ]*)([^\\w])`, "g");
-                    processedLines = processedLines.replace(matchRegex, `$1any$3`);
+                    // Replace type references with "any", but skip declaration sites (e.g. "export type ThemeMode")
+                    // to avoid producing invalid syntax like "export type any = ...".
+                    const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
+                    processedLines = processedLines.replace(matchRegex, (match, p1: string, _alias: string, p3: string, offset: number) => {
+                        const precedingText = processedLines.slice(0, offset + p1.length);
+                        if (/\b(?:type|class|var|const|let|function|interface|enum|namespace)\s+$/.test(precedingText)) {
+                            return match;
+                        }
+                        return `${p1}any${p3}`;
+                    });
                     return;
                 }
             }
@@ -417,9 +424,16 @@ function GetPackageDeclaration(
             if (!localDevPackageMap) {
                 if (externalName) {
                     if (externalName === "@fortawesome" || externalName === "@fluentui" || externalName === "@recast-navigation") {
-                        // replace with any
-                        const matchRegex = new RegExp(`([ <])(${alias}[^,;\n>) ]*)([^\\w])`, "g");
-                        processedSource = processedSource.replace(matchRegex, `$1any$3`);
+                        // Replace type references with "any", but skip declaration sites (e.g. "export type ThemeMode")
+                        // to avoid producing invalid syntax like "export type any = ...".
+                        const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
+                        processedSource = processedSource.replace(matchRegex, (match, p1: string, _alias: string, p3: string, offset: number) => {
+                            const precedingText = processedSource.slice(0, offset + p1.length);
+                            if (/\b(?:type|class|var|const|let|function|interface|enum|namespace)\s+$/.test(precedingText)) {
+                                return match;
+                            }
+                            return `${p1}any${p3}`;
+                        });
                         return;
                     } else if (externalName === "react") {
                         const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");


### PR DESCRIPTION
## Problem

The playground intermittently shows:

> Error at [193832, 2]: /external/babylon.global.d.ts:193832:2 ',' expected.

This is caused by the declaration generator (`generateDeclaration.ts`) producing **syntactically invalid `.d.ts` output** when replacing `@fluentui`/`@fortawesome`/`@recast-navigation` type references with `any`.

The regex has two bugs:

1. **Greedy trailing pattern eats colons** — `[^,;\n>) ]*` after the alias consumes `:`, turning `export var ThemeModeSD: SD<ThemeMode>` into `export var any SD<any>` (colon swallowed, producing a parse error).

2. **Matches declaration names** — The regex replaces the alias even when it appears as the *declared name* (after `type`, `class`, `var`, etc.), producing invalid syntax like `export type any = ...` or `export class any implements ...`.

Currently, `babylon.inspector-v2.d.ts` on `preview.babylonjs.com` has **5 broken declarations** from this bug (lines 135, 139, 144, 161, 187).

## Fix

Use exact alias matching (the same pattern already used for `react` replacements) plus a negative lookbehind to skip declaration sites.

Both locations in `generateDeclaration.ts` (module declarations and namespace declarations) are fixed.

| Test case | Old regex | Fixed regex |
|---|---|---|
| `export type ThemeMode = ...` | :x: `export type any = ...` | :white_check_mark: Kept as-is |
| `var ThemeModeSD: SD<ThemeMode>` | :x: `var any SD<any>` | :white_check_mark: `var ThemeModeSD: SD<any>` |
| `export class ThemeResolver ...` | :x: `export class any ...` | :white_check_mark: Kept as-is |
| `export var ThemeServiceId: ...` | :x: `var any unique symbol` | :white_check_mark: Kept as-is |
| Type references (params, generics, unions) | :white_check_mark: Replaced with `any` | :white_check_mark: Replaced with `any` |