### PR TITLE
Replace unnecessary Engine imports with EngineStore and Constants

### DIFF
--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -25,7 +25,6 @@ import { BindBonesParameters, BindMorphTargetParameters, PrepareDefinesAndAttrib
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { ObjectRenderer } from "core/Rendering/objectRenderer";
 import type { Vector2 } from "../Maths/math.vector";
-import { Engine } from "core/Engines/engine";
 
 /**
  * Special Glow Blur post process only blurring the alpha channel
@@ -53,7 +52,7 @@ export class ThinGlowBlurPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinGlowBlurPostProcess.FragmentUrl,

--- a/packages/dev/core/src/Misc/thinMinMaxReducer.ts
+++ b/packages/dev/core/src/Misc/thinMinMaxReducer.ts
@@ -1,7 +1,8 @@
 import type { Nullable, EffectWrapperCreationOptions, AbstractEngine, InternalTexture, Scene } from "core/index";
 import { Observable } from "./observable";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "core/Engines/engine";
+import { EngineStore } from "core/Engines/engineStore";
+import { Constants } from "../Engines/constants";
 
 /**
  * @internal
@@ -37,7 +38,7 @@ export class ThinMinMaxReducerPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinMinMaxReducerPostProcess.FragmentUrl,
@@ -127,7 +128,7 @@ export class ThinMinMaxReducer {
         // in the current frame, whereas in WebGPU, the read is asynchronous and we should normally wait for the promise to be resolved to get the updated values.
         // However, it's safe to avoid waiting for the promise to be resolved in WebGPU as well, because we will simply use the current values until "buffer" is updated later on.
         // Note that it means we can suffer some rendering artifacts in WebGPU because we may use previous min/max values for the current frame.
-        const isFloat = texture.type === Engine.TEXTURETYPE_FLOAT || texture.type === Engine.TEXTURETYPE_HALF_FLOAT;
+        const isFloat = texture.type === Constants.TEXTURETYPE_FLOAT || texture.type === Constants.TEXTURETYPE_HALF_FLOAT;
         const buffer = isFloat ? BufferFloat : BufferUint8;
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/dev/core/src/PostProcesses/thinAnaglyphPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinAnaglyphPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Postprocess used to generate anaglyphic rendering
@@ -35,7 +35,7 @@ export class ThinAnaglyphPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinAnaglyphPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinBlackAndWhitePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBlackAndWhitePostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to render in black and white
@@ -35,7 +35,7 @@ export class ThinBlackAndWhitePostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinBlackAndWhitePostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinBloomMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBloomMergePostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * @internal
@@ -25,7 +25,7 @@ export class ThinBloomMergePostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinBloomMergePostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinBlurPostProcess.ts
@@ -1,7 +1,7 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Vector2, Effect } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { ShaderLanguage } from "../Materials/shaderLanguage";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to apply a blur effect
@@ -54,7 +54,7 @@ export class ThinBlurPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinBlurPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinChromaticAberrationPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinChromaticAberrationPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { Vector2 } from "../Maths/math.vector";
 
 /**
@@ -36,7 +36,7 @@ export class ThinChromaticAberrationPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinChromaticAberrationPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinCircleOfConfusionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinCircleOfConfusionPostProcess.ts
@@ -1,7 +1,7 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import type { Camera } from "core/Cameras/camera";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Options used to create a ThinCircleOfConfusionPostProcess.
@@ -57,7 +57,7 @@ export class ThinCircleOfConfusionPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinCircleOfConfusionPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinConvolutionPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinConvolutionPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to apply a convolution effect
@@ -62,7 +62,7 @@ export class ThinConvolutionPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinConvolutionPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinCustomPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinCustomPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Effect } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { Observable } from "../Misc/observable";
 
 /**
@@ -21,7 +21,7 @@ export class ThinCustomPostProcess extends EffectWrapper {
     constructor(name: string, engine: Nullable<AbstractEngine> = null, options?: EffectWrapperCreationOptions) {
         super({
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             ...options,

--- a/packages/dev/core/src/PostProcesses/thinDepthOfFieldMergePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinDepthOfFieldMergePostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * @internal
@@ -23,7 +23,7 @@ export class ThinDepthOfFieldMergePostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinDepthOfFieldMergePostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinExtractHighlightsPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinExtractHighlightsPostProcess.ts
@@ -1,7 +1,7 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
 import { ToGammaSpace } from "../Maths/math.constants";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to extract highlights.
@@ -36,7 +36,7 @@ export class ThinExtractHighlightsPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinExtractHighlightsPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinFXAAPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinFXAAPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { Vector2 } from "../Maths/math.vector";
 
 /**
@@ -54,7 +54,7 @@ export class ThinFXAAPostProcess extends EffectWrapper {
         const localOptions = {
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             vertexShader: ThinFXAAPostProcess.VertexUrl,

--- a/packages/dev/core/src/PostProcesses/thinFilterPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinFilterPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { Matrix } from "../Maths/math.vector";
 
 /**
@@ -36,7 +36,7 @@ export class ThinFilterPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinFilterPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinGrainPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinGrainPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to render a grain effect
@@ -35,7 +35,7 @@ export class ThinGrainPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinGrainPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinImageProcessingPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinImageProcessingPostProcess.ts
@@ -1,6 +1,5 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Observer, NonNullableFields, Scene, ColorCurves, BaseTexture, Color4 } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
 import { EngineStore } from "../Engines/engineStore";
 import type { IImageProcessingConfigurationDefines } from "../Materials/imageProcessingConfiguration.defines";
 import { ImageProcessingConfiguration } from "../Materials/imageProcessingConfiguration";
@@ -466,7 +465,7 @@ export class ThinImageProcessingPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinImageProcessingPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinPassPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinPassPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, EffectWrapperCreationOptions, AbstractEngine } from "core/index";
 import { EffectWrapper } from "core/Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * PassPostProcess which produces an output the same as it's input
@@ -31,7 +31,7 @@ export class ThinPassPostProcess extends EffectWrapper {
     constructor(name: string, engine: Nullable<AbstractEngine> = null, options?: EffectWrapperCreationOptions) {
         const localOptions: EffectWrapperCreationOptions = {
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinPassPostProcess.FragmentUrl,
@@ -39,7 +39,7 @@ export class ThinPassPostProcess extends EffectWrapper {
         };
 
         if (!localOptions.engine) {
-            localOptions.engine = Engine.LastCreatedEngine!;
+            localOptions.engine = EngineStore.LastCreatedEngine!;
         }
 
         super(localOptions);
@@ -76,7 +76,7 @@ export class ThinPassCubePostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinPassCubePostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinSSAO2BlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSAO2BlurPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * @internal
@@ -25,7 +25,7 @@ export class ThinSSAO2BlurPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinSSAO2BlurPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinSSAO2CombinePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSAO2CombinePostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Camera } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { TmpVectors } from "core/Maths/math.vector";
 
 /**
@@ -26,7 +26,7 @@ export class ThinSSAO2CombinePostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinSSAO2CombinePostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinSSRBlurCombinerPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRBlurCombinerPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions, Camera } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { TmpVectors } from "../Maths/math.vector";
 
 /**
@@ -35,7 +35,7 @@ export class ThinSSRBlurCombinerPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinSSRBlurCombinerPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinSSRBlurPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSSRBlurPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 import { Vector2 } from "../Maths/math.vector";
 
 /**
@@ -26,7 +26,7 @@ export class ThinSSRBlurPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinSSRBlurPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinScreenSpaceCurvaturePostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinScreenSpaceCurvaturePostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to apply a screen space curvature post process
@@ -40,7 +40,7 @@ export class ThinScreenSpaceCurvaturePostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinScreenSpaceCurvaturePostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinSharpenPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinSharpenPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /**
  * Post process used to apply a sharpen effect
@@ -35,7 +35,7 @@ export class ThinSharpenPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinSharpenPostProcess.FragmentUrl,

--- a/packages/dev/core/src/PostProcesses/thinTonemapPostProcess.ts
+++ b/packages/dev/core/src/PostProcesses/thinTonemapPostProcess.ts
@@ -1,6 +1,6 @@
 import type { Nullable, AbstractEngine, EffectWrapperCreationOptions } from "core/index";
 import { EffectWrapper } from "../Materials/effectRenderer";
-import { Engine } from "../Engines/engine";
+import { EngineStore } from "../Engines/engineStore";
 
 /** Defines operator used for tonemapping */
 export const enum TonemappingOperator {
@@ -73,7 +73,7 @@ export class ThinTonemapPostProcess extends EffectWrapper {
         super({
             ...options,
             name,
-            engine: engine || Engine.LastCreatedEngine!,
+            engine: engine || EngineStore.LastCreatedEngine!,
             useShaderStore: true,
             useAsPostProcess: true,
             fragmentShader: ThinTonemapPostProcess.FragmentUrl,

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.ts
@@ -19,7 +19,6 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { GeometryBufferRenderer } from "core/Rendering/geometryBufferRenderer";
 import { RawTexture } from "core/Materials/Textures/rawTexture";
 import { RawTexture3D } from "core/Materials/Textures/rawTexture3D";
-import { Engine } from "core/Engines/engine";
 import { IBLShadowsPluginMaterial } from "./iblShadowsPluginMaterial";
 import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
 import { StandardMaterial } from "core/Materials/standardMaterial";
@@ -792,8 +791,8 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
         this._cameras = cameras || [scene.activeCamera!];
         // Create the dummy textures to be used when the pipeline is not ready
         const blackPixels = new Uint8Array([0, 0, 0, 255]);
-        this._dummyTexture2d = new RawTexture(blackPixels, 1, 1, Engine.TEXTUREFORMAT_RGBA, scene, false);
-        this._dummyTexture3d = new RawTexture3D(blackPixels, 1, 1, 1, Engine.TEXTUREFORMAT_RGBA, scene, false);
+        this._dummyTexture2d = new RawTexture(blackPixels, 1, 1, Constants.TEXTUREFORMAT_RGBA, scene, false);
+        this._dummyTexture3d = new RawTexture3D(blackPixels, 1, 1, 1, Constants.TEXTUREFORMAT_RGBA, scene, false);
 
         // Setup the geometry buffer target formats
         const textureTypesAndFormats: { [key: number]: { textureType: number; textureFormat: number } } = {};

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
@@ -1,5 +1,5 @@
 import { Constants } from "../../Engines/constants";
-import { Engine } from "../../Engines/engine";
+import type { Engine } from "../../Engines/engine";
 import { ShaderMaterial } from "../../Materials/shaderMaterial";
 import { MultiRenderTarget } from "../../Materials/Textures/multiRenderTarget";
 import { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture";
@@ -567,7 +567,7 @@ export class _IblShadowsVoxelRenderer {
         });
         this._voxelMaterial.cullBackFaces = false;
         this._voxelMaterial.backFaceCulling = false;
-        this._voxelMaterial.depthFunction = Engine.ALWAYS;
+        this._voxelMaterial.depthFunction = Constants.ALWAYS;
 
         this._voxelSlabDebugMaterial = new ShaderMaterial("voxelSlabDebug", this._scene, "iblVoxelSlabDebug", {
             uniforms: ["world", "viewMatrix", "cameraViewMatrix", "projection", "invWorldScale", "nearPlane", "farPlane", "stepSize"],

--- a/packages/dev/core/src/Rendering/iblCdfGenerator.ts
+++ b/packages/dev/core/src/Rendering/iblCdfGenerator.ts
@@ -14,7 +14,6 @@ import type { BaseTexture } from "../Materials/Textures/baseTexture";
 import { Observable } from "../Misc/observable";
 import type { CubeTexture } from "../Materials/Textures/cubeTexture";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
-import { Engine } from "../Engines/engine";
 import { _WarnImport } from "../Misc/devTools";
 import type { Nullable } from "../types";
 import { EngineStore } from "../Engines/engineStore";
@@ -170,7 +169,7 @@ export class IblCdfGenerator {
             return;
         }
         const blackPixels = new Uint16Array([0, 0, 0, 255]);
-        this._dummyTexture = new RawTexture(blackPixels, 1, 1, Engine.TEXTUREFORMAT_RGBA, sceneOrEngine, false, false, undefined, Constants.TEXTURETYPE_HALF_FLOAT);
+        this._dummyTexture = new RawTexture(blackPixels, 1, 1, Constants.TEXTUREFORMAT_RGBA, sceneOrEngine, false, false, undefined, Constants.TEXTURETYPE_HALF_FLOAT);
         if (this._scene) {
             IblCdfGenerator._SceneComponentInitialization(this._scene);
         }


### PR DESCRIPTION
After taking a quick look at bundle analysis for Viewer, Engine (WebGL) was being pulled into the root bundle chunk even when using WebGPUEngine only. This is because of a bunch of files that import `Engine` for `LastCreatedEngine` and for various constants. The fix is simply to replace those imports with imports of `EngineStore` and `Constants`. This reduces the Viewer root bundle by about 60kb (minified).