### PR TITLE
Fix playground webpack build error caused by duplicate ReactRefreshWebpackPlugin

### DIFF
--- a/packages/tools/playground/webpack.config.js
+++ b/packages/tools/playground/webpack.config.js
@@ -85,7 +85,7 @@ module.exports = (env) => {
             }),
         },
     };
-    const plugins = (commonConfig.plugins || []).filter((p) => !(p && p.constructor && p.constructor.name === "ReactRefreshWebpackPlugin"));
+    const plugins = (commonConfig.plugins || []).filter((p) => !(p && p.constructor && p.constructor.name === "ReactRefreshPlugin"));
     return {
         ...commonConfig,
         output: {


### PR DESCRIPTION
## Description

Reported in forums: https://forum.babylonjs.com/t/npm-build-playground-failure/62955

The playground's `webpack.config.js` filters out the `ReactRefreshWebpackPlugin` added by `commonDevWebpackConfiguration()` (from `@dev/build-tools`) so it can re-add it with custom options (`overlay: false`). However, the filter checked for constructor name `"ReactRefreshWebpackPlugin"` while the actual class name exported by `@pmmmwh/react-refresh-webpack-plugin` is `"ReactRefreshPlugin"`.

This caused **two** plugin instances to be active simultaneously — one from `buildTools/node_modules` and one from `playground/node_modules` — each injecting its own loader. The result was `$ReactRefreshModuleId$` being declared twice, producing a build error:

```
Module parse failed: Identifier '$ReactRefreshModuleId$' has already been declared
File was processed with these loaders:
 * ./node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
 * ../../dev/buildTools/node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
```

## Fix

Changed the constructor name check from `"ReactRefreshWebpackPlugin"` to `"ReactRefreshPlugin"` to match the actual class name.