### PR TITLE
Viewer: Don't enable ssao by default when all meshes are splats

### DIFF
--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -10,7 +10,6 @@ import {
     type Camera,
     type CubeTexture,
     type Engine,
-    type GaussianSplattingMesh,
     type HDRCubeTexture,
     type HotSpotQuery,
     type IblCdfGenerator,


### PR DESCRIPTION
This pull request enhances the viewer's logic for handling mesh types and SSAO (Screen Space Ambient Occlusion) options, particularly in scenes containing Gaussian Splatting meshes. The main changes introduce a utility function to detect Gaussian Splatting meshes and update the SSAO auto-enabling logic to account for these mesh types.

**Enhancements for mesh type detection and SSAO logic:**

* Added a new function `IsGaussianSplattingMesh` to reliably identify Gaussian Splatting meshes (including compound splat part proxies) by class name, without requiring a direct import of the class.
* Updated the SSAO "auto" enabling logic in the `Viewer` class to disable SSAO when all loaded meshes are Gaussian Splatting meshes, preventing unnecessary SSAO computations for these mesh types.
* Included `GaussianSplattingMesh` in the import type list for better type coverage.

**Other improvements:**

* Renamed the SSAO options type guard from `isSSAOOptions` to `IsSSAOOptions` for naming consistency.