### PR TITLE
Fix for coord flip of irradiance

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflection.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrBlockReflection.fx
@@ -281,10 +281,12 @@
 
             #ifdef REFLECTIONMAP_OPPOSITEZ
                 irradianceVector.z *= -1.0;
+                irradianceView.z *= -1.0;
             #endif
 
             #ifdef INVERTCUBICMAP
                 irradianceVector.y *= -1.0;
+                irradianceView.y *= -1.0;
             #endif
         #endif
         #ifdef USESPHERICALFROMREFLECTIONMAP


### PR DESCRIPTION
This is a pre-existing bug fix from PR #16253 (Diffuse Roughness support, May 2025) where irradianceView was introduced without the coordinate-space flips that irradianceVector already had. Since both vectors go through the same reflectionMatrix, they need the same adjustments.

This should be called out in the PR description as it affects more than just the new subsurface feature. Here's a suggested note for the PR description:

Bug fix: Fixed missing REFLECTIONMAP_OPPOSITEZ / INVERTCUBICMAP flips on irradianceView (introduced in #16253). Affected materials and code paths:

PBR materials (pbrBlockReflection.fx)
OpenPBR materials (openpbrIblFunctions.fx)
Both GLSL and WGSL variants
Impacted rendering paths:

Normal bending for diffuse roughness (EON / Burley models)
REALTIME_FILTERING (irradiance sampling)
USE_IRRADIANCE_DOMINANT_DIRECTION (dominant light BRDF)
Only scenes using cubemaps with REFLECTIONMAP_OPPOSITEZ or INVERTCUBICMAP were affected.