### PR TITLE
Fix alpha issue on NPE color4 block

### DIFF
--- a/packages/tools/nodeParticleEditor/src/graphSystem/display/inputDisplayManager.ts
+++ b/packages/tools/nodeParticleEditor/src/graphSystem/display/inputDisplayManager.ts
@@ -42,7 +42,7 @@ export class InputDisplayManager implements IDisplayManager {
         switch (inputBlock.type) {
             case NodeParticleBlockConnectionPointTypes.Color4: {
                 if (inputBlock.value) {
-                    color = inputBlock.value.toHexString();
+                    color = inputBlock.value.toHexString(true);
                     break;
                 }
             }
@@ -157,10 +157,9 @@ export class InputDisplayManager implements IDisplayManager {
                 case NodeParticleBlockConnectionPointTypes.Color4: {
                     const col4Value = inputBlock.value as Color4;
                     value = `(${col4Value.r.toFixed(2)}, ${col4Value.g.toFixed(2)}, ${col4Value.b.toFixed(2)}, ${col4Value.a.toFixed(2)})`;
-                    // Use black or white text for readability based on perceived luminance
+                    // Use black or white text for readability based on perceived luminance (ignore alpha)
                     const luminance = 0.3 * col4Value.r + 0.59 * col4Value.g + 0.11 * col4Value.b;
-                    const effectiveLuminance = luminance * col4Value.a + (1 - col4Value.a);
-                    const isDarkBackground = effectiveLuminance < 0.5;
+                    const isDarkBackground = luminance < 0.5;
                     contentArea.style.color = isDarkBackground ? "white" : "black";
                     break;
                 }


### PR DESCRIPTION
The Color4 block in NPE was updated to represent the color in its background, but it is taking alpha into value which it should not. This PR fixes it.

Bug:
<img width="212" height="136" alt="image" src="https://github.com/user-attachments/assets/bb01fcbf-6d51-4a4c-a9f0-e54074c3ced6" />

Fixed:
<img width="200" height="131" alt="image" src="https://github.com/user-attachments/assets/3aacb5a2-cf99-4553-9788-971b5c8ea9cc" />
