### PR TITLE
Fix alpha in Color4

### DIFF
--- a/packages/tools/nodeEditor/src/graphSystem/display/inputDisplayManager.ts
+++ b/packages/tools/nodeEditor/src/graphSystem/display/inputDisplayManager.ts
@@ -4,7 +4,7 @@ import { NodeMaterialSystemValues } from "core/Materials/Node/Enums/nodeMaterial
 import { NodeMaterialBlockConnectionPointTypes } from "core/Materials/Node/Enums/nodeMaterialBlockConnectionPointTypes";
 import { AnimatedInputBlockTypes } from "core/Materials/Node/Blocks/Input/animatedInputBlockTypes";
 import { type Vector2, type Vector3, type Vector4 } from "core/Maths/math.vector";
-import { Color3 } from "core/Maths/math.color";
+import { type Color3, type Color4 } from "core/Maths/math.color";
 import { BlockTools } from "../../blockTools";
 import { type IDisplayManager } from "shared-ui-components/nodeGraphSystem/interfaces/displayManager";
 import { type INodeData } from "shared-ui-components/nodeGraphSystem/interfaces/nodeData";
@@ -67,10 +67,16 @@ export class InputDisplayManager implements IDisplayManager {
         const inputBlock = nodeData.data as InputBlock;
 
         switch (inputBlock.type) {
-            case NodeMaterialBlockConnectionPointTypes.Color3:
+            case NodeMaterialBlockConnectionPointTypes.Color3: {
+                if (inputBlock.value) {
+                    color = (inputBlock.value as Color3).toHexString();
+                    break;
+                }
+            }
+            // eslint-disable-next-line no-fallthrough
             case NodeMaterialBlockConnectionPointTypes.Color4: {
                 if (inputBlock.value) {
-                    color = new Color3(inputBlock.value.r, inputBlock.value.g, inputBlock.value.b).toHexString();
+                    color = (inputBlock.value as Color4).toHexString(true);
                     break;
                 }
             }


### PR DESCRIPTION
NME Color4 block had the same alpha issue as Color4 in NPE: when you set a color to transparent, the background also goes transparent. This keeps the block changing its background but ignores the alpha value.