### PR TITLE
Fix inspector gui-editor import rewrite mapping

### DIFF
--- a/packages/public/@babylonjs/inspector-v2/rollup.config.lib.mjs
+++ b/packages/public/@babylonjs/inspector-v2/rollup.config.lib.mjs
@@ -8,7 +8,7 @@ import { rewriteDevImports, appendJsToExternalPaths } from "../../rollupUtils.mj
 // Map dev package names to their public @babylonjs/ equivalents.
 // Must be ordered longest-first to prevent prefix collisions (e.g. gui vs gui-editor).
 const devPackageMap = {
-    "gui-editor": "@babylonjs/gui-editor",
+    "gui-editor/guiEditor": "@babylonjs/gui-editor",
     "shared-ui-components": null, // handled by alias plugin below
     serializers: "@babylonjs/serializers",
     materials: "@babylonjs/materials",


### PR DESCRIPTION
### Summary
This PR fixes an import rewrite issue in inspector-v2 that could produce an invalid runtime import path for gui-editor in downstream Vite/Vitest environments.

### Root Cause
The Rollup dev package rewrite map was rewriting the broad gui-editor namespace:

```gui-editor -> @babylonjs/gui-editor```

When inspector-v2 source imports gui-editor/guiEditor, that mapping rewrites to @babylonjs/gui-editor/guiEditor, and later .js is appended, resulting in:

```@babylonjs/gui-editor/guiEditor.js```

That subpath is not exported by the published @babylonjs/gui-editor package.

<img width="2067" height="555" alt="Screenshot 2026-04-02 at 12 45 59 PM" src="https://github.com/user-attachments/assets/29d38f4e-fd3d-4929-bef3-d11a3680e0ea" />

### Change
Updated the mapping to target only the specific source import and rewrite it to the package root:

```gui-editor/guiEditor -> @babylonjs/gui-editor```

