### PR TITLE
[Shaders] Fix clustered lighting shader error when using anisotropy without clearcoat

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrClusteredLightingFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrClusteredLightingFunctions.fx
@@ -108,7 +108,7 @@
                         info.diffuse *= (vec3(1.0) - fresnel);
                     #endif
                     #ifdef ANISOTROPIC
-                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, clearcoatOut.specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightDiffuse.rgb);
+                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightDiffuse.rgb);
                     #else
                         info.specular = computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightDiffuse.rgb);
                     #endif

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions.fx
@@ -360,7 +360,7 @@ fn evalFuzz(L: vec3f, NdotL: f32, NdotV: f32, T: vec3f, B: vec3f, ltcLut: vec3f)
                         info.diffuse *= (vec3(1.0) - fresnel);
                     #endif
                     #ifdef ANISOTROPIC
-                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, clearcoatOut.specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightDiffuse.rgb);
+                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightDiffuse.rgb);
                     #else
                         info.specular = computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightDiffuse.rgb);
                     #endif


### PR DESCRIPTION
## Description

The **computeClusteredLighting** function in the PBR clustered lighting shader unconditionally accessed **clearcoatOut.specularEnvironmentR0** in the ANISOTROPIC code path, but **clearcoatOut** is only passed as a parameter when CLEARCOAT is defined. This caused a fragment shader compilation error:

> FRAGMENT SHADER ERROR: 0:863: 'clearcoatOut' : undeclared identifier

The error occurs when using PBR anisotropy with **ClusteredLightContainer** and no clearcoat — on both WebGL2 and WebGPU.

## Fix

Use the local **specularEnvironmentR0** variable instead of reading it from **clearcoatOut**. This variable (from the **pbrBlockReflectance0** include) already contains the correct value: it is overwritten from clearcoatOut when CLEARCOAT is enabled, and retains the base reflectance value otherwise. This is consistent with how the adjacent non-ANISOTROPIC code path already works.

Applied to both GLSL and WGSL shaders.

## Repro

[Playground #QAD7FB#0](https://playground.babylonjs.com/#QAD7FB#0)

## Forum post

https://forum.babylonjs.com/t/anisotropy-with-clusteredlightcontainer-bug/63040