### PR TITLE
Fix material readiness to gate on light texture readiness

### DIFF
--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -946,6 +946,15 @@ export abstract class Light extends Node implements ISortableLight {
     }
 
     /**
+     * Returns true when all texture resources used by this light are ready (e.g. projection textures).
+     * Override in subclasses that use texture resources.
+     * @returns true if all light textures are ready
+     */
+    public areLightTexturesReady(): boolean {
+        return true;
+    }
+
+    /**
      * Prepares the list of defines specific to the light type.
      * @param defines the list of defines
      * @param lightIndex defines the index of the light for the effect

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -511,6 +511,17 @@ export class SpotLight extends ShadowLight {
         return engine.useReverseDepthBuffer && engine.isNDCHalfZRange ? 0 : maxZ;
     }
 
+    /** @override */
+    public override areLightTexturesReady(): boolean {
+        if (this._projectionTexture && !this._projectionTexture.isReady()) {
+            return false;
+        }
+        if (this._iesProfileTexture && !this._iesProfileTexture.isReady()) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Prepares the list of defines specific to the light type.
      * @param defines the list of defines

--- a/packages/dev/core/src/Lights/spotLight.ts
+++ b/packages/dev/core/src/Lights/spotLight.ts
@@ -513,10 +513,10 @@ export class SpotLight extends ShadowLight {
 
     /** @override */
     public override areLightTexturesReady(): boolean {
-        if (this._projectionTexture && !this._projectionTexture.isReady()) {
+        if (this._projectionTexture && !this._projectionTexture.isReadyOrNotBlocking()) {
             return false;
         }
-        if (this._iesProfileTexture && !this._iesProfileTexture.isReady()) {
+        if (this._iesProfileTexture && !this._iesProfileTexture.isReadyOrNotBlocking()) {
             return false;
         }
         return true;

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -606,6 +606,10 @@ export class BackgroundMaterial extends BackgroundMaterialBase {
         PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights);
         defines._needNormals = true;
 
+        if (defines._areLightTexturesReady === false) {
+            return false;
+        }
+
         // Multiview
         PrepareDefinesForMultiview(scene, defines);
 

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -45,6 +45,7 @@ import {
     PrepareUniformsAndSamplersList,
     PrepareUniformsAndSamplersForIBL,
     PrepareUniformLayoutForIBL,
+    AreLightsTexturesReady,
 } from "../materialHelper.functions";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
 import { ShaderLanguage } from "../shaderLanguage";
@@ -606,7 +607,7 @@ export class BackgroundMaterial extends BackgroundMaterialBase {
         PrepareDefinesForLights(scene, mesh, defines, false, this._maxSimultaneousLights);
         defines._needNormals = true;
 
-        if (defines._areLightTexturesReady === false) {
+        if (!AreLightsTexturesReady(scene, mesh, this._maxSimultaneousLights)) {
             return false;
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -243,7 +243,6 @@ export class LightBlock extends NodeMaterialBlock {
                 lightmapMode: false,
                 shadowEnabled: false,
                 specularEnabled: false,
-                lightTexturesReady: true,
             };
 
             PrepareDefinesForLight(scene, mesh, this.light, this._lightId, defines, true, state);
@@ -251,9 +250,21 @@ export class LightBlock extends NodeMaterialBlock {
             if (state.needRebuild) {
                 defines.rebuild();
             }
-
-            defines._areLightTexturesReady = state.lightTexturesReady;
         }
+    }
+
+    /**
+     * Checks if the block is ready
+     * @param mesh - the mesh to check
+     * @param nodeMaterial - the node material
+     * @param defines - the list of defines
+     * @returns true if ready
+     */
+    public override isReady(mesh: AbstractMesh, nodeMaterial: NodeMaterial, defines: NodeMaterialDefines) {
+        if (this.light && !this.light.areLightTexturesReady()) {
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -404,6 +415,9 @@ export class LightBlock extends NodeMaterialBlock {
         const accessor = isWGSL ? "fragmentInputs." : "";
         state.sharedData.forcedBindableBlocks.push(this);
         state.sharedData.blocksWithDefines.push(this);
+        if (this.light) {
+            state.sharedData.blockingBlocks.push(this);
+        }
         const worldPos = this.worldPosition;
 
         let worldPosVariableName = worldPos.associatedVariableName;

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -243,6 +243,7 @@ export class LightBlock extends NodeMaterialBlock {
                 lightmapMode: false,
                 shadowEnabled: false,
                 specularEnabled: false,
+                lightTexturesReady: true,
             };
 
             PrepareDefinesForLight(scene, mesh, this.light, this._lightId, defines, true, state);
@@ -250,6 +251,8 @@ export class LightBlock extends NodeMaterialBlock {
             if (state.needRebuild) {
                 defines.rebuild();
             }
+
+            defines._areLightTexturesReady = state.lightTexturesReady;
         }
     }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -834,7 +834,6 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
                 lightmapMode: false,
                 shadowEnabled: false,
                 specularEnabled: false,
-                lightTexturesReady: true,
             };
 
             PrepareDefinesForLight(scene, mesh, this.light, this._lightId, defines, true, state);
@@ -842,8 +841,6 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
             if (state.needRebuild) {
                 defines.rebuild();
             }
-
-            defines._areLightTexturesReady = state.lightTexturesReady;
         }
     }
 
@@ -890,6 +887,10 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
             if (!nodeMaterial.imageProcessingConfiguration.isReady()) {
                 return false;
             }
+        }
+
+        if (this.light && !this.light.areLightTexturesReady()) {
+            return false;
         }
 
         return true;

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -834,6 +834,7 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
                 lightmapMode: false,
                 shadowEnabled: false,
                 specularEnabled: false,
+                lightTexturesReady: true,
             };
 
             PrepareDefinesForLight(scene, mesh, this.light, this._lightId, defines, true, state);
@@ -841,6 +842,8 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
             if (state.needRebuild) {
                 defines.rebuild();
             }
+
+            defines._areLightTexturesReady = state.lightTexturesReady;
         }
     }
 

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -62,7 +62,7 @@ import { type PrePassOutputBlock } from "./Blocks/Fragment/prePassOutputBlock";
 import { type NodeMaterialTeleportOutBlock } from "./Blocks/Teleport/teleportOutBlock";
 import { type NodeMaterialTeleportInBlock } from "./Blocks/Teleport/teleportInBlock";
 import { Logger } from "core/Misc/logger";
-import { PrepareDefinesForCamera, PrepareDefinesForPrePass } from "../materialHelper.functions";
+import { PrepareDefinesForCamera, PrepareDefinesForPrePass, AreLightsTexturesReady } from "../materialHelper.functions";
 import { ImageProcessingDefinesMixin } from "../imageProcessingConfiguration.defines";
 import { ShaderLanguage } from "../shaderLanguage";
 import { AbstractEngine } from "../../Engines/abstractEngine";
@@ -1663,11 +1663,11 @@ export class NodeMaterial extends NodeMaterialBase {
             return false;
         }
 
-        const result = this._processDefines(defines, mesh, useInstances, subMesh);
-
-        if (defines._areLightTexturesReady === false) {
+        if (!AreLightsTexturesReady(scene, mesh, this.maxSimultaneousLights)) {
             return false;
         }
+
+        const result = this._processDefines(defines, mesh, useInstances, subMesh);
 
         if (result) {
             const previousEffect = subMesh.effect;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -1665,6 +1665,10 @@ export class NodeMaterial extends NodeMaterialBase {
 
         const result = this._processDefines(defines, mesh, useInstances, subMesh);
 
+        if (defines._areLightTexturesReady === false) {
+            return false;
+        }
+
         if (result) {
             const previousEffect = subMesh.effect;
             // Compilation

--- a/packages/dev/core/src/Materials/PBR/openpbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/openpbrMaterial.ts
@@ -2241,6 +2241,10 @@ export class OpenPBRMaterial extends OpenPBRMaterialBase {
         const lightDisposed = defines._areLightsDisposed;
         const effect = this._prepareEffect(mesh, subMesh.getRenderingMesh(), defines, this.onCompiled, this.onError, useInstances, null);
 
+        if (defines._areLightTexturesReady === false) {
+            return false;
+        }
+
         let forceWasNotReadyPreviously = false;
 
         if (effect) {

--- a/packages/dev/core/src/Materials/PBR/openpbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/openpbrMaterial.ts
@@ -44,6 +44,7 @@ import {
     PrepareUniformsAndSamplersList,
     PrepareUniformsAndSamplersForIBL,
     PrepareUniformLayoutForIBL,
+    AreLightsTexturesReady,
 } from "../materialHelper.functions";
 import { Constants } from "../../Engines/constants";
 import { VertexBuffer } from "../../Buffers/buffer";
@@ -2237,13 +2238,13 @@ export class OpenPBRMaterial extends OpenPBRMaterialBase {
             Logger.Warn("OpenPBRMaterial: Normals have been created for the mesh: " + mesh.name);
         }
 
+        if (!AreLightsTexturesReady(scene, mesh, this._maxSimultaneousLights, this._disableLighting)) {
+            return false;
+        }
+
         const previousEffect = subMesh.effect;
         const lightDisposed = defines._areLightsDisposed;
         const effect = this._prepareEffect(mesh, subMesh.getRenderingMesh(), defines, this.onCompiled, this.onError, useInstances, null);
-
-        if (defines._areLightTexturesReady === false) {
-            return false;
-        }
 
         let forceWasNotReadyPreviously = false;
 

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1194,6 +1194,10 @@ export abstract class PBRBaseMaterial extends PBRBaseMaterialBase {
         const lightDisposed = defines._areLightsDisposed;
         const effect = this._prepareEffect(mesh, subMesh.getRenderingMesh(), defines, this.onCompiled, this.onError, useInstances, null);
 
+        if (defines._areLightTexturesReady === false) {
+            return false;
+        }
+
         let forceWasNotReadyPreviously = false;
 
         if (effect) {

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -66,6 +66,7 @@ import {
     PrepareUniformsAndSamplersList,
     PrepareUniformsAndSamplersForIBL,
     PrepareUniformLayoutForIBL,
+    AreLightsTexturesReady,
 } from "../materialHelper.functions";
 import { ShaderLanguage } from "../shaderLanguage";
 import { MaterialHelperGeometryRendering } from "../materialHelper.geometryrendering";
@@ -1190,13 +1191,13 @@ export abstract class PBRBaseMaterial extends PBRBaseMaterialBase {
             Logger.Warn("PBRMaterial: Normals have been created for the mesh: " + mesh.name);
         }
 
+        if (!AreLightsTexturesReady(scene, mesh, this._maxSimultaneousLights, this._disableLighting)) {
+            return false;
+        }
+
         const previousEffect = subMesh.effect;
         const lightDisposed = defines._areLightsDisposed;
         const effect = this._prepareEffect(mesh, subMesh.getRenderingMesh(), defines, this.onCompiled, this.onError, useInstances, null);
-
-        if (defines._areLightTexturesReady === false) {
-            return false;
-        }
 
         let forceWasNotReadyPreviously = false;
 

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -667,6 +667,7 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
         lightmapMode: false,
         shadowEnabled: false,
         specularEnabled: false,
+        lightTexturesReady: true,
     };
 
     if (scene.lightsEnabled && !disableLighting) {
@@ -682,6 +683,7 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
 
     defines["SPECULARTERM"] = state.specularEnabled;
     defines["SHADOWS"] = state.shadowEnabled;
+    defines._areLightTexturesReady = state.lightTexturesReady;
 
     // Resetting all other lights if any
     const maxLightCount = Math.max(maxSimultaneousLights, defines["MAXLIGHTCOUNT"] || 0);
@@ -899,6 +901,7 @@ export function PrepareDefinesForLight(
         shadowEnabled: boolean;
         specularEnabled: boolean;
         lightmapMode: boolean;
+        lightTexturesReady: boolean;
     }
 ) {
     state.needNormals = true;
@@ -917,6 +920,10 @@ export function PrepareDefinesForLight(
     defines["CLUSTLIGHT" + lightIndex] = false;
 
     light.prepareLightSpecificDefines(defines, lightIndex);
+
+    if (!light.areLightTexturesReady()) {
+        state.lightTexturesReady = false;
+    }
 
     // FallOff.
     defines["LIGHT_FALLOFF_PHYSICAL" + lightIndex] = false;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -646,6 +646,31 @@ export function PrepareDefinesForMisc(
 }
 
 /**
+ * Checks whether the texture resources used by the lights that will affect the given mesh are ready.
+ * This mirrors the light iteration performed by {@link PrepareDefinesForLights} and {@link BindLights}:
+ * it only considers lights that can affect the mesh (already filtered into `mesh.lightSources`)
+ * and respects the material's `maxSimultaneousLights` cap and the `disableLighting` flag.
+ * @param scene The scene the mesh belongs to
+ * @param mesh The mesh to check
+ * @param maxSimultaneousLights The material's max simultaneous lights cap
+ * @param disableLighting Whether lighting is disabled for the material
+ * @returns true if all affecting lights report their textures are ready
+ */
+export function AreLightsTexturesReady(scene: Scene, mesh: AbstractMesh, maxSimultaneousLights: number, disableLighting = false): boolean {
+    if (!scene.lightsEnabled || disableLighting) {
+        return true;
+    }
+    const lights = mesh.lightSources;
+    const count = Math.min(lights.length, maxSimultaneousLights);
+    for (let i = 0; i < count; i++) {
+        if (!lights[i].areLightTexturesReady()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * Prepares the defines related to the light information passed in parameter
  * @param scene The scene we are intending to draw
  * @param mesh The mesh the effect is compiling for
@@ -667,7 +692,6 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
         lightmapMode: false,
         shadowEnabled: false,
         specularEnabled: false,
-        lightTexturesReady: true,
     };
 
     if (scene.lightsEnabled && !disableLighting) {
@@ -683,7 +707,6 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
 
     defines["SPECULARTERM"] = state.specularEnabled;
     defines["SHADOWS"] = state.shadowEnabled;
-    defines._areLightTexturesReady = state.lightTexturesReady;
 
     // Resetting all other lights if any
     const maxLightCount = Math.max(maxSimultaneousLights, defines["MAXLIGHTCOUNT"] || 0);
@@ -901,7 +924,6 @@ export function PrepareDefinesForLight(
         shadowEnabled: boolean;
         specularEnabled: boolean;
         lightmapMode: boolean;
-        lightTexturesReady: boolean;
     }
 ) {
     state.needNormals = true;
@@ -920,10 +942,6 @@ export function PrepareDefinesForLight(
     defines["CLUSTLIGHT" + lightIndex] = false;
 
     light.prepareLightSpecificDefines(defines, lightIndex);
-
-    if (!light.areLightTexturesReady()) {
-        state.lightTexturesReady = false;
-    }
 
     // FallOff.
     defines["LIGHT_FALLOFF_PHYSICAL" + lightIndex] = false;

--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -216,7 +216,6 @@ export class MaterialHelper {
      * @param state.shadowEnabled
      * @param state.specularEnabled
      * @param state.lightmapMode
-     * @param state.lightTexturesReady
      */
     public static PrepareDefinesForLight: (
         scene: Scene,
@@ -231,7 +230,6 @@ export class MaterialHelper {
             shadowEnabled: boolean;
             specularEnabled: boolean;
             lightmapMode: boolean;
-            lightTexturesReady: boolean;
         }
     ) => void = PrepareDefinesForLight;
 

--- a/packages/dev/core/src/Materials/materialHelper.ts
+++ b/packages/dev/core/src/Materials/materialHelper.ts
@@ -216,6 +216,7 @@ export class MaterialHelper {
      * @param state.shadowEnabled
      * @param state.specularEnabled
      * @param state.lightmapMode
+     * @param state.lightTexturesReady
      */
     public static PrepareDefinesForLight: (
         scene: Scene,
@@ -230,6 +231,7 @@ export class MaterialHelper {
             shadowEnabled: boolean;
             specularEnabled: boolean;
             lightmapMode: boolean;
+            lightTexturesReady: boolean;
         }
     ) => void = PrepareDefinesForLight;
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -745,6 +745,10 @@ export class StandardMaterial extends StandardMaterialBase {
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, true, this._maxSimultaneousLights, this._disableLighting);
 
+        if (defines._areLightTexturesReady === false) {
+            return false;
+        }
+
         // Multiview
         PrepareDefinesForMultiview(scene, defines);
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -58,6 +58,7 @@ import {
     PrepareUniformsAndSamplersForIBL,
     PrepareUniformsAndSamplersList,
     PrepareUniformLayoutForIBL,
+    AreLightsTexturesReady,
 } from "./materialHelper.functions";
 import { SerializationHelper } from "../Misc/decorators.serialization";
 import { ShaderLanguage } from "./shaderLanguage";
@@ -745,7 +746,7 @@ export class StandardMaterial extends StandardMaterialBase {
         // Lights
         defines._needNormals = PrepareDefinesForLights(scene, mesh, defines, true, this._maxSimultaneousLights, this._disableLighting);
 
-        if (defines._areLightTexturesReady === false) {
+        if (!AreLightsTexturesReady(scene, mesh, this._maxSimultaneousLights, this._disableLighting)) {
             return false;
         }
 

--- a/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
+++ b/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
@@ -36,21 +36,17 @@ describe("SpotLight", () => {
     });
 
     describe("light texture readiness", () => {
-        // Regression tests for https://github.com/BabylonJS/Babylon.js/pull/18255.
+        // When a light owns texture resources that are not yet ready (e.g. a SpotLight's
+        // projectionTexture or iesProfileTexture), material readiness must reflect that
+        // so scene.isReady() returns false and scene.executeWhenReady() waits for those
+        // textures before firing. Otherwise, callers that render on executeWhenReady —
+        // such as visual-test harnesses — can produce frames before the texture-dependent
+        // effect is applied.
         //
-        // When a light owns texture resources that are not yet ready (a SpotLight's
-        // projectionTexture or iesProfileTexture being the current cases), material
-        // readiness must reflect that so that scene.isReady() returns false and
-        // scene.executeWhenReady() waits for the textures before firing. Callers such
-        // as the BN playground visual-test harness otherwise render frames before the
-        // projection effect is applied and produce intermittent visual-test regressions.
-        //
-        // Each test sets up a lit mesh with a StandardMaterial, pins some light-texture
+        // Each test sets up a lit mesh with a StandardMaterial, pins a light-texture
         // readiness signal to "not ready", and then polls scene.isReady(). Polling with
-        // a microtask yield lets the NullEngine's async shader compile settle, so that
-        // on master (no fix) the material reaches compiled state and scene.isReady()
-        // flips to true — reproducing the bug — while on the fix branch material
-        // readiness remains gated and scene.isReady() stays false.
+        // a microtask yield lets the NullEngine's async shader compile settle before the
+        // assertion, so the test guards against a material flipping to ready prematurely.
         async function pollSceneIsReady(scene: Scene): Promise<boolean> {
             for (let i = 0; i < 20; i++) {
                 if (scene.isReady()) {

--- a/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
+++ b/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
@@ -35,32 +35,69 @@ describe("SpotLight", () => {
         engine.dispose();
     });
 
-    describe("projectionTexture readiness", () => {
-        // Regression test for https://github.com/BabylonJS/Babylon.js/pull/18255 — a
-        // material lit by a SpotLight whose projectionTexture is not ready must cause
-        // scene.isReady() (and therefore scene.executeWhenReady) to wait.
-        it("scene.isReady() must not return true while a spot light's projection texture is not ready", async () => {
+    describe("light texture readiness", () => {
+        // Regression tests for https://github.com/BabylonJS/Babylon.js/pull/18255.
+        //
+        // When a light owns texture resources that are not yet ready (a SpotLight's
+        // projectionTexture or iesProfileTexture being the current cases), material
+        // readiness must reflect that so that scene.isReady() returns false and
+        // scene.executeWhenReady() waits for the textures before firing. Callers such
+        // as the BN playground visual-test harness otherwise render frames before the
+        // projection effect is applied and produce intermittent visual-test regressions.
+        //
+        // Each test sets up a lit mesh with a StandardMaterial, pins some light-texture
+        // readiness signal to "not ready", and then polls scene.isReady(). Polling with
+        // a microtask yield lets the NullEngine's async shader compile settle, so that
+        // on master (no fix) the material reaches compiled state and scene.isReady()
+        // flips to true — reproducing the bug — while on the fix branch material
+        // readiness remains gated and scene.isReady() stays false.
+        async function pollSceneIsReady(scene: Scene): Promise<boolean> {
+            for (let i = 0; i < 20; i++) {
+                if (scene.isReady()) {
+                    return true;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+            return false;
+        }
+
+        function createLitBoxScene(): SpotLight {
             const mesh = CreateBox("mesh", {}, scene);
             mesh.material = new StandardMaterial("mat", scene);
-            const light = new SpotLight("spot", new Vector3(0, 5, 0), new Vector3(0, -1, 0), Math.PI / 4, 2, scene);
+            return new SpotLight("spot", new Vector3(0, 5, 0), new Vector3(0, -1, 0), Math.PI / 4, 2, scene);
+        }
+
+        it("scene.isReady() must not return true while a light reports its textures are not ready", async () => {
+            const light = createLitBoxScene();
+
+            // Plumbing-level contract: material readiness must consult the Light's
+            // areLightTexturesReady() contract regardless of which texture(s) caused
+            // it to report not-ready. This ensures future light types that add their
+            // own textures (and override areLightTexturesReady) are gated automatically.
+            (light as any).areLightTexturesReady = () => false;
+
+            expect(await pollSceneIsReady(scene)).toBe(false);
+        });
+
+        it("scene.isReady() must not return true while a SpotLight's projectionTexture is not ready", async () => {
+            const light = createLitBoxScene();
 
             const tex = new Texture(null, scene);
             vi.spyOn(tex, "isReady").mockReturnValue(false);
             light.projectionTexture = tex;
 
-            // Poll scene.isReady(), yielding between polls so that async shader compiles
-            // in NullEngine can settle. Without the fix, the material compiles without a
-            // projection define and scene.isReady() flips to true despite the projection
-            // texture reporting not-ready. With the fix, scene.isReady() stays false.
-            let becameReady = false;
-            for (let i = 0; i < 20; i++) {
-                if (scene.isReady()) {
-                    becameReady = true;
-                    break;
-                }
-                await new Promise((resolve) => setTimeout(resolve, 0));
-            }
-            expect(becameReady).toBe(false);
+            expect(await pollSceneIsReady(scene)).toBe(false);
+        });
+
+        it("scene.isReady() must not return true while a SpotLight's iesProfileTexture is not ready", async () => {
+            const light = createLitBoxScene();
+
+            const tex = new Texture(null, scene);
+            vi.spyOn(tex, "isReady").mockReturnValue(false);
+            light.iesProfileTexture = tex;
+
+            expect(await pollSceneIsReady(scene)).toBe(false);
         });
     });
 });
+

--- a/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
+++ b/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type Engine } from "core/Engines/engine";
+import { NullEngine } from "core/Engines/nullEngine";
+import { SpotLight } from "core/Lights/spotLight";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Texture } from "core/Materials/Textures/texture";
+import { Vector3 } from "core/Maths/math.vector";
+import { CreateBox } from "core/Meshes/Builders/boxBuilder";
+import { Scene } from "core/scene";
+
+// Pre-load shader modules that StandardMaterial dynamically imports during
+// effect creation. Without these, the fire-and-forget import() may still be
+// resolving when the test environment tears down, causing EnvironmentTeardownError.
+import "core/Shaders/default.fragment";
+import "core/Shaders/default.vertex";
+
+describe("SpotLight", () => {
+    let engine: Engine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    describe("projectionTexture readiness", () => {
+        // Regression test for https://github.com/BabylonJS/Babylon.js/pull/18255 — a
+        // material lit by a SpotLight whose projectionTexture is not ready must cause
+        // scene.isReady() (and therefore scene.executeWhenReady) to wait.
+        it("scene.isReady() must not return true while a spot light's projection texture is not ready", async () => {
+            const mesh = CreateBox("mesh", {}, scene);
+            mesh.material = new StandardMaterial("mat", scene);
+            const light = new SpotLight("spot", new Vector3(0, 5, 0), new Vector3(0, -1, 0), Math.PI / 4, 2, scene);
+
+            const tex = new Texture(null, scene);
+            vi.spyOn(tex, "isReady").mockReturnValue(false);
+            light.projectionTexture = tex;
+
+            // Poll scene.isReady(), yielding between polls so that async shader compiles
+            // in NullEngine can settle. Without the fix, the material compiles without a
+            // projection define and scene.isReady() flips to true despite the projection
+            // texture reporting not-ready. With the fix, scene.isReady() stays false.
+            let becameReady = false;
+            for (let i = 0; i < 20; i++) {
+                if (scene.isReady()) {
+                    becameReady = true;
+                    break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+            expect(becameReady).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
# Fix material readiness to gate on light texture readiness

[Created by Copilot on behalf of @bghgary]

## Problem

SpotLight projection textures and IES profile textures were not gated by material readiness checks. When a projection texture was still loading, `prepareLightSpecificDefines` would set `PROJECTEDLIGHTTEXTURE` to `false`, the shader would compile without the projection effect, and the material would report `isReady() = true`. This caused `scene.executeWhenReady()` to fire before the projection texture loaded, producing incorrect rendering (e.g. intermittent visual-test failures in BabylonNative).

## Root cause

- `SpotLight.prepareLightSpecificDefines()` treats unloaded projection/IES textures as "not present" rather than "not ready".
- No readiness gate existed for light texture resources in the material pipeline.
- `scene.isReady()` → `mesh.isReady()` → `material.isReadyForSubMesh()` all returned true despite the texture still loading.

## Fix

1. **`Light`**: adds `areLightTexturesReady(): boolean` (default `true`) for subclasses that use texture resources.
2. **`SpotLight`**: overrides `areLightTexturesReady` and checks `_projectionTexture.isReadyOrNotBlocking()` and `_iesProfileTexture.isReadyOrNotBlocking()` (respects `BaseTexture.isBlocking` semantics, matching how other material textures are gated).
3. **`AreLightsTexturesReady` helper** (new, in `materialHelper.functions.ts`): iterates `mesh.lightSources` up to `maxSimultaneousLights`, respects `scene.lightsEnabled` and `disableLighting`, and mirrors the light selection used by `PrepareDefinesForLights` / `BindLights`.
4. **Materials** (`StandardMaterial`, `BackgroundMaterial`, `PBRBaseMaterial`, `OpenPBRMaterial`, `NodeMaterial`): each calls `AreLightsTexturesReady(...)` in `isReadyForSubMesh` and returns `false` early if any selected light is not ready. For `PBRBaseMaterial` and `OpenPBRMaterial` the gate is placed **before** `_prepareEffect()` so we don't compile and cache a throwaway shader while textures are still loading.
5. **Node blocks** (`LightBlock`, `PBRMetallicRoughnessBlock`): when an explicit `this.light` is bound, the block's `isReady` now checks `this.light.areLightTexturesReady()`. `LightBlock` registers itself as a blocking block when it has an explicit light, so the check participates in `NodeMaterial._sharedData.blockingBlocks`.

When a projection/IES texture finishes loading, the existing `_markMeshesAsLightDirty()` callback in `SpotLight`'s `projectionTexture` / `iesProfileTexture` setters triggers re-evaluation: the helper returns `true` on the next readiness pass, the material reports ready, and `scene.executeWhenReady()` proceeds.

## Tests

`packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts` adds three regression tests:

1. **Generic contract**: `scene.isReady()` stays `false` while any light reports its textures are not ready (monkey-patches `light.areLightTexturesReady`).
2. **SpotLight `projectionTexture`**: `scene.isReady()` stays `false` while the projection texture is not ready.
3. **SpotLight `iesProfileTexture`**: `scene.isReady()` stays `false` while the IES profile texture is not ready.

All three fail on `master` and pass on this branch. See #18336 for the test-only variant that demonstrates the master failure directly in CI.

## Related

- #18336 — test-only PR against master showing the failure.
