### PR TITLE
Inspector V2: Add missing mesh emitter properties and fix React warning

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/particles/emitterProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/particles/emitterProperties.tsx
@@ -101,6 +101,9 @@ export const ParticleSystemEmitterProperties: FunctionComponent<{ particleSystem
 
     const particleEmitterType = useProperty(system, "particleEmitterType");
 
+    const meshEmitter = particleEmitterType instanceof MeshParticleEmitter ? particleEmitterType : undefined;
+    const useMeshNormalsForDirection = useProperty(meshEmitter, "useMeshNormalsForDirection");
+
     // Use a simple string key for the dropdown, but store an emitter-type instance in the engine.
     type EmitterTypeKey = "box" | "sphere" | "cone" | "cylinder" | "hemispheric" | "point" | "mesh";
 
@@ -277,6 +280,13 @@ export const ParticleSystemEmitterProperties: FunctionComponent<{ particleSystem
                                 />
                             ) : (
                                 <Property component={TextPropertyLine} propertyPath="source" label="Source" value="No meshes in scene." />
+                            )}
+                            <BoundProperty component={SwitchPropertyLine} label="Use normals for direction" target={particleEmitterType} propertyKey="useMeshNormalsForDirection" />
+                            {!useMeshNormalsForDirection && (
+                                <>
+                                    <BoundProperty component={Vector3PropertyLine} label="Direction1" target={particleEmitterType} propertyKey="direction1" />
+                                    <BoundProperty component={Vector3PropertyLine} label="Direction2" target={particleEmitterType} propertyKey="direction2" />
+                                </>
                             )}
                         </>
                     )}

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/buttonLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/buttonLine.tsx
@@ -15,9 +15,11 @@ type ButtonLineProps = Omit<ButtonProps, "label"> & {
 export const ButtonLine: FunctionComponent<ButtonLineProps> = (props) => {
     ButtonLine.displayName = "ButtonLine";
 
+    const { uniqueId, ...buttonProps } = props;
+
     return (
-        <LineContainer uniqueId={props.uniqueId ?? props.label}>
-            <Button {...props} />
+        <LineContainer uniqueId={uniqueId ?? props.label}>
+            <Button {...buttonProps} />
         </LineContainer>
     );
 };


### PR DESCRIPTION
### Description

Adds missing particle emitter properties for `MeshParticleEmitter` in Inspector V2 that existed in V1 but were not carried over:

- **`useMeshNormalsForDirection`** — toggle to use mesh face normals for particle emission direction
- **`direction1`** / **`direction2`** — Vector3 fields for custom emission direction range, conditionally shown when `useMeshNormalsForDirection` is off

Also fixes a pre-existing React warning (`uniqueId` prop on DOM element) in `ButtonLine` by destructuring it out before spreading props into `<Button>`.

### Screenshots

<img width="599" height="262" alt="NormalsFalse" src="https://github.com/user-attachments/assets/d3f623ea-329a-48d2-a90d-defa7ef7826a" />
<img width="580" height="218" alt="NormalsTrue" src="https://github.com/user-attachments/assets/1ab2a7a5-531f-4764-955f-cf710c663c6b" />
