### PR TITLE
Inspector v2: Show ancestor nodes that are not in the scene if they have descendants that are in the scene

### DIFF
--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -821,13 +821,14 @@ const EntityTreeItem: FunctionComponent<
                     {...dragProps}
                 >
                     <TreeItemLayout
-                        iconBefore={entityItem.icon ? <entityItem.icon entity={entityItem.entity} /> : null}
-                        iconAfter={
+                        iconBefore={
                             displayInfo.isNotInScene ? (
                                 <Tooltip content="This entity is not in the scene but is shown because a descendant is still in the scene." relationship="description">
                                     <WarningRegular />
                                 </Tooltip>
-                            ) : undefined
+                            ) : entityItem.icon ? (
+                                <entityItem.icon entity={entityItem.entity} />
+                            ) : null
                         }
                         className={mergeClasses(
                             hasChildren ? classes.treeItemLayoutBranch : classes.treeItemLayoutLeaf,

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -88,10 +88,10 @@ export type EntityDisplayInfo = Partial<IDisposable> &
         onChange?: IReadonlyObservable<void>;
 
         /**
-         * When true, indicates that this entity is not tracked by the scene but is shown
-         * in the Scene Explorer because a descendant entity is still in the scene.
+         * An optional validation error message for this entity. When present, the entity's
+         * icon is replaced with a warning icon whose tooltip displays this message.
          */
-        isNotInScene?: boolean;
+        validationError?: string;
     }>;
 
 /**
@@ -477,9 +477,6 @@ const useStyles = makeStyles({
         outline: `${tokens.strokeWidthThick} solid ${tokens.colorBrandForeground1}`,
         outlineOffset: `-${tokens.strokeWidthThick}`,
     },
-    entityNameNotInScene: {
-        textDecorationLine: "line-through",
-    },
 });
 
 function GetCommandDescription(command: SceneExplorerCommand): string {
@@ -822,8 +819,8 @@ const EntityTreeItem: FunctionComponent<
                 >
                     <TreeItemLayout
                         iconBefore={
-                            displayInfo.isNotInScene ? (
-                                <Tooltip content="This entity is not in the scene but is shown because a descendant is still in the scene." relationship="description">
+                            displayInfo.validationError ? (
+                                <Tooltip content={displayInfo.validationError} relationship="description">
                                     <WarningRegular />
                                 </Tooltip>
                             ) : entityItem.icon ? (
@@ -848,7 +845,7 @@ const EntityTreeItem: FunctionComponent<
                         }}
                     >
                         <Tooltip content={name} relationship="description">
-                            <Body1 wrap={false} truncate className={displayInfo.isNotInScene ? classes.entityNameNotInScene : undefined}>
+                            <Body1 wrap={false} truncate>
                                 {name}
                             </Body1>
                         </Tooltip>

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -25,7 +25,16 @@ import {
     TreeItemLayout,
     treeItemLevelToken,
 } from "@fluentui/react-components";
-import { type FluentIcon, ArrowCollapseAllRegular, ArrowExpandAllRegular, createFluentIcon, FilterRegular, GlobeRegular, TextSortAscendingRegular } from "@fluentui/react-icons";
+import {
+    type FluentIcon,
+    ArrowCollapseAllRegular,
+    ArrowExpandAllRegular,
+    createFluentIcon,
+    FilterRegular,
+    GlobeRegular,
+    TextSortAscendingRegular,
+    WarningRegular,
+} from "@fluentui/react-icons";
 import { type ComponentType, type FunctionComponent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { type IDisposable, type IReadonlyObservable, type Nullable, type Scene } from "core/index";
@@ -77,6 +86,12 @@ export type EntityDisplayInfo = Partial<IDisposable> &
          * An observable that notifies when the display info (such as the name) changes.
          */
         onChange?: IReadonlyObservable<void>;
+
+        /**
+         * When true, indicates that this entity is not tracked by the scene but is shown
+         * in the Scene Explorer because a descendant entity is still in the scene.
+         */
+        isNotInScene?: boolean;
     }>;
 
 /**
@@ -462,6 +477,9 @@ const useStyles = makeStyles({
         outline: `${tokens.strokeWidthThick} solid ${tokens.colorBrandForeground1}`,
         outlineOffset: `-${tokens.strokeWidthThick}`,
     },
+    entityNameNotInScene: {
+        textDecorationLine: "line-through",
+    },
 });
 
 function GetCommandDescription(command: SceneExplorerCommand): string {
@@ -804,6 +822,13 @@ const EntityTreeItem: FunctionComponent<
                 >
                     <TreeItemLayout
                         iconBefore={entityItem.icon ? <entityItem.icon entity={entityItem.entity} /> : null}
+                        iconAfter={
+                            displayInfo.isNotInScene ? (
+                                <Tooltip content="This entity is not in the scene but is shown because a descendant is still in the scene." relationship="description">
+                                    <WarningRegular />
+                                </Tooltip>
+                            ) : undefined
+                        }
                         className={mergeClasses(
                             hasChildren ? classes.treeItemLayoutBranch : classes.treeItemLayoutLeaf,
                             compactMode ? classes.treeItemLayoutCompact : undefined,
@@ -822,7 +847,7 @@ const EntityTreeItem: FunctionComponent<
                         }}
                     >
                         <Tooltip content={name} relationship="description">
-                            <Body1 wrap={false} truncate>
+                            <Body1 wrap={false} truncate className={displayInfo.isNotInScene ? classes.entityNameNotInScene : undefined}>
                                 {name}
                             </Body1>
                         </Tooltip>

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -41,6 +41,10 @@ function IsCameraFrameGraphTask(task: FrameGraphTask): task is FrameGraphTask & 
     return (task as Partial<{ camera: Camera }>).camera instanceof Camera;
 }
 
+function IsNodesSectionType(node: Node): boolean {
+    return node instanceof TransformNode || node instanceof Camera || node instanceof Light;
+}
+
 export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorerService, ISceneContext, IGizmoService, IWatcherService]> = {
     friendlyName: "Node Explorer",
     consumes: [SceneExplorerServiceIdentity, SceneContextIdentity, GizmoServiceIdentity, WatcherServiceIdentity],
@@ -58,18 +62,28 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             getRootEntities: () => {
                 const rootNodes = [...scene.rootNodes];
 
-                // If any non-root node has a parent and that parent is not one of the node types shown in the Nodes section,
-                // then we should treat it as a root node, otherwise it won't show up anywhere in scene explorer.
-                // An example of this is when a Mesh or a TransformNode is parented under a Bone.
+                // Ensure all nodes in the scene are reachable in the explorer, even if their
+                // parent was removed from the scene or is not a type shown in the Nodes section.
                 for (const node of [...scene.meshes, ...scene.transformNodes, ...scene.cameras, ...scene.lights]) {
-                    if (
-                        node.parent &&
-                        !(node.parent instanceof AbstractMesh) &&
-                        !(node.parent instanceof TransformNode) &&
-                        !(node.parent instanceof Camera) &&
-                        !(node.parent instanceof Light)
-                    ) {
+                    if (!node.parent) {
+                        continue;
+                    }
+
+                    if (!IsNodesSectionType(node.parent)) {
+                        // Parent is not a type shown in the Nodes section (e.g. a Bone).
+                        // Treat this node as a root so it still appears in the explorer.
                         rootNodes.push(node);
+                    } else {
+                        // Walk up through Nodes-section-type parents to find the topmost ancestor.
+                        // If that ancestor was removed from the scene (not in rootNodes), add it
+                        // so the entire subtree remains visible in the explorer.
+                        let ancestor: Node = node.parent;
+                        while (ancestor.parent && IsNodesSectionType(ancestor.parent)) {
+                            ancestor = ancestor.parent;
+                        }
+                        if (!rootNodes.includes(ancestor)) {
+                            rootNodes.push(ancestor);
+                        }
                     }
                 }
 

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -123,13 +123,14 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                 // !IsNodesSectionType(parent) branch are unaffected because they always
                 // come from the scene's tracking lists. Clustered light children are also
                 // unaffected because they are added to knownSceneNodes explicitly.
-                const isNotInScene = IsNodesSectionType(node) && !knownSceneNodes.has(node);
+                const validationError =
+                    IsNodesSectionType(node) && !knownSceneNodes.has(node) ? "This entity is not in the scene but is shown because a descendant is still in the scene." : undefined;
 
                 return {
                     get name() {
                         return node.name || `Unnamed ${node.getClassName()}`;
                     },
-                    isNotInScene,
+                    validationError,
                     onChange: onChangeObservable,
                     dispose: () => {
                         nameHookToken.dispose();

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -56,15 +56,22 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
 
         const nodeMovedObservable = new Observable<Node>();
 
+        // Set of all nodes known to be in the scene, rebuilt each time getRootEntities
+        // is called. Used by getEntityDisplayInfo to detect orphaned ancestor nodes.
+        const knownSceneNodes = new Set<Node>();
+
         const sectionRegistration = sceneExplorerService.addSection({
             displayName: "Nodes",
             order: DefaultSectionsOrder.Nodes,
             getRootEntities: () => {
                 const rootNodes = [...scene.rootNodes];
+                knownSceneNodes.clear();
 
                 // Ensure all nodes in the scene are reachable in the explorer, even if their
                 // parent was removed from the scene or is not a type shown in the Nodes section.
                 for (const node of [...scene.meshes, ...scene.transformNodes, ...scene.cameras, ...scene.lights]) {
+                    knownSceneNodes.add(node);
+
                     if (!node.parent) {
                         continue;
                     }
@@ -92,6 +99,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                 for (const light of scene.lights) {
                     if (light instanceof ClusteredLightContainer) {
                         for (const childLight of light.lights) {
+                            knownSceneNodes.add(childLight);
                             if (!childLight.parent && !rootNodes.includes(childLight)) {
                                 rootNodes.push(childLight);
                             }
@@ -109,10 +117,19 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
 
                 const parentHookToken = watcherService.watchProperty(node, "parent", () => nodeMovedObservable.notifyObservers(node));
 
+                // A node is "not in the scene" if it is a Nodes-section type but is not
+                // a known scene node. This handles nodes that were removed from the scene
+                // but still appear because a descendant is in the scene. Nodes from the
+                // !IsNodesSectionType(parent) branch are unaffected because they always
+                // come from the scene's tracking lists. Clustered light children are also
+                // unaffected because they are added to knownSceneNodes explicitly.
+                const isNotInScene = IsNodesSectionType(node) && !knownSceneNodes.has(node);
+
                 return {
                     get name() {
                         return node.name || `Unnamed ${node.getClassName()}`;
                     },
+                    isNotInScene,
                     onChange: onChangeObservable,
                     dispose: () => {
                         nameHookToken.dispose();

--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -64,7 +64,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             displayName: "Nodes",
             order: DefaultSectionsOrder.Nodes,
             getRootEntities: () => {
-                const rootNodes = [...scene.rootNodes];
+                const rootNodes = new Set<Node>(scene.rootNodes);
                 knownSceneNodes.clear();
 
                 // Ensure all nodes in the scene are reachable in the explorer, even if their
@@ -79,7 +79,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                     if (!IsNodesSectionType(node.parent)) {
                         // Parent is not a type shown in the Nodes section (e.g. a Bone).
                         // Treat this node as a root so it still appears in the explorer.
-                        rootNodes.push(node);
+                        rootNodes.add(node);
                     } else {
                         // Walk up through Nodes-section-type parents to find the topmost ancestor.
                         // If that ancestor was removed from the scene (not in rootNodes), add it
@@ -88,9 +88,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                         while (ancestor.parent && IsNodesSectionType(ancestor.parent)) {
                             ancestor = ancestor.parent;
                         }
-                        if (!rootNodes.includes(ancestor)) {
-                            rootNodes.push(ancestor);
-                        }
+                        rootNodes.add(ancestor);
                     }
                 }
 
@@ -100,14 +98,14 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                     if (light instanceof ClusteredLightContainer) {
                         for (const childLight of light.lights) {
                             knownSceneNodes.add(childLight);
-                            if (!childLight.parent && !rootNodes.includes(childLight)) {
-                                rootNodes.push(childLight);
+                            if (!childLight.parent) {
+                                rootNodes.add(childLight);
                             }
                         }
                     }
                 }
 
-                return rootNodes;
+                return [...rootNodes];
             },
             getEntityChildren: (node) => node.getChildren(),
             getEntityDisplayInfo: (node) => {

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -136,11 +136,11 @@ function createTestBoxes() {
     const boxInstance = box.createInstance("boxInstance");
     boxInstance.position = new Vector3(0, 0, -0.5);
 
-    const level1Torus = MeshBuilder.CreateTorus("level1Torus");
-    const level2Torus = MeshBuilder.CreateTorus("level2Torus");
+    const level1Torus = MeshBuilder.CreateTorus("level1Torus", {}, scene);
+    const level2Torus = MeshBuilder.CreateTorus("level2Torus", {}, scene);
     level2Torus.position = new Vector3(0.5, 0, 0);
     level2Torus.parent = level1Torus;
-    const level3Torus = MeshBuilder.CreateTorus("level3Torus");
+    const level3Torus = MeshBuilder.CreateTorus("level3Torus", {}, scene);
     level3Torus.parent = level2Torus;
     level3Torus.position = new Vector3(0.5, 0, 0);
     scene.removeMesh(level1Torus);

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -135,6 +135,16 @@ function createTestBoxes() {
     box.material = redMat;
     const boxInstance = box.createInstance("boxInstance");
     boxInstance.position = new Vector3(0, 0, -0.5);
+
+    const level1Torus = MeshBuilder.CreateTorus("level1Torus");
+    const level2Torus = MeshBuilder.CreateTorus("level2Torus");
+    level2Torus.position = new Vector3(0.5, 0, 0);
+    level2Torus.parent = level1Torus;
+    const level3Torus = MeshBuilder.CreateTorus("level3Torus");
+    level3Torus.parent = level2Torus;
+    level3Torus.position = new Vector3(0.5, 0, 0);
+    scene.removeMesh(level1Torus);
+    scene.removeMesh(level2Torus);
 }
 
 function createTestMetadata() {


### PR DESCRIPTION
This is a simple example of the scenario:

```ts
const level1Torus = MeshBuilder.CreateTorus("level1Torus");
const level2Torus = MeshBuilder.CreateTorus("level2Torus");
level2Torus.position = new Vector3(0.5, 0, 0);
level2Torus.parent = level1Torus;
scene.removeMesh(level1Torus);
```

In this scenario, `level2Torus` is rendered, but you don't see it in Scene Explorer because  `level1Torus` is not in `scene.rootNodes`. The change in this PR is to include `level1Torus` in Scene Explorers root nodes, but with a visualization that clearly indicates it is not in the scene and won't be rendered. The screenshot below shows this, but for a slightly more complex scenario, where both level1Torus and level2Torus are removed from the scene, but level3Torus is left in the scene.
<img width="330" height="227" alt="image" src="https://github.com/user-attachments/assets/bc989559-92d9-4ffa-9a90-f8da8a636b08" />
