### PR TITLE
0 security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10148,9 +10148,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-            "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
@@ -11718,9 +11718,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-            "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
             "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
         },
         "react-refresh-typescript": {
             "typescript": "$typescript"
-        }
+        },
+        "dompurify": "3.3.3"
     }
 }


### PR DESCRIPTION
## Summary

Resolves all `npm audit` security vulnerabilities by adding an npm override for `dompurify`.

## Problem

`monaco-editor@0.55.1` (the latest stable release) pins `dompurify@3.2.7`, which has **4 moderate severity CVEs**:

| Advisory | Description |
|----------|-------------|
| [GHSA-h8r8-wccr-v5f2](https://github.com/advisories/GHSA-h8r8-wccr-v5f2) | Mutation-XSS via Re-Contextualization |
| [GHSA-v2wj-7wpq-c8vv](https://github.com/advisories/GHSA-v2wj-7wpq-c8vv) | Cross-site Scripting vulnerability |
| [GHSA-cjmm-f4jc-qw8r](https://github.com/advisories/GHSA-cjmm-f4jc-qw8r) | ADD_ATTR predicate skips URI validation |
| [GHSA-cj63-jhhr-wcxv](https://github.com/advisories/GHSA-cj63-jhhr-wcxv) | USE_PROFILES prototype pollution allows event handlers |

All are fixed in `dompurify@3.3.2+`, but there is no newer stable `monaco-editor` that updates the pinned version.

## Solution

Added `"dompurify": "3.3.3"` to the `overrides` section in `package.json`. This forces npm to resolve `dompurify@3.3.3` for all transitive dependencies, without downgrading `monaco-editor`.

**Before:** `npm audit` reported 2 moderate severity vulnerabilities
**After:** `npm audit` reports **0 vulnerabilities**

## Changes

- `package.json`: Added `dompurify` override in the existing `overrides` block
- `package-lock.json`: Regenerated to reflect the updated resolution