### PR TITLE
fix: snapshot rendering crash with clustered lighting

### DIFF
--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -4043,6 +4043,8 @@ export class WebGPUEngine extends ThinWebGPUEngine {
      * @param byteLength the byte length to clear (optional)
      */
     public clearStorageBuffer(storageBuffer: DataBuffer, byteOffset?: number, byteLength?: number): void {
+        // clearBuffer is a command encoder operation and cannot be recorded while a render pass is open on the same encoder.
+        this._endCurrentRenderPass();
         this._renderEncoder.clearBuffer(storageBuffer.underlyingResource, byteOffset, byteLength);
     }
 

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -341,6 +341,13 @@ export class ClusteredLightContainer extends Light {
         this._tileMaskTexture.onBeforeBindObservable.add(() => {
             currentRenderTarget = engine._currentRenderTarget;
             this._updateLightData();
+            // On WebGPU, clear the storage buffer here (before bindFramebuffer) because
+            // clearBuffer is a command encoder operation that cannot run while a render pass is open.
+            // In snapshot rendering mode, bindFramebuffer eagerly creates the render pass, so
+            // clearing must happen before that point.
+            if (engine.isWebGPU) {
+                this._tileMaskBuffer?.clear();
+            }
         });
 
         this._tileMaskTexture.onAfterUnbindObservable.add(() => {
@@ -354,10 +361,7 @@ export class ClusteredLightContainer extends Light {
         });
 
         this._tileMaskTexture.onClearObservable.add(() => {
-            if (engine.isWebGPU) {
-                // Clear the storage buffer for WebGPU
-                this._tileMaskBuffer?.clear();
-            } else {
+            if (!engine.isWebGPU) {
                 // Only clear the texture on WebGL
                 engine.clear({ r: 0, g: 0, b: 0, a: 1 }, true, false);
             }


### PR DESCRIPTION
## Bug

Enabling snapshot rendering (both STANDARD and FAST modes) while clustered lighting is active causes continuous WebGPU validation errors:

```
Recording in [CommandEncoder "RenderEncoder"] which is locked while
[RenderPassEncoder "TileMaskTexture - RenderPass"] is open.
 - While encoding ClearBuffer(...)
```

**Forum report:** https://forum.babylonjs.com/t/63139
**Repro:** https://playground.babylonjs.com/#QAD7FB#1 (STANDARD), https://playground.babylonjs.com/#QAD7FB#2 (FAST)

## Root Cause

`clearStorageBuffer()` calls `_renderEncoder.clearBuffer()`, which is a command encoder operation that **cannot** execute while a render pass is open on the same encoder.

In snapshot rendering mode, `bindFramebuffer()` eagerly creates the render pass (unlike normal mode which defers it). The clustered lighting system then fires `onClearObservable` — which calls `StorageBuffer.clear()` — while the render pass is still open, violating the WebGPU spec.

## Fix

1. **Clustered lighting** (`clusteredLightContainer.ts`): Move the WebGPU storage buffer clear from `onClearObservable` (fires after `bindFramebuffer` creates the render pass) to `onBeforeBindObservable` (fires before), so it runs while the command encoder is free. This also preserves bundle count synchronization for FAST mode snapshot rendering.

2. **Engine safety guard** (`webgpuEngine.ts`): Add `_endCurrentRenderPass()` in `clearStorageBuffer()` to prevent the same class of bug for any future callers.
