### PR TITLE
perf: interleaved sampling + paired t-test for performance tests

### DIFF
--- a/packages/tools/testTools/src/utils.ts
+++ b/packages/tools/testTools/src/utils.ts
@@ -272,6 +272,31 @@ export const performanceStats = {
         const pValue = 1 - tDistCDF(t, df);
         return { t, df, pValue };
     },
+
+    /**
+     * Perform a paired t-test on an array of differences (B - A).
+     * Tests the one-tailed hypothesis that the mean difference is greater than zero
+     * (i.e., B is slower than A).
+     * A low p-value (< 0.05) means B is significantly slower than A.
+     * @see https://en.wikipedia.org/wiki/Student%27s_t-test#Paired_samples
+     * @param differences Array of paired differences (candidate - baseline).
+     * @returns An object containing the t-statistic, degrees of freedom, and p-value.
+     */
+    pairedTTest(differences: number[]): { t: number; df: number; pValue: number } {
+        const n = differences.length;
+        if (n < 2) {
+            return { t: 0, df: 0, pValue: 1 };
+        }
+        const meanDiff = performanceStats.mean(differences);
+        const sdDiff = performanceStats.stddev(differences);
+        if (sdDiff === 0) {
+            return { t: meanDiff > 0 ? Infinity : meanDiff < 0 ? -Infinity : 0, df: n - 1, pValue: meanDiff > 0 ? 0 : 1 };
+        }
+        const t = meanDiff / (sdDiff / Math.sqrt(n));
+        const df = n - 1;
+        const pValue = 1 - tDistCDF(t, df);
+        return { t, df, pValue };
+    },
 };
 
 /**
@@ -461,6 +486,68 @@ const defaultPerfOptions: Required<PerformanceTestOptions> = {
 };
 
 /**
+ * Resolve the page URL for a given build type and performance test options.
+ * @param type - Whether to load the "dev", "stable", or "preview" build.
+ * @param baseUrl - Base URL of the local test server.
+ * @param opts - Performance test options (uses cdnVersion).
+ * @returns The resolved URL string.
+ */
+function resolvePageUrl(type: PerformanceTestType, baseUrl: string, opts: Required<PerformanceTestOptions>): string {
+    if (type === "dev") {
+        return baseUrl + "/empty.html";
+    } else if (opts.cdnVersion === "latest") {
+        return "https://cdn.babylonjs.com/empty.html";
+    } else if (opts.cdnVersion) {
+        return `https://cdn.babylonjs.com/v${opts.cdnVersion}/empty.html`;
+    } else {
+        return baseUrl + `/empty-${type}.html`;
+    }
+}
+
+/**
+ * Run a single measurement pass: navigate to the URL, init engine, create scene,
+ * render frames, dispose, and return the render time.
+ * @param page - Playwright page instance.
+ * @param url - The page URL to navigate to.
+ * @param baseUrl - Base URL of the test server (passed to engine init).
+ * @param createSceneFunction - Function evaluated in the page to create the scene.
+ * @param opts - Performance test options.
+ * @param evaluateArg - Optional serializable argument for the scene function.
+ * @returns The render time in ms, or `{ skipped: string }` if the API is incompatible.
+ */
+async function runSinglePass(
+    page: Page,
+    url: string,
+    baseUrl: string,
+    createSceneFunction: (...args: any[]) => Promise<void>,
+    opts: Required<PerformanceTestOptions>,
+    evaluateArg?: any
+): Promise<number | { skipped: string }> {
+    await page.goto(url, { timeout: 0 });
+    await page.waitForSelector("#babylon-canvas", { timeout: 20000 });
+    await page.evaluate(evaluateInitEngine, { engineName: opts.engineName, baseUrl });
+    try {
+        if (evaluateArg !== undefined) {
+            await page.evaluate(createSceneFunction, evaluateArg);
+        } else {
+            await page.evaluate(createSceneFunction);
+        }
+    } catch (e: any) {
+        const msg = e?.message || String(e);
+        if (msg.includes("is not a constructor") || msg.includes("is not defined") || msg.includes("is not a function") || msg.includes("Cannot read properties of undefined")) {
+            await page.evaluate(evaluateDisposeScene);
+            await page.evaluate(evaluateDisposeEngine);
+            return { skipped: `Incompatible API: ${msg}` };
+        }
+        throw e;
+    }
+    const time = await page.evaluate(evaluateRenderScene, opts.framesToRender);
+    await page.evaluate(evaluateDisposeScene);
+    await page.evaluate(evaluateDisposeEngine);
+    return time;
+}
+
+/**
  * Collect render-time measurements for a scene.
  * Includes warmup passes that are discarded, then `numberOfPasses` measured passes.
  * @param page - Playwright page instance.
@@ -555,12 +642,114 @@ export const collectPerformanceSamples = async (
 };
 
 /**
+ * Result of interleaved sample collection, containing individual build results
+ * and paired differences for the paired t-test.
+ */
+interface InterleavedSamplesResult {
+    /** Performance measurements for the baseline (stable/CDN) build. */
+    stable: PerformanceResult;
+    /** Performance measurements for the candidate (dev/CDN-B) build. */
+    dev: PerformanceResult;
+    /** Trimmed paired differences (candidate - baseline) from interleaved rounds. */
+    pairedDifferences: number[];
+}
+
+/**
+ * Collect interleaved render-time measurements for two builds.
+ * Alternates between stable and dev on each pass so that environmental drift
+ * (thermal throttling, noisy neighbors, GC pressure) affects both equally.
+ * Even-numbered passes run stable first; odd-numbered passes run dev first
+ * to cancel any ordering bias within a pair.
+ * @param page - Playwright page instance.
+ * @param baseUrl - Base URL of the test server.
+ * @param createSceneFunction - Function evaluated in the page to create the scene.
+ * @param opts - Performance test options.
+ * @param evaluateArg - Optional serializable argument for the scene function.
+ * @returns Interleaved results with paired differences, or `{ skipped }` if an API is incompatible.
+ */
+// eslint-disable-next-line no-restricted-syntax
+const collectInterleavedSamples = async (
+    page: Page,
+    baseUrl: string,
+    createSceneFunction: (...args: any[]) => Promise<void>,
+    opts: Required<PerformanceTestOptions>,
+    evaluateArg?: any
+): Promise<InterleavedSamplesResult | { skipped: string }> => {
+    const stableUrl = resolvePageUrl("stable", baseUrl, opts);
+    const devUrl = opts.cdnVersionB ? resolvePageUrl("stable", baseUrl, { ...opts, cdnVersion: opts.cdnVersionB }) : resolvePageUrl("dev", baseUrl, opts);
+
+    const stableRaw: number[] = [];
+    const devRaw: number[] = [];
+    const rawDifferences: number[] = [];
+    const totalPasses = opts.warmupPasses + opts.numberOfPasses;
+
+    for (let i = 0; i < totalPasses; i++) {
+        const isWarmup = i < opts.warmupPasses;
+        // Alternate which build runs first to cancel ordering bias
+        const stableFirst = i % 2 === 0;
+
+        let stableTime: number;
+        let devTime: number;
+
+        if (stableFirst) {
+            const s = await runSinglePass(page, stableUrl, baseUrl, createSceneFunction, opts, evaluateArg);
+            if (typeof s !== "number") {
+                return s;
+            }
+            const d = await runSinglePass(page, devUrl, baseUrl, createSceneFunction, opts, evaluateArg);
+            if (typeof d !== "number") {
+                return d;
+            }
+            stableTime = s;
+            devTime = d;
+        } else {
+            const d = await runSinglePass(page, devUrl, baseUrl, createSceneFunction, opts, evaluateArg);
+            if (typeof d !== "number") {
+                return d;
+            }
+            const s = await runSinglePass(page, stableUrl, baseUrl, createSceneFunction, opts, evaluateArg);
+            if (typeof s !== "number") {
+                return s;
+            }
+            stableTime = s;
+            devTime = d;
+        }
+
+        if (!isWarmup) {
+            stableRaw.push(stableTime);
+            devRaw.push(devTime);
+            rawDifferences.push(devTime - stableTime);
+        }
+    }
+
+    const stableTrimmed = performanceStats.trimmed(stableRaw, opts.trimCount);
+    const devTrimmed = performanceStats.trimmed(devRaw, opts.trimCount);
+    const pairedDifferences = performanceStats.trimmed(rawDifferences, opts.trimCount);
+
+    return {
+        stable: {
+            mean: performanceStats.mean(stableTrimmed),
+            raw: stableRaw,
+            trimmed: stableTrimmed,
+            cov: performanceStats.coefficientOfVariation(stableTrimmed),
+        },
+        dev: {
+            mean: performanceStats.mean(devTrimmed),
+            raw: devRaw,
+            trimmed: devTrimmed,
+            cov: performanceStats.coefficientOfVariation(devTrimmed),
+        },
+        pairedDifferences,
+    };
+};
+
+/**
  * Compare performance of stable vs dev builds for a scene.
- * Uses statistical analysis to determine if a regression is real:
- * 1. Collects samples for both stable and dev (with warmup).
+ * Uses interleaved sampling and paired statistical analysis for reliability:
+ * 1. Alternates stable/dev measurements so environmental drift affects both equally.
  * 2. Checks coefficient of variation to detect noisy measurements.
- * 3. Uses ratio check AND Welch's t-test — both must indicate regression to fail.
- * 4. On failure, runs confirmation passes to reduce false positives.
+ * 3. Uses ratio check AND paired t-test — both must indicate regression to fail.
+ * 4. On failure, runs confirmation passes (also interleaved) to reduce false positives.
  * @param page - Playwright page instance.
  * @param baseUrl - Base URL of the test server.
  * @param createSceneFunction - Function evaluated in the page to create the scene.
@@ -583,36 +772,23 @@ export const comparePerformance = async (
         opts.numberOfPasses = opts.trimCount * 2 + 3;
     }
 
-    // Collect initial samples
     const versionLabel = (v: string) => (v === "latest" ? "Latest" : `v${v}`);
     const baselineLabel = opts.cdnVersion ? versionLabel(opts.cdnVersion) : "Stable";
     const candidateLabel = opts.cdnVersionB ? versionLabel(opts.cdnVersionB) : "Dev";
 
-    const stable = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, opts, evaluateArg);
+    // Collect interleaved samples (stable/dev alternate to cancel environmental drift)
+    const initial = await collectInterleavedSamples(page, baseUrl, createSceneFunction, opts, evaluateArg);
 
-    // If the baseline was skipped due to incompatible APIs, skip the whole comparison
-    if (stable.skipped) {
+    if ("skipped" in initial) {
         const empty: PerformanceResult = { mean: 0, raw: [], trimmed: [], cov: 0 };
-        return { stable, dev: empty, ratio: 1, pValue: 1, passed: true, summary: stable.skipped, skipped: stable.skipped };
+        return { stable: empty, dev: empty, ratio: 1, pValue: 1, passed: true, summary: initial.skipped, skipped: initial.skipped };
     }
 
-    let dev: PerformanceResult;
-    if (opts.cdnVersionB) {
-        // CDN vs CDN: run the stable page again with the second version
-        const cdnBOpts = { ...opts, cdnVersion: opts.cdnVersionB };
-        dev = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, cdnBOpts, evaluateArg);
-    } else {
-        dev = await collectPerformanceSamples(page, baseUrl, "dev", createSceneFunction, opts, evaluateArg);
-    }
+    const { stable, dev, pairedDifferences } = initial;
 
-    // If the candidate was skipped due to incompatible APIs, skip the whole comparison
-    if (dev.skipped) {
-        return { stable, dev, ratio: 1, pValue: 1, passed: true, summary: dev.skipped, skipped: dev.skipped };
-    }
-
-    const buildResult = (stableRes: PerformanceResult, devRes: PerformanceResult): PerformanceComparisonResult => {
+    const buildResult = (stableRes: PerformanceResult, devRes: PerformanceResult, diffs: number[]): PerformanceComparisonResult => {
         const ratio = devRes.mean / stableRes.mean;
-        const { pValue } = performanceStats.welchTTest(stableRes.trimmed, devRes.trimmed);
+        const { pValue } = performanceStats.pairedTTest(diffs);
 
         const ratioExceeded = ratio > 1 + opts.acceptedThreshold;
         const statisticallySignificant = pValue < opts.pValueThreshold;
@@ -641,48 +817,46 @@ export const comparePerformance = async (
         return { stable: stableRes, dev: devRes, ratio, pValue, passed, summary };
     };
 
-    const initial = buildResult(stable, dev);
+    const result = buildResult(stable, dev, pairedDifferences);
 
     // If it looks like a regression and measurements are reliable, run confirmation passes
-    if (!initial.passed && opts.confirmationPasses > 0) {
+    if (!result.passed && opts.confirmationPasses > 0) {
         const effectiveConfirmationPasses = Math.max(opts.confirmationPasses, opts.trimCount * 2 + 3);
         console.log(
-            `[PERF] Initial result indicates regression (ratio: ${initial.ratio.toFixed(4)}, p: ${initial.pValue.toFixed(4)}). Running ${effectiveConfirmationPasses} confirmation passes...`
+            `[PERF] Initial result indicates regression (ratio: ${result.ratio.toFixed(4)}, p: ${result.pValue.toFixed(4)}). Running ${effectiveConfirmationPasses} confirmation passes...`
         );
 
         const confirmOpts = { ...opts, numberOfPasses: effectiveConfirmationPasses, warmupPasses: 1, confirmationPasses: 0 };
-        const stableConfirm = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, confirmOpts, evaluateArg);
-        let devConfirm: PerformanceResult;
-        if (opts.cdnVersionB) {
-            const cdnBOpts = { ...confirmOpts, cdnVersion: opts.cdnVersionB };
-            devConfirm = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, cdnBOpts, evaluateArg);
-        } else {
-            devConfirm = await collectPerformanceSamples(page, baseUrl, "dev", createSceneFunction, confirmOpts, evaluateArg);
+        const confirmResult = await collectInterleavedSamples(page, baseUrl, createSceneFunction, confirmOpts, evaluateArg);
+
+        if ("skipped" in confirmResult) {
+            return result;
         }
 
-        // Merge trimmed samples from both runs
-        const allStable = [...stable.trimmed, ...stableConfirm.trimmed];
-        const allDev = [...dev.trimmed, ...devConfirm.trimmed];
+        // Merge samples from both runs
+        const allStable = [...stable.trimmed, ...confirmResult.stable.trimmed];
+        const allDev = [...dev.trimmed, ...confirmResult.dev.trimmed];
+        const allDiffs = [...pairedDifferences, ...confirmResult.pairedDifferences];
 
         const mergedStable: PerformanceResult = {
             mean: performanceStats.mean(allStable),
-            raw: [...stable.raw, ...stableConfirm.raw],
+            raw: [...stable.raw, ...confirmResult.stable.raw],
             trimmed: allStable,
             cov: performanceStats.coefficientOfVariation(allStable),
         };
         const mergedDev: PerformanceResult = {
             mean: performanceStats.mean(allDev),
-            raw: [...dev.raw, ...devConfirm.raw],
+            raw: [...dev.raw, ...confirmResult.dev.raw],
             trimmed: allDev,
             cov: performanceStats.coefficientOfVariation(allDev),
         };
 
-        const confirmed = buildResult(mergedStable, mergedDev);
+        const confirmed = buildResult(mergedStable, mergedDev, allDiffs);
         confirmed.summary = `[CONFIRMED] ${confirmed.summary}`;
         return confirmed;
     }
 
-    return initial;
+    return result;
 };
 
 /**

--- a/packages/tools/testTools/src/utils.ts
+++ b/packages/tools/testTools/src/utils.ts
@@ -290,7 +290,11 @@ export const performanceStats = {
         const meanDiff = performanceStats.mean(differences);
         const sdDiff = performanceStats.stddev(differences);
         if (sdDiff === 0) {
-            return { t: meanDiff > 0 ? Infinity : meanDiff < 0 ? -Infinity : 0, df: n - 1, pValue: meanDiff > 0 ? 0 : 1 };
+            return {
+                t: meanDiff > 0 ? Infinity : meanDiff < 0 ? -Infinity : 0,
+                df: n - 1,
+                pValue: meanDiff > 0 ? 0 : meanDiff < 0 ? 1 : 0.5,
+            };
         }
         const t = meanDiff / (sdDiff / Math.sqrt(n));
         const df = n - 1;
@@ -421,7 +425,7 @@ export interface PerformanceComparisonResult {
     stable: PerformanceResult;
     dev: PerformanceResult;
     ratio: number;
-    /** Welch's t-test p-value (one-tailed: dev > stable) */
+    /** One-tailed p-value (dev \> stable). Paired t-test when `interleaved` is true, Welch's t-test otherwise. */
     pValue: number;
     passed: boolean;
     /** Human-readable summary */
@@ -578,21 +582,7 @@ export const collectPerformanceSamples = async (
     opts: Required<PerformanceTestOptions>,
     evaluateArg?: any
 ): Promise<PerformanceResult> => {
-    // Determine the URL to navigate to.
-    // When a specific CDN version is set, load empty.html directly from the CDN
-    // at the versioned path — its relative script tags resolve to the correct version
-    // automatically, no route interception needed.
-    // "latest" means use the base (unversioned) CDN path.
-    let url: string;
-    if (type === "dev") {
-        url = baseUrl + "/empty.html";
-    } else if (opts.cdnVersion === "latest") {
-        url = "https://cdn.babylonjs.com/empty.html";
-    } else if (opts.cdnVersion) {
-        url = `https://cdn.babylonjs.com/v${opts.cdnVersion}/empty.html`;
-    } else {
-        url = baseUrl + `/empty-${type}.html`;
-    }
+    const url = resolvePageUrl(type, baseUrl, opts);
 
     await page.goto(url, {
         timeout: 0,
@@ -688,9 +678,7 @@ const collectInterleavedSamples = async (
     const stableUrl = resolvePageUrl("stable", baseUrl, opts);
     const devUrl = opts.cdnVersionB ? resolvePageUrl("stable", baseUrl, { ...opts, cdnVersion: opts.cdnVersionB }) : resolvePageUrl("dev", baseUrl, opts);
 
-    const stableRaw: number[] = [];
-    const devRaw: number[] = [];
-    const rawDifferences: number[] = [];
+    const rounds: { stable: number; dev: number; diff: number }[] = [];
     const totalPasses = opts.warmupPasses + opts.numberOfPasses;
 
     for (let i = 0; i < totalPasses; i++) {
@@ -726,15 +714,20 @@ const collectInterleavedSamples = async (
         }
 
         if (!isWarmup) {
-            stableRaw.push(stableTime);
-            devRaw.push(devTime);
-            rawDifferences.push(devTime - stableTime);
+            rounds.push({ stable: stableTime, dev: devTime, diff: devTime - stableTime });
         }
     }
 
-    const stableTrimmed = performanceStats.trimmed(stableRaw, opts.trimCount);
-    const devTrimmed = performanceStats.trimmed(devRaw, opts.trimCount);
-    const pairedDifferences = performanceStats.trimmed(rawDifferences, opts.trimCount);
+    // Trim at the pair level: sort rounds by diff magnitude and drop outliers
+    // from both ends. This keeps stable, dev, and diff arrays aligned.
+    const sortedRounds = [...rounds].sort((a, b) => a.diff - b.diff);
+    const trimmedRounds = sortedRounds.slice(opts.trimCount, sortedRounds.length - opts.trimCount);
+
+    const stableRaw = rounds.map((r) => r.stable);
+    const devRaw = rounds.map((r) => r.dev);
+    const stableTrimmed = trimmedRounds.map((r) => r.stable);
+    const devTrimmed = trimmedRounds.map((r) => r.dev);
+    const pairedDifferences = trimmedRounds.map((r) => r.diff);
 
     return {
         stable: {

--- a/packages/tools/testTools/src/utils.ts
+++ b/packages/tools/testTools/src/utils.ts
@@ -467,6 +467,15 @@ export interface PerformanceTestOptions {
      * Set to "webgpu" to test WebGPU performance.
      */
     engineName?: string;
+    /**
+     * Use interleaved sampling with paired t-test analysis (default: true).
+     * When true, stable and dev measurements alternate each pass so environmental
+     * drift affects both equally, and a paired t-test is used for higher statistical
+     * power. Recommended for shared/noisy environments (e.g. BrowserStack).
+     * When false, all stable passes run first, then all dev passes, using Welch's
+     * t-test. Faster (~2x) since each build's page is loaded once instead of per-pass.
+     */
+    interleaved?: boolean;
 }
 
 const defaultPerfOptions: Required<PerformanceTestOptions> = {
@@ -483,6 +492,7 @@ const defaultPerfOptions: Required<PerformanceTestOptions> = {
     cdnVersion: "",
     cdnVersionB: "",
     engineName: "webgl2",
+    interleaved: true,
 };
 
 /**
@@ -776,19 +786,47 @@ export const comparePerformance = async (
     const baselineLabel = opts.cdnVersion ? versionLabel(opts.cdnVersion) : "Stable";
     const candidateLabel = opts.cdnVersionB ? versionLabel(opts.cdnVersionB) : "Dev";
 
-    // Collect interleaved samples (stable/dev alternate to cancel environmental drift)
-    const initial = await collectInterleavedSamples(page, baseUrl, createSceneFunction, opts, evaluateArg);
+    // Choose between interleaved (paired) or sequential (independent) sampling
+    let stable: PerformanceResult;
+    let dev: PerformanceResult;
+    let pairedDifferences: number[] | null = null;
 
-    if ("skipped" in initial) {
-        const empty: PerformanceResult = { mean: 0, raw: [], trimmed: [], cov: 0 };
-        return { stable: empty, dev: empty, ratio: 1, pValue: 1, passed: true, summary: initial.skipped, skipped: initial.skipped };
+    if (opts.interleaved) {
+        // Interleaved: stable/dev alternate each pass to cancel environmental drift
+        const initial = await collectInterleavedSamples(page, baseUrl, createSceneFunction, opts, evaluateArg);
+
+        if ("skipped" in initial) {
+            const empty: PerformanceResult = { mean: 0, raw: [], trimmed: [], cov: 0 };
+            return { stable: empty, dev: empty, ratio: 1, pValue: 1, passed: true, summary: initial.skipped, skipped: initial.skipped };
+        }
+
+        stable = initial.stable;
+        dev = initial.dev;
+        pairedDifferences = initial.pairedDifferences;
+    } else {
+        // Sequential: all stable passes first, then all dev passes (faster, ~2x)
+        stable = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, opts, evaluateArg);
+
+        if (stable.skipped) {
+            const empty: PerformanceResult = { mean: 0, raw: [], trimmed: [], cov: 0 };
+            return { stable, dev: empty, ratio: 1, pValue: 1, passed: true, summary: stable.skipped, skipped: stable.skipped };
+        }
+
+        if (opts.cdnVersionB) {
+            const cdnBOpts = { ...opts, cdnVersion: opts.cdnVersionB };
+            dev = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, cdnBOpts, evaluateArg);
+        } else {
+            dev = await collectPerformanceSamples(page, baseUrl, "dev", createSceneFunction, opts, evaluateArg);
+        }
+
+        if (dev.skipped) {
+            return { stable, dev, ratio: 1, pValue: 1, passed: true, summary: dev.skipped, skipped: dev.skipped };
+        }
     }
 
-    const { stable, dev, pairedDifferences } = initial;
-
-    const buildResult = (stableRes: PerformanceResult, devRes: PerformanceResult, diffs: number[]): PerformanceComparisonResult => {
+    const buildResult = (stableRes: PerformanceResult, devRes: PerformanceResult, diffs: number[] | null): PerformanceComparisonResult => {
         const ratio = devRes.mean / stableRes.mean;
-        const { pValue } = performanceStats.pairedTTest(diffs);
+        const { pValue } = diffs ? performanceStats.pairedTTest(diffs) : performanceStats.welchTTest(stableRes.trimmed, devRes.trimmed);
 
         const ratioExceeded = ratio > 1 + opts.acceptedThreshold;
         const statisticallySignificant = pValue < opts.pValueThreshold;
@@ -827,26 +865,43 @@ export const comparePerformance = async (
         );
 
         const confirmOpts = { ...opts, numberOfPasses: effectiveConfirmationPasses, warmupPasses: 1, confirmationPasses: 0 };
-        const confirmResult = await collectInterleavedSamples(page, baseUrl, createSceneFunction, confirmOpts, evaluateArg);
 
-        if ("skipped" in confirmResult) {
-            return result;
+        let confirmStable: PerformanceResult;
+        let confirmDev: PerformanceResult;
+        let confirmDiffs: number[] | null = null;
+
+        if (opts.interleaved) {
+            const confirmResult = await collectInterleavedSamples(page, baseUrl, createSceneFunction, confirmOpts, evaluateArg);
+            if ("skipped" in confirmResult) {
+                return result;
+            }
+            confirmStable = confirmResult.stable;
+            confirmDev = confirmResult.dev;
+            confirmDiffs = confirmResult.pairedDifferences;
+        } else {
+            confirmStable = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, confirmOpts, evaluateArg);
+            if (opts.cdnVersionB) {
+                const cdnBOpts = { ...confirmOpts, cdnVersion: opts.cdnVersionB };
+                confirmDev = await collectPerformanceSamples(page, baseUrl, "stable", createSceneFunction, cdnBOpts, evaluateArg);
+            } else {
+                confirmDev = await collectPerformanceSamples(page, baseUrl, "dev", createSceneFunction, confirmOpts, evaluateArg);
+            }
         }
 
         // Merge samples from both runs
-        const allStable = [...stable.trimmed, ...confirmResult.stable.trimmed];
-        const allDev = [...dev.trimmed, ...confirmResult.dev.trimmed];
-        const allDiffs = [...pairedDifferences, ...confirmResult.pairedDifferences];
+        const allStable = [...stable.trimmed, ...confirmStable.trimmed];
+        const allDev = [...dev.trimmed, ...confirmDev.trimmed];
+        const allDiffs = pairedDifferences && confirmDiffs ? [...pairedDifferences, ...confirmDiffs] : null;
 
         const mergedStable: PerformanceResult = {
             mean: performanceStats.mean(allStable),
-            raw: [...stable.raw, ...confirmResult.stable.raw],
+            raw: [...stable.raw, ...confirmStable.raw],
             trimmed: allStable,
             cov: performanceStats.coefficientOfVariation(allStable),
         };
         const mergedDev: PerformanceResult = {
             mean: performanceStats.mean(allDev),
-            raw: [...dev.raw, ...confirmResult.dev.raw],
+            raw: [...dev.raw, ...confirmDev.raw],
             trimmed: allDev,
             cov: performanceStats.coefficientOfVariation(allDev),
         };

--- a/packages/tools/tests/test/performance/README.md
+++ b/packages/tools/tests/test/performance/README.md
@@ -64,7 +64,7 @@ Each test scenario goes through this flow:
     - **Ratio check** verifies the candidate is more than 15% slower.
     - Both must be true to flag a regression.
 5. **Noise detection** — If either side's coefficient of variation exceeds 10%, the result is marked INCONCLUSIVE and the test passes (noisy data cannot reliably detect regressions).
-6. **Confirmation** — If a regression is detected, 6 additional interleaved rounds are run and merged with the initial data before making a final determination.
+6. **Confirmation** — If a regression is detected, additional interleaved rounds are run and merged with the initial data before making a final determination. The confirmation pass defaults to 6 rounds but may be increased to satisfy trimming/statistical minimums (e.g. 7 rounds with the default `trimCount=2`).
 
 ## Configuration
 

--- a/packages/tools/tests/test/performance/README.md
+++ b/packages/tools/tests/test/performance/README.md
@@ -57,14 +57,14 @@ CDN_VERSION=8.0.0 CDN_VERSION_B=latest npm run test:performance
 Each test scenario goes through this flow:
 
 1. **Warmup** — 2 passes (discarded), lets the browser JIT-compile and stabilize.
-2. **Measurement** — 10 passes per build. Each pass initializes the engine, creates the scene, calls `scene.render()` in a tight loop `framesToRender` times (default 2500), records the total wall-clock time, then disposes the scene and engine.
+2. **Interleaved measurement** — 10 rounds, each alternating between stable and dev builds. Even rounds run stable first; odd rounds run dev first — this cancels ordering bias. Each pass initializes the engine, creates the scene, calls `scene.render()` in a tight loop `framesToRender` times (default 2500), records the total wall-clock time, then disposes the scene and engine.
 3. **Trimming** — Removes 2 highest and 2 lowest values from each side, leaving 6 samples.
 4. **Statistical analysis**:
-    - **Welch's t-test** (one-tailed) checks if the difference is statistically significant (p < 0.05).
+    - **Paired t-test** (one-tailed) on the per-round differences (candidate − baseline) checks if the difference is statistically significant (p < 0.05). Because measurements are paired, machine-level variance (thermal throttling, noisy neighbors, GC pressure) cancels out.
     - **Ratio check** verifies the candidate is more than 15% slower.
     - Both must be true to flag a regression.
 5. **Noise detection** — If either side's coefficient of variation exceeds 10%, the result is marked INCONCLUSIVE and the test passes (noisy data cannot reliably detect regressions).
-6. **Confirmation** — If a regression is detected, 6 additional passes per build are run and merged with the initial data before making a final determination.
+6. **Confirmation** — If a regression is detected, 6 additional interleaved rounds are run and merged with the initial data before making a final determination.
 
 ## Configuration
 
@@ -83,6 +83,7 @@ Tests override defaults via `perfOptions`. All fields are optional:
 | `cdnVersion`         | `""`       | Pin baseline to a CDN version                                 |
 | `cdnVersionB`        | `""`       | Pin candidate to a CDN version (skips dev)                    |
 | `engineName`         | `"webgl2"` | Engine to use: `"webgl2"` or `"webgpu"`                       |
+| `interleaved`        | `true`     | Alternate stable/dev each round with paired t-test (see below) |
 
 ## Test Output
 
@@ -96,6 +97,20 @@ When comparing CDN versions, labels reflect the versions:
 
 ```
 [PERF] Default scene: v7.0.0: 19.6ms, v8.0.0: 18.2ms, v8.0.0 is 7.1% faster, p-value: 0.0023
+```
+
+## Interleaved vs Sequential Sampling
+
+By default, `interleaved` is `true`: stable and dev measurements alternate each round so that environmental drift (thermal throttling, noisy neighbors, GC pressure) affects both builds equally. A **paired t-test** analyzes the per-round differences, which is more powerful than an independent test when measurements share correlated noise.
+
+Set `interleaved: false` to use the faster sequential mode, where all stable passes run first, then all dev passes, analyzed with **Welch's t-test**. This is ~2× faster (each build's page loads once instead of per-round) and is suitable for dedicated or local hardware where environmental stability is guaranteed.
+
+```ts
+// Fast local run — sequential sampling
+const perfOptions = { framesToRender: 2500, numberOfPasses: 10, interleaved: false };
+
+// CI / BrowserStack — interleaved (default)
+const perfOptions = { framesToRender: 2500, numberOfPasses: 10 };
 ```
 
 ## Test Files

--- a/packages/tools/tests/test/performance/README.md
+++ b/packages/tools/tests/test/performance/README.md
@@ -70,19 +70,19 @@ Each test scenario goes through this flow:
 
 Tests override defaults via `perfOptions`. All fields are optional:
 
-| Option               | Default    | Description                                                   |
-| -------------------- | ---------- | ------------------------------------------------------------- |
-| `numberOfPasses`     | 10         | Measured passes per build                                     |
-| `framesToRender`     | 2500       | Frames rendered per pass                                      |
-| `warmupPasses`       | 2          | Warmup passes (discarded)                                     |
-| `acceptedThreshold`  | 0.15       | Max allowed ratio above 1.0 (15%)                             |
-| `maxCov`             | 0.10       | Coefficient of variation above which results are inconclusive |
-| `trimCount`          | 2          | Outliers removed from each end                                |
-| `pValueThreshold`    | 0.05       | Statistical significance threshold                            |
-| `confirmationPasses` | 6          | Extra passes on suspected regression                          |
-| `cdnVersion`         | `""`       | Pin baseline to a CDN version                                 |
-| `cdnVersionB`        | `""`       | Pin candidate to a CDN version (skips dev)                    |
-| `engineName`         | `"webgl2"` | Engine to use: `"webgl2"` or `"webgpu"`                       |
+| Option               | Default    | Description                                                    |
+| -------------------- | ---------- | -------------------------------------------------------------- |
+| `numberOfPasses`     | 10         | Measured passes per build                                      |
+| `framesToRender`     | 2500       | Frames rendered per pass                                       |
+| `warmupPasses`       | 2          | Warmup passes (discarded)                                      |
+| `acceptedThreshold`  | 0.15       | Max allowed ratio above 1.0 (15%)                              |
+| `maxCov`             | 0.10       | Coefficient of variation above which results are inconclusive  |
+| `trimCount`          | 2          | Outliers removed from each end                                 |
+| `pValueThreshold`    | 0.05       | Statistical significance threshold                             |
+| `confirmationPasses` | 6          | Extra passes on suspected regression                           |
+| `cdnVersion`         | `""`       | Pin baseline to a CDN version                                  |
+| `cdnVersionB`        | `""`       | Pin candidate to a CDN version (skips dev)                     |
+| `engineName`         | `"webgl2"` | Engine to use: `"webgl2"` or `"webgpu"`                        |
 | `interleaved`        | `true`     | Alternate stable/dev each round with paired t-test (see below) |
 
 ## Test Output


### PR DESCRIPTION
## Problem

Performance tests compare render times between a baseline (CDN) and candidate (dev) build by running all baseline passes first, then all candidate passes. On shared infrastructure like BrowserStack, this sequential approach is vulnerable to environmental drift — thermal throttling, noisy neighbors, or GC pressure can systematically bias one side over the other, leading to false positives or false negatives.

Additionally, the independent-samples Welch's t-test treats the two groups as unrelated, discarding the correlation between measurements taken on the same machine at roughly the same time.

## Solution

### Interleaved sampling
Instead of running all stable passes then all dev passes, the measurements now alternate: stable, dev, stable, dev, ... Each round pairs one stable measurement with one dev measurement taken back-to-back on the same machine. Even-numbered rounds run stable first; odd-numbered rounds run dev first — this cancels any ordering bias within a pair.

### Paired t-test
Since each round produces a matched pair, we compute per-round differences (candidate − baseline) and use a paired t-test instead of Welch's t-test. The paired test cancels out machine-level variance (the dominant noise source on BrowserStack), giving higher statistical power to detect real regressions while reducing false positives from environmental noise.

### Opt-out for local runs
The new `interleaved` option in `PerformanceTestOptions` (default: `true`) controls this behavior. Set `interleaved: false` to use the original sequential sampling with Welch's t-test, which is ~2× faster since each build's page loads once instead of per-round. This is appropriate for dedicated or local hardware where environmental stability is guaranteed.

## Changes

- **`pairedTTest`** added to `performanceStats` — one-tailed paired t-test on differences array
- **`resolvePageUrl`** — extracted URL resolution logic into a shared helper
- **`runSinglePass`** — extracted single measurement pass (navigate, init, create scene, render, dispose) into a reusable function
- **`collectInterleavedSamples`** — new function that alternates stable/dev measurements with paired differences
- **`comparePerformance`** — branches on `interleaved` flag: interleaved+paired or sequential+Welch's
- **`collectPerformanceSamples`** and **`checkPerformanceOfScene`** — preserved unchanged for backward compatibility
- **README** — updated "How It Works", configuration table, and new "Interleaved vs Sequential Sampling" section