### PR TITLE
fix(glowLayer): fix readiness check and spurious recompilation for NodeMaterial glow

### DIFF
--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -540,12 +540,15 @@ export class ThinEffectLayer {
 
         if (this._useMeshMaterial(subMesh.getRenderingMesh())) {
             // Enable glow mode during readiness check so the material compiles the
-            // correct shader variant (e.g. the ADDITIONAL_COLOR define for NodeMaterial).
+            // correct shader variant (e.g. the USEADDITIONALCOLOR define / useAdditionalColor
+            // uniform path for NodeMaterial).
             // This mirrors what _renderSubMesh does when actually rendering.
             material._glowModeEnabled = true;
-            const isReady = material.isReadyForSubMesh(subMesh.getMesh(), subMesh, useInstances);
-            material._glowModeEnabled = false;
-            return isReady;
+            try {
+                return material.isReadyForSubMesh(subMesh.getMesh(), subMesh, useInstances);
+            } finally {
+                material._glowModeEnabled = false;
+            }
         }
 
         const defines: string[] = [];

--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -544,11 +544,9 @@ export class ThinEffectLayer {
             // uniform path for NodeMaterial).
             // This mirrors what _renderSubMesh does when actually rendering.
             material._glowModeEnabled = true;
-            try {
-                return material.isReadyForSubMesh(subMesh.getMesh(), subMesh, useInstances);
-            } finally {
-                material._glowModeEnabled = false;
-            }
+            const isReady = material.isReadyForSubMesh(subMesh.getMesh(), subMesh, useInstances);
+            material._glowModeEnabled = false;
+            return isReady;
         }
 
         const defines: string[] = [];

--- a/packages/dev/core/src/Layers/thinEffectLayer.ts
+++ b/packages/dev/core/src/Layers/thinEffectLayer.ts
@@ -539,7 +539,13 @@ export class ThinEffectLayer {
         }
 
         if (this._useMeshMaterial(subMesh.getRenderingMesh())) {
-            return material.isReadyForSubMesh(subMesh.getMesh(), subMesh, useInstances);
+            // Enable glow mode during readiness check so the material compiles the
+            // correct shader variant (e.g. the ADDITIONAL_COLOR define for NodeMaterial).
+            // This mirrors what _renderSubMesh does when actually rendering.
+            material._glowModeEnabled = true;
+            const isReady = material.isReadyForSubMesh(subMesh.getMesh(), subMesh, useInstances);
+            material._glowModeEnabled = false;
+            return isReady;
         }
 
         const defines: string[] = [];

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -153,7 +153,9 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
     public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial) {
         defines.setValue(this._linearDefineName, this.convertToLinearSpace, true);
         defines.setValue(this._gammaDefineName, this.convertToGammaSpace, true);
-        defines.setValue(this._additionalColorDefineName, this.additionalColor.connectedPoint && nodeMaterial._useAdditionalColor, true);
+        if (this._additionalColorDefineName) {
+            defines.setValue(this._additionalColorDefineName, !!this.additionalColor.connectedPoint && nodeMaterial._useAdditionalColor, true);
+        }
     }
 
     /**

--- a/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Fragment/fragmentOutputBlock.ts
@@ -30,7 +30,7 @@ export enum FragmentOutputBlockColorSpace {
 export class FragmentOutputBlock extends NodeMaterialBlock {
     private _linearDefineName: string;
     private _gammaDefineName: string;
-    private _additionalColorDefineName: string;
+    private _additionalColorDefineName: string | undefined;
     protected _outputString: string;
 
     /**
@@ -153,7 +153,7 @@ export class FragmentOutputBlock extends NodeMaterialBlock {
     public override prepareDefines(defines: NodeMaterialDefines, nodeMaterial: NodeMaterial) {
         defines.setValue(this._linearDefineName, this.convertToLinearSpace, true);
         defines.setValue(this._gammaDefineName, this.convertToGammaSpace, true);
-        if (this._additionalColorDefineName) {
+        if (this._additionalColorDefineName !== undefined) {
             defines.setValue(this._additionalColorDefineName, !!this.additionalColor.connectedPoint && nodeMaterial._useAdditionalColor, true);
         }
     }


### PR DESCRIPTION
**Note**: this is an attempt to fix the flaky "dissolve-effect-with-node-material-and-glow-layer" visualization test.

## Description

Fixes two bugs in the effect/glow layer when used with NodeMaterial and `referenceMeshToUseItsOwnMaterial`:

### 1. Missing `_glowModeEnabled` during readiness check (`thinEffectLayer.ts`)

When the effect layer checks readiness for meshes using their own material, it calls `material.isReadyForSubMesh()` without setting `_glowModeEnabled = true`. However, the actual render path in `_renderSubMesh` **does** set it before calling `renderingMesh.render()`.

This mismatch means the readiness check may compile the shader with different defines than the render path expects (e.g. the `ADDITIONAL_COLOR` define for NodeMaterial).

The fix sets `_glowModeEnabled` during the readiness check to mirror the render path.

### 2. Spurious `markAsUnprocessed()` in `FragmentOutputBlock.prepareDefines`

When the `additionalColor` (glow) input is **not** connected on a `FragmentOutputBlock`, `_additionalColorDefineName` is never assigned (remains `undefined`). The old code called `defines.setValue(undefined, ...)`, which sets a stray `defines["undefined"]` property. On the first call, the value changes from JS `undefined` to `null`, triggering `markAsUnprocessed()` and forcing an unnecessary shader recompilation cycle.

The fix guards the call with `if (this._additionalColorDefineName)`.

## Testing

Tested with the `dissolve-effect-with-node-material-and-glow-layer` visualization test (playground `#F6PGMC#12`).