### PR TITLE
Optimization for panning

### DIFF
--- a/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
+++ b/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
@@ -54,7 +54,7 @@ export class GeospatialCameraMovement extends CameraMovement {
     ) {
         super(scene, cameraPosition, behavior);
         this.pickPredicate = pickPredicate;
-        this._tempPickingRay = new Ray(this._cameraPosition, this._cameraLookAt);
+        this._tempPickingRay = Ray.Zero();
         this.panInertia = 0;
         this.rotationInertia = 0;
         this.rotationXSpeed = Math.PI / 500; // Move 1/500th of a half circle per pixel
@@ -127,28 +127,26 @@ export class GeospatialCameraMovement extends CameraMovement {
 
     public handleDrag(pointerX: number, pointerY: number) {
         if (this._hitPointRadius) {
-            const pickResult = this._scene.pick(pointerX, pointerY, this.pickPredicate);
-            if (pickResult.ray) {
-                const localToEcef = TmpVectors.Matrix[0];
-                this._recalculateDragPlaneHitPoint(this._hitPointRadius, pickResult.ray, localToEcef);
+            this._scene.createPickingRayToRef(pointerX, pointerY, null, this._tempPickingRay, this._scene.activeCamera);
+            const localToEcef = TmpVectors.Matrix[0];
+            this._recalculateDragPlaneHitPoint(this._hitPointRadius, this._tempPickingRay, localToEcef);
 
-                const delta = this._dragPlaneHitPointLocal.subtractToRef(this._previousDragPlaneHitPointLocal, TmpVectors.Vector3[6]);
+            const delta = this._dragPlaneHitPointLocal.subtractToRef(this._previousDragPlaneHitPointLocal, TmpVectors.Vector3[6]);
 
-                // When the camera is pitched nearly parallel to the drag plane, ray-plane intersection
-                // can produce enormous deltas. Clamp the delta to avoid massive jumps.
-                const maxDragDelta = this._hitPointRadius * 0.1; // Max 10% of hit radius per frame
-                const deltaLength = delta.length();
-                if (deltaLength > maxDragDelta) {
-                    delta.scaleInPlace(maxDragDelta / deltaLength);
-                }
-
-                this._previousDragPlaneHitPointLocal.copyFrom(this._dragPlaneHitPointLocal);
-
-                Vector3.TransformNormalToRef(delta, localToEcef, delta);
-                this._dragPlaneOriginPointEcef.addInPlace(delta);
-
-                this.panAccumulatedPixels.subtractInPlace(delta);
+            // When the camera is pitched nearly parallel to the drag plane, ray-plane intersection
+            // can produce enormous deltas. Clamp the delta to avoid massive jumps.
+            const maxDragDelta = this._hitPointRadius * 0.1; // Max 10% of hit radius per frame
+            const deltaLength = delta.length();
+            if (deltaLength > maxDragDelta) {
+                delta.scaleInPlace(maxDragDelta / deltaLength);
             }
+
+            this._previousDragPlaneHitPointLocal.copyFrom(this._dragPlaneHitPointLocal);
+
+            Vector3.TransformNormalToRef(delta, localToEcef, delta);
+            this._dragPlaneOriginPointEcef.addInPlace(delta);
+
+            this.panAccumulatedPixels.subtractInPlace(delta);
         }
     }
 

--- a/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
+++ b/packages/dev/core/src/Cameras/geospatialCameraMovement.ts
@@ -126,28 +126,32 @@ export class GeospatialCameraMovement extends CameraMovement {
     }
 
     public handleDrag(pointerX: number, pointerY: number) {
-        if (this._hitPointRadius) {
-            this._scene.createPickingRayToRef(pointerX, pointerY, null, this._tempPickingRay, this._scene.activeCamera);
-            const localToEcef = TmpVectors.Matrix[0];
-            this._recalculateDragPlaneHitPoint(this._hitPointRadius, this._tempPickingRay, localToEcef);
-
-            const delta = this._dragPlaneHitPointLocal.subtractToRef(this._previousDragPlaneHitPointLocal, TmpVectors.Vector3[6]);
-
-            // When the camera is pitched nearly parallel to the drag plane, ray-plane intersection
-            // can produce enormous deltas. Clamp the delta to avoid massive jumps.
-            const maxDragDelta = this._hitPointRadius * 0.1; // Max 10% of hit radius per frame
-            const deltaLength = delta.length();
-            if (deltaLength > maxDragDelta) {
-                delta.scaleInPlace(maxDragDelta / deltaLength);
-            }
-
-            this._previousDragPlaneHitPointLocal.copyFrom(this._dragPlaneHitPointLocal);
-
-            Vector3.TransformNormalToRef(delta, localToEcef, delta);
-            this._dragPlaneOriginPointEcef.addInPlace(delta);
-
-            this.panAccumulatedPixels.subtractInPlace(delta);
+        const scene = this._scene;
+        if (!this._hitPointRadius || !scene.activeCamera) {
+            return;
         }
+
+        scene.createPickingRayToRef(pointerX, pointerY, null, this._tempPickingRay, scene.activeCamera);
+
+        const localToEcef = TmpVectors.Matrix[0];
+        this._recalculateDragPlaneHitPoint(this._hitPointRadius, this._tempPickingRay, localToEcef);
+
+        const delta = this._dragPlaneHitPointLocal.subtractToRef(this._previousDragPlaneHitPointLocal, TmpVectors.Vector3[6]);
+
+        // When the camera is pitched nearly parallel to the drag plane, ray-plane intersection
+        // can produce enormous deltas. Clamp the delta to avoid massive jumps.
+        const maxDragDelta = this._hitPointRadius * 0.1; // Max 10% of hit radius per frame
+        const deltaLength = delta.length();
+        if (deltaLength > maxDragDelta) {
+            delta.scaleInPlace(maxDragDelta / deltaLength);
+        }
+
+        this._previousDragPlaneHitPointLocal.copyFrom(this._dragPlaneHitPointLocal);
+
+        Vector3.TransformNormalToRef(delta, localToEcef, delta);
+        this._dragPlaneOriginPointEcef.addInPlace(delta);
+
+        this.panAccumulatedPixels.subtractInPlace(delta);
     }
 
     /** @override */


### PR DESCRIPTION
Compute the ray directly, avoiding the more expensive scene pick.