### PR TITLE
Inspector CLI: Don't auto connect by default

### DIFF
--- a/.github/instructions/fluent.instructions.md
+++ b/.github/instructions/fluent.instructions.md
@@ -34,6 +34,47 @@ const useStyles = makeStyles({
 
 Use `tokens.spacingVerticalXS`, `tokens.spacingHorizontalM`, etc. from `@fluentui/react-components` for padding, margin, and gap values instead of hard-coded pixel strings. This ensures consistency across themes. See: https://storybooks.fluentui.dev/react/?path=/docs/theme-spacing--docs
 
+## Typography
+
+### Use Fluent text presets, typographyStyles, or font tokens — never raw HTML text elements
+
+Do not use raw HTML text elements (`<span>`, `<p>`, `<h1>`, etc.) directly. Do not hard-code `fontSize`, `lineHeight`, or `fontFamily` values. Instead, use Fluent's typography system in this order of preference:
+
+1. **Text preset components** (preferred) — Use `<Body1>`, `<Caption1>`, `<Subtitle1>`, `<Title3>`, etc. from `@fluentui/react-components`. These render a styled element with the correct font size, line height, weight, and font family from the theme. See: https://storybooks.fluentui.dev/react/?path=/docs/components-text--docs#presets-2
+
+2. **`typographyStyles`** — When you need to apply text styles to a non-text component (e.g. a `<div>` or custom wrapper), spread a typography style preset into `makeStyles`. See: https://storybooks.fluentui.dev/react/?path=/docs/theme-typography--docs
+
+3. **Font tokens** — When you need individual font properties (e.g. only `fontFamily` for a monospace override), use `tokens.fontFamilyMonospace`, `tokens.fontSizeBase300`, etc. See: https://storybooks.fluentui.dev/react/?path=/docs/theme-fonts--docs
+
+```tsx
+// ✅ Good — text preset component
+import { Body1, Caption1 } from "@fluentui/react-components";
+<Body1>Status message</Body1>
+<Caption1>Secondary info</Caption1>
+
+// ✅ Good — typographyStyles in makeStyles
+import { makeStyles, typographyStyles } from "@fluentui/react-components";
+const useStyles = makeStyles({
+    header: { ...typographyStyles.subtitle1 },
+});
+
+// ✅ Good — font token for a specific override
+import { makeStyles, tokens } from "@fluentui/react-components";
+const useStyles = makeStyles({
+    code: { fontFamily: tokens.fontFamilyMonospace },
+});
+
+// ❌ Bad — raw HTML text element
+<span>Status message</span>
+
+// ❌ Bad — hard-coded font values
+const useStyles = makeStyles({
+    text: { fontSize: "14px", lineHeight: "20px", fontFamily: "Segoe UI" },
+});
+```
+
+When reviewing code, flag any use of raw HTML text elements or hard-coded font sizes/line heights/font families and suggest the appropriate Fluent alternative.
+
 ## Icon Imports
 
 ### Use unsized icon variants

--- a/packages/dev/inspector-v2/src/inspectable.ts
+++ b/packages/dev/inspector-v2/src/inspectable.ts
@@ -29,6 +29,12 @@ export type InspectableOptions = {
     name?: string;
 
     /**
+     * Whether the CLI bridge should automatically start trying to connect
+     * when the inspectable session is created. Defaults to false.
+     */
+    autoStart?: boolean;
+
+    /**
      * Additional service definitions to register with the inspectable container.
      * These are added in a separate call from the built-in services and are removed
      * when the returned token is disposed.
@@ -107,6 +113,7 @@ export function _StartInspectable(scene: Scene, options?: Partial<InspectableOpt
                 MakeInspectableBridgeServiceDefinition({
                     port,
                     name,
+                    autoStart: options?.autoStart ?? false,
                 }),
                 EntityQueryServiceDefinition,
                 ScreenshotCommandServiceDefinition,

--- a/packages/dev/inspector-v2/src/services/cli/cliConnectionStatus.ts
+++ b/packages/dev/inspector-v2/src/services/cli/cliConnectionStatus.ts
@@ -7,16 +7,23 @@ import { type IService } from "shared-ui-components/modularTool/modularity/servi
 export const CliConnectionStatusIdentity = Symbol("CliConnectionStatus");
 
 /**
- * Provides the connection status of the Inspector CLI bridge.
+ * Provides the connection status and enable/disable control for the Inspector CLI bridge.
  */
 export interface ICliConnectionStatus extends IService<typeof CliConnectionStatusIdentity> {
+    /**
+     * Whether the bridge is enabled. When true, the bridge actively tries to
+     * maintain a WebSocket connection. When false, the bridge is disconnected
+     * and idle.
+     */
+    isEnabled: boolean;
+
     /**
      * Whether the bridge WebSocket is currently connected.
      */
     readonly isConnected: boolean;
 
     /**
-     * Observable that fires when the connection status changes.
+     * Observable that fires when either {@link isEnabled} or {@link isConnected} changes.
      */
-    readonly onConnectionStatusChanged: IReadonlyObservable<boolean>;
+    readonly onConnectionStatusChanged: IReadonlyObservable<void>;
 }

--- a/packages/dev/inspector-v2/src/services/cli/inspectableBridgeService.ts
+++ b/packages/dev/inspector-v2/src/services/cli/inspectableBridgeService.ts
@@ -36,13 +36,18 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
             let ws: WebSocket | null = null;
             let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
             let disposed = false;
+            let enabled = false;
             let connected = false;
-            const onConnectionStatusChanged = new Observable<boolean>();
+            const onConnectionStatusChanged = new Observable<void>();
+
+            function notifyStatusChanged() {
+                onConnectionStatusChanged.notifyObservers();
+            }
 
             function setConnected(value: boolean) {
                 if (connected !== value) {
                     connected = value;
-                    onConnectionStatusChanged.notifyObservers(value);
+                    notifyStatusChanged();
                 }
             }
 
@@ -51,16 +56,13 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
             }
 
             function connect() {
-                if (disposed) {
+                if (disposed || !enabled) {
                     return;
                 }
 
-                try {
-                    ws = new WebSocket(`ws://127.0.0.1:${options.port}`);
-                } catch {
-                    scheduleReconnect();
-                    return;
-                }
+                // NOTE: The browser unconditionally logs a console error for failed WebSocket
+                // connections at the network level. This cannot be suppressed from JavaScript.
+                ws = new WebSocket(`ws://127.0.0.1:${options.port}`);
 
                 ws.onopen = () => {
                     setConnected(true);
@@ -87,8 +89,21 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
                 };
             }
 
+            function disconnect() {
+                if (reconnectTimer !== null) {
+                    clearTimeout(reconnectTimer);
+                    reconnectTimer = null;
+                }
+                if (ws) {
+                    ws.onclose = null;
+                    ws.close();
+                    ws = null;
+                }
+                setConnected(false);
+            }
+
             function scheduleReconnect() {
-                if (disposed || reconnectTimer !== null) {
+                if (disposed || !enabled || reconnectTimer !== null) {
                     return;
                 }
                 reconnectTimer = setTimeout(() => {
@@ -141,9 +156,6 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
                 }
             }
 
-            // Initiate connection.
-            connect();
-
             const registry: IInspectableCommandRegistry & ICliConnectionStatus & IDisposable = {
                 addCommand(descriptor: InspectableCommandDescriptor): IDisposable {
                     if (commands.has(descriptor.id)) {
@@ -156,24 +168,30 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
                         },
                     };
                 },
+                get isEnabled() {
+                    return enabled;
+                },
+                set isEnabled(value: boolean) {
+                    if (enabled !== value) {
+                        enabled = value;
+                        if (enabled) {
+                            connect();
+                        } else {
+                            disconnect();
+                        }
+                        notifyStatusChanged();
+                    }
+                },
                 get isConnected() {
                     return connected;
                 },
                 onConnectionStatusChanged,
                 dispose: () => {
                     disposed = true;
-                    if (reconnectTimer !== null) {
-                        clearTimeout(reconnectTimer);
-                        reconnectTimer = null;
-                    }
+                    enabled = false;
+                    disconnect();
                     commands.clear();
-                    setConnected(false);
                     onConnectionStatusChanged.clear();
-                    if (ws) {
-                        ws.onclose = null;
-                        ws.close();
-                        ws = null;
-                    }
                 },
             };
 

--- a/packages/dev/inspector-v2/src/services/cli/inspectableBridgeService.ts
+++ b/packages/dev/inspector-v2/src/services/cli/inspectableBridgeService.ts
@@ -65,9 +65,17 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
                     return;
                 }
 
-                // NOTE: The browser unconditionally logs a console error for failed WebSocket
-                // connections at the network level. This cannot be suppressed from JavaScript.
-                ws = new WebSocket(`ws://127.0.0.1:${options.port}`);
+                try {
+                    // NOTE: The browser unconditionally logs a console error for failed WebSocket
+                    // connections at the network level. This cannot be suppressed from JavaScript.
+                    ws = new WebSocket(`ws://127.0.0.1:${options.port}`);
+                } catch {
+                    ws = null;
+                    setConnected(false);
+                    Logger.Warn(`InspectableBridgeService: Failed to create WebSocket connection on port ${options.port}.`);
+                    scheduleReconnect();
+                    return;
+                }
 
                 ws.onopen = () => {
                     setConnected(true);

--- a/packages/dev/inspector-v2/src/services/cli/inspectableBridgeService.ts
+++ b/packages/dev/inspector-v2/src/services/cli/inspectableBridgeService.ts
@@ -20,6 +20,11 @@ export interface IInspectableBridgeServiceOptions {
      * The session display name sent to the bridge.
      */
     name: string;
+
+    /**
+     * Whether to automatically start connecting when the service is created.
+     */
+    autoStart: boolean;
 }
 
 /**
@@ -36,7 +41,7 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
             let ws: WebSocket | null = null;
             let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
             let disposed = false;
-            let enabled = false;
+            let enabled = options.autoStart;
             let connected = false;
             const onConnectionStatusChanged = new Observable<void>();
 
@@ -154,6 +159,10 @@ export function MakeInspectableBridgeServiceDefinition(options: IInspectableBrid
                         break;
                     }
                 }
+            }
+
+            if (enabled) {
+                connect();
             }
 
             const registry: IInspectableCommandRegistry & ICliConnectionStatus & IDisposable = {

--- a/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
+++ b/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
@@ -1,4 +1,4 @@
-import { Button, Link, makeStyles, tokens } from "@fluentui/react-components";
+import { Body1, Button, Link, makeStyles, tokens } from "@fluentui/react-components";
 import { PlugConnectedCheckmarkRegular, PlugConnectedRegular, PlugDisconnectedRegular } from "@fluentui/react-icons";
 import { useEffect, useRef, useState } from "react";
 
@@ -81,7 +81,7 @@ export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShell
 
                 const tooltipContent = (
                     <div className={classes.tooltipContent}>
-                        <span>{statusText}</span>
+                        <Body1>{statusText}</Body1>
                         <Link href={DocUrl} target="_blank">
                             Inspector CLI documentation
                         </Link>

--- a/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
+++ b/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
@@ -1,6 +1,6 @@
-import { Button, tokens } from "@fluentui/react-components";
-import { PlugConnectedRegular, PlugDisconnectedRegular } from "@fluentui/react-icons";
-import { useEffect, useRef } from "react";
+import { Button, makeStyles, tokens } from "@fluentui/react-components";
+import { PlugConnectedCheckmarkRegular, PlugConnectedRegular, PlugDisconnectedRegular } from "@fluentui/react-icons";
+import { useEffect, useRef, useState } from "react";
 
 import { useToast } from "shared-ui-components/fluent/primitives/toast";
 import { Tooltip } from "shared-ui-components/fluent/primitives/tooltip";
@@ -21,9 +21,22 @@ export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShell
             teachingMoment: false,
             order: DefaultToolbarItemOrder.CliStatus,
             component: () => {
+                const isEnabled = useObservableState(() => cliConnectionStatus.isEnabled, cliConnectionStatus.onConnectionStatusChanged);
                 const isConnected = useObservableState(() => cliConnectionStatus.isConnected, cliConnectionStatus.onConnectionStatusChanged);
                 const { showToast } = useToast();
                 const isFirstRender = useRef(true);
+                const [connectingIconToggle, setConnectingIconToggle] = useState(false);
+                const connecting = isEnabled && !isConnected;
+
+                useEffect(() => {
+                    if (!connecting) {
+                        return;
+                    }
+                    const interval = setInterval(() => {
+                        setConnectingIconToggle((prev) => !prev);
+                    }, 700);
+                    return () => clearInterval(interval);
+                }, [connecting]);
 
                 useEffect(() => {
                     if (isFirstRender.current) {
@@ -37,19 +50,32 @@ export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShell
                     }
                 }, [isConnected, showToast]);
 
-                // Using raw Fluent Button to pass color directly to the icon.
+                let icon: JSX.Element;
+                let tooltip: string;
+
+                if (!isEnabled) {
+                    icon = <PlugDisconnectedRegular color={tokens.colorNeutralForeground4} />;
+                    tooltip = "Inspector CLI bridge disabled — click to connect";
+                } else if (!isConnected) {
+                    icon = connectingIconToggle ? (
+                        <PlugConnectedRegular color={tokens.colorPaletteYellowForeground2} />
+                    ) : (
+                        <PlugDisconnectedRegular color={tokens.colorPaletteYellowForeground2} />
+                    );
+                    tooltip = "Connecting to Inspector CLI bridge — click to disconnect";
+                } else {
+                    icon = <PlugConnectedCheckmarkRegular color={tokens.colorPaletteGreenForeground2} />;
+                    tooltip = "Connected to Inspector CLI bridge — click to disconnect";
+                }
+
                 return (
-                    <Tooltip content={isConnected ? "Connected to Inspector CLI Bridge" : "Disconnected from Inspector CLI Bridge"}>
+                    <Tooltip content={tooltip}>
                         <Button
                             appearance="subtle"
-                            icon={
-                                isConnected ? (
-                                    <PlugConnectedRegular color={tokens.colorPaletteGreenForeground2} />
-                                ) : (
-                                    <PlugDisconnectedRegular color={tokens.colorPaletteRedForeground2} />
-                                )
-                            }
-                            onClick={() => window.open("https://www.npmjs.com/package/@babylonjs/inspector", "_blank")}
+                            icon={icon}
+                            onClick={() => {
+                                cliConnectionStatus.isEnabled = !cliConnectionStatus.isEnabled;
+                            }}
                         />
                     </Tooltip>
                 );

--- a/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
+++ b/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
@@ -1,4 +1,4 @@
-import { Button, makeStyles, tokens } from "@fluentui/react-components";
+import { Button, Link, makeStyles, tokens } from "@fluentui/react-components";
 import { PlugConnectedCheckmarkRegular, PlugConnectedRegular, PlugDisconnectedRegular } from "@fluentui/react-icons";
 import { useEffect, useRef, useState } from "react";
 
@@ -9,6 +9,16 @@ import { type ServiceDefinition } from "shared-ui-components/modularTool/modular
 import { type ICliConnectionStatus, CliConnectionStatusIdentity } from "./cli/cliConnectionStatus";
 import { DefaultToolbarItemOrder } from "./defaultToolbarMetadata";
 import { type IShellService, ShellServiceIdentity } from "shared-ui-components/modularTool/services/shellService";
+
+const DocUrl = "https://www.npmjs.com/package/@babylonjs/inspector#inspector-cli";
+
+const useStyles = makeStyles({
+    tooltipContent: {
+        display: "flex",
+        flexDirection: "column",
+        gap: tokens.spacingVerticalXS,
+    },
+});
 
 export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShellService, ICliConnectionStatus]> = {
     friendlyName: "CLI Connection Status",
@@ -21,6 +31,7 @@ export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShell
             teachingMoment: false,
             order: DefaultToolbarItemOrder.CliStatus,
             component: () => {
+                const classes = useStyles();
                 const isEnabled = useObservableState(() => cliConnectionStatus.isEnabled, cliConnectionStatus.onConnectionStatusChanged);
                 const isConnected = useObservableState(() => cliConnectionStatus.isConnected, cliConnectionStatus.onConnectionStatusChanged);
                 const { showToast } = useToast();
@@ -51,25 +62,34 @@ export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShell
                 }, [isConnected, showToast]);
 
                 let icon: JSX.Element;
-                let tooltip: string;
+                let statusText: string;
 
                 if (!isEnabled) {
                     icon = <PlugDisconnectedRegular color={tokens.colorNeutralForeground4} />;
-                    tooltip = "Inspector CLI bridge disabled — click to connect";
+                    statusText = "Inspector CLI bridge disabled — click to connect";
                 } else if (!isConnected) {
                     icon = connectingIconToggle ? (
                         <PlugConnectedRegular color={tokens.colorPaletteYellowForeground2} />
                     ) : (
                         <PlugDisconnectedRegular color={tokens.colorPaletteYellowForeground2} />
                     );
-                    tooltip = "Connecting to Inspector CLI bridge — click to disconnect";
+                    statusText = "Connecting to Inspector CLI bridge — click to disconnect";
                 } else {
                     icon = <PlugConnectedCheckmarkRegular color={tokens.colorPaletteGreenForeground2} />;
-                    tooltip = "Connected to Inspector CLI bridge — click to disconnect";
+                    statusText = "Connected to Inspector CLI bridge — click to disconnect";
                 }
 
+                const tooltipContent = (
+                    <div className={classes.tooltipContent}>
+                        <span>{statusText}</span>
+                        <Link href={DocUrl} target="_blank">
+                            Inspector CLI documentation
+                        </Link>
+                    </div>
+                );
+
                 return (
-                    <Tooltip content={tooltip}>
+                    <Tooltip content={tooltipContent}>
                         <Button
                             appearance="subtle"
                             icon={icon}

--- a/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
+++ b/packages/dev/inspector-v2/src/services/cliConnectionStatusService.tsx
@@ -1,7 +1,8 @@
-import { Body1, Button, Link, makeStyles, tokens } from "@fluentui/react-components";
+import { Body1, Button, makeStyles, tokens } from "@fluentui/react-components";
 import { PlugConnectedCheckmarkRegular, PlugConnectedRegular, PlugDisconnectedRegular } from "@fluentui/react-icons";
 import { useEffect, useRef, useState } from "react";
 
+import { Link } from "shared-ui-components/fluent/primitives/link";
 import { useToast } from "shared-ui-components/fluent/primitives/toast";
 import { Tooltip } from "shared-ui-components/fluent/primitives/tooltip";
 import { useObservableState } from "shared-ui-components/modularTool/hooks/observableHooks";
@@ -82,16 +83,16 @@ export const CliConnectionStatusServiceDefinition: ServiceDefinition<[], [IShell
                 const tooltipContent = (
                     <div className={classes.tooltipContent}>
                         <Body1>{statusText}</Body1>
-                        <Link href={DocUrl} target="_blank">
-                            Inspector CLI documentation
-                        </Link>
+                        <Link url={DocUrl} value="Inspector CLI documentation" />
                     </div>
                 );
 
+                // Using raw Fluent Button for custom icon coloring per connection state.
                 return (
                     <Tooltip content={tooltipContent}>
                         <Button
                             appearance="subtle"
+                            aria-label={statusText}
                             icon={icon}
                             onClick={() => {
                                 cliConnectionStatus.isEnabled = !cliConnectionStatus.isEnabled;

--- a/packages/dev/inspector-v2/test/unit/services/inspectableBridgeService.test.ts
+++ b/packages/dev/inspector-v2/test/unit/services/inspectableBridgeService.test.ts
@@ -6,24 +6,24 @@ import { MakeInspectableBridgeServiceDefinition } from "../../../src/services/cl
 describe("InspectableBridgeService", () => {
     describe("service definition", () => {
         it("produces InspectableCommandRegistryIdentity", () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });
             expect(definition.produces).toContain(InspectableCommandRegistryIdentity);
         });
 
         it("produces CliConnectionStatusIdentity", () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });
             expect(definition.produces).toContain(CliConnectionStatusIdentity);
         });
 
         it("has a friendly name", () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });
             expect(definition.friendlyName).toBe("Inspectable Bridge Service");
         });
     });
 
     describe("command registry", () => {
         it("can register and unregister a command", async () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
             const registry = await definition.factory();
 
             const disposal = registry.addCommand({
@@ -40,7 +40,7 @@ describe("InspectableBridgeService", () => {
         });
 
         it("throws when registering a duplicate command id", async () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
             const registry = await definition.factory();
 
             registry.addCommand({
@@ -61,7 +61,7 @@ describe("InspectableBridgeService", () => {
         });
 
         it("allows re-registration after disposal", async () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
             const registry = await definition.factory();
 
             const token = registry.addCommand({
@@ -86,7 +86,7 @@ describe("InspectableBridgeService", () => {
 
     describe("connection status", () => {
         it("starts disabled and disconnected", async () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
             const registry = await definition.factory();
 
             expect(registry.isEnabled).toBe(false);
@@ -95,8 +95,17 @@ describe("InspectableBridgeService", () => {
             registry.dispose?.();
         });
 
+        it("starts enabled when autoStart is true", async () => {
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: true });
+            const registry = await definition.factory();
+
+            expect(registry.isEnabled).toBe(true);
+
+            registry.dispose?.();
+        });
+
         it("exposes onConnectionStatusChanged observable", async () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
             const registry = await definition.factory();
 
             expect(registry.onConnectionStatusChanged).toBeDefined();
@@ -106,7 +115,7 @@ describe("InspectableBridgeService", () => {
         });
 
         it("notifies when isEnabled changes", async () => {
-            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
             const registry = await definition.factory();
 
             let notified = false;

--- a/packages/dev/inspector-v2/test/unit/services/inspectableBridgeService.test.ts
+++ b/packages/dev/inspector-v2/test/unit/services/inspectableBridgeService.test.ts
@@ -1,9 +1,27 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { InspectableCommandRegistryIdentity } from "../../../src/services/cli/inspectableCommandRegistry";
 import { CliConnectionStatusIdentity } from "../../../src/services/cli/cliConnectionStatus";
 import { MakeInspectableBridgeServiceDefinition } from "../../../src/services/cli/inspectableBridgeService";
 
 describe("InspectableBridgeService", () => {
+    let originalWebSocket: typeof WebSocket;
+
+    beforeEach(() => {
+        originalWebSocket = globalThis.WebSocket;
+        // Stub WebSocket to prevent real network I/O in tests.
+        globalThis.WebSocket = vi.fn(() => ({
+            onopen: null,
+            onclose: null,
+            onerror: null,
+            onmessage: null,
+            close: vi.fn(),
+            send: vi.fn(),
+        })) as unknown as typeof WebSocket;
+    });
+
+    afterEach(() => {
+        globalThis.WebSocket = originalWebSocket;
+    });
     describe("service definition", () => {
         it("produces InspectableCommandRegistryIdentity", () => {
             const definition = MakeInspectableBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });

--- a/packages/dev/inspector-v2/test/unit/services/inspectableBridgeService.test.ts
+++ b/packages/dev/inspector-v2/test/unit/services/inspectableBridgeService.test.ts
@@ -85,10 +85,11 @@ describe("InspectableBridgeService", () => {
     });
 
     describe("connection status", () => {
-        it("starts disconnected", async () => {
+        it("starts disabled and disconnected", async () => {
             const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
             const registry = await definition.factory();
 
+            expect(registry.isEnabled).toBe(false);
             expect(registry.isConnected).toBe(false);
 
             registry.dispose?.();
@@ -100,6 +101,21 @@ describe("InspectableBridgeService", () => {
 
             expect(registry.onConnectionStatusChanged).toBeDefined();
             expect(registry.onConnectionStatusChanged.add).toBeInstanceOf(Function);
+
+            registry.dispose?.();
+        });
+
+        it("notifies when isEnabled changes", async () => {
+            const definition = MakeInspectableBridgeServiceDefinition({ port: 0, name: "test" });
+            const registry = await definition.factory();
+
+            let notified = false;
+            registry.onConnectionStatusChanged.add(() => {
+                notified = true;
+            });
+
+            registry.isEnabled = true;
+            expect(notified).toBe(true);
 
             registry.dispose?.();
         });

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
@@ -4,7 +4,7 @@ import { type ReactElement, forwardRef } from "react";
 
 import { Tooltip as FluentTooltip } from "@fluentui/react-components";
 
-export type TooltipProps = { content?: Nullable<string>; children: ReactElement };
+export type TooltipProps = { content?: Nullable<string | ReactElement>; children: ReactElement };
 
 // forwardRef wrapper to avoid "function components cannot be given refs" warning
 // FluentTooltip handles ref forwarding to children internally via applyTriggerPropsToChildren


### PR DESCRIPTION
This change makes it so that by default, the user needs to explicitly click the CLI connection button in the Inspector toolbar before the browser side tries to establish a WebSocket connection with the CLI bridge on the node side. From an API standpoint, when explicitly calling `StartInspectable` you can now pass an `autoStart` option if you want to connect to the CLI bridge programmatically without user interaction.

<img width="366" height="134" alt="image" src="https://github.com/user-attachments/assets/2f012ea2-264a-484a-8ce0-46bcb003f63f" />
