### PR TITLE
Review skill improvements

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -53,7 +53,7 @@ Apply the severity categories and review checklist below to every changed line.
 #### Review Checklist
 
 1. **All applicable instruction files** — apply the rules from [instructions/index.md](../../instructions/index.md) to the changed code. If an instruction file's content is already in your system prompt context, apply it directly without re-reading from disk. Only read instruction files from disk when they are not already in context.
-2. **Correctness** — logic errors, off-by-one, null/undefined access, race conditions, unhandled edge cases.
+2. **Correctness** — logic errors, off-by-one, null/undefined access, race conditions, unhandled edge cases. Verify that doc comments accurately describe the implementation behavior, not just that they exist.
 3. **Security** — prototype pollution, unsafe `eval`/`Function()`, unsafe deserialization of untrusted input (e.g. parsed scene files, glTF extensions).
 4. **PR labels** — see `pr-labels.instructions.md`. Suggest labels based on the type and location of changes.
 5. **General quality** — dead code, unreachable branches, duplicated logic, overly complex control flow, poor naming.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -40,7 +40,7 @@ Combine the results into a deduplicated list of changed files. If there are no c
 
 ### Step 3: Review against the checklist
 
-Apply the severity categories and review checklist below to every changed line. For checklist items that reference instruction files, read the referenced file in full before checking.
+Apply the severity categories and review checklist below to every changed line.
 
 #### Severity Categories
 
@@ -94,8 +94,9 @@ Sort by severity: Critical first, then Warning, then Nit.
 **If automatic mode (default):**
 
 1. Fix all Critical and Warning issues. Fix Nit issues as well unless they are purely subjective.
-2. **Exception — design-impacting fixes**: If fixing a Warning or Nit would change the architectural approach or design intent of the code (e.g., restructuring data flow, changing when allocations happen, altering the public API shape), do NOT auto-fix. Instead, flag it in the summary table and ask the user for confirmation before applying.
+2. **Exception — design-impacting fixes**: If fixing a Warning or Nit would change the architectural approach or design intent of the code (e.g., restructuring data flow, changing when allocations happen, altering the public API shape), do NOT auto-fix. Mark those issues as "Needs confirmation" in the summary table and skip them during the fix pass.
 3. After fixing, re-run the quality tools (`format:check`, `lint:check`, `test:unit`) to verify the fixes don't introduce new problems.
+4. Present the summary table. If any issues were marked "Needs confirmation", ask the user once which of those to fix (all, specific numbers, or skip). Apply the approved fixes, then re-run quality tools if any were applied.
 
 ### Step 7: Present the summary table
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -52,11 +52,12 @@ Apply the severity categories and review checklist below to every changed line. 
 
 #### Review Checklist
 
-1. **All applicable instruction files** — read each file listed in [instructions/index.md](../../instructions/index.md) and apply its rules to the changed code.
+1. **All applicable instruction files** — apply the rules from [instructions/index.md](../../instructions/index.md) to the changed code. If an instruction file's content is already in your system prompt context, apply it directly without re-reading from disk. Only read instruction files from disk when they are not already in context.
 2. **Correctness** — logic errors, off-by-one, null/undefined access, race conditions, unhandled edge cases.
 3. **Security** — prototype pollution, unsafe `eval`/`Function()`, unsafe deserialization of untrusted input (e.g. parsed scene files, glTF extensions).
 4. **PR labels** — see `pr-labels.instructions.md`. Suggest labels based on the type and location of changes.
 5. **General quality** — dead code, unreachable branches, duplicated logic, overly complex control flow, poor naming.
+6. **Test coverage** — check whether new code paths, branches, and features introduced by the changes have adequate test coverage. Flag new public APIs, new runtime branches, or new features that lack corresponding unit or integration tests.
 
 ### Step 4: Run quality tools
 
@@ -93,7 +94,8 @@ Sort by severity: Critical first, then Warning, then Nit.
 **If automatic mode (default):**
 
 1. Fix all Critical and Warning issues. Fix Nit issues as well unless they are purely subjective.
-2. After fixing, re-run the quality tools (`format:check`, `lint:check`, `test:unit`) to verify the fixes don't introduce new problems.
+2. **Exception — design-impacting fixes**: If fixing a Warning or Nit would change the architectural approach or design intent of the code (e.g., restructuring data flow, changing when allocations happen, altering the public API shape), do NOT auto-fix. Instead, flag it in the summary table and ask the user for confirmation before applying.
+3. After fixing, re-run the quality tools (`format:check`, `lint:check`, `test:unit`) to verify the fixes don't introduce new problems.
 
 ### Step 7: Present the summary table
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -55,9 +55,7 @@ Apply the severity categories and review checklist below to every changed line.
 1. **All applicable instruction files** — apply the rules from [instructions/index.md](../../instructions/index.md) to the changed code. If an instruction file's content is already in your system prompt context, apply it directly without re-reading from disk. Only read instruction files from disk when they are not already in context.
 2. **Correctness** — logic errors, off-by-one, null/undefined access, race conditions, unhandled edge cases. Verify that doc comments accurately describe the implementation behavior, not just that they exist.
 3. **Security** — prototype pollution, unsafe `eval`/`Function()`, unsafe deserialization of untrusted input (e.g. parsed scene files, glTF extensions).
-4. **PR labels** — see `pr-labels.instructions.md`. Suggest labels based on the type and location of changes.
-5. **General quality** — dead code, unreachable branches, duplicated logic, overly complex control flow, poor naming.
-6. **Test coverage** — check whether new code paths, branches, and features introduced by the changes have adequate test coverage. Flag new public APIs, new runtime branches, or new features that lack corresponding unit or integration tests.
+4. **General quality** — dead code, unreachable branches, duplicated logic, overly complex control flow, poor naming.
 
 ### Step 4: Run quality tools
 


### PR DESCRIPTION
Running the code-review skill against my branches, and then discussing with the AI improvements to the skill after applying it.
- Do not reload instructions files already in memory
- Do not fix warnings when fixing would require architecture changes, ask the user first
- Flag missing test coverage