### PR TITLE
Fix flickering when shadow generator has refreshRate under snapshot rendering

### DIFF
--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -559,9 +559,20 @@ export class ObjectRenderer {
     /**
      * Indicates if the renderer should render the current frame.
      * The output is based on the specified refresh rate.
+     * When snapshot rendering is active, this always returns true to ensure render pass
+     * topology stays consistent between the recording frame and playback frames.
      * @returns true if the renderer should render the current frame
      */
     public shouldRender(): boolean {
+        if (this._engine.snapshotRendering) {
+            // When snapshot rendering is active (recording or playing), we must always render
+            // to ensure the number of render passes stays consistent between the recording frame
+            // and all playback frames. If a render target is skipped during recording but not
+            // during playback (or vice versa), the recorded bundle list indices become misaligned,
+            // causing visual artifacts such as flickering.
+            return true;
+        }
+
         if (this._currentRefreshId === -1) {
             // At least render once
             this._currentRefreshId = 1;

--- a/packages/dev/core/test/unit/Rendering/objectRenderer.shouldRender.test.ts
+++ b/packages/dev/core/test/unit/Rendering/objectRenderer.shouldRender.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { type Engine } from "core/Engines/engine";
+import { Scene } from "core/scene";
+import { ObjectRenderer } from "core/Rendering/objectRenderer";
+
+describe("ObjectRenderer.shouldRender", () => {
+    let engine: Engine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("should respect refreshRate when snapshot rendering is not active", () => {
+        const renderer = new ObjectRenderer("test", scene);
+        renderer.refreshRate = 3;
+
+        // First call always returns true (initial render, _currentRefreshId === -1)
+        expect(renderer.shouldRender()).toBe(true);
+
+        // refreshRate=3: counter starts at 1, increments each call, returns true when it reaches 3
+        expect(renderer.shouldRender()).toBe(false); // counter = 2
+        expect(renderer.shouldRender()).toBe(false); // counter = 3
+        expect(renderer.shouldRender()).toBe(true); // counter reaches 3, resets to 1
+
+        renderer.dispose();
+    });
+
+    it("should always return true when snapshot rendering is active", () => {
+        const renderer = new ObjectRenderer("test", scene);
+        renderer.refreshRate = 60;
+
+        // Simulate snapshot rendering being active
+        // NullEngine's snapshotRendering getter returns false by default.
+        // We override it to simulate the WebGPU snapshot rendering scenario.
+        Object.defineProperty(engine, "snapshotRendering", {
+            get: () => true,
+            configurable: true,
+        });
+
+        // Every call should return true regardless of refreshRate
+        for (let i = 0; i < 100; i++) {
+            expect(renderer.shouldRender()).toBe(true);
+        }
+
+        renderer.dispose();
+    });
+
+    it("should not advance the refresh counter while snapshot rendering is active", () => {
+        const renderer = new ObjectRenderer("test", scene);
+        renderer.refreshRate = 3;
+
+        // First call: returns true (initial render), counter goes to 1
+        expect(renderer.shouldRender()).toBe(true);
+
+        // Enable snapshot rendering
+        Object.defineProperty(engine, "snapshotRendering", {
+            get: () => true,
+            configurable: true,
+        });
+
+        // Call many times during snapshot — always returns true, counter frozen
+        for (let i = 0; i < 50; i++) {
+            expect(renderer.shouldRender()).toBe(true);
+        }
+
+        // Disable snapshot rendering
+        Object.defineProperty(engine, "snapshotRendering", {
+            get: () => false,
+            configurable: true,
+        });
+
+        // Counter should resume from where it was (1), so next calls follow normal pattern
+        // counter was 1 before snapshot, so now: id=1 (false->2), id=2 (false->3), id=3 (true->1)
+        expect(renderer.shouldRender()).toBe(false);
+        expect(renderer.shouldRender()).toBe(false);
+        expect(renderer.shouldRender()).toBe(true);
+
+        renderer.dispose();
+    });
+});


### PR DESCRIPTION
## Description

Fixes flickering when a shadow generator with a non-default `refreshRate` is used under WebGPU snapshot rendering.

**Root cause:** WebGPU snapshot rendering records GPU render pass bundles during one frame, then replays them by index on subsequent frames. `ObjectRenderer.shouldRender()` uses a counter to skip rendering based on `refreshRate`. If the counter state differs between the recording frame and a playback frame, the render pass topology changes and bundle list indices become misaligned -- causing the main scene pass to replay the wrong bundle (or none), resulting in flickering.

**Fix:** `ObjectRenderer.shouldRender()` now returns `true` when `engine.snapshotRendering` is active, ensuring consistent render pass topology. During playback the RTT isn't truly re-rendered (bundles are replayed), so the cost is minimal. The refresh counter is frozen during snapshot mode and resumes correctly when snapshot rendering is disabled.

**Testing:**
- Unit tests added for `ObjectRenderer.shouldRender()` covering normal refresh rate behavior, snapshot override, and counter freeze/resume.

Forum report: https://forum.babylonjs.com/t/63183
Repro playgrounds: https://playground.babylonjs.com/#BX2Y9K#0 / https://playground.babylonjs.com/#BX2Y9K#1