### PR TITLE
Fix dissolve-effect-with-node-material-and-glow-layer flaky test

### DIFF
--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -2503,8 +2503,7 @@
         },
         {
             "title": "dissolve-effect-with-node-material-and-glow-layer",
-            "renderCount": 2,
-            "playgroundId": "#F6PGMC#12"
+            "playgroundId": "#F6PGMC#16"
         },
         {
             "title": "cascaded-shadow-maps-and-flying-saucers",


### PR DESCRIPTION
Finally, the AI and I managed to figure out the problem!

The problem occurs when the thickness is defined by code:
```javascript
    var thickness = nodeMat.getInputBlockByPredicate((b) => b.name === "thickness");
    thickness.value = 0.05;
```
The node's material has been parsed and the `build()` method has already been called, but it's possible that the material's construction isn't complete by the time `thickness.value = 0.05` is executed! This happens if certain blocks defer certain operations to a later time by setting `codeIsReady` to **false**. In reality, when this happens, the test result is correct, because the value 0.05 is correctly used because the shader code has not yet been generated. But when construction is complete before `thickness.value = 0.05` is executed, the line has no effect and the code has already been generated with the default thickness value (which is 0.027).

The proper solution would be to disable compilation during the node material’s building, and manually recompile the materials once the inputs have been modified. However, a simpler solution is to not define the “Thickness” constant in the node material. This way, it uses a uniform to pass the value, which avoids the problem described above.