### PR TITLE
Flow Graph Editor: AutoCompleteInput ARIA accessibility and clear-after-commit fix

### DIFF
--- a/packages/tools/flowGraphEditor/src/sharedComponents/autoCompleteInputComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/sharedComponents/autoCompleteInputComponent.tsx
@@ -51,10 +51,13 @@ export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInp
 
     private _commit(value: string) {
         const trimmed = value.trim();
-        this.setState({ text: trimmed, showSuggestions: false, highlightIndex: -1 });
+        this.setState({ showSuggestions: false, highlightIndex: -1 });
         if (trimmed !== this.props.value) {
             this.props.onChange(trimmed);
         }
+        // Always reset the text to the prop value so the input clears after
+        // an action (e.g. adding a variable) when props.value stays constant.
+        this.setState({ text: this.props.value });
     }
 
     private _onKeyDown = (e: React.KeyboardEvent) => {
@@ -85,17 +88,27 @@ export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInp
 
     override render() {
         const { label } = this.props;
-        const { text, showSuggestions } = this.state;
+        const { text, showSuggestions, highlightIndex } = this.state;
         const suggestions = showSuggestions ? this._getFilteredSuggestions() : [];
+        const listboxId = `fge-autocomplete-listbox-${label.replace(/\s+/g, "-")}`;
+        const activeDescendant = highlightIndex >= 0 ? `${listboxId}-option-${highlightIndex}` : undefined;
 
         return (
             <div className="fge-autocomplete" style={{ position: "relative" }}>
                 <div className="fge-autocomplete-row">
-                    <span className="fge-autocomplete-label">{label}</span>
+                    <label className="fge-autocomplete-label" id={`${listboxId}-label`}>
+                        {label}
+                    </label>
                     <input
                         ref={this._inputRef}
                         className="fge-autocomplete-input"
                         value={text}
+                        role="combobox"
+                        aria-autocomplete="list"
+                        aria-expanded={suggestions.length > 0}
+                        aria-controls={listboxId}
+                        aria-activedescendant={activeDescendant}
+                        aria-labelledby={`${listboxId}-label`}
                         onChange={(e) => this.setState({ text: e.target.value, showSuggestions: true, highlightIndex: -1 })}
                         onFocus={() => {
                             if (this.props.lockObject) {
@@ -117,11 +130,14 @@ export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInp
                     />
                 </div>
                 {suggestions.length > 0 && (
-                    <div className="fge-autocomplete-dropdown">
+                    <div className="fge-autocomplete-dropdown" role="listbox" id={listboxId}>
                         {suggestions.map((s, i) => (
                             <div
                                 key={s}
-                                className={`fge-autocomplete-option${i === this.state.highlightIndex ? " fge-autocomplete-option-active" : ""}`}
+                                id={`${listboxId}-option-${i}`}
+                                role="option"
+                                aria-selected={i === highlightIndex}
+                                className={`fge-autocomplete-option${i === highlightIndex ? " fge-autocomplete-option-active" : ""}`}
                                 onMouseDown={(e) => {
                                     e.preventDefault();
                                     this._commit(s);

--- a/packages/tools/flowGraphEditor/src/sharedComponents/autoCompleteInputComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/sharedComponents/autoCompleteInputComponent.tsx
@@ -27,11 +27,11 @@ interface IAutoCompleteInputState {
  * A text input with autocomplete suggestions dropdown.
  * Users can type freely or pick from a filtered list of existing values.
  */
-let _uniqueIdSeed = 0;
+let _UniqueIdSeed = 0;
 
 export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInputProps, IAutoCompleteInputState> {
     private _inputRef = React.createRef<HTMLInputElement>();
-    private readonly _uniqueId = _uniqueIdSeed++;
+    private readonly _uniqueId = _UniqueIdSeed++;
 
     constructor(props: IAutoCompleteInputProps) {
         super(props);

--- a/packages/tools/flowGraphEditor/src/sharedComponents/autoCompleteInputComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/sharedComponents/autoCompleteInputComponent.tsx
@@ -27,8 +27,11 @@ interface IAutoCompleteInputState {
  * A text input with autocomplete suggestions dropdown.
  * Users can type freely or pick from a filtered list of existing values.
  */
+let _uniqueIdSeed = 0;
+
 export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInputProps, IAutoCompleteInputState> {
     private _inputRef = React.createRef<HTMLInputElement>();
+    private readonly _uniqueId = _uniqueIdSeed++;
 
     constructor(props: IAutoCompleteInputProps) {
         super(props);
@@ -51,13 +54,12 @@ export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInp
 
     private _commit(value: string) {
         const trimmed = value.trim();
-        this.setState({ showSuggestions: false, highlightIndex: -1 });
         if (trimmed !== this.props.value) {
             this.props.onChange(trimmed);
         }
-        // Always reset the text to the prop value so the input clears after
-        // an action (e.g. adding a variable) when props.value stays constant.
-        this.setState({ text: this.props.value });
+        // Reset the text to the prop value so the input clears after an
+        // action (e.g. adding a variable) when props.value stays constant.
+        this.setState({ showSuggestions: false, highlightIndex: -1, text: this.props.value });
     }
 
     private _onKeyDown = (e: React.KeyboardEvent) => {
@@ -90,23 +92,25 @@ export class AutoCompleteInputComponent extends React.Component<IAutoCompleteInp
         const { label } = this.props;
         const { text, showSuggestions, highlightIndex } = this.state;
         const suggestions = showSuggestions ? this._getFilteredSuggestions() : [];
-        const listboxId = `fge-autocomplete-listbox-${label.replace(/\s+/g, "-")}`;
+        const listboxId = `fge-autocomplete-listbox-${this._uniqueId}`;
+        const inputId = `fge-autocomplete-input-${this._uniqueId}`;
         const activeDescendant = highlightIndex >= 0 ? `${listboxId}-option-${highlightIndex}` : undefined;
 
         return (
             <div className="fge-autocomplete" style={{ position: "relative" }}>
                 <div className="fge-autocomplete-row">
-                    <label className="fge-autocomplete-label" id={`${listboxId}-label`}>
+                    <label className="fge-autocomplete-label" id={`${listboxId}-label`} htmlFor={inputId}>
                         {label}
                     </label>
                     <input
                         ref={this._inputRef}
+                        id={inputId}
                         className="fge-autocomplete-input"
                         value={text}
                         role="combobox"
                         aria-autocomplete="list"
                         aria-expanded={suggestions.length > 0}
-                        aria-controls={listboxId}
+                        aria-controls={suggestions.length > 0 ? listboxId : undefined}
                         aria-activedescendant={activeDescendant}
                         aria-labelledby={`${listboxId}-label`}
                         onChange={(e) => this.setState({ text: e.target.value, showSuggestions: true, highlightIndex: -1 })}


### PR DESCRIPTION
## Summary

Follow-up fixes for review comments acknowledged on PRs #18328 and #18329.

## Changes

### ARIA Accessibility for AutoCompleteInputComponent
- Add `role="combobox"`, `aria-autocomplete="list"`, `aria-expanded`, `aria-controls`, and `aria-activedescendant` to the input element
- Add `role="listbox"` to the dropdown container and `role="option"` with `aria-selected` to each option
- Change `<span>` label to `<label>` with `id` for proper `aria-labelledby` association

### AutoComplete Clear After Commit
- Reset text state to `props.value` after commit so the input clears when used with a constant `value=""` (e.g. the SetVariable "Add variable" picker)
- Previously, after selecting a suggestion, the input would keep showing the selected text instead of clearing

## Related PRs
- #18328 (thread 2: ARIA accessibility)
- #18329 (thread 7: AutoComplete not clearing after add)