### PR TITLE
chore: remove 8 unnecessary npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
                 "@dev/build-tools": "^1.0.0",
                 "@eslint/js": "^10.0.1",
                 "@playwright/test": "1.57.0",
-                "@typescript-eslint/eslint-plugin": "^8.56.1",
-                "@typescript-eslint/parser": "^8.56.1",
-                "@typescript-eslint/utils": "^8.56.1",
+                "@typescript-eslint/eslint-plugin": "^8.58.2",
+                "@typescript-eslint/parser": "^8.58.2",
+                "@typescript-eslint/utils": "^8.58.2",
                 "@vitest/coverage-v8": "^4.1.3",
                 "@vitest/eslint-plugin": "^1.6.14",
                 "ajv": "~8.18.0",
@@ -44,7 +44,7 @@
                 "tslib": "^2.4.0",
                 "typedoc": "^0.28.16",
                 "typescript": "~6.0.2",
-                "typescript-eslint": "^8.56.1",
+                "typescript-eslint": "^8.58.2",
                 "vite": "6.4.2",
                 "vitest": "^4.1.3",
                 "webpack": "^5.103.0",
@@ -8506,20 +8506,20 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
-            "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+            "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/type-utils": "8.57.2",
-                "@typescript-eslint/utils": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/type-utils": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8529,22 +8529,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.57.2",
+                "@typescript-eslint/parser": "^8.58.2",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-            "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -8556,18 +8556,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-            "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+            "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.2",
-                "@typescript-eslint/types": "^8.57.2",
+                "@typescript-eslint/tsconfig-utils": "^8.58.2",
+                "@typescript-eslint/types": "^8.58.2",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -8578,18 +8578,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-            "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+            "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2"
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8600,9 +8600,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-            "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+            "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8613,21 +8613,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
-            "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+            "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/utils": "8.57.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8638,13 +8638,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-            "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+            "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8656,21 +8656,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-            "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+            "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.57.2",
-                "@typescript-eslint/tsconfig-utils": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/project-service": "8.58.2",
+                "@typescript-eslint/tsconfig-utils": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8680,20 +8680,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
-            "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2"
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8704,17 +8704,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-            "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+            "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
+                "@typescript-eslint/types": "8.58.2",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -8808,160 +8808,6 @@
                 "vitest": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/project-service": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-            "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.58.1",
-                "@typescript-eslint/types": "^8.58.1",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-            "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/visitor-keys": "8.58.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-            "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/types": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-            "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-            "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.58.1",
-                "@typescript-eslint/tsconfig-utils": "8.58.1",
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/visitor-keys": "8.58.1",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.5.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/utils": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-            "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.58.1",
-                "@typescript-eslint/types": "8.58.1",
-                "@typescript-eslint/typescript-estree": "8.58.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.1.0"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.58.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-            "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.58.1",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@vitest/eslint-plugin/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@vitest/expect": {
@@ -11725,9 +11571,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+            "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
             "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
@@ -12777,160 +12623,6 @@
                 "@microsoft/tsdoc": "0.16.0",
                 "@microsoft/tsdoc-config": "0.18.1",
                 "@typescript-eslint/utils": "~8.56.0"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/project-service": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-            "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.56.1",
-                "@typescript-eslint/types": "^8.56.1",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-            "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-            "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/types": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-            "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-            "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.56.1",
-                "@typescript-eslint/tsconfig-utils": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/visitor-keys": "8.56.1",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/utils": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-            "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.56.1",
-                "@typescript-eslint/types": "8.56.1",
-                "@typescript-eslint/typescript-estree": "8.56.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.56.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-            "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.56.1",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/eslint-plugin-tsdoc/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint-rule-documentation": {
@@ -19057,16 +18749,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-refresh-typescript": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.11.tgz",
-            "integrity": "sha512-u6afET6t6NDNcxD67wSVlgazX/CiRuC7qSqALZueMckjmPQnOBajmwibJr2TTU6MtttDNPjBhD8K3AB8i0opJg==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x || 0.16.x || 0.17.x || 0.18.x || 0.19.x",
-                "typescript": "^4.8 || ^5.0"
-            }
-        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -22060,16 +21742,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
-            "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+            "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.57.2",
-                "@typescript-eslint/parser": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/utils": "8.57.2"
+                "@typescript-eslint/eslint-plugin": "8.58.2",
+                "@typescript-eslint/parser": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/utils": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -22080,7 +21762,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/uc.micro": {
@@ -23582,7 +23264,7 @@
             "dependencies": {
                 "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",
                 "dotenv": "^16.0.0",
-                "react-refresh-typescript": "^2.0.10"
+                "react-refresh-typescript": "^2.0.12"
             },
             "bin": {
                 "build-tools": "dist/index.js"
@@ -23633,6 +23315,16 @@
                 "webpack-plugin-serve": {
                     "optional": true
                 }
+            }
+        },
+        "packages/dev/buildTools/node_modules/react-refresh-typescript": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.12.tgz",
+            "integrity": "sha512-kFuSHaP8CbNtBJ4UrdCD0nHLac5k0V4yQnGbQQCZ5Xy8uoQwiIrtncm7Nwxwia6mCzmc8+LDmhslsO3FyzhCkA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x || 0.16.x || 0.17.x || 0.18.x || 0.19.x",
+                "typescript": "^4.8 || ^5.0 || ^6.0"
             }
         },
         "packages/dev/buildTools/node_modules/source-map": {
@@ -23710,7 +23402,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-refresh": "^0.17.0",
-                "react-refresh-typescript": "^2.0.10",
+                "react-refresh-typescript": "^2.0.12",
                 "sharp": "^0.33.0",
                 "webpack": "^5.103.0",
                 "webpack-cli": "6.0.1"
@@ -23762,6 +23454,17 @@
                 "webpack-plugin-serve": {
                     "optional": true
                 }
+            }
+        },
+        "packages/dev/inspector-v2/node_modules/react-refresh-typescript": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.12.tgz",
+            "integrity": "sha512-kFuSHaP8CbNtBJ4UrdCD0nHLac5k0V4yQnGbQQCZ5Xy8uoQwiIrtncm7Nwxwia6mCzmc8+LDmhslsO3FyzhCkA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x || 0.16.x || 0.17.x || 0.18.x || 0.19.x",
+                "typescript": "^4.8 || ^5.0 || ^6.0"
             }
         },
         "packages/dev/inspector-v2/node_modules/source-map": {
@@ -25177,7 +24880,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-refresh": "^0.17.0",
-                "react-refresh-typescript": "^2.0.10",
+                "react-refresh-typescript": "^2.0.12",
                 "sass-loader": "^16.0.0",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",
@@ -25240,6 +24943,17 @@
             "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
             "license": "MIT"
+        },
+        "packages/tools/playground/node_modules/react-refresh-typescript": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.12.tgz",
+            "integrity": "sha512-kFuSHaP8CbNtBJ4UrdCD0nHLac5k0V4yQnGbQQCZ5Xy8uoQwiIrtncm7Nwxwia6mCzmc8+LDmhslsO3FyzhCkA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x || 0.16.x || 0.17.x || 0.18.x || 0.19.x",
+                "typescript": "^4.8 || ^5.0 || ^6.0"
+            }
         },
         "packages/tools/playground/node_modules/source-map": {
             "version": "0.7.6",
@@ -25312,7 +25026,7 @@
                 "html-webpack-plugin": "^5.4.0",
                 "mini-css-extract-plugin": "^2.4.3",
                 "react-refresh": "^0.17.0",
-                "react-refresh-typescript": "^2.0.10",
+                "react-refresh-typescript": "^2.0.12",
                 "sass-loader": "^16.0.0",
                 "style-loader": "^3.3.0",
                 "url-loader": "^4.1.1",
@@ -25367,6 +25081,17 @@
                 "webpack-plugin-serve": {
                     "optional": true
                 }
+            }
+        },
+        "packages/tools/sandbox/node_modules/react-refresh-typescript": {
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.12.tgz",
+            "integrity": "sha512-kFuSHaP8CbNtBJ4UrdCD0nHLac5k0V4yQnGbQQCZ5Xy8uoQwiIrtncm7Nwxwia6mCzmc8+LDmhslsO3FyzhCkA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "react-refresh": "0.10.x || 0.11.x || 0.12.x || 0.13.x || 0.14.x || 0.15.x || 0.16.x || 0.17.x || 0.18.x || 0.19.x",
+                "typescript": "^4.8 || ^5.0 || ^6.0"
             }
         },
         "packages/tools/sandbox/node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
         "@dev/build-tools": "^1.0.0",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.57.0",
-        "@typescript-eslint/eslint-plugin": "^8.56.1",
-        "@typescript-eslint/parser": "^8.56.1",
-        "@typescript-eslint/utils": "^8.56.1",
+        "@typescript-eslint/eslint-plugin": "^8.58.2",
+        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/utils": "^8.58.2",
         "@vitest/coverage-v8": "^4.1.3",
         "@vitest/eslint-plugin": "^1.6.14",
         "ajv": "~8.18.0",
@@ -40,7 +40,7 @@
         "tslib": "^2.4.0",
         "typedoc": "^0.28.16",
         "typescript": "~6.0.2",
-        "typescript-eslint": "^8.56.1",
+        "typescript-eslint": "^8.58.2",
         "vite": "6.4.2",
         "vitest": "^4.1.3",
         "webpack": "^5.103.0",
@@ -130,33 +130,9 @@
         "@rollup/plugin-commonjs": {
             "glob": "^13.0.6"
         },
-        "@typescript-eslint/eslint-plugin": {
-            "typescript": "$typescript"
+        "eslint-plugin-tsdoc": {
+            "@typescript-eslint/utils": "^8.58.2"
         },
-        "@typescript-eslint/parser": {
-            "typescript": "$typescript"
-        },
-        "@typescript-eslint/typescript-estree": {
-            "typescript": "$typescript"
-        },
-        "@typescript-eslint/utils": {
-            "typescript": "$typescript"
-        },
-        "@typescript-eslint/type-utils": {
-            "typescript": "$typescript"
-        },
-        "@typescript-eslint/project-service": {
-            "typescript": "$typescript"
-        },
-        "@typescript-eslint/tsconfig-utils": {
-            "typescript": "$typescript"
-        },
-        "typedoc": {
-            "typescript": "$typescript"
-        },
-        "react-refresh-typescript": {
-            "typescript": "$typescript"
-        },
-        "dompurify": "3.3.3"
+        "dompurify": "3.4.0"
     }
 }

--- a/packages/dev/buildTools/package.json
+++ b/packages/dev/buildTools/package.json
@@ -19,6 +19,6 @@
     "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",
         "dotenv": "^16.0.0",
-        "react-refresh-typescript": "^2.0.10"
+        "react-refresh-typescript": "^2.0.12"
     }
 }

--- a/packages/dev/inspector-v2/package.json
+++ b/packages/dev/inspector-v2/package.json
@@ -36,7 +36,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-refresh": "^0.17.0",
-        "react-refresh-typescript": "^2.0.10",
+        "react-refresh-typescript": "^2.0.12",
         "sharp": "^0.33.0",
         "webpack": "^5.103.0",
         "webpack-cli": "6.0.1"

--- a/packages/tools/playground/package.json
+++ b/packages/tools/playground/package.json
@@ -34,7 +34,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-refresh": "^0.17.0",
-        "react-refresh-typescript": "^2.0.10",
+        "react-refresh-typescript": "^2.0.12",
         "sass-loader": "^16.0.0",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",

--- a/packages/tools/sandbox/package.json
+++ b/packages/tools/sandbox/package.json
@@ -40,7 +40,7 @@
         "html-webpack-plugin": "^5.4.0",
         "mini-css-extract-plugin": "^2.4.3",
         "react-refresh": "^0.17.0",
-        "react-refresh-typescript": "^2.0.10",
+        "react-refresh-typescript": "^2.0.12",
         "sass-loader": "^16.0.0",
         "style-loader": "^3.3.0",
         "url-loader": "^4.1.1",


### PR DESCRIPTION
## Summary

Removes 8 of 13 npm overrides that are no longer needed by bumping packages to versions that natively support TypeScript 6.

## Changes

**Package bumps:**
- `@typescript-eslint/*` and `typescript-eslint`: `^8.56.1` → `^8.58.2` (supports TS `<6.1.0`)
- `react-refresh-typescript`: `^2.0.10` → `^2.0.12` (supports TS `^6.0`)

**Overrides removed (8):**
- 7× `@typescript-eslint/*` → `typescript: $typescript`
- `react-refresh-typescript` → `typescript: $typescript`
- `typedoc` → `typescript: $typescript` (was already a no-op)

**Override added (1):**
- `eslint-plugin-tsdoc` → `@typescript-eslint/utils: ^8.58.2` (its bundled `~8.56.0` doesn't support TS 6; this dedupes to the root copy)

**Remaining overrides (5):**
- `eslint-plugin-github` → `eslint: ^10.0.0` (no new version with eslint 10 support)
- `eslint-plugin-import` → `eslint: ^10.0.0` (no new version with eslint 10 support)
- `@rollup/plugin-commonjs` → `glob: ^13.0.6` (installed v26 wants glob ^10; override dedupes)
- `eslint-plugin-tsdoc` → `@typescript-eslint/utils: ^8.58.2` (new, targeted)
- `dompurify` → `3.4.0` (monaco-editor pins 3.2.7, override fixes CVE)

## Verification
- `npm audit` clean (except pre-existing `basic-ftp` issue)
- No new peer dependency warnings from our changes
- 0 vulnerabilities from dompurify