### PR TITLE
test: SpotLight projection texture readiness regression test (expected to fail on master, companion to #18255)

### DIFF
--- a/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
+++ b/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
@@ -35,32 +35,69 @@ describe("SpotLight", () => {
         engine.dispose();
     });
 
-    describe("projectionTexture readiness", () => {
-        // Regression test for https://github.com/BabylonJS/Babylon.js/pull/18255 — a
-        // material lit by a SpotLight whose projectionTexture is not ready must cause
-        // scene.isReady() (and therefore scene.executeWhenReady) to wait.
-        it("scene.isReady() must not return true while a spot light's projection texture is not ready", async () => {
+    describe("light texture readiness", () => {
+        // Regression tests for https://github.com/BabylonJS/Babylon.js/pull/18255.
+        //
+        // When a light owns texture resources that are not yet ready (a SpotLight's
+        // projectionTexture or iesProfileTexture being the current cases), material
+        // readiness must reflect that so that scene.isReady() returns false and
+        // scene.executeWhenReady() waits for the textures before firing. Callers such
+        // as the BN playground visual-test harness otherwise render frames before the
+        // projection effect is applied and produce intermittent visual-test regressions.
+        //
+        // Each test sets up a lit mesh with a StandardMaterial, pins some light-texture
+        // readiness signal to "not ready", and then polls scene.isReady(). Polling with
+        // a microtask yield lets the NullEngine's async shader compile settle, so that
+        // on master (no fix) the material reaches compiled state and scene.isReady()
+        // flips to true — reproducing the bug — while on the fix branch material
+        // readiness remains gated and scene.isReady() stays false.
+        async function pollSceneIsReady(scene: Scene): Promise<boolean> {
+            for (let i = 0; i < 20; i++) {
+                if (scene.isReady()) {
+                    return true;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+            return false;
+        }
+
+        function createLitBoxScene(): SpotLight {
             const mesh = CreateBox("mesh", {}, scene);
             mesh.material = new StandardMaterial("mat", scene);
-            const light = new SpotLight("spot", new Vector3(0, 5, 0), new Vector3(0, -1, 0), Math.PI / 4, 2, scene);
+            return new SpotLight("spot", new Vector3(0, 5, 0), new Vector3(0, -1, 0), Math.PI / 4, 2, scene);
+        }
+
+        it("scene.isReady() must not return true while a light reports its textures are not ready", async () => {
+            const light = createLitBoxScene();
+
+            // Plumbing-level contract: material readiness must consult the Light's
+            // areLightTexturesReady() contract regardless of which texture(s) caused
+            // it to report not-ready. This ensures future light types that add their
+            // own textures (and override areLightTexturesReady) are gated automatically.
+            (light as any).areLightTexturesReady = () => false;
+
+            expect(await pollSceneIsReady(scene)).toBe(false);
+        });
+
+        it("scene.isReady() must not return true while a SpotLight's projectionTexture is not ready", async () => {
+            const light = createLitBoxScene();
 
             const tex = new Texture(null, scene);
             vi.spyOn(tex, "isReady").mockReturnValue(false);
             light.projectionTexture = tex;
 
-            // Poll scene.isReady(), yielding between polls so that async shader compiles
-            // in NullEngine can settle. Without the fix, the material compiles without a
-            // projection define and scene.isReady() flips to true despite the projection
-            // texture reporting not-ready. With the fix, scene.isReady() stays false.
-            let becameReady = false;
-            for (let i = 0; i < 20; i++) {
-                if (scene.isReady()) {
-                    becameReady = true;
-                    break;
-                }
-                await new Promise((resolve) => setTimeout(resolve, 0));
-            }
-            expect(becameReady).toBe(false);
+            expect(await pollSceneIsReady(scene)).toBe(false);
+        });
+
+        it("scene.isReady() must not return true while a SpotLight's iesProfileTexture is not ready", async () => {
+            const light = createLitBoxScene();
+
+            const tex = new Texture(null, scene);
+            vi.spyOn(tex, "isReady").mockReturnValue(false);
+            light.iesProfileTexture = tex;
+
+            expect(await pollSceneIsReady(scene)).toBe(false);
         });
     });
 });
+

--- a/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
+++ b/packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type Engine } from "core/Engines/engine";
+import { NullEngine } from "core/Engines/nullEngine";
+import { SpotLight } from "core/Lights/spotLight";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Texture } from "core/Materials/Textures/texture";
+import { Vector3 } from "core/Maths/math.vector";
+import { CreateBox } from "core/Meshes/Builders/boxBuilder";
+import { Scene } from "core/scene";
+
+// Pre-load shader modules that StandardMaterial dynamically imports during
+// effect creation. Without these, the fire-and-forget import() may still be
+// resolving when the test environment tears down, causing EnvironmentTeardownError.
+import "core/Shaders/default.fragment";
+import "core/Shaders/default.vertex";
+
+describe("SpotLight", () => {
+    let engine: Engine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    describe("projectionTexture readiness", () => {
+        // Regression test for https://github.com/BabylonJS/Babylon.js/pull/18255 — a
+        // material lit by a SpotLight whose projectionTexture is not ready must cause
+        // scene.isReady() (and therefore scene.executeWhenReady) to wait.
+        it("scene.isReady() must not return true while a spot light's projection texture is not ready", async () => {
+            const mesh = CreateBox("mesh", {}, scene);
+            mesh.material = new StandardMaterial("mat", scene);
+            const light = new SpotLight("spot", new Vector3(0, 5, 0), new Vector3(0, -1, 0), Math.PI / 4, 2, scene);
+
+            const tex = new Texture(null, scene);
+            vi.spyOn(tex, "isReady").mockReturnValue(false);
+            light.projectionTexture = tex;
+
+            // Poll scene.isReady(), yielding between polls so that async shader compiles
+            // in NullEngine can settle. Without the fix, the material compiles without a
+            // projection define and scene.isReady() flips to true despite the projection
+            // texture reporting not-ready. With the fix, scene.isReady() stays false.
+            let becameReady = false;
+            for (let i = 0; i < 20; i++) {
+                if (scene.isReady()) {
+                    becameReady = true;
+                    break;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            }
+            expect(becameReady).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
# Regression tests for light texture readiness (expected-to-fail against master)

[Created by Copilot on behalf of @bghgary]

This is a **test-only** PR demonstrating, against `master`, the bug that #18255 fixes. **CI failure on this PR is expected.**

## What it tests

`packages/dev/core/test/unit/Lights/babylon.spotLight.test.ts` — three tests under `describe("light texture readiness")`:

1. **Generic `Light.areLightTexturesReady` contract**
   `scene.isReady()` must not return true while any light reports its textures are not ready. Uses a monkey-patched `light.areLightTexturesReady = () => false` to exercise the base contract regardless of which light subclass is in use — guards future light types that gain their own textures.

2. **`SpotLight.projectionTexture` readiness**
   `scene.isReady()` must not return true while a SpotLight's `projectionTexture` is still loading. This is the original bug: playground visual tests rendered frames before the projection effect was applied, producing intermittent visual regressions.

3. **`SpotLight.iesProfileTexture` readiness**
   Same as (2) but for `iesProfileTexture` — the other texture the SpotLight override gates on.

Each test uses `NullEngine` + `StandardMaterial` with a `Texture` whose `isReady` is pinned to `false` via `vi.spyOn`, then polls `scene.isReady()` across microtask yields so NullEngine's async shader compile can settle.

## Expected CI behavior

On `master`, all three tests fail: nothing in the material readiness path consults light-texture readiness, so the material reports ready while the texture is still loading, `scene.isReady()` returns `true`, and the assertions trip. On #18255's branch, readiness is gated on `light.areLightTexturesReady()`, `scene.isReady()` stays `false`, and the assertions pass.

## Why a separate PR?

To demonstrate the test and the fix independently. This PR proves the tests are real regression indicators; #18255 includes the same tests alongside the fix to demonstrate they become green.

**Do not merge.**
