### PR TITLE
Inspector CLI: Require explicit session ID and rename autoStart to autoEnable

### DIFF
--- a/packages/dev/inspector-v2/src/cli/cli.ts
+++ b/packages/dev/inspector-v2/src/cli/cli.ts
@@ -45,6 +45,12 @@ EXAMPLES
   babylon-inspector --command query-mesh --help
   babylon-inspector --command query-mesh --uniqueId 42
   babylon-inspector --session 2 --command query-mesh --uniqueId 42
+
+ADDITIONAL RESOURCES
+  Babylon.js Documentation:  https://doc.babylonjs.com
+  Babylon.js Forum:          https://forum.babylonjs.com
+  Babylon.js Source:         https://github.com/babylonjs/Babylon.js
+  Babylon Native Source:     https://github.com/babylonjs/BabylonNative
 `;
 
 const KnownOptions = new Set(["help", "stop", "session", "command", "bridge-script"]);

--- a/packages/dev/inspector-v2/src/cli/cli.ts
+++ b/packages/dev/inspector-v2/src/cli/cli.ts
@@ -23,14 +23,13 @@ const HELP_TEXT = `babylon-inspector — Interact with running Babylon.js scenes
 
 USAGE
   babylon-inspector [options]
-  babylon-inspector --command <command-id> [--arg value ...]
+  babylon-inspector --session <session-id> --command <command-id> [--arg value ...]
 
 OPTIONS
   --help                   Show this help message.
-  --session [session-id]   List active sessions, or specifies the target session.
-                           A session id is only needed when multiple sessions
-                           are active.
+  --session [session-id]   List active sessions, or specify the target session.
   --command [command-id]   List available commands, or execute one.
+                           Requires --session <session-id>.
                            Use --command <id> --help to see its arguments.
   --stop                   Stop the bridge process.
 
@@ -40,10 +39,8 @@ CONFIGURATION
 
 EXAMPLES
   babylon-inspector --session
-  babylon-inspector --command
   babylon-inspector --session 2 --command
-  babylon-inspector --command query-mesh --help
-  babylon-inspector --command query-mesh --uniqueId 42
+  babylon-inspector --session 2 --command query-mesh --help
   babylon-inspector --session 2 --command query-mesh --uniqueId 42
 
 ADDITIONAL RESOURCES
@@ -264,28 +261,20 @@ export function ValidateSessionId(explicitId: string, sessions: SessionInfo[]): 
 }
 
 /**
- * Resolves the session id to use. If an explicit id is provided, validates it
- * against the active sessions. If not, queries the bridge: returns the sole
- * session's id when exactly one is active, or errors if zero or multiple.
+ * Resolves and validates the session id. Requires an explicit session id
+ * provided via `--session <id>`. Throws if the id is missing, non-numeric,
+ * or does not match an active session.
  * @param socket The WebSocket connection to the bridge.
- * @param explicitId An optional explicit session id string.
- * @returns The resolved numeric session id.
+ * @param explicitId The session id string from --session.
+ * @returns The validated numeric session id.
  */
-export async function ResolveSessionId(socket: WebSocket, explicitId?: string): Promise<number> {
+export async function ResolveSessionId(socket: WebSocket, explicitId: string | undefined): Promise<number> {
+    if (explicitId === undefined) {
+        throw new Error("A session id is required. Use --session to list active sessions, then pass --session <id>.");
+    }
+
     const response = await SendAndReceive<SessionsResponse>(socket, { type: "sessions" });
-
-    if (explicitId !== undefined) {
-        return ValidateSessionId(explicitId, response.sessions).id;
-    }
-
-    if (response.sessions.length === 0) {
-        throw new Error("No active sessions. Make sure a browser is running with StartInspectable enabled.");
-    }
-    if (response.sessions.length > 1) {
-        const list = response.sessions.map((s) => `  [${s.id}] ${s.name}`).join("\n");
-        throw new Error(`Multiple active sessions:\n${list}\nSpecify a session id with --session <session-id>`);
-    }
-    return response.sessions[0].id;
+    return ValidateSessionId(explicitId, response.sessions).id;
 }
 
 /**

--- a/packages/dev/inspector-v2/src/cli/cli.ts
+++ b/packages/dev/inspector-v2/src/cli/cli.ts
@@ -231,14 +231,6 @@ async function WithBridge(bridgeScript: string | undefined, fn: (socket: WebSock
 }
 
 /**
- * Resolves the session id to use. If an explicit id is provided, returns it.
- * If not, queries the bridge: returns the sole session's id when exactly one
- * is active, or errors if zero or multiple sessions are active.
- * @param socket The WebSocket connection to the bridge.
- * @param explicitId An optional explicit session id string.
- * @returns The resolved numeric session id.
- */
-/**
  * Parses and validates an explicit session id string against the list of active sessions.
  * @param explicitId The session id string to validate.
  * @param sessions The list of active sessions from the bridge.

--- a/packages/dev/inspector-v2/src/inspectable.ts
+++ b/packages/dev/inspector-v2/src/inspectable.ts
@@ -1,9 +1,9 @@
 import { type IDisposable, type Nullable } from "core/index";
 import { Observable } from "core/Misc/observable";
 import { type Scene } from "core/scene";
-import { type WeaklyTypedServiceDefinition, ServiceContainer } from "shared-ui-components/modularTool/modularity/serviceContainer";
+import { ServiceContainer } from "shared-ui-components/modularTool/modularity/serviceContainer";
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
-import { type ModularBridgeToken, MakeModularBridge } from "shared-ui-components/modularTool/modularBridge";
+import { type ModularBridgeOptions, type ModularBridgeToken, MakeModularBridge } from "shared-ui-components/modularTool/modularBridge";
 import { EntityQueryServiceDefinition } from "./services/cli/entityQueryService";
 import { PerfTraceCommandServiceDefinition } from "./services/cli/perfTraceCommandService";
 import { ScreenshotCommandServiceDefinition } from "./services/cli/screenshotCommandService";
@@ -16,15 +16,8 @@ const DefaultPort = 4400;
 /**
  * Options for making a scene inspectable via the Inspector CLI.
  */
-export type InspectableOptions = {
-    /**
-     * Additional service definitions to register with the inspectable container.
-     * These are added in a separate call from the built-in services and are removed
-     * when the returned token is disposed.
-     */
-    serviceDefinitions?: readonly WeaklyTypedServiceDefinition[];
-} & (
-    | {
+export type InspectableOptions =
+    | (Pick<ModularBridgeOptions, "serviceDefinitions"> & {
           /**
            * An existing modular bridge token whose ServiceContainer will be used as
            * the parent for the inspectable container. The bridge already exists
@@ -34,25 +27,11 @@ export type InspectableOptions = {
           bridgeToken: ModularBridgeToken;
           port?: never;
           name?: never;
-          autoStart?: never;
-      }
-    | {
+          autoEnable?: never;
+      })
+    | (ModularBridgeOptions & {
           bridgeToken?: never;
-          /**
-           * WebSocket port for the bridge's browser port. Defaults to 4400.
-           */
-          port?: number;
-          /**
-           * Session display name reported to the bridge. Defaults to `document.title`.
-           */
-          name?: string;
-          /**
-           * Whether the CLI bridge should automatically start trying to connect
-           * when the inspectable session is created. Defaults to false.
-           */
-          autoStart?: boolean;
-      }
-);
+      });
 
 /**
  * A token returned by {@link StartInspectable} that can be disposed to disconnect
@@ -107,7 +86,7 @@ export function _StartInspectable(scene: Scene, options?: Partial<InspectableOpt
             bridgeToken = MakeModularBridge({
                 port: options?.port ?? DefaultPort,
                 name: options?.name,
-                autoStart: options?.autoStart,
+                autoEnable: options?.autoEnable,
             });
             disposeActions.push(() => bridgeToken.dispose());
         }

--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -239,7 +239,7 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
         // Ensure the inspectable bridge is running for this scene. The inspector's
         // ServiceContainer will use the inspectable container as a parent, inheriting
         // services like ISceneContext and IBridgeCommandRegistry.
-        const inspectableToken = _StartInspectable(scene);
+        const inspectableToken = _StartInspectable(scene, { autoEnable: false });
         disposeActions.push(() => inspectableToken.dispose());
 
         // Create a container element for the inspector UI.

--- a/packages/dev/inspector-v2/test/unit/cli/cli.test.ts
+++ b/packages/dev/inspector-v2/test/unit/cli/cli.test.ts
@@ -279,32 +279,8 @@ describe("ResolveSessionId", () => {
         await expect(ResolveSessionId(socket as never, "2")).rejects.toThrow(/Session 2 does not exist.*No active sessions/);
     });
 
-    it("auto-resolves when exactly one session is active", async () => {
-        const response: SessionsResponse = {
-            type: "sessionsResponse",
-            sessions: [{ id: 7, name: "My Scene", connectedAt: new Date().toISOString() }],
-        };
-        const socket = makeMockSocket(response);
-        const id = await ResolveSessionId(socket as never);
-        expect(id).toBe(7);
-    });
-
-    it("throws when no sessions are active", async () => {
-        const response: SessionsResponse = { type: "sessionsResponse", sessions: [] };
-        const socket = makeMockSocket(response);
-        await expect(ResolveSessionId(socket as never)).rejects.toThrow("No active sessions");
-    });
-
-    it("throws when multiple sessions are active", async () => {
-        const response: SessionsResponse = {
-            type: "sessionsResponse",
-            sessions: [
-                { id: 1, name: "Scene A", connectedAt: new Date().toISOString() },
-                { id: 2, name: "Scene B", connectedAt: new Date().toISOString() },
-            ],
-        };
-        const socket = makeMockSocket(response);
-        await expect(ResolveSessionId(socket as never)).rejects.toThrow("Multiple active sessions");
+    it("throws when no explicit session id is provided", async () => {
+        await expect(ResolveSessionId({} as never, undefined)).rejects.toThrow("A session id is required");
     });
 });
 

--- a/packages/dev/sharedUiComponents/src/modularTool/modularBridge.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/modularBridge.ts
@@ -21,10 +21,10 @@ export type ModularBridgeOptions = {
     name?: string;
 
     /**
-     * Whether the bridge should automatically start trying to connect.
-     * Defaults to false.
+     * Whether the bridge should automatically enable trying to connect.
+     * Defaults to true.
      */
-    autoStart?: boolean;
+    autoEnable?: boolean;
 
     /**
      * Additional service definitions to register with the bridge container.
@@ -68,7 +68,7 @@ export function MakeModularBridge(options?: ModularBridgeOptions): ModularBridge
         get name() {
             return options?.name ?? (typeof document !== "undefined" ? document.title : "Babylon.js Scene");
         },
-        autoStart: options?.autoStart ?? false,
+        autoEnable: options?.autoEnable ?? true,
     });
 
     const allDefinitions: WeaklyTypedServiceDefinition[] = [bridgeDefinition];

--- a/packages/dev/sharedUiComponents/src/modularTool/services/cli/bridgeService.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/services/cli/bridgeService.ts
@@ -25,9 +25,9 @@ export type BridgeServiceOptions = {
     name: string;
 
     /**
-     * Whether to automatically start connecting when the service is created.
+     * Whether to automatically enable connecting when the service is created.
      */
-    autoStart: boolean;
+    autoEnable: boolean;
 };
 
 /**
@@ -46,7 +46,7 @@ export function MakeBridgeServiceDefinition(options: BridgeServiceOptions): Serv
             let ws: WebSocket | null = null;
             let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
             let disposed = false;
-            let enabled = options.autoStart;
+            let enabled = options.autoEnable;
             let connected = false;
             const onConnectionStatusChanged = new Observable<void>();
 

--- a/packages/dev/sharedUiComponents/test/unit/modularity/bridgeService.test.ts
+++ b/packages/dev/sharedUiComponents/test/unit/modularity/bridgeService.test.ts
@@ -24,24 +24,24 @@ describe("BridgeService", () => {
     });
     describe("service definition", () => {
         it("produces BridgeCommandRegistryIdentity", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 4400, name: "test", autoEnable: false });
             expect(definition.produces).toContain(BridgeCommandRegistryIdentity);
         });
 
         it("produces CliConnectionStatusIdentity", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 4400, name: "test", autoEnable: false });
             expect(definition.produces).toContain(CliConnectionStatusIdentity);
         });
 
         it("has a friendly name", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 4400, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 4400, name: "test", autoEnable: false });
             expect(definition.friendlyName).toBe("CLI Bridge Service");
         });
     });
 
     describe("command registry", () => {
         it("can register and unregister a command", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: false });
             const registry = definition.factory();
 
             const disposal = registry.addCommand({
@@ -58,7 +58,7 @@ describe("BridgeService", () => {
         });
 
         it("throws when registering a duplicate command id", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: false });
             const registry = definition.factory();
 
             registry.addCommand({
@@ -79,7 +79,7 @@ describe("BridgeService", () => {
         });
 
         it("allows re-registration after disposal", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: false });
             const registry = definition.factory();
 
             const token = registry.addCommand({
@@ -104,7 +104,7 @@ describe("BridgeService", () => {
 
     describe("connection status", () => {
         it("starts disabled and disconnected", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: false });
             const registry = definition.factory();
 
             expect(registry.isEnabled).toBe(false);
@@ -113,8 +113,8 @@ describe("BridgeService", () => {
             registry.dispose?.();
         });
 
-        it("starts enabled when autoStart is true", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: true });
+        it("starts enabled when autoEnable is true", () => {
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: true });
             const registry = definition.factory();
 
             expect(registry.isEnabled).toBe(true);
@@ -123,7 +123,7 @@ describe("BridgeService", () => {
         });
 
         it("exposes onConnectionStatusChanged observable", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: false });
             const registry = definition.factory();
 
             expect(registry.onConnectionStatusChanged).toBeDefined();
@@ -133,7 +133,7 @@ describe("BridgeService", () => {
         });
 
         it("notifies when isEnabled changes", () => {
-            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoStart: false });
+            const definition = MakeBridgeServiceDefinition({ port: 0, name: "test", autoEnable: false });
             const registry = definition.factory();
 
             let notified = false;

--- a/packages/public/@babylonjs/inspector-v2/readme.md
+++ b/packages/public/@babylonjs/inspector-v2/readme.md
@@ -46,5 +46,5 @@ While the Inspector UI is designed for humans, the Inspector CLI is designed for
 To get started:
 
 ```bash
-npx babylon-inspector --help
+npx @babylonjs/inspector --help
 ```

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -134,6 +134,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         const inspectorV2Module: InspectorV2Module | undefined = (globalThis as any).INSPECTOR;
         if (inspectorV2Module?.MakeModularBridge) {
             this._bridgeToken = inspectorV2Module.MakeModularBridge({
+                autoEnable: false,
                 serviceDefinitions: [MakePlaygroundCommandServiceDefinition(this.props.globalState, inspectorV2Module)],
             });
         }

--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -134,7 +134,7 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         const inspectorV2Module: InspectorV2Module | undefined = (globalThis as any).INSPECTOR;
         if (inspectorV2Module?.MakeModularBridge) {
             this._bridgeToken = inspectorV2Module.MakeModularBridge({
-                autoEnable: false,
+                autoEnable: location.search.includes("inspectable"),
                 serviceDefinitions: [MakePlaygroundCommandServiceDefinition(this.props.globalState, inspectorV2Module)],
             });
         }


### PR DESCRIPTION
> :robot: *This PR was created by the create-pr skill.*

## Summary

Follow-up fixes for the Inspector CLI and modular bridge infrastructure.

### Always require `--session <id>` for CLI commands

Previously, `ResolveSessionId` would auto-resolve the session when exactly one was active. This caused errors when an agent was working against a single session and a second session connected mid-operation. The session parameter is now always required when running a command, making the CLI behavior deterministic regardless of how many sessions come and go.

### Rename `autoStart` → `autoEnable` and default to `true`

The `autoStart` property on `ModularBridgeOptions` and `BridgeServiceOptions` has been renamed to `autoEnable` to better describe its purpose (it controls whether the bridge is *enabled* for connection, not whether it "starts"). The default has been changed from `false` to `true` so that `StartInspectable` connects automatically without requiring explicit opt-in. The Playground explicitly sets `autoEnable: false` since it manages its own bridge lifecycle.

### Other improvements
- Updated the readme to use the correct `npx @babylonjs/inspector` command
- Added additional resource links (docs, forum, GitHub) to the CLI help output
- Updated and simplified related unit tests