### PR TITLE
Pipeline updates: Node 22.x, Flow Graph Editor CD, BrowserStack variable fix

### DIFF
--- a/.azure-pipelines/VARIABLE-GROUPS.md
+++ b/.azure-pipelines/VARIABLE-GROUPS.md
@@ -47,6 +47,7 @@ These are Azure Front Door endpoint names used in CDN cache purge calls.
 | `CDN_ENDPOINT_NRGE`        | Node Render Graph Editor endpoint |
 | `CDN_ENDPOINT_GUIEDITOR`   | GUI Editor endpoint               |
 | `CDN_ENDPOINT_NPE`         | Node Particle Editor endpoint     |
+| `CDN_ENDPOINT_FGE`         | Flow Graph Editor endpoint        |
 | `CDN_ENDPOINT_DOCS`        | Documentation site endpoint       |
 
 ### CDN Purge Profiles
@@ -60,22 +61,39 @@ Azure Front Door profile names used alongside the endpoints above.
 | `CDN_PROFILE_PLAYGROUND` | Profile for the playground endpoint                     |
 | `CDN_PROFILE_TOOLS`      | Profile for all editor tool and documentation endpoints |
 
+## Variable Group: `BabylonJS-BrowserStack`
+
+BrowserStack credentials shared by pipelines that run browser tests.
+
+| Variable                  | Description             |
+| ------------------------- | ----------------------- |
+| `BROWSERSTACK_ACCESS_KEY` | BrowserStack access key |
+| `BROWSERSTACK_USERNAME`   | BrowserStack username   |
+
+Linked by: ci-monorepo, ci-browser-testing.
+
+## Variable Group: `BabylonJS-Deployment`
+
+Deployment server credentials shared by pipelines that upload snapshots or
+deploy tools.
+
+| Variable            | Description                           |
+| ------------------- | ------------------------------------- |
+| `BASIC_AUTH`        | Deployment server authorization token |
+| `DEPLOYMENT_SERVER` | Deployment server base URL            |
+
+Linked by: ci-monorepo, ci-playground-sandbox, ci-graph-tools, cd-publish, cd-tools.
+
 ### Secret Variables (per-pipeline)
 
 These must be configured as **secret variables** on each pipeline (not in the
 variable group) because they contain credentials:
 
-| Variable                  | Used By                                                                  | Description                                                   |
-| ------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| `BASIC_AUTH`              | ci-monorepo, ci-playground-sandbox, ci-graph-tools, cd-publish, cd-tools | Deployment server authorization token                         |
-| `DEPLOYMENT_SERVER`       | ci-monorepo, ci-playground-sandbox, ci-graph-tools, cd-publish, cd-tools | Deployment server base URL                                    |
-| `BROWSERSTACK_ACCESS_KEY` | ci-monorepo                                                              | BrowserStack access key                                       |
-| `BROWSERSTACK_USERNAME`   | ci-monorepo                                                              | BrowserStack username                                         |
-| `ACCESS_KEY`              | ci-browser-testing                                                       | BrowserStack access key (alternate name)                      |
-| `USERNAME`                | ci-browser-testing                                                       | BrowserStack username (alternate name)                        |
-| `GitHubPAT`               | cd-publish                                                               | GitHub Personal Access Token for git push and version scripts |
-| `NPM_TOKEN`               | cd-publish                                                               | npm registry auth token for publishing                        |
-| `SEARCH_KEY`              | ci-documentation                                                         | Search API key for documentation builds                       |
+| Variable     | Used By          | Description                                                   |
+| ------------ | ---------------- | ------------------------------------------------------------- |
+| `GitHubPAT`  | cd-publish       | GitHub Personal Access Token for git push and version scripts |
+| `NPM_TOKEN`  | cd-publish       | npm registry auth token for publishing                        |
+| `SEARCH_KEY` | ci-documentation | Search API key for documentation builds                       |
 
 ### Manual YAML Configuration
 

--- a/.azure-pipelines/cd-publish.yml
+++ b/.azure-pipelines/cd-publish.yml
@@ -26,6 +26,7 @@ pr: none
 
 variables:
     - group: BabylonJS-CI-Infrastructure
+    - group: BabylonJS-Deployment
 
 pool:
     vmImage: ubuntu-latest
@@ -39,10 +40,10 @@ jobs:
             fetchDepth: 0
             fetchTags: true
 
-          - task: NodeTool@0
-            displayName: "Use Node 20.x"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "20.x"
+                versionSpec: "22.x"
 
           - bash: |
                 git config --global user.email "$(BOT_EMAIL)"

--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -40,6 +40,7 @@ resources:
 
 variables:
     - group: BabylonJS-CI-Infrastructure
+    - group: BabylonJS-Deployment
 
 pool:
     vmImage: ubuntu-latest
@@ -53,10 +54,10 @@ jobs:
             fetchDepth: 1
             fetchTags: true
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "npm install"
@@ -126,6 +127,12 @@ jobs:
                 command: custom
                 customCommand: "run build:deployment -w @tools/node-particle-editor"
 
+          - task: Npm@1
+            displayName: "build flow graph editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/flow-graph-editor"
+
           # DISABLED in classic pipeline:
           # - task: Npm@1
           #   displayName: 'build smart filters editor'
@@ -194,6 +201,15 @@ jobs:
                 storageAccount: "$(TOOLS_STORAGE_ACCOUNT)"
                 displayName: "NPE deployment"
                 purgeEndpoint: "$(CDN_ENDPOINT_NPE)"
+                purgeProfile: "$(CDN_PROFILE_TOOLS)"
+
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/flowGraphEditor"
+                deployPath: "flowGraphEditor"
+                storageAccount: "$(TOOLS_STORAGE_ACCOUNT)"
+                displayName: "FGE deployment"
+                purgeEndpoint: "$(CDN_ENDPOINT_FGE)"
                 purgeProfile: "$(CDN_PROFILE_TOOLS)"
 
           # DISABLED in classic pipeline:

--- a/.azure-pipelines/ci-browser-testing.yml
+++ b/.azure-pipelines/ci-browser-testing.yml
@@ -8,8 +8,8 @@
 # Schedule: 1:00 AM PST daily (09:00 UTC)
 #
 # Secret variables (configure in pipeline UI):
-#   - ACCESS_KEY (BrowserStack)
-#   - USERNAME (BrowserStack)
+#   - BROWSERSTACK_ACCESS_KEY
+#   - BROWSERSTACK_USERNAME
 # =============================================================================
 
 trigger: none
@@ -25,7 +25,9 @@ schedules:
       always: false
 
 variables:
-    system.debug: false
+    - group: BabylonJS-BrowserStack
+    - name: system.debug
+      value: false
 
 pool:
     vmImage: ubuntu-latest
@@ -41,10 +43,10 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - script: npm install
             displayName: "NPM install"
@@ -59,8 +61,8 @@ jobs:
                 CI: "true"
                 BROWSER: "BrowserStack"
                 TIMEOUT: "20000"
-                BROWSERSTACK_USERNAME: $(USERNAME)
-                BROWSERSTACK_ACCESS_KEY: $(ACCESS_KEY)
+                BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
                 BROWSERSTACK_BROWSER: "playwright-webkit@latest:OSX Sonoma"
                 EXCLUDE_REGEX_ARRAY: "Picking Visual Test,GUI Input Test,Export GLTF Extension KHR_texture_transform,PBR refraction,Procedural textures playground,GLTF Serializer Morph Target Animation,GLTF Serializer KHR materials clearcoat,Motion Blur"
                 SCREENSHOT_MAX_PIXEL: "6"
@@ -82,10 +84,10 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - script: npm install
             displayName: "NPM install"
@@ -100,8 +102,8 @@ jobs:
                 CI: "true"
                 BROWSER: "BrowserStack"
                 TIMEOUT: "20000"
-                BROWSERSTACK_USERNAME: $(USERNAME)
-                BROWSERSTACK_ACCESS_KEY: $(ACCESS_KEY)
+                BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+                BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
                 BROWSERSTACK_BROWSER: "playwright-firefox@latest:OSX Sonoma"
                 EXCLUDE_REGEX_ARRAY: "Procedural textures playground,Normed 16 bits texture formats"
                 SCREENSHOT_THRESHOLD: "0.05"
@@ -124,10 +126,10 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: JavaToolInstaller@0
             displayName: "Use Java 21"

--- a/.azure-pipelines/ci-graph-tools.yml
+++ b/.azure-pipelines/ci-graph-tools.yml
@@ -29,6 +29,7 @@ pr:
 
 variables:
     - group: BabylonJS-CI-Infrastructure
+    - group: BabylonJS-Deployment
     - name: BuildName
       value: $(Build.SourceBranch)
 
@@ -43,10 +44,10 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "npm install"

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -62,6 +62,8 @@ resources:
 
 variables:
     - group: BabylonJS-CI-Infrastructure
+    - group: BabylonJS-BrowserStack
+    - group: BabylonJS-Deployment
     - name: BuildName
       value: $(Build.SourceBranch)
     - name: BROWSERSTACK_BROWSER
@@ -86,12 +88,12 @@ jobs:
             fetchDepth: 0
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - bash: |
                 git diff --name-status $(git rev-parse origin/master) $(git rev-parse HEAD) | grep -q "what's new.md" && echo "##vso[task.setvariable variable=WhatsNewChanged]true"
@@ -277,12 +279,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - script: npm install
             displayName: "npm install"
@@ -338,12 +340,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.17.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.17.1"
+                versionSpec: "22.x"
 
           - script: npm install
             displayName: "npm install"
@@ -393,12 +395,12 @@ jobs:
             fetchDepth: 0
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - script: npm install
             displayName: "npm install"
@@ -438,12 +440,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "npm install"
@@ -502,12 +504,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - template: templates/check-snapshot-exists.yml
             parameters:
@@ -575,12 +577,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           # ALL REMAINING STEPS DISABLED in classic pipeline:
           # - script: npm install
@@ -645,12 +647,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
+          - task: UseNode@1
             displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - template: templates/check-snapshot-exists.yml
             parameters:
@@ -721,12 +723,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
+          - task: UseNode@1
             displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - template: templates/check-snapshot-exists.yml
             parameters:
@@ -873,12 +875,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - script: npm install
             displayName: "npm install"
@@ -918,12 +920,12 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             continueOnError: true
             retryCountOnTaskFailure: 1
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "npm install"
@@ -966,8 +968,8 @@ jobs:
             displayName: "Placeholder - all steps disabled"
 
           # DISABLED in classic pipeline - full step list:
-          # - task: NodeTool@0
-          #   displayName: 'Use Node 22.4.1'
+          # - task: UseNode@1
+          #   displayName: 'Use Node 22.x'
           #   continueOnError: true
           #   retryCountOnTaskFailure: 1
           #   inputs:

--- a/.azure-pipelines/ci-playground-sandbox.yml
+++ b/.azure-pipelines/ci-playground-sandbox.yml
@@ -28,6 +28,7 @@ pr:
 
 variables:
     - group: BabylonJS-CI-Infrastructure
+    - group: BabylonJS-Deployment
     - name: BuildName
       value: $(Build.SourceBranch)
 
@@ -45,10 +46,10 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "npm install"
@@ -145,10 +146,10 @@ jobs:
             clean: true
             fetchTags: false
 
-          - task: NodeTool@0
-            displayName: "Use Node 22.4.1"
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
             inputs:
-                versionSpec: "22.4.1"
+                versionSpec: "22.x"
 
           - task: Npm@1
             displayName: "npm install"


### PR DESCRIPTION
## Summary

Prepares the YAML pipeline files for the UI → YAML migration.

### Changes

1. **Node 22.x** — Updated all `versionSpec` from pinned versions (`22.4.1`, `22.17.1`, `20.x`) to `22.x` across all pipeline files.

2. **Flow Graph Editor in CD** — Added build and deploy steps for the Flow Graph Editor to `cd-tools.yml`. New variable `CDN_ENDPOINT_FGE` must be added to the variable group.

3. **BrowserStack variable consistency** — `ci-browser-testing.yml` now uses `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` (matching ci-monorepo), instead of the old `USERNAME` / `ACCESS_KEY` names. Also linked the `BabylonJS-BrowserStack` variable group so the pipeline can actually read the values.

### ADO Setup Required

| Where | What |
|-------|------|
| Variable group `BabylonJS-CI-Infrastructure` | Add `CDN_ENDPOINT_FGE` with the Front Door endpoint name |
| Pipeline `ci-browser-testing` | Link `BabylonJS-BrowserStack` variable group; remove old `ACCESS_KEY` / `USERNAME` secret vars if present |