### PR TITLE
Flow Graph Editor: multi-graph editing support

### DIFF
--- a/packages/dev/core/src/FlowGraph/flowGraph.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraph.ts
@@ -15,6 +15,7 @@ import { type IFlowGraphEventTrigger, FlowGraphSceneEventCoordinator } from "./f
 import { type FlowGraphMeshPickEventBlock } from "./Blocks/Event/flowGraphMeshPickEventBlock";
 import { _IsDescendantOf } from "./utils";
 import { type IFlowGraphValidationResult, ValidateFlowGraphWithBlockList } from "./flowGraphValidator";
+import { RandomGUID } from "../Misc/guid";
 
 export const enum FlowGraphState {
     /**
@@ -43,6 +44,16 @@ export interface IFlowGraphParams {
      * The event coordinator used by the flow graph.
      */
     coordinator: FlowGraphCoordinator;
+    /**
+     * Optional human-readable name for the graph.
+     * Defaults to "Graph" if not provided.
+     */
+    name?: string;
+    /**
+     * Optional unique identifier for the graph.
+     * If not provided, a random UUID is generated.
+     */
+    uniqueId?: string;
 }
 
 /**
@@ -75,6 +86,16 @@ export interface IFlowGraphParseOptions {
  * @experimental FlowGraph is still in development and is subject to change.
  */
 export class FlowGraph {
+    /**
+     * A human-readable name for this graph.
+     */
+    public name: string;
+
+    /**
+     * A unique identifier for this graph. Auto-generated if not provided.
+     */
+    public uniqueId: string;
+
     /**
      * An observable that is triggered when the state of the graph changes.
      */
@@ -111,6 +132,13 @@ export class FlowGraph {
         return this._scene;
     }
     private _coordinator: FlowGraphCoordinator;
+
+    /**
+     * The coordinator that owns this flow graph.
+     */
+    public get coordinator(): FlowGraphCoordinator {
+        return this._coordinator;
+    }
     private _executionContexts: FlowGraphContext[] = [];
     private _sceneEventCoordinator: FlowGraphSceneEventCoordinator;
     private _eventObserver: Nullable<Observer<IFlowGraphEventTrigger>>;
@@ -143,6 +171,8 @@ export class FlowGraph {
         this._scene = params.scene;
         this._sceneEventCoordinator = new FlowGraphSceneEventCoordinator(this._scene);
         this._coordinator = params.coordinator;
+        this.name = params.name ?? "Graph";
+        this.uniqueId = params.uniqueId ?? RandomGUID();
     }
 
     private _attachEventObserver() {
@@ -541,6 +571,8 @@ export class FlowGraph {
      * @param valueSerializeFunction a function to serialize complex values
      */
     public serialize(serializationObject: any = {}, valueSerializeFunction?: (key: string, value: any, serializationObject: any) => void) {
+        serializationObject.name = this.name;
+        serializationObject.uniqueId = this.uniqueId;
         serializationObject.allBlocks = [];
         // Collect all blocks: traversal-reachable ones plus any registered
         // orphans in _allBlocks (e.g. disconnected blocks in the editor).

--- a/packages/dev/core/src/FlowGraph/flowGraphCoordinator.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphCoordinator.ts
@@ -118,10 +118,12 @@ export class FlowGraphCoordinator {
 
     /**
      * Creates a new flow graph and adds it to the list of existing flow graphs
+     * @param name - optional name for the new graph. If not provided, an auto-generated name is used.
      * @returns a new flow graph
      */
-    public createGraph(): FlowGraph {
-        const graph = new FlowGraph({ scene: this.config.scene, coordinator: this });
+    public createGraph(name?: string): FlowGraph {
+        const graphName = name ?? `Graph ${this._flowGraphs.length + 1}`;
+        const graph = new FlowGraph({ scene: this.config.scene, coordinator: this, name: graphName });
         this._flowGraphs.push(graph);
         return graph;
     }

--- a/packages/dev/core/src/FlowGraph/flowGraphParser.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphParser.ts
@@ -110,6 +110,13 @@ export async function ParseFlowGraphAsync(serializationObject: ISerializedFlowGr
  */
 export function ParseFlowGraph(serializationObject: ISerializedFlowGraph, options: IFlowGraphParseOptions, resolvedClasses: (typeof FlowGraphBlock)[]) {
     const graph = options.coordinator.createGraph();
+    // Restore graph identity from serialized data
+    if (serializationObject.name) {
+        graph.name = serializationObject.name;
+    }
+    if (serializationObject.uniqueId) {
+        graph.uniqueId = serializationObject.uniqueId;
+    }
     const blocks: FlowGraphBlock[] = [];
     const valueParseFunction = options.valueParseFunction ?? defaultValueParseFunction;
     // Parse all blocks

--- a/packages/dev/core/src/FlowGraph/typeDefinitions.ts
+++ b/packages/dev/core/src/FlowGraph/typeDefinitions.ts
@@ -179,6 +179,14 @@ export interface ISerializedFlowGraphBlock {
  */
 export interface ISerializedFlowGraph {
     /**
+     * Optional human-readable name for the graph
+     */
+    name?: string;
+    /**
+     * Optional unique identifier for the graph
+     */
+    uniqueId?: string;
+    /**
      * Contexts belonging to the flow graph
      */
     executionContexts: ISerializedFlowGraphContext[];

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
@@ -206,6 +206,38 @@ describe("Flow Graph Serialization", () => {
         expect(Logger.Log).toHaveBeenCalledWith(42);
     });
 
+    it("Preserves name and uniqueId across serialize/parse roundtrip", async () => {
+        const coordinator = new FlowGraphCoordinator({ scene });
+        const graph = coordinator.createGraph("My Custom Graph");
+        const originalUniqueId = graph.uniqueId;
+
+        // Verify defaults
+        expect(graph.name).toBe("My Custom Graph");
+        expect(graph.uniqueId).toBeDefined();
+
+        const serialized: any = {};
+        graph.serialize(serialized);
+        expect(serialized.name).toBe("My Custom Graph");
+        expect(serialized.uniqueId).toBe(originalUniqueId);
+
+        // Parse back
+        const coordinator2 = new FlowGraphCoordinator({ scene });
+        const parsed = ParseFlowGraph(serialized, { coordinator: coordinator2 }, []);
+        expect(parsed.name).toBe("My Custom Graph");
+        expect(parsed.uniqueId).toBe(originalUniqueId);
+    });
+
+    it("Uses default name and generates uniqueId when absent in serialized data", () => {
+        const coordinator = new FlowGraphCoordinator({ scene });
+        // Simulate legacy data with no name/uniqueId fields
+        const legacyData: any = { allBlocks: [], executionContexts: [] };
+        const parsed = ParseFlowGraph(legacyData, { coordinator }, []);
+        // Should have a default name and a generated uniqueId
+        expect(parsed.name).toBeDefined();
+        expect(parsed.uniqueId).toBeDefined();
+        expect(parsed.uniqueId.length).toBeGreaterThan(0);
+    });
+
     it("Serializes and parses a graph with vector and mesh references", () => {
         const coordinator = new FlowGraphCoordinator({ scene });
         const graph = coordinator.createGraph();

--- a/packages/tools/flowGraphEditor/src/components/graphTabBar/graphTabBar.scss
+++ b/packages/tools/flowGraphEditor/src/components/graphTabBar/graphTabBar.scss
@@ -1,0 +1,124 @@
+.fge-graph-tab-bar {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background: #1e1e1e;
+    border-bottom: 1px solid #555;
+    flex-shrink: 0;
+    height: 32px;
+    box-sizing: border-box;
+    overflow: hidden;
+
+    .fge-tab-scroll-area {
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        overflow-x: auto;
+        flex: 1;
+        scrollbar-width: none; /* Firefox */
+
+        &::-webkit-scrollbar {
+            display: none; /* Chrome/Safari */
+        }
+    }
+
+    .fge-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 0 12px;
+        height: 32px;
+        background: #2a2a2a;
+        color: #aaa;
+        border: none;
+        border-right: 1px solid #1e1e1e;
+        cursor: pointer;
+        font-size: 12px;
+        white-space: nowrap;
+        flex-shrink: 0;
+        transition:
+            background 0.15s,
+            color 0.15s;
+
+        &:hover {
+            background: #333;
+            color: #ddd;
+        }
+
+        &.fge-tab-active {
+            background: #3a3a3a;
+            color: white;
+            border-bottom: 2px solid #569cd6;
+        }
+
+        .fge-tab-name {
+            pointer-events: none;
+        }
+
+        .fge-tab-name-input {
+            background: #1e1e1e;
+            color: white;
+            border: 1px solid #569cd6;
+            border-radius: 2px;
+            font-size: 12px;
+            padding: 1px 4px;
+            width: 80px;
+            outline: none;
+        }
+
+        .fge-tab-close {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 16px;
+            height: 16px;
+            border: none;
+            background: transparent;
+            color: #888;
+            cursor: pointer;
+            font-size: 12px;
+            border-radius: 2px;
+            padding: 0;
+            line-height: 1;
+            opacity: 0;
+            transition:
+                opacity 0.15s,
+                background 0.15s,
+                color 0.15s;
+
+            &:hover {
+                background: rgba(255, 255, 255, 0.1);
+                color: #fff;
+            }
+        }
+
+        &:hover .fge-tab-close,
+        &.fge-tab-active .fge-tab-close {
+            opacity: 1;
+        }
+    }
+
+    .fge-tab-add {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        background: transparent;
+        color: #888;
+        border: none;
+        cursor: pointer;
+        font-size: 16px;
+        flex-shrink: 0;
+        border-radius: 4px;
+        margin: 0 4px;
+        transition:
+            background 0.15s,
+            color 0.15s;
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.1);
+            color: #ccc;
+        }
+    }
+}

--- a/packages/tools/flowGraphEditor/src/components/graphTabBar/graphTabBarComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/graphTabBar/graphTabBarComponent.tsx
@@ -1,0 +1,161 @@
+import * as React from "react";
+import { type Nullable } from "core/types";
+import { type Observer } from "core/Misc/observable";
+import { type FlowGraph } from "core/FlowGraph/flowGraph";
+import { type GlobalState } from "../../globalState";
+
+import "./graphTabBar.scss";
+
+interface IGraphTabBarProps {
+    globalState: GlobalState;
+}
+
+interface IGraphTabBarState {
+    graphs: Array<{ name: string; uniqueId: string }>;
+    activeIndex: number;
+    editingIndex: number | null;
+    editingName: string;
+}
+
+/**
+ * Tab bar component for switching between multiple flow graphs in the coordinator.
+ */
+export class GraphTabBarComponent extends React.Component<IGraphTabBarProps, IGraphTabBarState> {
+    private _graphListObserver: Nullable<Observer<void>> = null;
+    private _activeGraphObserver: Nullable<Observer<FlowGraph>> = null;
+    private _scrollRef = React.createRef<HTMLDivElement>();
+
+    constructor(props: IGraphTabBarProps) {
+        super(props);
+        this.state = {
+            graphs: this._getGraphList(),
+            activeIndex: props.globalState.activeGraphIndex,
+            editingIndex: null,
+            editingName: "",
+        };
+    }
+
+    private _getGraphList(): Array<{ name: string; uniqueId: string }> {
+        const coordinator = this.props.globalState.coordinator;
+        if (!coordinator) {
+            return [];
+        }
+        return coordinator.flowGraphs.map((g) => ({ name: g.name, uniqueId: g.uniqueId }));
+    }
+
+    override componentDidMount() {
+        this._graphListObserver = this.props.globalState.onGraphListChanged.add(() => {
+            this.setState({ graphs: this._getGraphList() });
+        });
+        this._activeGraphObserver = this.props.globalState.onActiveGraphChanged.add(() => {
+            this.setState({
+                activeIndex: this.props.globalState.activeGraphIndex,
+                graphs: this._getGraphList(),
+            });
+        });
+    }
+
+    override componentWillUnmount() {
+        if (this._graphListObserver) {
+            this.props.globalState.onGraphListChanged.remove(this._graphListObserver);
+        }
+        if (this._activeGraphObserver) {
+            this.props.globalState.onActiveGraphChanged.remove(this._activeGraphObserver);
+        }
+    }
+
+    private _onTabClick(index: number) {
+        if (index === this.state.activeIndex) {
+            return;
+        }
+        this.props.globalState.activeGraphIndex = index;
+    }
+
+    private _onTabDoubleClick(index: number) {
+        const graph = this.state.graphs[index];
+        if (!graph) {
+            return;
+        }
+        this.setState({ editingIndex: index, editingName: graph.name });
+    }
+
+    private _commitRename() {
+        const { editingIndex, editingName } = this.state;
+        if (editingIndex === null) {
+            return;
+        }
+        const trimmed = editingName.trim();
+        if (trimmed) {
+            this.props.globalState.renameGraph(editingIndex, trimmed);
+        }
+        this.setState({ editingIndex: null, editingName: "" });
+    }
+
+    private _onAddGraph() {
+        this.props.globalState.addGraph();
+        this.props.globalState.onResetRequiredObservable.notifyObservers(true);
+        this.props.globalState.onClearUndoStack.notifyObservers();
+    }
+
+    private _onCloseTab(index: number, evt: React.MouseEvent) {
+        evt.stopPropagation();
+        if (this.state.graphs.length <= 1) {
+            return;
+        }
+        this.props.globalState.removeGraph(index);
+        this.props.globalState.onResetRequiredObservable.notifyObservers(true);
+        this.props.globalState.onClearUndoStack.notifyObservers();
+    }
+
+    override render() {
+        const { graphs, activeIndex, editingIndex, editingName } = this.state;
+
+        if (graphs.length === 0) {
+            return null;
+        }
+
+        return (
+            <div className="fge-graph-tab-bar">
+                <div className="fge-tab-scroll-area" ref={this._scrollRef}>
+                    {graphs.map((graph, index) => (
+                        <div
+                            key={graph.uniqueId}
+                            className={`fge-tab${index === activeIndex ? " fge-tab-active" : ""}`}
+                            onClick={() => this._onTabClick(index)}
+                            onDoubleClick={() => this._onTabDoubleClick(index)}
+                            title={graph.name}
+                        >
+                            {editingIndex === index ? (
+                                <input
+                                    className="fge-tab-name-input"
+                                    value={editingName}
+                                    onChange={(e) => this.setState({ editingName: e.target.value })}
+                                    onBlur={() => this._commitRename()}
+                                    onKeyDown={(e) => {
+                                        if (e.key === "Enter") {
+                                            this._commitRename();
+                                        } else if (e.key === "Escape") {
+                                            this.setState({ editingIndex: null, editingName: "" });
+                                        }
+                                    }}
+                                    autoFocus
+                                    onClick={(e) => e.stopPropagation()}
+                                />
+                            ) : (
+                                <span className="fge-tab-name">{graph.name}</span>
+                            )}
+                            {graphs.length > 1 && (
+                                <button className="fge-tab-close" onClick={(evt) => this._onCloseTab(index, evt)} title="Close graph" aria-label={`Close ${graph.name}`}>
+                                    ×
+                                </button>
+                            )}
+                        </div>
+                    ))}
+                </div>
+                <button className="fge-tab-add" onClick={() => this._onAddGraph()} title="Add new graph" aria-label="Add new graph">
+                    +
+                </button>
+            </div>
+        );
+    }
+}

--- a/packages/tools/flowGraphEditor/src/components/graphTabBar/graphTabBarComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/graphTabBar/graphTabBarComponent.tsx
@@ -115,14 +115,32 @@ export class GraphTabBarComponent extends React.Component<IGraphTabBarProps, IGr
         }
 
         return (
-            <div className="fge-graph-tab-bar">
+            <div className="fge-graph-tab-bar" role="tablist">
                 <div className="fge-tab-scroll-area" ref={this._scrollRef}>
                     {graphs.map((graph, index) => (
                         <div
                             key={graph.uniqueId}
                             className={`fge-tab${index === activeIndex ? " fge-tab-active" : ""}`}
+                            role="tab"
+                            tabIndex={index === activeIndex ? 0 : -1}
+                            aria-selected={index === activeIndex}
+                            aria-label={graph.name}
                             onClick={() => this._onTabClick(index)}
                             onDoubleClick={() => this._onTabDoubleClick(index)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                    e.preventDefault();
+                                    this._onTabClick(index);
+                                } else if (e.key === "ArrowRight") {
+                                    e.preventDefault();
+                                    const next = (index + 1) % graphs.length;
+                                    (e.currentTarget.parentElement?.children[next] as HTMLElement)?.focus();
+                                } else if (e.key === "ArrowLeft") {
+                                    e.preventDefault();
+                                    const prev = (index - 1 + graphs.length) % graphs.length;
+                                    (e.currentTarget.parentElement?.children[prev] as HTMLElement)?.focus();
+                                }
+                            }}
                             title={graph.name}
                         >
                             {editingIndex === index ? (

--- a/packages/tools/flowGraphEditor/src/flowGraphEditor.ts
+++ b/packages/tools/flowGraphEditor/src/flowGraphEditor.ts
@@ -62,7 +62,18 @@ export class FlowGraphEditor {
 
         const scene = options.hostScene || options.flowGraph.scene;
         const globalState = new GlobalState(scene);
-        globalState.flowGraph = options.flowGraph;
+        // If the flow graph belongs to a coordinator, use it for multi-graph support.
+        // Otherwise the flowGraph setter will handle single-graph mode.
+        const existingCoordinator = options.flowGraph.coordinator;
+        if (existingCoordinator) {
+            globalState.coordinator = existingCoordinator;
+            const activeIndex = existingCoordinator.flowGraphs.indexOf(options.flowGraph);
+            if (activeIndex >= 0) {
+                globalState.activeGraphIndex = activeIndex;
+            }
+        } else {
+            globalState.flowGraph = options.flowGraph;
+        }
         globalState.hostElement = hostElement;
         globalState.hostDocument = hostElement.ownerDocument!;
         globalState.hostScene = options.hostScene;

--- a/packages/tools/flowGraphEditor/src/globalState.ts
+++ b/packages/tools/flowGraphEditor/src/globalState.ts
@@ -237,11 +237,18 @@ export class GlobalState {
         }
         const graph = graphs[index];
         this._coordinator.removeGraph(graph);
-        // Adjust active index
-        if (this._activeGraphIndex >= graphs.length) {
-            this._activeGraphIndex = graphs.length - 1;
+        // Adjust active index to keep the same graph selected when possible
+        if (index < this._activeGraphIndex) {
+            // Removed a graph before the active one — shift index down
+            this._activeGraphIndex--;
+        } else if (index === this._activeGraphIndex) {
+            // Removed the active graph — select the nearest remaining
+            if (this._activeGraphIndex >= graphs.length) {
+                this._activeGraphIndex = graphs.length - 1;
+            }
+            this._activateGraph(graphs[this._activeGraphIndex]);
         }
-        this._activateGraph(graphs[this._activeGraphIndex]);
+        // If index > _activeGraphIndex, no adjustment needed (active graph unchanged)
         this.onGraphListChanged.notifyObservers();
         return true;
     }
@@ -271,6 +278,9 @@ export class GlobalState {
     private _activateGraph(graph: FlowGraph): void {
         // Let observers (e.g. graphEditor) persist canvas state before the switch
         if (this._flowGraph) {
+            // Snapshot user variables/contexts for the outgoing graph so they
+            // survive the stop() that the flowGraph setter triggers.
+            this._snapshotUserVariablesFrom(this._flowGraph);
             this.onBeforeActiveGraphChanged.notifyObservers(this._flowGraph);
         }
         // Use the existing setter which does all the wiring
@@ -899,6 +909,12 @@ export class GlobalState {
     private _savedContextSnapshots: any[] | null = null;
 
     /**
+     * Per-graph serialized context snapshots, keyed by FlowGraph.uniqueId.
+     * Used to preserve context data for inactive graphs during multi-graph serialization.
+     */
+    private _perGraphContextSnapshots = new Map<string, any[]>();
+
+    /**
      * Runtime (non-serialized) copies of each execution context's data.
      * Unlike _savedContextSnapshots (which holds serialized/JSON-safe values for
      * injecting into saved files), these hold actual runtime objects (Vector3,
@@ -1432,6 +1448,8 @@ export class GlobalState {
                     uniqueId: context.uniqueId,
                 });
             }
+            // Store per-graph snapshots for multi-graph serialization
+            this._perGraphContextSnapshots.set(fg.uniqueId, [...this._savedContextSnapshots!]);
         }
     }
 
@@ -1458,6 +1476,16 @@ export class GlobalState {
      */
     public get savedContextSnapshots(): any[] | null {
         return this._savedContextSnapshots;
+    }
+
+    /**
+     * Returns saved context snapshots for a specific graph by uniqueId.
+     * Used by SerializationTools to inject context data for inactive graphs.
+     * @param graphUniqueId - the uniqueId of the graph
+     * @returns array of serialized context objects, or null if none saved
+     */
+    public getContextSnapshotsForGraph(graphUniqueId: string): any[] | null {
+        return this._perGraphContextSnapshots.get(graphUniqueId) ?? null;
     }
 
     /**

--- a/packages/tools/flowGraphEditor/src/globalState.ts
+++ b/packages/tools/flowGraphEditor/src/globalState.ts
@@ -21,6 +21,7 @@ import { type SceneContext } from "./sceneContext";
 import { FlowGraphInteger } from "core/FlowGraph/CustomTypes/flowGraphInteger";
 import { type IFlowGraphValidationResult, ValidateFlowGraphWithBlockList } from "core/FlowGraph/flowGraphValidator";
 import { type HelpTopicId } from "./components/help/helpContent";
+import { FlowGraphCoordinator } from "core/FlowGraph/flowGraphCoordinator";
 
 /**
  * Class used to hold the global state of the flow graph editor
@@ -143,6 +144,139 @@ export class GlobalState {
 
     /** Optional custom save handler */
     customSave?: { label: string; action: (data: string) => Promise<void> };
+
+    // ── Multi-Graph / Coordinator ──────────────────────────────────────
+    /** The coordinator that owns all graphs in this editor session. */
+    private _coordinator: Nullable<FlowGraphCoordinator> = null;
+
+    /** Index of the currently active (displayed) graph within the coordinator. */
+    private _activeGraphIndex: number = 0;
+
+    /** Observable triggered when the active graph changes (graph switch, add, remove). */
+    onActiveGraphChanged = new Observable<FlowGraph>();
+
+    /** Observable triggered *before* the active graph changes, with the outgoing graph. */
+    onBeforeActiveGraphChanged = new Observable<FlowGraph>();
+
+    /** Observable triggered when the graph list changes (add, remove, rename). */
+    onGraphListChanged = new Observable<void>();
+
+    /**
+     * Gets the coordinator that owns all graphs.
+     */
+    public get coordinator(): Nullable<FlowGraphCoordinator> {
+        return this._coordinator;
+    }
+
+    /**
+     * Sets the coordinator and activates its first graph.
+     * This is the primary entry point when loading a new set of graphs.
+     */
+    public set coordinator(coordinator: Nullable<FlowGraphCoordinator>) {
+        this._coordinator = coordinator;
+        if (coordinator && coordinator.flowGraphs.length > 0) {
+            this._activeGraphIndex = 0;
+            this._activateGraph(coordinator.flowGraphs[0]);
+        }
+    }
+
+    /**
+     * Gets the index of the currently active graph.
+     */
+    public get activeGraphIndex(): number {
+        return this._activeGraphIndex;
+    }
+
+    /**
+     * Sets the active graph index, switching the editor to display that graph.
+     */
+    public set activeGraphIndex(index: number) {
+        if (!this._coordinator) {
+            return;
+        }
+        const graphs = this._coordinator.flowGraphs;
+        if (index < 0 || index >= graphs.length) {
+            return;
+        }
+        if (index === this._activeGraphIndex && this._flowGraph === graphs[index]) {
+            return;
+        }
+        this._activeGraphIndex = index;
+        this._activateGraph(graphs[index]);
+    }
+
+    /**
+     * Adds a new empty graph to the coordinator and switches to it.
+     * @returns the newly created FlowGraph
+     */
+    public addGraph(): FlowGraph {
+        if (!this._coordinator) {
+            this._coordinator = new FlowGraphCoordinator({ scene: this.scene });
+        }
+        const graph = this._coordinator.createGraph();
+        this._activeGraphIndex = this._coordinator.flowGraphs.indexOf(graph);
+        this._activateGraph(graph);
+        this.onGraphListChanged.notifyObservers();
+        return graph;
+    }
+
+    /**
+     * Removes a graph from the coordinator by index.
+     * If the active graph is removed, switches to the nearest remaining graph.
+     * The last graph cannot be removed.
+     * @param index - the index of the graph to remove
+     * @returns true if the graph was removed
+     */
+    public removeGraph(index: number): boolean {
+        if (!this._coordinator) {
+            return false;
+        }
+        const graphs = this._coordinator.flowGraphs;
+        if (graphs.length <= 1 || index < 0 || index >= graphs.length) {
+            return false;
+        }
+        const graph = graphs[index];
+        this._coordinator.removeGraph(graph);
+        // Adjust active index
+        if (this._activeGraphIndex >= graphs.length) {
+            this._activeGraphIndex = graphs.length - 1;
+        }
+        this._activateGraph(graphs[this._activeGraphIndex]);
+        this.onGraphListChanged.notifyObservers();
+        return true;
+    }
+
+    /**
+     * Renames a graph.
+     * @param index - the index of the graph to rename
+     * @param name - the new name
+     */
+    public renameGraph(index: number, name: string): void {
+        if (!this._coordinator) {
+            return;
+        }
+        const graphs = this._coordinator.flowGraphs;
+        if (index < 0 || index >= graphs.length) {
+            return;
+        }
+        graphs[index].name = name;
+        this.onGraphListChanged.notifyObservers();
+    }
+
+    /**
+     * Internal: activate a graph — wire scene context, stop old graph, notify observers.
+     * This contains the same wiring logic that was previously in the `flowGraph` setter.
+     * @param graph - the graph to activate
+     */
+    private _activateGraph(graph: FlowGraph): void {
+        // Let observers (e.g. graphEditor) persist canvas state before the switch
+        if (this._flowGraph) {
+            this.onBeforeActiveGraphChanged.notifyObservers(this._flowGraph);
+        }
+        // Use the existing setter which does all the wiring
+        this.flowGraph = graph;
+        this.onActiveGraphChanged.notifyObservers(graph);
+    }
 
     // ── Validation ─────────────────────────────────────────────────────
     /** Whether live validation is enabled (re-validates on graph changes). */

--- a/packages/tools/flowGraphEditor/src/graphEditor.tsx
+++ b/packages/tools/flowGraphEditor/src/graphEditor.tsx
@@ -71,6 +71,8 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
     private _historyStack: HistoryStack;
     private _helpObserver: Nullable<Observer<any>> = null;
     private _howToUseObserver: Nullable<Observer<void>> = null;
+    private _beforeActiveGraphObserver: Nullable<Observer<any>> = null;
+    private _activeGraphObserver: Nullable<Observer<any>> = null;
     private _blockClassRegistry = new Map<string, typeof FlowGraphBlock>();
     /** Cache for O(1) block→GraphNode lookups (rebuilt on graph load) */
     private _blockToNodeMap = new Map<FlowGraphBlock, GraphNode>();
@@ -308,6 +310,10 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         this._helpObserver = null;
         this._howToUseObserver?.remove();
         this._howToUseObserver = null;
+        this._beforeActiveGraphObserver?.remove();
+        this._beforeActiveGraphObserver = null;
+        this._activeGraphObserver?.remove();
+        this._activeGraphObserver = null;
 
         if (this._historyStack) {
             this._historyStack.dispose();
@@ -375,12 +381,12 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
 
         // Persist canvas state (zoom, pan, node positions) on the outgoing graph
         // so it is restored when the user switches back to that tab.
-        this.props.globalState.onBeforeActiveGraphChanged.add((outgoingGraph) => {
+        this._beforeActiveGraphObserver = this.props.globalState.onBeforeActiveGraphChanged.add((outgoingGraph) => {
             SerializationTools.UpdateLocations(outgoingGraph, this.props.globalState);
         });
 
         // Rebuild the canvas when the active graph changes (multi-graph tab switch)
-        this.props.globalState.onActiveGraphChanged.add(() => {
+        this._activeGraphObserver = this.props.globalState.onActiveGraphChanged.add(() => {
             this.build();
             this.props.globalState.onClearUndoStack.notifyObservers();
         });

--- a/packages/tools/flowGraphEditor/src/graphEditor.tsx
+++ b/packages/tools/flowGraphEditor/src/graphEditor.tsx
@@ -37,6 +37,7 @@ import { ContextMenuComponent, type ContextMenuEntry } from "./components/contex
 import { ToastContainerComponent, ShowToast } from "./components/toast/toastComponent";
 import { HowToUseDialogComponent } from "./components/howToUse/howToUseDialogComponent";
 import { AllCompositeTemplates, type ICompositeTemplate } from "./compositeTemplates";
+import { GraphTabBarComponent } from "./components/graphTabBar/graphTabBarComponent";
 
 /**
  * Pre-populate string (and other primitive) config fields for blocks whose constructors
@@ -197,14 +198,41 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             globalState.stateManager.onSelectionChangedObservable.notifyObservers(null);
             // Resolve block classes synchronously from the session-wide registry
             const resolvedClasses = (data.allBlocks || []).map((b: any) => this._blockClassRegistry.get(b.className)!);
-            // Parse the snapshot into a new FlowGraph synchronously
-            const coordinator = new FlowGraphCoordinator({ scene: globalState.scene });
-            const parsedGraph = ParseFlowGraph(data, { coordinator }, resolvedClasses);
-            SerializationTools.PreserveUnresolvedNames(parsedGraph, data);
-            if (data.editorData) {
-                (parsedGraph as any)._editorData = data.editorData;
+
+            // When we have a coordinator with multiple graphs, replace only the
+            // active graph. Otherwise fall back to creating a throwaway coordinator
+            // (legacy path, also used for single-graph sessions).
+            const existingCoordinator = globalState.coordinator;
+            if (existingCoordinator && existingCoordinator.flowGraphs.length > 0) {
+                const activeIndex = globalState.activeGraphIndex;
+                const oldGraph = existingCoordinator.flowGraphs[activeIndex];
+                if (oldGraph) {
+                    existingCoordinator.removeGraph(oldGraph);
+                }
+                // Parse into the existing coordinator
+                const parsedGraph = ParseFlowGraph(data, { coordinator: existingCoordinator }, resolvedClasses);
+                // Move the parsed graph to the correct position in the coordinator
+                const graphs = existingCoordinator.flowGraphs;
+                const currentIndex = graphs.indexOf(parsedGraph);
+                if (currentIndex !== activeIndex && currentIndex >= 0) {
+                    graphs.splice(currentIndex, 1);
+                    graphs.splice(activeIndex, 0, parsedGraph);
+                }
+                SerializationTools.PreserveUnresolvedNames(parsedGraph, data);
+                if (data.editorData) {
+                    (parsedGraph as any)._editorData = data.editorData;
+                }
+                globalState.flowGraph = parsedGraph;
+            } else {
+                // Fallback: create a throwaway coordinator
+                const coordinator = new FlowGraphCoordinator({ scene: globalState.scene });
+                const parsedGraph = ParseFlowGraph(data, { coordinator }, resolvedClasses);
+                SerializationTools.PreserveUnresolvedNames(parsedGraph, data);
+                if (data.editorData) {
+                    (parsedGraph as any)._editorData = data.editorData;
+                }
+                globalState.flowGraph = parsedGraph;
             }
-            globalState.flowGraph = parsedGraph;
             globalState.onResetRequiredObservable.notifyObservers(false);
         };
 
@@ -343,6 +371,18 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             } else {
                 this.build();
             }
+        });
+
+        // Persist canvas state (zoom, pan, node positions) on the outgoing graph
+        // so it is restored when the user switches back to that tab.
+        this.props.globalState.onBeforeActiveGraphChanged.add((outgoingGraph) => {
+            SerializationTools.UpdateLocations(outgoingGraph, this.props.globalState);
+        });
+
+        // Rebuild the canvas when the active graph changes (multi-graph tab switch)
+        this.props.globalState.onActiveGraphChanged.add(() => {
+            this.build();
+            this.props.globalState.onClearUndoStack.notifyObservers();
         });
 
         this.props.globalState.onImportFrameObservable.add((source: any) => {
@@ -1196,6 +1236,7 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
                         }}
                     >
                         <div className="diagram-canvas-pane" onContextMenu={this._onContextMenu}>
+                            <GraphTabBarComponent globalState={this.props.globalState} />
                             <GraphControlsComponent globalState={this.props.globalState} />
                             <VariablesPanelComponent globalState={this.props.globalState} />
                             <GraphCanvasComponent

--- a/packages/tools/flowGraphEditor/src/serializationTools.ts
+++ b/packages/tools/flowGraphEditor/src/serializationTools.ts
@@ -95,9 +95,16 @@ export class SerializationTools {
             const serializationObject: any = {};
             graph.serialize(serializationObject);
 
-            // For the active graph, inject saved context snapshots when stopped
+            // Inject saved context snapshots when the graph is stopped
             if (graph === flowGraph) {
+                // Active graph — use the current snapshots
                 SerializationTools.InjectSavedContexts(serializationObject, globalState);
+            } else {
+                // Inactive graph — use per-graph saved snapshots
+                const graphSnapshots = globalState.getContextSnapshotsForGraph(graph.uniqueId);
+                if ((!serializationObject.executionContexts || serializationObject.executionContexts.length === 0) && graphSnapshots && graphSnapshots.length > 0) {
+                    serializationObject.executionContexts = graphSnapshots;
+                }
             }
 
             // Include editor layout data (block positions, frames, zoom)
@@ -153,22 +160,23 @@ export class SerializationTools {
                 topLevelFlowGraphSnippetId = serializationObject.flowGraphSnippetId;
             }
 
-            // Parse all graphs in parallel
-            const parsedGraphs = await Promise.all(
-                graphDataList.map(async (graphData) => {
-                    const parsedGraph = await ParseFlowGraphAsync(graphData, { coordinator, pathConverter });
+            // Parse graphs sequentially to preserve tab order (coordinator.flowGraphs
+            // array order must match _flowGraphs serialization order).
+            const parsedGraphs: FlowGraph[] = [];
+            for (const graphData of graphDataList) {
+                // eslint-disable-next-line no-await-in-loop -- sequential order is intentional
+                const parsedGraph = await ParseFlowGraphAsync(graphData, { coordinator, pathConverter });
 
-                    SerializationTools.PreserveUnresolvedNames(parsedGraph, graphData);
-                    SerializationTools.PreserveUnresolvedVariables(parsedGraph, graphData);
-                    SerializationTools.SyncConnectionValuesToDefaults(parsedGraph);
+                SerializationTools.PreserveUnresolvedNames(parsedGraph, graphData);
+                SerializationTools.PreserveUnresolvedVariables(parsedGraph, graphData);
+                SerializationTools.SyncConnectionValuesToDefaults(parsedGraph);
 
-                    if ((graphData as any).editorData) {
-                        (parsedGraph as any)._editorData = (graphData as any).editorData;
-                    }
+                if ((graphData as any).editorData) {
+                    (parsedGraph as any)._editorData = (graphData as any).editorData;
+                }
 
-                    return parsedGraph;
-                })
-            );
+                parsedGraphs.push(parsedGraph);
+            }
 
             // Clamp active index to valid range
             if (activeIndex < 0 || activeIndex >= parsedGraphs.length) {
@@ -176,9 +184,7 @@ export class SerializationTools {
             }
 
             // Set the coordinator and active graph on globalState
-            // eslint-disable-next-line require-atomic-updates
             globalState.coordinator = coordinator;
-            // eslint-disable-next-line require-atomic-updates
             globalState.activeGraphIndex = activeIndex;
 
             // Restore the scene snippet ID so the preview component can auto-load the scene
@@ -190,7 +196,6 @@ export class SerializationTools {
 
             // Restore the flow graph snippet ID
             if (topLevelFlowGraphSnippetId) {
-                // eslint-disable-next-line require-atomic-updates
                 globalState.flowGraphSnippetId = topLevelFlowGraphSnippetId;
             }
         } finally {

--- a/packages/tools/flowGraphEditor/src/serializationTools.ts
+++ b/packages/tools/flowGraphEditor/src/serializationTools.ts
@@ -7,6 +7,7 @@ import { FlowGraphCoordinator } from "core/FlowGraph/flowGraphCoordinator";
 import { ParseFlowGraphAsync } from "core/FlowGraph/flowGraphParser";
 import { type Scene } from "core/scene";
 import { Logger } from "core/Misc/logger";
+import { type ISerializedFlowGraph } from "core/FlowGraph/typeDefinitions";
 
 /**
  * Provides serialization and deserialization utilities for the flow graph editor.
@@ -65,11 +66,13 @@ export class SerializationTools {
     }
 
     /**
-     * Serialize the flow graph to a JSON string.
-     * @param flowGraph - the flow graph to serialize
+     * Serialize all graphs in the coordinator to a JSON string.
+     * Produces the coordinator-level format: `{ _flowGraphs: [...], activeGraphIndex, ... }`.
+     * Falls back to serializing the single active graph if no coordinator is set.
+     * @param flowGraph - the currently active flow graph (used for single-graph fallback and UpdateLocations)
      * @param globalState - the editor's global state
      * @param frame - optional graph frame to restrict to
-     * @returns a JSON string representing the serialized graph
+     * @returns a JSON string representing the serialized coordinator
      */
     public static Serialize(flowGraph: FlowGraph, globalState: GlobalState, frame?: Nullable<GraphFrame>) {
         this.UpdateLocations(flowGraph, globalState, frame);
@@ -80,35 +83,46 @@ export class SerializationTools {
         // the user clicks Save.
         globalState.snapshotUserVariables();
 
-        const serializationObject: any = {};
-        flowGraph.serialize(serializationObject);
+        const coordinator = globalState.coordinator;
+        const graphs = coordinator ? coordinator.flowGraphs : [flowGraph];
 
-        // When the graph is stopped, _executionContexts is empty so
-        // flowGraph.serialize() produces executionContexts: [].  Inject the
-        // editor's saved context snapshots to preserve user variables,
-        // variable type annotations, and connection values.
-        SerializationTools.InjectSavedContexts(serializationObject, globalState);
+        const coordinatorObject: any = {
+            _flowGraphs: [] as any[],
+            activeGraphIndex: globalState.activeGraphIndex,
+        };
 
-        // Include editor layout data (block positions, frames, zoom) so the
-        // graph looks the same when loaded back
-        serializationObject.editorData = (flowGraph as any)._editorData;
+        for (const graph of graphs) {
+            const serializationObject: any = {};
+            graph.serialize(serializationObject);
+
+            // For the active graph, inject saved context snapshots when stopped
+            if (graph === flowGraph) {
+                SerializationTools.InjectSavedContexts(serializationObject, globalState);
+            }
+
+            // Include editor layout data (block positions, frames, zoom)
+            serializationObject.editorData = (graph as any)._editorData;
+
+            coordinatorObject._flowGraphs.push(serializationObject);
+        }
 
         // Persist the scene snippet ID so loading the graph can also restore the scene context
         if (globalState.snippetId) {
-            serializationObject.sceneSnippetId = globalState.snippetId;
+            coordinatorObject.sceneSnippetId = globalState.snippetId;
         }
 
         // Persist the flow graph snippet ID so it survives round-trips
         if (globalState.flowGraphSnippetId) {
-            serializationObject.flowGraphSnippetId = globalState.flowGraphSnippetId;
+            coordinatorObject.flowGraphSnippetId = globalState.flowGraphSnippetId;
         }
 
-        return JSON.stringify(serializationObject, undefined, 2);
+        return JSON.stringify(coordinatorObject, undefined, 2);
     }
 
     /**
-     * Deserialize a flow graph from a serialization object.
-     * Creates a new FlowGraph from the serialized data and sets it on the global state.
+     * Deserialize flow graphs from a serialization object.
+     * Supports both coordinator-level format (`{ _flowGraphs: [...] }`) and
+     * legacy single-graph format (`{ allBlocks: [...], executionContexts: [...] }`).
      * @param serializationObject - the serialized data to load
      * @param globalState - the editor's global state
      * @param scene - optional scene to use instead of globalState.scene
@@ -119,46 +133,65 @@ export class SerializationTools {
         try {
             const targetScene = scene ?? globalState.scene;
             const coordinator = new FlowGraphCoordinator({ scene: targetScene });
-            const parsedGraph = await ParseFlowGraphAsync(serializationObject, { coordinator, pathConverter });
 
-            // The graph was parsed against the editor's host scene which may not
-            // contain scene objects (meshes, animation groups, animations) that
-            // only exist in the preview scene loaded from a snippet.  Stash the
-            // serialized names so _rebind*Reference can find them later.
-            SerializationTools.PreserveUnresolvedNames(parsedGraph, serializationObject);
+            // Detect format: coordinator-level vs legacy single-graph
+            let graphDataList: ISerializedFlowGraph[];
+            let activeIndex = 0;
+            let topLevelSnippetId: string | undefined;
+            let topLevelFlowGraphSnippetId: string | undefined;
 
-            // Patch unresolved user-variable descriptors back onto parsed
-            // contexts.  When parsing runs against the editor's host scene
-            // (which has no meshes), Mesh/Light/Camera references resolve to
-            // undefined.  Restore the original {id, name, className} descriptor
-            // so _rebindContextUserVariables can resolve them later against the
-            // preview scene.
-            SerializationTools.PreserveUnresolvedVariables(parsedGraph, serializationObject);
-
-            // Sync context connection values into _defaultValue for unconnected
-            // inputs so the editor UI shows the correct value (e.g. "2" instead
-            // of "0" for a divide block's unconnected divisor).
-            SerializationTools.SyncConnectionValuesToDefaults(parsedGraph);
-
-            // Restore editor layout data (block positions, frames, zoom)
-            if (serializationObject.editorData) {
-                (parsedGraph as any)._editorData = serializationObject.editorData;
+            if (serializationObject._flowGraphs && Array.isArray(serializationObject._flowGraphs)) {
+                // Coordinator-level format
+                graphDataList = serializationObject._flowGraphs;
+                activeIndex = serializationObject.activeGraphIndex ?? 0;
+                topLevelSnippetId = serializationObject.sceneSnippetId;
+                topLevelFlowGraphSnippetId = serializationObject.flowGraphSnippetId;
+            } else {
+                // Legacy single-graph format — wrap it
+                graphDataList = [serializationObject as ISerializedFlowGraph];
+                topLevelSnippetId = serializationObject.sceneSnippetId;
+                topLevelFlowGraphSnippetId = serializationObject.flowGraphSnippetId;
             }
 
+            // Parse all graphs in parallel
+            const parsedGraphs = await Promise.all(
+                graphDataList.map(async (graphData) => {
+                    const parsedGraph = await ParseFlowGraphAsync(graphData, { coordinator, pathConverter });
+
+                    SerializationTools.PreserveUnresolvedNames(parsedGraph, graphData);
+                    SerializationTools.PreserveUnresolvedVariables(parsedGraph, graphData);
+                    SerializationTools.SyncConnectionValuesToDefaults(parsedGraph);
+
+                    if ((graphData as any).editorData) {
+                        (parsedGraph as any)._editorData = (graphData as any).editorData;
+                    }
+
+                    return parsedGraph;
+                })
+            );
+
+            // Clamp active index to valid range
+            if (activeIndex < 0 || activeIndex >= parsedGraphs.length) {
+                activeIndex = 0;
+            }
+
+            // Set the coordinator and active graph on globalState
             // eslint-disable-next-line require-atomic-updates
-            globalState.flowGraph = parsedGraph;
+            globalState.coordinator = coordinator;
+            // eslint-disable-next-line require-atomic-updates
+            globalState.activeGraphIndex = activeIndex;
 
             // Restore the scene snippet ID so the preview component can auto-load the scene
-            const snippetId = serializationObject.sceneSnippetId ?? "";
+            const snippetId = topLevelSnippetId ?? "";
             if (snippetId && snippetId !== globalState.snippetId) {
                 globalState.snippetId = snippetId;
                 globalState.onSnippetIdChanged.notifyObservers(snippetId);
             }
 
             // Restore the flow graph snippet ID
-            if (serializationObject.flowGraphSnippetId) {
+            if (topLevelFlowGraphSnippetId) {
                 // eslint-disable-next-line require-atomic-updates
-                globalState.flowGraphSnippetId = serializationObject.flowGraphSnippetId;
+                globalState.flowGraphSnippetId = topLevelFlowGraphSnippetId;
             }
         } finally {
             globalState.onIsLoadingChanged.notifyObservers(false);


### PR DESCRIPTION
## Summary

Adds multi-graph editing to the Flow Graph Editor, allowing users to create, switch between, rename, and remove multiple flow graphs within a single coordinator session.

## Core Changes

- **`FlowGraph`**: Added `name` and `uniqueId` properties (with serialization/parse support)
- **`FlowGraphCoordinator`**: `createGraph()` now accepts an optional `name` parameter with auto-naming
- **`FlowGraphParser`**: Restores `name` and `uniqueId` from serialized data
- **`typeDefinitions`**: Extended `ISerializedFlowGraph` with `name?` and `uniqueId?`

## Editor Changes

- **`GlobalState`**: Manages a coordinator with multiple graphs — add/remove/rename/switch active graph. Fires `onBeforeActiveGraphChanged` to persist canvas state before tab switch.
- **`SerializationTools`**: Serialize/deserialize coordinator-level format (`_flowGraphs[]` array) with legacy single-graph fallback
- **`GraphEditor`**: Undo/redo replaces active graph within the existing coordinator. Saves zoom/pan/positions on tab switch and restores them when switching back.
- **`GraphTabBarComponent`** (new): Tab bar UI for switching between graphs with:
  - Click to switch, double-click to rename (inline input)
  - Close button per tab, "+" button to add new graphs
  - Always visible (even with one graph) for discoverability
- **`flowGraphEditor.ts`**: Entry point detects existing coordinator and wires it up

## Testing

- All 2865 unit tests pass (126 test files)
- ESLint clean, Prettier formatted
- No changes to shared-ui-components (no cross-tool impact)