### PR TITLE
test(xr): use jsdom env for WebXRBodyTracking tests (Node 20 fix)

### DIFF
--- a/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
+++ b/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
@@ -1,4 +1,6 @@
 /**
+ * @vitest-environment jsdom
+ *
  * Offline tests for WebXR Body Tracking bone-local computation.
  *
  * Uses a full 83-joint snapshot captured on Quest 3 with a Mixamo model.


### PR DESCRIPTION
## Problem

The `WebXRBodyTracking` unit test file (added in #18343) runs in the default `node` vitest environment. The `WebXRBodyTracking - feature class` suite stubs `navigator.xr` so that `WebXRSessionManager` can initialize and `isNative` resolves without touching a real XR runtime.

On **Node 20**, `navigator` is not exposed as a global, so the test fails during `beforeEach` with:

```
ReferenceError: navigator is not defined
  ❯ packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts:2097:9
      originalXr = (navigator as any).xr;
```

…followed by a cascading `Cannot read properties of undefined (reading 'dispose')` in `afterEach`.

Newer Node versions (21+) expose `navigator` as a global, which is why the tests passed during development on a newer Node and in CI for the original PR.

## Fix

Add `@vitest-environment jsdom` to the file docblock. This matches every other XR test in the repo (`webXRSessionManager.test.ts`, `webXRInput.test.ts`, `webXRCamera.test.ts`, `webXRFeaturesManager.test.ts`, `webXRInputSource.test.ts`, `webXRAbstractFeature.test.ts`, `webXRManagedOutputCanvasOptions.test.ts`, `webXRControllerPointerSelection.test.ts`, `webXRFeaturesManagerExtended.test.ts`). jsdom always provides `navigator`, so the stub works on all supported Node versions.

## Verification

```
npx vitest run --project=unit packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
# Test Files  1 passed (1)
#       Tests  81 passed (81)
```
