### PR TITLE
Disable OpenPBR Thin Walled Anisotropic Transmission - IBL visualization test

### DIFF
--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -3562,7 +3562,7 @@
             "playgroundId": "#GRQHVV#247",
             "excludedEngines": ["webgl1"],
             "renderCount": 5,
-            "skip": true
+            "excludeFromAutomaticTesting": true
         },
         {
             "title": "OpenPBR Thin Walled Anisotropic Transmission - Analytic Lights",

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -3561,7 +3561,8 @@
             "title": "OpenPBR Thin Walled Anisotropic Transmission - IBL",
             "playgroundId": "#GRQHVV#247",
             "excludedEngines": ["webgl1"],
-            "renderCount": 5
+            "renderCount": 5,
+            "skip": true
         },
         {
             "title": "OpenPBR Thin Walled Anisotropic Transmission - Analytic Lights",


### PR DESCRIPTION
Disables the flaky/failing visualization test "OpenPBR Thin Walled Anisotropic Transmission - IBL" by adding `"skip": true` to its config entry.