### PR TITLE
GUI 2D: Fix Rectangle cornerRadius to respect adaptive scaling

### DIFF
--- a/packages/dev/gui/src/2D/controls/rectangle.ts
+++ b/packages/dev/gui/src/2D/controls/rectangle.ts
@@ -202,8 +202,10 @@ export class Rectangle extends Container {
         const width = this._currentMeasure.width - offset * 2;
         const height = this._currentMeasure.height - offset * 2;
 
+        // Scale cornerRadius using idealRatio (same pattern as shadowOffset/spacing)
+        const idealRatio = this._host.idealRatio;
         for (let index = 0; index < this._cornerRadius.length; index++) {
-            this._cachedRadius[index] = Math.abs(Math.min(height / 2, Math.min(width / 2, this._cornerRadius[index])));
+            this._cachedRadius[index] = Math.abs(Math.min(height / 2, Math.min(width / 2, this._cornerRadius[index] * idealRatio)));
         }
 
         context.beginPath();


### PR DESCRIPTION
## Problem

When an `AdvancedDynamicTexture` uses adaptive scaling (`idealWidth`/`idealHeight`), `Rectangle.cornerRadius` was applied as a raw pixel value, while `thickness` and `shadowOffsetX/Y` were correctly multiplied by `host.idealRatio`. As the canvas got narrower, the corners shrank disproportionately, breaking the intended look (e.g. a `cornerRadius = height/2` "pill" shape stopped being a pill).

Reported on the forum: https://forum.babylonjs.com/t/63229

Repro playground: https://playground.babylonjs.com/#DDTSY8#1 — resize the window narrower and watch the corner radii fail to scale with the rest of the rectangles.

## Fix

In `Rectangle._drawRoundedRect`, multiply each `_cornerRadius[i]` by `this._host.idealRatio` when computing `_cachedRadius`. This applies to both the fill/stroke draw paths and `_clipForChildren` (both call `_drawRoundedRect`).

This is the same pattern as the previous adaptive-scaling fixes:
- #17377 — `shadowOffsetX/Y`
- StackPanel `spacing`

## Test coverage

Verified locally with the forum reporter's playground.