### PR TITLE
Fix CreateGroundFromHeightMap so scene.isReady waits for heightmap image load

### DIFF
--- a/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
+++ b/packages/dev/core/src/Meshes/Builders/groundBuilder.ts
@@ -467,20 +467,36 @@ export function CreateGroundFromHeightMap(
     };
 
     if (typeof url === "string") {
+        // Track the async image load as pending scene data so that scene.isReady()
+        // (and therefore scene.executeWhenReady) waits for it. Without this, an
+        // in-flight heightmap leaves the ground mesh with no subMeshes, which
+        // scene.isReady skips entirely, causing executeWhenReady to fire before
+        // geometry exists.
+        scene.addPendingData(ground);
+
         const onload = (img: HTMLImageElement | ImageBitmap) => {
             const bufferWidth = img.width;
             const bufferHeight = img.height;
 
             if (scene.isDisposed) {
+                scene.removePendingData(ground);
                 return;
             }
 
             const buffer = scene?.getEngine().resizeImageBitmap(img, bufferWidth, bufferHeight);
 
             onBufferLoaded(buffer, bufferWidth, bufferHeight);
+            scene.removePendingData(ground);
         };
 
-        Tools.LoadImage(url, onload, options.onError ? options.onError : () => {}, scene.offlineProvider);
+        const onError = (message?: string, exception?: any) => {
+            scene.removePendingData(ground);
+            if (options.onError) {
+                options.onError(message, exception);
+            }
+        };
+
+        Tools.LoadImage(url, onload, onError, scene.offlineProvider);
     } else {
         onBufferLoaded(url.data, url.width, url.height);
     }

--- a/packages/dev/core/test/unit/Meshes/babylon.groundFromHeightMap.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.groundFromHeightMap.test.ts
@@ -1,0 +1,74 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { CreateGroundFromHeightMap } from "core/Meshes/Builders/groundBuilder";
+import { Tools } from "core/Misc/tools";
+
+describe("CreateGroundFromHeightMap scene readiness", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let capturedOnLoad: ((img: HTMLImageElement | ImageBitmap) => void) | null;
+    let capturedOnError: ((message?: string, exception?: any) => void) | null;
+    let originalLoadImage: typeof Tools.LoadImage;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+        capturedOnLoad = null;
+        capturedOnError = null;
+
+        originalLoadImage = Tools.LoadImage;
+        // Intercept Tools.LoadImage so the load never completes unless the test chooses.
+        Tools.LoadImage = ((_input, onLoad, onError) => {
+            capturedOnLoad = onLoad;
+            capturedOnError = onError;
+            return null;
+        }) as typeof Tools.LoadImage;
+    });
+
+    afterEach(() => {
+        Tools.LoadImage = originalLoadImage;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("keeps scene not ready while the heightmap image load is in flight", () => {
+        CreateGroundFromHeightMap("ground", "heightMap.png", {}, scene);
+
+        // The ground mesh has no subMeshes yet (vertex data is applied inside onLoad),
+        // so without the fix scene.isReady() would return true. With the fix, the
+        // pending-data entry keeps the scene un-ready until onLoad/onError fires.
+        expect(scene.isReady()).toBe(false);
+        expect(scene.getWaitingItemsCount()).toBeGreaterThan(0);
+    });
+
+    it("clears pending data when the image fails to load", () => {
+        CreateGroundFromHeightMap("ground", "heightMap.png", {}, scene);
+        expect(scene.getWaitingItemsCount()).toBeGreaterThan(0);
+
+        // Simulate load failure.
+        capturedOnError!("failed to load");
+
+        expect(scene.getWaitingItemsCount()).toBe(0);
+    });
+
+    it("clears pending data when the scene is disposed before the image loads", () => {
+        CreateGroundFromHeightMap("ground", "heightMap.png", {}, scene);
+        expect(scene.getWaitingItemsCount()).toBeGreaterThan(0);
+
+        scene.dispose();
+
+        // Simulate the load arriving after dispose; the disposed-scene early-return
+        // should still remove the pending-data entry.
+        const fakeImage = { width: 1, height: 1 } as unknown as HTMLImageElement;
+        capturedOnLoad!(fakeImage);
+
+        expect(scene.getWaitingItemsCount()).toBe(0);
+    });
+
+    it("does not register pending data when a raw buffer is provided (no async load)", () => {
+        const data = new Uint8Array(4); // 1x1 image
+        CreateGroundFromHeightMap("ground", { data, width: 1, height: 1 }, {}, scene);
+
+        expect(scene.getWaitingItemsCount()).toBe(0);
+    });
+});


### PR DESCRIPTION
## Problem

`scene.isReady()` skips meshes with no subMeshes:

https://github.com/BabylonJS/Babylon.js/blob/9.3.3/packages/dev/core/src/scene.ts#L2400-L2405

```ts
for (index = 0; index < this.meshes.length; index++) {
    const mesh = this.meshes[index];
    if (!mesh.subMeshes || mesh.subMeshes.length === 0) {
        continue;
    }
    if (!mesh.isReady(true)) { isReady = false; continue; }
}
```

`CreateGroundFromHeightMap` creates a `GroundMesh`, calls `ground._setReady(false)`, and populates `subMeshes` (via `vertexData.applyToMesh`) only inside the async `Tools.LoadImage` onload callback. During the load window the ground has no subMeshes, so `scene.isReady` *skips it entirely* and returns `true`. `scene.executeWhenReady` fires on an empty scene.

`CreateGroundFromHeightMap` does **not** register the ground with `scene._pendingData`, so there is nothing else holding the scene "not ready" during the heightmap load.

## Reproduction

BabylonNative's validation suite includes the Light Projection Texture playground (#CQNGRK#0), which uses `CreateGroundFromHeightMap`. It fails intermittently in CI — the rendered output for a failing run is a solid clear-color image (no geometry), confirming the race.

## Fix

Register the ground as scene pending data around the async heightmap image load. Remove it when the load succeeds, fails, or the scene is disposed.

Only applies to the `url` (string) branch; the synchronous `Uint8Array` branch is unchanged.

## Behavioral change

`scene.isReady()` now correctly returns `false` while a `CreateGroundFromHeightMap` heightmap image is in flight.

Existing callers relying on `executeWhenReady` to fire after `onReady`-based `CreateGroundFromHeightMap` will keep working (and now be correct by default).

[Created by Copilot on behalf of @bghgary]
