### PR TITLE
Fix DepthRenderer.isReady corrupting current pass draw wrapper

### DIFF
--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -561,7 +561,13 @@ export class DepthRenderer {
         PrepareStringDefinesForClipPlanes(material, scene, defines);
 
         // Get correct effect
-        const drawWrapper = subMesh._getDrawWrapper(undefined, true)!;
+        // Use the depth map's render pass ID to look up / create the draw wrapper. isReady can be
+        // called outside of the depth renderer's render pass (e.g. from the RTT's
+        // customIsReadyFunction during scene.isReady()), in which case engine.currentRenderPassId
+        // would be the main render pass. Using it here would corrupt that pass's draw wrapper with
+        // the depth effect, which is especially harmful for frozen materials that won't restore the
+        // correct effect on their next isReady call (forum bug 63230).
+        const drawWrapper = subMesh._getDrawWrapper(this._depthMap.renderPassId, true)!;
         const cachedDefines = drawWrapper.defines;
         const join = defines.join("\n");
         if (cachedDefines !== join) {

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -561,13 +561,20 @@ export class DepthRenderer {
         PrepareStringDefinesForClipPlanes(material, scene, defines);
 
         // Get correct effect
-        // Use the depth map's render pass ID to look up / create the draw wrapper. isReady can be
-        // called outside of the depth renderer's render pass (e.g. from the RTT's
-        // customIsReadyFunction during scene.isReady()), in which case engine.currentRenderPassId
-        // would be the main render pass. Using it here would corrupt that pass's draw wrapper with
-        // the depth effect, which is especially harmful for frozen materials that won't restore the
-        // correct effect on their next isReady call (forum bug 63230).
-        const drawWrapper = subMesh._getDrawWrapper(this._depthMap.renderPassId, true)!;
+        // Determine which render pass id to use for the draw wrapper. isReady can be called from
+        // contexts where engine.currentRenderPassId is *not* one of the depth map's render pass ids
+        // (e.g. from EffectLayer / scene readiness checks). In that case, using
+        // engine.currentRenderPassId would stamp the depth effect onto the main pass's draw wrapper,
+        // which is especially harmful for frozen materials that won't restore the correct effect on
+        // their next isReady call (forum bug 63230).
+        // When engine.currentRenderPassId already belongs to this depth map (the normal in-pass
+        // case, including multi-pass render targets like cube/array depth textures), keep using it
+        // so each pass keeps its own draw wrapper. Otherwise fall back to the depth map's primary
+        // render pass id.
+        const currentPassId = engine.currentRenderPassId;
+        const depthPassIds = this._depthMap.renderPassIds;
+        const passId = depthPassIds.includes(currentPassId) ? currentPassId : this._depthMap.renderPassId;
+        const drawWrapper = subMesh._getDrawWrapper(passId, true)!;
         const cachedDefines = drawWrapper.defines;
         const join = defines.join("\n");
         if (cachedDefines !== join) {

--- a/packages/dev/core/test/unit/Rendering/babylon.depthRenderer.test.ts
+++ b/packages/dev/core/test/unit/Rendering/babylon.depthRenderer.test.ts
@@ -5,6 +5,7 @@ import { StandardMaterial } from "core/Materials/standardMaterial";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { Vector3 } from "core/Maths/math.vector";
 import { Scene } from "core/scene";
+import { vi } from "vitest";
 
 import "core/Rendering/depthRendererSceneComponent";
 
@@ -62,5 +63,42 @@ describe("DepthRenderer", () => {
         // so the readiness check should skip them too.
         const result = depthMap.customIsReadyFunction!(mesh, 1, true);
         expect(result).toBe(true);
+    });
+
+    it("isReady should not corrupt the draw wrapper of a non-depth render pass (forum bug 63230)", async () => {
+        const depthRenderer = scene.enableDepthRenderer();
+        const depthMap = depthRenderer.getDepthMap();
+        const depthPassId = depthMap.renderPassId;
+
+        const mesh = MeshBuilder.CreateBox("box", { size: 1 }, scene);
+        mesh.material = new StandardMaterial("mat", scene);
+        const subMesh = mesh.subMeshes[0];
+
+        // Simulate isReady being called from outside the depth render pass (e.g. from
+        // EffectLayer / scene readiness checks). engine.currentRenderPassId is the
+        // main render pass id, which is not one of the depth map's render pass ids.
+        engine.currentRenderPassId = 0; // RENDERPASS_MAIN
+        expect(depthMap.renderPassIds.includes(0)).toBe(false);
+
+        // The depth shader is loaded asynchronously by the constructor. Poll until isReady
+        // actually proceeds past the early _shadersLoaded guard.
+        await vi.waitFor(() => {
+            depthRenderer.isReady(subMesh, false);
+            expect(subMesh._getDrawWrapper(depthPassId, false)).toBeDefined();
+        });
+
+        // The depth effect must be stamped onto the depth pass's draw wrapper,
+        // not onto the current (main) pass's draw wrapper. Otherwise frozen materials
+        // sharing the main-pass draw wrapper render with the depth effect (black).
+        const mainPassWrapper = subMesh._getDrawWrapper(0, false);
+        const depthPassWrapper = subMesh._getDrawWrapper(depthPassId, false)!;
+
+        // The depth pass wrapper must own the depth effect.
+        expect(depthPassWrapper.effect).not.toBeNull();
+        // The main pass wrapper must not have been polluted with the depth effect.
+        // Either it doesn't exist (no draw wrapper at the main pass), or it doesn't
+        // carry the depth effect.
+        const mainPassEffect = mainPassWrapper?.effect ?? null;
+        expect(mainPassEffect).not.toBe(depthPassWrapper.effect);
     });
 });


### PR DESCRIPTION
## Problem

Reported on the forum: https://forum.babylonjs.com/t/63230

When using `SelectionOutlineLayer` together with `SnapshotRenderingHelper` and **frozen** materials in WebGPU fast snapshot mode, the outlined mesh renders fully black after the depth renderer becomes active.

Repro PG: https://playground.babylonjs.com/#VGJ1BQ#1

## Root cause

`DepthRenderer.isReady()` is called from the depth map's `customIsReadyFunction` during `scene.isReady()` — i.e. **outside** the depth render pass. Inside `isReady`, the draw wrapper was retrieved with:

```ts
const drawWrapper = subMesh._getDrawWrapper(undefined, true)!;
```

`undefined` resolves to `engine.currentRenderPassId`, which during a `scene.isReady()` call is the **main** render pass id (not the depth one). The depth shader effect then got stamped onto the main pass's draw wrapper.

Normally a subsequent `material.isReadyForSubMesh` call would restore the correct effect on the next frame, but with `material.freeze()` the early-out via `_wasPreviouslyReady` prevents `StandardMaterial.isReadyForSubMesh` from restoring anything, so the mesh keeps rendering with the depth shader → fully black.

## Fix

Pass the depth map's render pass id explicitly to `_getDrawWrapper`, matching `engine.currentRenderPassId` at actual depth render time inside `renderSubMesh`.

## Validation

- Built the local repo, reproduced the bug against the local playground (sphere fully black after `addSelection`/`clearSelection`)
- Applied the fix → sphere renders correctly with all sub-materials and the orange selection outline (matches v9.3.1 behavior)
- `npx vitest run --project=unit packages/dev/core/test/unit/Rendering` ✅
- `npx tsc --noEmit -p packages/dev/core/tsconfig.build.json` ✅
- `npx eslint packages/dev/core/src/Rendering/depthRenderer.ts` ✅
