### PR TITLE
GaussianSplatting: use view-backed retained part sources for compound rebuilds

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.ts
@@ -21,7 +21,7 @@ const _GaussianSplattingBytesPerShTexel = 16;
 interface IGaussianSplattingPartSource {
     name: string;
     _vertexCount: number;
-    _splatsData: Nullable<ArrayBuffer>;
+    _splatsData: Nullable<ArrayBuffer | ArrayBufferView>;
     _shData: Nullable<Uint8Array[]>;
     _shDegree: number;
     isCompound: boolean;
@@ -464,12 +464,13 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
         const splatByteLength = proxy._vertexCount * _GaussianSplattingBytesPerSplat;
         const shByteOffset = proxy._shDataOffset * _GaussianSplattingBytesPerShTexel;
         const shByteLength = proxy._vertexCount * _GaussianSplattingBytesPerShTexel;
+        const splatBytes = GaussianSplattingMeshBase._GetSplatDataBytes(this._splatsData);
 
         return {
             name: proxy.name,
             _vertexCount: proxy._vertexCount,
-            _splatsData: this._splatsData.slice(splatByteOffset, splatByteOffset + splatByteLength),
-            _shData: this._shData?.map((texture) => texture.slice(shByteOffset, shByteOffset + shByteLength)) ?? null,
+            _splatsData: splatBytes.subarray(splatByteOffset, splatByteOffset + splatByteLength),
+            _shData: this._shData?.map((texture) => texture.subarray(shByteOffset, shByteOffset + shByteLength)) ?? null,
             _shDegree: this._shData?.length ?? 0,
             isCompound: false,
             getWorldMatrix: () => proxy.getWorldMatrix(),
@@ -485,15 +486,14 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
             return;
         }
 
-        const getSourceBuffer = (data: ArrayBuffer): ArrayBuffer => {
-            return data instanceof ArrayBuffer ? data : ((data as unknown as ArrayBufferView).buffer as ArrayBuffer);
-        };
-
         const mergedSplatsData = new Uint8Array(totalCount * _GaussianSplattingBytesPerSplat);
         let splatByteOffset = 0;
 
         if (this._splatsData && existingVertexCount > 0) {
-            mergedSplatsData.set(new Uint8Array(getSourceBuffer(this._splatsData), 0, existingVertexCount * _GaussianSplattingBytesPerSplat), splatByteOffset);
+            mergedSplatsData.set(
+                GaussianSplattingMeshBase._GetSplatDataBytes(this._splatsData).subarray(0, existingVertexCount * _GaussianSplattingBytesPerSplat),
+                splatByteOffset
+            );
             splatByteOffset += existingVertexCount * _GaussianSplattingBytesPerSplat;
         }
 
@@ -503,7 +503,7 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
             }
 
             const splatByteLength = other._vertexCount * _GaussianSplattingBytesPerSplat;
-            mergedSplatsData.set(new Uint8Array(getSourceBuffer(other._splatsData), 0, splatByteLength), splatByteOffset);
+            mergedSplatsData.set(GaussianSplattingMeshBase._GetSplatDataBytes(other._splatsData).subarray(0, splatByteLength), splatByteOffset);
             splatByteOffset += splatByteLength;
         }
 
@@ -583,7 +583,7 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
         const colorArray = new Uint8Array(textureLength * 4);
 
         // Determine merged SH degree
-        const hasSH = this._shData !== null && others.every((o) => o._shData !== null);
+        const hasSH = (splatCountA === 0 || this._shData !== null) && others.every((o) => o._shData !== null);
         const shDegreeNew = hasSH ? Math.max(this._shDegree, ...others.map((o) => o._shDegree)) : 0;
         let sh: Uint8Array[] | undefined = undefined;
         if (hasSH && shDegreeNew > 0) {
@@ -667,8 +667,8 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
                         const proxyVertexCount = this._partProxies.reduce((sum, proxy) => sum + (proxy ? proxy._vertexCount : 0), 0);
                         const part0Count = splatCountA - proxyVertexCount;
                         if (part0Count > 0) {
-                            const uBufA = new Uint8Array(this._splatsData);
-                            const fBufA = new Float32Array(this._splatsData);
+                            const uBufA = GaussianSplattingMeshBase._GetSplatDataBytes(this._splatsData);
+                            const fBufA = GaussianSplattingMeshBase._GetSplatDataFloats(this._splatsData);
                             for (let i = 0; i < part0Count; i++) {
                                 this._makeSplat(i, fBufA, uBufA, covA, covB, colorArray, minimum, maximum, false);
                             }
@@ -705,8 +705,8 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
                     // In the preferred scenario B (empty composer) splatCountA is 0 and this
                     // entire branch is skipped by the outer `if (splatCountA > 0)` guard.
                     if (this._splatsData) {
-                        const uBufA = new Uint8Array(this._splatsData);
-                        const fBufA = new Float32Array(this._splatsData);
+                        const uBufA = GaussianSplattingMeshBase._GetSplatDataBytes(this._splatsData);
+                        const fBufA = GaussianSplattingMeshBase._GetSplatDataFloats(this._splatsData);
                         for (let i = 0; i < splatCountA; i++) {
                             this._makeSplat(i, fBufA, uBufA, covA, covB, colorArray, minimum, maximum, false);
                         }
@@ -735,8 +735,8 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
                     // addPart call (scenario A legacy path). Re-process the partial boundary
                     // row so it is not clobbered by stale zeros during the sub-texture upload.
                     if (this._splatsData) {
-                        const uBufA = new Uint8Array(this._splatsData);
-                        const fBufA = new Float32Array(this._splatsData);
+                        const uBufA = GaussianSplattingMeshBase._GetSplatDataBytes(this._splatsData);
+                        const fBufA = GaussianSplattingMeshBase._GetSplatDataFloats(this._splatsData);
                         for (let i = firstNewTexel; i < splatCountA; i++) {
                             this._makeSplat(i, fBufA, uBufA, covA, covB, colorArray, minimum, maximum, false, i);
                         }
@@ -755,8 +755,8 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
                     const partStarts: number[] = new Array(this._partProxies.length).fill(0);
                     // Legacy scenario A: part 0 is the mesh's own loaded data.
                     if (!this._partProxies[0] && this._splatsData && part0Count > 0) {
-                        srcUBufs[0] = new Uint8Array(this._splatsData);
-                        srcFBufs[0] = new Float32Array(this._splatsData);
+                        srcUBufs[0] = GaussianSplattingMeshBase._GetSplatDataBytes(this._splatsData);
+                        srcFBufs[0] = GaussianSplattingMeshBase._GetSplatDataFloats(this._splatsData);
                         partStarts[0] = 0;
                     }
                     // All proxied parts — start from pi=0 to cover preferred scenario B.
@@ -770,8 +770,8 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
                         if (!source || !source._splatsData) {
                             throw new Error(`Cannot rebuild compound part "${proxy.name}": the retained compound source data is not available.`);
                         }
-                        srcUBufs[pi] = new Uint8Array(source._splatsData);
-                        srcFBufs[pi] = new Float32Array(source._splatsData);
+                        srcUBufs[pi] = GaussianSplattingMeshBase._GetSplatDataBytes(source._splatsData);
+                        srcFBufs[pi] = GaussianSplattingMeshBase._GetSplatDataFloats(source._splatsData);
                         partStarts[pi] = cumOffset;
                         cumOffset += source._vertexCount;
                     }

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
@@ -411,14 +411,19 @@ export class GaussianSplattingMeshBase extends Mesh {
      */
     protected static _GetSplatDataFloats(data: ArrayBuffer | ArrayBufferView): Float32Array {
         const bytes = GaussianSplattingMeshBase._GetSplatDataBytes(data);
+        const floatSize = Float32Array.BYTES_PER_ELEMENT;
 
-        if (bytes.byteOffset % Float32Array.BYTES_PER_ELEMENT !== 0 || bytes.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) {
-            const copy = new Uint8Array(bytes.byteLength);
-            copy.set(bytes);
-            return new Float32Array(copy.buffer);
+        if (bytes.byteLength % floatSize !== 0) {
+            throw new Error(`Gaussian splat data byte length (${bytes.byteLength}) is not divisible by ${floatSize} and cannot be reinterpreted as Float32 data.`);
         }
 
-        return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Float32Array.BYTES_PER_ELEMENT);
+        if (bytes.byteOffset % floatSize !== 0) {
+            const copy = new Uint8Array(bytes.byteLength);
+            copy.set(bytes);
+            return new Float32Array(copy.buffer, 0, bytes.byteLength / floatSize);
+        }
+
+        return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / floatSize);
     }
 
     /**

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
@@ -10,9 +10,9 @@ import { Matrix, TmpVectors, Vector2, Vector3, type Quaternion } from "core/Math
 import { Logger } from "core/Misc/logger";
 import { GaussianSplattingMaterial } from "core/Materials/GaussianSplatting/gaussianSplattingMaterial";
 import { RawTexture } from "core/Materials/Textures/rawTexture";
+import { type InternalTexture } from "core/Materials/Textures/internalTexture";
 import { Constants } from "core/Engines/constants";
 import "core/Meshes/thinInstanceMesh";
-import { type ThinEngine } from "core/Engines/thinEngine";
 import { ToHalfFloat } from "core/Misc/textureTools";
 import { type Material } from "core/Materials/material";
 import { type Effect } from "core/Materials/effect";
@@ -39,6 +39,31 @@ interface IUpdateOptions {
     flipY?: boolean;
     /** @internal When set, skips reprocessing splats [0, previousVertexCount) and copies from cached arrays instead. */
     previousVertexCount?: number;
+}
+
+interface ITextureDataUpdateCapableEngine {
+    updateTextureData(
+        texture: InternalTexture,
+        imageData: ArrayBufferView,
+        xOffset: number,
+        yOffset: number,
+        width: number,
+        height: number,
+        faceIndex?: number,
+        lod?: number,
+        generateMipMaps?: boolean
+    ): void;
+    updateRawTexture(
+        texture: Nullable<InternalTexture>,
+        data: Nullable<ArrayBufferView>,
+        format: number,
+        invertY: boolean,
+        compression?: Nullable<string>,
+        type?: number,
+        useSRGBBuffer?: boolean
+    ): void;
+    _gl?: unknown;
+    isWebGPU?: boolean;
 }
 
 // @internal
@@ -2137,8 +2162,8 @@ export class GaussianSplattingMeshBase extends Mesh {
             return new RawTexture(data, width, height, format, this._scene, false, false, Constants.TEXTURE_BILINEAR_SAMPLINGMODE, Constants.TEXTURETYPE_UNSIGNED_BYTE);
         };
 
-        const createTextureFromDataU32 = (data: Uint32Array, width: number, height: number, format: number) => {
-            return new RawTexture(data, width, height, format, this._scene, false, false, Constants.TEXTURE_NEAREST_SAMPLINGMODE, Constants.TEXTURETYPE_UNSIGNED_INTEGER);
+        const createEmptyTextureU32 = (width: number, height: number, format: number) => {
+            return new RawTexture(null, width, height, format, this._scene, false, false, Constants.TEXTURE_NEAREST_SAMPLINGMODE, Constants.TEXTURETYPE_UNSIGNED_INTEGER);
         };
 
         const createTextureFromDataF16 = (data: Uint16Array, width: number, height: number, format: number) => {
@@ -2159,12 +2184,12 @@ export class GaussianSplattingMeshBase extends Mesh {
             // Handle SH textures in update path - create if they don't exist
             if (sh && !this._shTextures) {
                 this._shTextures = [];
-                for (const shData of sh) {
-                    const buffer = new Uint32Array(shData.buffer);
-                    const shTexture = createTextureFromDataU32(buffer, textureSize.x, textureSize.y, Constants.TEXTUREFORMAT_RGBA_INTEGER);
+                for (let textureIndex = 0; textureIndex < sh.length; textureIndex++) {
+                    const shTexture = createEmptyTextureU32(textureSize.x, textureSize.y, Constants.TEXTUREFORMAT_RGBA_INTEGER);
                     shTexture.wrapU = Constants.TEXTURE_CLAMP_ADDRESSMODE;
                     shTexture.wrapV = Constants.TEXTURE_CLAMP_ADDRESSMODE;
                     this._shTextures!.push(shTexture);
+                    this._updateShTextureData(shTexture, sh[textureIndex], textureSize.x, 0, textureSize.y);
                 }
             }
 
@@ -2204,12 +2229,14 @@ export class GaussianSplattingMeshBase extends Mesh {
 
             if (sh) {
                 this._shTextures = [];
-                for (const shData of sh) {
-                    const buffer = new Uint32Array(shData.buffer);
-                    const shTexture = createTextureFromDataU32(buffer, textureSize.x, textureSize.y, Constants.TEXTUREFORMAT_RGBA_INTEGER);
+                for (let textureIndex = 0; textureIndex < sh.length; textureIndex++) {
+                    const shTexture = createEmptyTextureU32(textureSize.x, textureSize.y, Constants.TEXTUREFORMAT_RGBA_INTEGER);
                     shTexture.wrapU = Constants.TEXTURE_CLAMP_ADDRESSMODE;
                     shTexture.wrapV = Constants.TEXTURE_CLAMP_ADDRESSMODE;
                     this._shTextures!.push(shTexture);
+                }
+                for (let textureIndex = 0; textureIndex < sh.length; textureIndex++) {
+                    this._updateShTextureData(this._shTextures[textureIndex], sh[textureIndex], textureSize.x, 0, textureSize.y);
                 }
             }
 
@@ -2492,8 +2519,68 @@ export class GaussianSplattingMeshBase extends Mesh {
     }
 
     protected _updateTextureFromData = (texture: BaseTexture, data: ArrayBufferView, width: number, lineStart: number, lineCount: number) => {
-        (this.getEngine() as ThinEngine).updateTextureData(texture.getInternalTexture()!, data, 0, lineStart, width, lineCount, 0, 0, false);
+        const engine = this._getTextureDataUpdateEngine();
+        engine.updateTextureData(texture.getInternalTexture()!, data, 0, lineStart, width, lineCount, 0, 0, false);
     };
+
+    protected _updateTextureFromDataRect = (texture: BaseTexture, data: ArrayBufferView, xOffset: number, yOffset: number, width: number, height: number) => {
+        const engine = this._getTextureDataUpdateEngine();
+        engine.updateTextureData(texture.getInternalTexture()!, data, xOffset, yOffset, width, height, 0, 0, false);
+    };
+
+    protected _getTextureDataUpdateEngine(): ITextureDataUpdateCapableEngine {
+        return this.getEngine() as unknown as ITextureDataUpdateCapableEngine;
+    }
+
+    protected _updateShTextureData(texture: BaseTexture, shData: Uint8Array, textureWidth: number, lineStart: number, lineCount: number): void {
+        const engine = this._getTextureDataUpdateEngine();
+
+        // NativeEngine/NullEngine, updateTextureData unsupported
+        if (!engine._gl && !engine.isWebGPU) {
+            const internalTexture = texture.getInternalTexture()!;
+            const expectedByteLength = textureWidth * internalTexture.height * 16;
+            let uploadData: Uint32Array;
+            if (shData.byteLength === expectedByteLength && shData.byteOffset % Uint32Array.BYTES_PER_ELEMENT === 0) {
+                uploadData = new Uint32Array(shData.buffer, shData.byteOffset, shData.byteLength / Uint32Array.BYTES_PER_ELEMENT);
+            } else {
+                const padded = new Uint8Array(expectedByteLength);
+                padded.set(shData.subarray(0, Math.min(shData.byteLength, expectedByteLength)));
+                uploadData = new Uint32Array(padded.buffer);
+            }
+            engine.updateRawTexture(internalTexture, uploadData, internalTexture.format, internalTexture.invertY, null, internalTexture.type, internalTexture._useSRGBBuffer);
+            return;
+        }
+
+        const bytesPerTexel = 16;
+        const componentsPerTexel = 4;
+        const startTexel = lineStart * textureWidth;
+        const availableTexelCount = Math.floor(shData.byteLength / bytesPerTexel);
+
+        if (startTexel >= availableTexelCount) {
+            return;
+        }
+
+        let texelCount = Math.min(lineCount * textureWidth, availableTexelCount - startTexel);
+        if (texelCount <= 0) {
+            return;
+        }
+
+        const createView = (byteOffset: number, viewTexelCount: number) => {
+            return new Uint32Array(shData.buffer, shData.byteOffset + byteOffset, viewTexelCount * componentsPerTexel);
+        };
+
+        const fullRowCount = Math.floor(texelCount / textureWidth);
+        if (fullRowCount > 0) {
+            const fullRowTexelCount = fullRowCount * textureWidth;
+            this._updateTextureFromData(texture, createView(startTexel * bytesPerTexel, fullRowTexelCount), textureWidth, lineStart, fullRowCount);
+            texelCount -= fullRowTexelCount;
+        }
+
+        if (texelCount > 0) {
+            const partialRowOffset = (startTexel + fullRowCount * textureWidth) * bytesPerTexel;
+            this._updateTextureFromDataRect(texture, createView(partialRowOffset, texelCount), 0, lineStart + fullRowCount, texelCount, 1);
+        }
+    }
 
     protected _updateSubTextures(centers: Float32Array, covA: Uint16Array, covB: Uint16Array, colors: Uint8Array, lineStart: number, lineCount: number, sh?: Uint8Array[]): void {
         const textureSize = this._getTextureSize(this._vertexCount);
@@ -2518,9 +2605,7 @@ export class GaussianSplattingMeshBase extends Mesh {
         }
         if (sh) {
             for (let i = 0; i < sh.length; i++) {
-                const componentCount = 4;
-                const shView = new Uint32Array(sh[i].buffer, texelStart * componentCount * 4, texelCount * componentCount);
-                this._updateTextureFromData(this._shTextures![i], shView, textureSize.x, lineStart, lineCount);
+                this._updateShTextureData(this._shTextures![i], sh[i], textureSize.x, lineStart, lineCount);
             }
         }
     }

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
@@ -394,6 +394,34 @@ export class GaussianSplattingMeshBase extends Mesh {
     protected static readonly _DefaultViewUpdateThreshold = 1e-4;
 
     /**
+     * Returns a byte-accurate view for retained splat data, preserving any non-zero byte offset.
+     * @param data The retained splat source bytes.
+     * @returns A Uint8Array covering the exact source byte range.
+     * @internal
+     */
+    protected static _GetSplatDataBytes(data: ArrayBuffer | ArrayBufferView): Uint8Array {
+        return ArrayBuffer.isView(data) ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength) : new Uint8Array(data);
+    }
+
+    /**
+     * Returns a Float32 reinterpretation for retained splat data, copying only when alignment requires it.
+     * @param data The retained splat source bytes.
+     * @returns A Float32Array over the exact source byte range.
+     * @internal
+     */
+    protected static _GetSplatDataFloats(data: ArrayBuffer | ArrayBufferView): Float32Array {
+        const bytes = GaussianSplattingMeshBase._GetSplatDataBytes(data);
+
+        if (bytes.byteOffset % Float32Array.BYTES_PER_ELEMENT !== 0 || bytes.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0) {
+            const copy = new Uint8Array(bytes.byteLength);
+            copy.set(bytes);
+            return new Float32Array(copy.buffer);
+        }
+
+        return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Float32Array.BYTES_PER_ELEMENT);
+    }
+
+    /**
      * Cosine value of the angle threshold to update view dependent splat sorting. Default is 0.0001.
      */
     public viewUpdateThreshold: number = GaussianSplattingMeshBase._DefaultViewUpdateThreshold;
@@ -2657,12 +2685,8 @@ export class GaussianSplattingMeshBase extends Mesh {
         if (!srcRaw || srcCount === 0) {
             return;
         }
-        // _splatsData is typed as ArrayBuffer but callers may have stored a TypedArray before this
-        // guard was added. Extract the underlying ArrayBuffer so Float32Array reinterprets bytes
-        // correctly instead of value-converting each element.
-        const srcBuffer: ArrayBuffer = srcRaw instanceof ArrayBuffer ? srcRaw : ((srcRaw as unknown as ArrayBufferView).buffer as ArrayBuffer);
-        const uBuffer = new Uint8Array(srcBuffer);
-        const fBuffer = new Float32Array(srcBuffer);
+        const uBuffer = GaussianSplattingMeshBase._GetSplatDataBytes(srcRaw);
+        const fBuffer = GaussianSplattingMeshBase._GetSplatDataFloats(srcRaw);
 
         for (let i = 0; i < srcCount; i++) {
             this._makeSplat(dstOffset + i, fBuffer, uBuffer, covA, covB, colorArray, minimum, maximum, false, i);

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
@@ -1,6 +1,6 @@
 import { NullEngine } from "core/Engines/nullEngine";
-import "core/Loading/Plugins/babylonFileLoader";
 import { AppendSceneAsync } from "core/Loading/sceneLoader";
+import { LoadAssetContainerFromSerializedScene } from "core/Loading/Plugins/babylonFileLoader";
 import { Vector3 } from "core/Maths/math.vector";
 import "core/Materials/standardMaterial";
 import { GaussianSplattingCompoundMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingCompoundMesh";
@@ -44,6 +44,17 @@ const createTestShData = (seed: number): Uint8Array[] => {
     }
 
     return [texture];
+};
+
+const createMultiTextureShData = (seed: number, textureCount: number): Uint8Array[] => {
+    return Array.from({ length: textureCount }, (_, textureIndex) => {
+        const texture = new Uint8Array(16);
+        for (let i = 0; i < texture.length; i++) {
+            texture[i] = (seed + textureIndex * 17 + i) & 0xff;
+        }
+
+        return texture;
+    });
 };
 
 describe("GaussianSplatting serialization", () => {
@@ -191,6 +202,100 @@ describe("GaussianSplatting serialization", () => {
         expect(loadedChild).toBeTruthy();
         expect(loadedChild!.parent).toBeTruthy();
         expect(loadedChild!.parent!.getClassName()).toBe("GaussianSplattingPartProxyMesh");
+
+        loadedScene.dispose();
+    });
+
+    it("rebuilds retained SH data as the exact concatenation of surviving parts after removePart", () => {
+        const sourceASplat = createTestSplatData([1, 2, 3], [255, 0, 0, 255]);
+        const sourceBSplat = createTestSplatData([4, 5, 6], [0, 255, 0, 255]);
+        const sourceCSplat = createTestSplatData([7, 8, 9], [0, 0, 255, 255]);
+        const sourceASh = createMultiTextureShData(11, 3);
+        const sourceBSh = createMultiTextureShData(67, 3);
+        const sourceCSh = createMultiTextureShData(123, 3);
+
+        const sourceA = new GaussianSplattingMesh("sourceA", null, scene);
+        sourceA.disableDepthSort = true;
+        sourceA.updateData(sourceASplat, sourceASh, undefined, undefined, 3);
+
+        const sourceB = new GaussianSplattingMesh("sourceB", null, scene);
+        sourceB.disableDepthSort = true;
+        sourceB.updateData(sourceBSplat, sourceBSh, undefined, undefined, 3);
+
+        const sourceC = new GaussianSplattingMesh("sourceC", null, scene);
+        sourceC.disableDepthSort = true;
+        sourceC.updateData(sourceCSplat, sourceCSh, undefined, undefined, 3);
+
+        const compound = new GaussianSplattingCompoundMesh("compound", null, scene, true);
+        compound.disableDepthSort = true;
+        compound.addParts([sourceA, sourceB, sourceC], false);
+
+        compound.removePart(1);
+
+        const rebuiltSh = compound.shData;
+        expect(rebuiltSh).toBeTruthy();
+        expect(rebuiltSh).toHaveLength(3);
+
+        for (let textureIndex = 0; textureIndex < 3; textureIndex++) {
+            const expected = new Uint8Array(32);
+            expected.set(sourceASh[textureIndex], 0);
+            expected.set(sourceCSh[textureIndex], 16);
+
+            expect(Array.from(rebuiltSh![textureIndex])).toEqual(Array.from(expected));
+        }
+
+        const rebuiltPartIndices = (compound as any)._partIndices as Uint8Array;
+        expect(Array.from(rebuiltPartIndices.subarray(0, 2))).toEqual([0, 1]);
+    });
+
+    it("round-trips serialized multi-texture SH compounds through LoadAssetContainerFromSerializedScene", () => {
+        const compound = new GaussianSplattingCompoundMesh("renderMesh", null, scene, true);
+        compound.disableDepthSort = true;
+
+        const sourceShData: Uint8Array[][] = [];
+        const sources: GaussianSplattingMesh[] = [];
+
+        for (let i = 0; i < 5; i++) {
+            const source = new GaussianSplattingMesh(`source${i}`, null, scene, true);
+            source.disableDepthSort = true;
+            const shData = createMultiTextureShData(31 + i * 23, 3);
+            sourceShData.push(shData);
+            source.updateData(createTestSplatData([i + 1, i + 2, i + 3], [255 - i * 20, 32 + i * 10, 64 + i * 15, 255]), shData, undefined, undefined, 3);
+            sources.push(source);
+        }
+
+        const proxies = compound.addParts(sources);
+        proxies.forEach((part, i) => {
+            part.name = `Part ${i}`;
+            part.visibility = 0.5 - i * 0.12;
+            part.position.set(i * 2 - 3, -2, 0);
+            part.computeWorldMatrix(true);
+        });
+
+        compound.removePart(1);
+
+        const serializedScene = SceneSerializer.Serialize(scene);
+
+        const loadedScene = new Scene(engine);
+        const container = LoadAssetContainerFromSerializedScene(loadedScene, serializedScene, "");
+
+        const loadedCompound = container.meshes.find((mesh) => mesh.getClassName() === "GaussianSplattingMesh" && mesh.name === "renderMesh") as GaussianSplattingMesh | undefined;
+        expect(loadedCompound).toBeTruthy();
+
+        const expectedSurvivorIndices = [0, 2, 3, 4];
+        const expectedSh = Array.from({ length: 3 }, (_, textureIndex) => {
+            const merged = new Uint8Array(expectedSurvivorIndices.length * 16);
+            expectedSurvivorIndices.forEach((sourceIndex, survivorIndex) => {
+                merged.set(sourceShData[sourceIndex][textureIndex], survivorIndex * 16);
+            });
+            return merged;
+        });
+        const loadedSh = (loadedCompound as any)._shData as Uint8Array[];
+        expect(loadedSh).toBeTruthy();
+        expect(loadedSh).toHaveLength(3);
+        for (let textureIndex = 0; textureIndex < 3; textureIndex++) {
+            expect(Array.from(loadedSh[textureIndex])).toEqual(Array.from(expectedSh[textureIndex]));
+        }
 
         loadedScene.dispose();
     });

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
@@ -9,7 +9,7 @@ import { Mesh } from "core/Meshes/mesh";
 import { TransformNode } from "core/Meshes/transformNode";
 import { SceneSerializer } from "core/Misc/sceneSerializer";
 import { Scene } from "core/scene";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const createTestSplatData = (position: [number, number, number], color: [number, number, number, number]): ArrayBuffer => {
     const data = new ArrayBuffer(32);
@@ -47,11 +47,21 @@ const createTestShData = (seed: number): Uint8Array[] => {
 };
 
 describe("GaussianSplatting serialization", () => {
-    it("creates retained part sources as shared views into merged splat and SH buffers", () => {
-        const engine = new NullEngine();
-        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
-        const scene = new Scene(engine);
+    let engine: NullEngine;
+    let scene: Scene;
 
+    beforeEach(() => {
+        engine = new NullEngine();
+        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("creates retained part sources as shared views into merged splat and SH buffers", () => {
         const sourceASplat = createTestSplatData([1, 2, 3], [255, 0, 0, 255]);
         const sourceBSplat = createTestSplatData([4, 5, 6], [0, 255, 0, 255]);
         const sourceASh = createTestShData(11);
@@ -87,10 +97,6 @@ describe("GaussianSplatting serialization", () => {
     });
 
     it("round-trips compound meshes and keeps part metadata valid after removePart", () => {
-        const engine = new NullEngine();
-        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
-        const scene = new Scene(engine);
-
         const sourceASplat = createTestSplatData([1, 2, 3], [255, 0, 0, 255]);
         const sourceBSplat = createTestSplatData([4, 5, 6], [0, 255, 0, 255]);
         const sourceASh = createTestShData(11);
@@ -156,13 +162,11 @@ describe("GaussianSplatting serialization", () => {
         expect(reparsedSerialized.partProxies[0].vertexCount).toBe(1);
         expect(reparsedSerialized.partProxies[0].splatsDataOffset).toBe(0);
         expect(reparsedSerialized.partProxies[0].shDataOffset).toBe(0);
+
+        parsedScene.dispose();
     });
 
     it("reconnects nodes parented to part proxies through the scene loader", async () => {
-        const engine = new NullEngine();
-        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
-        const scene = new Scene(engine);
-
         const sourceA = new GaussianSplattingMesh("sourceA", null, scene);
         sourceA.disableDepthSort = true;
         sourceA.updateData(createTestSplatData([1, 2, 3], [255, 0, 0, 255]));
@@ -187,5 +191,7 @@ describe("GaussianSplatting serialization", () => {
         expect(loadedChild).toBeTruthy();
         expect(loadedChild!.parent).toBeTruthy();
         expect(loadedChild!.parent!.getClassName()).toBe("GaussianSplattingPartProxyMesh");
+
+        loadedScene.dispose();
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
@@ -1,0 +1,191 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import "core/Loading/Plugins/babylonFileLoader";
+import { AppendSceneAsync } from "core/Loading/sceneLoader";
+import { Vector3 } from "core/Maths/math.vector";
+import "core/Materials/standardMaterial";
+import { GaussianSplattingCompoundMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingCompoundMesh";
+import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
+import { Mesh } from "core/Meshes/mesh";
+import { TransformNode } from "core/Meshes/transformNode";
+import { SceneSerializer } from "core/Misc/sceneSerializer";
+import { Scene } from "core/scene";
+import { describe, expect, it } from "vitest";
+
+const createTestSplatData = (position: [number, number, number], color: [number, number, number, number]): ArrayBuffer => {
+    const data = new ArrayBuffer(32);
+    const floats = new Float32Array(data);
+    const bytes = new Uint8Array(data);
+
+    floats[0] = position[0];
+    floats[1] = position[1];
+    floats[2] = position[2];
+    floats[3] = 0.5;
+    floats[4] = 0.5;
+    floats[5] = 0.5;
+
+    bytes[24] = color[0];
+    bytes[25] = color[1];
+    bytes[26] = color[2];
+    bytes[27] = color[3];
+
+    // Identity quaternion in the packed splat layout.
+    bytes[28] = 0;
+    bytes[29] = 128;
+    bytes[30] = 128;
+    bytes[31] = 128;
+
+    return data;
+};
+
+const createTestShData = (seed: number): Uint8Array[] => {
+    const texture = new Uint8Array(16);
+    for (let i = 0; i < texture.length; i++) {
+        texture[i] = (seed + i) & 0xff;
+    }
+
+    return [texture];
+};
+
+describe("GaussianSplatting serialization", () => {
+    it("creates retained part sources as shared views into merged splat and SH buffers", () => {
+        const engine = new NullEngine();
+        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
+        const scene = new Scene(engine);
+
+        const sourceASplat = createTestSplatData([1, 2, 3], [255, 0, 0, 255]);
+        const sourceBSplat = createTestSplatData([4, 5, 6], [0, 255, 0, 255]);
+        const sourceASh = createTestShData(11);
+        const sourceBSh = createTestShData(37);
+
+        const sourceA = new GaussianSplattingMesh("sourceA", null, scene);
+        sourceA.disableDepthSort = true;
+        sourceA.updateData(sourceASplat, sourceASh, undefined, undefined, 1);
+
+        const sourceB = new GaussianSplattingMesh("sourceB", null, scene);
+        sourceB.disableDepthSort = true;
+        sourceB.updateData(sourceBSplat, sourceBSh, undefined, undefined, 1);
+
+        const compound = new GaussianSplattingCompoundMesh("compound", null, scene, true);
+        compound.disableDepthSort = true;
+
+        const proxies = compound.addParts([sourceA, sourceB], false);
+        const retainedPart = (compound as any)._createRetainedPartSource(proxies[1]);
+
+        expect(retainedPart).toBeTruthy();
+        expect(ArrayBuffer.isView(retainedPart._splatsData)).toBe(true);
+        expect(retainedPart._splatsData.buffer).toBe((compound as any)._splatsData);
+        expect(retainedPart._splatsData.byteOffset).toBe(32);
+        expect(retainedPart._splatsData.byteLength).toBe(32);
+        expect(Array.from(retainedPart._splatsData as Uint8Array)).toEqual(Array.from(new Uint8Array(sourceBSplat)));
+
+        expect(retainedPart._shData).toBeTruthy();
+        expect(retainedPart._shData).toHaveLength(1);
+        expect(retainedPart._shData[0].buffer).toBe((compound as any)._shData[0].buffer);
+        expect(retainedPart._shData[0].byteOffset).toBe(16);
+        expect(retainedPart._shData[0].byteLength).toBe(16);
+        expect(Array.from(retainedPart._shData[0])).toEqual(Array.from(sourceBSh[0]));
+    });
+
+    it("round-trips compound meshes and keeps part metadata valid after removePart", () => {
+        const engine = new NullEngine();
+        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
+        const scene = new Scene(engine);
+
+        const sourceASplat = createTestSplatData([1, 2, 3], [255, 0, 0, 255]);
+        const sourceBSplat = createTestSplatData([4, 5, 6], [0, 255, 0, 255]);
+        const sourceASh = createTestShData(11);
+        const sourceBSh = createTestShData(37);
+
+        const sourceA = new GaussianSplattingMesh("sourceA", null, scene);
+        sourceA.disableDepthSort = true;
+        sourceA.updateData(sourceASplat, sourceASh, undefined, undefined, 1);
+
+        const sourceB = new GaussianSplattingMesh("sourceB", null, scene);
+        sourceB.disableDepthSort = true;
+        sourceB.updateData(sourceBSplat, sourceBSh, undefined, undefined, 1);
+
+        const compound = new GaussianSplattingCompoundMesh("compound", null, scene, true);
+        compound.disableDepthSort = true;
+
+        const proxies = compound.addParts([sourceA, sourceB], false);
+        proxies[1].position = new Vector3(7, 8, 9);
+        proxies[1].visibility = 0.25;
+        proxies[1].computeWorldMatrix(true);
+
+        const serialized = compound.serialize();
+
+        expect(serialized._isCompound).toBe(true);
+        expect(serialized.partIndices).toBeDefined();
+        expect(serialized.partProxies).toHaveLength(2);
+        expect(serialized.partProxies[1].splatsDataOffset).toBe(1);
+        expect(serialized.partProxies[1].shDataOffset).toBe(1);
+
+        const parsedScene = new Scene(engine);
+        const parsed = Mesh.Parse(serialized, parsedScene, "") as GaussianSplattingCompoundMesh;
+        const parsedProxies = (parsed as any)._partProxies.filter(Boolean);
+
+        expect(parsed).toBeInstanceOf(GaussianSplattingCompoundMesh);
+        expect(parsed.partCount).toBe(2);
+        expect(parsedProxies).toHaveLength(2);
+        expect(parsedProxies[1].visibility).toBeCloseTo(0.25);
+        expect(parsedProxies[1].position.asArray()).toEqual([7, 8, 9]);
+
+        expect(() => parsed.removePart(0)).not.toThrow();
+        expect(parsed.partCount).toBe(1);
+
+        const rebuiltProxy = (parsed as any)._partProxies.filter(Boolean)[0];
+        const rebuiltRetainedPart = (parsed as any)._createRetainedPartSource(rebuiltProxy);
+        expect(ArrayBuffer.isView(rebuiltRetainedPart._splatsData)).toBe(true);
+        expect(rebuiltRetainedPart._splatsData.buffer).toBe((parsed as any)._splatsData);
+        expect(rebuiltRetainedPart._splatsData.byteOffset).toBe(0);
+        expect(rebuiltRetainedPart._shData[0].buffer).toBe((parsed as any)._shData[0].buffer);
+        expect(rebuiltRetainedPart._shData[0].byteOffset).toBe(0);
+
+        const rebuiltSplats = parsed.splatsData;
+        expect(rebuiltSplats).toBeTruthy();
+        expect(Array.from(new Uint8Array(rebuiltSplats!))).toEqual(Array.from(new Uint8Array(sourceBSplat)));
+
+        const rebuiltSh = parsed.shData;
+        expect(rebuiltSh).toBeTruthy();
+        expect(rebuiltSh).toHaveLength(1);
+        expect(Array.from(rebuiltSh![0])).toEqual(Array.from(sourceBSh[0]));
+
+        const reparsedSerialized = parsed.serialize();
+        expect(reparsedSerialized.partProxies).toHaveLength(1);
+        expect(reparsedSerialized.partProxies[0].partIndex).toBe(0);
+        expect(reparsedSerialized.partProxies[0].vertexCount).toBe(1);
+        expect(reparsedSerialized.partProxies[0].splatsDataOffset).toBe(0);
+        expect(reparsedSerialized.partProxies[0].shDataOffset).toBe(0);
+    });
+
+    it("reconnects nodes parented to part proxies through the scene loader", async () => {
+        const engine = new NullEngine();
+        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
+        const scene = new Scene(engine);
+
+        const sourceA = new GaussianSplattingMesh("sourceA", null, scene);
+        sourceA.disableDepthSort = true;
+        sourceA.updateData(createTestSplatData([1, 2, 3], [255, 0, 0, 255]));
+
+        const sourceB = new GaussianSplattingMesh("sourceB", null, scene);
+        sourceB.disableDepthSort = true;
+        sourceB.updateData(createTestSplatData([4, 5, 6], [0, 255, 0, 255]));
+
+        const compound = new GaussianSplattingCompoundMesh("compound", null, scene);
+        compound.disableDepthSort = true;
+
+        const proxies = compound.addParts([sourceA, sourceB], false);
+        const child = new TransformNode("proxyChild", scene);
+        child.parent = proxies[1];
+
+        const serializedScene = SceneSerializer.Serialize(scene);
+
+        const loadedScene = new Scene(engine);
+        await AppendSceneAsync(`data:${JSON.stringify(serializedScene)}`, loadedScene, { pluginExtension: ".babylon" });
+
+        const loadedChild = loadedScene.getTransformNodeByName("proxyChild");
+        expect(loadedChild).toBeTruthy();
+        expect(loadedChild!.parent).toBeTruthy();
+        expect(loadedChild!.parent!.getClassName()).toBe("GaussianSplattingPartProxyMesh");
+    });
+});


### PR DESCRIPTION
## Summary

This change implements phase 1 of the view-backed raw splat source proposal for compound Gaussian Splatting rebuilds.

The main goal is to remove avoidable transient retained-source copies during compound `addPart()` and `removePart()` flows while keeping the current merged-buffer ownership model intact.

In particular:

- retained part sources created during compound rebuilds now use byte views instead of copying with `slice()`,
- compound rebuild reads now preserve `byteOffset` correctly for raw splat data,
- SH retained-part sources are also view-backed,
- empty-compound rebuilds now preserve SH correctly when all incoming parts provide SH.

## What Changed

### 1. Centralized view-safe splat reads

`GaussianSplattingMeshBase` now has internal helpers that:

- produce a `Uint8Array` covering the exact byte range of an `ArrayBuffer` or `ArrayBufferView`,
- produce a `Float32Array` reinterpretation over that exact range,
- copy only if float alignment is invalid.

This is the key correctness fix for non-zero-offset retained sources.

### 2. Retained part sources are now true views

`GaussianSplattingMesh._createRetainedPartSource()` previously copied both splat and SH bytes with `slice()`.

It now returns:

- `_splatsData` as a `Uint8Array.subarray(...)`,
- `_shData` entries as `Uint8Array.subarray(...)`.

That removes the temporary retained-source copy that `removePart()` used to pay for before the final merged retained-buffer copy.

### 3. Compound rebuild paths now respect `byteOffset`

The rebuild paths that previously assumed offset `0` now use the centralized helpers instead of constructing typed arrays directly from the whole backing buffer.

This applies to:

- `_appendSourceToArrays()`,
- `_retainMergedPartData()`,
- direct rebuild reads in `_addPartsInternal()`.

### 4. SH retention on empty-compound rebuilds is fixed

While adding SH coverage, a correctness bug surfaced:

- when rebuilding from an empty compound, `_addPartsInternal()` could drop SH even if all incoming parts had SH.

This is now fixed by computing `hasSH` correctly for the empty-compound case.

## Copy Model After This Change

### Add/remove retained-source behavior

For compound add/remove rebuilds, the retained-source copy model is now:

- no temporary retained-part copy for splat bytes,
- no temporary retained-part copy for SH bytes,
- one final authoritative merged retained-buffer copy for splat bytes,
- one final authoritative merged retained-buffer copy for SH bytes.

That final merged copy is still intentional and required by the current single-buffer retained ownership design.

### What is not counted here

This change does not remove the normal CPU processing and GPU upload work in `_updateData()` / `_addPartsInternal()`.

Texture staging arrays like `covA`, `covB`, `colorArray`, and temporary SH upload arrays are still allocated as part of normal processing. Those are not retained-source copies and are outside the scope of this phase.

## Loader Impact

This should not change SPLAT loader behavior.

Current loaders still parse into packed standalone `ArrayBuffer`s and call `updateData()` with `ArrayBuffer`, not `ArrayBufferView`.

So:

- normal `.splat` / `.ply` / `.spz` / `.sog` loading behavior is unchanged,
- the new view-handling logic is primarily exercised by internal compound retained-source rebuilds.

## Tests Added / Updated

Unit coverage now verifies:

- retained part sources alias the compound's merged retained splat buffer and merged retained SH buffer,
- the aliasing uses the expected non-zero `byteOffset` for later parts,
- `removePart()` rebuild preserves the surviving splat bytes exactly,
- `removePart()` rebuild preserves the surviving SH bytes exactly,
- the rebuilt surviving retained part source still aliases the authoritative retained buffers after rebuild,
- existing serialization / proxy reconnection behavior still works.

Focused test command used during development:

```bash
npx vitest run packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
```

## Reviewer Focus

The most important things to review are:

1. Byte-offset correctness in the new helper-based splat reads.
2. Whether the retained-source copy model now matches the intended "single retained merge copy" behavior.
3. Whether the empty-compound SH fix matches expected API behavior.
4. Whether any adjacent code paths still incorrectly assume offset `0` for retained splat or SH data.

## Deliberately Out of Scope

This PR does not widen the public mesh API to accept `ArrayBufferView` in `updateData()` / `updateDataAsync()`.

It also does not change the public `splatsData` getter contract.

Those are phase 2 API-level changes and still need separate review because broader base-class upload code would need to be audited for offset-safe `ArrayBufferView` support.

## Forum post

<https://forum.babylonjs.com/t/gaussiansplattingmesh-reducing-buffer-copy-of-removepart/63164>