### PR TITLE
ci: checkout version tag on build-completion triggers

### DIFF
--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -49,10 +49,7 @@ jobs:
     - job: BuildTools
       displayName: "Build tools"
       steps:
-          - checkout: self
-            clean: true
-            fetchDepth: 1
-            fetchTags: true
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"

--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -50,6 +50,8 @@ jobs:
       displayName: "Build tools"
       steps:
           - template: templates/checkout-with-tag-override.yml
+            parameters:
+                fetchTags: true
 
           - task: UseNode@1
             displayName: "Use Node 22.x"

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -80,10 +80,9 @@ jobs:
     - job: Build
       displayName: "Build job"
       steps:
-          - checkout: self
-            clean: true
-            fetchDepth: 0
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
+            parameters:
+                fetchDepth: 0
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -272,9 +271,7 @@ jobs:
     - job: ES6
       displayName: "ES6"
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -333,9 +330,7 @@ jobs:
     - job: FormatLint
       displayName: "Format, Lint, and more"
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -370,10 +365,9 @@ jobs:
       displayName: "TypeDoc check"
       condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
       steps:
-          - checkout: self
-            clean: true
-            fetchDepth: 0
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
+            parameters:
+                fetchDepth: 0
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -416,9 +410,7 @@ jobs:
       displayName: "Unit tests"
       dependsOn: Build
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -480,9 +472,7 @@ jobs:
       displayName: "Interaction tests"
       dependsOn: Build
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -551,9 +541,7 @@ jobs:
       displayName: "Visualization tests - WebGL 2"
       dependsOn: Build
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -627,9 +615,7 @@ jobs:
       displayName: "Visualization tests - WebGPU"
       dependsOn: Build
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -707,9 +693,7 @@ jobs:
       pool:
           vmImage: windows-latest
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: DownloadPipelineArtifact@2
             displayName: "Download Pipeline Artifact"
@@ -824,9 +808,7 @@ jobs:
     - job: ViewerTests
       displayName: "Viewer tests"
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
             displayName: "Use Node 22.x"
@@ -998,9 +980,7 @@ jobs:
             )
           )
       steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+          - template: templates/checkout-with-tag-override.yml
 
           - bash: mkdir download
             displayName: "Prepare download directory"

--- a/.azure-pipelines/templates/checkout-with-tag-override.yml
+++ b/.azure-pipelines/templates/checkout-with-tag-override.yml
@@ -17,10 +17,10 @@ parameters:
       default: true
     - name: fetchDepth
       type: number
-      default: 0
+      default: 1
     - name: fetchTags
       type: boolean
-      default: true
+      default: false
     - name: triggeringPipeline
       type: string
       default: "Publish pipeline"
@@ -32,7 +32,7 @@ steps:
       fetchTags: ${{ parameters.fetchTags }}
 
     - bash: |
-          git fetch origin --tags
+          git fetch origin --tags master:refs/remotes/origin/master
           LATEST_TAG=$(git describe --tags --abbrev=0 origin/master)
           echo "Checking out version tag: $LATEST_TAG"
           git checkout "$LATEST_TAG"

--- a/.azure-pipelines/templates/checkout-with-tag-override.yml
+++ b/.azure-pipelines/templates/checkout-with-tag-override.yml
@@ -1,0 +1,44 @@
+# =============================================================================
+# Checkout Template with Version Tag Override
+#
+# Wraps `checkout: self` and, when triggered by a build-completion/resource
+# trigger (Build.Reason == ResourceTrigger), checks out the latest version
+# tag on origin/master. This ensures pipelines triggered after a Publish
+# build use the exact commit that was published, not the stale commit the
+# Publish pipeline originally started from.
+#
+# For all other triggers (PR, Manual, Schedule, IndividualCI) the default
+# checkout behavior is preserved.
+# =============================================================================
+
+parameters:
+    - name: clean
+      type: boolean
+      default: true
+    - name: fetchDepth
+      type: number
+      default: 0
+    - name: fetchTags
+      type: boolean
+      default: true
+    - name: triggeringPipeline
+      type: string
+      default: "Publish pipeline"
+
+steps:
+    - checkout: self
+      clean: ${{ parameters.clean }}
+      fetchDepth: ${{ parameters.fetchDepth }}
+      fetchTags: ${{ parameters.fetchTags }}
+
+    - bash: |
+          git fetch origin --tags
+          LATEST_TAG=$(git describe --tags --abbrev=0 origin/master)
+          echo "Checking out version tag: $LATEST_TAG"
+          git checkout "$LATEST_TAG"
+      displayName: "Override checkout to latest version tag"
+      condition: >-
+          and(
+            or(eq(variables['Build.Reason'], 'ResourceTrigger'), eq(variables['Build.Reason'], 'BuildCompletion')),
+            eq(variables['Build.TriggeredBy.DefinitionName'], '${{ parameters.triggeringPipeline }}')
+          )

--- a/.azure-pipelines/templates/checkout-with-tag-override.yml
+++ b/.azure-pipelines/templates/checkout-with-tag-override.yml
@@ -2,10 +2,10 @@
 # Checkout Template with Version Tag Override
 #
 # Wraps `checkout: self` and, when triggered by a build-completion/resource
-# trigger (Build.Reason == ResourceTrigger), checks out the latest version
-# tag on origin/master. This ensures pipelines triggered after a Publish
-# build use the exact commit that was published, not the stale commit the
-# Publish pipeline originally started from.
+# trigger (Build.Reason == ResourceTrigger or Build.Reason == BuildCompletion),
+# checks out the latest version tag on origin/master. This ensures pipelines
+# triggered after a Publish build use the exact commit that was published,
+# not the stale commit the Publish pipeline originally started from.
 #
 # For all other triggers (PR, Manual, Schedule, IndividualCI) the default
 # checkout behavior is preserved.
@@ -32,8 +32,20 @@ steps:
       fetchTags: ${{ parameters.fetchTags }}
 
     - bash: |
+          set -euo pipefail
+
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --unshallow origin
+          fi
+
           git fetch origin --tags master:refs/remotes/origin/master
-          LATEST_TAG=$(git describe --tags --abbrev=0 origin/master)
+          LATEST_TAG=$(git describe --tags --abbrev=0 origin/master 2>/dev/null || true)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "##vso[task.logissue type=error]Failed to resolve the latest version tag from origin/master."
+            exit 1
+          fi
+
           echo "Checking out version tag: $LATEST_TAG"
           git checkout "$LATEST_TAG"
       displayName: "Override checkout to latest version tag"


### PR DESCRIPTION
## Problem

When the **Publish pipeline** completes and triggers downstream pipelines (`ci-monorepo`, `cd-tools`) via Azure DevOps resource triggers (`resources.pipelines`), the triggered builds run at the **commit the Publish pipeline originally started from** — not the commit it pushed.

The Publish pipeline:
1. Starts at commit X on master (triggered by `.build/config.json` change)
2. Runs `updateVersion.js` and `tagVersion.js` — creates a "Version update" commit and a version tag (e.g. `7.52.0`)
3. Builds, publishes to npm, then pushes the version bump commit + tags to master
4. Completes → triggers `ci-monorepo` and `cd-tools` **at commit X** (stale)

This means all jobs (build, unit tests, visualization tests, interaction tests, deploy, tools build) run against code that does not match the just-published npm packages.

This is by design in Azure DevOps — `resources.pipelines` triggers always use the triggering pipeline source commit, not the latest on the branch.

## Solution

Introduce a **checkout template** (`.azure-pipelines/templates/checkout-with-tag-override.yml`) that wraps `checkout: self` and adds a conditional step:

- **When** `Build.Reason` is `ResourceTrigger` or `BuildCompletion` **AND** the triggering pipeline is `Publish pipeline`:
  - Unshallows the repo if needed
  - Fetches tags and the master ref from origin
  - Checks out the **latest version tag** on `origin/master` (e.g. `7.52.0`) — the exact commit the Publish pipeline created and pushed
  - Fails with a clear error if no tag can be resolved

- **For all other triggers** (PR, Manual, Schedule, IndividualCI):
  - The conditional step is skipped
  - Normal checkout behavior is preserved

### Why version tag instead of latest master?

Using `origin/master` HEAD could pick up commits that landed after the publish but before the triggered pipeline starts. Those commits would not match the published npm packages. The version tag gives the **exact** commit that was published.

### Template parameters

| Parameter | Default | Description |
|---|---|---|
| `clean` | `true` | Clean workspace before checkout |
| `fetchDepth` | `1` | Git fetch depth (shallow by default to match previous behavior) |
| `fetchTags` | `false` | Fetch git tags (disabled by default to match previous behavior; override step fetches what it needs) |
| `triggeringPipeline` | `"Publish pipeline"` | Name of the pipeline that should trigger the tag override. Update this if the Publish pipeline is renamed. |

## Changes

- **New**: `.azure-pipelines/templates/checkout-with-tag-override.yml` — the checkout template
- **Modified**: `.azure-pipelines/ci-monorepo.yml` — replaced all 11 `checkout: self` blocks with template references (Build, ES6, FormatLint, TypeDocCheck, UnitTests, InteractionTests, VisualizationWebGL2, VisualizationWebGPU, NativeTests, ViewerTests, Deploy)
- **Modified**: `.azure-pipelines/cd-tools.yml` — replaced `checkout: self` with template reference (passes `fetchTags: true` to preserve its original setting)

## Not changed

- `VisualizationDevhost` job — disabled placeholder, no checkout
- `PerformanceTests` job — entirely commented out
- `cd-publish.yml` — no changes needed (already creates and pushes version tags via `scripts/tagVersion.js`)

## Verification

1. Trigger a test publish → confirm all jobs log "Checking out version tag: X.Y.Z"
2. Open a PR → confirm normal checkout (no tag override step in logs)
3. Run a scheduled build → confirm normal checkout
4. Run a manual build at a specific commit → confirm that commit is used (no override)

## Forward compatibility

The Publish pipeline is currently Classic and will be ported to YAML. This change is forward-compatible:
- `Build.Reason = ResourceTrigger` is the same regardless of whether the triggering pipeline is Classic or YAML
- If the Publish pipeline is renamed after the port, update the `triggeringPipeline` default in the template