### PR TITLE
fix: make toBase64/fromBase64 declarations non-optional for TypeScript 6.0 compat

### DIFF
--- a/packages/dev/core/src/LibDeclarations/browser.d.ts
+++ b/packages/dev/core/src/LibDeclarations/browser.d.ts
@@ -12,7 +12,7 @@ interface Uint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> {
      * @param options If provided, sets the alphabet and padding behavior used.
      * @returns A base64-encoded string.
      */
-    toBase64?(options?: { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined }): string;
+    toBase64(options?: { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined }): string;
 }
 
 interface Int8ArrayConstructor {
@@ -30,7 +30,7 @@ interface Uint8ArrayConstructor {
      * @throws {SyntaxError} If the input string contains characters outside the specified alphabet, or if the last
      * chunk is inconsistent with the `lastChunkHandling` option.
      */
-    fromBase64?(
+    fromBase64(
         string: string,
         options?: {
             alphabet?: "base64" | "base64url" | undefined;

--- a/packages/dev/core/src/Misc/stringTools.ts
+++ b/packages/dev/core/src/Misc/stringTools.ts
@@ -90,7 +90,7 @@ function JsDecodeBase64ToBinary(base64Data: string): ArrayBuffer {
 export const EncodeArrayBufferToBase64 = (buffer: ArrayBuffer | ArrayBufferView): string => {
     const bytes = ArrayBuffer.isView(buffer) ? new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength) : new Uint8Array(buffer);
 
-    return bytes.toBase64 ? bytes.toBase64() : JsEncodeArrayBufferToBase64(bytes);
+    return typeof bytes.toBase64 === "function" ? bytes.toBase64() : JsEncodeArrayBufferToBase64(bytes);
 };
 
 /**
@@ -108,7 +108,7 @@ export const DecodeBase64ToString = (base64Data: string): string => {
  * @returns ArrayBuffer of byte data
  */
 export const DecodeBase64ToBinary = (base64Data: string): ArrayBuffer => {
-    return Uint8Array.fromBase64 ? Uint8Array.fromBase64(base64Data).buffer : JsDecodeBase64ToBinary(base64Data);
+    return typeof Uint8Array.fromBase64 === "function" ? Uint8Array.fromBase64(base64Data).buffer : JsDecodeBase64ToBinary(base64Data);
 };
 
 /**


### PR DESCRIPTION
Fixes TypeScript 6.0 compatibility issue reported on the forum:
https://forum.babylonjs.com/t/lib-dom-conflicts-using-typescript-6-0/63103/5

## Problem

TypeScript 6.0's `esnext.typedarrays.d.ts` declares `toBase64` on `Uint8Array` and `fromBase64` on `Uint8ArrayConstructor` as **required** methods. Babylon's `browser.d.ts` declared them as **optional** (`?`), causing `TS2386: Overload signatures must all be optional or required` when users include both `ESNext` and `DOM` libs.

## Fix

1. **`browser.d.ts`** — Remove the optional markers (`?`) from `toBase64` and `fromBase64` to match the official TypeScript declarations.
2. **`stringTools.ts`** — Change runtime feature-detection from truthy checks (`bytes.toBase64 ? ...`) to `typeof` guards (`typeof bytes.toBase64 === "function"`), so the code remains safe on runtimes that lack these methods even though the type declarations are now non-optional.
