### PR TITLE
fix(audio): prevent iOS Safari FPS throttle from silent HTML audio

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -202,6 +202,7 @@ export abstract class AbstractSound extends AbstractSoundSource {
         }
 
         instance.onEndedObservable.addOnce(this._onInstanceEnded);
+        instance.onStateChangedObservable.add(this._onInstanceStateChanged);
         this._privateInstances.add(instance);
         this._newestInstance = instance;
     }
@@ -248,6 +249,7 @@ export abstract class AbstractSound extends AbstractSoundSource {
             this._newestInstance = null;
         }
 
+        instance.onStateChangedObservable.removeCallback(this._onInstanceStateChanged);
         this._privateInstances.delete(instance);
 
         if (this._instances.size === 0) {
@@ -257,6 +259,10 @@ export abstract class AbstractSound extends AbstractSoundSource {
 
         instance.dispose();
 
+        this.engine._onSoundPlaybackStateChanged();
+    };
+
+    private _onInstanceStateChanged: (instance: _AbstractSoundInstance) => void = (_instance) => {
         this.engine._onSoundPlaybackStateChanged();
     };
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -169,6 +169,7 @@ export abstract class AbstractSound extends AbstractSoundSource {
         }
 
         this._state = SoundState.Paused;
+        this.engine._onSoundPlaybackStateChanged();
     }
 
     /**
@@ -185,6 +186,7 @@ export abstract class AbstractSound extends AbstractSoundSource {
         }
 
         this._state = SoundState.Started;
+        this.engine._onSoundPlaybackStateChanged();
     }
 
     /**
@@ -206,6 +208,7 @@ export abstract class AbstractSound extends AbstractSoundSource {
 
     protected _afterPlay(instance: _AbstractSoundInstance): void {
         this._state = instance.state;
+        this.engine._onSoundPlaybackStateChanged();
     }
 
     protected _getNewestInstance(): Nullable<_AbstractSoundInstance> {
@@ -253,5 +256,7 @@ export abstract class AbstractSound extends AbstractSoundSource {
         }
 
         instance.dispose();
+
+        this.engine._onSoundPlaybackStateChanged();
     };
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts
@@ -300,6 +300,15 @@ export abstract class AudioEngineV2 {
         this._removeNode(sound);
     }
 
+    /**
+     * Called when any sound's playback state changes (started, stopped, paused, resumed).
+     * Override in platform-specific implementations to react to sound playback state changes.
+     * @internal
+     */
+    public _onSoundPlaybackStateChanged(): void {
+        // No-op base implementation.
+    }
+
     private _disposeSoundsArray(): void {
         if (this._soundsArray) {
             this._soundsArray.length = 0;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -436,6 +436,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
         if (hasActiveSounds && this._silentHtmlAudio.paused) {
             // Resume silent audio for iOS ringer switch workaround while sounds are playing.
+            // Errors are safe to ignore — the silent audio element is a workaround, not a
+            // user-facing sound, so a rejected play (e.g. missing user gesture) is harmless.
             // eslint-disable-next-line github/no-then
             void this._silentHtmlAudio.play().catch(() => {});
         } else if (!hasActiveSounds && !this._silentHtmlAudio.paused) {
@@ -512,6 +514,10 @@ export class _WebAudioEngine extends AudioEngineV2 {
             audio.src = "data:audio/wav;base64,UklGRjAAAABXQVZFZm10IBAAAAABAAEAgLsAAAB3AQACABAAZGF0YQwAAAAAAAEA/v8CAP//AQA=";
 
             // Play briefly to activate the element, then immediately pause.
+            // The rejection handler is intentionally empty — play() can reject if the
+            // browser requires a more specific user gesture; this is non-fatal since
+            // the audio context unlock is the primary goal, and the silent element is
+            // only a supplementary iOS ringer-switch workaround.
             // eslint-disable-next-line github/no-then
             audio.play().then(
                 () => audio.pause(),

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -2,6 +2,7 @@ import { Observable } from "../../Misc/observable";
 import { type Nullable } from "../../types";
 import { type AbstractNamedAudioNode } from "../abstractAudio/abstractAudioNode";
 import { type AbstractSound } from "../abstractAudio/abstractSound";
+import { SoundState } from "../soundState";
 import { type AbstractSoundSource, type ISoundSourceOptions } from "../abstractAudio/abstractSoundSource";
 import { type AudioBus, type IAudioBusOptions } from "../abstractAudio/audioBus";
 import { type AudioEngineV2State, type IAudioEngineV2Options, AudioEngineV2 } from "../abstractAudio/audioEngineV2";
@@ -426,6 +427,25 @@ export class _WebAudioEngine extends AudioEngineV2 {
     }
 
     /** @internal */
+    public override _onSoundPlaybackStateChanged(): void {
+        if (!this._silentHtmlAudio) {
+            return;
+        }
+
+        const hasActiveSounds = this.sounds.some((s) => s.state === SoundState.Started);
+
+        if (hasActiveSounds && this._silentHtmlAudio.paused) {
+            // Resume silent audio for iOS ringer switch workaround while sounds are playing.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            this._silentHtmlAudio.play();
+        } else if (!hasActiveSounds && !this._silentHtmlAudio.paused) {
+            // Pause silent audio when no sounds are playing to avoid triggering iOS Safari's
+            // audio playback detection, which causes FPS throttling and shows a blue audio icon.
+            this._silentHtmlAudio.pause();
+        }
+    }
+
+    /** @internal */
     public _addUpdateObserver(callback: () => void): void {
         if (!this._updateObservable) {
             this._updateObservable = new Observable<void>();
@@ -477,6 +497,9 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
         // On iOS the ringer switch must be turned on for WebAudio to play.
         // This gets WebAudio to play with the ringer switch turned off by playing an HTMLAudioElement.
+        // The element is activated during a user gesture so it can be played/paused programmatically
+        // later. It is immediately paused to avoid triggering iOS Safari's "now playing" detection,
+        // which throttles the page to 30 FPS.
         if (!this._silentHtmlAudio) {
             this._silentHtmlAudio = document.createElement("audio");
 
@@ -488,8 +511,12 @@ export class _WebAudioEngine extends AudioEngineV2 {
             // Wave data for 0.0001 seconds of silence.
             audio.src = "data:audio/wav;base64,UklGRjAAAABXQVZFZm10IBAAAAABAAEAgLsAAAB3AQACABAAZGF0YQwAAAAAAAEA/v8CAP//AQA=";
 
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            audio.play();
+            // Play briefly to activate the element, then immediately pause.
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises, github/no-then
+            audio.play().then(
+                () => audio.pause(),
+                () => {}
+            );
         }
 
         this.userGestureObservable.notifyObservers();

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -432,12 +432,12 @@ export class _WebAudioEngine extends AudioEngineV2 {
             return;
         }
 
-        const hasActiveSounds = this.sounds.some((s) => s.state === SoundState.Started);
+        const hasActiveSounds = this.sounds.some((s) => s.state === SoundState.Started || s.state === SoundState.Starting || s.state === SoundState.Stopping);
 
         if (hasActiveSounds && this._silentHtmlAudio.paused) {
             // Resume silent audio for iOS ringer switch workaround while sounds are playing.
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            this._silentHtmlAudio.play();
+            // eslint-disable-next-line github/no-then
+            void this._silentHtmlAudio.play().catch(() => {});
         } else if (!hasActiveSounds && !this._silentHtmlAudio.paused) {
             // Pause silent audio when no sounds are playing to avoid triggering iOS Safari's
             // audio playback detection, which causes FPS throttling and shows a blue audio icon.
@@ -512,7 +512,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
             audio.src = "data:audio/wav;base64,UklGRjAAAABXQVZFZm10IBAAAAABAAEAgLsAAAB3AQACABAAZGF0YQwAAAAAAAEA/v8CAP//AQA=";
 
             // Play briefly to activate the element, then immediately pause.
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises, github/no-then
+            // eslint-disable-next-line github/no-then
             audio.play().then(
                 () => audio.pause(),
                 () => {}


### PR DESCRIPTION
## Problem

On iOS Safari, initializing the audio engine (v1 or v2) causes FPS to drop from 60 to 30. This happens because the engine plays a looping silent HTML `<audio>` element to work around the iOS ringer switch restriction. Safari detects this as active audio playback, shows a blue audio icon in the address bar, and throttles the page to 30 FPS — even when no actual sounds are playing.

**Forum report:** https://forum.babylonjs.com/t/audio-engine-tanking-fps-in-ios-safari/63232

## Fix

1. **On user gesture:** The silent audio element is still activated (played then immediately paused) during a user gesture to "unlock" it for later programmatic use. It no longer loops indefinitely.

2. **Sound playback tracking:** Added `_onSoundPlaybackStateChanged()` hook to `AudioEngineV2` base class, called from `AbstractSound` on play, pause, resume, and stop events.

3. **Conditional silent audio:** `_WebAudioEngine` overrides the hook to play the silent audio only while actual sounds are active, and pauses it when all sounds stop. This removes the blue icon and restores 60 FPS.

## Changed files

- `packages/dev/core/src/AudioV2/abstractAudio/audioEngineV2.ts` — Added `_onSoundPlaybackStateChanged()` base hook
- `packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts` — Notify engine on play/pause/resume/stop
- `packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts` — Manage silent audio lifecycle based on active sounds

## Testing

- All 39 existing audio unit tests pass
- No TypeScript compilation errors in changed files