### PR TITLE
docs: clarify Material.freeze() and SnapshotRenderingHelper.updateMesh()

### DIFF
--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1121,12 +1121,17 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     /**
      * Locks updates for the material.
      *
-     * Note: while a material is frozen, per-frame uniform binding is skipped on
-     * subsequent frames (only the first frame after `freeze()` uploads them).
+     * Note: while a material is frozen, the scene can still rebind it at least
+     * once per camera render (and again whenever another material was bound in
+     * between). What can be skipped while the frozen material stays cached are
+     * per-mesh updates performed during a rebind.
+     *
      * This includes per-mesh morph target influences. If the same frozen
      * material is shared across several meshes that each have different
-     * per-mesh morph influences, only the influences that were bound last stay
-     * live in the uniform, so every mesh ends up rendering with those values.
+     * per-mesh morph influences, only the mesh that triggers the rebind updates
+     * those values. Other meshes rendered afterward with the same cached frozen
+     * material may reuse stale influences and render with the wrong values.
+     *
      * For that scenario either keep the material unfrozen, clone the material
      * per mesh and freeze each clone, or `unfreeze()` before changing
      * influences and `freeze()` again afterwards.

--- a/packages/dev/core/src/Materials/material.ts
+++ b/packages/dev/core/src/Materials/material.ts
@@ -1119,7 +1119,17 @@ export class Material implements IAnimatable, IClipPlanesHolder {
     }
 
     /**
-     * Locks updates for the material
+     * Locks updates for the material.
+     *
+     * Note: while a material is frozen, per-frame uniform binding is skipped on
+     * subsequent frames (only the first frame after `freeze()` uploads them).
+     * This includes per-mesh morph target influences. If the same frozen
+     * material is shared across several meshes that each have different
+     * per-mesh morph influences, only the influences that were bound last stay
+     * live in the uniform, so every mesh ends up rendering with those values.
+     * For that scenario either keep the material unfrozen, clone the material
+     * per mesh and freeze each clone, or `unfreeze()` before changing
+     * influences and `freeze()` again afterwards.
      */
     public freeze(): void {
         this.markDirty();

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -313,9 +313,11 @@ export class SnapshotRenderingHelper {
     /**
      * Call this method to update a mesh on the GPU after some properties have changed (position, rotation, scaling).
      * Note: in FAST snapshot mode the GPU bundle is recorded once and replayed every frame, so draw calls
-     * (including instance counts) are baked in. Visibility cannot be toggled with this method — to hide or show
-     * a mesh or an instance, wrap the change in a disableSnapshotRendering() / enableSnapshotRendering() pair so
-     * the snapshot is re-recorded.
+     * (including instance counts) are baked in. This method updates per-mesh GPU data such as transforms and
+     * `mesh.visibility`, but it cannot change whether a recorded draw call is emitted. To apply changes such as
+     * `mesh.isVisible`, `setEnabled(false)`, or per-instance visibility/state changes that affect instance counts,
+     * wrap the change in a disableSnapshotRendering() / enableSnapshotRendering() pair so the snapshot is
+     * re-recorded.
      * @param mesh The mesh to update. Can be a single mesh or an array of meshes to update.
      * @param updateInstancedMeshes If true, the method will also update instanced meshes. Default is true. If you know instanced meshes won't move (or you don't have instanced meshes), you can set this to false to save some CPU time.
      */

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -311,7 +311,11 @@ export class SnapshotRenderingHelper {
     }
 
     /**
-     * Call this method to update a mesh on the GPU after some properties have changed (position, rotation, scaling, visibility).
+     * Call this method to update a mesh on the GPU after some properties have changed (position, rotation, scaling).
+     * Note: in FAST snapshot mode the GPU bundle is recorded once and replayed every frame, so draw calls
+     * (including instance counts) are baked in. Visibility cannot be toggled with this method — to hide or show
+     * a mesh or an instance, wrap the change in a disableSnapshotRendering() / enableSnapshotRendering() pair so
+     * the snapshot is re-recorded.
      * @param mesh The mesh to update. Can be a single mesh or an array of meshes to update.
      * @param updateInstancedMeshes If true, the method will also update instanced meshes. Default is true. If you know instanced meshes won't move (or you don't have instanced meshes), you can set this to false to save some CPU time.
      */


### PR DESCRIPTION
Doc-string only changes — no behavior changes.

### `Material.freeze()` (`packages/dev/core/src/Materials/material.ts`)

Adds a note that while a material is frozen, per-frame uniform binding is skipped on subsequent frames. In particular, per-mesh morph-target influences are no longer uploaded, so if one frozen material is shared across multiple meshes with **different** per-mesh morph influences, only the last-bound influences stay live and every mesh ends up rendering with those (i.e. they all look the same). Documents the three workarounds:

1. Don't `freeze()` the shared material.
2. Clone the material per mesh and `freeze()` each clone.
3. `unfreeze()` before changing influences and `freeze()` again.

Surfaced from forum thread: <https://forum.babylonjs.com/t/is-it-intentional-that-morph-targets-do-not-work-on-meshes-with-frozen-materials/63252>.

### `SnapshotRenderingHelper.updateMesh()` (`packages/dev/core/src/Misc/snapshotRenderingHelper.ts`)

Clarifies that in FAST snapshot mode the GPU bundle is recorded once and replayed every frame, so visibility cannot be toggled through this method — to hide/show a mesh wrap the change in a `disableSnapshotRendering()` / `enableSnapshotRendering()` pair.
