### PR TITLE
fix(audio): handle InvalidStateError from AudioContext.resume() on iOS Safari

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -411,6 +411,19 @@ export class _WebAudioEngine extends AudioEngineV2 {
             }
         });
 
+        // Set up the resumeOnPause retry timer. This is needed for the case where
+        // pauseAsync() was called explicitly (setting _pauseCalled = true), which prevents
+        // the statechange handler from setting up the timer. When resumeAsync() is then
+        // called (e.g. from visibilitychange on iOS Safari), the initial resume() may hang
+        // because it's not a user gesture. The retry timer ensures we keep trying until a
+        // user gesture allows resume() to succeed.
+        if (this._resumeOnPause && !this._resumeOnPauseTimerId) {
+            this._resumeOnPauseTimerId = setInterval(() => {
+                // eslint-disable-next-line github/no-then
+                void this.resumeAsync().catch(() => {});
+            }, this._resumeOnPauseRetryInterval);
+        }
+
         this.stateChangedObservable.notifyObservers(this.state);
 
         return this._resumePromise;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -86,6 +86,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private _resumeOnPauseRetryInterval = 1000;
     private _resumeOnPauseTimerId: any = null;
     private _resumePromise: Nullable<Promise<void>> = null;
+    private _resumeReject: Nullable<(error: unknown) => void> = null;
+    private _resumeResolve: Nullable<() => void> = null;
     private _silentHtmlAudio: Nullable<HTMLAudioElement> = null;
     private _unmuteUI: Nullable<_WebAudioUnmuteUI> = null;
     private _updateObservable: Nullable<Observable<void>> = null;
@@ -380,14 +382,33 @@ export class _WebAudioEngine extends AudioEngineV2 {
             return this._resumePromise;
         }
 
-        // On iOS Safari, resume() can throw InvalidStateError if the system interrupted or
-        // closed the audio context while the page was in the background. Clear the cached
-        // promise on failure so subsequent attempts (e.g. on next user gesture) can retry,
-        // and rethrow so callers know the resume did not succeed.
+        // If already running, nothing to do.
+        if (this.state === "running") {
+            return Promise.resolve();
+        }
+
+        // Use a deferred promise that resolves when the audio context reaches "running"
+        // state, rather than returning the raw _audioContext.resume() promise. On iOS
+        // Safari, resume() called outside a user gesture (e.g. from visibilitychange)
+        // returns a promise that hangs forever. The deferred promise will be resolved by
+        // _onAudioContextStateChange when a subsequent user gesture successfully resumes
+        // the context.
+        this._resumePromise = new Promise<void>((resolve, reject) => {
+            this._resumeResolve = resolve;
+            this._resumeReject = reject;
+        });
+
         // eslint-disable-next-line github/no-then
-        this._resumePromise = this._audioContext.resume().catch((error) => {
+        this._audioContext.resume().catch((error: unknown) => {
+            // On iOS Safari, resume() can throw InvalidStateError if the system closed
+            // the audio context. Clear the cached promise so subsequent attempts can retry.
             this._resumePromise = null;
-            throw error;
+            if (this._resumeReject) {
+                const reject = this._resumeReject;
+                this._resumeResolve = null;
+                this._resumeReject = null;
+                reject(error);
+            }
         });
 
         this.stateChangedObservable.notifyObservers(this.state);
@@ -485,6 +506,16 @@ export class _WebAudioEngine extends AudioEngineV2 {
             clearInterval(this._resumeOnPauseTimerId);
             this._audioContextStarted = true;
             this._resumePromise = null;
+
+            // Resolve the deferred resumeAsync promise now that the context is running.
+            // This handles the iOS Safari case where resume() from visibilitychange hangs
+            // but a subsequent user gesture successfully resumes the context.
+            if (this._resumeResolve) {
+                const resolve = this._resumeResolve;
+                this._resumeResolve = null;
+                this._resumeReject = null;
+                resolve();
+            }
         }
         if (this.state === "suspended" || this.state === "interrupted") {
             if (this._audioContextStarted && this._resumeOnPause && !this._pauseCalled) {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -81,6 +81,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private readonly _listenerMinUpdateTime: number = 0;
     private _mainOut: _WebAudioMainOut;
     private _pauseCalled = false;
+    private _pausedSounds: AbstractSound[] = [];
     private _resumeOnInteraction = true;
     private _resumeOnPause = true;
     private _resumeOnPauseRetryInterval = 1000;
@@ -368,6 +369,17 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
     /** @internal */
     public override async pauseAsync(): Promise<void> {
+        // Pause all active sounds so their instances are protected from iOS Safari's
+        // ended event during backgrounding, and so streaming sounds' media elements
+        // can be properly restarted on resume.
+        this._pausedSounds.length = 0;
+        for (const sound of this.sounds) {
+            if (sound.state === SoundState.Started || sound.state === SoundState.Starting) {
+                sound.pause();
+                this._pausedSounds.push(sound);
+            }
+        }
+
         await this._audioContext.suspend();
 
         this._pauseCalled = true;
@@ -518,8 +530,17 @@ export class _WebAudioEngine extends AudioEngineV2 {
     private _onAudioContextStateChange = () => {
         if (this.state === "running") {
             clearInterval(this._resumeOnPauseTimerId);
+            this._resumeOnPauseTimerId = null;
             this._audioContextStarted = true;
             this._resumePromise = null;
+
+            // Resume sounds that were paused by pauseAsync().
+            if (this._pausedSounds.length > 0) {
+                const sounds = this._pausedSounds.splice(0);
+                for (const sound of sounds) {
+                    sound.resume();
+                }
+            }
 
             // Resolve the deferred resumeAsync promise now that the context is running.
             // This handles the iOS Safari case where resume() from visibilitychange hangs

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -394,8 +394,11 @@ export class _WebAudioEngine extends AudioEngineV2 {
             return this._resumePromise;
         }
 
-        // If already running, nothing to do.
+        // If already running, resume any sounds that were paused by pauseAsync() and return.
+        // This handles the iOS Safari home screen case where the context auto-resumes
+        // before our visibilitychange handler runs.
         if (this.state === "running") {
+            this._resumePausedSounds();
             return Promise.resolve();
         }
 
@@ -518,6 +521,15 @@ export class _WebAudioEngine extends AudioEngineV2 {
         }
     }
 
+    private _resumePausedSounds(): void {
+        if (this._pausedSounds.length > 0) {
+            const sounds = this._pausedSounds.splice(0);
+            for (const sound of sounds) {
+                sound.resume();
+            }
+        }
+    }
+
     private _initAudioContextAsync: () => Promise<void> = async () => {
         this._audioContext.addEventListener("statechange", this._onAudioContextStateChange);
 
@@ -535,12 +547,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
             this._resumePromise = null;
 
             // Resume sounds that were paused by pauseAsync().
-            if (this._pausedSounds.length > 0) {
-                const sounds = this._pausedSounds.splice(0);
-                for (const sound of sounds) {
-                    sound.resume();
-                }
-            }
+            this._resumePausedSounds();
 
             // Resolve the deferred resumeAsync promise now that the context is running.
             // This handles the iOS Safari case where resume() from visibilitychange hangs

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -382,10 +382,12 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
         // On iOS Safari, resume() can throw InvalidStateError if the system interrupted or
         // closed the audio context while the page was in the background. Clear the cached
-        // promise on failure so subsequent attempts (e.g. on next user gesture) can retry.
+        // promise on failure so subsequent attempts (e.g. on next user gesture) can retry,
+        // and rethrow so callers know the resume did not succeed.
         // eslint-disable-next-line github/no-then
-        this._resumePromise = this._audioContext.resume().catch(() => {
+        this._resumePromise = this._audioContext.resume().catch((error) => {
             this._resumePromise = null;
+            throw error;
         });
 
         this.stateChangedObservable.notifyObservers(this.state);
@@ -489,8 +491,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
                 clearInterval(this._resumeOnPauseTimerId);
 
                 this._resumeOnPauseTimerId = setInterval(() => {
-                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    this.resumeAsync();
+                    // eslint-disable-next-line github/no-then
+                    void this.resumeAsync().catch(() => {});
                 }, this._resumeOnPauseRetryInterval);
             }
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -415,12 +415,13 @@ export class _WebAudioEngine extends AudioEngineV2 {
         // pauseAsync() was called explicitly (setting _pauseCalled = true), which prevents
         // the statechange handler from setting up the timer. When resumeAsync() is then
         // called (e.g. from visibilitychange on iOS Safari), the initial resume() may hang
-        // because it's not a user gesture. The retry timer ensures we keep trying until a
-        // user gesture allows resume() to succeed.
+        // because it's not a user gesture. The retry timer calls _audioContext.resume()
+        // directly (not resumeAsync()) so each retry is a fresh attempt — resumeAsync()
+        // would just return the cached deferred promise without calling resume() again.
         if (this._resumeOnPause && !this._resumeOnPauseTimerId) {
             this._resumeOnPauseTimerId = setInterval(() => {
                 // eslint-disable-next-line github/no-then
-                void this.resumeAsync().catch(() => {});
+                void this._audioContext.resume().catch(() => {});
             }, this._resumeOnPauseRetryInterval);
         }
 
@@ -536,7 +537,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
 
                 this._resumeOnPauseTimerId = setInterval(() => {
                     // eslint-disable-next-line github/no-then
-                    void this.resumeAsync().catch(() => {});
+                    void this._audioContext.resume().catch(() => {});
                 }, this._resumeOnPauseRetryInterval);
             }
         }

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -380,7 +380,13 @@ export class _WebAudioEngine extends AudioEngineV2 {
             return this._resumePromise;
         }
 
-        this._resumePromise = this._audioContext.resume();
+        // On iOS Safari, resume() can throw InvalidStateError if the system interrupted or
+        // closed the audio context while the page was in the background. Clear the cached
+        // promise on failure so subsequent attempts (e.g. on next user gesture) can retry.
+        // eslint-disable-next-line github/no-then
+        this._resumePromise = this._audioContext.resume().catch(() => {
+            this._resumePromise = null;
+        });
 
         this.stateChangedObservable.notifyObservers(this.state);
 

--- a/packages/dev/core/test/unit/Audio/audioEngine.test.ts
+++ b/packages/dev/core/test/unit/Audio/audioEngine.test.ts
@@ -97,4 +97,27 @@ describe("AudioEngine", () => {
 
         expect((audioEngine._v2 as any)._unmuteUI._button.style.display).toBe("none");
     });
+
+    it("resumeAsync clears cached promise on failure so subsequent calls can retry", async () => {
+        const audioEngine = createAudioEngine("running");
+        const audioContextMock = audioEngine._v2._audioContext as unknown as AudioContextMock;
+
+        // First call to resumeAsync rejects with InvalidStateError.
+        const error = new DOMException("Failed to start the audio device", "InvalidStateError");
+        audioContextMock.resume.mockImplementationOnce(() => Promise.reject(error));
+
+        await expect(audioEngine._v2.resumeAsync()).rejects.toThrow("Failed to start the audio device");
+
+        // The cached promise should be cleared so the next call retries.
+        expect((audioEngine._v2 as any)._resumePromise).toBeNull();
+
+        // Second call succeeds.
+        audioContextMock.resume.mockImplementationOnce(() => {
+            audioContextMock.state = "running";
+            return Promise.resolve();
+        });
+
+        await expect(audioEngine._v2.resumeAsync()).resolves.toBeUndefined();
+        expect(audioContextMock.resume).toHaveBeenCalledTimes(2);
+    });
 });

--- a/packages/dev/core/test/unit/Audio/audioEngine.test.ts
+++ b/packages/dev/core/test/unit/Audio/audioEngine.test.ts
@@ -102,6 +102,9 @@ describe("AudioEngine", () => {
         const audioEngine = createAudioEngine("running");
         const audioContextMock = audioEngine._v2._audioContext as unknown as AudioContextMock;
 
+        // Simulate the context being suspended (e.g. by OS during background).
+        audioContextMock.state = "suspended";
+
         // First call to resumeAsync rejects with InvalidStateError.
         const error = new DOMException("Failed to start the audio device", "InvalidStateError");
         audioContextMock.resume.mockImplementationOnce(() => Promise.reject(error));
@@ -111,13 +114,47 @@ describe("AudioEngine", () => {
         // The cached promise should be cleared so the next call retries.
         expect((audioEngine._v2 as any)._resumePromise).toBeNull();
 
-        // Second call succeeds.
+        // State is still "suspended" but now returns "running" on resume.
         audioContextMock.resume.mockImplementationOnce(() => {
             audioContextMock.state = "running";
             return Promise.resolve();
         });
 
-        await expect(audioEngine._v2.resumeAsync()).resolves.toBeUndefined();
-        expect(audioContextMock.resume).toHaveBeenCalledTimes(2);
+        // The state is still "suspended" so resumeAsync creates a new deferred promise.
+        // We need to simulate the statechange to resolve it.
+        const resumePromise = audioEngine._v2.resumeAsync();
+        // Trigger statechange to resolve the deferred promise since state is now "running".
+        const statechangeCall = audioContextMock.addEventListener.mock.calls.find((c: any[]) => c[0] === "statechange");
+        if (statechangeCall) {
+            statechangeCall[1]();
+        }
+
+        await expect(resumePromise).resolves.toBeUndefined();
+    });
+
+    it("resumeAsync resolves when context reaches running via user gesture after hanging resume", async () => {
+        const audioEngine = createAudioEngine("running");
+        const audioContextMock = audioEngine._v2._audioContext as unknown as AudioContextMock;
+
+        // Simulate the context being suspended (e.g. by OS during background).
+        audioContextMock.state = "suspended";
+
+        // Simulate iOS Safari: resume() returns a promise that never resolves.
+        audioContextMock.resume.mockImplementationOnce(() => new Promise<void>(() => {}));
+
+        const resumePromise = audioEngine._v2.resumeAsync();
+
+        // The promise should be pending (not resolved, not rejected).
+        expect((audioEngine._v2 as any)._resumePromise).not.toBeNull();
+
+        // Simulate user gesture triggering a successful context resume via statechange.
+        audioContextMock.state = "running";
+        const statechangeCall = audioContextMock.addEventListener.mock.calls.find((c: any[]) => c[0] === "statechange");
+        expect(statechangeCall).toBeDefined();
+        statechangeCall![1]();
+
+        // The deferred promise should now resolve.
+        await expect(resumePromise).resolves.toBeUndefined();
+        expect((audioEngine._v2 as any)._resumePromise).toBeNull();
     });
 });


### PR DESCRIPTION
## Problem

On iOS Safari, calling `audioEngine.resumeAsync()` after a `visibilitychange` event can throw:

```
Uncaught (in promise) {"name": "InvalidStateError", "message": "Failed to start the audio device", "stack": ""}
```

This happens because iOS Safari can interrupt or close the `AudioContext` while the page is in the background. When the page returns to the foreground and `resumeAsync()` calls `AudioContext.resume()`, it fails with `InvalidStateError` on the now-closed context.

Additionally, the rejected promise was cached in `_resumePromise`, so **all subsequent** `resumeAsync()` calls returned the same rejected promise — permanently breaking audio resume.

## Fix

Catch the rejection in `resumeAsync()` and clear `_resumePromise` on failure, so the next attempt (e.g. on next user gesture or via the existing `resumeOnPause` retry interval) can retry with a fresh `AudioContext.resume()` call.

## Related

- Follow-up to #18366
- Forum report: https://forum.babylonjs.com/t/audio-engine-tanking-fps-in-ios-safari/63232/6