### PR TITLE
fix(core): serialize freezeWorldMatrix for Mesh and TransformNode

### DIFF
--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -709,6 +709,13 @@ const LoadAssetContainer = (scene: Scene, data: string | object, rootUrl: string
         }
 
         // freeze world matrix application
+        for (index = 0, cache = scene.transformNodes.length; index < cache; index++) {
+            const currentTransformNode = scene.transformNodes[index];
+            if (currentTransformNode._waitingFreezeWorldMatrix) {
+                currentTransformNode.freezeWorldMatrix();
+                currentTransformNode._waitingFreezeWorldMatrix = null;
+            }
+        }
         for (index = 0, cache = scene.meshes.length; index < cache; index++) {
             const currentMesh = scene.meshes[index];
             if (currentMesh._waitingData.freezeWorldMatrix) {
@@ -1147,6 +1154,13 @@ RegisterSceneLoaderPlugin({
                 }
 
                 // freeze and compute world matrix application
+                for (let index = 0, cache = scene.transformNodes.length; index < cache; index++) {
+                    const currentTransformNode = scene.transformNodes[index];
+                    if (currentTransformNode._waitingFreezeWorldMatrix) {
+                        currentTransformNode.freezeWorldMatrix();
+                        currentTransformNode._waitingFreezeWorldMatrix = null;
+                    }
+                }
                 for (let index = 0, cache = scene.meshes.length; index < cache; index++) {
                     currentMesh = scene.meshes[index];
                     if (currentMesh._waitingData.freezeWorldMatrix) {

--- a/packages/dev/core/src/Meshes/mesh.ts
+++ b/packages/dev/core/src/Meshes/mesh.ts
@@ -4134,6 +4134,10 @@ export class Mesh extends AbstractMesh implements IGetSetVerticesData {
         serializationObject.isBlocker = this.isBlocker;
         serializationObject.sideOrientation = this.sideOrientation;
 
+        if (this._isWorldMatrixFrozen) {
+            serializationObject.freezeWorldMatrix = true;
+        }
+
         // Parent
         if (this.parent) {
             this.parent._serializeAsParent(serializationObject);

--- a/packages/dev/core/src/Meshes/transformNode.ts
+++ b/packages/dev/core/src/Meshes/transformNode.ts
@@ -154,6 +154,13 @@ export class TransformNode extends Node {
 
     protected _isWorldMatrixFrozen = false;
 
+    /**
+     * @internal
+     * Set by .babylon parsers to defer freezeWorldMatrix() until parent links are resolved.
+     * Declared (not initialized) to avoid pushing every TransformNode/Mesh instance into V8 dictionary mode.
+     */
+    declare public _waitingFreezeWorldMatrix?: Nullable<boolean>;
+
     /** @internal */
     public _indexInSceneTransformNodesArray = -1;
 
@@ -1469,6 +1476,10 @@ export class TransformNode extends Node {
 
         serializationObject.isEnabled = this.isEnabled();
 
+        if (this._isWorldMatrixFrozen) {
+            serializationObject.freezeWorldMatrix = true;
+        }
+
         // Animations
         SerializationHelper.AppendSerializedAnimations(this, serializationObject);
         serializationObject.ranges = this.serializeAnimationRanges();
@@ -1504,6 +1515,10 @@ export class TransformNode extends Node {
 
         if (parsedTransformNode.parentInstanceIndex !== undefined) {
             transformNode._waitingParentInstanceIndex = parsedTransformNode.parentInstanceIndex;
+        }
+
+        if (parsedTransformNode.freezeWorldMatrix) {
+            transformNode._waitingFreezeWorldMatrix = parsedTransformNode.freezeWorldMatrix;
         }
 
         // Animations

--- a/packages/dev/core/test/unit/Scene/babylon.sceneSerializer.test.ts
+++ b/packages/dev/core/test/unit/Scene/babylon.sceneSerializer.test.ts
@@ -2,6 +2,7 @@ import { ActionManager, IncrementValueAction } from "core/Actions";
 import { FreeCamera } from "core/Cameras/freeCamera";
 import { type Engine, NullEngine } from "core/Engines";
 import { HemisphericLight } from "core/Lights";
+import { LoadAssetContainerFromSerializedScene } from "core/Loading/Plugins/babylonFileLoader";
 import { Vector2, Vector3 } from "core/Maths";
 import { TransformNode } from "core/Meshes";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
@@ -160,6 +161,64 @@ describe("Babylon scene serializer", () => {
             expect(resultWithoutParentAndChild).toBeTruthy();
             expect(resultWithoutParentAndChild.meshes.length).toBe(1);
             expect(resultWithoutParentAndChild.transformNodes.length).toBe(0);
+        });
+    });
+
+    describe("#freezeWorldMatrix round-trip", () => {
+        it("should serialize freezeWorldMatrix for frozen Mesh and TransformNode and skip it for unfrozen ones", () => {
+            const frozenMesh = MeshBuilder.CreateBox("frozenMesh", { size: 1 }, scene);
+            frozenMesh.position.set(1, 2, 3);
+            frozenMesh.freezeWorldMatrix();
+
+            MeshBuilder.CreateBox("unfrozenMesh", { size: 1 }, scene);
+
+            const frozenTransformNode = new TransformNode("frozenTransformNode", scene);
+            frozenTransformNode.position.set(4, 5, 6);
+            frozenTransformNode.freezeWorldMatrix();
+
+            new TransformNode("unfrozenTransformNode", scene);
+
+            const result = SceneSerializer.Serialize(scene);
+
+            const meshById = new Map<string, any>(result.meshes.map((m: any) => [m.name, m]));
+            expect(meshById.get("frozenMesh").freezeWorldMatrix).toBe(true);
+            expect(meshById.get("unfrozenMesh").freezeWorldMatrix).toBeUndefined();
+
+            const tnById = new Map<string, any>(result.transformNodes.map((t: any) => [t.name, t]));
+            expect(tnById.get("frozenTransformNode").freezeWorldMatrix).toBe(true);
+            expect(tnById.get("unfrozenTransformNode").freezeWorldMatrix).toBeUndefined();
+        });
+
+        it("should preserve frozen state for Mesh and TransformNode through a serialize/parse round-trip", () => {
+            const sourceMesh = MeshBuilder.CreateBox("box", { size: 1 }, scene);
+            sourceMesh.position.set(1, 2, 3);
+            sourceMesh.freezeWorldMatrix();
+
+            const sourceTransformNode = new TransformNode("tn", scene);
+            sourceTransformNode.position.set(4, 5, 6);
+            sourceTransformNode.freezeWorldMatrix();
+
+            const serialized = SceneSerializer.Serialize(scene);
+
+            const targetEngine = new NullEngine({
+                renderHeight: 256,
+                renderWidth: 256,
+                textureSize: 256,
+                deterministicLockstep: false,
+                lockstepMaxSteps: 1,
+            });
+            const targetScene = new Scene(targetEngine);
+            const container = LoadAssetContainerFromSerializedScene(targetScene, serialized, "");
+
+            const loadedMesh = container.meshes.find((m) => m.name === "box");
+            expect(loadedMesh).toBeDefined();
+            expect(loadedMesh!.isWorldMatrixFrozen).toBe(true);
+
+            const loadedTransformNode = container.transformNodes.find((t) => t.name === "tn");
+            expect(loadedTransformNode).toBeDefined();
+            expect(loadedTransformNode!.isWorldMatrixFrozen).toBe(true);
+
+            targetEngine.dispose();
         });
     });
 });


### PR DESCRIPTION
## Problem

Forum bug: [Mesh._isWorldMatrixFrozen not serialized](https://forum.babylonjs.com/t/63255) (reported by `@kzhsw`).

`Mesh.Parse` already consumes `parsedMesh.freezeWorldMatrix` (mesh.ts:4593-4596), but **nothing was writing it on the producer side**, so the freeze state was always lost on a `.babylon` serialize/parse round-trip. `TransformNode` had no support at all, even though `_isWorldMatrixFrozen` lives on `TransformNode`.

## Fix

- `Mesh.serialize()` and `TransformNode.serialize()` now emit `freezeWorldMatrix: true` when the node is frozen.
- `TransformNode.Parse()` stashes the value into a new internal `_waitingFreezeWorldMatrix` flag so the freeze can be applied **after** parent links are resolved (the world matrix would otherwise be wrong).
  - The field is `declare`'d (not initialized) so it does not become an own property on every `TransformNode`/`Mesh` instance — important to stay under V8's dictionary-mode threshold (`Mesh` is at 127 own properties; the existing `babylon.dictionaryMode.test.ts` guards `< 128`).
- `babylonFileLoader` applies the freeze pass for transform nodes in both load paths (`LoadAssetContainer` and the append-scene flow), after parent wiring and before the mesh freeze/compute pass.

## Tests

Added two tests to `babylon.sceneSerializer.test.ts`:
1. Frozen `Mesh`/`TransformNode` get `freezeWorldMatrix: true` in the serialized output; unfrozen ones omit the field.
2. Full round-trip via `LoadAssetContainerFromSerializedScene` — the loaded `Mesh` and `TransformNode` both report `isWorldMatrixFrozen === true`.

Existing `babylon.dictionaryMode.test.ts` still passes (the `declare` trick keeps `Mesh` at 127 own properties).

Closes the forum report.