### PR TITLE
ray: per-instance bounding-info culling for thin-instance picking

### DIFF
--- a/packages/dev/core/src/Culling/ray.core.ts
+++ b/packages/dev/core/src/Culling/ray.core.ts
@@ -2,6 +2,7 @@ import { Epsilon } from "core/Maths/math.constants";
 import { Matrix, TmpVectors, Vector3 } from "core/Maths/math.vector";
 import { BuildArray } from "core/Misc/arrayTools";
 import { IntersectionInfo } from "../Collisions/intersectionInfo";
+import { type BoundingInfo } from "./boundingInfo";
 import { type BoundingBox } from "./boundingBox";
 import { type BoundingSphere } from "./boundingSphere";
 import { type DeepImmutable, type float, type Nullable } from "core/types";
@@ -828,6 +829,19 @@ function InternalPickForMesh(
 ) {
     const ray = rayFunction(world, mesh.enableDistantPicking);
 
+    return InternalPickForMeshWithRay(pickingInfo, mesh, world, ray, fastCheck, onlyBoundingInfo, trianglePredicate, skipBoundingInfo);
+}
+
+function InternalPickForMeshWithRay(
+    pickingInfo: Nullable<PickingInfo>,
+    mesh: AbstractMesh,
+    world: Matrix,
+    ray: Ray,
+    fastCheck?: boolean,
+    onlyBoundingInfo?: boolean,
+    trianglePredicate?: TrianglePickingPredicate,
+    skipBoundingInfo?: boolean
+) {
     const result = mesh.intersects(ray, fastCheck, trianglePredicate, onlyBoundingInfo, world, skipBoundingInfo);
     if (!result || !result.hit) {
         return null;
@@ -838,6 +852,26 @@ function InternalPickForMesh(
     }
 
     return result;
+}
+
+function GetThinInstancePickingIntersectionThreshold(className: string, mesh: AbstractMesh): number {
+    return className === "InstancedLinesMesh" || className === "LinesMesh" ? (mesh as any).intersectionThreshold : 0;
+}
+
+function ThinInstanceIntersectsRawBoundingInfo(
+    rayFunction: (world: Matrix, enableDistantPicking: boolean) => Ray,
+    mesh: AbstractMesh,
+    world: Matrix,
+    rawBoundingInfo: BoundingInfo,
+    intersectionThreshold: number
+): Nullable<Ray> {
+    const ray = rayFunction(world, mesh.enableDistantPicking);
+
+    if (!ray.intersectsSphere(rawBoundingInfo.boundingSphere, intersectionThreshold) || !ray.intersectsBox(rawBoundingInfo.boundingBox, intersectionThreshold)) {
+        return null;
+    }
+
+    return ray;
 }
 
 function InternalPick(
@@ -876,6 +910,10 @@ function InternalPick(
                     // the user only asked for a bounding info check so we can return
                     return result;
                 }
+                const thinInstanceClassName = mesh.getClassName();
+                // GreasedLineMesh has a custom width-aware pick path, so the generic raw sphere+box precheck is not safe there.
+                const thinInstanceRawBoundingInfo = thinInstanceClassName === "GreasedLineMesh" ? null : mesh.rawBoundingInfo;
+                const thinInstanceIntersectionThreshold = thinInstanceRawBoundingInfo ? GetThinInstancePickingIntersectionThreshold(thinInstanceClassName, mesh) : 0;
                 const thinMatrixData = (mesh as Mesh)._thinInstanceDataStorage.matrixData;
                 if (thinMatrixData) {
                     const thinMatrix = TmpVectors.Matrix[0];
@@ -887,7 +925,18 @@ function InternalPick(
                         }
                         Matrix.FromArrayToRef(thinMatrixData, index << 4, thinMatrix);
                         thinMatrix.multiplyToRef(world, combinedWorld);
-                        const result = picker(pickingInfo, rayFunction, mesh, combinedWorld, fastCheck, onlyBoundingInfo, trianglePredicate, true);
+                        const thinInstanceRay = thinInstanceRawBoundingInfo
+                            ? ThinInstanceIntersectsRawBoundingInfo(rayFunction, mesh, combinedWorld, thinInstanceRawBoundingInfo, thinInstanceIntersectionThreshold)
+                            : null;
+
+                        if (thinInstanceRawBoundingInfo && !thinInstanceRay) {
+                            continue;
+                        }
+
+                        const result: Nullable<PickingInfo> =
+                            picker === InternalPickForMesh && thinInstanceRay
+                                ? InternalPickForMeshWithRay(pickingInfo, mesh, combinedWorld, thinInstanceRay, fastCheck, onlyBoundingInfo, trianglePredicate, true)
+                                : picker(pickingInfo, rayFunction, mesh, combinedWorld, fastCheck, onlyBoundingInfo, trianglePredicate, true);
 
                         if (result) {
                             pickingInfo = result;
@@ -947,6 +996,10 @@ function InternalMultiPick(
         if (mesh.hasThinInstances && (mesh as Mesh).thinInstanceEnablePicking) {
             const result = picker(null, rayFunction, mesh, world, true, true, trianglePredicate);
             if (result) {
+                const thinInstanceClassName = mesh.getClassName();
+                // GreasedLineMesh has a custom width-aware pick path, so the generic raw sphere+box precheck is not safe there.
+                const thinInstanceRawBoundingInfo = thinInstanceClassName === "GreasedLineMesh" ? null : mesh.rawBoundingInfo;
+                const thinInstanceIntersectionThreshold = thinInstanceRawBoundingInfo ? GetThinInstancePickingIntersectionThreshold(thinInstanceClassName, mesh) : 0;
                 const thinMatrixData = (mesh as Mesh)._thinInstanceDataStorage.matrixData;
                 if (thinMatrixData) {
                     const thinMatrix = TmpVectors.Matrix[0];
@@ -958,7 +1011,18 @@ function InternalMultiPick(
                         }
                         Matrix.FromArrayToRef(thinMatrixData, index << 4, thinMatrix);
                         thinMatrix.multiplyToRef(world, combinedWorld);
-                        const result = picker(null, rayFunction, mesh, combinedWorld, false, false, trianglePredicate, true);
+                        const thinInstanceRay = thinInstanceRawBoundingInfo
+                            ? ThinInstanceIntersectsRawBoundingInfo(rayFunction, mesh, combinedWorld, thinInstanceRawBoundingInfo, thinInstanceIntersectionThreshold)
+                            : null;
+
+                        if (thinInstanceRawBoundingInfo && !thinInstanceRay) {
+                            continue;
+                        }
+
+                        const result: Nullable<PickingInfo> =
+                            picker === InternalPickForMesh && thinInstanceRay
+                                ? InternalPickForMeshWithRay(null, mesh, combinedWorld, thinInstanceRay, false, false, trianglePredicate, true)
+                                : picker(null, rayFunction, mesh, combinedWorld, false, false, trianglePredicate, true);
 
                         if (result) {
                             result.thinInstanceIndex = index;

--- a/packages/dev/core/src/Culling/ray.core.ts
+++ b/packages/dev/core/src/Culling/ray.core.ts
@@ -832,6 +832,7 @@ function InternalPickForMesh(
     return InternalPickForMeshWithRay(pickingInfo, mesh, world, ray, fastCheck, onlyBoundingInfo, trianglePredicate, skipBoundingInfo);
 }
 
+// Used when a caller already has the mesh-local ray and wants to avoid rebuilding it through rayFunction.
 function InternalPickForMeshWithRay(
     pickingInfo: Nullable<PickingInfo>,
     mesh: AbstractMesh,
@@ -858,6 +859,20 @@ function GetThinInstancePickingIntersectionThreshold(className: string, mesh: Ab
     return className === "InstancedLinesMesh" || className === "LinesMesh" ? (mesh as any).intersectionThreshold : 0;
 }
 
+function GetThinInstanceRawBoundingInfo(mesh: AbstractMesh): { rawBoundingInfo: Nullable<BoundingInfo>; intersectionThreshold: number } {
+    const className = mesh.getClassName();
+
+    // GreasedLineMesh has a custom width-aware pick path, so the generic raw sphere+box precheck is not safe there.
+    if (className === "GreasedLineMesh") {
+        return { rawBoundingInfo: null, intersectionThreshold: 0 };
+    }
+
+    const rawBoundingInfo = mesh.rawBoundingInfo;
+
+    return { rawBoundingInfo, intersectionThreshold: rawBoundingInfo ? GetThinInstancePickingIntersectionThreshold(className, mesh) : 0 };
+}
+
+// Returns null when the raw-bounds precheck rejects; otherwise returns the mesh-local thin-instance ray to reuse downstream.
 function ThinInstanceIntersectsRawBoundingInfo(
     rayFunction: (world: Matrix, enableDistantPicking: boolean) => Ray,
     mesh: AbstractMesh,
@@ -887,6 +902,7 @@ function InternalPick(
     const computeWorldMatrixForCamera = !!(scene.activeCameras && scene.activeCameras.length > 1 && scene.cameraToUseForPointers !== scene.activeCamera);
     const currentCamera = scene.cameraToUseForPointers || scene.activeCamera;
     const picker = PickingCustomization.internalPickerForMesh || InternalPickForMesh;
+    const useFastPath = picker === InternalPickForMesh;
 
     for (let meshIndex = 0; meshIndex < scene.meshes.length; meshIndex++) {
         const mesh = scene.meshes[meshIndex];
@@ -910,10 +926,7 @@ function InternalPick(
                     // the user only asked for a bounding info check so we can return
                     return result;
                 }
-                const thinInstanceClassName = mesh.getClassName();
-                // GreasedLineMesh has a custom width-aware pick path, so the generic raw sphere+box precheck is not safe there.
-                const thinInstanceRawBoundingInfo = thinInstanceClassName === "GreasedLineMesh" ? null : mesh.rawBoundingInfo;
-                const thinInstanceIntersectionThreshold = thinInstanceRawBoundingInfo ? GetThinInstancePickingIntersectionThreshold(thinInstanceClassName, mesh) : 0;
+                const { rawBoundingInfo: thinInstanceRawBoundingInfo, intersectionThreshold: thinInstanceIntersectionThreshold } = GetThinInstanceRawBoundingInfo(mesh);
                 const thinMatrixData = (mesh as Mesh)._thinInstanceDataStorage.matrixData;
                 if (thinMatrixData) {
                     const thinMatrix = TmpVectors.Matrix[0];
@@ -925,16 +938,17 @@ function InternalPick(
                         }
                         Matrix.FromArrayToRef(thinMatrixData, index << 4, thinMatrix);
                         thinMatrix.multiplyToRef(world, combinedWorld);
-                        const thinInstanceRay = thinInstanceRawBoundingInfo
-                            ? ThinInstanceIntersectsRawBoundingInfo(rayFunction, mesh, combinedWorld, thinInstanceRawBoundingInfo, thinInstanceIntersectionThreshold)
-                            : null;
+                        const thinInstanceRay =
+                            useFastPath && thinInstanceRawBoundingInfo
+                                ? ThinInstanceIntersectsRawBoundingInfo(rayFunction, mesh, combinedWorld, thinInstanceRawBoundingInfo, thinInstanceIntersectionThreshold)
+                                : null;
 
-                        if (thinInstanceRawBoundingInfo && !thinInstanceRay) {
+                        if (useFastPath && thinInstanceRawBoundingInfo && !thinInstanceRay) {
                             continue;
                         }
 
                         const result: Nullable<PickingInfo> =
-                            picker === InternalPickForMesh && thinInstanceRay
+                            useFastPath && thinInstanceRay
                                 ? InternalPickForMeshWithRay(pickingInfo, mesh, combinedWorld, thinInstanceRay, fastCheck, onlyBoundingInfo, trianglePredicate, true)
                                 : picker(pickingInfo, rayFunction, mesh, combinedWorld, fastCheck, onlyBoundingInfo, trianglePredicate, true);
 
@@ -978,6 +992,7 @@ function InternalMultiPick(
     const computeWorldMatrixForCamera = !!(scene.activeCameras && scene.activeCameras.length > 1 && scene.cameraToUseForPointers !== scene.activeCamera);
     const currentCamera = scene.cameraToUseForPointers || scene.activeCamera;
     const picker = PickingCustomization.internalPickerForMesh || InternalPickForMesh;
+    const useFastPath = picker === InternalPickForMesh;
 
     for (let meshIndex = 0; meshIndex < scene.meshes.length; meshIndex++) {
         const mesh = scene.meshes[meshIndex];
@@ -996,10 +1011,7 @@ function InternalMultiPick(
         if (mesh.hasThinInstances && (mesh as Mesh).thinInstanceEnablePicking) {
             const result = picker(null, rayFunction, mesh, world, true, true, trianglePredicate);
             if (result) {
-                const thinInstanceClassName = mesh.getClassName();
-                // GreasedLineMesh has a custom width-aware pick path, so the generic raw sphere+box precheck is not safe there.
-                const thinInstanceRawBoundingInfo = thinInstanceClassName === "GreasedLineMesh" ? null : mesh.rawBoundingInfo;
-                const thinInstanceIntersectionThreshold = thinInstanceRawBoundingInfo ? GetThinInstancePickingIntersectionThreshold(thinInstanceClassName, mesh) : 0;
+                const { rawBoundingInfo: thinInstanceRawBoundingInfo, intersectionThreshold: thinInstanceIntersectionThreshold } = GetThinInstanceRawBoundingInfo(mesh);
                 const thinMatrixData = (mesh as Mesh)._thinInstanceDataStorage.matrixData;
                 if (thinMatrixData) {
                     const thinMatrix = TmpVectors.Matrix[0];
@@ -1011,16 +1023,17 @@ function InternalMultiPick(
                         }
                         Matrix.FromArrayToRef(thinMatrixData, index << 4, thinMatrix);
                         thinMatrix.multiplyToRef(world, combinedWorld);
-                        const thinInstanceRay = thinInstanceRawBoundingInfo
-                            ? ThinInstanceIntersectsRawBoundingInfo(rayFunction, mesh, combinedWorld, thinInstanceRawBoundingInfo, thinInstanceIntersectionThreshold)
-                            : null;
+                        const thinInstanceRay =
+                            useFastPath && thinInstanceRawBoundingInfo
+                                ? ThinInstanceIntersectsRawBoundingInfo(rayFunction, mesh, combinedWorld, thinInstanceRawBoundingInfo, thinInstanceIntersectionThreshold)
+                                : null;
 
-                        if (thinInstanceRawBoundingInfo && !thinInstanceRay) {
+                        if (useFastPath && thinInstanceRawBoundingInfo && !thinInstanceRay) {
                             continue;
                         }
 
                         const result: Nullable<PickingInfo> =
-                            picker === InternalPickForMesh && thinInstanceRay
+                            useFastPath && thinInstanceRay
                                 ? InternalPickForMeshWithRay(null, mesh, combinedWorld, thinInstanceRay, false, false, trianglePredicate, true)
                                 : picker(null, rayFunction, mesh, combinedWorld, false, false, trianglePredicate, true);
 

--- a/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
@@ -1,5 +1,5 @@
 import { type Engine, NullEngine } from "core/Engines";
-import { Matrix, Vector3 } from "core/Maths/math.vector";
+import { Matrix, Quaternion, Vector3 } from "core/Maths/math.vector";
 import { type Mesh, MeshBuilder } from "core/Meshes";
 import { Scene } from "core/scene";
 import { Ray } from "core/Culling/ray";
@@ -152,6 +152,55 @@ describe("ThinInstance picking", () => {
             expect(normal!.x).toBeCloseTo(0);
             expect(normal!.y).toBeCloseTo(1);
             expect(normal!.z).toBeCloseTo(0);
+        });
+
+        it("picks thin instances with mirrored non-uniform transforms", () => {
+            const transform = Matrix.Compose(new Vector3(-2, 0.5, 1.5), Quaternion.FromEulerAngles(0, 0, Math.PI / 4), new Vector3(3, 1, 0));
+            box.thinInstanceAdd(transform, true);
+            box.thinInstanceEnablePicking = true;
+
+            const ray = new Ray(new Vector3(3, 5, 0), new Vector3(0, -1, 0));
+            const info = scene.pickWithRay(ray);
+
+            expect(info!.hit).toBe(true);
+            expect(info!.thinInstanceIndex).toBe(0);
+            expect(info!.pickedMesh).toBe(box);
+        });
+
+        it("preserves thin-instance picking when rawBoundingInfo is missing", () => {
+            box.thinInstanceAdd(Matrix.Translation(5, 0, 0), false);
+            box.thinInstanceAdd(Matrix.Translation(10, 0, 0), true);
+            box.thinInstanceEnablePicking = true;
+
+            expect(box.getBoundingInfo().boundingBox.minimum.x).toBeCloseTo(4.5);
+            box.rawBoundingInfo = null;
+
+            const ray = new Ray(new Vector3(5, 5, 0), new Vector3(0, -1, 0));
+            const info = scene.pickWithRay(ray);
+
+            expect(info!.hit).toBe(true);
+            expect(info!.thinInstanceIndex).toBe(0);
+            expect(info!.pickedMesh).toBe(box);
+        });
+
+        it("uses the line intersectionThreshold for thin-instance raw-bounds checks", () => {
+            const line = MeshBuilder.CreateLines(
+                "line",
+                {
+                    points: [new Vector3(0, -1, 0), new Vector3(0, 1, 0)],
+                },
+                scene
+            );
+            line.intersectionThreshold = 0.1;
+            line.thinInstanceAdd(Matrix.Translation(5, 0, 0), true);
+            line.thinInstanceEnablePicking = true;
+
+            const ray = new Ray(new Vector3(5.05, 2, 0), new Vector3(0, -1, 0));
+            const info = scene.pickWithRay(ray);
+
+            expect(info!.hit).toBe(true);
+            expect(info!.thinInstanceIndex).toBe(0);
+            expect(info!.pickedMesh).toBe(line);
         });
     });
 

--- a/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
@@ -2,7 +2,8 @@ import { type Engine, NullEngine } from "core/Engines";
 import { Matrix, Quaternion, Vector3 } from "core/Maths/math.vector";
 import { type Mesh, MeshBuilder } from "core/Meshes";
 import { Scene } from "core/scene";
-import { Ray } from "core/Culling/ray";
+import { PickingInfo } from "core/Collisions/pickingInfo";
+import { PickingCustomization, Ray } from "core/Culling/ray";
 import "core/Culling/ray";
 import "core/Meshes/thinInstanceMesh";
 
@@ -25,6 +26,12 @@ describe("ThinInstance picking", () => {
         box.thinInstanceEnablePicking = true;
     }
 
+    function createThinInstancesAroundAggregateRayGap() {
+        box.thinInstanceAdd(Matrix.Translation(0, 0, 0), false);
+        box.thinInstanceAdd(Matrix.Translation(10, 0, 0), true);
+        box.thinInstanceEnablePicking = true;
+    }
+
     beforeEach(() => {
         engine = new NullEngine({
             renderHeight: 256,
@@ -40,6 +47,7 @@ describe("ThinInstance picking", () => {
     });
 
     afterEach(() => {
+        PickingCustomization.internalPickerForMesh = undefined;
         scene.dispose();
         engine.dispose();
     });
@@ -202,6 +210,43 @@ describe("ThinInstance picking", () => {
             expect(info!.thinInstanceIndex).toBe(0);
             expect(info!.pickedMesh).toBe(line);
         });
+
+        it("rejects thin instances with raw bounds before triangle intersection", () => {
+            createThinInstancesAroundAggregateRayGap();
+
+            const ray = new Ray(new Vector3(5, 5, 0), new Vector3(0, -1, 0));
+            let trianglePredicateCalled = false;
+            const info = scene.pickWithRay(ray, undefined, false, () => {
+                trianglePredicateCalled = true;
+                return true;
+            });
+
+            expect(info!.hit).toBe(false);
+            expect(trianglePredicateCalled).toBe(false);
+        });
+
+        it("does not raw-bounds reject thin instances before a custom picker", () => {
+            createThinInstancesAroundAggregateRayGap();
+
+            let thinInstancePickerCalls = 0;
+            PickingCustomization.internalPickerForMesh = (_pickingInfo, _rayFunction, mesh, _world, _fastCheck, onlyBoundingInfo) => {
+                if (onlyBoundingInfo) {
+                    const result = new PickingInfo();
+                    result.hit = true;
+                    result.pickedMesh = mesh;
+                    return result;
+                }
+
+                thinInstancePickerCalls++;
+                return null!;
+            };
+
+            const ray = new Ray(new Vector3(5, 5, 0), new Vector3(0, -1, 0));
+            const info = scene.pickWithRay(ray);
+
+            expect(info!.hit).toBe(false);
+            expect(thinInstancePickerCalls).toBe(2);
+        });
     });
 
     describe("multiPickWithRay", () => {
@@ -245,6 +290,43 @@ describe("ThinInstance picking", () => {
             expect(infos).toBeTruthy();
             const indices = infos!.map((i) => i.thinInstanceIndex).sort((a, b) => a - b);
             expect(indices).toEqual([0, 1]);
+        });
+
+        it("rejects thin instances with raw bounds before triangle intersection", () => {
+            createThinInstancesAroundAggregateRayGap();
+
+            const ray = new Ray(new Vector3(5, 5, 0), new Vector3(0, -1, 0));
+            let trianglePredicateCalled = false;
+            const infos = scene.multiPickWithRay(ray, undefined, () => {
+                trianglePredicateCalled = true;
+                return true;
+            });
+
+            expect(infos).toEqual([]);
+            expect(trianglePredicateCalled).toBe(false);
+        });
+
+        it("does not raw-bounds reject thin instances before a custom picker", () => {
+            createThinInstancesAroundAggregateRayGap();
+
+            let thinInstancePickerCalls = 0;
+            PickingCustomization.internalPickerForMesh = (_pickingInfo, _rayFunction, mesh, _world, _fastCheck, onlyBoundingInfo) => {
+                if (onlyBoundingInfo) {
+                    const result = new PickingInfo();
+                    result.hit = true;
+                    result.pickedMesh = mesh;
+                    return result;
+                }
+
+                thinInstancePickerCalls++;
+                return null!;
+            };
+
+            const ray = new Ray(new Vector3(5, 5, 0), new Vector3(0, -1, 0));
+            const infos = scene.multiPickWithRay(ray);
+
+            expect(infos).toEqual([]);
+            expect(thinInstancePickerCalls).toBe(2);
         });
     });
 });


### PR DESCRIPTION
## Summary

The current thin-instance picking flow performs one whole-mesh broad-phase in [`InternalPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) and [`InternalMultiPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L915), then iterates every thin instance and calls the picker with bounding-info checks skipped for each instance. That means dense source meshes can still pay the full submesh and triangle cost for many thin instances that an instance-level broad-phase would have rejected immediately.

This proposal updates the thin-instance path so that, when [`thinInstanceEnablePicking`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/thinInstanceMesh.ts#L15) is `true` and [`rawBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L473) is available, the engine always runs a per-instance sphere-plus-box precheck against the source-only bounds before entering triangle intersection. There is no new property, no threshold, and no additional opt-in. If `rawBoundingInfo` is missing, the precheck is skipped and the current behavior is preserved, so there is no risk of false negatives from missing source bounds.

The implementation should use the existing local-ray approach already available through [`rayFunction`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L821), and it must mirror the [`intersectionThreshold`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2074) handling used by [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) for standard line meshes so thin-instance line meshes are not rejected incorrectly. One upstream caveat is that [`GreasedLineMesh`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts#L22) now has a custom pick path, so it should not be treated as a drop-in match for the standard `AbstractMesh.intersects()` broad-phase without separate verification.

## Current behavior

Today the thin-instance path in [`InternalPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) works like this:

1. Run a whole-mesh bounding-info check once through the picker.
2. If that broad-phase passes, iterate all thin-instance matrices.
3. Build the combined instance world matrix from the thin-instance matrix and the mesh world matrix.
4. Call the picker again for each instance, but with bounding-info checks bypassed so the code reaches [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) in skip-bounds mode.
5. Let submesh tests and triangle tests decide the hit.

That is correct, but it can do unnecessary work for thin instances that are trivially outside the ray.

## Goal

Add a reject-only per-instance broad-phase before the expensive submesh and triangle walk, while preserving the existing public API, avoiding false negatives, and leaving behavior unchanged when source-only bounds are unavailable.

## Updated behavior

The updated behavior is:

- Keep existing [`thinInstanceEnablePicking`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/thinInstanceMesh.ts#L15) unchanged as the only public gate.
- When thin-instance picking is active and [`rawBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L473) is available, always run the per-instance broad-phase.
- Do not add a new mesh property.
- Do not add a vertex-count threshold.
- Do not add an extra opt-in.
- If `rawBoundingInfo` is missing, skip the precheck and preserve current behavior.
- Use the instance-local ray already built through [`rayFunction`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L821).
- Inflate the sphere and box checks with the same `intersectionThreshold` logic used by [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) for the standard mesh and lines-mesh path.
- Do not silently substitute [`getRawBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L1445) for `rawBoundingInfo` in the new helper, because that upstream helper falls back to aggregated bounds when source-only bounds are missing.

## Decision rationale


- a bounding sphere plus box test is extremely cheap,
- rejecting even one thin instance early usually repays the full cost of the extra prechecks,
- the downside on simple meshes is theoretical and expected to be lost in the noise compared with even a single unnecessary triangle walk,
- adding a new property or threshold would complicate the API and documentation for an optimization that should help by default.

So the plan is to treat the precheck as a low-cost reject-only optimization, not as a feature that needs new configuration.

## Recommended implementation approach

### Prefer local-ray plus raw bounds over world-space AABB construction

The first implementation should not build a transformed world-space AABB from 8 corners for every thin instance.

A cheaper and cleaner path already exists in the picking pipeline:

- [`InternalPickForMesh()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L819) already uses the per-instance world matrix to derive a local ray through `rayFunction`.
- The thin-instance loops can derive that same local ray directly by calling `rayFunction(world, mesh.enableDistantPicking)`.
- [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) already performs the standard sphere-plus-box broad-phase when bounds are not skipped.
- [`Mesh.prototype.thinInstanceRefreshBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/thinInstanceMesh.ts#L408) already preserves the source mesh bounds in [`rawBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L473) before expanding the aggregated thin-instance bounds.

So the recommended precheck is:

1. Get the instance matrix exactly as today in [`InternalPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) and [`InternalMultiPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L915).
2. Build the same instance-local ray that the picker would use by calling `rayFunction(world, mesh.enableDistantPicking)`.
3. Resolve the same `intersectionThreshold` that [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) would use for that mesh.
4. Test that local ray against the raw bounding sphere and raw bounding box.
5. Only if that precheck passes, call the picker with skip-bounds mode and let triangle picking continue.

This reuses the existing picking math, avoids any per-instance corner-transform loop, and keeps the new broad-phase aligned with the normal mesh broad-phase. For the built-in picker path, it is worth structuring the helper so the same local ray can be reused for both the precheck and the subsequent `mesh.intersects()` call instead of recomputing it twice.

## Where the checks should live

The broad-phase should live in [`packages/dev/core/src/Culling/ray.core.ts`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843), directly in the thin-instance loops inside [`InternalPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) and [`InternalMultiPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L915).

Recommended structure:

1. Keep the existing whole-mesh broad-phase exactly as it is today.
2. Resolve `mesh.rawBoundingInfo` once for the mesh after the whole-mesh pass succeeds.
3. For each thin instance:
   - apply the mesh-instance predicate,
   - build the combined matrix,
   - if `rawBoundingInfo` exists, build the local ray and run the raw sphere-plus-box precheck,
   - skip triangle picking if that precheck fails,
   - otherwise keep the current picker call with skip-bounds enabled.

If it helps reduce duplication, the raw-bounds precheck can be factored into a small internal helper in [`ray.core.ts`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L819) and reused by both thin-instance loops.

## Runtime condition

There is no new heuristic beyond what already exists.

Conceptually, once the code is already inside the thin-instance picking branch, the only runtime question is whether source-only bounds are available:

```ts
const rawBounds = mesh.rawBoundingInfo;
const usePerInstanceBounds = !!rawBounds;
```

The full decision remains:

```ts
if (mesh.hasThinInstances && mesh.thinInstanceEnablePicking) {
    // existing whole-mesh broad-phase
    // ...
    if (rawBounds) {
        // per-instance raw sphere+box precheck
    }
}
```

If `rawBoundingInfo` is absent, the engine simply falls back to the current behavior for that mesh.

## Raw-bounds source and fallback behavior

The new precheck must use source-only bounds, not the aggregated thin-instance bounds.

Relevant existing behavior:

- [`Mesh.prototype.thinInstanceRefreshBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/thinInstanceMesh.ts#L408) refreshes the base mesh bounds and copies them into [`rawBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L473) before expanding the mesh bounds to include all thin instances.
- The regular mesh [`getBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L1427) result may already be expanded to cover all thin instances, so it is not suitable for per-instance rejection.
- [`AbstractMesh.getRawBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L1445) now falls back to `getBoundingInfo()` when `rawBoundingInfo` is absent, so the new helper should read `mesh.rawBoundingInfo` directly and explicitly skip the precheck on `null`.

Recommended fallback rules:

- If source raw bounds are available, use them.
- If source raw bounds are missing, do not try to derive per-instance culling from the aggregated mesh bounds.
- Instead, skip the new precheck and preserve current behavior for that mesh.

That avoids false negatives and avoids using overly large aggregated bounds that would provide little or no benefit.

## Broad-phase details

The new per-instance precheck should mirror the existing mesh broad-phase in [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) for the normal mesh and lines-mesh path:

- use the same `intersectionThreshold` logic used there today,
- test the local ray against the raw bounding sphere first,
- then test against the raw bounding box,
- continue to triangle picking only if both pass.

Conceptually:

```ts
const threshold =
    className === "InstancedLinesMesh" || className === "LinesMesh"
        ? (mesh as any).intersectionThreshold
        : 0;

if (!localRay.intersectsSphere(rawBounds.boundingSphere, threshold) || !localRay.intersectsBox(rawBounds.boundingBox, threshold)) {
    continue;
}
```

The important correctness detail is that `LinesMesh` and `InstancedLinesMesh` need the same threshold inflation here that they already get in [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064). Without that, line-mesh thin instances could be rejected before their actual picking path has a chance to run.

### GreasedLineMesh is not on the standard broad-phase path

[`GreasedLineMesh`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts#L22) now overrides [`intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts#L278) and routes picking through width-aware segment tests in `findAllIntersections()`. Its broad-phase behavior is therefore not the same as the standard `AbstractMesh.intersects()` sphere-plus-box path:

- its `onlyBoundingInfo` check uses a sphere test, not the standard sphere-plus-box pair,
- its actual segment precision scales with line width and per-segment width, not just the plain `intersectionThreshold`.

Because of that, the proposal should not treat `GreasedLineMesh` as automatically covered by the generic raw sphere-plus-box helper. The conservative implementation choices are:

- either limit the first pass of this optimization to meshes that follow the standard `AbstractMesh.intersects()` broad-phase,
- or add a GreasedLine-specific precheck only if it is proven to match the custom width-aware picking semantics without false negatives.

## Behavior and compatibility requirements

### Preserve current public API

This proposal intentionally introduces no new public property and no new scene-setting behavior. Existing [`thinInstanceEnablePicking`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/thinInstanceMesh.ts#L15) semantics remain unchanged.

### Preserve [`onlyBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2068)

The current thin-instance path returns early after the whole-mesh broad-phase when only bounding info is requested. The proposal keeps that unchanged. The new per-instance precheck is not needed in that path.

### Preserve [`fastCheck`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L847)

Once a valid pick is found, fast mode should still return immediately. The precheck only reduces the number of expensive instance tests that are attempted before that point.

### Preserve predicate behavior

The mesh-instance predicate currently runs before each thin-instance pick attempt. That ordering must remain unchanged.

### Preserve pick data

The following result fields must remain correct:

- thin instance index,
- picked point,
- distance,
- submesh id,
- picked mesh reference.

### Custom picker compatibility

[`PickingCustomization`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L49) can override the picker used for meshes. The new per-instance broad-phase should still run before invoking that picker when `rawBoundingInfo` is available, because it is a reject-only optimization. If raw bounds are not available, the custom picker should continue to see the current behavior unchanged.

## Public API and serialization

No new public API is proposed.

That means:

- no new property on [`Mesh`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/mesh.ts#L262),
- no new serialization field in [`packages/dev/core/src/Meshes/mesh.ts`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/mesh.ts#L4264),
- no parser changes for thin-instance scene data,
- no scene round-trip changes beyond existing behavior.

## Validation plan

### Correctness tests

Add tests that compare current behavior and the new behavior in the cases where the precheck should and should not apply.

Coverage should include:

- thin instances translated away from the ray,
- thin instances rotated and non-uniformly scaled,
- negative scaling or mirrored transforms,
- dense meshes and low-vertex meshes,
- hit and miss parity,
- preservation of thin-instance indices,
- preservation of [`fastCheck`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L847),
- preservation of [`onlyBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2068),
- fallback behavior when `rawBoundingInfo` is missing,
- `LinesMesh` or `InstancedLinesMesh` with nonzero `intersectionThreshold`,
- any `GreasedLineMesh` thin-instance case that is either explicitly excluded from the new helper or covered by a separate verified implementation.

The critical guarantee is no false negatives when the new precheck is active, including the standard line-mesh threshold case and any explicit GreasedLine handling.

### Performance validation

Benchmark at least these scenarios:

1. Dense source mesh, many thin instances, low hit ratio.
2. Dense source mesh, many thin instances, high hit ratio.
3. Low-vertex source mesh with a small thin-instance count.
4. Low-vertex source mesh with many thin instances, to confirm the always-on precheck is still neutral or beneficial in practice.
5. A case where `rawBoundingInfo` is absent, to confirm behavior and cost stay aligned with the current path.

Measure time spent in scene picking paths that flow through [`InternalPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) and [`InternalMultiPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L915).

## Non-goals

This proposal does not aim to:

- add a new per-mesh thin-instance picking property,
- add a vertex-count threshold or heuristic gate,
- introduce a global static switch for the optimization,
- add per-instance cached bounding boxes or spheres,
- redesign non-thin-instance picking in [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064),
- replace the current triangle picking path with a new acceleration structure.

## Risks

Key risks for implementation are:

- false negatives if the precheck accidentally uses aggregated thin-instance bounds instead of [`rawBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L473),
- false negatives for `LinesMesh` or `InstancedLinesMesh` if the `intersectionThreshold` inflation does not match [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064),
- false negatives for [`GreasedLineMesh`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts#L22) if it is forced through the generic helper without matching its width-aware pick semantics,
- accidental use of [`AbstractMesh.getRawBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L1445) in the helper, which would silently convert the intended `rawBoundingInfo`-missing fallback into an aggregated-bounds precheck,
- stale source bounds if updates around [`Mesh.prototype.thinInstanceRefreshBoundingInfo()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/thinInstanceMesh.ts#L408) are bypassed or not synchronized with source geometry changes,
- compatibility surprises for custom pickers wired through [`PickingCustomization`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L49) if the reject-only helper changes ordering incorrectly,
- small regressions in pathological all-hit or tiny-mesh scenes where the extra broad-phase prunes very little work.

## Performance impact

Expected CPU impact:

- positive for dense source meshes with many thin instances and low hit ratios, because fewer instances reach the expensive submesh and triangle tests,
- positive or neutral for many practical scenes because the added sphere-plus-box test is very cheap and rejecting even one instance tends to pay it back,
- theoretically slightly negative in tiny-mesh or all-hit cases, but expected to be noise compared with even a single unnecessary triangle walk,
- unchanged when `rawBoundingInfo` is missing,
- unchanged for [`onlyBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2068), because that path already exits after the whole-mesh broad-phase.

## Memory impact

Expected memory impact:

- near-zero steady-state increase because the implementation reuses existing [`rawBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L473),
- no new property on [`Mesh`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/mesh.ts#L262),
- no new per-instance arrays in thin-instance storage,
- no meaningful hot-path allocation increase if the implementation reuses the existing temporary math objects already used by the picking flow in [`packages/dev/core/src/Culling/ray.core.ts`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843).

## Mermaid overview

```mermaid
flowchart TD
    A[Whole mesh bounds pass]
    B{Only bounding info}
    C[Thin instance loop]
    D{Predicate passes}
    E{Raw bounds available}
    F[Local ray plus thresholded sphere and box precheck]
    G[Skip instance]
    H[Triangle picker with skip bounds]
    I[Update picking result]

    A --> B
    B -- yes --> I
    B -- no --> C
    C --> D
    D -- no --> G
    D -- yes --> E
    E -- no --> H
    E -- yes --> F
    F -- fail --> G
    F -- pass --> H
    H --> I
```

## Implementation handoff

Implementation mode should execute the following steps:

1. Add a small internal helper in [`packages/dev/core/src/Culling/ray.core.ts`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) that tests a thin instance against `mesh.rawBoundingInfo` using the instance-local ray and the same `intersectionThreshold` rule as [`AbstractMesh.intersects()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2064) for the standard mesh and lines-mesh path.
2. Apply that helper in both [`InternalPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L843) and [`InternalMultiPick()`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L915) after the whole-mesh broad-phase passes and after the per-instance predicate check.
3. On a failed raw-bounds precheck, skip triangle picking for that thin instance.
4. On a passed precheck, keep the current picker call with skip-bounds enabled.
5. If `rawBoundingInfo` is missing, preserve the current behavior with no extra rejection step.
6. Keep current behavior for [`onlyBoundingInfo`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/abstractMesh.ts#L2068), [`fastCheck`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Culling/ray.core.ts#L847), predicates, custom pickers, and thin-instance result data.
7. Add tests for hit parity, false-negative prevention, direct-`rawBoundingInfo` fallback behavior, and standard line-mesh threshold inflation.
8. Decide explicitly whether [`GreasedLineMesh`](https://github.com/BabylonJS/Babylon.js/blob/9.2.1/packages/dev/core/src/Meshes/GreasedLine/greasedLineMesh.ts#L22) is excluded from the first implementation or handled by a separate verified precheck.
9. Benchmark dense and simple cases to validate the always-on choice.

## Alternatives

* Per-instance Octree, updated only on thinInstanceSetBuffer("matrix") or equivalent, costing extra memory usage and update cpu overhead
* Keep it as-it, thin instance picking is already an opt-in feature, users should take their own risk

## Forum post

<https://forum.babylonjs.com/t/per-instance-bbox-culling-for-thin-instance-picking/57251> And a micro benchmark is added to the forum post.