### PR TITLE
Add inspector instructions for dynamically loaded extensions source folder

### DIFF
--- a/.github/instructions/inspector.instructions.md
+++ b/.github/instructions/inspector.instructions.md
@@ -36,6 +36,10 @@ function MyComponent() {
 
 ## Extension Architecture
 
+### Dynamically loaded extensions
+
+Extensions that are loaded dynamically via the extension manager dialog must live in `packages/dev/inspector-v2/src/extensions/`. Each extension should be a separate subfolder within that directory.
+
 ### Service definitions
 
 Extensions expose functionality through `ServiceDefinition` objects that declare their dependencies (`consumes`) and what they provide (`produces`). Export a default object with a `serviceDefinitions` array:

--- a/.github/instructions/inspector.instructions.md
+++ b/.github/instructions/inspector.instructions.md
@@ -38,7 +38,7 @@ function MyComponent() {
 
 ### Dynamically loaded extensions
 
-Extensions that are loaded dynamically via the extension manager dialog must live in `packages/dev/inspector-v2/src/extensions/`. Each extension should be a separate subfolder within that directory.
+New extensions that are loaded dynamically via the extension manager dialog should live in `packages/dev/inspector-v2/src/extensions/`, with each extension in its own subfolder. Some existing extensions (e.g. Reflector) may reside elsewhere in the source tree.
 
 ### Service definitions
 


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Updates the inspector Copilot instructions (`.github/instructions/inspector.instructions.md`) to document where dynamically loaded extensions should live.

**Changes:**
- Adds a new "Dynamically loaded extensions" subsection under "Extension Architecture" specifying that extensions loaded via the extension manager dialog must be placed in `packages/dev/inspector-v2/src/extensions/`, with each extension in its own subfolder.

This clarifies the expected directory structure for contributors adding new dynamically loaded inspector extensions.
