### PR TITLE
Add scene options to set default layer masks

### DIFF
--- a/packages/dev/core/src/Cameras/camera.ts
+++ b/packages/dev/core/src/Cameras/camera.ts
@@ -474,6 +474,7 @@ export class Camera extends Node {
     constructor(name: string, position: Vector3, scene?: Scene, setActiveOnSceneIfNoneActive = true) {
         super(name, scene, false);
 
+        this.layerMask = this.getScene().defaultCameraLayerMask;
         this.getScene().addCamera(this);
 
         if (setActiveOnSceneIfNoneActive && !this.getScene().activeCamera) {

--- a/packages/dev/core/src/Layers/layer.ts
+++ b/packages/dev/core/src/Layers/layer.ts
@@ -193,11 +193,17 @@ export class Layer {
         color?: Color4,
         forceGLSL = false
     ) {
+        if (!scene) {
+            scene = EngineStore.LastCreatedScene!;
+        }
+        this.layerMask = scene.defaultRenderableLayerMask;
+
         this.texture = imgUrl ? new Texture(imgUrl, scene, true) : null;
         this.isBackground = isBackground === undefined ? true : isBackground;
         this.color = color === undefined ? new Color4(1, 1, 1, 1) : color;
 
-        this._scene = <Scene>(scene || EngineStore.LastCreatedScene);
+        this._scene = scene;
+
         const engine = this._scene.getEngine();
         if (engine.isWebGPU && !forceGLSL && !Layer.ForceGLSL) {
             this._shaderLanguage = ShaderLanguage.WGSL;

--- a/packages/dev/core/src/LensFlares/lensFlareSystem.ts
+++ b/packages/dev/core/src/LensFlares/lensFlareSystem.ts
@@ -109,6 +109,8 @@ export class LensFlareSystem {
         scene: Scene
     ) {
         this._scene = scene || EngineStore.LastCreatedScene;
+        this.layerMask = this._scene.defaultRenderableLayerMask;
+
         LensFlareSystem._SceneComponentInitialization(this._scene);
 
         this._emitter = emitter;

--- a/packages/dev/core/src/Meshes/abstractMesh.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.ts
@@ -1000,7 +1000,7 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
         super(name, scene, false);
 
         scene = this.getScene();
-
+        this.layerMask = scene.defaultRenderableLayerMask;
         scene.addMesh(this);
 
         this._resyncLightSources();

--- a/packages/dev/core/src/Particles/gpuParticleSystem.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.ts
@@ -972,6 +972,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
             this._scene = (sceneOrEngine as Scene) || EngineStore.LastCreatedScene;
             this._engine = this._scene.getEngine();
             this.uniqueId = this._scene.getUniqueId();
+            this.layerMask = this._scene.defaultRenderableLayerMask;
             this._scene.particleSystems.push(this);
         } else {
             this._engine = sceneOrEngine as AbstractEngine;

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -558,6 +558,7 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
             this._scene = (sceneOrEngine as Scene) || EngineStore.LastCreatedScene;
             this._engine = this._scene.getEngine();
             this.uniqueId = this._scene.getUniqueId();
+            this.layerMask = this._scene.defaultRenderableLayerMask;
             this._scene.particleSystems.push(this);
         } else {
             this._engine = sceneOrEngine as AbstractEngine;

--- a/packages/dev/core/src/Sprites/spriteManager.ts
+++ b/packages/dev/core/src/Sprites/spriteManager.ts
@@ -338,6 +338,7 @@ export class SpriteManager implements ISpriteManager {
         if (!scene) {
             scene = EngineStore.LastCreatedScene!;
         }
+        this.layerMask = scene.defaultRenderableLayerMask;
 
         if (!scene._getComponent(SceneComponentConstants.NAME_SPRITE)) {
             scene._addComponent(new SpriteSceneComponent(scene));

--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -156,6 +156,16 @@ export interface SceneOptions {
 
     /** Defines if the creation of the scene should impact the engine (Eg. UtilityLayer's scene) */
     virtual?: boolean;
+
+    /**
+     * Defines the default layerMask used when creating cameras in the scene (default: 0x0fffffff)
+     */
+    defaultCameraLayerMask?: number;
+
+    /**
+     * Defines the default layerMask used when creating renderable objects in the scene (default: 0x0fffffff)
+     */
+    defaultRenderableLayerMask?: number;
 }
 
 /**
@@ -1811,6 +1821,16 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     private _uid: Nullable<string>;
 
     /**
+     * Gets or sets the default layerMask used for cameras created in this scene.
+     */
+    public defaultCameraLayerMask: number;
+
+    /**
+     * Gets or sets the default layerMask used for renderable objects created in this scene.
+     */
+    public defaultRenderableLayerMask: number;
+
+    /**
      * @internal
      * Backing store of defined scene components.
      */
@@ -2021,8 +2041,14 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             useMaterialMeshMap: true,
             useClonedMeshMap: true,
             virtual: false,
+            defaultCameraLayerMask: 0x0fffffff,
+            defaultRenderableLayerMask: 0x0fffffff,
             ...options,
         };
+
+        // Scene Default Layer Masks
+        this.defaultCameraLayerMask = fullOptions.defaultCameraLayerMask;
+        this.defaultRenderableLayerMask = fullOptions.defaultRenderableLayerMask;
 
         engine = this._engine = engine || EngineStore.LastCreatedEngine;
         if (fullOptions.virtual) {


### PR DESCRIPTION
This adds scene optional scene options to set default layerMask values for when the scene creates new cameras and renderable objects that use the layerMask property.

If left undefined the normal 0x0FFFFFFF layerMask is used.