### PR TITLE
fix(depthRenderer): key Scene._depthRenderer by camera.uniqueId instead of camera.id

### DIFF
--- a/packages/dev/core/src/Misc/depthReducer.ts
+++ b/packages/dev/core/src/Misc/depthReducer.ts
@@ -50,7 +50,7 @@ export class DepthReducer extends MinMaxReducer {
                 scene._depthRenderer = {};
             }
 
-            this._depthRendererId = "minmax_" + this._camera.id;
+            this._depthRendererId = "minmax_" + this._camera.uniqueId;
 
             depthRenderer = this._depthRenderer = new DepthRenderer(
                 scene,

--- a/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
+++ b/packages/dev/core/src/Rendering/depthRendererSceneComponent.ts
@@ -57,7 +57,7 @@ Scene.prototype.enableDepthRenderer = function (
     if (!this._depthRenderer) {
         this._depthRenderer = {};
     }
-    if (!this._depthRenderer[camera.id]) {
+    if (!this._depthRenderer[camera.uniqueId]) {
         const supportFullfloat = !!this.getEngine().getCaps().textureFloatRender;
         let textureType: number;
         if (this.getEngine().getCaps().textureHalfFloatRender && (!force32bitsFloat || !supportFullfloat)) {
@@ -67,19 +67,28 @@ Scene.prototype.enableDepthRenderer = function (
         } else {
             textureType = Constants.TEXTURETYPE_UNSIGNED_BYTE;
         }
-        this._depthRenderer[camera.id] = new DepthRenderer(this, textureType, camera, storeNonLinearDepth, samplingMode, storeCameraSpaceZ, undefined, existingRenderTargetTexture);
+        this._depthRenderer[camera.uniqueId] = new DepthRenderer(
+            this,
+            textureType,
+            camera,
+            storeNonLinearDepth,
+            samplingMode,
+            storeCameraSpaceZ,
+            undefined,
+            existingRenderTargetTexture
+        );
     }
 
-    return this._depthRenderer[camera.id];
+    return this._depthRenderer[camera.uniqueId];
 };
 
 Scene.prototype.disableDepthRenderer = function (camera?: Nullable<Camera>): void {
     camera = camera || this.activeCamera;
-    if (!camera || !this._depthRenderer || !this._depthRenderer[camera.id]) {
+    if (!camera || !this._depthRenderer || !this._depthRenderer[camera.uniqueId]) {
         return;
     }
 
-    this._depthRenderer[camera.id].dispose();
+    this._depthRenderer[camera.uniqueId].dispose();
 };
 
 /**
@@ -178,7 +187,7 @@ export class DepthRendererSceneComponent implements ISceneComponent {
         if (this.scene._depthRenderer) {
             for (const key in this.scene._depthRenderer) {
                 const depthRenderer = this.scene._depthRenderer[key];
-                if (depthRenderer.enabled && depthRenderer.useOnlyInActiveCamera && this.scene.activeCamera!.id === key) {
+                if (depthRenderer.enabled && depthRenderer.useOnlyInActiveCamera && `${this.scene.activeCamera!.uniqueId}` === key) {
                     renderTargets.push(depthRenderer.getDepthMap());
                 }
             }

--- a/packages/dev/core/test/unit/Rendering/babylon.depthRenderer.test.ts
+++ b/packages/dev/core/test/unit/Rendering/babylon.depthRenderer.test.ts
@@ -65,6 +65,26 @@ describe("DepthRenderer", () => {
         expect(result).toBe(true);
     });
 
+    it("enableDepthRenderer should return distinct renderers for cameras sharing the same id (forum bug 63268)", () => {
+        const camera1 = new ArcRotateCamera("", 0, 0, 10, Vector3.Zero(), scene);
+        const camera2 = new ArcRotateCamera("", 0, 0, 10, Vector3.Zero(), scene);
+
+        // Both cameras have empty names, so their `id` (which falls back to `name`) collides.
+        expect(camera1.id).toBe(camera2.id);
+        // But their `uniqueId` must always differ.
+        expect(camera1.uniqueId).not.toBe(camera2.uniqueId);
+
+        const depthRenderer1 = scene.enableDepthRenderer(camera1);
+        const depthRenderer2 = scene.enableDepthRenderer(camera2);
+
+        // Each camera must get its own DepthRenderer (regression for the id-collision bug).
+        expect(depthRenderer1).not.toBe(depthRenderer2);
+
+        // Calling enableDepthRenderer again with the same camera should return the existing one.
+        expect(scene.enableDepthRenderer(camera1)).toBe(depthRenderer1);
+        expect(scene.enableDepthRenderer(camera2)).toBe(depthRenderer2);
+    });
+
     it("isReady should not corrupt the draw wrapper of a non-depth render pass (forum bug 63230)", async () => {
         const depthRenderer = scene.enableDepthRenderer();
         const depthMap = depthRenderer.getDepthMap();


### PR DESCRIPTION
## Description

Fix [forum report](https://forum.babylonjs.com/t/separate-depthrenderer-s-not-created-for-camera-s-with-the-same-name/63268): two cameras sharing the same `id` (typically when both have empty/default names, since `Node.id` defaults to `name`) end up sharing a single `DepthRenderer` because `Scene._depthRenderer` is keyed by `camera.id`. Visible symptom in the report: `SelectionOutlineLayer` rendering incorrectly when switching between an `ArcRotateCamera` and a `FreeCamera` that share an id.

## Fix

Switch the key from `camera.id` to `camera.uniqueId`, which is guaranteed unique per `Camera` instance. The `enableDepthRenderer(camera)` contract (same camera instance => same renderer) is preserved; only id-based collisions are eliminated.

Same change applied in `DepthReducer` for the `"minmax_" + camera.id` key.

## Breaking change?

No — `Scene._depthRenderer` is declared `@internal`. The public `enableDepthRenderer` / `disableDepthRenderer` API still takes a `Camera` instance and behaves the same for any single-camera caller. Only code reaching into the internal dictionary by string id would notice, and that path was already broken by id collisions.

## History note

The `camera.id` keying was introduced in 2018 in commit 2087027851 ("multi depth cameras working") as a direct push, with no PR or comment explaining the choice — so there's no recorded design intent tying us to `camera.id`.
