### PR TITLE
[Addons] Fix AtmospherePBRMaterialPlugin breaking PBRMaterial compile for non-irradiance-map envs

### DIFF
--- a/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
@@ -205,7 +205,7 @@ export class AtmospherePBRMaterialPlugin extends MaterialPluginBase {
         // env (e.g. a cube env using spherical harmonics), the standard PBR reflection block must run
         // instead, otherwise the injected `sampleReflection(irradianceSampler, ...)` would reference an
         // undeclared identifier. See forum 63276.
-        defines.USE_CUSTOM_REFLECTION = this._atmosphere.diffuseSkyIrradianceLut !== null && !!(defines as unknown as { USEIRRADIANCEMAP: boolean }).USEIRRADIANCEMAP;
+        defines.USE_CUSTOM_REFLECTION = this._atmosphere.diffuseSkyIrradianceLut !== null && !!defines.USEIRRADIANCEMAP;
         defines.USE_AERIAL_PERSPECTIVE_LUT = this._isAerialPerspectiveEnabled && this._atmosphere.isAerialPerspectiveLutEnabled;
         defines.APPLY_AERIAL_PERSPECTIVE_INTENSITY = this._isAerialPerspectiveEnabled && this._atmosphere.aerialPerspectiveIntensity !== 1.0;
         defines.APPLY_AERIAL_PERSPECTIVE_RADIANCE_BIAS = this._isAerialPerspectiveEnabled && this._atmosphere.aerialPerspectiveRadianceBias !== 0.0;

--- a/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
+++ b/packages/dev/addons/src/atmosphere/atmospherePBRMaterialPlugin.ts
@@ -14,6 +14,7 @@ import "./ShadersWGSL/ShadersInclude/atmosphereFunctions";
 import "./ShadersWGSL/ShadersInclude/atmosphereUboDeclaration";
 
 class AtmospherePBRMaterialDefines extends MaterialDefines {
+    public USE_CUSTOM_REFLECTION = false;
     public USE_AERIAL_PERSPECTIVE_LUT: boolean;
     public APPLY_AERIAL_PERSPECTIVE_INTENSITY = false;
     public APPLY_AERIAL_PERSPECTIVE_RADIANCE_BIAS = false;
@@ -68,7 +69,12 @@ export class AtmospherePBRMaterialPlugin extends MaterialPluginBase {
             PluginName,
             PluginPriority,
             {
-                USE_CUSTOM_REFLECTION: _atmosphere.diffuseSkyIrradianceLut !== null,
+                // USE_CUSTOM_REFLECTION is computed dynamically in prepareDefines because it
+                // depends on whether the material's currently-active reflection setup actually
+                // declares `irradianceSampler` (i.e. has USEIRRADIANCEMAP set). Setting it
+                // unconditionally here would inject shader code that references an undeclared
+                // sampler when the material renders against a cube env. See forum 63276.
+                USE_CUSTOM_REFLECTION: false,
                 CUSTOM_FRAGMENT_BEFORE_FOG: _isAerialPerspectiveEnabled,
                 USE_AERIAL_PERSPECTIVE_LUT: _isAerialPerspectiveEnabled && _atmosphere.isAerialPerspectiveLutEnabled,
                 APPLY_AERIAL_PERSPECTIVE_INTENSITY: _isAerialPerspectiveEnabled && _atmosphere.aerialPerspectiveIntensity !== 1.0,
@@ -190,13 +196,21 @@ export class AtmospherePBRMaterialPlugin extends MaterialPluginBase {
      * @override
      */
     public override prepareDefines(defines: AtmospherePBRMaterialDefines): void {
+        const lastUseCustomReflection = defines.USE_CUSTOM_REFLECTION;
         const lastUseAerialPerspectiveLut = defines.USE_AERIAL_PERSPECTIVE_LUT;
         const lastApplyAerialPerspectiveIntensity = defines.APPLY_AERIAL_PERSPECTIVE_INTENSITY;
         const lastApplyAerialPerspectiveRadianceBias = defines.APPLY_AERIAL_PERSPECTIVE_RADIANCE_BIAS;
+        // Only override the PBR reflection block when the surrounding shader actually declares
+        // `irradianceSampler` (USEIRRADIANCEMAP). When the material renders against a non-irradiance-map
+        // env (e.g. a cube env using spherical harmonics), the standard PBR reflection block must run
+        // instead, otherwise the injected `sampleReflection(irradianceSampler, ...)` would reference an
+        // undeclared identifier. See forum 63276.
+        defines.USE_CUSTOM_REFLECTION = this._atmosphere.diffuseSkyIrradianceLut !== null && !!(defines as unknown as { USEIRRADIANCEMAP: boolean }).USEIRRADIANCEMAP;
         defines.USE_AERIAL_PERSPECTIVE_LUT = this._isAerialPerspectiveEnabled && this._atmosphere.isAerialPerspectiveLutEnabled;
         defines.APPLY_AERIAL_PERSPECTIVE_INTENSITY = this._isAerialPerspectiveEnabled && this._atmosphere.aerialPerspectiveIntensity !== 1.0;
         defines.APPLY_AERIAL_PERSPECTIVE_RADIANCE_BIAS = this._isAerialPerspectiveEnabled && this._atmosphere.aerialPerspectiveRadianceBias !== 0.0;
         if (
+            lastUseCustomReflection !== defines.USE_CUSTOM_REFLECTION ||
             lastUseAerialPerspectiveLut !== defines.USE_AERIAL_PERSPECTIVE_LUT ||
             lastApplyAerialPerspectiveIntensity !== defines.APPLY_AERIAL_PERSPECTIVE_INTENSITY ||
             lastApplyAerialPerspectiveRadianceBias !== defines.APPLY_AERIAL_PERSPECTIVE_RADIANCE_BIAS


### PR DESCRIPTION
## Problem

`AtmospherePBRMaterialPlugin` auto-attaches to **every** `PBRMaterial` constructed in the scene as soon as `new Atmosphere(...)` runs (its constructor calls `RegisterMaterialPlugin` with a factory). The plugin set `USE_CUSTOM_REFLECTION` once in its constructor based on `_atmosphere.diffuseSkyIrradianceLut !== null`, then unconditionally injected a `CUSTOM_REFLECTION` chunk that references `irradianceSampler`.

Core PBR only declares `irradianceSampler` when `USEIRRADIANCEMAP` is set on the parent material — which only happens when the active reflection texture has an `.irradianceTexture` (the diffuse sky LUT the addon wires up). When a `PBRMaterial` created after `new Atmosphere(...)` renders against a regular cube environment (`USESPHERICALFROMREFLECTIONMAP`, no `irradianceTexture`), the injected `sampleReflection(irradianceSampler, ...)` referenced an undeclared identifier and the fragment shader failed to compile:

```
FRAGMENT SHADER ERROR: 'irradianceSampler' : undeclared identifier
Offending line: vec3 environmentIrradiance = lightIntensity * sampleReflection(irradianceSampler, uv).rgb;
```

The material then renders invisible.

Reported on the forum: https://forum.babylonjs.com/t/63276
Minimal repro PG: https://playground.babylonjs.com/#9O0Y6G#1

## Fix

Compute `USE_CUSTOM_REFLECTION` dynamically in `prepareDefines` based on the parent material's `USEIRRADIANCEMAP` define:

```ts
defines.USE_CUSTOM_REFLECTION =
    this._atmosphere.diffuseSkyIrradianceLut !== null
    && !!(defines as unknown as { USEIRRADIANCEMAP: boolean }).USEIRRADIANCEMAP;
```

The plugin's `prepareDefines` runs after `PBRBaseMaterial._prepareDefines` (line ~1825 of `pbrBaseMaterial.ts`), so `USEIRRADIANCEMAP` is finalized by that point. Dirty tracking is added so a transition triggers a recompile.

When `USEIRRADIANCEMAP` is unset, `USE_CUSTOM_REFLECTION` becomes `false` and the standard PBR reflection block runs (no hijack, no undeclared identifier). When the user switches back to atmosphere mode, the define flips back on and the plugin's custom reflection is re-emitted.

This is the narrowest, safest fix — it does not change the registration/attachment semantics of the plugin, so existing atmosphere scenes are unaffected. The "attached but inactive" plugin on a cube-env material is now a true no-op for reflection.

## Tests

- `npx tsc --noEmit -p packages/dev/addons/tsconfig.build.json` passes.
- Lint produces only pre-existing doc-comment warnings.
- The 10 existing `Atmosphere *` visualization tests cover the happy path (atmosphere is the active env, `USEIRRADIANCEMAP` set) and are unaffected by this change since `USE_CUSTOM_REFLECTION` evaluates to the same value as before for them.

## Out of scope

The reporter also suggested:
1. `Atmosphere.setEnabled(false)` should detach plugin instances + unregister the global factory.
3. Expose a public `MaterialPluginManager.removePlugin` API.

These are reasonable follow-ups about the addon's lifecycle contract but are bigger changes. With the shader gating fixed in this PR, an "attached but inactive" plugin instance is no longer harmful, which removes the urgency.

Ping @kircher1 to review the PR.