### PR TITLE
Inspector: switch picking to GPU picking

### DIFF
--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -918,7 +918,11 @@ export class GPUPicker {
             for (let i = 0; i < renderList.length; i++) {
                 const mesh = renderList[i];
                 const material = this._meshMaterialMap.get(mesh);
-                if (material && !material.isReady(mesh, mesh.hasInstances || mesh.hasThinInstances)) {
+                // Match the canonical "uses instanced shader variant" check used elsewhere in this file
+                // (see addPickingList) — InstancedMesh entries report isAnInstance=true while
+                // hasInstances=false, so omitting isAnInstance would validate the wrong shader variant.
+                const useInstances = mesh.hasInstances || mesh.isAnInstance || mesh.hasThinInstances;
+                if (material && !material.isReady(mesh, useInstances)) {
                     allReady = false;
                 }
             }

--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -556,9 +556,6 @@ export class GPUPicker {
         const invertedY = rttSizeH - adjustedY - 1;
         this._preparePickingBuffer(this._engine!, rttSizeW, rttSizeH, adjustedX, invertedY);
 
-        // Make sure every picking material variant is compiled before the picking texture
-        // is rendered, otherwise the renderer will silently skip meshes whose effect is
-        // not yet ready and the click pixel will read back as background.
         await this._waitForPickingMaterialsReadyAsync();
 
         return await this._executePickingAsync(adjustedX, invertedY, disposeWhenDone);
@@ -936,6 +933,8 @@ export class GPUPicker {
                 this._cachedScene!.onAfterRenderObservable.addOnce(() => resolve());
             });
         }
+
+        Logger.Warn(`GPUPicker: gave up waiting for picking materials to compile after ${maxAttempts} attempts; picking results may be incorrect.`);
     }
 
     private _getMeshFromMultiplePoints(x: number, y: number, minX: number, maxY: number, w: number): { pickedMesh: Nullable<AbstractMesh>; thinInstanceIndex: number | undefined } {

--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -556,6 +556,11 @@ export class GPUPicker {
         const invertedY = rttSizeH - adjustedY - 1;
         this._preparePickingBuffer(this._engine!, rttSizeW, rttSizeH, adjustedX, invertedY);
 
+        // Make sure every picking material variant is compiled before the picking texture
+        // is rendered, otherwise the renderer will silently skip meshes whose effect is
+        // not yet ready and the click pixel will read back as background.
+        await this._waitForPickingMaterialsReadyAsync();
+
         return await this._executePickingAsync(adjustedX, invertedY, disposeWhenDone);
     }
 
@@ -618,6 +623,8 @@ export class GPUPicker {
 
         this._preparePickingBuffer(this._engine!, rttSizeW, rttSizeH, minX, partialCutH, w, h);
 
+        await this._waitForPickingMaterialsReadyAsync();
+
         return await this._executeMultiPickingAsync(processedXY, minX, maxY, rttSizeH, w, h, disposeWhenDone);
     }
 
@@ -661,6 +668,8 @@ export class GPUPicker {
         const partialCutH = rttSizeH - maxY - 1;
 
         this._preparePickingBuffer(this._engine!, rttSizeW, rttSizeH, minX, partialCutH, w, h);
+
+        await this._waitForPickingMaterialsReadyAsync();
 
         return await this._executeBoxPickingAsync(minX, partialCutH, w, h, disposeWhenDone);
     }
@@ -882,6 +891,51 @@ export class GPUPicker {
 
         this._meshRenderingCount = 0;
         return false; // Wait for shaders to be ready
+    }
+
+    /**
+     * Polls the picking material variant for every mesh in the render list until every
+     * variant is ready. Picking materials use parallel shader compilation, and a single
+     * ShaderMaterial may produce different effect variants per mesh (instances, thin
+     * instances, vertex colors, ...). If we render the picking texture before all variants
+     * are compiled, the renderer silently skips meshes whose effect is not yet ready, which
+     * can leave the click pixel cleared (0,0,0,0) and cause pickAsync to incorrectly return
+     * null. Once compiled, effects are cached by define string in the engine, so this
+     * polling only blocks on the very first pick (or whenever the render list changes to
+     * include meshes with new define combinations).
+     */
+    private async _waitForPickingMaterialsReadyAsync(): Promise<void> {
+        const renderList = this._pickingTexture?.renderList;
+        if (!renderList || renderList.length === 0) {
+            return;
+        }
+
+        // Cap the number of polling attempts to avoid hanging forever if a shader fails to compile.
+        const maxAttempts = 200;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            let allReady = true;
+            // Iterate every mesh (do not break early): each isReady call kicks off compilation
+            // of that mesh's effect variant if not yet started, so visiting them all on the first
+            // attempt lets the compiles run in parallel (KHR_parallel_shader_compile) instead of
+            // being serialized one variant per render frame.
+            for (let i = 0; i < renderList.length; i++) {
+                const mesh = renderList[i];
+                const material = this._meshMaterialMap.get(mesh);
+                if (material && !material.isReady(mesh, mesh.hasInstances || mesh.hasThinInstances)) {
+                    allReady = false;
+                }
+            }
+            if (allReady) {
+                return;
+            }
+            // Wait for the next scene render before re-checking. Effect compilation status
+            // (especially with KHR_parallel_shader_compile) is typically observed between
+            // frames, so tying the poll to the render loop is more efficient than a fixed timer.
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise<void>((resolve) => {
+                this._cachedScene!.onAfterRenderObservable.addOnce(() => resolve());
+            });
+        }
     }
 
     private _getMeshFromMultiplePoints(x: number, y: number, minX: number, maxY: number, w: number): { pickedMesh: Nullable<AbstractMesh>; thinInstanceIndex: number | undefined } {

--- a/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
@@ -34,8 +34,10 @@ export const PickingToolbar: FunctionComponent<{
     const gpuPicker = useResource(useCallback(() => new GPUPicker(), [scene]));
 
     // Track the meshes the picker should know about. Re-evaluate whenever meshes are added or removed.
+    // Do not filter on vertex count here: meshes can be created before their geometry is populated,
+    // and they still need to remain in the GPUPicker list so they become pickable once geometry arrives.
     const pickableMeshes = useObservableState(
-        useCallback(() => scene.meshes.filter((mesh) => mesh.isEnabled() && mesh.isVisible && mesh.getTotalVertices() > 0), [scene]),
+        useCallback(() => scene.meshes.filter((mesh) => mesh.isEnabled() && mesh.isVisible), [scene]),
         scene.onNewMeshAddedObservable,
         scene.onMeshRemovedObservable
     );

--- a/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
@@ -1,14 +1,17 @@
 import { type MenuButtonProps, Menu, MenuItemCheckbox, MenuList, MenuPopover, MenuTrigger, SplitButton, tokens, Tooltip } from "@fluentui/react-components";
-import { type FunctionComponent, useCallback, useEffect, useMemo, useState } from "react";
+import { type FunctionComponent, useCallback, useEffect, useState } from "react";
 
-import { type AbstractMesh, type IMeshDataCache, type Nullable, type Scene } from "core/index";
+import { type Nullable, type Scene } from "core/index";
 import { type IGizmoService } from "../services/gizmoService";
 
 import { TargetRegular } from "@fluentui/react-icons";
 
+import { GPUPicker } from "core/Collisions/gpuPicker";
 import { PointerEventTypes } from "core/Events/pointerEvents";
-import { TmpVectors, Vector3 } from "core/Maths/math.vector";
+import { AsyncLock } from "core/Misc/asyncLock";
 import { useKeyListener } from "shared-ui-components/fluent/hooks/keyboardHooks";
+import { useObservableState } from "shared-ui-components/modularTool/hooks/observableHooks";
+import { useResource } from "shared-ui-components/modularTool/hooks/resourceHooks";
 
 export const PickingToolbar: FunctionComponent<{
     scene: Scene;
@@ -20,11 +23,46 @@ export const PickingToolbar: FunctionComponent<{
 }> = (props) => {
     const { scene, selectEntity, gizmoService, ignoreBackfaces, highlightSelectedEntity, onHighlightSelectedEntityChange } = props;
 
-    const meshDataCache = useMemo(() => new WeakMap<AbstractMesh, IMeshDataCache>(), [scene]);
     // Not sure why changing the cursor on the canvas itself doesn't work, so change it on the parent.
     const sceneElement = scene.getEngine().getRenderingCanvas()?.parentElement;
 
     const [pickingEnabled, setPickingEnabled] = useState(false);
+
+    // One GPUPicker per (scene, component lifetime). useResource handles disposal on unmount or when scene changes.
+    // The factory must be stable (memoized) so useResource doesn't recreate the picker on every render.
+    const gpuPicker = useResource(useCallback(() => new GPUPicker(), [scene]));
+
+    // Track the meshes the picker should know about. Re-evaluate whenever meshes are added or removed.
+    const pickableMeshes = useObservableState(
+        useCallback(() => scene.meshes.filter((mesh) => mesh.isEnabled() && mesh.isVisible && mesh.getTotalVertices() > 0), [scene]),
+        scene.onNewMeshAddedObservable,
+        scene.onMeshRemovedObservable
+    );
+
+    // Keep the GPUPicker's picking list in sync with the current pickable meshes (and apply the
+    // backface culling preference) while picking is enabled.
+    useEffect(() => {
+        if (!pickingEnabled) {
+            gpuPicker.clearPickingList();
+            return;
+        }
+
+        if (pickableMeshes.length === 0) {
+            gpuPicker.clearPickingList();
+            return;
+        }
+
+        gpuPicker.setPickingList(pickableMeshes);
+
+        // GPUPicker creates its picking ShaderMaterials lazily inside setPickingList. Apply the
+        // backface culling preference now so subsequent renders use the correct setting.
+        // (ShaderMaterial.backFaceCulling defaults to true, which matches ignoreBackfaces=true.)
+        for (const material of gpuPicker.defaultRenderMaterials) {
+            if (material) {
+                material.backFaceCulling = ignoreBackfaces ?? false;
+            }
+        }
+    }, [pickingEnabled, pickableMeshes, gpuPicker, ignoreBackfaces]);
 
     // Exit picking mode if the escape key is pressed.
     useKeyListener({
@@ -40,69 +78,42 @@ export const PickingToolbar: FunctionComponent<{
             const originalCursor = getComputedStyle(sceneElement).cursor;
             sceneElement.style.cursor = "crosshair";
 
+            const pickingLock = new AsyncLock();
+
             const pointerObserver = scene.onPrePointerObservable.add(() => {
-                let pickedEntity: Nullable<object> = null;
+                void pickingLock.lockAsync(async () => {
+                    let pickedEntity: Nullable<object> = null;
 
-                // Check camera gizmos.
-                if (!pickedEntity) {
-                    for (const cameraGizmo of gizmoService.getCameraGizmos(scene)) {
-                        if (cameraGizmo.isHovered) {
-                            pickedEntity = cameraGizmo.camera;
-                        }
-                    }
-                }
-
-                // Check light gizmos.
-                if (!pickedEntity) {
-                    for (const lightGizmo of gizmoService.getLightGizmos(scene)) {
-                        if (lightGizmo.isHovered) {
-                            pickedEntity = lightGizmo.light;
-                        }
-                    }
-                }
-
-                // Check the main scene.
-                if (!pickedEntity) {
-                    // Refresh bounding info to ensure morph target and skeletal animations are taken into account.
-                    for (const mesh of scene.meshes) {
-                        let cache = meshDataCache.get(mesh);
-                        if (!cache) {
-                            cache = {};
-                            meshDataCache.set(mesh, cache);
-                        }
-                        mesh.refreshBoundingInfo({ applyMorph: true, applySkeleton: true, cache });
-                    }
-
-                    const pickingInfo = scene.pick(
-                        scene.unTranslatedPointer.x,
-                        scene.unTranslatedPointer.y,
-                        (mesh) => mesh.isEnabled() && mesh.isVisible && mesh.getTotalVertices() > 0,
-                        false,
-                        undefined,
-                        (p0, p1, p2, ray) => {
-                            if (!ignoreBackfaces) {
-                                return true;
+                    // Check camera gizmos.
+                    if (!pickedEntity) {
+                        for (const cameraGizmo of gizmoService.getCameraGizmos(scene)) {
+                            if (cameraGizmo.isHovered) {
+                                pickedEntity = cameraGizmo.camera;
                             }
-
-                            const p0p1 = TmpVectors.Vector3[0];
-                            const p1p2 = TmpVectors.Vector3[1];
-
-                            p1.subtractToRef(p0, p0p1);
-                            p2.subtractToRef(p1, p1p2);
-
-                            const normal = Vector3.Cross(p0p1, p1p2);
-
-                            return Vector3.Dot(normal, ray.direction) < 0;
                         }
-                    );
+                    }
 
-                    pickedEntity = pickingInfo.pickedMesh;
-                }
+                    // Check light gizmos.
+                    if (!pickedEntity) {
+                        for (const lightGizmo of gizmoService.getLightGizmos(scene)) {
+                            if (lightGizmo.isHovered) {
+                                pickedEntity = lightGizmo.light;
+                            }
+                        }
+                    }
 
-                // If an entity was picked, select it.
-                if (pickedEntity) {
-                    selectEntity(pickedEntity);
-                }
+                    // Check the main scene.
+                    if (!pickedEntity) {
+                        const x = scene.unTranslatedPointer.x;
+                        const y = scene.unTranslatedPointer.y;
+                        const pickingInfo = await gpuPicker.pickAsync(x, y);
+                        pickedEntity = pickingInfo?.mesh ?? null;
+                    }
+
+                    if (pickedEntity) {
+                        selectEntity(pickedEntity);
+                    }
+                });
             }, PointerEventTypes.POINTERTAP);
 
             return () => {
@@ -114,7 +125,7 @@ export const PickingToolbar: FunctionComponent<{
         return () => {
             /* No-op */
         };
-    }, [pickingEnabled, sceneElement, ignoreBackfaces]);
+    }, [pickingEnabled, sceneElement, scene, gizmoService, gpuPicker, selectEntity]);
 
     const togglePicking = useCallback(() => {
         setPickingEnabled((prev) => !prev);

--- a/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
+++ b/packages/dev/inspector-v2/src/components/pickingToolbar.tsx
@@ -9,6 +9,7 @@ import { TargetRegular } from "@fluentui/react-icons";
 import { GPUPicker } from "core/Collisions/gpuPicker";
 import { PointerEventTypes } from "core/Events/pointerEvents";
 import { AsyncLock } from "core/Misc/asyncLock";
+import { Logger } from "core/Misc/logger";
 import { useKeyListener } from "shared-ui-components/fluent/hooks/keyboardHooks";
 import { useObservableState } from "shared-ui-components/modularTool/hooks/observableHooks";
 import { useResource } from "shared-ui-components/modularTool/hooks/resourceHooks";
@@ -81,39 +82,51 @@ export const PickingToolbar: FunctionComponent<{
             const pickingLock = new AsyncLock();
 
             const pointerObserver = scene.onPrePointerObservable.add(() => {
-                void pickingLock.lockAsync(async () => {
-                    let pickedEntity: Nullable<object> = null;
+                // Capture pointer position and synchronous gizmo hover state at click time.
+                // The async GPU pick may queue behind a previous pick (e.g. while picking shaders
+                // compile on the very first click), and by the time the queued callback runs the
+                // pointer and gizmo hover state may have changed.
+                let pickedEntity: Nullable<object> = null;
 
-                    // Check camera gizmos.
-                    if (!pickedEntity) {
-                        for (const cameraGizmo of gizmoService.getCameraGizmos(scene)) {
-                            if (cameraGizmo.isHovered) {
-                                pickedEntity = cameraGizmo.camera;
-                            }
+                // Check camera gizmos.
+                if (!pickedEntity) {
+                    for (const cameraGizmo of gizmoService.getCameraGizmos(scene)) {
+                        if (cameraGizmo.isHovered) {
+                            pickedEntity = cameraGizmo.camera;
                         }
                     }
+                }
 
-                    // Check light gizmos.
-                    if (!pickedEntity) {
-                        for (const lightGizmo of gizmoService.getLightGizmos(scene)) {
-                            if (lightGizmo.isHovered) {
-                                pickedEntity = lightGizmo.light;
-                            }
+                // Check light gizmos.
+                if (!pickedEntity) {
+                    for (const lightGizmo of gizmoService.getLightGizmos(scene)) {
+                        if (lightGizmo.isHovered) {
+                            pickedEntity = lightGizmo.light;
                         }
                     }
+                }
 
-                    // Check the main scene.
-                    if (!pickedEntity) {
-                        const x = scene.unTranslatedPointer.x;
-                        const y = scene.unTranslatedPointer.y;
-                        const pickingInfo = await gpuPicker.pickAsync(x, y);
-                        pickedEntity = pickingInfo?.mesh ?? null;
-                    }
+                if (pickedEntity) {
+                    selectEntity(pickedEntity);
+                    return;
+                }
 
-                    if (pickedEntity) {
-                        selectEntity(pickedEntity);
+                // Check the main scene via GPU pick. Serialize concurrent picks via the lock so
+                // rapid clicks don't overlap on the GPU picker (which would otherwise no-op).
+                const x = scene.unTranslatedPointer.x;
+                const y = scene.unTranslatedPointer.y;
+                void (async () => {
+                    try {
+                        await pickingLock.lockAsync(async () => {
+                            const pickingInfo = await gpuPicker.pickAsync(x, y);
+                            if (pickingInfo?.mesh) {
+                                selectEntity(pickingInfo.mesh);
+                            }
+                        });
+                    } catch (error) {
+                        Logger.Warn(`GPU picking failed: ${error}`);
                     }
-                });
+                })();
             }, PointerEventTypes.POINTERTAP);
 
             return () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Switches the Inspector's picking toolbar from CPU picking (`scene.pick`) to GPU picking (`GPUPicker.pickAsync`), and fixes a first-pick race in `GPUPicker` that surfaced as part of the migration.

This makes picking work with alternative mesh types like gaussian splats and thin instances.

## Inspector changes (`packages/dev/inspector-v2/src/components/pickingToolbar.tsx`)

- Replaced `scene.pick` with a single `GPUPicker` instance owned by the component, created via `useResource(useCallback(() => new GPUPicker(), [scene]))` so it's reused for the lifetime of the component (and disposed on unmount).
- Tracks the set of pickable meshes via `useObservableState` over `scene.onNewMeshAddedObservable` / `scene.onMeshRemovedObservable`, and keeps the picker's picking list in sync from a `useEffect` rather than rebuilding it inside the pointer handler. This gives the picking shaders time to compile before the user actually clicks.
- Pointer handler is now wrapped in an `AsyncLock` so back-to-back clicks are serialized cleanly without a manual `pickingInProgress` early-return.
- The "Ignore Backfaces For Picking" setting is preserved by toggling `material.backFaceCulling` on `gpuPicker.defaultRenderMaterials`.

## GPUPicker fix (`packages/dev/core/src/Collisions/gpuPicker.ts`)

The first call to `pickAsync` was intermittently returning `null` even when a mesh was clearly under the cursor. Root cause: `_checkRenderStatus` checked `material.isReady()` in `onAfterRender` — *after* the picking RTT had already rendered. With parallel shader compilation, an effect could finish compiling between the renderer skipping the mesh (because the effect wasn't ready when `bindForSubMesh` ran) and `_checkRenderStatus` accepting the frame (because by then `isReady` returned true). Result: the first frame's texture was empty for the click target, `gl.readPixels` saw the cleared `(0, 0, 0, 0)`, and `pickAsync` resolved to `null`.

Fix: added `_waitForPickingMaterialsReadyAsync()` which polls every mesh's picking material variant via `material.isReady(mesh, useInstances)` *before* the picking RTT is pushed onto `customRenderTargets`. The poll is driven by `scene.onAfterRenderObservable.addOnce(...)` rather than a fixed timer, so it ties to the actual render cadence. Each iteration visits every mesh (no early break) so all variants kick off compilation in parallel via `KHR_parallel_shader_compile` rather than being serialized one-per-frame. The engine effect cache is keyed by define string, so the wait only blocks on the first pick (or when the render list grows new define combinations); subsequent picks resolve immediately.

The same wait was added to `multiPickAsync` and `boxPickAsync` for consistency.

## Verified

- Three consecutive picks (box / aerobatic plane / PBR sphere) all selected the correct mesh on the first try in the inspector-v2 dev host (WebGL2).
- `npm run format:check` and ESLint both pass.
