### PR TITLE
fix(scene): include procedural textures in Scene.isReady()

### DIFF
--- a/packages/dev/core/src/scene.ts
+++ b/packages/dev/core/src/scene.ts
@@ -2498,6 +2498,15 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             }
         }
 
+        // Procedural textures
+        if (this.proceduralTexturesEnabled) {
+            for (const proceduralTexture of this.proceduralTextures) {
+                if (!proceduralTexture.isReady()) {
+                    isReady = false;
+                }
+            }
+        }
+
         // Layers
         if (this.layers) {
             for (const layer of this.layers) {


### PR DESCRIPTION
## Bug

Reported on the forum: https://forum.babylonjs.com/t/63278

Using a `ParticleSystem` together with a `NoiseProceduralTexture` (even unused) under `SnapshotRenderingHelper` (FAST mode, WebGPU) causes WebGPU validation errors and a crash:

```\nAttachment state of renderBundles[0] not compatible with the pass's attachment state.\n```\n
## Root cause

`Scene.isReady()` did not include procedural textures. `SnapshotRenderingHelper.enableSnapshotRendering()` waits on `scene.executeWhenReady()` and then schedules `engine.snapshotRendering = true` two frames later. If a procedural texture has not yet compiled its effect by then, `proceduralTexture._shouldRender()` returns false on the recording frame, so its render pass is omitted from the snapshot's `_allBundleLists`. Once the effect compiles on a later frame, every playback frame has an extra render pass, and the recorded canvas bundle (BGRA8 / 4× MSAA) is replayed inside the procedural texture's render pass (RGBA8 / 1×) — triggering the validation error.

## Fix

Add `scene.proceduralTextures` to the readiness check in `Scene.isReady()` (gated on `proceduralTexturesEnabled`), so `executeWhenReady` correctly waits for procedural textures before consumers (such as the snapshot helper) proceed.

## Verification

- Repro playground: https://playground.babylonjs.com/?webgpu#PR6L8C#0 — before: 1 bundle list captured, ~190 WebGPU warnings, crash. After: 2 bundle lists captured, no warnings, particle renders at 120 fps.
- `npm run test:unit` — 2930 / 2930 passed.