### PR TITLE
fix: always run vis-test jobs so required checks report status

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -548,10 +548,13 @@ jobs:
     - job: VisualizationWebGL2
       displayName: "Visualization tests - WebGL 2"
       dependsOn: Build
-      condition: and(succeeded(), ne(dependencies.Build.outputs['ComputeVisTags.AFFECTED_TAGS'], 'NONE'))
       variables:
           AFFECTED_TAGS: $[ dependencies.Build.outputs['ComputeVisTags.AFFECTED_TAGS'] ]
       steps:
+          - bash: echo "No visualization tests affected by this change — skipping."
+            displayName: "Skip — no affected tests"
+            condition: eq(variables['AFFECTED_TAGS'], 'NONE')
+
           - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
@@ -570,6 +573,7 @@ jobs:
                 #npx playwright install
                 #npx playwright install --force chrome
             displayName: "npm install"
+            condition: ne(variables['AFFECTED_TAGS'], 'NONE')
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -577,6 +581,7 @@ jobs:
 
           - script: npm run test:playwright -w @tools/tests -- --project=webgl2
             displayName: "WebGL2 BStack"
+            condition: ne(variables['AFFECTED_TAGS'], 'NONE')
             env:
                 CDN_BASE_URL: "$(SNAPSHOT_CDN_URL)/$(BuildName)"
                 CI: "true"
@@ -626,10 +631,13 @@ jobs:
     - job: VisualizationWebGPU
       displayName: "Visualization tests - WebGPU"
       dependsOn: Build
-      condition: and(succeeded(), ne(dependencies.Build.outputs['ComputeVisTags.AFFECTED_TAGS'], 'NONE'))
       variables:
           AFFECTED_TAGS: $[ dependencies.Build.outputs['ComputeVisTags.AFFECTED_TAGS'] ]
       steps:
+          - bash: echo "No visualization tests affected by this change — skipping."
+            displayName: "Skip — no affected tests"
+            condition: eq(variables['AFFECTED_TAGS'], 'NONE')
+
           - template: templates/checkout-with-tag-override.yml
 
           - task: UseNode@1
@@ -647,6 +655,7 @@ jobs:
                 npm install
                 #npx playwright install --force chrome
             displayName: "npm install"
+            condition: ne(variables['AFFECTED_TAGS'], 'NONE')
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -654,6 +663,7 @@ jobs:
 
           - script: npm run test:playwright -w @tools/tests -- --project=webgpu
             displayName: "WebGPU BStack"
+            condition: ne(variables['AFFECTED_TAGS'], 'NONE')
             retryCountOnTaskFailure: 1
             env:
                 CDN_BASE_URL: "$(SNAPSHOT_CDN_URL)/$(BuildName)"

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -596,7 +596,7 @@ jobs:
                 curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/webgl2playwright" -X POST -H "Authorization: $(BASIC_AUTH)"
             displayName: "Delete test results"
             continueOnError: true
-            condition: eq(variables['SNAPSHOTEXISTS'], 'true')
+            condition: and(eq(variables['SNAPSHOTEXISTS'], 'true'), ne(variables['AFFECTED_TAGS'], 'NONE'))
 
           - template: templates/upload-test-results.yml
             parameters:
@@ -604,10 +604,11 @@ jobs:
                 fallbackReportDir: "playwright-report"
                 deployPath: "$(BuildName)/testResults/webgl2playwright"
                 continueOnError: true
+                condition: ne(variables['AFFECTED_TAGS'], 'NONE')
 
           - task: GitHubComment@0
             displayName: "GitHub WebGL2 comment"
-            condition: eq(variables['SNAPSHOTEXISTS'], 'false')
+            condition: and(eq(variables['SNAPSHOTEXISTS'], 'false'), ne(variables['AFFECTED_TAGS'], 'NONE'))
             inputs:
                 gitHubConnection: "$(GITHUB_SERVICE_CONNECTION)"
                 repositoryName: "$(Build.Repository.Name)"
@@ -618,7 +619,7 @@ jobs:
 
           - task: PublishTestResults@2
             displayName: "Publish webgl2 test results"
-            condition: succeededOrFailed()
+            condition: and(succeededOrFailed(), ne(variables['AFFECTED_TAGS'], 'NONE'))
             inputs:
                 testResultsFormat: JUnit
                 testResultsFiles: "./packages/tools/tests/junit.xml"
@@ -679,7 +680,7 @@ jobs:
                 curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/webgpuplaywright" -X POST -H "Authorization: $(BASIC_AUTH)"
             displayName: "Delete test results"
             continueOnError: true
-            condition: eq(variables['SNAPSHOTEXISTS'], 'true')
+            condition: and(eq(variables['SNAPSHOTEXISTS'], 'true'), ne(variables['AFFECTED_TAGS'], 'NONE'))
 
           - template: templates/upload-test-results.yml
             parameters:
@@ -687,11 +688,12 @@ jobs:
                 fallbackReportDir: "playwright-report"
                 deployPath: "$(BuildName)/testResults/webgpuplaywright"
                 continueOnError: true
+                condition: ne(variables['AFFECTED_TAGS'], 'NONE')
 
           - task: GitHubComment@0
             displayName: "Writing GitHub comment"
             continueOnError: true
-            condition: eq(variables['SNAPSHOTEXISTS'], 'false')
+            condition: and(eq(variables['SNAPSHOTEXISTS'], 'false'), ne(variables['AFFECTED_TAGS'], 'NONE'))
             inputs:
                 gitHubConnection: "$(GITHUB_SERVICE_CONNECTION)"
                 repositoryName: "$(Build.Repository.Name)"
@@ -702,7 +704,7 @@ jobs:
 
           - task: PublishTestResults@2
             displayName: "Publish webgpu test results"
-            condition: succeededOrFailed()
+            condition: and(succeededOrFailed(), ne(variables['AFFECTED_TAGS'], 'NONE'))
             inputs:
                 testResultsFormat: JUnit
                 testResultsFiles: "./packages/tools/tests/junit.xml"


### PR DESCRIPTION
## Problem

When `AFFECTED_TAGS` computes to `NONE` (e.g. a PR that only touches `shared-ui-components` or other non-vis-test code), the WebGL2 and WebGPU visualization test jobs were **skipped entirely** via job-level conditions:

```yaml
condition: and(succeeded(), ne(dependencies.Build.outputs['ComputeVisTags.AFFECTED_TAGS'], 'NONE'))
```

This meant Azure DevOps never reported a status for these jobs. Since they are **required checks**, the PR was blocked from merging — even though there were no relevant tests to run.

**Example:** #18389 — WebGL2 job shows as "expected" but never runs: [build logs](https://dev.azure.com/babylonjs/ContinousIntegration/_build/results?buildId=52627&view=logs&jobId=41c91092-7737-59ad-bca4-0f81503fea43&j=e5cc6727-28b8-51a4-d48e-c84cfcad289b)

## Fix

- **Remove the job-level `NONE` condition** — both vis-test jobs now always run, so Azure DevOps always reports a status (satisfying the required check).
- **Add step-level conditions** on `npm install` and the BrowserStack test step: `condition: ne(variables['AFFECTED_TAGS'], 'NONE')` — skips the expensive work when there are no affected tests.
- **Add an echo step** (`"Skip — no affected tests"`) that runs when `NONE` — produces a clear green status in the build log.

The job runs, reports green, and the required check is satisfied. No BrowserStack sessions are wasted.

## Changes

- `.azure-pipelines/ci-monorepo.yml` — WebGL2 and WebGPU job conditions
