### PR TITLE
Materials Library: add native WGSL shaders for all materials

### DIFF
--- a/packages/dev/buildTools/src/buildShaders.ts
+++ b/packages/dev/buildTools/src/buildShaders.ts
@@ -114,7 +114,11 @@ export function BuildShader(filePath: string, basePackageName: string | undefine
     const filename = path.basename(filePath);
     const normalized = path.normalize(filePath);
     const directory = path.dirname(normalized);
-    const isWGSL = directory.indexOf("WGSL") > -1;
+    // Treat a shader as WGSL if any path segment is exactly "wgsl" (case-insensitive,
+    // covering the per-material `wgsl/` convention) or contains the uppercase "WGSL"
+    // marker (covering the legacy `ShadersWGSL/` convention). Substring-only matching
+    // would also pick up unrelated folders such as `twgsl/`.
+    const isWGSL = directory.split(/[/\\]/).some((segment) => segment.toLowerCase() === "wgsl" || segment.indexOf("WGSL") > -1);
     const tsFilename = filename.replace(".fx", ".ts").replace(".wgsl", ".ts");
     const shaderName = GetShaderName(filename);
     const appendDirName = isWGSL ? "WGSL" : "";

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -15,10 +15,9 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { type IAnimatable } from "core/Animations/animatable.interface";
 
-import "./cell.fragment";
-import "./cell.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -96,8 +95,16 @@ export class CellMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a Cell Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -259,6 +266,18 @@ export class CellMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this.maxSimultaneousLights - 1 },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/cell.vertex"), import("./wgsl/cell.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./cell.vertex"), import("./cell.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/cell/wgsl/cell.fragment.fx
+++ b/packages/dev/materials/src/cell/wgsl/cell.fragment.fx
@@ -1,0 +1,144 @@
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<helperFunctions>
+
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogFragmentDeclaration>
+
+fn computeCustomDiffuseLighting(info: lightingInfo, diffuseBaseIn: vec3f, shadow: f32) -> vec3f
+{
+    var diffuseBase: vec3f = info.diffuse * shadow;
+#ifdef CELLBASIC
+    var level: f32 = 1.0;
+    if (info.ndl < 0.5) {
+        level = 0.5;
+    }
+    diffuseBase = diffuseBase.rgb *  vec3f(level, level, level);
+#else
+    var ToonThresholds: array<f32, 4>;
+    ToonThresholds[0] = 0.95;
+    ToonThresholds[1] = 0.5;
+    ToonThresholds[2] = 0.2;
+    ToonThresholds[3] = 0.03;
+    var ToonBrightnessLevels: array<f32, 5>;
+    ToonBrightnessLevels[0] = 1.0;
+    ToonBrightnessLevels[1] = 0.8;
+    ToonBrightnessLevels[2] = 0.6;
+    ToonBrightnessLevels[3] = 0.35;
+    ToonBrightnessLevels[4] = 0.2;
+    if (info.ndl > ToonThresholds[0])
+    {
+        diffuseBase = diffuseBase.rgb * ToonBrightnessLevels[0];
+    }
+    else if (info.ndl > ToonThresholds[1])
+    {
+        diffuseBase = diffuseBase.rgb * ToonBrightnessLevels[1];
+    }
+    else if (info.ndl > ToonThresholds[2])
+    {
+        diffuseBase = diffuseBase.rgb * ToonBrightnessLevels[2];
+    }
+    else if (info.ndl > ToonThresholds[3])
+    {
+        diffuseBase = diffuseBase.rgb * ToonBrightnessLevels[3];
+    }
+    else
+    {
+        diffuseBase = diffuseBase.rgb * ToonBrightnessLevels[4];
+    }
+#endif
+    return max(diffuseBase,  vec3f(0.2));
+}
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+#ifdef DIFFUSE
+	baseColor = textureSample(diffuseSampler, diffuseSamplerSampler, fragmentInputs.vDiffuseUV);
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+        discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vDiffuseInfos.y, baseColor.a);
+#endif
+
+#ifdef VERTEXCOLOR
+	baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	var info: lightingInfo;
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+	var shadow: f32 = 1.;
+    var glossiness: f32 = 0.;
+    var aggShadow: f32 = 0.;
+    var numLights: f32 = 0.;
+#ifdef SPECULARTERM
+    var specularBase: vec3f =  vec3f(0., 0., 0.);
+#endif
+
+#include<lightFragment>[0..maxSimultaneousLights]
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+	var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor, vec3f(0.0), vec3f(1.0)) * baseColor.rgb;
+	var color: vec4f =  vec4f(finalDiffuse, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/cell/wgsl/cell.vertex.fx
+++ b/packages/dev/materials/src/cell/wgsl/cell.vertex.fx
@@ -1,0 +1,117 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+uniform diffuseMatrix: mat4x4f;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vDiffuseInfos.x == 0.)
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+    // Fog
+#include<fogVertex>
+#include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+	#include<logDepthVertex>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/fire/fireMaterial.ts
+++ b/packages/dev/materials/src/fire/fireMaterial.ts
@@ -16,10 +16,9 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { type IAnimatable } from "core/Animations/animatable.interface";
 
-import "./fire.fragment";
-import "./fire.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -85,9 +84,16 @@ export class FireMaterial extends PushMaterial {
 
     private _scaledDiffuse = new Color3();
     private _lastTime: number = 0;
+    private _shadersLoaded = false;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    /**
+     * Instantiates a Fire Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -227,6 +233,18 @@ export class FireMaterial extends PushMaterial {
                         indexParameters: null,
                         maxSimultaneousLights: 4,
                         transformFeedbackVaryings: null,
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/fire.vertex"), import("./wgsl/fire.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./fire.vertex"), import("./fire.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/fire/wgsl/fire.fragment.fx
+++ b/packages/dev/materials/src/fire/wgsl/fire.fragment.fx
@@ -1,0 +1,116 @@
+// Constants
+uniform vEyePosition: vec4f;
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+// Samplers
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+// Fire
+var distortionSamplerSampler: sampler;
+var distortionSampler: texture_2d<f32>;
+var opacitySamplerSampler: sampler;
+var opacitySampler: texture_2d<f32>;
+
+#ifdef DIFFUSE
+varying vDistortionCoords1: vec2f;
+varying vDistortionCoords2: vec2f;
+varying vDistortionCoords3: vec2f;
+#endif
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+fn bx2(x: vec4f) -> vec4f
+{
+   return  vec4f(2.0) * x -  vec4f(1.0);
+}
+
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+
+	// Alpha
+	var alpha: f32 = 1.0;
+
+#ifdef DIFFUSE
+	// Fire
+	let distortionAmount0: f32 = 0.092;
+	let distortionAmount1: f32 = 0.092;
+	let distortionAmount2: f32 = 0.092;
+
+	var heightAttenuation: vec2f =  vec2f(0.3, 0.39);
+
+	var noise0: vec4f = textureSample(distortionSampler, distortionSamplerSampler, fragmentInputs.vDistortionCoords1);
+	var noise1: vec4f = textureSample(distortionSampler, distortionSamplerSampler, fragmentInputs.vDistortionCoords2);
+	var noise2: vec4f = textureSample(distortionSampler, distortionSamplerSampler, fragmentInputs.vDistortionCoords3);
+
+	var noiseSum: vec4f = bx2(noise0) * distortionAmount0 + bx2(noise1) * distortionAmount1 + bx2(noise2) * distortionAmount2;
+
+	var perturbedBaseCoords: vec4f =  vec4f(fragmentInputs.vDiffuseUV, 0.0, 1.0) + noiseSum * (fragmentInputs.vDiffuseUV.y * heightAttenuation.x + heightAttenuation.y);
+
+	var opacityColor: vec4f = textureSample(opacitySampler, opacitySamplerSampler, perturbedBaseCoords.xy);
+
+#ifdef ALPHATEST
+	if (opacityColor.r < 0.1) {
+        discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = textureSample(diffuseSampler, diffuseSamplerSampler, perturbedBaseCoords.xy) * 2.0;
+	baseColor = baseColor * opacityColor;
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vDiffuseInfos.y, baseColor.a);
+#endif
+
+#ifdef VERTEXCOLOR
+	baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(1.0, 1.0, 1.0);
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+	// Composition
+	var color: vec4f =  vec4f(baseColor.rgb, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/fire/wgsl/fire.vertex.fx
+++ b/packages/dev/materials/src/fire/wgsl/fire.vertex.fx
@@ -1,0 +1,99 @@
+// Attributes
+attribute position: vec3f;
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+
+// Fire
+uniform time: f32;
+uniform speed: f32;
+
+#ifdef DIFFUSE
+varying vDistortionCoords1: vec2f;
+varying vDistortionCoords2: vec2f;
+varying vDistortionCoords3: vec2f;
+#endif
+
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+	// Texture coordinates
+#ifdef DIFFUSE
+	vertexOutputs.vDiffuseUV = vec2f(vertexInputs.uv.x, vertexInputs.uv.y - 0.2);
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+#include<logDepthVertex>
+	// Fog
+#include<fogVertex>
+
+	// Vertex color
+#include<vertexColorMixing>
+
+#ifdef DIFFUSE
+	// Fire
+	var layerSpeed: vec3f =  vec3f(-0.2, -0.52, -0.1) * uniforms.speed;
+
+	vertexOutputs.vDistortionCoords1 = vec2f(vertexInputs.uv.x, vertexInputs.uv.y + layerSpeed.x * uniforms.time / 1000.0);
+	vertexOutputs.vDistortionCoords2 = vec2f(vertexInputs.uv.x, vertexInputs.uv.y + layerSpeed.y * uniforms.time / 1000.0);
+	vertexOutputs.vDistortionCoords3 = vec2f(vertexInputs.uv.x, vertexInputs.uv.y + layerSpeed.z * uniforms.time / 1000.0);
+#endif
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -19,10 +19,9 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 
-import "./fur.fragment";
-import "./fur.vertex";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
     BindBonesParameters,
@@ -133,9 +132,16 @@ export class FurMaterial extends PushMaterial {
     public _meshes: AbstractMesh[];
 
     private _furTime: number = 0;
+    private _shadersLoaded = false;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    /**
+     * Instantiates a Fur Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     @serialize()
@@ -347,6 +353,18 @@ export class FurMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this.maxSimultaneousLights },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/fur.vertex"), import("./wgsl/fur.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./fur.vertex"), import("./fur.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/fur/wgsl/fur.fragment.fx
+++ b/packages/dev/materials/src/fur/wgsl/fur.fragment.fx
@@ -1,0 +1,153 @@
+// Constants
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+// Input
+uniform furColor: vec4f;
+uniform furLength: f32;
+varying vPositionW: vec3f;
+varying vfur_length: f32;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+// Samplers
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+// Fur uniforms
+#ifdef HIGHLEVEL
+uniform furOffset: f32;
+uniform furOcclusion: f32;
+var furTextureSampler: sampler;
+var furTexture: texture_2d<f32>;
+
+varying vFurUV: vec2f;
+#endif
+
+#include<logDepthDeclaration>
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+#include<fogFragmentDeclaration>
+#include<clipPlaneFragmentDeclaration>
+
+fn Rand(rv: vec3f) -> f32 {
+	var x: f32 = dot(rv,  vec3f(12.9898, 78.233, 24.65487));
+	return fract(sin(x) * 43758.5453);
+}
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+	#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f = uniforms.furColor;
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+#ifdef DIFFUSE
+	baseColor = baseColor * textureSample(diffuseSampler, diffuseSamplerSampler, fragmentInputs.vDiffuseUV);
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+		discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vDiffuseInfos.y, baseColor.a);
+#endif
+
+#ifdef VERTEXCOLOR
+	baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Bump
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	#ifdef HIGHLEVEL
+	// Fur
+	var furTextureColor: vec4f = textureSample(furTexture, furTextureSampler,  vec2f(fragmentInputs.vFurUV.x, fragmentInputs.vFurUV.y));
+
+	if (furTextureColor.a <= 0.0 || furTextureColor.g < uniforms.furOffset) {
+		discard;
+	}
+
+    var occlusion: f32 = mix(0.0, furTextureColor.b * 1.2, uniforms.furOffset);
+
+	baseColor =  vec4f(baseColor.xyz * max(occlusion, uniforms.furOcclusion), 1.1 - uniforms.furOffset);
+	#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+
+	var shadow: f32 = 1.;
+	var glossiness: f32 = 0.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#ifdef SPECULARTERM
+	var specularBase: vec3f =  vec3f(0., 0., 0.);
+#endif
+
+	#include<lightFragment>[0..maxSimultaneousLights]
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+    var finalDiffuse: vec3f = clamp(diffuseBase.rgb * baseColor.rgb, vec3f(0.0), vec3f(1.0));
+
+	// Composition
+	#ifdef HIGHLEVEL
+	var color: vec4f =  vec4f(finalDiffuse, alpha);
+	#else
+	var rr: f32 = fragmentInputs.vfur_length / uniforms.furLength * 0.5;
+	var color: vec4f =  vec4f(finalDiffuse * (0.5 + rr), alpha);
+	#endif
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/fur/wgsl/fur.vertex.fx
+++ b/packages/dev/materials/src/fur/wgsl/fur.vertex.fx
@@ -1,0 +1,182 @@
+// Attributes
+attribute position: vec3f;
+attribute normal: vec3f;
+
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+uniform furLength: f32;
+uniform furAngle: f32;
+#ifdef HIGHLEVEL
+uniform furOffset: f32;
+uniform furGravity: vec3f;
+uniform furTime: f32;
+uniform furSpacing: f32;
+uniform furDensity: f32;
+#endif
+#ifdef HEIGHTMAP
+var heightTextureSampler: sampler;
+var heightTexture: texture_2d<f32>;
+#endif
+
+#ifdef HIGHLEVEL
+varying vFurUV: vec2f;
+#endif
+
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+uniform diffuseMatrix: mat4x4f;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+varying vfur_length: f32;
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+fn Rand(rv: vec3f) -> f32 {
+	var x: f32 = dot(rv,  vec3f(12.9898, 78.233, 24.65487));
+	return fract(sin(x) * 43758.5453);
+}
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+	#include<instancesVertex>
+    #include<bonesVertex>
+    #include<bakedVertexAnimation>
+
+//FUR
+var r: f32 = Rand(vertexInputs.position);
+#ifdef HEIGHTMAP
+	vertexOutputs.vfur_length = uniforms.furLength * textureSampleLevel(heightTexture, heightTextureSampler, vertexInputs.uv, 0.).x;
+#else
+	vertexOutputs.vfur_length = (uniforms.furLength * r);
+#endif
+	var tangent1: vec3f =  vec3f(vertexInputs.normal.y, -vertexInputs.normal.x, 0);
+	var tangent2: vec3f =  vec3f(-vertexInputs.normal.z, 0, vertexInputs.normal.x);
+	r = Rand(tangent1 * r);
+	var J: f32 = (2.0 + 4.0 * r);
+	r = Rand(tangent2*r);
+	var K: f32 = (2.0 + 2.0 * r);
+	tangent1 = tangent1*J + tangent2 * K;
+	tangent1 = normalize(tangent1);
+
+    var newPosition: vec3f = vertexInputs.position + vertexInputs.normal * vertexOutputs.vfur_length * cos(uniforms.furAngle) + tangent1 * vertexOutputs.vfur_length * sin(uniforms.furAngle);
+
+	#ifdef HIGHLEVEL
+	// Compute fur data passed to the pixel shader
+	var forceDirection: vec3f =  vec3f(0.0, 0.0, 0.0);
+	forceDirection.x = sin(uniforms.furTime + vertexInputs.position.x * 0.05) * 0.2;
+	forceDirection.y = cos(uniforms.furTime * 0.7 + vertexInputs.position.y * 0.04) * 0.2;
+	forceDirection.z = sin(uniforms.furTime * 0.7 + vertexInputs.position.z * 0.04) * 0.2;
+
+	var displacement: vec3f =  vec3f(0.0, 0.0, 0.0);
+	displacement = uniforms.furGravity + forceDirection;
+
+	var displacementFactor: f32 = pow(uniforms.furOffset, 3.0);
+
+	var aNormal: vec3f = vertexInputs.normal;
+	aNormal = vec3f(aNormal.xyz + displacement * displacementFactor);
+
+	newPosition =  vec3f(newPosition.x, newPosition.y, newPosition.z) + (normalize(aNormal) * uniforms.furOffset * uniforms.furSpacing);
+	#endif
+
+	#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+	#endif
+
+//END FUR
+	vertexOutputs.position = uniforms.viewProjection * finalWorld *  vec4f(newPosition, 1.0);
+
+	var worldPos: vec4f = finalWorld *  vec4f(newPosition, 1.0);
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vDiffuseInfos.x == 0.)
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+
+    #ifdef HIGHLEVEL
+	vertexOutputs.vFurUV = vertexOutputs.vDiffuseUV * uniforms.furDensity;
+	#endif
+#else
+    #ifdef HIGHLEVEL
+	vertexOutputs.vFurUV = uv * uniforms.furDensity;
+	#endif
+#endif
+
+	// Clip plane
+	#include<clipPlaneVertex>
+
+	#include<logDepthVertex>
+	// Fog
+	#include<fogVertex>
+
+	// Shadows
+	#include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+	#include<vertexColorMixing>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -15,9 +15,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./gradient.fragment";
-import "./gradient.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -103,8 +102,16 @@ export class GradientMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public disableLighting: boolean;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a Gradient Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -253,6 +260,18 @@ export class GradientMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: 4 },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/gradient.vertex"), import("./wgsl/gradient.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./gradient.vertex"), import("./gradient.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/gradient/wgsl/gradient.fragment.fx
+++ b/packages/dev/materials/src/gradient/wgsl/gradient.fragment.fx
@@ -1,0 +1,119 @@
+uniform vEyePosition: vec4f;
+
+// Gradient variables
+uniform topColor: vec4f;
+uniform bottomColor: vec4f;
+uniform offset: f32;
+uniform scale: f32;
+uniform smoothness: f32;
+
+// Input
+varying vPositionW: vec3f;
+varying vPosition: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0]
+#include<lightUboDeclaration>[1]
+#include<lightUboDeclaration>[2]
+#include<lightUboDeclaration>[3]
+
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+    var h: f32 = fragmentInputs.vPosition.y * uniforms.scale + uniforms.offset;
+    var mysmoothness: f32 = clamp(uniforms.smoothness, 0.01, max(uniforms.smoothness, 10.));
+
+    var baseColor: vec4f = mix(uniforms.bottomColor, uniforms.topColor, vec4f(max(pow(max(h, 0.0), mysmoothness), 0.0)));
+
+	// Base color
+	var diffuseColor: vec3f = baseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = baseColor.a;
+
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+        discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+#ifdef VERTEXCOLOR
+	baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Bump
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	// Lighting
+#ifdef EMISSIVE
+	var diffuseBase: vec3f = baseColor.rgb;
+#else
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+#endif
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+    var glossiness: f32 = 0.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#include<lightFragment>[0..maxSimultaneousLights]
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+	var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor, vec3f(0.0), vec3f(1.0)) * baseColor.rgb;
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/gradient/wgsl/gradient.vertex.fx
+++ b/packages/dev/materials/src/gradient/wgsl/gradient.vertex.fx
@@ -1,0 +1,101 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+varying vPosition: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+	vertexOutputs.vPosition = vertexInputs.position;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+#include<logDepthVertex>
+
+    // Fog
+#include<fogVertex>
+#include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/grid/gridMaterial.ts
+++ b/packages/dev/materials/src/grid/gridMaterial.ts
@@ -13,9 +13,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { type Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./grid.fragment";
-import "./grid.vertex";
 import {
     BindFogParameters,
     BindLogDepth,
@@ -132,10 +131,13 @@ export class GridMaterial extends PushMaterial {
      * constructor
      * @param name The name given to the material in order to identify it afterwards.
      * @param scene The scene the material is used in.
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
      */
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
+
+    private _shadersLoaded = false;
 
     /**
      * @returns whether or not the grid requires alpha blending.
@@ -258,6 +260,18 @@ export class GridMaterial extends PushMaterial {
                         fallbacks: null,
                         onCompiled: this.onCompiled,
                         onError: this.onError,
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/grid.vertex"), import("./wgsl/grid.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./grid.vertex"), import("./grid.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     scene.getEngine()
                 ),

--- a/packages/dev/materials/src/grid/wgsl/grid.fragment.fx
+++ b/packages/dev/materials/src/grid/wgsl/grid.fragment.fx
@@ -1,0 +1,148 @@
+#define SQRT2 1.41421356
+#define PI 3.14159
+
+uniform visibility: f32;
+
+uniform mainColor: vec3f;
+uniform lineColor: vec3f;
+uniform gridControl: vec4f;
+uniform gridOffset: vec3f;
+
+// Varying
+varying vPosition: vec3f;
+varying vNormal: vec3f;
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+#include<fogFragmentDeclaration>
+
+// Samplers
+#ifdef OPACITY
+varying vOpacityUV: vec2f;
+var opacitySamplerSampler: sampler;
+var opacitySampler: texture_2d<f32>;
+uniform vOpacityInfos: vec2f;
+#endif
+
+fn getDynamicVisibility(position: f32) -> f32 {
+    // Major grid line every Frequency defined in material.
+    var majorGridFrequency: f32 = uniforms.gridControl.y;
+    if (floor(position + 0.5) == floor(position / majorGridFrequency + 0.5) * majorGridFrequency)
+    {
+        return 1.0;
+    }
+
+    return uniforms.gridControl.z;
+}
+
+fn getAnisotropicAttenuation(differentialLength: f32) -> f32 {
+    let maxNumberOfLines: f32 = 10.0;
+    return clamp(1.0 / (differentialLength + 1.0) - 1.0 / maxNumberOfLines, 0.0, 1.0);
+}
+
+fn isPointOnLine(position: f32, differentialLength: f32) -> f32 {
+    var fractionPartOfPosition: f32 = position - floor(position + 0.5);
+    fractionPartOfPosition = fractionPartOfPosition / differentialLength;
+
+    #ifdef ANTIALIAS
+    fractionPartOfPosition = clamp(fractionPartOfPosition, -1., 1.);
+    var result: f32 = 0.5 + 0.5 * cos(fractionPartOfPosition * PI);
+    return result;
+    #else
+    if (abs(fractionPartOfPosition) < SQRT2 / 4.) {
+        return 1.;
+    }
+    return 0.;
+    #endif
+}
+
+fn contributionOnAxis(position: f32) -> f32 {
+    var differentialLength: f32 = length( vec2f(dpdx(position), dpdy(position)));
+    differentialLength = differentialLength * SQRT2;
+
+    // Is the point on the line.
+    var result: f32 = isPointOnLine(position, differentialLength);
+
+    // Add dynamic visibility.
+    var dynamicVisibility: f32 = getDynamicVisibility(position);
+    result = result * dynamicVisibility;
+
+    // Anisotropic filtering.
+    var anisotropicAttenuation: f32 = getAnisotropicAttenuation(differentialLength);
+    result = result * anisotropicAttenuation;
+
+    return result;
+}
+
+fn normalImpactOnAxis(x: f32) -> f32 {
+    var normalImpact: f32 = clamp(1.0 - 3.0 * abs(x * x * x), 0.0, 1.0);
+    return normalImpact;
+}
+
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+    #include<clipPlaneFragment>
+
+    // Scale position to the requested ratio.
+    var gridRatio: f32 = uniforms.gridControl.x;
+    var gridPos: vec3f = (fragmentInputs.vPosition + uniforms.gridOffset.xyz) / gridRatio;
+
+    // Find the contribution of each coords.
+    var x: f32 = contributionOnAxis(gridPos.x);
+    var y: f32 = contributionOnAxis(gridPos.y);
+    var z: f32 = contributionOnAxis(gridPos.z);
+
+    // Find the normal contribution.
+    var normal: vec3f = normalize(fragmentInputs.vNormal);
+    x = x * normalImpactOnAxis(normal.x);
+    y = y * normalImpactOnAxis(normal.y);
+    z = z * normalImpactOnAxis(normal.z);
+
+#ifdef MAX_LINE
+    // Create the grid value from the max axis.
+    var grid: f32 = clamp(max(max(x, y), z), 0., 1.);
+#else
+    // Create the grid value by combining axes.
+    var grid: f32 = clamp(x + y + z, 0., 1.);
+#endif
+
+    // Create the color.
+    var color: vec4f = vec4f(mix(uniforms.mainColor, uniforms.lineColor, vec3f(grid)), 1.0);
+
+#ifdef FOG
+    #include<fogFragment>
+#endif
+
+    var opacity: f32 = 1.0;
+#ifdef TRANSPARENT
+    opacity = clamp(grid, 0.08, uniforms.gridControl.w * grid);
+#endif
+
+#ifdef OPACITY
+	opacity = opacity * textureSample(opacitySampler, opacitySamplerSampler, fragmentInputs.vOpacityUV).a;
+#endif
+
+    // Apply the color.
+    fragmentOutputs.color =  vec4f(color.rgb, opacity * uniforms.visibility);
+
+#ifdef TRANSPARENT
+    #ifdef PREMULTIPLYALPHA
+        fragmentOutputs.color = vec4f(fragmentOutputs.color.rgb * opacity, fragmentOutputs.color.a);
+    #endif
+#else
+#endif
+
+#include<logDepthFragment>
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/grid/wgsl/grid.vertex.fx
+++ b/packages/dev/materials/src/grid/wgsl/grid.vertex.fx
@@ -1,0 +1,77 @@
+// Attributes
+attribute position: vec3f;
+attribute normal: vec3f;
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+
+#include<instancesDeclaration>
+
+// Uniforms
+#include<sceneUboDeclaration>
+
+// Varying
+varying vPosition: vec3f;
+varying vNormal: vec3f;
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+
+#ifdef OPACITY
+varying vOpacityUV: vec2f;
+uniform opacityMatrix: mat4x4f;
+uniform vOpacityInfos: vec2f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+	#include<instancesVertex>
+
+    var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+    #include<fogVertex>
+
+    var cameraSpacePosition: vec4f = scene.view * worldPos;
+    vertexOutputs.position = scene.projection * cameraSpacePosition;
+
+#ifdef OPACITY
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+	if (uniforms.vOpacityInfos.x == 0.)
+	{
+		vertexOutputs.vOpacityUV = (uniforms.opacityMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vOpacityUV = (uniforms.opacityMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+	#include<clipPlaneVertex>
+
+	#include<logDepthVertex>
+
+    vertexOutputs.vPosition = vertexInputs.position;
+    vertexOutputs.vNormal = vertexInputs.normal;
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -16,9 +16,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./lava.fragment";
-import "./lava.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -156,9 +155,16 @@ export class LavaMaterial extends PushMaterial {
     public maxSimultaneousLights: number;
 
     private _scaledDiffuse = new Color3();
+    private _shadersLoaded = false;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    /**
+     * Instantiates a Lava Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -329,6 +335,18 @@ export class LavaMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this.maxSimultaneousLights },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/lava.vertex"), import("./wgsl/lava.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./lava.vertex"), import("./lava.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/lava/wgsl/lava.fragment.fx
+++ b/packages/dev/materials/src/lava/wgsl/lava.fragment.fx
@@ -1,0 +1,170 @@
+// Constants
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+// Input
+varying vPositionW: vec3f;
+
+// MAGMAAAA
+uniform time: f32;
+uniform speed: f32;
+uniform movingSpeed: f32;
+uniform fogColor: vec3f;
+var noiseTextureSampler: sampler;
+var noiseTexture: texture_2d<f32>;
+uniform fogDensity: f32;
+
+// Varying
+varying noise: f32;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0]
+#include<lightUboDeclaration>[1]
+#include<lightUboDeclaration>[2]
+#include<lightUboDeclaration>[3]
+
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+
+// Samplers
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+
+fn random(scale: vec3f, seed: f32) -> f32 {
+    return fract(sin(dot(fragmentInputs.position.xyz + seed, scale)) * 43758.5453 + seed);
+}
+
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+
+
+#ifdef DIFFUSE
+    ////// MAGMA ///
+
+	var noiseTex: vec4f = textureSample(noiseTexture, noiseTextureSampler, fragmentInputs.vDiffuseUV);
+	var T1: vec2f = fragmentInputs.vDiffuseUV +  vec2f(1.5, -1.5) * uniforms.time * 0.02;
+	var T2: vec2f = fragmentInputs.vDiffuseUV +  vec2f(-0.5, 2.0) * uniforms.time * 0.01 * uniforms.speed;
+
+	T1 = vec2f(T1.x + noiseTex.x * 2.0, T1.y + noiseTex.y * 2.0);
+	T2 = vec2f(T2.x - noiseTex.y * 0.2 - uniforms.time * 0.001 * uniforms.movingSpeed, T2.y + noiseTex.z * 0.2 + uniforms.time * 0.002 * uniforms.movingSpeed);
+
+	var p: f32 = textureSample(noiseTexture, noiseTextureSampler, T1 * 3.0).a;
+
+	var lavaColor: vec4f = textureSample(diffuseSampler, diffuseSamplerSampler, T2 * 4.0);
+	var temp: vec4f = lavaColor * ( vec4f(p, p, p, p) * 2.) + (lavaColor * lavaColor - 0.1);
+
+	baseColor = temp;
+
+	var depth: f32 = fragmentInputs.position.z * 4.0;
+	let LOG2: f32 = 1.442695;
+    var fogFactor: f32 = exp2(-uniforms.fogDensity * uniforms.fogDensity * depth * depth * LOG2);
+    fogFactor = 1.0 - clamp(fogFactor, 0.0, 1.0);
+
+    baseColor = mix(baseColor,  vec4f(uniforms.fogColor, baseColor.w),  vec4f(fogFactor));
+    diffuseColor = baseColor.rgb;
+    ///// END MAGMA ////
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+		discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vDiffuseInfos.y, baseColor.a);
+#endif
+
+#ifdef VERTEXCOLOR
+	baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Bump
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+#ifdef UNLIT
+	var diffuseBase: vec3f =  vec3f(1., 1., 1.);
+#else
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+    var glossiness: f32 = 0.;
+    var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#include<lightFragment>[0]
+#include<lightFragment>[1]
+#include<lightFragment>[2]
+#include<lightFragment>[3]
+
+#endif
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+	var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor, vec3f(0.0), vec3f(1.0)) * baseColor.rgb;
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/lava/wgsl/lava.vertex.fx
+++ b/packages/dev/materials/src/lava/wgsl/lava.vertex.fx
@@ -1,0 +1,240 @@
+// Inputs
+uniform time: f32;
+uniform lowFrequencySpeed: f32;
+// Varying
+varying noise: f32;
+
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+uniform diffuseMatrix: mat4x4f;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+/* NOISE FUNCTIONS */
+fn mod289v3(x: vec3f) -> vec3f
+{
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+fn mod289v4(x: vec4f) -> vec4f
+{
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+fn permute(x: vec4f) -> vec4f
+{
+  return mod289v4(((x*34.0)+1.0)*x);
+}
+
+fn taylorInvSqrt(r: vec4f) -> vec4f
+{
+  return  vec4f(1.79284291400159) - 0.85373472095314 * r;
+}
+
+fn fade(t: vec3f) -> vec3f {
+  return t*t*t*(t*(t*6.0-15.0)+10.0);
+}
+
+// Classic Perlin noise, periodic variant
+fn pnoise(P: vec3f, rep: vec3f) -> f32
+{
+  var Pi0: vec3f = (P - rep * floor(P / rep)); // mod
+  Pi0 = floor(Pi0);
+  var Pi1: vec3f = Pi0 +  vec3f(1.0);
+  Pi1 = Pi1 - rep * floor(Pi1 / rep);
+  Pi0 = mod289v3(Pi0);
+  Pi1 = mod289v3(Pi1);
+  var Pf0: vec3f = fract(P);
+  var Pf1: vec3f = Pf0 -  vec3f(1.0);
+  var ix: vec4f =  vec4f(Pi0.x, Pi1.x, Pi0.x, Pi1.x);
+  var iy: vec4f =  vec4f(Pi0.y, Pi0.y, Pi1.y, Pi1.y);
+  var iz0: vec4f =  vec4f(Pi0.z);
+  var iz1: vec4f =  vec4f(Pi1.z);
+
+  var ixy: vec4f = permute(permute(ix) + iy);
+  var ixy0: vec4f = permute(ixy + iz0);
+  var ixy1: vec4f = permute(ixy + iz1);
+
+  var gx0: vec4f = ixy0 * (1.0 / 7.0);
+  var gy0: vec4f = fract(floor(gx0) * (1.0 / 7.0)) - 0.5;
+  gx0 = fract(gx0);
+  var gz0: vec4f =  vec4f(0.5) - abs(gx0) - abs(gy0);
+  var sz0: vec4f = step(gz0,  vec4f(0.0));
+  gx0 = gx0 - sz0 * (step( vec4f(0.0), gx0) - 0.5);
+  gy0 = gy0 - sz0 * (step( vec4f(0.0), gy0) - 0.5);
+
+  var gx1: vec4f = ixy1 * (1.0 / 7.0);
+  var gy1: vec4f = fract(floor(gx1) * (1.0 / 7.0)) - 0.5;
+  gx1 = fract(gx1);
+  var gz1: vec4f =  vec4f(0.5) - abs(gx1) - abs(gy1);
+  var sz1: vec4f = step(gz1,  vec4f(0.0));
+  gx1 = gx1 - sz1 * (step( vec4f(0.0), gx1) - 0.5);
+  gy1 = gy1 - sz1 * (step( vec4f(0.0), gy1) - 0.5);
+
+  var g000: vec3f =  vec3f(gx0.x, gy0.x, gz0.x);
+  var g100: vec3f =  vec3f(gx0.y, gy0.y, gz0.y);
+  var g010: vec3f =  vec3f(gx0.z, gy0.z, gz0.z);
+  var g110: vec3f =  vec3f(gx0.w, gy0.w, gz0.w);
+  var g001: vec3f =  vec3f(gx1.x, gy1.x, gz1.x);
+  var g101: vec3f =  vec3f(gx1.y, gy1.y, gz1.y);
+  var g011: vec3f =  vec3f(gx1.z, gy1.z, gz1.z);
+  var g111: vec3f =  vec3f(gx1.w, gy1.w, gz1.w);
+
+  var norm0: vec4f = taylorInvSqrt( vec4f(dot(g000, g000), dot(g010, g010), dot(g100, g100), dot(g110, g110)));
+  g000 = g000 * norm0.x;
+  g010 = g010 * norm0.y;
+  g100 = g100 * norm0.z;
+  g110 = g110 * norm0.w;
+  var norm1: vec4f = taylorInvSqrt( vec4f(dot(g001, g001), dot(g011, g011), dot(g101, g101), dot(g111, g111)));
+  g001 = g001 * norm1.x;
+  g011 = g011 * norm1.y;
+  g101 = g101 * norm1.z;
+  g111 = g111 * norm1.w;
+
+  var n000: f32 = dot(g000, Pf0);
+  var n100: f32 = dot(g100,  vec3f(Pf1.x, Pf0.yz));
+  var n010: f32 = dot(g010,  vec3f(Pf0.x, Pf1.y, Pf0.z));
+  var n110: f32 = dot(g110,  vec3f(Pf1.xy, Pf0.z));
+  var n001: f32 = dot(g001,  vec3f(Pf0.xy, Pf1.z));
+  var n101: f32 = dot(g101,  vec3f(Pf1.x, Pf0.y, Pf1.z));
+  var n011: f32 = dot(g011,  vec3f(Pf0.x, Pf1.yz));
+  var n111: f32 = dot(g111, Pf1);
+
+  var fade_xyz: vec3f = fade(Pf0);
+  var n_z: vec4f = mix( vec4f(n000, n100, n010, n110),  vec4f(n001, n101, n011, n111),  vec4f(fade_xyz.z));
+  var n_yz: vec2f = mix(n_z.xy, n_z.zw,  vec2f(fade_xyz.y));
+  var n_xyz: f32 = mix(n_yz.x, n_yz.y, fade_xyz.x);
+  return 2.2 * n_xyz;
+}
+/* END FUNCTION */
+
+fn turbulence(p: vec3f) -> f32 {
+    var w: f32 = 100.0;
+    var t: f32 = -.5;
+    for (var f: f32 = 1.0; f <= 10.0; f = f + 1.0){
+        var power: f32 = pow(2.0, f);
+        t = t + abs(pnoise( vec3f(power * p),  vec3f(10.0, 10.0, 10.0)) / power);
+    }
+    return t;
+}
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+#ifdef NORMAL
+    // get a turbulent 3d noise using the normal, normal to high freq
+    vertexOutputs.noise = 10.0 * -.10 * turbulence(.5 * vertexInputs.normal + uniforms.time * 1.15);
+    // get a 3d noise using the position, low frequency
+    var b: f32 = uniforms.lowFrequencySpeed * 5.0 * pnoise(0.05 * vertexInputs.position +  vec3f(uniforms.time * 1.025),  vec3f(100.0));
+    // compose both noises
+    var displacement: f32 = -1.5 * vertexOutputs.noise + b;
+
+    // move the position along the normal and transform it
+    var newPosition: vec3f = vertexInputs.position + vertexInputs.normal * displacement;
+    vertexOutputs.position = uniforms.viewProjection * finalWorld *  vec4f(newPosition, 1.0);
+
+
+	var worldPos: vec4f = finalWorld *  vec4f(newPosition, 1.0);
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vDiffuseInfos.x == 0.)
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+	// Fog
+#include<fogVertex>
+#include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+#include<logDepthVertex>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/mix/mixMaterial.ts
+++ b/packages/dev/materials/src/mix/mixMaterial.ts
@@ -17,9 +17,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./mix.fragment";
-import "./mix.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -152,8 +151,16 @@ export class MixMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a Mix Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -368,6 +375,18 @@ export class MixMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this.maxSimultaneousLights },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/mix.vertex"), import("./wgsl/mix.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./mix.vertex"), import("./mix.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/mix/wgsl/mix.fragment.fx
+++ b/packages/dev/materials/src/mix/wgsl/mix.fragment.fx
@@ -1,0 +1,194 @@
+// Constants
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+#ifdef SPECULARTERM
+uniform vSpecularColor: vec4f;
+#endif
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+// Samplers
+#ifdef DIFFUSE
+varying vTextureUV: vec2f;
+var mixMap1SamplerSampler: sampler;
+var mixMap1Sampler: texture_2d<f32>;
+uniform vTextureInfos: vec2f;
+
+#ifdef MIXMAP2
+var mixMap2SamplerSampler: sampler;
+var mixMap2Sampler: texture_2d<f32>;
+#endif
+
+var diffuse1SamplerSampler: sampler;
+var diffuse1Sampler: texture_2d<f32>;
+var diffuse2SamplerSampler: sampler;
+var diffuse2Sampler: texture_2d<f32>;
+var diffuse3SamplerSampler: sampler;
+var diffuse3Sampler: texture_2d<f32>;
+var diffuse4SamplerSampler: sampler;
+var diffuse4Sampler: texture_2d<f32>;
+
+uniform diffuse1Infos: vec2f;
+uniform diffuse2Infos: vec2f;
+uniform diffuse3Infos: vec2f;
+uniform diffuse4Infos: vec2f;
+
+#ifdef MIXMAP2
+var diffuse5SamplerSampler: sampler;
+var diffuse5Sampler: texture_2d<f32>;
+var diffuse6SamplerSampler: sampler;
+var diffuse6Sampler: texture_2d<f32>;
+var diffuse7SamplerSampler: sampler;
+var diffuse7Sampler: texture_2d<f32>;
+var diffuse8SamplerSampler: sampler;
+var diffuse8Sampler: texture_2d<f32>;
+
+uniform diffuse5Infos: vec2f;
+uniform diffuse6Infos: vec2f;
+uniform diffuse7Infos: vec2f;
+uniform diffuse8Infos: vec2f;
+#endif
+
+#endif
+
+// Shadows
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+	#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var finalMixColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+#ifdef MIXMAP2
+	var mixColor2: vec4f =  vec4f(1., 1., 1., 1.);
+#endif
+
+#ifdef SPECULARTERM
+	var glossiness: f32 = uniforms.vSpecularColor.a;
+	var specularColor: vec3f = uniforms.vSpecularColor.rgb;
+#else
+	var glossiness: f32 = 0.;
+#endif
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+	// Normal
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+#ifdef DIFFUSE
+	var mixColor: vec4f = textureSample(mixMap1Sampler, mixMap1SamplerSampler, fragmentInputs.vTextureUV);
+
+#include<depthPrePass>
+
+	mixColor = vec4f(mixColor.rgb * uniforms.vTextureInfos.y, mixColor.a);
+
+	var diffuse1Color: vec4f = textureSample(diffuse1Sampler, diffuse1SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse1Infos);
+	var diffuse2Color: vec4f = textureSample(diffuse2Sampler, diffuse2SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse2Infos);
+	var diffuse3Color: vec4f = textureSample(diffuse3Sampler, diffuse3SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse3Infos);
+	var diffuse4Color: vec4f = textureSample(diffuse4Sampler, diffuse4SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse4Infos);
+
+	diffuse1Color = vec4f(diffuse1Color.rgb * mixColor.r, diffuse1Color.a);
+   	diffuse2Color = vec4f(mix(diffuse1Color.rgb, diffuse2Color.rgb, vec3f(mixColor.g)), diffuse2Color.a);
+   	diffuse3Color = vec4f(mix(diffuse2Color.rgb, diffuse3Color.rgb, vec3f(mixColor.b)), diffuse3Color.a);
+	finalMixColor = vec4f(mix(diffuse3Color.rgb, diffuse4Color.rgb, vec3f(1.0 - mixColor.a)), finalMixColor.a);
+
+#ifdef MIXMAP2
+	mixColor = textureSample(mixMap2Sampler, mixMap2SamplerSampler, fragmentInputs.vTextureUV);
+	mixColor = vec4f(mixColor.rgb * uniforms.vTextureInfos.y, mixColor.a);
+
+	var diffuse5Color: vec4f = textureSample(diffuse5Sampler, diffuse5SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse5Infos);
+	var diffuse6Color: vec4f = textureSample(diffuse6Sampler, diffuse6SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse6Infos);
+	var diffuse7Color: vec4f = textureSample(diffuse7Sampler, diffuse7SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse7Infos);
+	var diffuse8Color: vec4f = textureSample(diffuse8Sampler, diffuse8SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse8Infos);
+
+	diffuse5Color = vec4f(mix(finalMixColor.rgb, diffuse5Color.rgb, vec3f(mixColor.r)), diffuse5Color.a);
+   	diffuse6Color = vec4f(mix(diffuse5Color.rgb, diffuse6Color.rgb, vec3f(mixColor.g)), diffuse6Color.a);
+   	diffuse7Color = vec4f(mix(diffuse6Color.rgb, diffuse7Color.rgb, vec3f(mixColor.b)), diffuse7Color.a);
+	finalMixColor = vec4f(mix(diffuse7Color.rgb, diffuse8Color.rgb, vec3f(1.0 - mixColor.a)), finalMixColor.a);
+#endif
+
+#endif
+
+#ifdef VERTEXCOLOR
+	finalMixColor = vec4f(finalMixColor.rgb * fragmentInputs.vColor.rgb, finalMixColor.a);
+#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#ifdef SPECULARTERM
+	var specularBase: vec3f =  vec3f(0., 0., 0.);
+#endif
+	#include<lightFragment>[0..maxSimultaneousLights]
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+#ifdef SPECULARTERM
+	var finalSpecular: vec3f = specularBase * specularColor;
+#else
+	var finalSpecular: vec3f =  vec3f(0.0);
+#endif
+
+    var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor * finalMixColor.rgb, vec3f(0.0), vec3f(1.0));
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse + finalSpecular, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/mix/wgsl/mix.vertex.fx
+++ b/packages/dev/materials/src/mix/wgsl/mix.vertex.fx
@@ -1,0 +1,117 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vTextureUV: vec2f;
+uniform textureMatrix: mat4x4f;
+uniform vTextureInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+	#include<instancesVertex>
+    #include<bonesVertex>
+    #include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vTextureInfos.x == 0.)
+	{
+		vertexOutputs.vTextureUV = (uniforms.textureMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vTextureUV = (uniforms.textureMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+	#include<clipPlaneVertex>
+
+	// Fog
+	#include<fogVertex>
+
+	// Shadows
+    #include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+	#include<logDepthVertex>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -16,9 +16,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./normal.fragment";
-import "./normal.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -128,8 +127,16 @@ export class NormalMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a Normal Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -294,6 +301,18 @@ export class NormalMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: 4 },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/normal.vertex"), import("./wgsl/normal.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./normal.vertex"), import("./normal.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/normal/wgsl/normal.fragment.fx
+++ b/packages/dev/materials/src/normal/wgsl/normal.fragment.fx
@@ -1,0 +1,118 @@
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef LIGHTING
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0]
+#include<lightUboDeclaration>[1]
+#include<lightUboDeclaration>[2]
+#include<lightUboDeclaration>[3]
+
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+#endif
+
+// Samplers
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+#ifdef DIFFUSE
+	baseColor = textureSample(diffuseSampler, diffuseSamplerSampler, fragmentInputs.vDiffuseUV);
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+        discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vDiffuseInfos.y, baseColor.a);
+#endif
+
+#ifdef NORMAL
+    baseColor = mix(baseColor,  vec4f(fragmentInputs.vNormalW, 1.0), 0.5);
+#endif
+
+	// Normal
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	// Lighting
+
+#ifdef LIGHTING
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+    var glossiness: f32 = 0.;
+    var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#include<lightFragment>[0]
+#include<lightFragment>[1]
+#include<lightFragment>[2]
+#include<lightFragment>[3]
+	var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor, vec3f(0.0), vec3f(1.0)) * baseColor.rgb;
+#else
+	var finalDiffuse: vec3f =  baseColor.rgb;
+#endif
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/normal/wgsl/normal.vertex.fx
+++ b/packages/dev/materials/src/normal/wgsl/normal.vertex.fx
@@ -1,0 +1,105 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+uniform diffuseMatrix: mat4x4f;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vDiffuseInfos.x == 0.)
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+#include<logDepthVertex>
+
+    // Fog
+#include<fogVertex>
+#include<shadowsVertex>[0..maxSimultaneousLights]
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
@@ -14,9 +14,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./shadowOnly.fragment";
-import "./shadowOnly.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { type CascadedShadowGenerator } from "core/Lights/Shadows/cascadedShadowGenerator";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
@@ -61,9 +60,16 @@ class ShadowOnlyMaterialDefines extends MaterialDefines {
 export class ShadowOnlyMaterial extends PushMaterial {
     private _activeLight: IShadowLight;
     private _needAlphaBlending = true;
+    private _shadersLoaded = false;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    /**
+     * Instantiates a ShadowOnly Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public shadowColor = Color3.Black();
@@ -242,6 +248,18 @@ export class ShadowOnlyMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: 1 },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/shadowOnly.vertex"), import("./wgsl/shadowOnly.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./shadowOnly.vertex"), import("./shadowOnly.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/shadowOnly/wgsl/shadowOnly.fragment.fx
+++ b/packages/dev/materials/src/shadowOnly/wgsl/shadowOnly.fragment.fx
@@ -1,0 +1,70 @@
+// Constants
+#include<sceneUboDeclaration>
+uniform alpha: f32;
+uniform shadowColor: vec3f;
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(scene.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Normal
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+    var glossiness: f32 = 0.;
+    var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#include<lightFragment>[0..1]
+
+	// Composition
+	var color: vec4f =  vec4f(uniforms.shadowColor, (1.0 - clamp(shadow, 0., 1.)) * uniforms.alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/shadowOnly/wgsl/shadowOnly.vertex.fx
+++ b/packages/dev/materials/src/shadowOnly/wgsl/shadowOnly.vertex.fx
@@ -1,0 +1,71 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+#include<sceneUboDeclaration>
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = scene.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+#include<logDepthVertex>
+
+    // Fog
+#include<fogVertex>
+#include<shadowsVertex>[0..maxSimultaneousLights]
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/simple/simpleMaterial.ts
+++ b/packages/dev/materials/src/simple/simpleMaterial.ts
@@ -16,9 +16,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./simple.fragment";
-import "./simple.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -88,8 +87,16 @@ export class SimpleMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a Simple Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -248,6 +255,18 @@ export class SimpleMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this._maxSimultaneousLights - 1 },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/simple.vertex"), import("./wgsl/simple.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./simple.vertex"), import("./simple.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/simple/wgsl/simple.fragment.fx
+++ b/packages/dev/materials/src/simple/wgsl/simple.fragment.fx
@@ -1,0 +1,117 @@
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+
+// Samplers
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+var diffuseSamplerSampler: sampler;
+var diffuseSampler: texture_2d<f32>;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+#ifdef DIFFUSE
+	baseColor = textureSample(diffuseSampler, diffuseSamplerSampler, fragmentInputs.vDiffuseUV);
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+        discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vDiffuseInfos.y, baseColor.a);
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Normal
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+    var glossiness: f32 = 0.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#ifdef SPECULARTERM
+	var specularBase: vec3f =  vec3f(0., 0., 0.);
+#endif
+#include<lightFragment>[0..maxSimultaneousLights]
+
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+	var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor, vec3f(0.0), vec3f(1.0)) * baseColor.rgb;
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/simple/wgsl/simple.vertex.fx
+++ b/packages/dev/materials/src/simple/wgsl/simple.vertex.fx
@@ -1,0 +1,117 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vDiffuseUV: vec2f;
+uniform diffuseMatrix: mat4x4f;
+uniform vDiffuseInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+#include<instancesVertex>
+#include<bonesVertex>
+#include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vDiffuseInfos.x == 0.)
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vDiffuseUV = (uniforms.diffuseMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+#include<logDepthVertex>
+
+    // Fog
+#include<fogVertex>
+#include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/sky/skyMaterial.ts
+++ b/packages/dev/materials/src/sky/skyMaterial.ts
@@ -13,9 +13,9 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
+import { type IEffectCreationOptions } from "core/Materials/effect";
 
-import "./sky.fragment";
-import "./sky.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import { BindFogParameters, BindLogDepth, PrepareDefinesForAttributes, PrepareDefinesForMisc } from "core/Materials/materialHelper.functions";
@@ -135,6 +135,8 @@ export class SkyMaterial extends PushMaterial {
     private _cameraPosition: Vector3 = Vector3.Zero();
     private _skyOrientation: Quaternion = new Quaternion();
 
+    private _shadersLoaded = false;
+
     /**
      * Instantiates a new sky material.
      * This material allows to create dynamic and texture free
@@ -142,9 +144,10 @@ export class SkyMaterial extends PushMaterial {
      * @see https://doc.babylonjs.com/toolsAndResources/assetLibraries/materialsLibrary/skyMat
      * @param name Define the name of the material in the scene
      * @param scene Define the scene the material belong to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
      */
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     /**
@@ -267,7 +270,36 @@ export class SkyMaterial extends PushMaterial {
             ];
             AddClipPlaneUniforms(uniforms);
             const join = defines.toString();
-            subMesh.setEffect(scene.getEngine().createEffect(shaderName, attribs, uniforms, [], join, fallbacks, this.onCompiled, this.onError), defines, this._materialContext);
+            subMesh.setEffect(
+                scene.getEngine().createEffect(
+                    shaderName,
+                    <IEffectCreationOptions>{
+                        attributes: attribs,
+                        uniformsNames: uniforms,
+                        uniformBuffersNames: [],
+                        samplers: [],
+                        defines: join,
+                        fallbacks: fallbacks,
+                        onCompiled: this.onCompiled,
+                        onError: this.onError,
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/sky.vertex"), import("./wgsl/sky.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./sky.vertex"), import("./sky.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
+                    },
+                    scene.getEngine()
+                ),
+                defines,
+                this._materialContext
+            );
         }
 
         if (!subMesh.effect || !subMesh.effect.isReady()) {

--- a/packages/dev/materials/src/sky/wgsl/sky.fragment.fx
+++ b/packages/dev/materials/src/sky/wgsl/sky.fragment.fx
@@ -1,0 +1,180 @@
+// Input
+varying vPositionW: vec3f;
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneFragmentDeclaration>
+
+// Sky
+uniform cameraPosition: vec3f;
+uniform cameraOffset: vec3f;
+uniform up: vec3f;
+uniform luminance: f32;
+uniform turbidity: f32;
+uniform rayleigh: f32;
+uniform mieCoefficient: f32;
+uniform mieDirectionalG: f32;
+uniform sunPosition: vec3f;
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+// Constants
+const ce: f32 = 2.71828182845904523536028747135266249775724709369995957;
+const pi: f32 = 3.141592653589793238462643383279502884197169;
+const cn: f32 = 1.0003;
+const cN: f32 = 2.545E25;
+const pn: f32 = 0.035;
+
+const lambda: vec3f =  vec3f(680E-9, 550E-9, 450E-9);
+
+const cK: vec3f =  vec3f(0.686, 0.678, 0.666);
+const cv: f32 = 4.0;
+
+const rayleighZenithLength: f32 = 8.4E3;
+const mieZenithLength: f32 = 1.25E3;
+
+const EE: f32 = 1000.0;
+const sunAngularDiameterCos: f32 = 0.999956676946448443553574619906976478926848692873900859324;
+
+const cutoffAngle: f32 = pi / 1.95;
+const steepness: f32 = 1.5;
+
+fn totalRayleigh(lambdaIn: vec3f) -> vec3f
+{
+	return (8.0 * pow(pi, 3.0) * pow(pow(cn, 2.0) - 1.0, 2.0) * (6.0 + 3.0 * pn)) / (3.0 * cN * pow(lambdaIn,  vec3f(4.0)) * (6.0 - 7.0 * pn));
+}
+
+fn simplifiedRayleigh() -> vec3f
+{
+	return  vec3f(0.0005) /  vec3f(94, 40, 18);
+}
+
+fn rayleighPhase(cosTheta: f32) -> f32
+{
+	return (3.0 / (16.0 * pi)) * (1.0 + pow(cosTheta, 2.0));
+}
+
+fn totalMie(lambdaIn: vec3f, KIn: vec3f, T: f32) -> vec3f
+{
+	var c: f32 = (0.2 * T) * 10E-18;
+	return 0.434 * c * pi * pow((2.0 * pi) / lambdaIn,  vec3f(cv - 2.0)) * KIn;
+}
+
+fn hgPhase(cosTheta: f32, g: f32) -> f32
+{
+	return (1.0 / (4.0 * pi)) * ((1.0 - pow(g, 2.0)) / pow(1.0 - 2.0 * g * cosTheta + pow(g, 2.0), 1.5));
+}
+
+fn sunIntensity(zenithAngleCos: f32) -> f32
+{
+	return EE * max(0.0, 1.0 - exp((-(cutoffAngle - acos(zenithAngleCos)) / steepness)));
+}
+
+const A: f32 = 0.15;
+const B: f32 = 0.50;
+const C: f32 = 0.10;
+const D: f32 = 0.20;
+const EEE: f32 = 0.02;
+const F: f32 = 0.30;
+const W: f32 = 1000.0;
+
+fn Uncharted2Tonemap(x: vec3f) -> vec3f
+{
+	return ((x * (A * x + C * B) + D * EEE) / (x * (A * x + B) + D * F)) - EEE / F;
+}
+
+#if DITHER
+#include<helperFunctions>
+#endif
+
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+#include<clipPlaneFragment>
+
+	/**
+	* Sky Color
+	*/
+	var sunfade: f32 = 1.0 - clamp(1.0 - exp((uniforms.sunPosition.y / 450000.0)), 0.0, 1.0);
+	var rayleighCoefficient: f32 = uniforms.rayleigh - (1.0 * (1.0 - sunfade));
+	var sunDirection: vec3f = normalize(uniforms.sunPosition);
+	var sunE: f32 = sunIntensity(dot(sunDirection, uniforms.up));
+	var betaR: vec3f = simplifiedRayleigh() * rayleighCoefficient;
+	var betaM: vec3f = totalMie(lambda, cK, uniforms.turbidity) * uniforms.mieCoefficient;
+	var zenithAngle: f32 = acos(max(0.0, dot(uniforms.up, normalize(fragmentInputs.vPositionW - uniforms.cameraPosition + uniforms.cameraOffset))));
+	var sR: f32 = rayleighZenithLength / (cos(zenithAngle) + 0.15 * pow(93.885 - ((zenithAngle * 180.0) / pi), -1.253));
+	var sM: f32 = mieZenithLength / (cos(zenithAngle) + 0.15 * pow(93.885 - ((zenithAngle * 180.0) / pi), -1.253));
+	var Fex: vec3f = exp(-(betaR * sR + betaM * sM));
+	var cosTheta: f32 = dot(normalize(fragmentInputs.vPositionW - uniforms.cameraPosition), sunDirection);
+	var rPhase: f32 = rayleighPhase(cosTheta * 0.5 + 0.5);
+	var betaRTheta: vec3f = betaR * rPhase;
+	var mPhase: f32 = hgPhase(cosTheta, uniforms.mieDirectionalG);
+	var betaMTheta: vec3f = betaM * mPhase;
+
+	var Lin: vec3f = pow(sunE * ((betaRTheta + betaMTheta) / (betaR + betaM)) * (1.0 - Fex),  vec3f(1.5));
+	Lin = Lin * mix( vec3f(1.0), pow(sunE * ((betaRTheta + betaMTheta) / (betaR + betaM)) * Fex,  vec3f(1.0 / 2.0)),  vec3f(clamp(pow(1.0 - dot(uniforms.up, sunDirection), 5.0), 0.0, 1.0)));
+
+	var direction: vec3f = normalize(fragmentInputs.vPositionW - uniforms.cameraPosition);
+	var theta: f32 = acos(direction.y);
+	var phi: f32 = atan2(direction.z, direction.x);
+	var uv: vec2f =  vec2f(phi, theta) /  vec2f(2.0 * pi, pi) +  vec2f(0.5, 0.0);
+	var L0: vec3f =  vec3f(0.1) * Fex;
+
+	var sundisk: f32 = smoothstep(sunAngularDiameterCos, sunAngularDiameterCos + 0.00002, cosTheta);
+	L0 = L0 + (sunE * 19000.0 * Fex) * sundisk;
+
+	var whiteScale: vec3f = 1.0 / Uncharted2Tonemap( vec3f(W));
+	var texColor: vec3f = (Lin + L0);
+	texColor = texColor * 0.04;
+	texColor = texColor +  vec3f(0.0, 0.001, 0.0025) * 0.3;
+
+	var g_fMaxLuminance: f32 = 1.0;
+	var fLumScaled: f32 = 0.1 / uniforms.luminance;
+	var fLumCompressed: f32 = (fLumScaled * (1.0 + (fLumScaled / (g_fMaxLuminance * g_fMaxLuminance)))) / (1.0 + fLumScaled);
+
+	var ExposureBias: f32 = fLumCompressed;
+
+	var curr: vec3f = Uncharted2Tonemap((log2(2.0 / pow(uniforms.luminance, 4.0))) * texColor);
+
+	var retColor: vec3f = curr * whiteScale;
+
+	// Alpha
+	var alpha: f32 = 1.0;
+
+#ifdef VERTEXCOLOR
+	retColor = retColor.rgb * fragmentInputs.vColor.rgb;
+#endif
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+#if DITHER
+	retColor = retColor.rgb + dither(fragmentInputs.position.xy, 0.5);
+#endif
+
+	// Composition
+	var color: vec4f = clamp( vec4f(retColor.rgb, alpha),  vec4f(0.0),  vec4f(1.0));
+
+#include<logDepthFragment>
+
+    // Fog
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/sky/wgsl/sky.vertex.fx
+++ b/packages/dev/materials/src/sky/wgsl/sky.vertex.fx
@@ -1,0 +1,55 @@
+// Attributes
+attribute position: vec3f;
+
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+// Uniforms
+uniform world: mat4x4f;
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+
+#ifdef VERTEXCOLOR
+varying vColor: vec4f;
+#endif
+
+#include<logDepthDeclaration>
+#include<clipPlaneVertexDeclaration>
+#include<fogVertexDeclaration>
+
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+	vertexOutputs.position = uniforms.viewProjection * uniforms.world *  vec4f(vertexInputs.position, 1.0);
+
+	var worldPos: vec4f = uniforms.world *  vec4f(vertexInputs.position, 1.0);
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+	// Clip plane
+#include<clipPlaneVertex>
+
+#include<logDepthVertex>
+
+	// Fog
+#include<fogVertex>
+
+	// Vertex color
+#ifdef VERTEXCOLOR
+	vertexOutputs.vColor = vertexInputs.color;
+#endif
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/terrain/terrainMaterial.ts
+++ b/packages/dev/materials/src/terrain/terrainMaterial.ts
@@ -17,9 +17,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./terrain.fragment";
-import "./terrain.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -127,8 +126,16 @@ export class TerrainMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a Terrain Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -328,6 +335,18 @@ export class TerrainMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this.maxSimultaneousLights },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/terrain.vertex"), import("./wgsl/terrain.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./terrain.vertex"), import("./terrain.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/terrain/wgsl/terrain.fragment.fx
+++ b/packages/dev/materials/src/terrain/wgsl/terrain.fragment.fx
@@ -1,0 +1,207 @@
+// Constants
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+#ifdef SPECULARTERM
+uniform vSpecularColor: vec4f;
+#endif
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+// Samplers
+#ifdef DIFFUSE
+varying vTextureUV: vec2f;
+var textureSamplerSampler: sampler;
+var textureSampler: texture_2d<f32>;
+uniform vTextureInfos: vec2f;
+
+var diffuse1SamplerSampler: sampler;
+var diffuse1Sampler: texture_2d<f32>;
+var diffuse2SamplerSampler: sampler;
+var diffuse2Sampler: texture_2d<f32>;
+var diffuse3SamplerSampler: sampler;
+var diffuse3Sampler: texture_2d<f32>;
+
+uniform diffuse1Infos: vec2f;
+uniform diffuse2Infos: vec2f;
+uniform diffuse3Infos: vec2f;
+
+#endif
+
+#ifdef BUMP
+var bump1SamplerSampler: sampler;
+var bump1Sampler: texture_2d<f32>;
+var bump2SamplerSampler: sampler;
+var bump2Sampler: texture_2d<f32>;
+var bump3SamplerSampler: sampler;
+var bump3Sampler: texture_2d<f32>;
+#endif
+
+// Shadows
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+#include<clipPlaneFragmentDeclaration>
+
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+// Bump
+#ifdef BUMP
+// Thanks to http://www.thetenthplanet.de/archives/1180
+fn cotangent_frame(normal: vec3f, p: vec3f, uv: vec2f) -> mat3x3f
+{
+	// get edge vectors of the pixel triangle
+	var dp1: vec3f = dpdx(p);
+	var dp2: vec3f = dpdy(p);
+	var duv1: vec2f = dpdx(uv);
+	var duv2: vec2f = dpdy(uv);
+
+	// solve the linear system
+	var dp2perp: vec3f = cross(dp2, normal);
+	var dp1perp: vec3f = cross(normal, dp1);
+	var tangent: vec3f = dp2perp * duv1.x + dp1perp * duv2.x;
+	var binormal: vec3f = dp2perp * duv1.y + dp1perp * duv2.y;
+
+	// construct a scale-invariant frame
+	var invmax: f32 = inverseSqrt(max(dot(tangent, tangent), dot(binormal, binormal)));
+	return mat3x3f(tangent * invmax, binormal * invmax, normal);
+}
+
+fn perturbNormal(viewDir: vec3f, mixColor: vec3f) -> vec3f
+{
+	var bump1Color: vec3f = textureSample(bump1Sampler, bump1SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse1Infos).xyz;
+	var bump2Color: vec3f = textureSample(bump2Sampler, bump2SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse2Infos).xyz;
+	var bump3Color: vec3f = textureSample(bump3Sampler, bump3SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse3Infos).xyz;
+
+	bump1Color = bump1Color.rgb * mixColor.r;
+   	bump2Color = mix(bump1Color.rgb, bump2Color.rgb, vec3f(mixColor.g));
+   	var map: vec3f = mix(bump2Color.rgb, bump3Color.rgb, vec3f(mixColor.b));
+
+	map = map * 255. / 127. - 128. / 127.;
+	var TBN: mat3x3f = cotangent_frame(fragmentInputs.vNormalW * uniforms.vTextureInfos.y, -viewDir, fragmentInputs.vTextureUV);
+	return normalize(TBN * map);
+}
+#endif
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+	#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+#ifdef SPECULARTERM
+	var glossiness: f32 = uniforms.vSpecularColor.a;
+	var specularColor: vec3f = uniforms.vSpecularColor.rgb;
+#else
+	var glossiness: f32 = 0.;
+#endif
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+	// Bump
+#ifdef NORMAL
+	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+#ifdef DIFFUSE
+	baseColor = textureSample(textureSampler, textureSamplerSampler, fragmentInputs.vTextureUV);
+
+#if defined(BUMP) && defined(DIFFUSE)
+	normalW = perturbNormal(viewDirectionW, baseColor.rgb);
+#endif
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+		discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vTextureInfos.y, baseColor.a);
+
+	var diffuse1Color: vec4f = textureSample(diffuse1Sampler, diffuse1SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse1Infos);
+	var diffuse2Color: vec4f = textureSample(diffuse2Sampler, diffuse2SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse2Infos);
+	var diffuse3Color: vec4f = textureSample(diffuse3Sampler, diffuse3SamplerSampler, fragmentInputs.vTextureUV * uniforms.diffuse3Infos);
+
+	diffuse1Color = vec4f(diffuse1Color.rgb * baseColor.r, diffuse1Color.a);
+   	diffuse2Color = vec4f(mix(diffuse1Color.rgb, diffuse2Color.rgb, vec3f(baseColor.g)), diffuse2Color.a);
+   	baseColor = vec4f(mix(diffuse2Color.rgb, diffuse3Color.rgb, vec3f(baseColor.b)), baseColor.a);
+
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+    baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#ifdef SPECULARTERM
+	var specularBase: vec3f =  vec3f(0., 0., 0.);
+#endif
+	#include<lightFragment>[0..maxSimultaneousLights]
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+#ifdef SPECULARTERM
+	var finalSpecular: vec3f = specularBase * specularColor;
+#else
+	var finalSpecular: vec3f =  vec3f(0.0);
+#endif
+
+    var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor * baseColor.rgb, vec3f(0.0), vec3f(1.0));
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse + finalSpecular, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/terrain/wgsl/terrain.vertex.fx
+++ b/packages/dev/materials/src/terrain/wgsl/terrain.vertex.fx
@@ -1,0 +1,117 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSE
+varying vTextureUV: vec2f;
+uniform textureMatrix: mat4x4f;
+uniform vTextureInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+varying vColor: vec4f;
+#endif
+
+#include<logDepthDeclaration>
+#include<clipPlaneVertexDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+	#include<instancesVertex>
+    #include<bonesVertex>
+    #include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef DIFFUSE
+	if (uniforms.vTextureInfos.x == 0.)
+	{
+		vertexOutputs.vTextureUV = (uniforms.textureMatrix *  vec4f(uv, 1.0, 0.0)).xy;
+	}
+	else
+	{
+		vertexOutputs.vTextureUV = (uniforms.textureMatrix *  vec4f(uv2, 1.0, 0.0)).xy;
+	}
+#endif
+
+	// Clip plane
+	#include<clipPlaneVertex>
+
+	#include<logDepthVertex>
+
+	// Fog
+	#include<fogVertex>
+
+	// Shadows
+    #include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
+++ b/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
@@ -17,9 +17,8 @@ import { type SubMesh } from "core/Meshes/subMesh";
 import { type Mesh } from "core/Meshes/mesh";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./triplanar.fragment";
-import "./triplanar.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
 import {
@@ -133,8 +132,16 @@ export class TriPlanarMaterial extends PushMaterial {
     @expandToProperty("_markAllSubMeshesAsLightsDirty")
     public maxSimultaneousLights: number;
 
-    constructor(name: string, scene?: Scene) {
-        super(name, scene);
+    private _shadersLoaded = false;
+
+    /**
+     * Instantiates a TriPlanar Material in the given scene
+     * @param name The friendly name of the material
+     * @param scene The scene to add the material to
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
+     */
+    constructor(name: string, scene?: Scene, forceGLSL = false) {
+        super(name, scene, undefined, forceGLSL);
     }
 
     public override needAlphaBlending(): boolean {
@@ -317,6 +324,18 @@ export class TriPlanarMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this.maxSimultaneousLights },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/triplanar.vertex"), import("./wgsl/triplanar.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./triplanar.vertex"), import("./triplanar.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/triPlanar/wgsl/triplanar.fragment.fx
+++ b/packages/dev/materials/src/triPlanar/wgsl/triplanar.fragment.fx
@@ -1,0 +1,177 @@
+// Constants
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+#ifdef SPECULARTERM
+uniform vSpecularColor: vec4f;
+#endif
+
+// Input
+varying vPositionW: vec3f;
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+// Samplers
+#ifdef DIFFUSEX
+varying vTextureUVX: vec2f;
+var diffuseSamplerXSampler: sampler;
+var diffuseSamplerX: texture_2d<f32>;
+#ifdef BUMPX
+var normalSamplerXSampler: sampler;
+var normalSamplerX: texture_2d<f32>;
+#endif
+#endif
+
+#ifdef DIFFUSEY
+varying vTextureUVY: vec2f;
+var diffuseSamplerYSampler: sampler;
+var diffuseSamplerY: texture_2d<f32>;
+#ifdef BUMPY
+var normalSamplerYSampler: sampler;
+var normalSamplerY: texture_2d<f32>;
+#endif
+#endif
+
+#ifdef DIFFUSEZ
+varying vTextureUVZ: vec2f;
+var diffuseSamplerZSampler: sampler;
+var diffuseSamplerZ: texture_2d<f32>;
+#ifdef BUMPZ
+var normalSamplerZSampler: sampler;
+var normalSamplerZ: texture_2d<f32>;
+#endif
+#endif
+
+#ifdef NORMAL
+varying tangentSpace0: vec3f;
+varying tangentSpace1: vec3f;
+varying tangentSpace2: vec3f;
+#endif
+
+#include<logDepthDeclaration>
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+#include<clipPlaneFragmentDeclaration>
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+	#include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(0., 0., 0., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+	// Bump
+#ifdef NORMAL
+	var normalW: vec3f = fragmentInputs.tangentSpace2;
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+#endif
+
+	var baseNormal: vec4f =  vec4f(0.0, 0.0, 0.0, 1.0);
+	normalW = normalW * normalW;
+
+#ifdef DIFFUSEX
+	baseColor = baseColor + textureSample(diffuseSamplerX, diffuseSamplerXSampler, fragmentInputs.vTextureUVX) * normalW.x;
+#ifdef BUMPX
+	baseNormal = baseNormal + textureSample(normalSamplerX, normalSamplerXSampler, fragmentInputs.vTextureUVX) * normalW.x;
+#endif
+#endif
+
+#ifdef DIFFUSEY
+	baseColor = baseColor + textureSample(diffuseSamplerY, diffuseSamplerYSampler, fragmentInputs.vTextureUVY) * normalW.y;
+#ifdef BUMPY
+	baseNormal = baseNormal + textureSample(normalSamplerY, normalSamplerYSampler, fragmentInputs.vTextureUVY) * normalW.y;
+#endif
+#endif
+
+#ifdef DIFFUSEZ
+	baseColor = baseColor + textureSample(diffuseSamplerZ, diffuseSamplerZSampler, fragmentInputs.vTextureUVZ) * normalW.z;
+#ifdef BUMPZ
+	baseNormal = baseNormal + textureSample(normalSamplerZ, normalSamplerZSampler, fragmentInputs.vTextureUVZ) * normalW.z;
+#endif
+#endif
+
+#ifdef NORMAL
+	var tangentSpace: mat3x3f = mat3x3f(fragmentInputs.tangentSpace0, fragmentInputs.tangentSpace1, fragmentInputs.tangentSpace2);
+	normalW = normalize((2.0 * baseNormal.xyz - 1.0) * tangentSpace);
+#endif
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+		discard;
+    }
+#endif
+
+#include<depthPrePass>
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+    baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Lighting
+	var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+	var shadow: f32 = 1.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+#ifdef SPECULARTERM
+	var glossiness: f32 = uniforms.vSpecularColor.a;
+	var specularBase: vec3f =  vec3f(0., 0., 0.);
+    var specularColor: vec3f = uniforms.vSpecularColor.rgb;
+#else
+	var glossiness: f32 = 0.;
+#endif
+
+#include<lightFragment>[0..maxSimultaneousLights]
+
+#if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+	alpha *= fragmentInputs.vColor.a;
+#endif
+
+#ifdef SPECULARTERM
+	var finalSpecular: vec3f = specularBase * specularColor;
+#else
+	var finalSpecular: vec3f =  vec3f(0.0);
+#endif
+
+	var finalDiffuse: vec3f = clamp(diffuseBase * diffuseColor, vec3f(0.0), vec3f(1.0)) * baseColor.rgb;
+
+	// Composition
+	var color: vec4f =  vec4f(finalDiffuse + finalSpecular, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+	fragmentOutputs.color = color;
+
+#include<imageProcessingCompatibility>
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/triPlanar/wgsl/triplanar.vertex.fx
+++ b/packages/dev/materials/src/triPlanar/wgsl/triplanar.vertex.fx
@@ -1,0 +1,142 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<helperFunctions>
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef DIFFUSEX
+varying vTextureUVX: vec2f;
+#endif
+
+#ifdef DIFFUSEY
+varying vTextureUVY: vec2f;
+#endif
+
+#ifdef DIFFUSEZ
+varying vTextureUVZ: vec2f;
+#endif
+
+uniform tileSize: f32;
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying tangentSpace0: vec3f;
+varying tangentSpace1: vec3f;
+varying tangentSpace2: vec3f;
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+
+#include<logDepthDeclaration>
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs
+{
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+	#include<instancesVertex>
+    #include<bonesVertex>
+    #include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+
+	vertexOutputs.position = uniforms.viewProjection * worldPos;
+
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef DIFFUSEX
+	vertexOutputs.vTextureUVX = worldPos.zy / uniforms.tileSize;
+#endif
+
+#ifdef DIFFUSEY
+	vertexOutputs.vTextureUVY = worldPos.xz / uniforms.tileSize;
+#endif
+
+#ifdef DIFFUSEZ
+	vertexOutputs.vTextureUVZ = worldPos.xy / uniforms.tileSize;
+#endif
+
+#ifdef NORMAL
+	// Compute tangent space (used for normal mapping + tri planar color mapping)
+	var xtan: vec3f =  vec3f(0,0,1);//tangent space for the X aligned plane
+   	var xbin: vec3f =  vec3f(0,1,0);
+
+   	var ytan: vec3f =  vec3f(1,0,0);//tangent space for the Y aligned plane
+   	var ybin: vec3f =  vec3f(0,0,1);
+
+   	var ztan: vec3f =  vec3f(1,0,0);//tangent space for the Z aligned plane
+   	var zbin: vec3f =  vec3f(0,1,0);
+
+	var normalizedNormal: vec3f = normalize(vertexInputs.normal);
+   	normalizedNormal = normalizedNormal * normalizedNormal;
+
+	var worldBinormal: vec3f = normalize(xbin * normalizedNormal.x + ybin * normalizedNormal.y + zbin * normalizedNormal.z);
+   	var worldTangent: vec3f = normalize(xtan * normalizedNormal.x + ytan * normalizedNormal.y + ztan * normalizedNormal.z);
+
+	var normalWorld: mat3x3f =  mat3x3f(finalWorld[0].xyz, finalWorld[1].xyz, finalWorld[2].xyz);
+
+	#ifdef NONUNIFORMSCALING
+		normalWorld = transposeMat3(inverseMat3(normalWorld));
+	#endif
+
+	worldTangent = normalize((normalWorld * worldTangent).xyz);
+    worldBinormal = normalize((normalWorld * worldBinormal).xyz);
+	var worldNormal: vec3f = normalize((normalWorld * normalize(vertexInputs.normal)).xyz);
+
+	vertexOutputs.tangentSpace0 = worldTangent;
+    vertexOutputs.tangentSpace1 = worldBinormal;
+    vertexOutputs.tangentSpace2 = worldNormal;
+#endif
+
+	// Clip plane
+	#include<clipPlaneVertex>
+
+	#include<logDepthVertex>
+
+	// Fog
+	#include<fogVertex>
+
+	// Shadows
+	#include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+#define CUSTOM_VERTEX_MAIN_END
+}

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -24,9 +24,8 @@ import { type Mesh } from "core/Meshes/mesh";
 import { type Camera } from "core/Cameras/camera";
 import { Scene } from "core/scene";
 import { RegisterClass } from "core/Misc/typeStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 
-import "./water.fragment";
-import "./water.vertex";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { CreateGround } from "core/Meshes/Builders/groundBuilder";
 import { AddClipPlaneUniforms, BindClipPlane } from "core/Materials/clipPlaneMaterialHelper";
@@ -241,6 +240,7 @@ export class WaterMaterial extends PushMaterial {
     private _offsetMirror: Matrix = Matrix.Zero();
     private _tempPlane: Plane = new Plane(0, 0, 0, 0);
     private _lastTime: number = 0;
+    private _shadersLoaded = false;
     private _lastDeltaTime: number = 0;
 
     private _waitingRenderList: Nullable<string[]>;
@@ -260,13 +260,15 @@ export class WaterMaterial extends PushMaterial {
      * @param name
      * @param scene
      * @param renderTargetSize
+     * @param forceGLSL Use the GLSL code generation for the shader (even on WebGPU). Default is false
      */
     constructor(
         name: string,
         scene?: Scene,
-        public renderTargetSize: Vector2 = new Vector2(512, 512)
+        public renderTargetSize: Vector2 = new Vector2(512, 512),
+        forceGLSL = false
     ) {
-        super(name, scene);
+        super(name, scene, undefined, forceGLSL);
 
         this._createRenderTargets(this.getScene(), renderTargetSize);
 
@@ -561,6 +563,18 @@ export class WaterMaterial extends PushMaterial {
                         onCompiled: this.onCompiled,
                         onError: this.onError,
                         indexParameters: { maxSimultaneousLights: this._maxSimultaneousLights },
+                        shaderLanguage: this._shaderLanguage,
+                        extraInitializationsAsync: this._shadersLoaded
+                            ? undefined
+                            : async () => {
+                                  if (this.shaderLanguage === ShaderLanguage.WGSL) {
+                                      await Promise.all([import("./wgsl/water.vertex"), import("./wgsl/water.fragment")]);
+                                  } else {
+                                      await Promise.all([import("./water.vertex"), import("./water.fragment")]);
+                                  }
+
+                                  this._shadersLoaded = true;
+                              },
                     },
                     engine
                 ),

--- a/packages/dev/materials/src/water/wgsl/water.fragment.fx
+++ b/packages/dev/materials/src/water/wgsl/water.fragment.fx
@@ -1,0 +1,270 @@
+// Constants
+uniform vEyePosition: vec4f;
+uniform vDiffuseColor: vec4f;
+
+#ifdef SPECULARTERM
+uniform vSpecularColor: vec4f;
+#endif
+
+// Input
+varying vPositionW: vec3f;
+
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+varying vColor: vec4f;
+#endif
+
+// Helper functions
+#include<helperFunctions>
+
+#include<imageProcessingDeclaration>
+#include<imageProcessingFunctions>
+
+// Lights
+#include<lightUboDeclaration>[0..maxSimultaneousLights]
+
+#include<lightsFragmentFunctions>
+#include<shadowsFragmentFunctions>
+
+// Samplers
+#ifdef BUMP
+varying vNormalUV: vec2f;
+#ifdef BUMPSUPERIMPOSE
+    varying vNormalUV2: vec2f;
+#endif
+var normalSamplerSampler: sampler;
+var normalSampler: texture_2d<f32>;
+uniform vNormalInfos: vec2f;
+#endif
+
+var refractionSamplerSampler: sampler;
+var refractionSampler: texture_2d<f32>;
+var reflectionSamplerSampler: sampler;
+var reflectionSampler: texture_2d<f32>;
+
+// Water uniforms
+const LOG2: f32 = 1.442695;
+
+uniform cameraPosition: vec3f;
+
+uniform waterColor: vec4f;
+uniform colorBlendFactor: f32;
+
+uniform waterColor2: vec4f;
+uniform colorBlendFactor2: f32;
+
+uniform bumpHeight: f32;
+
+uniform time: f32;
+
+// Water varyings
+varying vRefractionMapTexCoord: vec3f;
+varying vReflectionMapTexCoord: vec3f;
+
+#include<clipPlaneFragmentDeclaration>
+#include<logDepthDeclaration>
+
+// Fog
+#include<fogFragmentDeclaration>
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+#define CUSTOM_FRAGMENT_DEFINITIONS
+
+@fragment
+fn main(input: FragmentInputs) -> FragmentOutputs {
+
+#define CUSTOM_FRAGMENT_MAIN_BEGIN
+
+	// Clip plane
+    #include<clipPlaneFragment>
+
+	var viewDirectionW: vec3f = normalize(uniforms.vEyePosition.xyz - fragmentInputs.vPositionW);
+
+	// Base color
+	var baseColor: vec4f =  vec4f(1., 1., 1., 1.);
+	var diffuseColor: vec3f = uniforms.vDiffuseColor.rgb;
+
+	// Alpha
+	var alpha: f32 = uniforms.vDiffuseColor.a;
+
+#ifdef BUMP
+    #ifdef BUMPSUPERIMPOSE
+    	baseColor = 0.6 * textureSample(normalSampler, normalSamplerSampler, fragmentInputs.vNormalUV) + 0.4 * textureSample(normalSampler, normalSamplerSampler,  vec2f(fragmentInputs.vNormalUV2.x, fragmentInputs.vNormalUV2.y));
+    #else
+	    baseColor = textureSample(normalSampler, normalSamplerSampler, fragmentInputs.vNormalUV);
+    #endif
+	var bumpColor: vec3f = baseColor.rgb;
+
+#ifdef ALPHATEST
+	if (baseColor.a < 0.4) {
+		discard;
+    }
+#endif
+
+	baseColor = vec4f(baseColor.rgb * uniforms.vNormalInfos.y, baseColor.a);
+#else
+	var bumpColor: vec3f =  vec3f(1.0);
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+    baseColor = vec4f(baseColor.rgb * fragmentInputs.vColor.rgb, baseColor.a);
+#endif
+
+	// Bump
+#ifdef NORMAL
+	var perturbation: vec2f = uniforms.bumpHeight * (baseColor.rg - 0.5);
+	#ifdef BUMPAFFECTSREFLECTION
+	    var normalW: vec3f = normalize(fragmentInputs.vNormalW +  vec3f(perturbation.x*8.0, 0.0, perturbation.y*8.0));
+	    if (normalW.y < 0.0) {
+	        normalW.y = -normalW.y;
+	    }
+    #else
+    	var normalW: vec3f = normalize(fragmentInputs.vNormalW);
+	#endif
+#else
+	var normalW: vec3f =  vec3f(1.0, 1.0, 1.0);
+	var perturbation: vec2f = uniforms.bumpHeight * ( vec2f(1.0, 1.0) - 0.5);
+#endif
+
+#ifdef FRESNELSEPARATE
+    #ifdef REFLECTION
+        // Water
+        var projectedRefractionTexCoords: vec2f = clamp(fragmentInputs.vRefractionMapTexCoord.xy / fragmentInputs.vRefractionMapTexCoord.z + perturbation*0.5,  vec2f(0.0),  vec2f(1.0));
+        var refractiveColor: vec4f = textureSample(refractionSampler, refractionSamplerSampler, projectedRefractionTexCoords);
+        #ifdef IS_REFRACTION_LINEAR
+            refractiveColor = vec4f(toGammaSpace(refractiveColor.rgb), refractiveColor.a);
+        #endif
+
+        var projectedReflectionTexCoords: vec2f =  vec2f(
+            fragmentInputs.vReflectionMapTexCoord.x / fragmentInputs.vReflectionMapTexCoord.z + perturbation.x * 0.3,
+            fragmentInputs.vReflectionMapTexCoord.y / fragmentInputs.vReflectionMapTexCoord.z + perturbation.y
+        );
+
+        var reflectiveColor: vec4f = textureSample(reflectionSampler, reflectionSamplerSampler, projectedReflectionTexCoords);
+        #ifdef IS_REFLECTION_LINEAR
+            reflectiveColor = vec4f(toGammaSpace(reflectiveColor.rgb), reflectiveColor.a);
+        #endif
+
+        var upVector: vec3f =  vec3f(0.0, 1.0, 0.0);
+
+        var fresnelTerm: f32 = clamp(abs(pow(dot(viewDirectionW, upVector), 3.0)), 0.05, 0.65);
+        var IfresnelTerm: f32 = 1.0 - fresnelTerm;
+
+        refractiveColor = uniforms.colorBlendFactor * uniforms.waterColor + (1.0 - uniforms.colorBlendFactor) * refractiveColor;
+        reflectiveColor = IfresnelTerm * uniforms.colorBlendFactor2 * uniforms.waterColor + (1.0 - uniforms.colorBlendFactor2 * IfresnelTerm) * reflectiveColor;
+
+        var combinedColor: vec4f = refractiveColor * fresnelTerm + reflectiveColor * IfresnelTerm;
+        baseColor = combinedColor;
+    #endif
+
+    // Lighting
+    var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+    var shadow: f32 = 1.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+    #ifdef SPECULARTERM
+        var glossiness: f32 = uniforms.vSpecularColor.a;
+        var specularBase: vec3f =  vec3f(0., 0., 0.);
+        var specularColor: vec3f = uniforms.vSpecularColor.rgb;
+    #else
+        var glossiness: f32 = 0.;
+    #endif
+
+    #include<lightFragment>[0..maxSimultaneousLights]
+
+    var finalDiffuse: vec3f = clamp(baseColor.rgb, vec3f(0.0), vec3f(1.0));
+
+    #if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+        alpha *= fragmentInputs.vColor.a;
+    #endif
+
+    #ifdef SPECULARTERM
+        var finalSpecular: vec3f = specularBase * specularColor;
+    #else
+        var finalSpecular: vec3f =  vec3f(0.0);
+    #endif
+
+
+#else // !FRESNELSEPARATE
+    #ifdef REFLECTION
+        // Water
+        var projectedRefractionTexCoords: vec2f = clamp(fragmentInputs.vRefractionMapTexCoord.xy / fragmentInputs.vRefractionMapTexCoord.z + perturbation,  vec2f(0.0),  vec2f(1.0));
+        var refractiveColor: vec4f = textureSample(refractionSampler, refractionSamplerSampler, projectedRefractionTexCoords);
+        #ifdef IS_REFRACTION_LINEAR
+            refractiveColor = vec4f(toGammaSpace(refractiveColor.rgb), refractiveColor.a);
+        #endif
+
+        var projectedReflectionTexCoords: vec2f = fragmentInputs.vReflectionMapTexCoord.xy / fragmentInputs.vReflectionMapTexCoord.z + perturbation;
+        var reflectiveColor: vec4f = textureSample(reflectionSampler, reflectionSamplerSampler, projectedReflectionTexCoords);
+        #ifdef IS_REFLECTION_LINEAR
+            reflectiveColor = vec4f(toGammaSpace(reflectiveColor.rgb), reflectiveColor.a);
+        #endif
+
+        var upVector: vec3f =  vec3f(0.0, 1.0, 0.0);
+
+        var fresnelTerm: f32 = max(dot(viewDirectionW, upVector), 0.0);
+
+        var combinedColor: vec4f = refractiveColor * fresnelTerm + reflectiveColor * (1.0 - fresnelTerm);
+
+        baseColor = uniforms.colorBlendFactor * uniforms.waterColor + (1.0 - uniforms.colorBlendFactor) * combinedColor;
+    #endif
+
+    // Lighting
+    var diffuseBase: vec3f =  vec3f(0., 0., 0.);
+    var info: lightingInfo;
+    var shadow: f32 = 1.;
+	var aggShadow: f32 = 0.;
+	var numLights: f32 = 0.;
+
+    #ifdef SPECULARTERM
+        var glossiness: f32 = uniforms.vSpecularColor.a;
+        var specularBase: vec3f =  vec3f(0., 0., 0.);
+        var specularColor: vec3f = uniforms.vSpecularColor.rgb;
+    #else
+        var glossiness: f32 = 0.;
+    #endif
+
+    #include<lightFragment>[0..maxSimultaneousLights]
+
+    var finalDiffuse: vec3f = clamp(baseColor.rgb, vec3f(0.0), vec3f(1.0));
+
+
+    #if defined(VERTEXALPHA) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+        alpha *= fragmentInputs.vColor.a;
+    #endif
+
+    #ifdef SPECULARTERM
+        var finalSpecular: vec3f = specularBase * specularColor;
+    #else
+        var finalSpecular: vec3f =  vec3f(0.0);
+    #endif
+
+#endif
+
+// Composition
+var color: vec4f =  vec4f(finalDiffuse + finalSpecular, alpha);
+
+#include<logDepthFragment>
+#include<fogFragment>
+
+// Apply image processing if relevant. As this applies in linear space,
+// We first move from gamma to linear.
+#ifdef IMAGEPROCESSINGPOSTPROCESS
+	color = vec4f(toLinearSpace(color.rgb), color.a);
+#elif defined(IMAGEPROCESSING)
+    color = vec4f(toLinearSpace(color.rgb), color.a);
+    color = applyImageProcessing(color);
+#endif
+
+	fragmentOutputs.color = color;
+
+#define CUSTOM_FRAGMENT_MAIN_END
+}

--- a/packages/dev/materials/src/water/wgsl/water.vertex.fx
+++ b/packages/dev/materials/src/water/wgsl/water.vertex.fx
@@ -1,0 +1,174 @@
+// Attributes
+attribute position: vec3f;
+#ifdef NORMAL
+attribute normal: vec3f;
+#endif
+#ifdef UV1
+attribute uv: vec2f;
+#endif
+#ifdef UV2
+attribute uv2: vec2f;
+#endif
+#ifdef VERTEXCOLOR
+attribute color: vec4f;
+#endif
+
+#include<bonesDeclaration>
+#include<bakedVertexAnimationDeclaration>
+
+// Uniforms
+#include<instancesDeclaration>
+
+uniform view: mat4x4f;
+uniform viewProjection: mat4x4f;
+
+#ifdef BUMP
+varying vNormalUV: vec2f;
+#ifdef BUMPSUPERIMPOSE
+    varying vNormalUV2: vec2f;
+#endif
+uniform normalMatrix: mat4x4f;
+uniform vNormalInfos: vec2f;
+#endif
+
+#ifdef POINTSIZE
+uniform pointSize: f32;
+#endif
+
+// Output
+varying vPositionW: vec3f;
+#ifdef NORMAL
+varying vNormalW: vec3f;
+#endif
+
+#if defined(VERTEXCOLOR) || defined(INSTANCESCOLOR) && defined(INSTANCES)
+varying vColor: vec4f;
+#endif
+
+#include<clipPlaneVertexDeclaration>
+
+#include<fogVertexDeclaration>
+#include<__decl__lightVxFragment>[0..maxSimultaneousLights]
+
+#include<logDepthDeclaration>
+
+// Water uniforms
+uniform reflectionViewProjection: mat4x4f;
+uniform windDirection: vec2f;
+uniform waveLength: f32;
+uniform time: f32;
+uniform windForce: f32;
+uniform waveHeight: f32;
+uniform waveSpeed: f32;
+uniform waveCount: f32;
+
+// Water varyings
+varying vRefractionMapTexCoord: vec3f;
+varying vReflectionMapTexCoord: vec3f;
+
+#if defined(CLUSTLIGHT_BATCH) && CLUSTLIGHT_BATCH > 0
+varying vViewDepth: f32;
+#endif
+
+
+#define CUSTOM_VERTEX_DEFINITIONS
+
+@vertex
+fn main(input : VertexInputs) -> FragmentInputs {
+
+#define CUSTOM_VERTEX_MAIN_BEGIN
+
+#ifdef VERTEXCOLOR
+    var colorUpdated: vec4f = vertexInputs.color;
+#endif
+
+    #include<instancesVertex>
+    #include<bonesVertex>
+    #include<bakedVertexAnimation>
+
+	var worldPos: vec4f = finalWorld *  vec4f(vertexInputs.position, 1.0);
+	vertexOutputs.vPositionW =  worldPos.xyz;
+
+#ifdef NORMAL
+	vertexOutputs.vNormalW = normalize(( finalWorld *  vec4f(vertexInputs.normal, 0.0)).xyz);
+#endif
+
+	// Texture coordinates
+#ifndef UV1
+	var uv: vec2f =  vec2f(0., 0.);
+#else
+    var uv: vec2f = vertexInputs.uv;
+#endif
+#ifndef UV2
+	var uv2: vec2f =  vec2f(0., 0.);
+#else
+    var uv2: vec2f = vertexInputs.uv2;
+#endif
+
+#ifdef BUMP
+	if (uniforms.vNormalInfos.x == 0.)
+	{
+		vertexOutputs.vNormalUV = (uniforms.normalMatrix *  vec4f((uv * 1.0) / uniforms.waveLength + uniforms.time * uniforms.windForce * uniforms.windDirection, 1.0, 0.0)).xy;
+        #ifdef BUMPSUPERIMPOSE
+		    vertexOutputs.vNormalUV2 = (uniforms.normalMatrix *  vec4f((uv * 0.721) / uniforms.waveLength + uniforms.time * 1.2 * uniforms.windForce * uniforms.windDirection, 1.0, 0.0)).xy;
+		#endif
+	}
+	else
+	{
+		vertexOutputs.vNormalUV = (uniforms.normalMatrix *  vec4f((uv2 * 1.0) / uniforms.waveLength + uniforms.time * uniforms.windForce * uniforms.windDirection, 1.0, 0.0)).xy;
+        #ifdef BUMPSUPERIMPOSE
+    		vertexOutputs.vNormalUV2 = (uniforms.normalMatrix *  vec4f((uv2 * 0.721) / uniforms.waveLength + uniforms.time * 1.2 * uniforms.windForce * uniforms.windDirection, 1.0, 0.0)).xy;
+    	#endif
+	}
+#endif
+
+	// Clip plane
+	#include<clipPlaneVertex>
+
+	// Fog
+    #include<fogVertex>
+
+	// Shadows
+    #include<shadowsVertex>[0..maxSimultaneousLights]
+
+	// Vertex color
+#include<vertexColorMixing>
+
+	var finalWaveCount: f32 = 1.0 / (uniforms.waveCount * 0.5);
+
+#ifdef USE_WORLD_COORDINATES
+	var p: vec3f = worldPos.xyz;
+#else
+	var p: vec3f = vertexInputs.position;
+#endif
+	var newY: f32 = (sin(((p.x / finalWaveCount) + uniforms.time * uniforms.waveSpeed)) * uniforms.waveHeight * uniforms.windDirection.x * 5.0)
+			   + (cos(((p.z / finalWaveCount) + uniforms.time * uniforms.waveSpeed)) * uniforms.waveHeight * uniforms.windDirection.y * 5.0);
+	p.y = p.y + abs(newY);
+
+#ifdef USE_WORLD_COORDINATES
+	vertexOutputs.position = uniforms.viewProjection *  vec4f(p, 1.0);
+#else
+	vertexOutputs.position = uniforms.viewProjection * finalWorld *  vec4f(p, 1.0);
+#endif
+
+#ifdef REFLECTION
+	// Water
+
+	vertexOutputs.vRefractionMapTexCoord = vec3f(
+        0.5 * (vertexOutputs.position.w + vertexOutputs.position.x),
+        0.5 * (vertexOutputs.position.w + vertexOutputs.position.y),
+        vertexOutputs.position.w
+    );
+
+	worldPos = uniforms.reflectionViewProjection * finalWorld *  vec4f(vertexInputs.position, 1.0);
+	vertexOutputs.vReflectionMapTexCoord = vec3f(
+        0.5 * (worldPos.w + worldPos.x),
+        0.5 * (worldPos.w + worldPos.y),
+        worldPos.w
+    );
+#endif
+
+#include<logDepthVertex>
+
+#define CUSTOM_VERTEX_MAIN_END
+}


### PR DESCRIPTION
## Summary

Adds native WGSL shaders to every material in `@babylonjs/materials` (except `Custom`):
**cell, fire, fur, gradient, grid, lava, mix, normal, shadowOnly, simple, sky, terrain, triPlanar, water**.

Each material now ships both a GLSL and a WGSL shader pair, and selects between them at runtime based on the engine, mirroring the pattern used by `BackgroundMaterial` in core. WebGPU users get native WGSL shaders instead of going through the GLSL→WGSL transpiler.

## Per-material changes

- New `wgsl/<name>.{vertex,fragment}.fx` next to the existing GLSL sources.
- `<name>Material` constructor gains an optional `forceGLSL = false` parameter, forwarded through `PushMaterial` to `Material`.
- `createEffect` now passes `shaderLanguage: this._shaderLanguage` and an `extraInitializationsAsync` that lazy-imports the GLSL or WGSL shader pair based on `this.shaderLanguage` (gated by a `_shadersLoaded` flag).
- The static side-effect imports of the GLSL `.ts` shader files (`import "./<name>.fragment"` / `import "./<name>.vertex"`) are removed in favour of the lazy path. This matches `BackgroundMaterial` exactly.

## Build tool change

`packages/dev/buildTools/src/buildShaders.ts` `BuildShader` now treats a path as WGSL when any path **segment** is exactly `wgsl` (case-insensitive) **or** contains the literal uppercase `WGSL` substring. This:

- Picks up the new per-material `wgsl/` subfolders (lowercase, co-located with the material).
- Keeps the legacy `ShadersWGSL/` convention used in `packages/dev/core`.
- Avoids accidental matches on unrelated paths such as `tools/babylonServer/public/twgsl/`.

## Backward compatibility

- `forceGLSL` is appended after every existing constructor parameter (after `renderTargetSize` for `WaterMaterial`), so no existing call sites break. No subclasses of these materials exist in the repo.
- Removing the static GLSL shader-side-effect imports means the GLSL shader is no longer eagerly registered into `ShaderStore.ShadersStore` simply by importing the material module — registration now happens on the first `createEffect` call. This is the same behavior `BackgroundMaterial` has had, but worth flagging for any consumer that referenced the shader by name without instantiating the material.

## Validation

- `npm run format:check` ✓
- `npm run lint:check` ✓ on changed files (pre-existing errors elsewhere in the repo are unrelated)
- `npm run test:unit` ✓ — all 2930 unit tests pass
- `npm run compile -w @dev/materials` ✓
- Manual visual validation of all 14 materials in the Playground under WebGPU: `http://localhost:1338/?webgpu#GIC9U1#0`
