### PR TITLE
Fix ClusteredLightContainer.maxRange ignored for some lights

### DIFF
--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -539,15 +539,16 @@ export class ClusteredLightContainer extends Light {
             Logger.Warn("Attempting to add a light to cluster that does not support clustering");
             return;
         }
-        this._scene.removeLight(light);
-        // scene.removeLight only updates mesh.lightSources when the light was present in scene.lights.
-        // Lights constructed with `dontAddToScene = true` are still pushed into mesh.lightSources by
-        // Light's constructor (the `includedOnlyMeshes` setter calls `_resyncMeshes`), so we must
-        // explicitly clear them here. Otherwise the orphaned light would still be picked up by
-        // PrepareDefinesForLights and rendered as a regular point/spot light, bypassing the cluster
-        // (notably ignoring `maxRange`).
-        for (const mesh of this._scene.meshes) {
-            mesh._removeLightSource(light, false);
+        // scene.removeLight returns -1 if the light wasn't in scene.lights. In that case the
+        // mesh.lightSources cleanup it normally performs didn't happen — but the light may still be
+        // there: lights constructed with `dontAddToScene = true` are pushed into mesh.lightSources
+        // by the Light constructor (the `includedOnlyMeshes` setter calls `_resyncMeshes`).
+        // Without explicit cleanup, the orphan would be picked up by PrepareDefinesForLights and
+        // rendered as a regular point/spot light, bypassing the cluster (notably ignoring `maxRange`).
+        if (this._scene.removeLight(light) === -1) {
+            for (const mesh of this._scene.meshes) {
+                mesh._removeLightSource(light, false);
+            }
         }
         this._lights.push(light);
         this._sortedLights.push(<PointLight | SpotLight>light);

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -540,6 +540,15 @@ export class ClusteredLightContainer extends Light {
             return;
         }
         this._scene.removeLight(light);
+        // scene.removeLight only updates mesh.lightSources when the light was present in scene.lights.
+        // Lights constructed with `dontAddToScene = true` are still pushed into mesh.lightSources by
+        // Light's constructor (the `includedOnlyMeshes` setter calls `_resyncMeshes`), so we must
+        // explicitly clear them here. Otherwise the orphaned light would still be picked up by
+        // PrepareDefinesForLights and rendered as a regular point/spot light, bypassing the cluster
+        // (notably ignoring `maxRange`).
+        for (const mesh of this._scene.meshes) {
+            mesh._removeLightSource(light, false);
+        }
         this._lights.push(light);
         this._sortedLights.push(<PointLight | SpotLight>light);
 

--- a/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
+++ b/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
@@ -101,6 +101,24 @@ describe("ClusteredLightContainer", () => {
             // But the container itself should be in scene.lights
             expect(scene.lights).toContain(container);
         });
+
+        it("should not include child lights in mesh.lightSources after addLight", async () => {
+            const { CreateBox } = await import("core/Meshes/Builders/boxBuilder");
+            const mesh = CreateBox("box", { size: 1 }, scene);
+            const container = new ClusteredLightContainer("cluster", [], scene);
+
+            // Light constructed with dontAddToScene=true is still pushed into mesh.lightSources
+            // by the Light constructor (via the includedOnlyMeshes setter calling _resyncMeshes).
+            // addLight() must clean that up, otherwise the orphan light is rendered as a regular
+            // point/spot light bypassing the cluster (e.g. ignoring maxRange).
+            const point = new PointLight("point1", new Vector3(1, 2, 3), scene, true);
+            expect(mesh.lightSources).toContain(point);
+
+            container.addLight(point);
+
+            expect(mesh.lightSources).not.toContain(point);
+            expect(mesh.lightSources).toContain(container);
+        });
     });
 
     describe("parse", () => {


### PR DESCRIPTION
## Summary

Fixes [forum report](https://forum.babylonjs.com/t/clusteredlightcontainer-maxrange-does-not-work-for-some-lights/63287): `ClusteredLightContainer.maxRange` was being ignored for some lights, which would illuminate the scene as if the cluster's range clamp didn't exist.

## Root cause

When a `PointLight` / `SpotLight` is constructed - even with `dontAddToScene = true` - the `Light` constructor's `includedOnlyMeshes = []` setter calls `_resyncMeshes()`, which pushes the light into every `mesh.lightSources`.

`ClusteredLightContainer.addLight(light)` then calls `scene.removeLight(light)`, but that is a no-op when the light isn't in `scene.lights`, so the orphaned reference in `mesh.lightSources` is never cleaned up.

The PBR shader picks the orphan up as a regular `POINTLIGHT`/`SPOTLIGHT`, bypassing the cluster entirely - notably ignoring `maxRange` (and using the light's own `range` directly).

Because PBR materials default to `maxSimultaneousLights = 4`, only the first few lights show the issue, which matches the OP's observation: *""while most pointLights have their range correctly clamped to 0.1, a few lights ignore this range and illuminate a wider area""*.

## Fix

In `ClusteredLightContainer.addLight()`, explicitly call `mesh._removeLightSource(light, false)` on every scene mesh after `scene.removeLight()`, ensuring the light is no longer referenced by any mesh's per-mesh light list.

## Test

Added a regression test `should not include child lights in mesh.lightSources after addLight` in `clusteredLightContainer.test.ts`. All 9 tests in that suite pass.

Verified manually with the reporter's repro (https://playground.babylonjs.com/#CSCJO2#96): before the fix, a single point light with `range = 5` and `clustered.maxRange = 0.1` floods the visible Sponza geometry; after the fix, it correctly behaves as a 0.1-unit light (visible geometry stays unlit from the default camera, just like setting `pointLight.range = 0.1` directly).
