### PR TITLE
Reduce hot path allocations in core

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraTouchInput.ts
@@ -4,7 +4,7 @@ import { type Nullable } from "../../types";
 import { type ICameraInput, CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import { type FreeCamera } from "../../Cameras/freeCamera";
 import { type PointerInfo, PointerEventTypes } from "../../Events/pointerEvents";
-import { Matrix, Vector3 } from "../../Maths/math.vector";
+import { Matrix, TmpVectors, Vector3 } from "../../Maths/math.vector";
 import { Tools } from "../../Misc/tools";
 import { type IPointerEvent } from "../../Events/deviceInputEvents";
 /**
@@ -196,10 +196,12 @@ export class FreeCameraTouchInput implements ICameraInput<FreeCamera> {
             camera.cameraRotation.x = -(this._offsetY * handednessMultiplier) / this.touchAngularSensibility;
         } else {
             const speed = camera._computeLocalCameraSpeed();
-            const direction = new Vector3(0, 0, this.touchMoveSensibility !== 0 ? (speed * this._offsetY) / this.touchMoveSensibility : 0);
+            const direction = TmpVectors.Vector3[0];
+            direction.copyFromFloats(0, 0, this.touchMoveSensibility !== 0 ? (speed * this._offsetY) / this.touchMoveSensibility : 0);
 
             Matrix.RotationYawPitchRollToRef(camera.rotation.y, camera.rotation.x, 0, camera._cameraRotationMatrix);
-            camera.cameraDirection.addInPlace(Vector3.TransformCoordinates(direction, camera._cameraRotationMatrix));
+            Vector3.TransformCoordinatesToRef(direction, camera._cameraRotationMatrix, direction);
+            camera.cameraDirection.addInPlace(direction);
         }
     }
 

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraVirtualJoystickInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraVirtualJoystickInput.ts
@@ -1,7 +1,7 @@
 import { VirtualJoystick, JoystickAxis } from "../../Misc/virtualJoystick";
 import { type ICameraInput, CameraInputTypes } from "../../Cameras/cameraInputsManager";
 import { type FreeCamera } from "../../Cameras/freeCamera";
-import { Matrix, Vector3 } from "../../Maths/math.vector";
+import { Matrix, TmpVectors, Vector3 } from "../../Maths/math.vector";
 import { FreeCameraInputsManager } from "../../Cameras/freeCameraInputsManager";
 
 // Module augmentation to abstract virtual joystick from camera.
@@ -62,19 +62,20 @@ export class FreeCameraVirtualJoystickInput implements ICameraInput<FreeCamera> 
         if (this._leftjoystick) {
             const camera = this.camera;
             const speed = camera._computeLocalCameraSpeed() * 50;
-            const cameraTransform = Matrix.RotationYawPitchRoll(camera.rotation.y, camera.rotation.x, 0);
-            const deltaTransform = Vector3.TransformCoordinates(
-                new Vector3(this._leftjoystick.deltaPosition.x * speed, this._leftjoystick.deltaPosition.y * speed, this._leftjoystick.deltaPosition.z * speed),
-                cameraTransform
-            );
-            camera.cameraDirection = camera.cameraDirection.add(deltaTransform);
-            camera.cameraRotation = camera.cameraRotation.addVector3(this._rightjoystick.deltaPosition);
+            const cameraTransform = TmpVectors.Matrix[0];
+            const deltaPosition = TmpVectors.Vector3[0];
+            const transformedDeltaPosition = TmpVectors.Vector3[1];
+            Matrix.RotationYawPitchRollToRef(camera.rotation.y, camera.rotation.x, 0, cameraTransform);
+            deltaPosition.copyFromFloats(this._leftjoystick.deltaPosition.x * speed, this._leftjoystick.deltaPosition.y * speed, this._leftjoystick.deltaPosition.z * speed);
+            Vector3.TransformCoordinatesToRef(deltaPosition, cameraTransform, transformedDeltaPosition);
+            camera.cameraDirection.addInPlace(transformedDeltaPosition);
+            camera.cameraRotation.addInPlaceFromFloats(this._rightjoystick.deltaPosition.x, this._rightjoystick.deltaPosition.y);
 
             if (!this._leftjoystick.pressed) {
-                this._leftjoystick.deltaPosition = this._leftjoystick.deltaPosition.scale(0.9);
+                this._leftjoystick.deltaPosition.scaleInPlace(0.9);
             }
             if (!this._rightjoystick.pressed) {
-                this._rightjoystick.deltaPosition = this._rightjoystick.deltaPosition.scale(0.9);
+                this._rightjoystick.deltaPosition.scaleInPlace(0.9);
             }
         }
     }

--- a/packages/dev/core/src/Cameras/arcRotateCamera.ts
+++ b/packages/dev/core/src/Cameras/arcRotateCamera.ts
@@ -1076,7 +1076,8 @@ export class ArcRotateCamera extends TargetCamera {
         if (this.inertialPanningX !== 0 || this.inertialPanningY !== 0) {
             hasUserInteractions = true;
 
-            const localDirection = new Vector3(this.inertialPanningX, this.inertialPanningY, this.inertialPanningY);
+            const localDirection = TmpVectors.Vector3[0];
+            localDirection.copyFromFloats(this.inertialPanningX, this.inertialPanningY, this.inertialPanningY);
 
             this._viewMatrix.invertToRef(this._cameraTransformMatrix);
             localDirection.multiplyInPlace(this.panningAxis);

--- a/packages/dev/core/src/Cameras/followCamera.ts
+++ b/packages/dev/core/src/Cameras/followCamera.ts
@@ -160,7 +160,7 @@ export class FollowCamera extends TargetCamera {
             vz = vz < 1 ? -this.maxCameraSpeed : this.maxCameraSpeed;
         }
 
-        this.position = new Vector3(this.position.x + vx, this.position.y + vy, this.position.z + vz);
+        this.position.addInPlaceFromFloats(vx, vy, vz);
         this.setTarget(targetPosition);
     }
 

--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingGpuPickingMaterialPlugin.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingGpuPickingMaterialPlugin.ts
@@ -22,6 +22,7 @@ export class GaussianSplattingGpuPickingMaterialPlugin extends MaterialPluginBas
     private _isCompound: boolean = false;
     private _partPickingColors: number[] = [];
     private _partVisibility: number[] = [];
+    private _defaultPartVisibility: number[] = [];
     private _maxPartCount: number;
 
     /**
@@ -33,6 +34,7 @@ export class GaussianSplattingGpuPickingMaterialPlugin extends MaterialPluginBas
         super(material, "GaussianSplatGpuPicking", 200);
 
         this._maxPartCount = maxPartCount ?? GetGaussianSplattingMaxPartCount(material.getScene().getEngine());
+        this._defaultPartVisibility = new Array(this._maxPartCount).fill(1.0);
         this._enable(true);
     }
 
@@ -89,13 +91,14 @@ export class GaussianSplattingGpuPickingMaterialPlugin extends MaterialPluginBas
      * @param activeParts Array of part indices that should be pickable.
      */
     public setPartActive(activeParts: number[]): void {
-        const visibility = new Array(this._maxPartCount).fill(0.0);
+        const visibility = this._partVisibility;
+        visibility.length = this._maxPartCount;
+        visibility.fill(0.0);
         for (const index of activeParts) {
             if (index >= 0 && index < this._maxPartCount) {
                 visibility[index] = 1.0;
             }
         }
-        this._partVisibility = visibility;
     }
 
     /**
@@ -249,7 +252,7 @@ uniform pickingColor: vec3f;
         if (this._isCompound) {
             effect.setArray3("partPickingColors", this._partPickingColors);
             // default all visible when setPartActive hasn't been called
-            const visibility = this._partVisibility.length > 0 ? this._partVisibility : new Array(this._maxPartCount).fill(1.0);
+            const visibility = this._partVisibility.length > 0 ? this._partVisibility : this._defaultPartVisibility;
             effect.setArray("partVisibility", visibility);
         } else {
             effect.setFloat3("pickingColor", this._pickingColor[0], this._pickingColor[1], this._pickingColor[2]);

--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
@@ -590,6 +590,8 @@ export class GaussianSplattingMaterial extends PushMaterial {
     }
 
     private _voxelMissingTextureWarned = new Set<number>();
+    private _voxelPartWorldData = new Float32Array(0);
+    private readonly _voxelPartVisibilityData: number[] = [];
 
     protected _bindVoxelEffectUniforms(gsMesh: GaussianSplattingMesh, gsMaterial: GaussianSplattingMaterial, shaderMaterial: ShaderMaterial): boolean {
         if (!gsMesh.rotationsATexture) {
@@ -626,14 +628,19 @@ export class GaussianSplattingMaterial extends PushMaterial {
 
         if (gsMesh.partIndicesTexture) {
             effect.setTexture("partIndicesTexture", gsMesh.partIndicesTexture);
-            const partWorldData = new Float32Array(gsMesh.partCount * 16);
+            const partWorldDataLength = gsMesh.partCount * 16;
+            if (this._voxelPartWorldData.length !== partWorldDataLength) {
+                this._voxelPartWorldData = new Float32Array(partWorldDataLength);
+            }
+            const partWorldData = this._voxelPartWorldData;
             for (let i = 0; i < gsMesh.partCount; i++) {
                 gsMesh.getWorldMatrixForPart(i).toArray(partWorldData, i * 16);
             }
             effect.setMatrices("partWorld", partWorldData);
-            const partVisibilityData: number[] = [];
+            const partVisibilityData = this._voxelPartVisibilityData;
+            partVisibilityData.length = gsMesh.partCount;
             for (let i = 0; i < gsMesh.partCount; i++) {
-                partVisibilityData.push(gsMesh.partVisibility[i] ?? 1.0);
+                partVisibilityData[i] = gsMesh.partVisibility[i] ?? 1.0;
             }
             effect.setArray("partVisibility", partVisibilityData);
         }

--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingSolidColorMaterialPlugin.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingSolidColorMaterialPlugin.ts
@@ -5,7 +5,7 @@ import { type SubMesh } from "../../Meshes/subMesh";
 import { type UniformBuffer } from "../uniformBuffer";
 import { type MaterialDefines } from "../materialDefines";
 import { serialize, expandToProperty } from "../../Misc/decorators";
-import { Color3 } from "../../Maths/math.color";
+import { type Color3 } from "../../Maths/math.color";
 import { MaterialPluginBase } from "../materialPluginBase";
 import { ShaderLanguage } from "../shaderLanguage";
 import { RegisterClass } from "../../Misc/typeStore";
@@ -20,6 +20,7 @@ export class GaussianSplattingSolidColorMaterialPlugin extends MaterialPluginBas
     private _partColors: Color3[];
     private _maxPartCount: number;
     private _isEnabled = true;
+    private readonly _partColorArray: number[] = [];
     /**
      * Whether the solid-color override is active. When false, splats
      * render with their original per-splat colors.
@@ -200,10 +201,15 @@ if (uniforms.solidColorEnabled > 0.5) {
 
         effect.setFloat("solidColorEnabled", this._isEnabled ? 1.0 : 0.0);
 
-        const colorArray: number[] = [];
+        const colorArray = this._partColorArray;
+        colorArray.length = 0;
         for (let i = 0; i < this._maxPartCount; i++) {
-            const color = this._partColors[i] ?? new Color3(0, 0, 0);
-            colorArray.push(color.r, color.g, color.b);
+            const color = this._partColors[i];
+            if (color) {
+                colorArray.push(color.r, color.g, color.b);
+            } else {
+                colorArray.push(0, 0, 0);
+            }
         }
 
         effect.setArray3("partColors", colorArray);

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -6,7 +6,7 @@ import { type IAnimatable } from "../Animations/animatable.interface";
 import { type Nullable } from "../types";
 import { Scene } from "../scene";
 import { type Matrix } from "../Maths/math.vector";
-import { Color3 } from "../Maths/math.color";
+import { Color3, TmpColors } from "../Maths/math.color";
 import { VertexBuffer } from "../Buffers/buffer";
 import { type SubMesh } from "../Meshes/subMesh";
 import { type AbstractMesh } from "../Meshes/abstractMesh";
@@ -1434,15 +1434,13 @@ export class StandardMaterial extends StandardMaterialBase {
                     }
 
                     if (this.opacityFresnelParameters && this.opacityFresnelParameters.isEnabled) {
-                        ubo.updateColor4(
-                            "opacityParts",
-                            new Color3(
-                                this.opacityFresnelParameters.leftColor.toLuminance(),
-                                this.opacityFresnelParameters.rightColor.toLuminance(),
-                                this.opacityFresnelParameters.bias
-                            ),
-                            this.opacityFresnelParameters.power
+                        const opacityParts = TmpColors.Color3[0];
+                        opacityParts.set(
+                            this.opacityFresnelParameters.leftColor.toLuminance(),
+                            this.opacityFresnelParameters.rightColor.toLuminance(),
+                            this.opacityFresnelParameters.bias
                         );
+                        ubo.updateColor4("opacityParts", opacityParts, this.opacityFresnelParameters.power);
                     }
 
                     if (this.reflectionFresnelParameters && this.reflectionFresnelParameters.isEnabled) {

--- a/packages/dev/core/src/PostProcesses/postProcessManager.ts
+++ b/packages/dev/core/src/PostProcesses/postProcessManager.ts
@@ -16,6 +16,7 @@ export class PostProcessManager {
     private _scene: Scene;
     private _indexBuffer: Nullable<DataBuffer>;
     private _vertexBuffers: { [key: string]: Nullable<VertexBuffer> } = {};
+    private readonly _activePostProcesses: PostProcess[] = [];
 
     /**
      * Creates a new instance PostProcess
@@ -56,6 +57,20 @@ export class PostProcessManager {
         this._indexBuffer = this._scene.getEngine().createIndexBuffer(indices);
     }
 
+    private _getActivePostProcesses(source: Nullable<PostProcess>[]): PostProcess[] {
+        const activePostProcesses = this._activePostProcesses;
+        activePostProcesses.length = 0;
+
+        for (let index = 0; index < source.length; index++) {
+            const postProcess = source[index];
+            if (postProcess) {
+                activePostProcesses.push(postProcess);
+            }
+        }
+
+        return activePostProcesses;
+    }
+
     public onBeforeRenderObservable = new Observable<PostProcessManager>();
 
     /**
@@ -86,9 +101,7 @@ export class PostProcessManager {
             return false;
         }
 
-        postProcesses = postProcesses || <Nullable<PostProcess[]>>camera._postProcesses.filter((pp) => {
-                return pp != null;
-            });
+        postProcesses = postProcesses || this._getActivePostProcesses(camera._postProcesses);
 
         if (!postProcesses || postProcesses.length === 0 || !this._scene.postProcessesEnabled) {
             return false;
@@ -178,11 +191,7 @@ export class PostProcessManager {
 
         this.onBeforeRenderObservable.notifyObservers(this);
 
-        postProcesses =
-            postProcesses ||
-            camera._postProcesses.filter((pp) => {
-                return pp != null;
-            });
+        postProcesses = postProcesses || this._getActivePostProcesses(camera._postProcesses);
         if (postProcesses.length === 0 || !this._scene.postProcessesEnabled) {
             return;
         }

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.ts
@@ -767,17 +767,21 @@ export class _IblShadowsVoxelRenderer {
             mrt.renderSprites = false;
             mrt.enableOutlineRendering = false;
 
-            mrt.customRenderFunction = (opaqueSubMeshes, alphaTestSubMeshes, transparentSubMeshes, depthOnlySubMeshes) => {
-                const buckets = [depthOnlySubMeshes, opaqueSubMeshes, alphaTestSubMeshes, transparentSubMeshes];
-                for (const bucket of buckets) {
-                    for (let index = 0; index < bucket.length; index++) {
-                        const subMesh = bucket.data[index];
-                        if (subMesh.getMaterial() !== voxelMaterial) {
-                            continue;
-                        }
-                        subMesh.render(false);
+            const renderBucket = (bucket: SmartArray<SubMesh>) => {
+                for (let index = 0; index < bucket.length; index++) {
+                    const subMesh = bucket.data[index];
+                    if (subMesh.getMaterial() !== voxelMaterial) {
+                        continue;
                     }
+                    subMesh.render(false);
                 }
+            };
+
+            mrt.customRenderFunction = (opaqueSubMeshes, alphaTestSubMeshes, transparentSubMeshes, depthOnlySubMeshes) => {
+                renderBucket(depthOnlySubMeshes);
+                renderBucket(opaqueSubMeshes);
+                renderBucket(alphaTestSubMeshes);
+                renderBucket(transparentSubMeshes);
             };
 
             mrt.renderList = [];

--- a/packages/dev/core/src/Rendering/prePassRenderer.ts
+++ b/packages/dev/core/src/Rendering/prePassRenderer.ts
@@ -285,8 +285,11 @@ export class PrePassRenderer {
 
     private _enabled: boolean = false;
 
+    private readonly _geometryBufferRenderList: AbstractMesh[] = [];
     private _needsCompositionForThisPass = false;
-    private _postProcessesSourceForThisPass: Nullable<PostProcess>[];
+    private readonly _postProcessesSourceForThisPass: PostProcess[] = [];
+    private readonly _postProcessChainForThisPass: PostProcess[] = [];
+    private readonly _postProcessesForUpdate: PostProcess[] = [];
 
     /**
      * Indicates if the prepass is enabled
@@ -517,7 +520,10 @@ export class PrePassRenderer {
         }
 
         if (this._geometryBuffer) {
-            this._geometryBuffer.renderList = [];
+            this._geometryBufferRenderList.length = 0;
+            if (this._geometryBuffer.renderList !== this._geometryBufferRenderList) {
+                this._geometryBuffer.renderList = this._geometryBufferRenderList;
+            }
         }
 
         this._setupOutputForThisPass(this._currentTarget, camera);
@@ -559,7 +565,12 @@ export class PrePassRenderer {
         let postProcessChain = this._currentTarget._beforeCompositionPostProcesses;
 
         if (this._needsCompositionForThisPass) {
-            postProcessChain = postProcessChain.concat([this._currentTarget.imageProcessingPostProcess]);
+            postProcessChain = this._postProcessChainForThisPass;
+            postProcessChain.length = 0;
+            for (let index = 0; index < this._currentTarget._beforeCompositionPostProcesses.length; index++) {
+                postProcessChain.push(this._currentTarget._beforeCompositionPostProcesses[index]);
+            }
+            postProcessChain.push(this._currentTarget.imageProcessingPostProcess);
         }
 
         // Activates and renders the chain
@@ -733,10 +744,14 @@ export class PrePassRenderer {
     private _setupOutputForThisPass(prePassRenderTarget: PrePassRenderTarget, camera?: Camera) {
         // Order is : draw ===> prePassRenderTarget._postProcesses ==> ipp ==> camera._postProcesses
         const secondaryCamera = camera && this._scene.activeCameras && !!this._scene.activeCameras.length && this._scene.activeCameras.indexOf(camera) !== 0;
-        this._postProcessesSourceForThisPass = this._getPostProcessesSource(prePassRenderTarget, camera);
-        this._postProcessesSourceForThisPass = this._postProcessesSourceForThisPass.filter((pp) => {
-            return pp != null;
-        });
+        const postProcessesSource = this._getPostProcessesSource(prePassRenderTarget, camera);
+        this._postProcessesSourceForThisPass.length = 0;
+        for (let index = 0; index < postProcessesSource.length; index++) {
+            const postProcess = postProcessesSource[index];
+            if (postProcess) {
+                this._postProcessesSourceForThisPass.push(postProcess);
+            }
+        }
         this._scene.autoClear = true;
 
         const cameraHasImageProcessing = this._hasImageProcessing(this._postProcessesSourceForThisPass);
@@ -919,9 +934,15 @@ export class PrePassRenderer {
                 continue;
             }
 
-            postProcesses = <Nullable<PostProcess[]>>postProcesses.filter((pp) => {
-                return pp != null;
-            });
+            const postProcessesSource = postProcesses;
+            postProcesses = this._postProcessesForUpdate;
+            postProcesses.length = 0;
+            for (let j = 0; j < postProcessesSource.length; j++) {
+                const postProcess = postProcessesSource[j];
+                if (postProcess) {
+                    postProcesses.push(postProcess);
+                }
+            }
 
             if (postProcesses) {
                 for (let j = 0; j < postProcesses.length; j++) {


### PR DESCRIPTION
## Summary

This PR reduces avoidable allocations in several core hot paths:

- Replaces per-frame camera/input temporary allocations with `TmpVectors` and in-place vector operations.
- Reuses post-process/prepass scratch arrays instead of allocating with `filter`/`concat` in render paths.
- Reuses Gaussian splatting uniform buffers/arrays during material bind and voxel rendering paths.
- Avoids a per-render temporary bucket array in IBL shadows voxel rendering.
- Preserves external `GeometryBufferRenderer.renderList` ownership by using a prepass-owned scratch render list instead of mutating a user-provided array.

## Self-review notes

I reviewed the changes critically for temp-object aliasing, reused-array lifetime, uniform upload timing, and behavior changes from in-place vector math. One issue was found and fixed before opening the PR: clearing `geometryBuffer.renderList` in place could have mutated an external array reference, so the prepass renderer now uses its own scratch list.

## Validation

- `npm run format:check` passed.
- `npm run lint:check` passed.
- `npm run compile:source -w @dev/core` passed.
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` passed.
- `npx vitest run --project=unit packages/dev/loaders/test/unit/Interactivity/flow\ nodes.test.ts` passed.

Full `npm run test:unit` was attempted twice. The first run reported all 2,930 tests passing but exited with a Vitest environment teardown error while importing shader includes after teardown. The second run failed in `packages/dev/loaders/test/unit/Interactivity/flow nodes.test.ts`; that file passed when run in isolation immediately afterward.