### PR TITLE
[GUI] Fix InputText not calling preventDefault for printable characters

### DIFF
--- a/packages/dev/gui/src/2D/controls/inputText.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.ts
@@ -762,6 +762,9 @@ export class InputText extends Control {
                     this._textWrapper.removePart(insertPosition, insertPosition, key);
                     this._textHasChanged();
                 }
+                if (evt) {
+                    evt.preventDefault();
+                }
             }
         }
     }

--- a/packages/dev/gui/test/unit/inputText.test.ts
+++ b/packages/dev/gui/test/unit/inputText.test.ts
@@ -41,7 +41,9 @@ describe("InputText processKey", () => {
     it("does not call preventDefault for dead keys", () => {
         const input = new InputText("test");
 
-        const evt = createKeyEvent("Dead", 229);
+        // keyCode 192 (backtick/tilde) falls within the printable range (159-193),
+        // so this enters the printable character block and exercises the _deadKey guard.
+        const evt = createKeyEvent("Dead", 192);
         input.processKey(evt.keyCode, evt.key, evt);
 
         expect(evt.preventDefault).not.toHaveBeenCalled();

--- a/packages/dev/gui/test/unit/inputText.test.ts
+++ b/packages/dev/gui/test/unit/inputText.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { InputText } from "../../src/2D/controls/inputText";
+import { type IKeyboardEvent } from "@babylonjs/core/Events/deviceInputEvents";
+
+function createKeyEvent(key: string, keyCode: number, overrides?: Partial<IKeyboardEvent>): IKeyboardEvent {
+    return {
+        key,
+        keyCode,
+        code: "",
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: "keydown",
+        target: null,
+        inputIndex: 0,
+        preventDefault: vi.fn(),
+        ...overrides,
+    };
+}
+
+describe("InputText processKey", () => {
+    it("calls preventDefault for printable character keys", () => {
+        const input = new InputText("test");
+
+        const evt = createKeyEvent("5", 53); // '5' key
+        input.processKey(evt.keyCode, evt.key, evt);
+
+        expect(evt.preventDefault).toHaveBeenCalled();
+    });
+
+    it("calls preventDefault for letter keys", () => {
+        const input = new InputText("test");
+
+        const evt = createKeyEvent("a", 65);
+        input.processKey(evt.keyCode, evt.key, evt);
+
+        expect(evt.preventDefault).toHaveBeenCalled();
+    });
+
+    it("does not call preventDefault for dead keys", () => {
+        const input = new InputText("test");
+
+        const evt = createKeyEvent("Dead", 229);
+        input.processKey(evt.keyCode, evt.key, evt);
+
+        expect(evt.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("does not call preventDefault when addKey is set to false", () => {
+        const input = new InputText("test");
+        input.onBeforeKeyAddObservable.add(() => {
+            input.addKey = false;
+        });
+
+        const evt = createKeyEvent("a", 65);
+        input.processKey(evt.keyCode, evt.key, evt);
+
+        expect(evt.preventDefault).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Description

When a focused `InputText` GUI control processes a printable character (numbers, letters, special characters), the browser keyboard event was not being prevented via `evt.preventDefault()`. This allowed browser-level keyboard shortcuts to fire simultaneously with text input.

In Chromium-based browsers, Ctrl+number shortcuts switch tabs and Ctrl+plus/minus controls zoom. Since `InputText.processKey()` already calls `preventDefault()` for special keys (Backspace, Delete, Slash, Ctrl+A, Ctrl+Arrow) but omitted it for printable characters, these browser shortcuts would fire even while the input had focus.

## Changes

- **`packages/dev/gui/src/2D/controls/inputText.ts`**: Added `evt.preventDefault()` inside the printable-character branch of `processKey()`, guarded by the existing `_addKey && !_deadKey` condition. This ensures it only fires when the input actually consumes the keystroke, leaving dead key events (for international keyboard input) untouched.

- **`packages/dev/gui/test/unit/inputText.test.ts`**: New unit tests verifying:
  - `preventDefault` is called for number and letter keys
  - `preventDefault` is NOT called for dead keys
  - `preventDefault` is NOT called when `addKey` is set to false

## Forum Reference

https://forum.babylonjs.com/t/gui-text-input-with-opera-browser/63288
