### PR TITLE
Lottie player: support solid layers, fix loop reset and layer-level decorators, modernize readme

### DIFF
--- a/packages/dev/lottiePlayer/src/nodes/node.ts
+++ b/packages/dev/lottiePlayer/src/nodes/node.ts
@@ -294,7 +294,11 @@ export class Node {
         this._updateOpacity(frame);
 
         for (let i = 0; i < this._children.length; i++) {
-            this._children[i].update(frame, isUpdated || isParentUpdated);
+            // Propagate `isReset` so animated descendants whose first keyframe is after `frame` still
+            // recompose their localMatrix from the just-reset `currentValue`. Without this, after a
+            // loop wrap the child would keep the END-of-previous-loop interpolated localMatrix even
+            // though `reset()` already restored its `currentValue` to `startValue`.
+            this._children[i].update(frame, isUpdated || isParentUpdated, isReset);
         }
 
         return isUpdated || isParentUpdated;

--- a/packages/dev/lottiePlayer/src/parsing/parser.ts
+++ b/packages/dev/lottiePlayer/src/parsing/parser.ts
@@ -8,6 +8,7 @@ import {
     type RawLottieLayer,
     type RawScalarProperty,
     type RawShapeLayer,
+    type RawSolidLayer,
     type RawTextLayer,
     type RawTransform,
     type RawTransformShape,
@@ -53,6 +54,39 @@ type LayerTree = {
     layer: RawLottieLayer;
     children: LayerTree[];
 };
+
+/**
+ * Parses a CSS hex color string in `#RGB` or `#RRGGBB` form into normalized 0..1 RGB components.
+ * Used for solid layers (`ty:1`), whose color is stored as a CSS string in `sc`. Falls back to
+ * black and pushes a warning for any other form (e.g. `rgb()`, named colors) so the source is
+ * traceable instead of silently producing the wrong color.
+ * @param value The raw `sc` string from a solid layer.
+ * @param layerName The owning layer's name (for the warning message).
+ * @param unsupported Mutable list to push a warning into when the value cannot be parsed.
+ * @returns A `[r, g, b]` triple of normalized components in 0..1.
+ */
+function ParseCssColorString(value: string, layerName: string | undefined, unsupported: string[]): [number, number, number] {
+    if (typeof value === "string") {
+        if (value.length === 7 && value[0] === "#") {
+            const r = parseInt(value.substring(1, 3), 16);
+            const g = parseInt(value.substring(3, 5), 16);
+            const b = parseInt(value.substring(5, 7), 16);
+            if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
+                return [r / 255, g / 255, b / 255];
+            }
+        }
+        if (value.length === 4 && value[0] === "#") {
+            const r = parseInt(value[1] + value[1], 16);
+            const g = parseInt(value[2] + value[2], 16);
+            const b = parseInt(value[3] + value[3], 16);
+            if (Number.isFinite(r) && Number.isFinite(g) && Number.isFinite(b)) {
+                return [r / 255, g / 255, b / 255];
+            }
+        }
+    }
+    unsupported.push(`Unsupported CSS color string in solid layer ${layerName ?? "<unknown>"}: ${value}`);
+    return [0, 0, 0];
+}
 
 /**
  * Parses a lottie animation file from a URL and returns the json representation of the file.
@@ -285,8 +319,8 @@ export class Parser {
             return; // Ignore hidden layers
         }
 
-        // We only support null, shape and text layers
-        if (layer.ty !== 3 && layer.ty !== 4 && layer.ty !== 5) {
+        // We only support solid, null, shape and text layers
+        if (layer.ty !== 1 && layer.ty !== 3 && layer.ty !== 4 && layer.ty !== 5) {
             this._unsupportedFeatures.push(`UnsupportedLayerType - Layer Name: ${layer.nm} - Layer Index: ${layer.ind} - Layer Type: ${layer.ty}`);
             return;
         }
@@ -320,6 +354,9 @@ export class Parser {
 
         let anchorNode: Node | undefined = undefined;
         switch (layer.ty) {
+            case 1: // Solid layer
+                anchorNode = this._parseSolidLayer(layer as RawSolidLayer, transform, trsNode);
+                break;
             case 3: // Null layer
                 anchorNode = this._parseNullLayer(layer, transform, trsNode);
                 break;
@@ -363,6 +400,82 @@ export class Parser {
         const anchorNode = this._parseNullLayer(layer, transform, parent);
         const rasterizationFrame = this._getRasterizationFrame(layer);
         this._parseElements(layer.shapes, anchorNode, rasterizationFrame);
+
+        return anchorNode;
+    }
+
+    private _parseSolidLayer(layer: RawSolidLayer, transform: Transform, parent: Node): Node {
+        const anchorNode = this._parseNullLayer(layer, transform, parent);
+
+        // Defensive: malformed solid layer with no usable rectangle. Skip rasterization but keep the
+        // anchor node so any layers parented to this one (via `ind`) still get a valid parent slot.
+        if (!(layer.sw > 0) || !(layer.sh > 0)) {
+            this._unsupportedFeatures.push(`Solid layer ${layer.nm} has invalid sw/sh and will not render`);
+            return anchorNode;
+        }
+
+        const [r, g, b] = ParseCssColorString(layer.sc, layer.nm, this._unsupportedFeatures);
+
+        // Solid layers are by definition a single flat color (Lottie schema only allows `sc` as a
+        // CSS color string — no gradient, no animation). Rasterize it into a 1x1 atlas cell instead
+        // of an `sw`x`sh` cell: the sprite samples one pixel and the GPU stretches it, which is
+        // pixel-equivalent for a flat fill and avoids consuming a multi-megabyte chunk of the atlas
+        // for what's typically a full-stage backplate (e.g. Pages.json's 960x540 "Grey" layer would
+        // otherwise eat ~90% of a 2048-pixel atlas page at devicePixelRatio=2).
+        const atlasShapes: RawElement[] = [
+            {
+                ty: "rc",
+                nm: "Solid Rect (atlas)",
+                d: 1,
+                p: { a: 0, k: [0.5, 0.5] },
+                s: { a: 0, k: [1, 1] },
+                r: { a: 0, k: 0 },
+            } as unknown as RawElement,
+            {
+                ty: "fl",
+                nm: "Solid Fill",
+                c: { a: 0, k: [r, g, b, 1] },
+                o: { a: 0, k: 100 },
+                r: 1,
+            } as unknown as RawElement,
+        ];
+
+        // Atlas write at unit scale: the cell is 1 lottie pixel * 1 = 1 atlas pixel (multiplied by
+        // devicePixelRatio internally). Using the layer's actual rasterization scale would defeat
+        // the optimization by reintroducing the sw*sh cell.
+        const atlasScale = { x: 1, y: 1 };
+        const spriteInfo = this._packer.addLottieShape(atlasShapes, atlasScale, layer.nm);
+
+        // Build the sprite ourselves rather than going through `_parseShapes`, so we can keep the
+        // tiny atlas cell while sizing the on-screen sprite to the layer's full sw*sh. The sprite
+        // is positioned with its center at (sw/2, -sh/2) in the layer's local space so its top-left
+        // sits at the layer origin (0, 0) — matching how After Effects positions a solid layer.
+        const sprite = new ThinSprite();
+        sprite._xOffset = spriteInfo.uOffset;
+        sprite._yOffset = spriteInfo.vOffset;
+        sprite._xSize = spriteInfo.cellWidth;
+        sprite._ySize = spriteInfo.cellHeight;
+        sprite.width = layer.sw;
+        sprite.height = layer.sh;
+        sprite.invertV = true;
+
+        this._renderingManager.addSprite(sprite, this._currentLayerOriginalIndex, spriteInfo.atlasIndex);
+
+        const positionProperty: Vector2Property = {
+            startValue: { x: layer.sw / 2, y: -layer.sh / 2 },
+            currentValue: { x: layer.sw / 2, y: -layer.sh / 2 },
+            currentKeyframeIndex: 0,
+        };
+
+        new SpriteNode(
+            "Sprite",
+            sprite,
+            positionProperty,
+            undefined, // Rotation is not used for sprites final transform
+            undefined, // Scale is not used for sprites final transform
+            undefined, // Opacity is not used for sprites final transform
+            anchorNode
+        );
 
         return anchorNode;
     }

--- a/packages/dev/lottiePlayer/src/parsing/parser.ts
+++ b/packages/dev/lottiePlayer/src/parsing/parser.ts
@@ -425,6 +425,26 @@ export class Parser {
             return;
         }
 
+        // Lottie/After Effects shape stack: a fill/stroke (or gradient fill/stroke) at a given level
+        // applies to every sibling shape/group above it. When a layer (or a group) mixes child groups
+        // with sibling decorators, those decorators have to flow into each child group so each group's
+        // sprite is rasterized with them. Without this, e.g. `[gr, gr, fl]` would render only the
+        // groups that already carry their own fill — the others would rasterize as empty sprites
+        let hasGroup = false;
+        let levelDecorators: RawElement[] | undefined;
+        for (let i = 0; i < elements.length; i++) {
+            const el = elements[i];
+            if (el.hd === true || el.ty === "tr") {
+                continue;
+            }
+            if (el.ty === "gr") {
+                hasGroup = true;
+            } else if (el.ty === "fl" || el.ty === "st" || el.ty === "gf" || el.ty === "gs") {
+                (levelDecorators ??= []).push(el);
+            }
+        }
+        const propagateDecorators = hasGroup && levelDecorators !== undefined && levelDecorators.length > 0;
+
         for (let i = 0; i < elements.length; i++) {
             if (elements[i].hd === true) {
                 continue; // Ignore hidden shapes
@@ -435,11 +455,14 @@ export class Parser {
             }
 
             if (elements[i].ty === "gr") {
-                this._parseGroup(elements[i], parent, rasterizationFrame);
+                this._parseGroup(elements[i], parent, rasterizationFrame, propagateDecorators ? levelDecorators : undefined);
                 //break;
             } else if (elements[i].ty === "sh" || elements[i].ty === "rc" || elements[i].ty === "el") {
                 this._parseShapes(elements, parent, rasterizationFrame);
                 break; // After parsing the shapes, this array of elements is done
+            } else if (propagateDecorators && (elements[i].ty === "fl" || elements[i].ty === "st" || elements[i].ty === "gf" || elements[i].ty === "gs")) {
+                // Already absorbed into the preceding sibling groups via `_parseGroup` above.
+                continue;
             } else {
                 this._unsupportedFeatures.push(`Only groups or shapes are supported as children of layers - Name: ${elements[i].nm} Type: ${elements[i].ty}`);
                 continue;
@@ -447,7 +470,7 @@ export class Parser {
         }
     }
 
-    private _parseGroup(group: RawElement, parent: Node, rasterizationFrame: number): void {
+    private _parseGroup(group: RawElement, parent: Node, rasterizationFrame: number, inheritedDecorators?: RawElement[]): void {
         if (group.it === undefined || group.it.length === 0) {
             this._unsupportedFeatures.push(`Unexpected empty group: ${group.nm}`);
             return;
@@ -457,6 +480,15 @@ export class Parser {
         if (transform === undefined) {
             this._unsupportedFeatures.push(`Group ${group.nm} does not have a transform which is not supported`);
             return;
+        }
+
+        // Splice any inherited decorators (parent-level fills/strokes) just before the group's
+        // transform so the rasterizer sees them in the same relative position they had at the
+        // parent level — i.e. below the group's own contents in z-order. Lottie's terminal-`tr`
+        // contract (relied on by `_getTransform` and `_drawVectorShape`) is preserved.
+        let items = group.it;
+        if (inheritedDecorators && inheritedDecorators.length > 0) {
+            items = group.it.slice(0, -1).concat(inheritedDecorators, group.it[group.it.length - 1]);
         }
 
         // Create the nodes on the scenegraph for this group
@@ -472,7 +504,7 @@ export class Parser {
         );
 
         // Parse the children of the group
-        this._parseElements(group.it, anchorNode, rasterizationFrame);
+        this._parseElements(items, anchorNode, rasterizationFrame);
     }
 
     private _parseShapes(elements: RawElement[], parent: Node, rasterizationFrame: number): void {

--- a/packages/dev/lottiePlayer/src/parsing/parser.ts
+++ b/packages/dev/lottiePlayer/src/parsing/parser.ts
@@ -58,7 +58,7 @@ type LayerTree = {
 /**
  * Parses a CSS hex color string in `#RGB` or `#RRGGBB` form into normalized 0..1 RGB components.
  * Used for solid layers (`ty:1`), whose color is stored as a CSS string in `sc`. Falls back to
- * black and pushes a warning for any other form (e.g. `rgb()`, named colors) so the source is
+ * white and pushes a warning for any other form (e.g. `rgb()`, named colors) so the source is
  * traceable instead of silently producing the wrong color.
  * @param value The raw `sc` string from a solid layer.
  * @param layerName The owning layer's name (for the warning message).
@@ -85,7 +85,7 @@ function ParseCssColorString(value: string, layerName: string | undefined, unsup
         }
     }
     unsupported.push(`Unsupported CSS color string in solid layer ${layerName ?? "<unknown>"}: ${value}`);
-    return [0, 0, 0];
+    return [1, 1, 1];
 }
 
 /**

--- a/packages/dev/lottiePlayer/src/parsing/rawTypes.ts
+++ b/packages/dev/lottiePlayer/src/parsing/rawTypes.ts
@@ -58,6 +58,13 @@ export type RawTextLayer = RawLottieLayer & {
     t: RawTextData;
 };
 
+export type RawSolidLayer = RawLottieLayer & {
+    ty: 1; // Solid layer type
+    sw: number; // Solid layer width in pixels
+    sh: number; // Solid layer height in pixels
+    sc: string; // Solid layer color as a CSS color string (e.g. "#rrggbb")
+};
+
 export type RawElement = {
     nm?: string; // Human readable name
     hd?: boolean; // Hidden

--- a/packages/dev/lottiePlayer/test/unit/node.test.ts
+++ b/packages/dev/lottiePlayer/test/unit/node.test.ts
@@ -373,3 +373,67 @@ describe("decomposeWorldMatrixAtFrame", () => {
         expect(node.rotationCurrent).toBeCloseTo(0, 5); // reset restored startValue; decomposeWorldMatrixAtFrame did not mutate
     });
 });
+
+describe("Node loop reset of nested animated nodes", () => {
+    // Regression: when looping back to a frame that is BEFORE the first keyframe of an animated
+    // child node, the controller's reset()+update(currentFrame) sequence used to leave the child's
+    // localMatrix at the END-of-previous-loop interpolated value, even though `currentValue` had
+    // been correctly reset to `startValue`. The cause was that `Node.update` only honored
+    // `isReset` on the node it was first called on (the root) and did not propagate it to
+    // children, so animated descendants whose animation functions return false at the new frame
+    // (idx < 0 — frame before first keyframe) never recomposed their localMatrix.
+    //
+    // This was visible in the Pages.json animation where layers parented under "Null 19" / "Null
+    // Pages" (which have keyframes starting at t=37 / t=109) appeared in their previous-loop
+    // end-state for the first ~30+ frames of every loop.
+    it("recomposes a nested animated child's worldMatrix after looping back before its first keyframe", () => {
+        // Parent: animated keyframes 30→60. Mirrors a "Null" layer whose own animation starts late.
+        const parentScale: Vector2Property = {
+            startValue: { x: 1, y: 1 },
+            currentValue: { x: 1, y: 1 },
+            currentKeyframeIndex: 0,
+            keyframes: [
+                { time: 30, value: { x: 1, y: 1 }, easeFunction1: linearEase(), easeFunction2: linearEase() },
+                { time: 60, value: { x: 5, y: 5 }, easeFunction1: linearEase(), easeFunction2: linearEase() },
+            ],
+        };
+        const parent = new Node("parent", undefined, undefined, parentScale);
+        parent.isVisible = true;
+
+        // Child: own animated position with first keyframe at t=10. Its localMatrix gets recomposed
+        // every time its animation function fires (frames 10..40), then stays at the final
+        // interpolated value once frame > 40.
+        const childPosition = makePositionProperty(0, 0, [
+            { time: 10, x: 0, y: 0 },
+            { time: 40, x: 100, y: 200 },
+        ]);
+        const child = new Node("child", childPosition, undefined, undefined, undefined, parent);
+        child.isVisible = true;
+
+        // Drive the animation to its end so both parent.localMatrix and child.localMatrix sit at
+        // their last-keyframe interpolated values.
+        parent.update(90);
+
+        // Sanity: child's local position is at the last keyframe value before the loop reset.
+        expect(child.positionCurrent.x).toBeCloseTo(100, 5);
+        expect(child.positionCurrent.y).toBeCloseTo(200, 5);
+
+        // Loop back: reset all properties and replay from frame 0 (before the child's first
+        // keyframe at t=10). This mirrors what AnimationController does on loop wrap.
+        parent.reset();
+        parent.update(0);
+
+        // After reset+update at frame 0:
+        //  - child.currentValue must be back to startValue (0, 0) — reset's responsibility.
+        //  - child.worldMatrix translation must reflect (0, 0) too — i.e. its localMatrix must
+        //    have been recomposed from the reset currentValue, not left at the end-of-loop state.
+        expect(child.positionCurrent.x).toBeCloseTo(0, 5);
+        expect(child.positionCurrent.y).toBeCloseTo(0, 5);
+
+        const worldScale = { x: 0, y: 0 };
+        const worldTranslation = { x: 0, y: 0 };
+        child.worldMatrix.decompose(worldScale, worldTranslation);
+        expect(worldTranslation.x).toBeCloseTo(0, 5);
+        expect(worldTranslation.y).toBeCloseTo(0, 5);
+    });
+});

--- a/packages/dev/lottiePlayer/test/unit/parser.test.ts
+++ b/packages/dev/lottiePlayer/test/unit/parser.test.ts
@@ -6,7 +6,7 @@ import { type RenderingManager } from "../../src/rendering/renderingManager";
 import { SpriteNode } from "../../src/nodes/spriteNode";
 import { ControlNode } from "../../src/nodes/controlNode";
 import { Node } from "../../src/nodes/node";
-import { type RawLottieAnimation, type RawShapeLayer, type RawTextLayer, type RawTransform } from "../../src/parsing/rawTypes";
+import { type RawElement, type RawLottieAnimation, type RawShapeLayer, type RawTextLayer, type RawTransform } from "../../src/parsing/rawTypes";
 import { type AnimationConfiguration } from "../../src/animationConfiguration";
 
 // Minimal valid empty transform (all fields optional, parser fills in defaults).
@@ -432,5 +432,152 @@ describe("Parser per-axis easing on Vector2 keyframes (I-06)", () => {
         expect(ease2.y1).toBe(0.6);
         expect(ease2.x2).toBe(0.7);
         expect(ease2.y2).toBe(0.8);
+    });
+});
+
+describe("Parser layer-level shape decorators", () => {
+    // Builds a SpritePacker mock that records every addLottieShape invocation so tests can
+    // assert which raw elements were rasterized into each sprite.
+    function makeRecordingPacker(): { packer: SpritePacker; calls: RawElement[][] } {
+        const calls: RawElement[][] = [];
+        const baseInfo: SpriteAtlasInfo = {
+            uOffset: 0,
+            vOffset: 0,
+            cellWidth: 16,
+            cellHeight: 16,
+            widthPx: 16,
+            heightPx: 16,
+            centerX: 8,
+            centerY: 8,
+            atlasIndex: 0,
+        };
+
+        const mock = {
+            addLottieShape: (rawElements: RawElement[]) => {
+                // Snapshot the array contents at call time; the parser may mutate sources later.
+                calls.push(rawElements.slice());
+                return baseInfo;
+            },
+            addLottieText: () => baseInfo,
+            updateAtlasTexture: () => {},
+            releaseCanvas: () => {},
+            get textures() {
+                return [];
+            },
+            get unsupportedFeatures() {
+                return [];
+            },
+            set rawFonts(_: unknown) {},
+        };
+
+        return { packer: mock as unknown as SpritePacker, calls };
+    }
+
+    // Mirrors the real-world structure that surfaced this bug (Lottie EDU_V2_07 "Search" layer):
+    // two sibling groups followed by a layer-level fill that should color both. Group 1 has its
+    // own fill (white inner circle); Group 2 has no fill of its own (the dark gray magnifying-glass
+    // body and handle); the layer-level dark-gray Fill 1 is supposed to fill Group 2 (and would also
+    // be drawn behind Group 1's white circle, where it is invisible).
+    it("propagates a layer-level fill to every sibling group's rasterized shape", () => {
+        const innerCirclePath = { ind: 0, ty: "sh", nm: "Path 1", ks: { a: 0, k: { i: [], o: [], v: [], c: true } } };
+        const lensPath = { ind: 0, ty: "sh", nm: "Path 2", ks: { a: 0, k: { i: [], o: [], v: [], c: true } } };
+        const whiteFill = { ty: "fl", nm: "Fill 1 (white)", c: { a: 0, k: [1, 1, 1, 1] }, o: { a: 0, k: 100 } };
+        const grayLayerFill = { ty: "fl", nm: "Fill 1 (gray)", c: { a: 0, k: [0.25, 0.25, 0.25, 1] }, o: { a: 0, k: 100 } };
+        const groupTransform = { ty: "tr", nm: "Transform" };
+
+        const animation: RawLottieAnimation = {
+            v: "5.0.0",
+            fr: 30,
+            ip: 0,
+            op: 60,
+            w: 100,
+            h: 100,
+            layers: [
+                {
+                    ty: 4,
+                    ind: 1,
+                    nm: "Search",
+                    ip: 0,
+                    op: 60,
+                    st: 0,
+                    ks: makeTransform(),
+                    shapes: [
+                        { ty: "gr", nm: "Group 1", it: [innerCirclePath, whiteFill, groupTransform] },
+                        { ty: "gr", nm: "Group 2", it: [lensPath, groupTransform] },
+                        grayLayerFill,
+                    ] as any,
+                } as RawShapeLayer,
+            ],
+        };
+
+        const { packer, calls } = makeRecordingPacker();
+        new Parser(packer, animation, makeConfiguration(), makeMockRenderingManager());
+
+        // Both groups must produce a sprite call.
+        expect(calls).toHaveLength(2);
+
+        // Group 1's call must include both the original white fill (so the inner circle stays
+        // white on top) AND the layer-level gray fill (drawn behind it).
+        const group1Items = calls[0];
+        const group1Fills = group1Items.filter((el) => el.ty === "fl");
+        expect(group1Fills).toHaveLength(2);
+        expect(group1Fills.map((f) => f.nm)).toContain("Fill 1 (white)");
+        expect(group1Fills.map((f) => f.nm)).toContain("Fill 1 (gray)");
+        // Transform must remain the last item; Lottie/AE require it and the parser's bounding box
+        // / fill code rely on it being terminal.
+        expect(group1Items[group1Items.length - 1].ty).toBe("tr");
+
+        // Group 2's call must inherit the layer-level gray fill (otherwise the magnifying glass
+        // outline rasterizes to nothing — the original bug from EDU_V2_07).
+        const group2Items = calls[1];
+        const group2Fills = group2Items.filter((el) => el.ty === "fl");
+        expect(group2Fills).toHaveLength(1);
+        expect(group2Fills[0].nm).toBe("Fill 1 (gray)");
+        expect(group2Items[group2Items.length - 1].ty).toBe("tr");
+    });
+
+    // A layer-level stroke (`st`) follows the same Lottie semantics as a layer-level fill: it
+    // applies to all sibling shapes/groups above it. Cover it here too so a future tweak to the
+    // decorator-detection list does not silently drop strokes.
+    it("propagates a layer-level stroke to every sibling group's rasterized shape", () => {
+        const path = { ind: 0, ty: "sh", nm: "Path 1", ks: { a: 0, k: { i: [], o: [], v: [], c: true } } };
+        const layerStroke = {
+            ty: "st",
+            nm: "Stroke 1",
+            c: { a: 0, k: [0, 0, 0, 1] },
+            o: { a: 0, k: 100 },
+            w: { a: 0, k: 2 },
+        };
+        const groupTransform = { ty: "tr", nm: "Transform" };
+
+        const animation: RawLottieAnimation = {
+            v: "5.0.0",
+            fr: 30,
+            ip: 0,
+            op: 60,
+            w: 100,
+            h: 100,
+            layers: [
+                {
+                    ty: 4,
+                    ind: 1,
+                    nm: "Outlined",
+                    ip: 0,
+                    op: 60,
+                    st: 0,
+                    ks: makeTransform(),
+                    shapes: [{ ty: "gr", nm: "Group 1", it: [path, groupTransform] }, layerStroke] as any,
+                } as RawShapeLayer,
+            ],
+        };
+
+        const { packer, calls } = makeRecordingPacker();
+        new Parser(packer, animation, makeConfiguration(), makeMockRenderingManager());
+
+        expect(calls).toHaveLength(1);
+        const group1Items = calls[0];
+        const group1Strokes = group1Items.filter((el) => el.ty === "st");
+        expect(group1Strokes).toHaveLength(1);
+        expect(group1Strokes[0].nm).toBe("Stroke 1");
     });
 });

--- a/packages/dev/lottiePlayer/test/unit/parser.test.ts
+++ b/packages/dev/lottiePlayer/test/unit/parser.test.ts
@@ -581,3 +581,210 @@ describe("Parser layer-level shape decorators", () => {
         expect(group1Strokes[0].nm).toBe("Stroke 1");
     });
 });
+
+describe("Parser solid layer (ty:1)", () => {
+    // Same recording packer pattern as the layer-level decorator suite above. Defined inline so each
+    // describe block is self-contained.
+    function makeRecordingPacker(): { packer: SpritePacker; calls: RawElement[][] } {
+        const calls: RawElement[][] = [];
+        const baseInfo: SpriteAtlasInfo = {
+            uOffset: 0,
+            vOffset: 0,
+            cellWidth: 16,
+            cellHeight: 16,
+            widthPx: 16,
+            heightPx: 16,
+            centerX: 8,
+            centerY: 8,
+            atlasIndex: 0,
+        };
+
+        const mock = {
+            addLottieShape: (rawElements: RawElement[]) => {
+                calls.push(rawElements.slice());
+                return baseInfo;
+            },
+            addLottieText: () => baseInfo,
+            updateAtlasTexture: () => {},
+            releaseCanvas: () => {},
+            get textures() {
+                return [];
+            },
+            get unsupportedFeatures() {
+                return [];
+            },
+            set rawFonts(_: unknown) {},
+        };
+
+        return { packer: mock as unknown as SpritePacker, calls };
+    }
+
+    // Recording rendering manager so tests can assert the on-screen sprite dimensions handed to the
+    // sprite renderer. Solid layers stretch a 1x1 atlas cell to full sw*sh, so the on-screen size
+    // is the meaningful surface — distinct from `widthPx` reported by the packer.
+    function makeRecordingRenderingManager(): { rm: RenderingManager; sprites: { width: number; height: number }[] } {
+        const sprites: { width: number; height: number }[] = [];
+        const mock = {
+            addSprite: (sprite: { width: number; height: number }) => {
+                // Snapshot at call time — the parser may continue mutating the sprite afterwards.
+                sprites.push({ width: sprite.width, height: sprite.height });
+            },
+            ready: () => {},
+        };
+        return { rm: mock as unknown as RenderingManager, sprites };
+    }
+
+    it("rasterizes a ty:1 solid layer using a 1x1 atlas cell stretched to full sw*sh on screen", () => {
+        // Mirrors the "Grey" backplate in EDU/Pages.json: a 960x540 #f0f0f0 solid layer that the
+        // official Lottie player draws as a flat backplate. Solid layers are by definition a single
+        // flat color (Lottie schema only allows `sc` as a CSS color string), so we rasterize a 1x1
+        // cell into the atlas and let the sprite renderer stretch it. Otherwise a 960x540 backplate
+        // at devicePixelRatio=2 would consume ~90% of a 2048-pixel atlas page.
+        const animation: RawLottieAnimation = {
+            v: "5.0.0",
+            fr: 30,
+            ip: 0,
+            op: 60,
+            w: 960,
+            h: 540,
+            layers: [
+                {
+                    ty: 1,
+                    ind: 1,
+                    nm: "Grey",
+                    ip: 0,
+                    op: 60,
+                    st: 0,
+                    ks: makeTransform(),
+                    sw: 960,
+                    sh: 540,
+                    sc: "#f0f0f0",
+                } as any,
+            ],
+        };
+
+        const { packer, calls } = makeRecordingPacker();
+        const { rm, sprites } = makeRecordingRenderingManager();
+        new Parser(packer, animation, makeConfiguration(), rm);
+
+        // Solid layer must produce exactly one rasterization call containing a rectangle and a fill
+        // (in that order, mirroring the [shape, decorator] convention used by Lottie shape layers).
+        expect(calls).toHaveLength(1);
+        const items = calls[0];
+        expect(items).toHaveLength(2);
+
+        const rect = items[0] as any;
+        const fill = items[1] as any;
+        expect(rect.ty).toBe("rc");
+        expect(fill.ty).toBe("fl");
+
+        // Atlas cell geometry: 1x1 lottie pixel centered at (0.5, 0.5). Independent of sw/sh — that
+        // sizing happens on the sprite (below), not in the atlas.
+        expect(rect.s.k).toEqual([1, 1]);
+        expect(rect.p.k).toEqual([0.5, 0.5]);
+
+        // Fill color: #f0f0f0 -> 240/255 on each channel, alpha 1.
+        const expectedChannel = 240 / 255;
+        expect(fill.c.k[0]).toBeCloseTo(expectedChannel, 6);
+        expect(fill.c.k[1]).toBeCloseTo(expectedChannel, 6);
+        expect(fill.c.k[2]).toBeCloseTo(expectedChannel, 6);
+        expect(fill.c.k[3]).toBe(1);
+
+        // On-screen sprite size must reflect the layer's full sw/sh — that's the dimension the GPU
+        // stretches the 1x1 cell to. Pages.json's "Grey" layer is the regression case: dropping
+        // these dimensions or wiring sw/sh into the atlas instead would either lose the backplate
+        // or eat the atlas.
+        expect(sprites).toHaveLength(1);
+        expect(sprites[0].width).toBe(960);
+        expect(sprites[0].height).toBe(540);
+    });
+
+    it("handles short #RGB hex form for solid layer color", () => {
+        // After Effects normally exports the long form, but the CSS spec also allows #RGB. Cover it
+        // explicitly so the helper's two-branch path doesn't regress on shorter strings (e.g.
+        // hand-edited animations or third-party exporters).
+        const animation: RawLottieAnimation = {
+            v: "5.0.0",
+            fr: 30,
+            ip: 0,
+            op: 60,
+            w: 100,
+            h: 100,
+            layers: [
+                {
+                    ty: 1,
+                    ind: 1,
+                    nm: "Short",
+                    ip: 0,
+                    op: 60,
+                    st: 0,
+                    ks: makeTransform(),
+                    sw: 100,
+                    sh: 100,
+                    sc: "#f00",
+                } as any,
+            ],
+        };
+
+        const { packer, calls } = makeRecordingPacker();
+        new Parser(packer, animation, makeConfiguration(), makeMockRenderingManager());
+
+        expect(calls).toHaveLength(1);
+        const fill = calls[0][1] as any;
+        expect(fill.c.k[0]).toBe(1);
+        expect(fill.c.k[1]).toBe(0);
+        expect(fill.c.k[2]).toBe(0);
+    });
+
+    it("skips rasterization but still registers the anchor node when sw/sh are zero", () => {
+        // Defensive: malformed solid layer with no usable rectangle. We must not call addLottieShape
+        // with zero-size geometry (which produces zero-area sprites and risks divide-by-zero in
+        // bounding-box code), but we still need a valid anchor slot so child layers parented via
+        // `ind` resolve correctly.
+        const animation: RawLottieAnimation = {
+            v: "5.0.0",
+            fr: 30,
+            ip: 0,
+            op: 60,
+            w: 100,
+            h: 100,
+            layers: [
+                {
+                    ty: 1,
+                    ind: 1,
+                    nm: "Empty",
+                    ip: 0,
+                    op: 60,
+                    st: 0,
+                    ks: makeTransform(),
+                    sw: 0,
+                    sh: 0,
+                    sc: "#000000",
+                } as any,
+                {
+                    ty: 4,
+                    ind: 2,
+                    nm: "Child",
+                    parent: 1,
+                    ip: 0,
+                    op: 60,
+                    st: 0,
+                    ks: makeTransform(),
+                    shapes: [{ ty: "rc", nm: "rect" } as any],
+                } as RawShapeLayer,
+            ],
+        };
+
+        const { packer, calls } = makeRecordingPacker();
+        const parser = new Parser(packer, animation, makeConfiguration(), makeMockRenderingManager());
+
+        // Only the child shape rasterizes; the malformed solid layer is skipped.
+        expect(calls).toHaveLength(1);
+
+        // Solid layer's anchor was still created so the child resolves its parent and ends up as a
+        // descendant of the solid layer's ControlNode (not a stray root).
+        const roots = parser.animationInfo.nodes;
+        expect(roots).toHaveLength(1);
+        expect(roots[0].id).toBe("ControlNode (TRS) - Empty");
+    });
+});

--- a/packages/public/@babylonjs/lottiePlayer/readme.md
+++ b/packages/public/@babylonjs/lottiePlayer/readme.md
@@ -10,24 +10,38 @@ Play Lottie JSON animations on a lightweight Babylon ThinEngine using an Offscre
 import { Player } from "@babylonjs/lottie-player";
 
 const container = document.getElementById("myDiv") as HTMLDivElement;
-const player = new Player(container, "/animations/hero.json");
-player.playAnimation();
+const player = new Player();
+await player.playAnimationAsync({
+    container,
+    animationSource: "/animations/hero.json", // or a parsed RawLottieAnimation object
+    variables: null,
+    configuration: { loopAnimation: true },
+});
 ```
 
 ## Important Notes
 
-The public API of this package is formed by Player, LocalPlayer and AnimationConfiguration. All other files are internal implementation details.
+The public API of this package is formed by `Player`, `LocalPlayer`, `AnimationConfiguration` and the `RawLottieAnimation` type. All other files are internal implementation details.
 
 Future updates could move or rename files and require you to update your references if you take dependencies on those files. Do not depend on the paths of those files either as they could be moved or renamed as part of the internal implementation.
 
 ## Options
 
-You can pass a variables map in the constructor of Player. These variables will be used in:
+You can pass a variables map through `AnimationInput.variables`. These variables will be used in:
 
 - Text from a text layer to be localized.
 - Text fill from a text layer to use a particular color.
 
-You can use the AnimationConfiguration to change certain parameters of the parser/player. For example, loopAnimation to loop the animation, or ignoreOpacityAnimation for performance if you know your animation doesn't modify opacity.
+You can use `AnimationConfiguration` to change certain parameters of the parser/player. The most commonly used options are:
+
+- `loopAnimation`: when `true`, the animation restarts from the beginning after the last frame.
+- `backgroundColor`: RGBA color used to clear the canvas before each frame.
+- `spriteAtlasWidth` / `spriteAtlasHeight`: explicit atlas size (set both to `0` to auto-detect from GPU capabilities).
+- `devicePixelRatio`: rendering scale; set to `0` to auto-detect based on atlas size and the system DPR.
+- `gapSize`, `spritesCapacity`, `scaleMultiplier`, `easingSteps`: tuning knobs for the atlas packer and animation evaluator.
+- `supportDeviceLost`: enable WebGL context-lost recovery.
+- `stopAtFrame`: stop playback at a specific frame number (useful for visual testing).
+- `debug`: when `true`, the parser logs unsupported Lottie features to the console after parsing — useful for diagnosing why a given animation does not render as expected.
 
 ## Security
 
@@ -40,16 +54,19 @@ script-src is used by the scripts the worker references, like the classes it nee
 
 ## Remarks
 
-- Prefer to use the class Player that uses an Offscreen canvas and the worker thread. If for some reason that is not available to you, you can use LocalPlayer and call playAnimationAsync which renders in the main JS thread.
+- Prefer to use the `Player` class that uses an OffscreenCanvas and a worker thread. If for some reason that is not available to you (for example in browsers that do not support OffscreenCanvas), you can use `LocalPlayer` instead and call `playAnimationAsync`, which renders on the main JS thread with the same `AnimationInput` shape.
 
 - Only certain features of the Lottie format are currently supported:
-  - Layers: null, shape, text
-  - Parenting: layers with layers, layers with groups
-  - Layer Animations: translation, rotation, scale, opacity (we apply animations to the layer rather than the individual shapes/fills/text within the layer)
-  - Shapes: rectangle, rounded corner rectangle, vector path
-  - Shapes fills: regular fill, gradient fill, radial fill, stroke fill
-  - Text: font, size, weight, alignment, fill color. Each text layer must contain a single line of text
-  - Variables: for text strings and text fill color (useful for localization and themes)
-- More features may be added in the future but there is no timeline for them
+    - Layers: solid, null, shape, text
+    - Parenting: layers with layers, layers with groups, including transform inheritance through the chain
+    - Layer animations: position, rotation, scale, opacity, anchor point — driven by keyframe interpolation with cubic-bezier easing (per-axis easing on Vector2 properties such as position and scale). Animations are applied to the layer rather than to the individual shapes/fills/text within the layer.
+    - Shapes: rectangle (including rounded corners), ellipse, vector path
+    - Shape decorators: solid fill, gradient fill (linear and radial), stroke, gradient stroke. Layer-level decorators are inherited by the layer's sibling shape groups when those groups don't define their own.
+    - Text: font, size, weight, alignment, fill color, multi-line text and paragraph-box word wrapping with tracking and line height
+    - Variables: for text strings and text fill color (useful for localization and themes)
+
+- Notable Lottie features that are **not** currently supported include precomp/image/audio layers, masks and matte layers, layer effects, expressions, animations on individual shapes/groups/fills/strokes within a layer (only the layer's own transform is animated), trim/repeater/merge-paths and other shape modifiers, and per-character text animators.
+
+- More features may be added in the future but there is no timeline for them.
 
 **- This is a highly experimental feature, use it at your own risk :)**

--- a/packages/tools/devHost/src/lottie/main.ts
+++ b/packages/tools/devHost/src/lottie/main.ts
@@ -60,7 +60,6 @@ export async function Main(searchParams: URLSearchParams): Promise<void> {
         backgroundColor: { r: 255 / 255, g: 255 / 255, b: 255 / 255, a: 1 }, // Background color for the animation canvas, visual tests use white
         stopAtFrame: stopAtFrame, // If set, the animation will stop at this frame (used by visual tests)
         debug: debug, // Log unsupported lottie features after parsing
-        //loopAnimation: true,
     };
 
     // Signal that the first frame has been rendered (used by visual tests for deterministic screenshots)

--- a/packages/tools/devHost/src/lottie/main.ts
+++ b/packages/tools/devHost/src/lottie/main.ts
@@ -57,9 +57,10 @@ export async function Main(searchParams: URLSearchParams): Promise<void> {
 
     // This is the configuration for the player, you can pass as much or as little as you want, the rest will be defaulted
     const configuration: Partial<AnimationConfiguration> = {
-        backgroundColor: { r: 255 / 255, g: 255 / 255, b: 255 / 255, a: 1 }, // Background color for the animation canvas, visual tests use white
+        backgroundColor: { r: 240 / 255, g: 240 / 255, b: 240 / 255, a: 1 }, // Background color for the animation canvas, visual tests use white
         stopAtFrame: stopAtFrame, // If set, the animation will stop at this frame (used by visual tests)
         debug: debug, // Log unsupported lottie features after parsing
+        loopAnimation: true,
     };
 
     // Signal that the first frame has been rendered (used by visual tests for deterministic screenshots)

--- a/packages/tools/devHost/src/lottie/main.ts
+++ b/packages/tools/devHost/src/lottie/main.ts
@@ -57,10 +57,10 @@ export async function Main(searchParams: URLSearchParams): Promise<void> {
 
     // This is the configuration for the player, you can pass as much or as little as you want, the rest will be defaulted
     const configuration: Partial<AnimationConfiguration> = {
-        backgroundColor: { r: 240 / 255, g: 240 / 255, b: 240 / 255, a: 1 }, // Background color for the animation canvas, visual tests use white
+        backgroundColor: { r: 255 / 255, g: 255 / 255, b: 255 / 255, a: 1 }, // Background color for the animation canvas, visual tests use white
         stopAtFrame: stopAtFrame, // If set, the animation will stop at this frame (used by visual tests)
         debug: debug, // Log unsupported lottie features after parsing
-        loopAnimation: true,
+        //loopAnimation: true,
     };
 
     // Signal that the first frame has been rendered (used by visual tests for deterministic screenshots)


### PR DESCRIPTION
## Summary

This PR groups together several fixes and a small optimization to the experimental `@babylonjs/lottie-player`, plus an update to the public package readme so it reflects what the player actually supports today.

### Solid layer (`ty:1`) support
- Added `RawSolidLayer` to `parsing/rawTypes.ts`.
- Added `_parseSolidLayer` in `parsing/parser.ts`, which synthesizes a 1×1 `[rc, fl]` shape pair and stretches a single atlas cell to the full `sw × sh` on screen.
- Added a file-private `ParseCssColorString` helper for `#RRGGBB` / `#RGB` solid colors with a warn-and-fallback-to-white for unsupported color forms.
- Updated the layer-type guard to accept `ty === 1` alongside `3`/`4`/`5`.

The 1×1 atlas optimization avoids consuming a large chunk of the atlas for full-size solid layers (a 960×540 backplate at DPR=2 would otherwise eat ~90% of an atlas page).

### Loop reset of nested animated nodes
- `Node.update` now propagates `isReset` to children, so all animated descendants re-evaluate their local matrix when the playhead wraps back to the start of a loop.

### Layer-level shape decorators propagated to sibling groups
- `_parseElements` now detects sibling decorators (`fl`, `st`, `gf`, `gs`) when a layer mixes decorator shapes with shape groups.
- `_parseGroup` accepts an optional `inheritedDecorators` parameter and splices them in before the terminal `tr` in `group.it`.

### Tests
Added regression tests covering all of the above:
- `parser.test.ts` — "Parser layer-level shape decorators" (2 tests) and "Parser solid layer (ty:1)" (3 tests).
- `node.test.ts` — "Node loop reset of nested animated nodes" (1 test).

All 81 lottiePlayer unit tests pass; prettier and eslint are clean on changed files.

### Public readme refresh (`packages/public/@babylonjs/lottiePlayer/readme.md`)
The previous readme was significantly out of date. It has been rewritten to reflect the current state of the player:

- Fixed the Usage example: `new Player()` + `await playAnimationAsync({ container, animationSource, ... })` instead of the stale `new Player(container, url)` + `playAnimation()`.
- Removed the non-existent `ignoreOpacityAnimation` option and listed the real `AnimationConfiguration` fields (`loopAnimation`, `backgroundColor`, atlas/DPR sizing, `stopAtFrame`, `debug`, etc.).
- Added `RawLottieAnimation` to the documented public API surface.
- Updated the supported-features list:
  - Added **solid layers**.
  - Added **ellipse** shapes and **gradient stroke** decorators.
  - Replaced "Each text layer must contain a single line of text" with the real capability: **multi-line text and paragraph-box word wrapping with tracking and line height**.
  - Replaced "translation" with "position, rotation, scale, opacity, anchor point" with a note about cubic-bezier easing (per-axis on Vector2 properties).
  - Mentioned the new sibling-group layer-level decorator propagation.
- Added a "not supported" call-out (precomp/image/audio layers, masks, mattes, effects, expressions, animations on individual shapes/groups/fills/strokes within a layer, shape modifiers, per-character text animators) so users have realistic expectations.