### PR TITLE
Fix ResourceTrigger tag override, perf test graceful skip, exclude Atmosphere

### DIFF
--- a/.azure-pipelines/templates/checkout-with-tag-override.yml
+++ b/.azure-pipelines/templates/checkout-with-tag-override.yml
@@ -50,7 +50,10 @@ steps:
           git checkout "$LATEST_TAG"
       displayName: "Override checkout to latest version tag"
       condition: >-
-          and(
-            or(eq(variables['Build.Reason'], 'ResourceTrigger'), eq(variables['Build.Reason'], 'BuildCompletion')),
-            eq(variables['Build.TriggeredBy.DefinitionName'], '${{ parameters.triggeringPipeline }}')
+          or(
+            eq(variables['Build.Reason'], 'ResourceTrigger'),
+            and(
+              eq(variables['Build.Reason'], 'BuildCompletion'),
+              eq(variables['Build.TriggeredBy.DefinitionName'], '${{ parameters.triggeringPipeline }}')
+            )
           )

--- a/packages/tools/tests/test/performance/visualization.test.ts
+++ b/packages/tools/tests/test/performance/visualization.test.ts
@@ -91,9 +91,11 @@ const perfOptions = {
 
 for (const engine of engines) {
     test.describe(`Visualization Performance (${engine})`, () => {
-        // Skip the entire suite if not explicitly enabled
-        if (!enabled) {
-            test.skip();
+        // Skip the entire suite if not explicitly enabled or no tests match
+        if (!enabled || runnableTests.length === 0) {
+            test(`No tests to run (${engine})`, () => {
+                test.skip(true, `No runnable performance tests (AFFECTED_TAGS: ${affectedTagsEnv || "not set"})`);
+            });
             return;
         }
 

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -3581,7 +3581,7 @@
             "referenceImage": "atmosphere-day.png",
             "excludedEngines": ["webgl1"],
             "dependsOn": ["Atmosphere", "Lights", "PBR", "PostProcesses"],
-            "performanceTest": true
+            "excludeFromPerformance": true
         },
         {
             "title": "Atmosphere Day (Planet Origin)",


### PR DESCRIPTION
Three CI fixes:

### 1. Fix `checkout-with-tag-override` condition for ResourceTrigger

When the Publish pipeline triggers `ci-monorepo` via `resources.pipelines`, Azure DevOps sets `Build.Reason` to `ResourceTrigger` but does **not** populate `Build.TriggeredBy.DefinitionName` (that variable is only set for classic `BuildCompletion` triggers). The previous condition required both `ResourceTrigger` AND the definition name check, which always evaluated to `False` because the definition name was `Null`.

Fixed by restructuring the condition: `ResourceTrigger` alone is sufficient (only one pipeline resource has a trigger section), while `BuildCompletion` still checks the definition name as a guard.

### 2. Graceful skip when no performance tests match

When `AFFECTED_TAGS=NONE`, all perf tests are filtered out and Playwright errors with "no tests found", marking the job as failed. Fixed by emitting a single explicitly-skipped placeholder test when no tests match, so Playwright reports a skip instead of a failure.

### 3. Exclude flaky Atmosphere Day from performance tests

Replaced `"performanceTest": true` with `"excludeFromPerformance": true` on the "Atmosphere Day" config entry.