### PR TITLE
Update checks of *Source and *Element to be `typeof` checks in effect components

### DIFF
--- a/packages/dev/core/src/Compute/computeEffect.ts
+++ b/packages/dev/core/src/Compute/computeEffect.ts
@@ -158,9 +158,9 @@ export class ComputeEffect {
 
         if (typeof baseName === "string") {
             computeSource = baseName;
-        } else if (typeof baseName.computeSource === 'string') {
+        } else if (typeof baseName.computeSource === "string") {
             computeSource = "source:" + baseName.computeSource;
-        } else if (typeof baseName.computeElement === 'string') {
+        } else if (typeof baseName.computeElement === "string") {
             computeSource = hostDocument?.getElementById(baseName.computeElement) || baseName.computeElement;
         } else {
             computeSource = baseName.compute || baseName;

--- a/packages/dev/core/src/Compute/computeEffect.ts
+++ b/packages/dev/core/src/Compute/computeEffect.ts
@@ -158,9 +158,9 @@ export class ComputeEffect {
 
         if (typeof baseName === "string") {
             computeSource = baseName;
-        } else if (baseName.computeSource) {
+        } else if (typeof baseName.computeSource === 'string') {
             computeSource = "source:" + baseName.computeSource;
-        } else if (baseName.computeElement) {
+        } else if (typeof baseName.computeElement === 'string') {
             computeSource = hostDocument?.getElementById(baseName.computeElement) || baseName.computeElement;
         } else {
             computeSource = baseName.compute || baseName;

--- a/packages/dev/core/src/Materials/effect.functions.ts
+++ b/packages/dev/core/src/Materials/effect.functions.ts
@@ -135,18 +135,18 @@ export function _ProcessShaderCode(
 
     if (typeof baseName === "string") {
         vertexSource = baseName;
-    } else if (baseName.vertexSource) {
+    } else if (typeof baseName.vertexSource === 'string') {
         vertexSource = "source:" + baseName.vertexSource;
-    } else if (baseName.vertexElement) {
+    } else if (typeof baseName.vertexElement === 'string') {
         vertexSource = hostDocument?.getElementById(baseName.vertexElement) || baseName.vertexElement;
     } else {
         vertexSource = baseName.vertex || baseName;
     }
     if (typeof baseName === "string") {
         fragmentSource = baseName;
-    } else if (baseName.fragmentSource) {
+    } else if (typeof baseName.fragmentSource === 'string') {
         fragmentSource = "source:" + baseName.fragmentSource;
-    } else if (baseName.fragmentElement) {
+    } else if (typeof baseName.fragmentElement === 'string') {
         fragmentSource = hostDocument?.getElementById(baseName.fragmentElement) || baseName.fragmentElement;
     } else {
         fragmentSource = baseName.fragment || baseName;

--- a/packages/dev/core/src/Materials/effect.functions.ts
+++ b/packages/dev/core/src/Materials/effect.functions.ts
@@ -135,18 +135,18 @@ export function _ProcessShaderCode(
 
     if (typeof baseName === "string") {
         vertexSource = baseName;
-    } else if (typeof baseName.vertexSource === 'string') {
+    } else if (typeof baseName.vertexSource === "string") {
         vertexSource = "source:" + baseName.vertexSource;
-    } else if (typeof baseName.vertexElement === 'string') {
+    } else if (typeof baseName.vertexElement === "string") {
         vertexSource = hostDocument?.getElementById(baseName.vertexElement) || baseName.vertexElement;
     } else {
         vertexSource = baseName.vertex || baseName;
     }
     if (typeof baseName === "string") {
         fragmentSource = baseName;
-    } else if (typeof baseName.fragmentSource === 'string') {
+    } else if (typeof baseName.fragmentSource === "string") {
         fragmentSource = "source:" + baseName.fragmentSource;
-    } else if (typeof baseName.fragmentElement === 'string') {
+    } else if (typeof baseName.fragmentElement === "string") {
         fragmentSource = hostDocument?.getElementById(baseName.fragmentElement) || baseName.fragmentElement;
     } else {
         fragmentSource = baseName.fragment || baseName;


### PR DESCRIPTION
Some of the checks in `_ProcessShaderCode` seem to be incorrect, as it can cause an error when effects are created by `ShadowDepthWrapper._makeEffect`.

The issue comes from `computeSource` being able to be empty string `''` which evaluates to false in these conditions, which then results in e.g. `vertexSource` being assigned to the value of `baseName`. This `baseName` is then passed into `LoadShader` where it is treated as a `string`, followed by `substring` being invoked and an error being raised.

I noticed this issue in BabylonJS version 7.54.3, which is pretty old, but looking at the existing codebase, the same conditions for this error seem to exist. Here is a stack trace (somewhat mangled due to build system):
```log
effect.functions.ts:228 Uncaught (in promise) TypeError: shader578.substring is not a function
    at _loadShader (effect.functions.ts:228:16)
    at _processShaderCode (effect.functions.ts:177:5)
    at _Effect._processShaderCodeAsync (effect.ts:441:9)
    at new _Effect (effect.ts:391:18)
    at _Engine.createEffect (thinEngine.ts:2008:24)
    at ShadowDepthWrapper._makeEffect (shadowDepthWrapper.ts:302:48)
    at ShadowDepthWrapper.isReadyForSubMesh (shadowDepthWrapper.ts:183:21)
    at _ShadowGenerator.isReady (shadowGenerator.ts:1583:37)
    at _ShadowGenerator._renderSubMeshForShadowMap (shadowGenerator.ts:1308:18)
    at _ShadowGenerator._renderForShadowMap (shadowGenerator.ts:1241:18)
```

Here is a simple reproduction: https://playground.babylonjs.com/#28WKKT
```ts
engine.createEffect(
  {
    vertexSource: '',
    fragmentSource: '',
  },
  {
    attributes: [],
    uniformsNames: [],
    samplers: [],
    defines: '',
    fallbacks: null,
    onCompiled: null,
    onError: null,
  },
  engine,
);
```