### PR TITLE
Add CPU particle system support to FAST snapshot rendering

### DIFF
--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -483,7 +483,23 @@ export class SnapshotRenderingHelper {
             return;
         }
 
-        (particleSystem as ParticleSystem).useFixedCapacityForSnapshot = true;
+        const ps = particleSystem as ParticleSystem;
+        if (ps.useFixedCapacityForSnapshot) {
+            return;
+        }
+        ps.useFixedCapacityForSnapshot = true;
+
+        // The recorded bundle bakes in the draw-call vertex/instance count. If snapshot rendering is already active
+        // (or in the process of being enabled) when we flip the flag, the bundle was recorded with the live particle
+        // count and is now stale. Cycle disable/enable so the next recording picks up the fixed-capacity draw count.
+        if (this._fastSnapshotRenderingEnabled || this._isEnabling) {
+            Logger.Warn(
+                `SnapshotRenderingHelper.fixParticleSystem("${particleSystem.name}") was called after snapshot rendering was enabled. ` +
+                    `Forcing a re-record so the bundle uses the fixed-capacity draw count. Call fixParticleSystem before enableSnapshotRendering to avoid this.`
+            );
+            this.disableSnapshotRendering("fixParticleSystem auto-recover");
+            this.enableSnapshotRendering("fixParticleSystem auto-recover");
+        }
     }
 
     private _particleSystemUpdateEffects(ps: ParticleSystem, camera: Camera) {
@@ -494,20 +510,29 @@ export class SnapshotRenderingHelper {
 
         const viewMatrix = ps.defaultViewMatrix ?? camera.getViewMatrix();
         const projectionMatrix = ps.defaultProjectionMatrix ?? camera.getProjectionMatrix();
+        // Compute invView lazily once per system per frame, only if any draw wrapper actually needs it.
+        let invViewMatrix: Nullable<Matrix> = null;
+        const getInvView = () => {
+            if (!invViewMatrix) {
+                invViewMatrix = TmpVectors.Matrix[0];
+                viewMatrix.invertToRef(invViewMatrix);
+            }
+            return invViewMatrix;
+        };
 
         for (const perPass of drawWrappers) {
             if (!perPass) {
                 continue;
             }
             for (const dw of perPass) {
-                this._particleSystemDirectMatrixUpdate(dw, viewMatrix, projectionMatrix, camera);
+                this._particleSystemDirectMatrixUpdate(dw, viewMatrix, projectionMatrix, camera, getInvView);
             }
         }
     }
 
     private _particleSystemBillboardFlags = new WeakMap<object, { billboard: boolean; billboardAll: boolean }>();
 
-    private _particleSystemDirectMatrixUpdate(dw: Nullable<DrawWrapper>, viewMatrix: Matrix, projectionMatrix: Matrix, camera: Camera) {
+    private _particleSystemDirectMatrixUpdate(dw: Nullable<DrawWrapper>, viewMatrix: Matrix, projectionMatrix: Matrix, camera: Camera, getInvView: () => Matrix) {
         const effect = dw?.effect;
         if (!effect) {
             return;
@@ -529,9 +554,7 @@ export class SnapshotRenderingHelper {
             effect.setVector3("eyePosition", camera.globalPosition);
         }
         if (flags.billboardAll) {
-            const invView = TmpVectors.Matrix[0];
-            viewMatrix.invertToRef(invView);
-            effect.setMatrix("invView", invView);
+            effect.setMatrix("invView", getInvView());
         }
         ubLeftOver.update();
     }

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -57,7 +57,6 @@ export class SnapshotRenderingHelper {
     private _isEnabling = false;
     private _enableCancelFunctions: Map<() => void, () => void> = new Map(); // first function is the callback, second function is the cancel function
     private _disableCancelFunctions: Map<() => void, () => void> = new Map(); // same as above
-    private readonly _fixedParticleSystems = new Set<ParticleSystem>();
 
     /**
      * Indicates if debug logs should be displayed
@@ -166,10 +165,12 @@ export class SnapshotRenderingHelper {
             }
 
             // Handles fixed-capacity particle systems
-            if (this._fixedParticleSystems.size > 0 && camera) {
-                this._fixedParticleSystems.forEach((ps) => {
-                    this._particleSystemUpdateEffects(ps, camera);
-                });
+            if (scene.particleSystems && camera) {
+                for (const ps of scene.particleSystems) {
+                    if ((ps as ParticleSystem).useFixedCapacityForSnapshot) {
+                        this._particleSystemUpdateEffects(ps as ParticleSystem, camera);
+                    }
+                }
             }
         });
     }
@@ -482,9 +483,7 @@ export class SnapshotRenderingHelper {
             return;
         }
 
-        const ps = particleSystem as ParticleSystem;
-        ps.useFixedCapacityForSnapshot = true;
-        this._fixedParticleSystems.add(ps);
+        (particleSystem as ParticleSystem).useFixedCapacityForSnapshot = true;
     }
 
     private _particleSystemUpdateEffects(ps: ParticleSystem, camera: Camera) {
@@ -506,23 +505,30 @@ export class SnapshotRenderingHelper {
         }
     }
 
+    private _particleSystemBillboardFlags = new WeakMap<object, { billboard: boolean; billboardAll: boolean }>();
+
     private _particleSystemDirectMatrixUpdate(dw: Nullable<DrawWrapper>, viewMatrix: Matrix, projectionMatrix: Matrix, camera: Camera) {
         const effect = dw?.effect;
-        if (!effect || !dw) {
+        if (!effect) {
             return;
         }
-        const dataBuffer = (dw.drawContext as WebGPUDrawContext)?.buffers?.["LeftOver" satisfies (typeof WebGPUShaderProcessor)["LeftOvertUBOName"]];
+        const dataBuffer = (dw!.drawContext as WebGPUDrawContext).buffers["LeftOver" satisfies (typeof WebGPUShaderProcessor)["LeftOvertUBOName"]];
         const ubLeftOver = (effect._pipelineContext as WebGPUPipelineContext)?.uniformBuffer;
         if (!dataBuffer || !ubLeftOver || !ubLeftOver.setDataBuffer(dataBuffer)) {
             return;
         }
         effect.setMatrix("view", viewMatrix);
         effect.setMatrix("projection", projectionMatrix);
-        const defines = effect.defines;
-        if (defines && defines.indexOf("#define BILLBOARD") >= 0) {
+        let flags = this._particleSystemBillboardFlags.get(effect);
+        if (!flags) {
+            const defines = effect.defines ?? "";
+            flags = { billboard: defines.indexOf("#define BILLBOARD") >= 0, billboardAll: defines.indexOf("#define BILLBOARDMODE_ALL") >= 0 };
+            this._particleSystemBillboardFlags.set(effect, flags);
+        }
+        if (flags.billboard) {
             effect.setVector3("eyePosition", camera.globalPosition);
         }
-        if (defines && defines.indexOf("#define BILLBOARDMODE_ALL") >= 0) {
+        if (flags.billboardAll) {
             const invView = TmpVectors.Matrix[0];
             viewMatrix.invertToRef(invView);
             effect.setMatrix("invView", invView);

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -13,11 +13,15 @@ import {
     type DrawWrapper,
     type Camera,
     type SpriteManager,
+    type IParticleSystem,
+    type ParticleSystem,
+    type Matrix,
 } from "core/index";
 
 import { Constants } from "core/Engines/constants";
 import { BindMorphTargetParameters } from "core/Materials/materialHelper.functions";
 import { ScenePerformancePriority } from "core/scene";
+import { TmpVectors } from "core/Maths/math.vector";
 import { Logger } from "core/Misc/logger";
 import { FrameGraphBaseLayerTask } from "../FrameGraph/Tasks/Layers/baseLayerTask";
 import { FrameGraphUtils } from "../FrameGraph/frameGraphUtils";
@@ -53,6 +57,7 @@ export class SnapshotRenderingHelper {
     private _isEnabling = false;
     private _enableCancelFunctions: Map<() => void, () => void> = new Map(); // first function is the callback, second function is the cancel function
     private _disableCancelFunctions: Map<() => void, () => void> = new Map(); // same as above
+    private readonly _fixedParticleSystems = new Set<ParticleSystem>();
 
     /**
      * Indicates if debug logs should be displayed
@@ -158,6 +163,13 @@ export class SnapshotRenderingHelper {
 
                     this._spriteRendererUpdateEffects(renderer._drawWrapperBase, renderer._drawWrapperDepth, camera);
                 }
+            }
+
+            // Handles fixed-capacity particle systems
+            if (this._fixedParticleSystems.size > 0 && camera) {
+                this._fixedParticleSystems.forEach((ps) => {
+                    this._particleSystemUpdateEffects(ps, camera);
+                });
             }
         });
     }
@@ -441,6 +453,81 @@ export class SnapshotRenderingHelper {
     private _spriteRendererUpdateEffects(drawWrapperBase: DrawWrapper, drawWrapperDepth: DrawWrapper, camera: Camera) {
         this._spriteRendererDirectMatrixUpdate(drawWrapperBase, camera);
         this._spriteRendererDirectMatrixUpdate(drawWrapperDepth, camera);
+    }
+
+    /**
+     * Make a CPU particle system compatible with FAST snapshot rendering.
+     * The particle system will always render at full capacity (`getCapacity()` quads), with inactive slots collapsed
+     * to degenerate triangles via zero-fill. This keeps the recorded GPU bundle's draw call valid every frame, while
+     * the live particle data is uploaded to the bundle-referenced vertex buffer through the normal `animate()` path.
+     *
+     * The helper additionally updates view/projection (and `eyePosition`/`invView` for billboard modes) into the
+     * particle system's draw wrappers each frame, so a moving camera continues to work after the bundle is recorded.
+     *
+     * Notes:
+     * - Call this BEFORE `enableSnapshotRendering()` so the recording sees the correct draw count.
+     * - GPU particle systems (`GPUParticleSystem`) are not supported by this method.
+     * - Vertex shader cost scales with `getCapacity()` rather than the live particle count, so size capacity realistically.
+     * - Per-frame uniforms other than camera matrices (e.g. `textureMask`, `translationPivot`, clip planes, fog) are
+     *   baked at recording time and will not update during snapshot replay.
+     * @param particleSystem The particle system to fix
+     */
+    public fixParticleSystem(particleSystem: IParticleSystem): void {
+        if (!this._engine.isWebGPU) {
+            return;
+        }
+
+        if (particleSystem.getClassName() !== "ParticleSystem") {
+            this._log("fixParticleSystem", `skipping ${particleSystem.name}: only CPU ParticleSystem is supported (got ${particleSystem.getClassName()})`);
+            return;
+        }
+
+        const ps = particleSystem as ParticleSystem;
+        ps.useFixedCapacityForSnapshot = true;
+        this._fixedParticleSystems.add(ps);
+    }
+
+    private _particleSystemUpdateEffects(ps: ParticleSystem, camera: Camera) {
+        const drawWrappers = (ps as unknown as { _drawWrappers: DrawWrapper[][] })._drawWrappers;
+        if (!drawWrappers) {
+            return;
+        }
+
+        const viewMatrix = ps.defaultViewMatrix ?? camera.getViewMatrix();
+        const projectionMatrix = ps.defaultProjectionMatrix ?? camera.getProjectionMatrix();
+
+        for (const perPass of drawWrappers) {
+            if (!perPass) {
+                continue;
+            }
+            for (const dw of perPass) {
+                this._particleSystemDirectMatrixUpdate(dw, viewMatrix, projectionMatrix, camera);
+            }
+        }
+    }
+
+    private _particleSystemDirectMatrixUpdate(dw: Nullable<DrawWrapper>, viewMatrix: Matrix, projectionMatrix: Matrix, camera: Camera) {
+        const effect = dw?.effect;
+        if (!effect || !dw) {
+            return;
+        }
+        const dataBuffer = (dw.drawContext as WebGPUDrawContext)?.buffers?.["LeftOver" satisfies (typeof WebGPUShaderProcessor)["LeftOvertUBOName"]];
+        const ubLeftOver = (effect._pipelineContext as WebGPUPipelineContext)?.uniformBuffer;
+        if (!dataBuffer || !ubLeftOver || !ubLeftOver.setDataBuffer(dataBuffer)) {
+            return;
+        }
+        effect.setMatrix("view", viewMatrix);
+        effect.setMatrix("projection", projectionMatrix);
+        const defines = effect.defines;
+        if (defines && defines.indexOf("#define BILLBOARD") >= 0) {
+            effect.setVector3("eyePosition", camera.globalPosition);
+        }
+        if (defines && defines.indexOf("#define BILLBOARDMODE_ALL") >= 0) {
+            const invView = TmpVectors.Matrix[0];
+            viewMatrix.invertToRef(invView);
+            effect.setMatrix("invView", invView);
+        }
+        ubLeftOver.update();
     }
 
     private _executeAtFrame(frameId: number, func: () => void, mode: "whenEnabled" | "whenDisabled" = "whenEnabled") {

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -209,6 +209,7 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
      * This makes the particle system compatible with FAST snapshot rendering, where the recorded draw call parameters
      * are baked into the GPU bundle. Activate via `SnapshotRenderingHelper.fixParticleSystem(ps)`.
      * Note: vertex shader cost scales with capacity rather than the live particle count, so size capacity realistically.
+     * This property is runtime-only and is not persisted by `serialize()` / `Parse()`.
      */
     public get useFixedCapacityForSnapshot(): boolean {
         return this._useFixedCapacityForSnapshot;

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -200,6 +200,23 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
     private _alive: boolean;
     private _useInstancing = false;
     private _vertexArrayObject: Nullable<WebGLVertexArrayObject>;
+    private _useFixedCapacityForSnapshot = false;
+
+    /**
+     * Gets or sets a boolean indicating that the particle system should always render at full capacity.
+     * When enabled, the draw call always emits `getCapacity()` quads/instances and inactive slots are zero-filled in the
+     * vertex buffer (collapsing them to degenerate triangles that produce no fragments).
+     * This makes the particle system compatible with FAST snapshot rendering, where the recorded draw call parameters
+     * are baked into the GPU bundle. Activate via `SnapshotRenderingHelper.fixParticleSystem(ps)`.
+     * Note: vertex shader cost scales with capacity rather than the live particle count, so size capacity realistically.
+     */
+    public get useFixedCapacityForSnapshot(): boolean {
+        return this._useFixedCapacityForSnapshot;
+    }
+
+    public set useFixedCapacityForSnapshot(value: boolean) {
+        this._useFixedCapacityForSnapshot = value;
+    }
 
     private _isDisposed = false;
 
@@ -2058,7 +2075,19 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
             }
 
             if (this._vertexBuffer) {
-                this._vertexBuffer.updateDirectly(this._vertexData, 0, this._particles.length);
+                if (this._useFixedCapacityForSnapshot) {
+                    // Zero-fill inactive slots so they collapse to degenerate (size=0) quads that emit no fragments,
+                    // and upload the full capacity so the draw call can stay constant for FAST snapshot rendering.
+                    const stride = this._vertexBufferSize * (this._useInstancing ? 1 : 4);
+                    const usedFloats = this._particles.length * stride;
+                    const totalFloats = this._capacity * stride;
+                    if (usedFloats < totalFloats) {
+                        this._vertexData.fill(0, usedFloats, totalFloats);
+                    }
+                    this._vertexBuffer.updateDirectly(this._vertexData, 0, this._capacity);
+                } else {
+                    this._vertexBuffer.updateDirectly(this._vertexData, 0, this._particles.length);
+                }
             }
         }
 
@@ -2250,13 +2279,13 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
             if (this._scene?.forceWireframe) {
                 engine.drawElementsType(Constants.MATERIAL_LineStripDrawMode, 0, 10, this._particles.length);
             } else {
-                engine.drawArraysType(Constants.MATERIAL_TriangleStripDrawMode, 0, 4, this._particles.length);
+                engine.drawArraysType(Constants.MATERIAL_TriangleStripDrawMode, 0, 4, this._useFixedCapacityForSnapshot ? this._capacity : this._particles.length);
             }
         } else {
             if (this._scene?.forceWireframe) {
                 engine.drawElementsType(Constants.MATERIAL_WireFrameFillMode, 0, this._particles.length * 10);
             } else {
-                engine.drawElementsType(Constants.MATERIAL_TriangleFillMode, 0, this._particles.length * 6);
+                engine.drawElementsType(Constants.MATERIAL_TriangleFillMode, 0, (this._useFixedCapacityForSnapshot ? this._capacity : this._particles.length) * 6);
             }
         }
 
@@ -2269,7 +2298,7 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
      */
     public render(): number {
         // Check
-        if (!this.isReady() || !this._particles.length) {
+        if (!this.isReady() || (!this._particles.length && !this._useFixedCapacityForSnapshot)) {
             return 0;
         }
 

--- a/packages/dev/core/src/Particles/thinParticleSystem.ts
+++ b/packages/dev/core/src/Particles/thinParticleSystem.ts
@@ -201,6 +201,7 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
     private _useInstancing = false;
     private _vertexArrayObject: Nullable<WebGLVertexArrayObject>;
     private _useFixedCapacityForSnapshot = false;
+    private _fixedCapacityHighWaterMark = 0;
 
     /**
      * Gets or sets a boolean indicating that the particle system should always render at full capacity.
@@ -2077,13 +2078,18 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
 
             if (this._vertexBuffer) {
                 if (this._useFixedCapacityForSnapshot) {
-                    // Zero-fill inactive slots so they collapse to degenerate (size=0) quads that emit no fragments,
-                    // and upload the full capacity so the draw call can stay constant for FAST snapshot rendering.
+                    // The vertex buffer is uploaded at full capacity so the FAST-snapshot bundle's draw call stays valid.
+                    // Inactive slots must be zeroed so they collapse to degenerate (size=0) quads that emit no fragments.
+                    // Float32Array starts zeroed and `_appendParticleVertices` overwrites only the active range, so we
+                    // only need to clear slots that were active in a previous frame and aren't anymore — i.e. the range
+                    // [currentCount, highWaterMark). When the active count grows we just bump the high-water mark.
                     const stride = this._vertexBufferSize * (this._useInstancing ? 1 : 4);
-                    const usedFloats = this._particles.length * stride;
-                    const totalFloats = this._capacity * stride;
-                    if (usedFloats < totalFloats) {
-                        this._vertexData.fill(0, usedFloats, totalFloats);
+                    const currentCount = this._particles.length;
+                    if (currentCount < this._fixedCapacityHighWaterMark) {
+                        this._vertexData.fill(0, currentCount * stride, this._fixedCapacityHighWaterMark * stride);
+                    }
+                    if (currentCount > this._fixedCapacityHighWaterMark) {
+                        this._fixedCapacityHighWaterMark = currentCount;
                     }
                     this._vertexBuffer.updateDirectly(this._vertexData, 0, this._capacity);
                 } else {
@@ -2278,13 +2284,13 @@ export class ThinParticleSystem extends BaseParticleSystem implements IDisposabl
 
         if (this._useInstancing) {
             if (this._scene?.forceWireframe) {
-                engine.drawElementsType(Constants.MATERIAL_LineStripDrawMode, 0, 10, this._particles.length);
+                engine.drawElementsType(Constants.MATERIAL_LineStripDrawMode, 0, 10, this._useFixedCapacityForSnapshot ? this._capacity : this._particles.length);
             } else {
                 engine.drawArraysType(Constants.MATERIAL_TriangleStripDrawMode, 0, 4, this._useFixedCapacityForSnapshot ? this._capacity : this._particles.length);
             }
         } else {
             if (this._scene?.forceWireframe) {
-                engine.drawElementsType(Constants.MATERIAL_WireFrameFillMode, 0, this._particles.length * 10);
+                engine.drawElementsType(Constants.MATERIAL_WireFrameFillMode, 0, (this._useFixedCapacityForSnapshot ? this._capacity : this._particles.length) * 10);
             } else {
                 engine.drawElementsType(Constants.MATERIAL_TriangleFillMode, 0, (this._useFixedCapacityForSnapshot ? this._capacity : this._particles.length) * 6);
             }


### PR DESCRIPTION
## Summary

Adds support for CPU `ParticleSystem` instances under `SnapshotRenderingHelper` (FAST snapshot mode, WebGPU). Follows the same pattern as how SpriteRenderer is supported in FAST snapshot mode.

## Approach

- New opt-in flag `ThinParticleSystem.useFixedCapacityForSnapshot`. When set, the particle system always uploads `capacity` quads/instances and emits a draw call sized for the full capacity. Inactive slots are zero-filled, collapsing them into degenerate (size = 0) quads that produce no fragments.
- New helper API `SnapshotRenderingHelper.fixParticleSystem(ps)` flips the flag and registers the system to receive per-frame camera-uniform refreshes (view / projection, plus `eyePosition` and `invView` when the effect uses billboards). Tracking mirrors the existing sprite-manager pattern: the helper iterates `scene.particleSystems` each frame and acts on those whose flag is set, so disposed systems naturally drop out without explicit cleanup.
- Billboard `defines` are scanned once per `Effect` and cached in a `WeakMap`, so the per-frame path does only setMatrix/setVector calls and one UBO update.

## Limitations

- WebGPU only (matches the rest of `SnapshotRenderingHelper`). No-op on WebGL.
- CPU `ParticleSystem` only — `GPUParticleSystem` is rejected with a debug log.
- Vertex shader cost scales with `capacity`, not the live count, so capacity should be sized realistically.
- Per-frame uniforms other than camera matrices (e.g. `textureMask`, `translationPivot`, clip planes, fog) are baked at recording time.
- Must be called before `enableSnapshotRendering()`, same convention as the rest of the helper.
- Flag is runtime-only; not persisted by `serialize()` / `Parse()`.

## Example

https://github.com/user-attachments/assets/5f32b49a-88c2-4b95-a373-10cd954c07a9

