### PR TITLE
fix(dev): bundle gltf2interface stub and emit usable sourcemaps in dev UMD builds

### DIFF
--- a/packages/public/glTF2Interface/babylonjs-gltf2interface.stub.ts
+++ b/packages/public/glTF2Interface/babylonjs-gltf2interface.stub.ts
@@ -20,3 +20,7 @@ export const TextureMinFilter = { NEAREST: 9728, LINEAR: 9729, NEAREST_MIPMAP_NE
 export const TextureWrapMode = { CLAMP_TO_EDGE: 33071, MIRRORED_REPEAT: 33648, REPEAT: 10497 };
 export const ImageMimeType = { JPEG: "image/jpeg", PNG: "image/png", WEBP: "image/webp" };
 export const KHRLightsPunctual_LightType = { DIRECTIONAL: "directional", POINT: "point", SPOT: "spot" };
+export const EXTLightsArea_LightType = { RECT: "rect", DISK: "disk" };
+export const IMSFTAudioEmitter_DistanceModel = { linear: "linear", inverse: "inverse", exponential: "exponential" };
+export const IMSFTAudioEmitter_AudioMimeType = { WAV: "audio/wav" };
+export const IMSFTAudioEmitter_AnimationEventAction = { play: "play", pause: "pause", stop: "stop" };

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -18,7 +18,7 @@ import postcss from "rollup-plugin-postcss";
 import url from "@rollup/plugin-url";
 import { copyFileSync, existsSync } from "fs";
 import { resolve, join, dirname, relative as pathRelative } from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { transform as esbuildTransform } from "esbuild";
 
 // Repo root — used as the filterRoot for @rollup/plugin-typescript so that
@@ -548,7 +548,9 @@ export function commonUMDRollupConfiguration(options) {
         const abs = resolve(dirname(sourcemapPath), relativePath);
         const repoRel = relativeFromRepoRoot(abs);
         if (repoRel.startsWith("..")) {
-            return `file://${abs}`;
+            // Use pathToFileURL so Windows paths (drive letter + backslashes)
+            // become a valid `file:///C:/...` URL that debuggers can resolve.
+            return pathToFileURL(abs).href;
         }
         return `webpack:///./${repoRel}`;
     };

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -17,7 +17,7 @@ import terser from "@rollup/plugin-terser";
 import postcss from "rollup-plugin-postcss";
 import url from "@rollup/plugin-url";
 import { copyFileSync, existsSync } from "fs";
-import { resolve, join, dirname } from "path";
+import { resolve, join, dirname, relative as pathRelative } from "path";
 import { fileURLToPath } from "url";
 import { transform as esbuildTransform } from "esbuild";
 
@@ -25,6 +25,11 @@ import { transform as esbuildTransform } from "esbuild";
 // `**/*.ts` patterns are matched against repo-relative paths (which never start
 // with "..") regardless of where in the monorepo the file being compiled lives.
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** Returns `absPath` rewritten as a forward-slash repo-relative path. */
+function relativeFromRepoRoot(absPath) {
+    return pathRelative(REPO_ROOT, absPath).split("\\").join("/");
+}
 
 // ---------------------------------------------------------------------------
 // Package name mappings
@@ -169,16 +174,29 @@ function resolveSubPathNamespace(source, pkg) {
  * corresponding global so the UMD output receives the correct namespace.
  *
  * @param {string[]} excludePackages Dev package names to bundle rather than externalize.
+ * @param {object} [opts]
+ * @param {boolean} [opts.bundleGltf2Interface]
+ *   When true, do NOT externalize `babylonjs-gltf2interface` — let the alias
+ *   plugin redirect it to the JS stub at packages/public/glTF2Interface/
+ *   babylonjs-gltf2interface.stub.ts so its const-enum values are bundled as
+ *   real runtime values.  Required for fast-rebuild paths (esbuild) that
+ *   cannot inline TS const enums.  In production builds this stays false so
+ *   the UMD output continues to reference `BABYLON.GLTF2`.
  */
-export function babylonUMDExternalsPlugin(excludePackages = []) {
+export function babylonUMDExternalsPlugin(excludePackages = [], opts = {}) {
+    const { bundleGltf2Interface = false } = opts;
     /** Extra globals discovered via sub-path namespace resolution. */
     const extraGlobals = {};
 
     return {
         name: "babylon-umd-externals",
         resolveId(source) {
-            // gltf2interface is always external
+            // gltf2interface — externalize by default (production), or fall
+            // through to the alias plugin (dev) so the stub is bundled.
             if (source.includes("babylonjs-gltf2interface")) {
+                if (bundleGltf2Interface) {
+                    return null;
+                }
                 return { id: "babylonjs-gltf2interface", external: true };
             }
             // Extract the leading package name segment (e.g. "core" from "core/Legacy/legacy")
@@ -425,12 +443,20 @@ export function commonUMDRollupConfiguration(options) {
     // Path to source for the package being built
     const defaultAliasSrc = devPackageAliasPath ?? `../../../dev/${camelize(devPackageName)}/src`;
 
+    // In devMode (esbuild transpilation) const enums from babylonjs-gltf2interface
+    // are NOT inlined, so we must bundle a JS stub that provides the runtime values.
+    // In production (tsc) the const-enum values are inlined and the package stays
+    // externalized to BABYLON.GLTF2 (see babylonUMDExternalsPlugin).
+    const bundleGltf2Interface = devMode && !production;
+    const gltf2InterfaceStub = resolve(REPO_ROOT, "packages/public/glTF2Interface/babylonjs-gltf2interface.stub.ts");
+
     const aliasEntries = [
         { find: devPackageName, replacement: resolve(defaultAliasSrc) },
         ...Object.entries(aliasMap).map(([find, replacement]) => ({
             find,
             replacement: resolve(replacement),
         })),
+        ...(bundleGltf2Interface ? [{ find: "babylonjs-gltf2interface", replacement: gltf2InterfaceStub }] : []),
     ];
 
     /**
@@ -455,7 +481,7 @@ export function commonUMDRollupConfiguration(options) {
 
     const chunkNames = entryPoints ? Object.keys(entryPoints) : [devPackageName];
 
-    const externalsPlugin = babylonUMDExternalsPlugin([devPackageName, ...optionalExternalFunctionSkip]);
+    const externalsPlugin = babylonUMDExternalsPlugin([devPackageName, ...optionalExternalFunctionSkip], { bundleGltf2Interface });
 
     /**
      * Globals resolver used as Rollup's `output.globals` option.
@@ -466,7 +492,7 @@ export function commonUMDRollupConfiguration(options) {
     // In devMode, use esbuild for fast type-stripping transpilation instead of tsc.
     const useEsbuild = devMode && !production;
     const transpilePlugins = useEsbuild
-        ? [esbuildTranspilePlugin({ sourceMap: !devMode })]
+        ? [esbuildTranspilePlugin({ sourceMap: true })]
         : [
               typescript({
                   tsconfig: "tsconfig.build.json",
@@ -512,6 +538,21 @@ export function commonUMDRollupConfiguration(options) {
      * UMD format does not support code-splitting (multiple inputs), so we emit
      * one config per entry and return an array when entryPoints is provided.
      */
+    // Rewrite sourcemap source paths so VS Code's js-debug can resolve them
+    // back to disk for breakpoint binding.  We emit `webpack:///./packages/...`
+    // URLs because js-debug's default sourceMapPathOverrides already maps
+    // `webpack:///./*` → `${webRoot}/*`, so no per-launch-config setup is
+    // required for files inside packages/.  Sources outside the repo (rare,
+    // e.g. some tslib re-exports) fall through to an absolute file:// URL.
+    const sourcemapPathTransform = (relativePath, sourcemapPath) => {
+        const abs = resolve(dirname(sourcemapPath), relativePath);
+        const repoRel = relativeFromRepoRoot(abs);
+        if (repoRel.startsWith("..")) {
+            return `file://${abs}`;
+        }
+        return `webpack:///./${repoRel}`;
+    };
+
     const makeSingleConfig = (inputFile, chunkName) => ({
         input: inputFile,
         output: {
@@ -520,7 +561,8 @@ export function commonUMDRollupConfiguration(options) {
             name: outputName,
             globals: resolveGlobal,
             exports: "named",
-            sourcemap: !devMode,
+            sourcemap: true,
+            sourcemapPathTransform,
             // extend:true makes Rollup emit `global.BABYLON = global.BABYLON || {}`
             // instead of `global.BABYLON = {}`, so each bundle merges into the shared
             // namespace rather than overwriting the previous bundle's exports.
@@ -542,7 +584,7 @@ export function commonUMDRollupConfiguration(options) {
         // The copyMinToMaxPlugin is only attached to the first config to avoid
         // copying the same files multiple times.
         return Object.entries(entryPoints).map(([chunkName, inputFile], i) => {
-            const perEntryExternals = babylonUMDExternalsPlugin([devPackageName, ...optionalExternalFunctionSkip]);
+            const perEntryExternals = babylonUMDExternalsPlugin([devPackageName, ...optionalExternalFunctionSkip], { bundleGltf2Interface });
             const perEntryResolveGlobal = (id) => perEntryExternals.globals[id] ?? umdGlobals[id] ?? id;
             // In devMode, esbuild is stateless so the shared transpilePlugins can be reused.
             // In non-devMode, each entry needs its own tsc plugin instance.
@@ -587,7 +629,8 @@ export function commonUMDRollupConfiguration(options) {
                     name: outputName,
                     globals: perEntryResolveGlobal,
                     exports: "named",
-                    sourcemap: !devMode,
+                    sourcemap: true,
+                    sourcemapPathTransform,
                     extend: true,
                     // Inline any dynamic imports so UMD format (which forbids code-splitting) is happy.
                     inlineDynamicImports: true,

--- a/packages/tools/babylonServer/vite.config.ts
+++ b/packages/tools/babylonServer/vite.config.ts
@@ -302,14 +302,35 @@ function babylonServerPlugin(): Plugin {
                     const jsUrl = url.replace(/\.map$/, "");
                     const jsEntry = umdUrlMap[jsUrl];
                     if (jsEntry) {
-                        const mapPath = path.join(UMD_ROOT, jsEntry.dir, jsEntry.file + ".map");
-                        if (fs.existsSync(mapPath)) {
-                            log(200, "/" + url, "sourcemap");
-                            res.setHeader("Content-Type", "application/json");
-                            res.setHeader("Access-Control-Allow-Origin", "*");
-                            sendFile(mapPath, res);
-                            return;
+                        // The map file may be named after the served file (e.g. babylon.max.js.map)
+                        // OR after the original rollup output (e.g. babylon.js.map / babylon.min.js.map),
+                        // depending on whether copyMinToMaxPlugin ran for this entry.  Try both.
+                        const candidates = [
+                            jsEntry.file + ".map",
+                            jsEntry.file.replace(/\.max\.js$/, ".js") + ".map",
+                            jsEntry.file.replace(/\.js$/, ".min.js") + ".map",
+                            jsEntry.file.replace(/\.min\.js$/, ".js") + ".map",
+                        ];
+                        for (const candidate of candidates) {
+                            const mapPath = path.join(UMD_ROOT, jsEntry.dir, candidate);
+                            if (fs.existsSync(mapPath)) {
+                                log(200, "/" + url, "sourcemap");
+                                res.setHeader("Content-Type", "application/json");
+                                res.setHeader("Access-Control-Allow-Origin", "*");
+                                sendFile(mapPath, res);
+                                return;
+                            }
                         }
+                        // No sourcemap exists for this UMD bundle.  Return 404 with an
+                        // empty JSON body so DevTools doesn't try to parse Vite's SPA
+                        // fallback HTML as JSON (which is the source of "Unexpected
+                        // token '<'" warnings in the browser console).
+                        log(404, "/" + url, "sourcemap missing");
+                        res.statusCode = 404;
+                        res.setHeader("Content-Type", "application/json");
+                        res.setHeader("Access-Control-Allow-Origin", "*");
+                        res.end("{}");
+                        return;
                     }
                 }
 


### PR DESCRIPTION
## Problem

After the webpack → Vite migration of the dev servers, two regressions surfaced:

1. **`Cannot read properties of undefined (reading 'AccessorType')`** when loading GLBs in dev. Root cause: in dev:fast UMD builds we use esbuild for transpilation, which (unlike `tsc`) does not inline `const enum`s. `babylonjs-gltf2interface` is a types-only package, and the externals plugin marked it external, so loaders evaluated to `BABYLON.GLTF2.AccessorType.SCALAR` etc. before `legacy-glTF2.ts` set up `BABYLON.GLTF2 = BABYLON.GLTF2 || {}`.
2. **VS Code breakpoints in `packages/dev/**` did not bind**, and DevTools logged `Could not read source map for http://localhost:1337/babylon.js: Unexpected token '<'`. Two causes: dev:fast was emitting no sourcemaps at all, and when a map was missing the babylonServer middleware fell through to Vite's SPA HTML, which DevTools tried to parse as JSON.

## Fix

- **`packages/public/rollupUMDHelper.mjs`**
  - In devMode, alias `babylonjs-gltf2interface` to the existing JS stub (`packages/public/glTF2Interface/babylonjs-gltf2interface.stub.ts`) instead of marking it external. The externals plugin now accepts a `bundleGltf2Interface` flag that lets the alias take over.
  - Always emit sourcemaps in dev (`sourcemap: true`, was `!devMode`).
  - Add a `sourcemapPathTransform` that rewrites paths to `webpack:///./<repo-relative>`, which matches the js-debug default `webpack:///./*` → `${webRoot}/*` override so breakpoints bind without any `launch.json` customization.
  - Production rollup path is **unchanged**: `gltf2interface` remains external and `tsc` continues to inline its const enums.
- **`packages/public/glTF2Interface/babylonjs-gltf2interface.stub.ts`** — added the missing const-enum runtime exports needed by loaders/serializers (TextureMagFilter, TextureMinFilter, TextureWrapMode, AnimationSamplerInterpolation, plus a few others).
- **`packages/tools/babylonServer/vite.config.ts`** — sourcemap middleware now tries multiple candidate filenames (`.js.map`, `.max.js.map`, `.min.js.map`) and returns an empty JSON `404` instead of falling through to the SPA HTML when nothing matches.

## Verification

- `grep -c "babylonjs-gltf2interface" packages/public/umd/babylonjs-loaders/babylonjs.loaders.js` → `0` (stub inlined).
- Stub values present in dev bundle: `"VEC4"`, `"SCALAR"`, etc.
- Production build unchanged: `npm run build:prod -w babylonjs-loaders` still produces a min.js with `0` references to `babylonjs-gltf2interface`.
- Source paths in fresh dev maps: `webpack:///./packages/dev/loaders/src/...` — js-debug binds breakpoints to the workspace files using its defaults.
- GLB loading in the sandbox no longer throws `AccessorType` undefined.

## Scope

Dev-server / dev:fast only. No runtime, public-API, or production-build changes.
