### PR TITLE
Fix WebGPU CSM shader view uniform fallback

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/shadowsVertex.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/shadowsVertex.fx
@@ -1,6 +1,10 @@
 #ifdef SHADOWS
 	#if defined(SHADOWCSM{X})
-		vertexOutputs.vPositionFromCamera{X} = scene.view * worldPos;
+		#ifdef SCENE_UBO
+			vertexOutputs.vPositionFromCamera{X} = scene.view * worldPos;
+		#else
+			vertexOutputs.vPositionFromCamera{X} = uniforms.view * worldPos;
+		#endif
 		#if SHADOWCSMNUM_CASCADES{X} > 0
 			vertexOutputs.vPositionFromLight{X}_0 = uniforms.lightMatrix{X}[0] * worldPos;
             #ifdef USE_REVERSE_DEPTHBUFFER

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuShaderProcessorWGSL.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuShaderProcessorWGSL.test.ts
@@ -189,7 +189,7 @@ describe("WebGPUShaderProcessorWGSL", () => {
 
     describe("cascaded shadow vertex include", () => {
         it("should use uniforms.view when the scene uniform buffer is not declared", () => {
-            const shadowsVertex = readFileSync("packages/dev/core/src/ShadersWGSL/ShadersInclude/shadowsVertex.fx", "utf8");
+            const shadowsVertex = readFileSync(new URL("../../../../src/ShadersWGSL/ShadersInclude/shadowsVertex.fx", import.meta.url), "utf8");
 
             expect(shadowsVertex).toContain("#ifdef SCENE_UBO");
             expect(shadowsVertex).toContain("vertexOutputs.vPositionFromCamera{X} = scene.view * worldPos;");

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuShaderProcessorWGSL.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuShaderProcessorWGSL.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { readFileSync } from "fs";
 import { WebGPUShaderProcessorWGSL } from "core/Engines/WebGPU/webgpuShaderProcessorsWGSL";
 import { WebGPUShaderProcessingContext } from "core/Engines/WebGPU/webgpuShaderProcessingContext";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -183,6 +184,17 @@ describe("WebGPUShaderProcessorWGSL", () => {
             const layoutEntry = context.bindGroupLayoutEntries[0][0];
             expect(layoutEntry.storageTexture!.access).toBe("read-only");
             expect(layoutEntry.storageTexture!.format).toBe("rgba32float");
+        });
+    });
+
+    describe("cascaded shadow vertex include", () => {
+        it("should use uniforms.view when the scene uniform buffer is not declared", () => {
+            const shadowsVertex = readFileSync("packages/dev/core/src/ShadersWGSL/ShadersInclude/shadowsVertex.fx", "utf8");
+
+            expect(shadowsVertex).toContain("#ifdef SCENE_UBO");
+            expect(shadowsVertex).toContain("vertexOutputs.vPositionFromCamera{X} = scene.view * worldPos;");
+            expect(shadowsVertex).toContain("#else");
+            expect(shadowsVertex).toContain("vertexOutputs.vPositionFromCamera{X} = uniforms.view * worldPos;");
         });
     });
 });


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Problem

Babylon.js 9.5.0 can fail to start WebGPU scenes that use cascaded shadows on WGSL material paths without the scene uniform buffer. The `shadowsVertex` CSM include emits `scene.view`, but materials such as `SimpleMaterial` expose the view matrix through the leftovers uniform buffer as `uniforms.view` instead.

Forum report: https://forum.babylonjs.com/t/webgpu-uncaptured-error-version-9-5-seems-to-break-i-dont-have-any-more-scenes-that-start/63313
Repro PG: https://playground.babylonjs.com/?webgpu#ARKTK1#0

## Fix

Guard the CSM `vPositionFromCamera` assignment on `SCENE_UBO`: use `scene.view` when the scene UBO exists, otherwise fall back to `uniforms.view`.

## Validation

- `npm run build:shaders`
- `npx eslint packages\dev\core\test\unit\Engines\WebGPU\webgpuShaderProcessorWGSL.test.ts --quiet --cache`
- `npx vitest run --project=unit packages\dev\core\test\unit\Engines\WebGPU\webgpuShaderProcessorWGSL.test.ts`

Note: full `npm run lint:check` currently fails on unrelated pre-existing `curly` errors in `packages\tools\babylonServer\src\createScene.js`.
