### PR TITLE
fix: editor launches from inspector-v2 (NRGE URL + GUI editor destructure)

### DIFF
--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
@@ -58,8 +58,16 @@ export class NodeRenderGraph {
     /** @returns the inspector from bundle or global */
     private _getGlobalNodeRenderGraphEditor(): any {
         // UMD Global name detection from Webpack Bundle UMD Name.
+        // Note: rollup-built UMD bundles do not expose the editor class
+        // directly on the namespace - it lives on `.default.NodeRenderGraphEditor` -
+        // so we unwrap that case before falling back to the BABYLON global.
         if (typeof NODERENDERGRAPHEDITOR !== "undefined") {
-            return NODERENDERGRAPHEDITOR;
+            if ((NODERENDERGRAPHEDITOR as any).NodeRenderGraphEditor) {
+                return NODERENDERGRAPHEDITOR;
+            }
+            if ((NODERENDERGRAPHEDITOR as any).default?.NodeRenderGraphEditor) {
+                return (NODERENDERGRAPHEDITOR as any).default;
+            }
         }
 
         // In case of module let's check the global emitted from the editor entry point.

--- a/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
+++ b/packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts
@@ -45,7 +45,7 @@ export class NodeRenderGraph {
     private _buildId: number = NodeRenderGraph._BuildIdGenerator++;
 
     /** Define the Url to load node editor script */
-    public static EditorURL = `${Tools._DefaultCdnUrl}/v${Engine.Version}/NodeRenderGraph/babylon.nodeRenderGraph.js`;
+    public static EditorURL = `${Tools._DefaultCdnUrl}/v${Engine.Version}/nodeRenderGraphEditor/babylon.nodeRenderGraphEditor.js`;
 
     /** Define the Url to load snippets */
     public static SnippetUrl = Constants.SnippetUrl;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -317,8 +317,16 @@ export class NodeMaterial extends NodeMaterialBase {
      */
     private _getGlobalNodeMaterialEditor(): any {
         // UMD Global name detection from Webpack Bundle UMD Name.
+        // Note: rollup-built UMD bundles do not expose the editor class
+        // directly on the namespace - it lives on `.default.NodeEditor` -
+        // so we unwrap that case before falling back to the BABYLON global.
         if (typeof NODEEDITOR !== "undefined") {
-            return NODEEDITOR;
+            if ((NODEEDITOR as any).NodeEditor) {
+                return NODEEDITOR;
+            }
+            if ((NODEEDITOR as any).default?.NodeEditor) {
+                return (NODEEDITOR as any).default;
+            }
         }
 
         // In case of module let's check the global emitted from the editor entry point.

--- a/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
+++ b/packages/dev/core/src/Meshes/Node/nodeGeometry.ts
@@ -60,8 +60,16 @@ export class NodeGeometry {
     /** @returns the inspector from bundle or global */
     private _getGlobalNodeGeometryEditor(): any {
         // UMD Global name detection from Webpack Bundle UMD Name.
+        // Note: rollup-built UMD bundles do not expose the editor class
+        // directly on the namespace - it lives on `.default.NodeGeometryEditor` -
+        // so we unwrap that case before falling back to the BABYLON global.
         if (typeof NODEGEOMETRYEDITOR !== "undefined") {
-            return NODEGEOMETRYEDITOR;
+            if ((NODEGEOMETRYEDITOR as any).NodeGeometryEditor) {
+                return NODEGEOMETRYEDITOR;
+            }
+            if ((NODEGEOMETRYEDITOR as any).default?.NodeGeometryEditor) {
+                return (NODEGEOMETRYEDITOR as any).default;
+            }
         }
 
         // In case of module let's check the global emitted from the editor entry point.

--- a/packages/dev/core/src/Particles/Node/nodeParticleSystemSet.ts
+++ b/packages/dev/core/src/Particles/Node/nodeParticleSystemSet.ts
@@ -200,8 +200,16 @@ export class NodeParticleSystemSet {
      */
     private _getGlobalNodeParticleEditor(): any {
         // UMD Global name detection from Webpack Bundle UMD Name.
+        // Note: rollup-built UMD bundles do not expose the editor class
+        // directly on the namespace - it lives on `.default.NodeParticleEditor` -
+        // so we unwrap that case before falling back to the BABYLON global.
         if (typeof NODEPARTICLEEDITOR !== "undefined") {
-            return NODEPARTICLEEDITOR;
+            if ((NODEPARTICLEEDITOR as any).NodeParticleEditor) {
+                return NODEPARTICLEEDITOR;
+            }
+            if ((NODEPARTICLEEDITOR as any).default?.NodeParticleEditor) {
+                return (NODEPARTICLEEDITOR as any).default;
+            }
         }
 
         // In case of module let's check the global emitted from the editor entry point.

--- a/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
@@ -72,6 +72,7 @@ export const AdvancedDynamicTexturePreviewProperties: FunctionComponent<{ textur
                     // The UMD inspector bundle externalizes "gui-editor/guiEditor" to BABYLON.GuiEditor,
                     // which is the GUIEditor class itself rather than a namespace { GUIEditor }.
                     // Tolerate both shapes so this works in both UMD and module builds.
+                    // eslint-disable-next-line @typescript-eslint/naming-convention
                     const guiEditorModule: { GUIEditor: typeof GUIEditor } | typeof GUIEditor = await import("gui-editor/guiEditor");
                     const guiEditor = "GUIEditor" in guiEditorModule ? guiEditorModule.GUIEditor : guiEditorModule;
                     await guiEditor.Show({ liveGuiTexture: texture });

--- a/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
@@ -68,8 +68,12 @@ export const AdvancedDynamicTexturePreviewProperties: FunctionComponent<{ textur
                 label="Edit GUI"
                 icon={EditRegular}
                 onClick={async () => {
-                    const { GUIEditor } = await import("gui-editor/guiEditor");
-                    await GUIEditor.Show({ liveGuiTexture: texture });
+                    // The UMD inspector bundle externalizes "gui-editor/guiEditor" to BABYLON.GuiEditor,
+                    // which is the GUIEditor class itself rather than a namespace { GUIEditor }.
+                    // Tolerate both shapes so this works in both UMD and module builds.
+                    const guiEditorModule: any = await import("gui-editor/guiEditor");
+                    const guiEditor = guiEditorModule.GUIEditor ?? guiEditorModule;
+                    await guiEditor.Show({ liveGuiTexture: texture });
                 }}
             />
         </>

--- a/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/textures/advancedDynamicTextureProperties.tsx
@@ -1,6 +1,7 @@
 import { type FunctionComponent, useCallback } from "react";
 
 import { type AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
+import { type GUIEditor } from "gui-editor/guiEditor";
 
 import { EditRegular } from "@fluentui/react-icons";
 import { ButtonLine } from "shared-ui-components/fluent/hoc/buttonLine";
@@ -71,8 +72,8 @@ export const AdvancedDynamicTexturePreviewProperties: FunctionComponent<{ textur
                     // The UMD inspector bundle externalizes "gui-editor/guiEditor" to BABYLON.GuiEditor,
                     // which is the GUIEditor class itself rather than a namespace { GUIEditor }.
                     // Tolerate both shapes so this works in both UMD and module builds.
-                    const guiEditorModule: any = await import("gui-editor/guiEditor");
-                    const guiEditor = guiEditorModule.GUIEditor ?? guiEditorModule;
+                    const guiEditorModule: { GUIEditor: typeof GUIEditor } | typeof GUIEditor = await import("gui-editor/guiEditor");
+                    const guiEditor = "GUIEditor" in guiEditorModule ? guiEditorModule.GUIEditor : guiEditorModule;
                     await guiEditor.Show({ liveGuiTexture: texture });
                 }}
             />

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -115,8 +115,12 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
                     icon: () => <EditRegular />,
                     // eslint-disable-next-line @typescript-eslint/naming-convention
                     execute: async () => {
-                        const { GUIEditor } = await import("gui-editor/guiEditor");
-                        await GUIEditor.Show({ liveGuiTexture: texture });
+                        // The UMD inspector bundle externalizes "gui-editor/guiEditor" to BABYLON.GuiEditor,
+                        // which is the GUIEditor class itself rather than a namespace { GUIEditor }.
+                        // Tolerate both shapes so this works in both UMD and module builds.
+                        const guiEditorModule: any = await import("gui-editor/guiEditor");
+                        const guiEditor = guiEditorModule.GUIEditor ?? guiEditorModule;
+                        await guiEditor.Show({ liveGuiTexture: texture });
                     },
                 };
             },

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -1,4 +1,5 @@
 import { type AdvancedDynamicTexture, type Container, type Control } from "gui/index";
+import { type GUIEditor } from "gui-editor/guiEditor";
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
 import { type ISceneContext, SceneContextIdentity } from "../../sceneContext";
 import { type IWatcherService, WatcherServiceIdentity } from "../../watcherService";
@@ -118,8 +119,8 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
                         // The UMD inspector bundle externalizes "gui-editor/guiEditor" to BABYLON.GuiEditor,
                         // which is the GUIEditor class itself rather than a namespace { GUIEditor }.
                         // Tolerate both shapes so this works in both UMD and module builds.
-                        const guiEditorModule: any = await import("gui-editor/guiEditor");
-                        const guiEditor = guiEditorModule.GUIEditor ?? guiEditorModule;
+                        const guiEditorModule: { GUIEditor: typeof GUIEditor } | typeof GUIEditor = await import("gui-editor/guiEditor");
+                        const guiEditor = "GUIEditor" in guiEditorModule ? guiEditorModule.GUIEditor : guiEditorModule;
                         await guiEditor.Show({ liveGuiTexture: texture });
                     },
                 };

--- a/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx
@@ -119,6 +119,7 @@ export const GuiExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplorer
                         // The UMD inspector bundle externalizes "gui-editor/guiEditor" to BABYLON.GuiEditor,
                         // which is the GUIEditor class itself rather than a namespace { GUIEditor }.
                         // Tolerate both shapes so this works in both UMD and module builds.
+                        // eslint-disable-next-line @typescript-eslint/naming-convention
                         const guiEditorModule: { GUIEditor: typeof GUIEditor } | typeof GUIEditor = await import("gui-editor/guiEditor");
                         const guiEditor = "GUIEditor" in guiEditorModule ? guiEditorModule.GUIEditor : guiEditorModule;
                         await guiEditor.Show({ liveGuiTexture: texture });

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -31,6 +31,32 @@ function relativeFromRepoRoot(absPath) {
     return pathRelative(REPO_ROOT, absPath).split("\\").join("/");
 }
 
+/**
+ * Rollup plugin that rewrites `import * as styles from "*.module.scss"` to
+ * `import styles from "*.module.scss"` so that bracket-notation access like
+ * `styles["graph-canvas"]` resolves against the CSS module's class-map default
+ * export instead of an empty namespace object.
+ *
+ * Mirrors the equivalent transform in `viteToolsHelper.mjs` so source code that
+ * uses webpack-style namespace imports keeps working under both build systems.
+ */
+function cssModuleNamespaceInteropPlugin() {
+    const IMPORT_NS_RE = /\bimport\s+\*\s+as\s+(\w+)\s+from\s+(["'][^"']+\.module\.(?:scss|css|less|sass)["'])/g;
+    return {
+        name: "css-module-namespace-interop",
+        transform(code, id) {
+            if (!/\.[tj]sx?$/.test(id)) {
+                return null;
+            }
+            if (!code.includes(".module.")) {
+                return null;
+            }
+            const newCode = code.replace(IMPORT_NS_RE, (_match, name, path) => `import ${name} from ${path}`);
+            return newCode !== code ? { code: newCode, map: null } : null;
+        },
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Package name mappings
 // ---------------------------------------------------------------------------
@@ -513,6 +539,9 @@ export function commonUMDRollupConfiguration(options) {
     const plugins = [
         externalsPlugin,
         aliasPlugin({ entries: aliasEntries }),
+        // Rewrite `import * as styles from "*.module.scss"` to a default import
+        // before TS/postcss see it (see plugin doc above).
+        cssModuleNamespaceInteropPlugin(),
         // Inline SVG/PNG/image assets imported from dist/ files as data URIs.
         url({ include: ["**/*.svg", "**/*.png", "**/*.jpg", "**/*.gif"], limit: Infinity }),
         // Handle SCSS/CSS imports from compiled dist/ files (tool packages).
@@ -610,6 +639,7 @@ export function commonUMDRollupConfiguration(options) {
             const perEntryPlugins = [
                 perEntryExternals,
                 aliasPlugin({ entries: aliasEntries }),
+                cssModuleNamespaceInteropPlugin(),
                 url({ include: ["**/*.svg", "**/*.png", "**/*.jpg", "**/*.gif"], limit: Infinity }),
                 postcss({ inject: true, extract: false, minimize: production, use: ["sass"], autoModules: true }),
                 ...perEntryTranspilePlugins,

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -516,8 +516,11 @@ export function commonUMDRollupConfiguration(options) {
         // Inline SVG/PNG/image assets imported from dist/ files as data URIs.
         url({ include: ["**/*.svg", "**/*.png", "**/*.jpg", "**/*.gif"], limit: Infinity }),
         // Handle SCSS/CSS imports from compiled dist/ files (tool packages).
-        // Extracts styles to a companion .css file alongside the UMD bundle.
-        postcss({ extract: true, minimize: production, use: ["sass"] }),
+        // Inject styles into <head> at runtime to match the previous webpack
+        // style-loader behavior - the editor UMDs do not have a companion
+        // <link> element loading a separate .css file. autoModules treats
+        // *.module.scss / *.module.css as CSS Modules with named exports.
+        postcss({ inject: true, extract: false, minimize: production, use: ["sass"], autoModules: true }),
         ...transpilePlugins,
         nodeResolve({ mainFields: ["browser", "module", "main"], browser: true, extensions: [".ts", ".tsx", ".js", ".jsx"] }),
         commonjs(),
@@ -608,7 +611,7 @@ export function commonUMDRollupConfiguration(options) {
                 perEntryExternals,
                 aliasPlugin({ entries: aliasEntries }),
                 url({ include: ["**/*.svg", "**/*.png", "**/*.jpg", "**/*.gif"], limit: Infinity }),
-                postcss({ extract: true, minimize: production, use: ["sass"] }),
+                postcss({ inject: true, extract: false, minimize: production, use: ["sass"], autoModules: true }),
                 ...perEntryTranspilePlugins,
                 nodeResolve({ mainFields: ["browser", "module", "main"], browser: true, extensions: [".ts", ".tsx", ".js", ".jsx"] }),
                 commonjs(),


### PR DESCRIPTION
## What

Fixes editor launches from `inspector-v2` (Node Render Graph Editor, Node Material Editor, Node Geometry Editor, Node Particle Editor, GUI Editor) and restores their styling and interactivity after the webpack → Vite/Rollup migration (#18398, #18372).

## Why

After the Vite migration, opening any editor from the new inspector failed with `Cannot read properties of undefined (reading 'Show')`. Once the editor opened, the panels were unstyled, unresizable, and the graph canvas didn't respond to interaction.

Root causes:

1. **NRGE** — `NodeRenderGraph.EditorURL` pointed at the wrong CDN path, so the script load 404'd.
2. **All four node editors** — the rollup-built UMD bundle exposes the editor class on `BABYLON.<NS>.default.<ClassName>`, not directly on `BABYLON.<NS>.<ClassName>`, so `_getGlobalNodeXxxEditor()` returned `undefined`.
3. **GUI editor** — the UMD inspector bundle externalises `gui-editor/guiEditor` to `BABYLON.GuiEditor`, which is the `GUIEditor` class itself, not a namespace `{ GUIEditor }`. The `const { GUIEditor } = await import(...)` destructure threw.
4. **Editor styling missing** — `rollup-plugin-postcss` was using `extract: true`, which writes a separate `.css` file the editor popups never load. (Webpack used `style-loader` to inject styles at runtime.)
5. **Editor panels not interactive** — even after switching to `inject: true + autoModules: true`, `import * as styles from "*.module.scss"` returned an empty namespace object instead of the class map (rollup-plugin-postcss exposes the map via the *default* export). Every CSS-module class lookup like `styles["graph-canvas"]` resolved to `undefined`, so the bundle rendered `<div id="graph-canvas" className={undefined}>` — no resize bars, no splitters, broken pointer-events on the canvas.

## What changed

- `packages/dev/core/src/FrameGraph/Node/nodeRenderGraph.ts` — corrected `EditorURL` and added a `.default` unwrap fallback in `_getGlobalNodeRenderGraphEditor`.
- `packages/dev/core/src/Materials/Node/nodeMaterial.ts`, `Meshes/Node/nodeGeometry.ts`, `Particles/Node/nodeParticleSystemSet.ts` — same `.default` unwrap pattern in their `_getGlobal…Editor` lookups.
- `packages/dev/inspector-v2/src/services/panes/scene/guiExplorerService.tsx` and `…/components/properties/textures/advancedDynamicTextureProperties.tsx` — tolerate both module shapes via a typed union `{ GUIEditor: typeof GUIEditor } | typeof GUIEditor` and a `"GUIEditor" in guiEditorModule` discriminator (keeps `.Show` type-checked).
- `packages/public/rollupUMDHelper.mjs`:
  - `postcss({ inject: true, extract: false, autoModules: true, … })` so styles are injected into `<head>` at runtime, matching the previous webpack `style-loader` behavior.
  - New `cssModuleNamespaceInteropPlugin()` (mirroring the equivalent transform already in `viteToolsHelper.mjs`) that rewrites `import * as styles from "*.module.scss"` to `import styles from "*.module.scss"`, so the class-map is read from the default export.

## Validation

- `npm run format:check` ✅
- `npm run lint:check` ✅
- Manually rebuilt all editor UMDs (`ROLLUP_DEVMODE=true npm run build:dev`) and verified each generated bundle now contains the CSS-module class map (e.g. `"graph-canvas":"graphCanvas-module_graph-canvas__q6u5u"`) plus the matching CSS rules (e.g. `cursor: row-resize` for the resize bars).
- Verified each editor opens from the inspector-v2, is fully styled, and supports panel resize / scroll / canvas interaction.
