### PR TITLE
fix(build): embed sourcesContent in production UMD sourcemaps

### DIFF
--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -292,6 +292,8 @@ function transpileExternalTsPlugin() {
                     esModuleInterop: true,
                     allowSyntheticDefaultImports: true,
                     experimentalDecorators: true,
+                    sourceMap: true,
+                    inlineSources: true,
                 },
             });
             return { code: result.outputText, map: result.sourceMapText || null };
@@ -499,7 +501,10 @@ export function commonUMDRollupConfiguration(options) {
                   declaration: false,
                   declarationMap: false,
                   sourceMap: true,
-                  inlineSources: false,
+                  // Embed source contents in the generated sourcemap so DevTools/playground
+                  // can display the original .ts files even when the relative source paths
+                  // (which start with `../../../../../../../`) cannot be fetched over HTTP.
+                  inlineSources: true,
                   // filterRoot set to the repo root so **/*.ts patterns match files from
                   // any package (including aliased cross-package tool sources).
                   filterRoot: REPO_ROOT,
@@ -598,7 +603,7 @@ export function commonUMDRollupConfiguration(options) {
                           declaration: false,
                           declarationMap: false,
                           sourceMap: true,
-                          inlineSources: false,
+                          inlineSources: true,
                           filterRoot: REPO_ROOT,
                           include: ["**/*.ts", "**/*.tsx"],
                       }),

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -549,15 +549,40 @@ export function commonUMDRollupConfiguration(options) {
     // `webpack:///./*` → `${webRoot}/*`, so no per-launch-config setup is
     // required for files inside packages/.  Sources outside the repo (rare,
     // e.g. some tslib re-exports) fall through to an absolute file:// URL.
+    //
+    // NOTE: When Rollup merges chained source maps from pre-compiled
+    // `packages/dev/*/dist/*.js.map` (which use `sources: ['../../src/foo.ts']`),
+    // the merged sources can end up as `…/dev/<pkg>/src/foo.ts` — i.e. lacking
+    // the `packages/` prefix — depending on how each plugin reports its sources.
+    // We pattern-match on `dev/<pkg>/src|dist/...` and `tools/<pkg>/src|dist/...`
+    // segments and rebuild a repo-relative path so the final sourcemap stays
+    // correct on both local builds and CI.
+    const PACKAGE_PATH_RE = /(?:^|[\\/])(dev|tools)[\\/]([^\\/]+)[\\/](src|dist)[\\/](.+)$/;
+    const tryRebaseToRepo = (anyPath) => {
+        const normalized = anyPath.split("\\").join("/");
+        const m = normalized.match(PACKAGE_PATH_RE);
+        if (!m) {
+            return null;
+        }
+        return `packages/${m[1]}/${m[2]}/${m[3]}/${m[4]}`;
+    };
     const sourcemapPathTransform = (relativePath, sourcemapPath) => {
         const abs = resolve(dirname(sourcemapPath), relativePath);
         const repoRel = relativeFromRepoRoot(abs);
-        if (repoRel.startsWith("..")) {
-            // Use pathToFileURL so Windows paths (drive letter + backslashes)
-            // become a valid `file:///C:/...` URL that debuggers can resolve.
-            return pathToFileURL(abs).href;
+        if (!repoRel.startsWith("..")) {
+            return `webpack:///./${repoRel}`;
         }
-        return `webpack:///./${repoRel}`;
+        // Fallback: try to recover a repo-relative path from the package layout
+        // baked into the sources (e.g. `…/dev/core/src/X.ts` → `packages/dev/core/src/X.ts`).
+        // This handles aliased/cross-package source paths like `core: ../../../dev/core/src`,
+        // which would otherwise resolve to a non-existent absolute path outside the repo.
+        const recovered = tryRebaseToRepo(abs) ?? tryRebaseToRepo(relativePath);
+        if (recovered) {
+            return `webpack:///./${recovered}`;
+        }
+        // Use pathToFileURL so Windows paths (drive letter + backslashes)
+        // become a valid `file:///C:/...` URL that debuggers can resolve.
+        return pathToFileURL(abs).href;
     };
 
     const makeSingleConfig = (inputFile, chunkName) => ({


### PR DESCRIPTION
## Problem

Source maps don't work in the playground / browser DevTools for any deployed Babylon UMD bundle on the CDN. Stack traces and the playground "View Source" panel show file names + line numbers but no code, because:

1. The recorded `sources` paths in the maps (e.g. `https://cdn.babylonjs.com/v9.5.0/babylon.js.map`) are deep relative paths like `../../../../../../../dev/core/src/Engines/constants.ts` that go seven levels above the bundle URL — there is nothing to fetch at that location.
2. `sourcesContent` is `null` for **2056 / 2057** entries in the v9.5.0 core map, so DevTools has no fallback content.

Combined effect: no source viewable.

## Cause

`@rollup/plugin-typescript` is configured with `inlineSources: false` in `rollupUMDHelper.mjs` (both the `makeSingleConfig` path and the per-entry path). Without `inlineSources`, TypeScript emits maps without embedded source contents, and rollup has nothing to merge. The fallback `transpileExternalTsPlugin` (used for aliased cross-package tool sources that are outside the tsconfig rootDir) likewise omits `sourceMap` / `inlineSources` from its `ts.transpileModule` compiler options.

## Fix

Set `inlineSources: true` in:

- both `@rollup/plugin-typescript` invocations (`commonUMDRollupConfiguration` shared + per-entry)
- `transpileExternalTsPlugin`'s `ts.transpileModule` options (also added the matching `sourceMap: true`)

## Verification

Clean prod build of `babylonjs` UMD on this branch:

```
total sources: 2057   null sourcesContent: 0
first source path: ../../../../../../../dev/core/src/Engines/constants.ts
first sourcesContent[0]: '/* eslint-disable @typescript-eslint/naming-convention */\r\n/** Defines the cross...'
```

vs. the deployed v9.5.0 map (`null sourcesContent: 2056`). With sources embedded, DevTools can render the original `.ts` file even without resolving the unfetchable relative paths.

## Trade-off

Maps grow because contents are embedded. They are only downloaded on demand by DevTools (and never by end-user runtime), so this should not affect production page loads.
