### PR TITLE
Fix clustered child light resync after parent enabled changes

### DIFF
--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -539,7 +539,11 @@ export class ClusteredLightContainer extends Light {
             Logger.Warn("Attempting to add a light to cluster that does not support clustering");
             return;
         }
-        light._isClusteredLight = true;
+        if (light._clusteredContainer) {
+            Logger.Warn("Attempting to add a light to a cluster that is already owned by a clustered light container");
+            return;
+        }
+        light._clusteredContainer = this;
         // scene.removeLight returns -1 if the light wasn't in scene.lights. In that case the
         // mesh.lightSources cleanup it normally performs didn't happen — but the light may still be
         // there: lights constructed with `dontAddToScene = true` are pushed into mesh.lightSources
@@ -580,7 +584,9 @@ export class ClusteredLightContainer extends Light {
         if (index !== -1) {
             this._lights.splice(index, 1);
             // We treat the unsorted array as the "real" one so only add back to the scene if it was found in that
-            light._isClusteredLight = false;
+            if (light._clusteredContainer === this) {
+                light._clusteredContainer = null;
+            }
             this._scene.addLight(light);
         }
         return index;

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -539,6 +539,7 @@ export class ClusteredLightContainer extends Light {
             Logger.Warn("Attempting to add a light to cluster that does not support clustering");
             return;
         }
+        light._isClusteredLight = true;
         // scene.removeLight returns -1 if the light wasn't in scene.lights. In that case the
         // mesh.lightSources cleanup it normally performs didn't happen — but the light may still be
         // there: lights constructed with `dontAddToScene = true` are pushed into mesh.lightSources
@@ -579,6 +580,7 @@ export class ClusteredLightContainer extends Light {
         if (index !== -1) {
             this._lights.splice(index, 1);
             // We treat the unsorted array as the "real" one so only add back to the scene if it was found in that
+            light._isClusteredLight = false;
             this._scene.addLight(light);
         }
         return index;

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -373,6 +373,12 @@ export abstract class Light extends Node implements ISortableLight {
     public _currentViewDepth = 0;
 
     /**
+     * Used internally by ClusteredLightContainer to keep child lights out of mesh light source lists.
+     * @internal
+     */
+    public _isClusteredLight = false;
+
+    /**
      * Creates a Light object in the scene.
      * Documentation : https://doc.babylonjs.com/features/featuresDeepDive/lights/lights_introduction
      * @param name The friendly name of the light
@@ -848,6 +854,10 @@ export abstract class Light extends Node implements ISortableLight {
     }
 
     private _resyncMeshes() {
+        if (this._isClusteredLight) {
+            return;
+        }
+
         for (const mesh of this.getScene().meshes) {
             mesh._resyncLightSource(this);
         }

--- a/packages/dev/core/src/Lights/light.ts
+++ b/packages/dev/core/src/Lights/light.ts
@@ -376,7 +376,7 @@ export abstract class Light extends Node implements ISortableLight {
      * Used internally by ClusteredLightContainer to keep child lights out of mesh light source lists.
      * @internal
      */
-    public _isClusteredLight = false;
+    public _clusteredContainer: Nullable<Light> = null;
 
     /**
      * Creates a Light object in the scene.
@@ -808,6 +808,10 @@ export abstract class Light extends Node implements ISortableLight {
         array.push = (...items: AbstractMesh[]) => {
             const result = oldPush.apply(array, items);
 
+            if (this._clusteredContainer) {
+                return result;
+            }
+
             for (const item of items) {
                 item._resyncLightSource(this);
             }
@@ -819,6 +823,10 @@ export abstract class Light extends Node implements ISortableLight {
         array.splice = (index: number, deleteCount?: number) => {
             const deleted = oldSplice.call(array, index, deleteCount ?? array.length);
 
+            if (this._clusteredContainer) {
+                return deleted;
+            }
+
             for (const item of deleted) {
                 item._resyncLightSource(this);
             }
@@ -826,8 +834,10 @@ export abstract class Light extends Node implements ISortableLight {
             return deleted;
         };
 
-        for (const item of array) {
-            item._resyncLightSource(this);
+        if (!this._clusteredContainer) {
+            for (const item of array) {
+                item._resyncLightSource(this);
+            }
         }
     }
 
@@ -854,7 +864,7 @@ export abstract class Light extends Node implements ISortableLight {
     }
 
     private _resyncMeshes() {
-        if (this._isClusteredLight) {
+        if (this._clusteredContainer) {
             return;
         }
 

--- a/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
+++ b/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
@@ -119,6 +119,27 @@ describe("ClusteredLightContainer", () => {
             expect(mesh.lightSources).not.toContain(point);
             expect(mesh.lightSources).toContain(container);
         });
+
+        it("should not re-add child lights to mesh.lightSources when their parent enabled state changes", async () => {
+            const { CreateBox } = await import("core/Meshes/Builders/boxBuilder");
+            const mesh = CreateBox("box", { size: 1 }, scene);
+            const parent = CreateBox("parent", { size: 1 }, scene);
+            parent.setEnabled(false);
+            const container = new ClusteredLightContainer("cluster", [], scene);
+            const point = new PointLight("point", new Vector3(0, 1, 0), scene, true);
+            point.parent = parent;
+
+            container.addLight(point);
+
+            expect(mesh.lightSources).toContain(container);
+            expect(mesh.lightSources).not.toContain(point);
+
+            parent.setEnabled(true);
+
+            expect(mesh.lightSources).toContain(container);
+            expect(mesh.lightSources).not.toContain(point);
+            expect(scene.lights).not.toContain(point);
+        });
     });
 
     describe("parse", () => {

--- a/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
+++ b/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
@@ -140,6 +140,47 @@ describe("ClusteredLightContainer", () => {
             expect(mesh.lightSources).not.toContain(point);
             expect(scene.lights).not.toContain(point);
         });
+
+        it("should not re-add child lights to mesh.lightSources when their excluded meshes change", async () => {
+            const { CreateBox } = await import("core/Meshes/Builders/boxBuilder");
+            const mesh = CreateBox("box", { size: 1 }, scene);
+            const container = new ClusteredLightContainer("cluster", [], scene);
+            const point = new PointLight("point", new Vector3(0, 1, 0), scene, true);
+            point.excludedMeshes.push(mesh);
+
+            container.addLight(point);
+
+            expect(mesh.lightSources).toContain(container);
+            expect(mesh.lightSources).not.toContain(point);
+
+            point.excludedMeshes.splice(0, 1);
+
+            expect(mesh.lightSources).toContain(container);
+            expect(mesh.lightSources).not.toContain(point);
+            expect(scene.lights).not.toContain(point);
+        });
+
+        it("should not let multiple clustered light containers own the same child light", () => {
+            const container1 = new ClusteredLightContainer("cluster1", [], scene);
+            const container2 = new ClusteredLightContainer("cluster2", [], scene);
+            const point = new PointLight("point", new Vector3(0, 1, 0), scene, true);
+
+            container1.addLight(point);
+            container1.addLight(point);
+            container2.addLight(point);
+
+            expect(container1.lights).toEqual([point]);
+            expect(container2.lights).toEqual([]);
+            expect(scene.lights).not.toContain(point);
+
+            container2.removeLight(point);
+
+            expect(scene.lights).not.toContain(point);
+
+            container1.removeLight(point);
+
+            expect(scene.lights).toContain(point);
+        });
     });
 
     describe("parse", () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Fixes a clustered lighting bug reported on the forum: https://forum.babylonjs.com/t/issue-when-using-lights-with-a-mesh-as-a-parent-in-clustered-lighting/63308

When a point or spot light is owned by a `ClusteredLightContainer`, it must not also be present in per-mesh `lightSources`, otherwise materials can bind it as a regular light in addition to the clustered container.

The previous cleanup handled `addLight()`, but a parent enabled-state change triggered `Light._syncParentEnabledState()` and `_resyncMeshes()`, which could re-add the raw child light to meshes even though it was still owned by the clustered container.

## Fix

- Mark lights internally while they are owned by a `ClusteredLightContainer`.
- Skip regular mesh light-source resync for those clustered child lights.
- Clear the marker when a light is removed from the container and added back to the scene.
- Add a regression test for changing the enabled state of a parent mesh.

## Validation

- `npx prettier --check packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts packages/dev/core/src/Lights/light.ts packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts`
- `npm test -- --run packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts`
