### PR TITLE
Fix NodeMaterial SSS with clustered lights

### DIFF
--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -45,7 +45,7 @@ export class ClusteredLightContainer extends Light {
         if (!caps.texelFetch) {
             return 0;
         } else if (engine.isWebGPU) {
-            // On WebGPU we use atomic writes to storage textures
+            // On WebGPU we use atomic writes to storage buffers
             return 32;
         } else if (engine.version > 1) {
             // On WebGL 2 we use additive float blending as the light mask

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -610,7 +610,7 @@ export class ClusteredLightContainer extends Light {
     public override transferTexturesToEffect(effect: Effect, lightIndex: string): Light {
         const engine = this.getEngine();
         effect.setTexture("lightDataTexture" + lightIndex, this._lightDataTexture);
-        if (engine.isWebGPU && effect.shaderLanguage === ShaderLanguage.WGSL) {
+        if (engine.isWebGPU) {
             (<WebGPUEngine>engine).setStorageBuffer("tileMaskBuffer" + lightIndex, this._tileMaskBuffer);
         } else {
             effect.setTexture("tileMaskTexture" + lightIndex, this._tileMaskTexture);

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.ts
@@ -610,7 +610,7 @@ export class ClusteredLightContainer extends Light {
     public override transferTexturesToEffect(effect: Effect, lightIndex: string): Light {
         const engine = this.getEngine();
         effect.setTexture("lightDataTexture" + lightIndex, this._lightDataTexture);
-        if (engine.isWebGPU) {
+        if (engine.isWebGPU && effect.shaderLanguage === ShaderLanguage.WGSL) {
             (<WebGPUEngine>engine).setStorageBuffer("tileMaskBuffer" + lightIndex, this._tileMaskBuffer);
         } else {
             effect.setTexture("tileMaskTexture" + lightIndex, this._tileMaskTexture);

--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.ts
@@ -806,6 +806,7 @@ export class BackgroundMaterial extends BackgroundMaterialBase {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this._maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             const join = defines.toString();

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/imageSourceBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/imageSourceBlock.ts
@@ -6,7 +6,9 @@ import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { type Nullable } from "../../../../types";
 import { Texture } from "../../../Textures/texture";
+import { ThinTexture } from "../../../Textures/thinTexture";
 import { Constants } from "../../../../Engines/constants";
+import { type AbstractEngine } from "../../../../Engines/abstractEngine";
 import { type Effect } from "../../../effect";
 import { NodeMaterial } from "../../nodeMaterial";
 import { type Scene } from "../../../../scene";
@@ -17,8 +19,21 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
  * Block used to provide an image for a TextureBlock
  */
 export class ImageSourceBlock extends NodeMaterialBlock {
+    private static _DefaultTextureByEngine = new WeakMap<AbstractEngine, ThinTexture>();
+
     private _samplerName: string;
     protected _texture: Nullable<Texture>;
+
+    private static _GetDefaultTexture(engine: AbstractEngine): ThinTexture {
+        let texture = ImageSourceBlock._DefaultTextureByEngine.get(engine);
+
+        if (!texture) {
+            texture = new ThinTexture(engine.emptyTexture);
+            ImageSourceBlock._DefaultTextureByEngine.set(engine, texture);
+        }
+
+        return texture;
+    }
     /**
      * Gets or sets the texture associated with the node
      */
@@ -79,6 +94,10 @@ export class ImageSourceBlock extends NodeMaterialBlock {
      */
     public override bind(effect: Effect, _nodeMaterial: NodeMaterial) {
         if (!this.texture) {
+            const engine = effect.getEngine();
+            if (engine.isWebGPU) {
+                effect.setTexture(this._samplerName, ImageSourceBlock._GetDefaultTexture(engine));
+            }
             return;
         }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/lightBlock.ts
@@ -291,7 +291,8 @@ export class LightBlock extends NodeMaterialBlock {
                 onlyUpdateBuffersList,
                 defines["IESLIGHTTEXTURE" + lightIndex],
                 defines["CLUSTLIGHT" + lightIndex],
-                defines["RECTAREALIGHTEMISSIONTEXTURE" + lightIndex]
+                defines["RECTAREALIGHTEMISSIONTEXTURE" + lightIndex],
+                state.shaderLanguage === ShaderLanguage.WGSL
             );
         }
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/textureBlock.ts
@@ -9,9 +9,11 @@ import { type Effect } from "../../../effect";
 import { type Nullable } from "../../../../types";
 import { RegisterClass } from "../../../../Misc/typeStore";
 import { Texture } from "../../../Textures/texture";
+import { ThinTexture } from "../../../Textures/thinTexture";
 import { type Scene } from "../../../../scene";
 import { NodeMaterialModes } from "../../Enums/nodeMaterialModes";
 import { Constants } from "../../../../Engines/constants";
+import { type AbstractEngine } from "../../../../Engines/abstractEngine";
 import "../../../../Shaders/ShadersInclude/helperFunctions";
 import { ImageSourceBlock } from "./imageSourceBlock";
 import { NodeMaterialConnectionPointCustomObject } from "../../nodeMaterialConnectionPointCustomObject";
@@ -23,6 +25,8 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
  * Block used to read a texture from a sampler
  */
 export class TextureBlock extends NodeMaterialBlock {
+    private static _DefaultTextureByEngine = new WeakMap<AbstractEngine, ThinTexture>();
+
     private _defineName: string;
     private _linearDefineName: string;
     private _gammaDefineName: string;
@@ -84,6 +88,15 @@ export class TextureBlock extends NodeMaterialBlock {
 
     private static _IsPrePassTextureBlock(block: Nullable<ImageSourceBlock | PrePassTextureBlock>): block is PrePassTextureBlock {
         return block?.getClassName() === "PrePassTextureBlock";
+    }
+
+    private static _GetDefaultTexture(engine: AbstractEngine): ThinTexture {
+        let defaultTexture = TextureBlock._DefaultTextureByEngine.get(engine);
+        if (!defaultTexture || defaultTexture.getInternalTexture() !== engine.emptyTexture) {
+            defaultTexture = new ThinTexture(engine.emptyTexture);
+            TextureBlock._DefaultTextureByEngine.set(engine, defaultTexture);
+        }
+        return defaultTexture;
     }
 
     private get _isSourcePrePass() {
@@ -443,17 +456,22 @@ export class TextureBlock extends NodeMaterialBlock {
             effect.setFloat(this._textureInfoName, 1);
         }
 
-        if (!this.texture) {
+        const texture = this.texture;
+        if (!texture) {
+            const engine = effect.getEngine();
+            if (engine.isWebGPU && !this._imageSource) {
+                effect.setTexture(this._samplerName, TextureBlock._GetDefaultTexture(engine));
+            }
             return;
         }
 
         if (this._isMixed) {
-            effect.setFloat(this._textureInfoName, this.texture.level);
-            effect.setMatrix(this._textureTransformName, this.texture.getTextureMatrix());
+            effect.setFloat(this._textureInfoName, texture.level);
+            effect.setMatrix(this._textureTransformName, texture.getTextureMatrix());
         }
 
         if (!this._imageSource) {
-            effect.setTexture(this._samplerName, this.texture);
+            effect.setTexture(this._samplerName, texture);
         }
     }
 

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -1260,11 +1260,6 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         state._emitFunctionFromInclude("pbrBlockAlphaFresnel", comments);
         state._emitFunctionFromInclude("pbrBlockAnisotropic", comments);
 
-        if (!isWebGPU) {
-            // In WebGPU, those functions are part of pbrDirectLightingFunctions
-            state._emitFunctionFromInclude("pbrClusteredLightingFunctions", comments);
-        }
-
         //
         // code
         //
@@ -1445,6 +1440,11 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
                 { search: /SS_REFRACTIONMAP_OPPOSITEZ/g, replace: refractionBlock?._defineOppositeZ ?? "SS_REFRACTIONMAP_OPPOSITEZ" },
             ],
         });
+
+        if (!isWebGPU) {
+            // In WebGPU, those functions are part of pbrDirectLightingFunctions
+            state._emitFunctionFromInclude("pbrClusteredLightingFunctions", comments);
+        }
 
         // _____________________________ Direct Lighting Info __________________________________
         state.compilationString += state._emitCodeFromInclude("pbrBlockDirectLighting", comments);

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -1251,6 +1251,10 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         });
         state._emitFunctionFromInclude("hdrFilteringFunctions", comments);
 
+        if (!isWebGPU) {
+            state._emitFunctionFromInclude("pbrDirectLightingFunctions", comments);
+        }
+
         state._emitFunctionFromInclude("pbrIBLFunctions", comments);
 
         state._emitFunctionFromInclude("pbrBlockAlbedoOpacity", comments);
@@ -1440,7 +1444,9 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
             ],
         });
 
-        state._emitFunctionFromInclude("pbrDirectLightingFunctions", comments);
+        if (isWebGPU) {
+            state._emitFunctionFromInclude("pbrDirectLightingFunctions", comments);
+        }
 
         if (!isWebGPU) {
             // In WebGPU, those functions are part of pbrDirectLightingFunctions

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -866,7 +866,8 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
                 onlyUpdateBuffersList,
                 defines["IESLIGHTTEXTURE" + lightIndex],
                 defines["CLUSTLIGHT" + lightIndex],
-                defines["RECTAREALIGHTEMISSIONTEXTURE" + lightIndex]
+                defines["RECTAREALIGHTEMISSIONTEXTURE" + lightIndex],
+                state.shaderLanguage === ShaderLanguage.WGSL
             );
         }
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock.ts
@@ -1251,8 +1251,6 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
         });
         state._emitFunctionFromInclude("hdrFilteringFunctions", comments);
 
-        state._emitFunctionFromInclude("pbrDirectLightingFunctions", comments);
-
         state._emitFunctionFromInclude("pbrIBLFunctions", comments);
 
         state._emitFunctionFromInclude("pbrBlockAlbedoOpacity", comments);
@@ -1441,6 +1439,8 @@ export class PBRMetallicRoughnessBlock extends NodeMaterialBlock {
                 { search: /SS_REFRACTIONMAP_OPPOSITEZ/g, replace: refractionBlock?._defineOppositeZ ?? "SS_REFRACTIONMAP_OPPOSITEZ" },
             ],
         });
+
+        state._emitFunctionFromInclude("pbrDirectLightingFunctions", comments);
 
         if (!isWebGPU) {
             // In WebGPU, those functions are part of pbrDirectLightingFunctions

--- a/packages/dev/core/src/Materials/PBR/openpbrMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/openpbrMaterial.ts
@@ -2993,6 +2993,7 @@ export class OpenPBRMaterial extends OpenPBRMaterialBase {
             samplers: samplers,
             defines: defines,
             maxSimultaneousLights: this._maxSimultaneousLights,
+            shaderLanguage: this._shaderLanguage,
         });
 
         const csnrOptions: ICustomShaderNameResolveOptions = {};

--- a/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrBaseMaterial.ts
@@ -1506,6 +1506,7 @@ export abstract class PBRBaseMaterial extends PBRBaseMaterialBase {
             samplers: samplers,
             defines: defines,
             maxSimultaneousLights: this._maxSimultaneousLights,
+            shaderLanguage: this._shaderLanguage,
         });
 
         const csnrOptions: ICustomShaderNameResolveOptions = {};

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -22,6 +22,7 @@ import { MaterialFlags } from "./materialFlags";
 import { Texture } from "./Textures/texture";
 import { type CubeTexture } from "./Textures/cubeTexture";
 import { type Color3 } from "core/Maths/math.color";
+import { ShaderLanguage } from "./shaderLanguage";
 
 // For backwards compatibility, we export everything from the pure version of this file.
 export * from "./materialHelper.functions.pure";
@@ -1375,6 +1376,7 @@ export function PrepareDefinesForCamera(scene: Scene, defines: any): boolean {
  * @param iesLightTexture defines if IES texture must be used
  * @param clusteredLightTextures defines if the clustered light textures must be used
  * @param rectAreaLightTexture defines if rect area light is using a emission texture.
+ * @param clusteredLightStorageBuffer defines if the clustered light tile mask uses a storage buffer instead of a texture
  */
 export function PrepareUniformsAndSamplersForLight(
     lightIndex: number,
@@ -1385,7 +1387,8 @@ export function PrepareUniformsAndSamplersForLight(
     updateOnlyBuffersList = false,
     iesLightTexture = false,
     clusteredLightTextures = false,
-    rectAreaLightTexture = false
+    rectAreaLightTexture = false,
+    clusteredLightStorageBuffer = false
 ) {
     if (uniformBuffersList) {
         uniformBuffersList.push("Light" + lightIndex);
@@ -1435,7 +1438,9 @@ export function PrepareUniformsAndSamplersForLight(
     }
     if (clusteredLightTextures) {
         samplersList.push("lightDataTexture" + lightIndex);
-        samplersList.push("tileMaskTexture" + lightIndex);
+        if (!clusteredLightStorageBuffer) {
+            samplersList.push("tileMaskTexture" + lightIndex);
+        }
     }
 }
 
@@ -1494,6 +1499,7 @@ export function PrepareUniformsAndSamplersForIBL(uniformsList: string[], sampler
 export function PrepareUniformsAndSamplersList(uniformsListOrOptions: string[] | IEffectCreationOptions, samplersList?: string[], defines?: any, maxSimultaneousLights = 4): void {
     let uniformsList: string[];
     let uniformBuffersList: string[] | undefined;
+    let shaderLanguage: Nullable<ShaderLanguage> = null;
 
     if ((<IEffectCreationOptions>uniformsListOrOptions).uniformsNames) {
         const options = <IEffectCreationOptions>uniformsListOrOptions;
@@ -1502,6 +1508,7 @@ export function PrepareUniformsAndSamplersList(uniformsListOrOptions: string[] |
         samplersList = options.samplers;
         defines = options.defines;
         maxSimultaneousLights = options.maxSimultaneousLights || 0;
+        shaderLanguage = options.shaderLanguage ?? null;
     } else {
         uniformsList = <string[]>uniformsListOrOptions;
         if (!samplersList) {
@@ -1522,7 +1529,8 @@ export function PrepareUniformsAndSamplersList(uniformsListOrOptions: string[] |
             false,
             defines["IESLIGHTTEXTURE" + lightIndex],
             defines["CLUSTLIGHT" + lightIndex],
-            defines["RECTAREALIGHTEMISSIONTEXTURE" + lightIndex]
+            defines["RECTAREALIGHTEMISSIONTEXTURE" + lightIndex],
+            shaderLanguage === ShaderLanguage.WGSL
         );
     }
 

--- a/packages/dev/core/src/Materials/standardMaterial.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.ts
@@ -1216,6 +1216,7 @@ export class StandardMaterial extends StandardMaterialBase {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this._maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             AddClipPlaneUniforms(uniforms);

--- a/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
+++ b/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
@@ -225,7 +225,7 @@ describe("ClusteredLightContainer", () => {
     });
 
     describe("transferTexturesToEffect", () => {
-        it("binds the GLSL tile mask texture for GLSL effects on WebGPU", () => {
+        it("binds the tile mask storage buffer for WebGPU effects", () => {
             const setStorageBuffer = vi.fn();
             const setTexture = vi.fn();
 
@@ -244,8 +244,8 @@ describe("ClusteredLightContainer", () => {
             );
 
             expect(setTexture).toHaveBeenCalledWith("lightDataTexture0", "lightDataTexture");
-            expect(setTexture).toHaveBeenCalledWith("tileMaskTexture0", "tileMaskTexture");
-            expect(setStorageBuffer).not.toHaveBeenCalled();
+            expect(setTexture).not.toHaveBeenCalledWith("tileMaskTexture0", "tileMaskTexture");
+            expect(setStorageBuffer).toHaveBeenCalledWith("tileMaskBuffer0", "tileMaskBuffer");
         });
 
         it("binds the WGSL tile mask storage buffer for WGSL effects on WebGPU", () => {
@@ -271,5 +271,4 @@ describe("ClusteredLightContainer", () => {
             expect(setStorageBuffer).toHaveBeenCalledWith("tileMaskBuffer0", "tileMaskBuffer");
         });
     });
-
 });

--- a/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
+++ b/packages/dev/core/test/unit/Lights/Clustered/clusteredLightContainer.test.ts
@@ -5,6 +5,7 @@ import { PointLight } from "core/Lights/pointLight";
 import { SpotLight } from "core/Lights/spotLight";
 import { Light } from "core/Lights/light";
 import { ClusteredLightContainer } from "core/Lights/Clustered/clusteredLightContainer";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { Vector3 } from "core/Maths/math.vector";
 import { Scene } from "core/scene";
 
@@ -222,4 +223,53 @@ describe("ClusteredLightContainer", () => {
             scene2.dispose();
         });
     });
+
+    describe("transferTexturesToEffect", () => {
+        it("binds the GLSL tile mask texture for GLSL effects on WebGPU", () => {
+            const setStorageBuffer = vi.fn();
+            const setTexture = vi.fn();
+
+            ClusteredLightContainer.prototype.transferTexturesToEffect.call(
+                {
+                    getEngine: () => ({ isWebGPU: true, setStorageBuffer }),
+                    _lightDataTexture: "lightDataTexture",
+                    _tileMaskTexture: "tileMaskTexture",
+                    _tileMaskBuffer: "tileMaskBuffer",
+                },
+                {
+                    shaderLanguage: ShaderLanguage.GLSL,
+                    setTexture,
+                },
+                "0"
+            );
+
+            expect(setTexture).toHaveBeenCalledWith("lightDataTexture0", "lightDataTexture");
+            expect(setTexture).toHaveBeenCalledWith("tileMaskTexture0", "tileMaskTexture");
+            expect(setStorageBuffer).not.toHaveBeenCalled();
+        });
+
+        it("binds the WGSL tile mask storage buffer for WGSL effects on WebGPU", () => {
+            const setStorageBuffer = vi.fn();
+            const setTexture = vi.fn();
+
+            ClusteredLightContainer.prototype.transferTexturesToEffect.call(
+                {
+                    getEngine: () => ({ isWebGPU: true, setStorageBuffer }),
+                    _lightDataTexture: "lightDataTexture",
+                    _tileMaskTexture: "tileMaskTexture",
+                    _tileMaskBuffer: "tileMaskBuffer",
+                },
+                {
+                    shaderLanguage: ShaderLanguage.WGSL,
+                    setTexture,
+                },
+                "0"
+            );
+
+            expect(setTexture).toHaveBeenCalledWith("lightDataTexture0", "lightDataTexture");
+            expect(setTexture).not.toHaveBeenCalledWith("tileMaskTexture0", "tileMaskTexture");
+            expect(setStorageBuffer).toHaveBeenCalledWith("tileMaskBuffer0", "tileMaskBuffer");
+        });
+    });
+
 });

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/pbrMetallicRoughnessBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/pbrMetallicRoughnessBlock.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { type Engine } from "core/Engines/engine";
+import {
+    FragmentOutputBlock,
+    InputBlock,
+    NodeMaterial,
+    NodeMaterialBlockConnectionPointTypes,
+    NodeMaterialBlockTargets,
+    NodeMaterialSystemValues,
+    PBRMetallicRoughnessBlock,
+    SubSurfaceBlock,
+    TransformBlock,
+    VertexOutputBlock,
+} from "core/Materials";
+import { Color3 } from "core/Maths/math.color";
+import { Scene } from "core/scene";
+
+describe("PBRMetallicRoughnessBlock", () => {
+    let engine: Engine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        engine.dispose();
+    });
+
+    it("emits subsurface declarations before clustered lighting functions", async () => {
+        const nodeMaterial = new NodeMaterial("node material", scene);
+
+        const position = new InputBlock("position");
+        position.setAsAttribute("position");
+
+        const normal = new InputBlock("normal");
+        normal.setAsAttribute("normal");
+
+        const world = new InputBlock("world");
+        world.setAsSystemValue(NodeMaterialSystemValues.World);
+
+        const viewProjection = new InputBlock("viewProjection");
+        viewProjection.setAsSystemValue(NodeMaterialSystemValues.ViewProjection);
+
+        const worldPosition = new TransformBlock("worldPosition");
+        position.output.connectTo(worldPosition.vector);
+        world.output.connectTo(worldPosition.transform);
+
+        const clipPosition = new TransformBlock("clipPosition");
+        worldPosition.output.connectTo(clipPosition.vector);
+        viewProjection.output.connectTo(clipPosition.transform);
+
+        const worldNormal = new TransformBlock("worldNormal");
+        normal.output.connectTo(worldNormal.vector);
+        world.output.connectTo(worldNormal.transform);
+
+        const vertexOutput = new VertexOutputBlock("vertexOutput");
+        clipPosition.output.connectTo(vertexOutput.vector);
+
+        const pbr = new PBRMetallicRoughnessBlock("pbr");
+        worldPosition.output.connectTo(pbr.worldPosition);
+        worldNormal.output.connectTo(pbr.worldNormal);
+
+        const baseColor = new InputBlock("baseColor", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Color3);
+        baseColor.value = new Color3(1, 0.7, 0.4);
+        baseColor.output.connectTo(pbr.baseColor);
+
+        const metallic = new InputBlock("metallic", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Float);
+        metallic.value = 0;
+        metallic.output.connectTo(pbr.metallic);
+
+        const roughness = new InputBlock("roughness", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Float);
+        roughness.value = 0.5;
+        roughness.output.connectTo(pbr.roughness);
+
+        const translucencyIntensity = new InputBlock("translucencyIntensity", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Float);
+        translucencyIntensity.value = 1;
+
+        const subSurface = new SubSurfaceBlock("subSurface");
+        translucencyIntensity.output.connectTo(subSurface.translucencyIntensity);
+        subSurface.subsurface.connectTo(pbr.subsurface);
+
+        const fragmentOutput = new FragmentOutputBlock("fragmentOutput");
+        pbr.lighting.connectTo(fragmentOutput.rgb);
+        pbr.alpha.connectTo(fragmentOutput.a);
+
+        nodeMaterial.addOutputNode(vertexOutput);
+        nodeMaterial.addOutputNode(fragmentOutput);
+
+        const buildPromise = new Promise<void>((resolve, reject) => {
+            nodeMaterial.onBuildObservable.addOnce(() => resolve());
+            nodeMaterial.onBuildErrorObservable.addOnce((error) => reject(new Error(error)));
+        });
+        nodeMaterial.build();
+        await buildPromise;
+
+        const shaders = nodeMaterial.compiledShaders;
+        const subSurfaceDeclarationIndex = shaders.indexOf("struct subSurfaceOutParams");
+        const clusteredLightingFunctionsIndex = shaders.indexOf("#include<pbrClusteredLightingFunctions>");
+
+        expect(subSurfaceDeclarationIndex).toBeGreaterThanOrEqual(0);
+        expect(clusteredLightingFunctionsIndex).toBeGreaterThanOrEqual(0);
+        expect(subSurfaceDeclarationIndex).toBeLessThan(clusteredLightingFunctionsIndex);
+    });
+});

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/pbrMetallicRoughnessBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/pbrMetallicRoughnessBlock.test.ts
@@ -3,6 +3,7 @@ import { NullEngine } from "core/Engines/nullEngine";
 import { type Engine } from "core/Engines/engine";
 import { FragmentOutputBlock } from "core/Materials/Node/Blocks/Fragment/fragmentOutputBlock";
 import { InputBlock } from "core/Materials/Node/Blocks/Input/inputBlock";
+import { ClearCoatBlock } from "core/Materials/Node/Blocks/PBR/clearCoatBlock";
 import { PBRMetallicRoughnessBlock } from "core/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock";
 import { SubSurfaceBlock } from "core/Materials/Node/Blocks/PBR/subSurfaceBlock";
 import { TransformBlock } from "core/Materials/Node/Blocks/transformBlock";
@@ -101,5 +102,81 @@ describe("PBRMetallicRoughnessBlock", () => {
         expect(subSurfaceDeclarationIndex).toBeGreaterThanOrEqual(0);
         expect(clusteredLightingFunctionsIndex).toBeGreaterThanOrEqual(0);
         expect(subSurfaceDeclarationIndex).toBeLessThan(clusteredLightingFunctionsIndex);
+    });
+
+    it("emits clear coat reflectance constants before clear coat functions", async () => {
+        const nodeMaterial = new NodeMaterial("node material", scene);
+
+        const position = new InputBlock("position");
+        position.setAsAttribute("position");
+
+        const normal = new InputBlock("normal");
+        normal.setAsAttribute("normal");
+
+        const world = new InputBlock("world");
+        world.setAsSystemValue(NodeMaterialSystemValues.World);
+
+        const viewProjection = new InputBlock("viewProjection");
+        viewProjection.setAsSystemValue(NodeMaterialSystemValues.ViewProjection);
+
+        const worldPosition = new TransformBlock("worldPosition");
+        position.output.connectTo(worldPosition.vector);
+        world.output.connectTo(worldPosition.transform);
+
+        const clipPosition = new TransformBlock("clipPosition");
+        worldPosition.output.connectTo(clipPosition.vector);
+        viewProjection.output.connectTo(clipPosition.transform);
+
+        const worldNormal = new TransformBlock("worldNormal");
+        normal.output.connectTo(worldNormal.vector);
+        world.output.connectTo(worldNormal.transform);
+
+        const vertexOutput = new VertexOutputBlock("vertexOutput");
+        clipPosition.output.connectTo(vertexOutput.vector);
+
+        const pbr = new PBRMetallicRoughnessBlock("pbr");
+        worldPosition.output.connectTo(pbr.worldPosition);
+        worldNormal.output.connectTo(pbr.worldNormal);
+
+        const baseColor = new InputBlock("baseColor", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Color3);
+        baseColor.value = new Color3(1, 0.7, 0.4);
+        baseColor.output.connectTo(pbr.baseColor);
+
+        const metallic = new InputBlock("metallic", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Float);
+        metallic.value = 0;
+        metallic.output.connectTo(pbr.metallic);
+
+        const roughness = new InputBlock("roughness", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Float);
+        roughness.value = 0.5;
+        roughness.output.connectTo(pbr.roughness);
+
+        const clearCoatIntensity = new InputBlock("clearCoatIntensity", NodeMaterialBlockTargets.Fragment, NodeMaterialBlockConnectionPointTypes.Float);
+        clearCoatIntensity.value = 1;
+
+        const clearCoat = new ClearCoatBlock("clearCoat");
+        clearCoatIntensity.output.connectTo(clearCoat.intensity);
+        clearCoat.clearcoat.connectTo(pbr.clearcoat);
+
+        const fragmentOutput = new FragmentOutputBlock("fragmentOutput");
+        pbr.lighting.connectTo(fragmentOutput.rgb);
+        pbr.alpha.connectTo(fragmentOutput.a);
+
+        nodeMaterial.addOutputNode(vertexOutput);
+        nodeMaterial.addOutputNode(fragmentOutput);
+
+        const buildPromise = new Promise<void>((resolve, reject) => {
+            nodeMaterial.onBuildObservable.addOnce(() => resolve());
+            nodeMaterial.onBuildErrorObservable.addOnce((error) => reject(new Error(error)));
+        });
+        nodeMaterial.build();
+        await buildPromise;
+
+        const shaders = nodeMaterial.compiledShaders;
+        const clearCoatReflectanceIndex = shaders.indexOf("#include<pbrDirectLightingFunctions>");
+        const clearCoatFunctionsIndex = shaders.indexOf("fresnelIBLClearCoat");
+
+        expect(clearCoatReflectanceIndex).toBeGreaterThanOrEqual(0);
+        expect(clearCoatFunctionsIndex).toBeGreaterThanOrEqual(0);
+        expect(clearCoatReflectanceIndex).toBeLessThan(clearCoatFunctionsIndex);
     });
 });

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/pbrMetallicRoughnessBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/pbrMetallicRoughnessBlock.test.ts
@@ -1,18 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { NullEngine } from "core/Engines/nullEngine";
 import { type Engine } from "core/Engines/engine";
-import {
-    FragmentOutputBlock,
-    InputBlock,
-    NodeMaterial,
-    NodeMaterialBlockConnectionPointTypes,
-    NodeMaterialBlockTargets,
-    NodeMaterialSystemValues,
-    PBRMetallicRoughnessBlock,
-    SubSurfaceBlock,
-    TransformBlock,
-    VertexOutputBlock,
-} from "core/Materials";
+import { FragmentOutputBlock } from "core/Materials/Node/Blocks/Fragment/fragmentOutputBlock";
+import { InputBlock } from "core/Materials/Node/Blocks/Input/inputBlock";
+import { PBRMetallicRoughnessBlock } from "core/Materials/Node/Blocks/PBR/pbrMetallicRoughnessBlock";
+import { SubSurfaceBlock } from "core/Materials/Node/Blocks/PBR/subSurfaceBlock";
+import { TransformBlock } from "core/Materials/Node/Blocks/transformBlock";
+import { VertexOutputBlock } from "core/Materials/Node/Blocks/Vertex/vertexOutputBlock";
+import { NodeMaterialBlockConnectionPointTypes } from "core/Materials/Node/Enums/nodeMaterialBlockConnectionPointTypes";
+import { NodeMaterialBlockTargets } from "core/Materials/Node/Enums/nodeMaterialBlockTargets";
+import { NodeMaterialSystemValues } from "core/Materials/Node/Enums/nodeMaterialSystemValues";
+import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { Color3 } from "core/Maths/math.color";
 import { Scene } from "core/scene";
 

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/textureBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/textureBlock.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { type AbstractEngine } from "core/Engines/abstractEngine";
 import { type Effect } from "core/Materials/effect";
+import { ImageSourceBlock } from "core/Materials/Node/Blocks/Dual/imageSourceBlock";
 import { TextureBlock } from "core/Materials/Node/Blocks/Dual/textureBlock";
+import { type NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { ThinTexture } from "core/Materials/Textures/thinTexture";
 
 describe("TextureBlock", () => {
@@ -43,5 +45,27 @@ describe("TextureBlock", () => {
         block.bind(effect);
 
         expect(effect.setTexture).not.toHaveBeenCalled();
+    });
+
+    it("binds a default texture for missing image source resources on WebGPU", () => {
+        let engine: AbstractEngine;
+        const emptyTexture = { getEngine: () => engine };
+        engine = {
+            isWebGPU: true,
+            emptyTexture,
+        } as unknown as AbstractEngine;
+        const setTexture = vi.fn();
+        const effect = {
+            getEngine: () => engine,
+            setTexture,
+        } as unknown as Effect;
+        const block = new ImageSourceBlock("test");
+
+        Object.assign(block, { _samplerName: "testTexture" });
+
+        block.bind(effect, {} as NodeMaterial);
+
+        expect(setTexture).toHaveBeenCalledWith("testTexture", expect.any(ThinTexture));
+        expect((setTexture.mock.calls[0][1] as ThinTexture).getInternalTexture()).toBe(emptyTexture);
     });
 });

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/textureBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/textureBlock.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { type AbstractEngine } from "core/Engines/abstractEngine";
+import { type Effect } from "core/Materials/effect";
+import { TextureBlock } from "core/Materials/Node/Blocks/Dual/textureBlock";
+import { ThinTexture } from "core/Materials/Textures/thinTexture";
+
+describe("TextureBlock", () => {
+    it("binds a default texture for missing texture resources on WebGPU", () => {
+        let engine: AbstractEngine;
+        const emptyTexture = { getEngine: () => engine };
+        engine = {
+            isWebGPU: true,
+            emptyTexture,
+        } as unknown as AbstractEngine;
+        const setTexture = vi.fn();
+        const effect = {
+            getEngine: () => engine,
+            setTexture,
+            setFloat: vi.fn(),
+            setMatrix: vi.fn(),
+        } as unknown as Effect;
+        const block = new TextureBlock("test");
+
+        Object.assign(block, { _samplerName: "testTexture" });
+
+        block.bind(effect);
+
+        expect(setTexture).toHaveBeenCalledWith("testTexture", expect.any(ThinTexture));
+        expect((setTexture.mock.calls[0][1] as ThinTexture).getInternalTexture()).toBe(emptyTexture);
+    });
+
+    it("does not bind a default texture for missing texture resources outside WebGPU", () => {
+        const effect = {
+            getEngine: () => ({ isWebGPU: false }),
+            setTexture: vi.fn(),
+            setFloat: vi.fn(),
+            setMatrix: vi.fn(),
+        } as unknown as Effect;
+        const block = new TextureBlock("test");
+
+        Object.assign(block, { _samplerName: "testTexture" });
+
+        block.bind(effect);
+
+        expect(effect.setTexture).not.toHaveBeenCalled();
+    });
+});

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { PrepareUniformsAndSamplersForLight } from "core/Materials/materialHelper.functions";
+
+describe("PrepareUniformsAndSamplersForLight", () => {
+    it("keeps clustered light tile masks as textures by default", () => {
+        const uniforms: string[] = [];
+        const samplers: string[] = [];
+
+        PrepareUniformsAndSamplersForLight(0, uniforms, samplers, false, null, false, false, true);
+
+        expect(samplers).toContain("lightDataTexture0");
+        expect(samplers).toContain("tileMaskTexture0");
+    });
+
+    it("does not add a clustered light tile mask texture when using a storage buffer", () => {
+        const uniforms: string[] = [];
+        const samplers: string[] = [];
+
+        PrepareUniformsAndSamplersForLight(0, uniforms, samplers, false, null, false, false, true, false, true);
+
+        expect(samplers).toContain("lightDataTexture0");
+        expect(samplers).not.toContain("tileMaskTexture0");
+    });
+});

--- a/packages/dev/materials/src/cell/cellMaterial.ts
+++ b/packages/dev/materials/src/cell/cellMaterial.ts
@@ -252,6 +252,7 @@ export class CellMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
             subMesh.setEffect(
                 scene.getEngine().createEffect(

--- a/packages/dev/materials/src/fur/furMaterial.ts
+++ b/packages/dev/materials/src/fur/furMaterial.ts
@@ -338,6 +338,7 @@ export class FurMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/gradient/gradientMaterial.ts
+++ b/packages/dev/materials/src/gradient/gradientMaterial.ts
@@ -245,6 +245,7 @@ export class GradientMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: 4,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/lava/lavaMaterial.ts
+++ b/packages/dev/materials/src/lava/lavaMaterial.ts
@@ -320,6 +320,7 @@ export class LavaMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/mix/mixMaterial.ts
+++ b/packages/dev/materials/src/mix/mixMaterial.ts
@@ -360,6 +360,7 @@ export class MixMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/normal/normalMaterial.ts
+++ b/packages/dev/materials/src/normal/normalMaterial.ts
@@ -286,6 +286,7 @@ export class NormalMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: 4,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
+++ b/packages/dev/materials/src/shadowOnly/shadowOnlyMaterial.ts
@@ -233,6 +233,7 @@ export class ShadowOnlyMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: 1,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/simple/simpleMaterial.ts
+++ b/packages/dev/materials/src/simple/simpleMaterial.ts
@@ -241,6 +241,7 @@ export class SimpleMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
             subMesh.setEffect(
                 scene.getEngine().createEffect(

--- a/packages/dev/materials/src/terrain/terrainMaterial.ts
+++ b/packages/dev/materials/src/terrain/terrainMaterial.ts
@@ -320,6 +320,7 @@ export class TerrainMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
+++ b/packages/dev/materials/src/triPlanar/triPlanarMaterial.ts
@@ -309,6 +309,7 @@ export class TriPlanarMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
 
             subMesh.setEffect(

--- a/packages/dev/materials/src/water/waterMaterial.ts
+++ b/packages/dev/materials/src/water/waterMaterial.ts
@@ -549,6 +549,7 @@ export class WaterMaterial extends PushMaterial {
                 samplers: samplers,
                 defines: defines,
                 maxSimultaneousLights: this.maxSimultaneousLights,
+                shaderLanguage: this._shaderLanguage,
             });
             subMesh.setEffect(
                 scene.getEngine().createEffect(


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Fix NodeMaterial PBR shader generation so subsurface-scattering declarations are emitted before clustered/direct-light helper functions that depend on them.
- Prepare clustered-light tile-mask resources according to shader language so WebGPU WGSL effects use `tileMaskBuffer`.
- Keep WebGPU clustered-light runtime binding on the storage-buffer path; the WebGPU NodeMaterial repro should load the snippet as WGSL instead of relying on a GLSL texture fallback.
- Bind a default empty texture for WebGPU `TextureBlock` and `ImageSourceBlock` resources that have no texture assigned, preventing bind group creation failures.
- Propagate material shader language through materials-library clustered-light preparation.

## Motivation
The forum repro at https://forum.babylonjs.com/t/nodematerial-compile-error-when-using-sub-surface-scattering-with-clustered-lights/63299 failed with NodeMaterial subsurface scattering and clustered lights.

For the WebGPU playground repro (`#CSCJO2#97`), the NodeMaterial snippet must be loaded as WGSL, for example by passing `{ shaderLanguage: BABYLON.ShaderLanguage.WGSL }` to `NodeMaterial.ParseFromSnippetAsync`. This preserves the WebGPU clustered-light fast path (`tileMaskBuffer`, batch size 32) instead of adding a slower GLSL texture fallback.

## Validation
- Added unit coverage for NodeMaterial SSS clustered-light shader ordering.
- Added unit coverage for clustered-light tile-mask sampler/buffer selection.
- Added unit coverage for WebGPU default texture binding for missing `TextureBlock` and `ImageSourceBlock` resources.
- Verified the WebGPU playground repro locally with the snippet loaded as WGSL, clustered lights using `tileMaskBuffer`, and WebGPU batch size remaining 32.