### PR TITLE
Fix UMD Rollup namespace exports

### DIFF
--- a/packages/dev/loaders/src/legacy/legacy-glTF2.ts
+++ b/packages/dev/loaders/src/legacy/legacy-glTF2.ts
@@ -3,6 +3,16 @@ import * as Extensions from "loaders/glTF/2.0/Extensions/index";
 import * as Interfaces from "loaders/glTF/2.0/glTFLoaderInterfaces";
 import * as GLTF2 from "loaders/glTF/2.0/index";
 
+const LoaderExtensions = { ...Extensions };
+const GLTF2Loader = {
+    ...Interfaces,
+    ["Extensions"]: LoaderExtensions,
+};
+const GLTF2Legacy = {
+    ...GLTF2,
+    ["Loader"]: GLTF2Loader,
+};
+
 /**
  * This is the entry point for the UMD module.
  * The entry point for a future ESM package should be index.ts
@@ -16,24 +26,28 @@ if (typeof GlobalObject !== "undefined") {
     BABYLON.GLTF2.Loader = BABYLON.GLTF2.Loader || {};
     BABYLON.GLTF2.Loader.Extensions = BABYLON.GLTF2.Loader.Extensions || {};
 
-    const keys = [];
-    for (const key in Extensions) {
-        BABYLON.GLTF2.Loader.Extensions[key] = (<any>Extensions)[key];
+    const keys = ["Loader"];
+    for (const key in LoaderExtensions) {
+        BABYLON.GLTF2.Loader.Extensions[key] = (<any>LoaderExtensions)[key];
         keys.push(key);
     }
-    for (const key in Interfaces) {
-        BABYLON.GLTF2.Loader[key] = (<any>Interfaces)[key];
+    for (const key in GLTF2Loader) {
+        if (key === "Extensions") {
+            continue;
+        }
+
+        BABYLON.GLTF2.Loader[key] = (<any>GLTF2Loader)[key];
         keys.push(key);
     }
 
-    for (const key in GLTF2) {
+    for (const key in GLTF2Legacy) {
         // Prevent Reassignment.
         if (keys.indexOf(key) > -1) {
             continue;
         }
 
-        BABYLON.GLTF2[key] = (<any>GLTF2)[key];
+        BABYLON.GLTF2[key] = (<any>GLTF2Legacy)[key];
     }
 }
 
-export { GLTF2 };
+export { GLTF2Legacy as GLTF2 };

--- a/packages/dev/loaders/src/legacy/legacy-glTF2.ts
+++ b/packages/dev/loaders/src/legacy/legacy-glTF2.ts
@@ -11,7 +11,7 @@ const GLTF2Loader = {
 const GLTF2Legacy = {
     ...GLTF2,
     ["Loader"]: GLTF2Loader,
-};
+} as typeof GLTF2;
 
 /**
  * This is the entry point for the UMD module.

--- a/packages/dev/loaders/src/legacy/legacy.ts
+++ b/packages/dev/loaders/src/legacy/legacy.ts
@@ -4,6 +4,6 @@ export * from "./legacy-bvhFileLoader";
 export * from "./legacy-dynamic";
 export * from "./legacy-glTF";
 export * from "./legacy-glTF1";
-export * from "./legacy-glTF2";
+export { GLTF2 } from "./legacy-glTF2";
 export * from "./legacy-objFileLoader";
 export * from "./legacy-stlFileLoader";

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -636,6 +636,7 @@ export function commonUMDRollupConfiguration(options) {
             freeze: false,
         },
         plugins,
+        treeshake: false,
         // Suppress noisy circular-dependency warnings from the large Babylon packages.
         onwarn(warning, warn) {
             if (warning.code === "CIRCULAR_DEPENDENCY") return;
@@ -702,6 +703,7 @@ export function commonUMDRollupConfiguration(options) {
                     freeze: false,
                 },
                 plugins: perEntryPlugins,
+                treeshake: false,
                 onwarn(warning, warn) {
                     if (warning.code === "CIRCULAR_DEPENDENCY") return;
                     warn(warning);

--- a/packages/public/umd/babylonjs-accessibility/src/index.ts
+++ b/packages/public/umd/babylonjs-accessibility/src/index.ts
@@ -1,3 +1,2 @@
-import * as accessibility from "accessibility/legacy/legacy";
-export { accessibility };
-export default accessibility;
+import "accessibility/legacy/legacy";
+export * from "accessibility/legacy/legacy";

--- a/packages/public/umd/babylonjs-addons/src/index.ts
+++ b/packages/public/umd/babylonjs-addons/src/index.ts
@@ -5,4 +5,5 @@
 // IMPORTANT: Do NOT also `import * as addons; export { addons }` here.
 // When both patterns coexist, terser collapses all individual exports into the
 // namespace object in the minified bundle, leaving ADDONS.X undefined at runtime.
+import "addons/index";
 export * from "addons/index";

--- a/packages/public/umd/babylonjs-gui-editor/src/index.ts
+++ b/packages/public/umd/babylonjs-gui-editor/src/index.ts
@@ -1,3 +1,2 @@
-import * as guiEditor from "gui-editor/legacy/legacy";
-export { guiEditor };
-export default guiEditor;
+import "gui-editor/legacy/legacy";
+export * from "gui-editor/legacy/legacy";

--- a/packages/public/umd/babylonjs-gui/src/index.ts
+++ b/packages/public/umd/babylonjs-gui/src/index.ts
@@ -5,4 +5,5 @@
 // IMPORTANT: Do NOT also `import * as gui; export { gui }` here.
 // When both patterns coexist, terser collapses all individual exports into the
 // namespace object in the minified bundle, leaving BABYLON.GUI.X undefined at runtime.
+import "gui/legacy/legacy";
 export * from "gui/legacy/legacy";

--- a/packages/public/umd/babylonjs-inspector-v2/src/index.ts
+++ b/packages/public/umd/babylonjs-inspector-v2/src/index.ts
@@ -1,3 +1,2 @@
-import * as inspector from "inspector/legacy/legacy";
-export { inspector };
-export default inspector;
+import "inspector/legacy/legacy";
+export * from "inspector/legacy/legacy";

--- a/packages/public/umd/babylonjs-inspector/src/index.ts
+++ b/packages/public/umd/babylonjs-inspector/src/index.ts
@@ -1,3 +1,2 @@
-import * as inspector from "inspector-legacy/legacy/legacy";
-export { inspector };
-export default inspector;
+import "inspector-legacy/legacy/legacy";
+export * from "inspector-legacy/legacy/legacy";

--- a/packages/public/umd/babylonjs-ktx2decoder/src/index.ts
+++ b/packages/public/umd/babylonjs-ktx2decoder/src/index.ts
@@ -5,4 +5,5 @@
 // IMPORTANT: Do NOT also `import * as ktx2decoder; export { ktx2decoder }` here.
 // When both patterns coexist, terser collapses all individual exports into the
 // namespace object in the minified bundle, leaving KTX2DECODER.X undefined at runtime.
+import "ktx2decoder/legacy/legacy";
 export * from "ktx2decoder/legacy/legacy";

--- a/packages/public/umd/babylonjs-loaders/src/bvhFileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/bvhFileLoader.ts
@@ -1,3 +1,2 @@
-import * as loaders from "loaders/legacy/legacy-bvhFileLoader";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy-bvhFileLoader";
+export * from "loaders/legacy/legacy-bvhFileLoader";

--- a/packages/public/umd/babylonjs-loaders/src/glTF1FileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/glTF1FileLoader.ts
@@ -1,4 +1,2 @@
-// eslint-disable-next-line import/export
-import * as loaders from "loaders/legacy/legacy-glTF1FileLoader";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy-glTF1FileLoader";
+export * from "loaders/legacy/legacy-glTF1FileLoader";

--- a/packages/public/umd/babylonjs-loaders/src/glTF2FileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/glTF2FileLoader.ts
@@ -1,3 +1,2 @@
-import * as loaders from "loaders/legacy/legacy-glTF2FileLoader";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy-glTF2FileLoader";
+export * from "loaders/legacy/legacy-glTF2FileLoader";

--- a/packages/public/umd/babylonjs-loaders/src/glTFFileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/glTFFileLoader.ts
@@ -1,3 +1,2 @@
-import * as loaders from "loaders/legacy/legacy-glTFFileLoader";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy-glTFFileLoader";
+export * from "loaders/legacy/legacy-glTFFileLoader";

--- a/packages/public/umd/babylonjs-loaders/src/index.ts
+++ b/packages/public/umd/babylonjs-loaders/src/index.ts
@@ -1,3 +1,2 @@
-import * as loaders from "loaders/legacy/legacy";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy";
+export * from "loaders/legacy/legacy";

--- a/packages/public/umd/babylonjs-loaders/src/objFileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/objFileLoader.ts
@@ -1,3 +1,2 @@
-import * as loaders from "loaders/legacy/legacy-objFileLoader";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy-objFileLoader";
+export * from "loaders/legacy/legacy-objFileLoader";

--- a/packages/public/umd/babylonjs-loaders/src/stlFileLoader.ts
+++ b/packages/public/umd/babylonjs-loaders/src/stlFileLoader.ts
@@ -1,3 +1,2 @@
-import * as loaders from "loaders/legacy/legacy-stlFileLoader";
-export { loaders };
-export default loaders;
+import "loaders/legacy/legacy-stlFileLoader";
+export * from "loaders/legacy/legacy-stlFileLoader";

--- a/packages/public/umd/babylonjs-materials/src/cell.ts
+++ b/packages/public/umd/babylonjs-materials/src/cell.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-cell";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-cell";
+export * from "materials/legacy/legacy-cell";

--- a/packages/public/umd/babylonjs-materials/src/custom.ts
+++ b/packages/public/umd/babylonjs-materials/src/custom.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-custom";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-custom";
+export * from "materials/legacy/legacy-custom";

--- a/packages/public/umd/babylonjs-materials/src/fire.ts
+++ b/packages/public/umd/babylonjs-materials/src/fire.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-fire";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-fire";
+export * from "materials/legacy/legacy-fire";

--- a/packages/public/umd/babylonjs-materials/src/fur.ts
+++ b/packages/public/umd/babylonjs-materials/src/fur.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-fur";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-fur";
+export * from "materials/legacy/legacy-fur";

--- a/packages/public/umd/babylonjs-materials/src/gradient.ts
+++ b/packages/public/umd/babylonjs-materials/src/gradient.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-gradient";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-gradient";
+export * from "materials/legacy/legacy-gradient";

--- a/packages/public/umd/babylonjs-materials/src/grid.ts
+++ b/packages/public/umd/babylonjs-materials/src/grid.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-grid";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-grid";
+export * from "materials/legacy/legacy-grid";

--- a/packages/public/umd/babylonjs-materials/src/index.ts
+++ b/packages/public/umd/babylonjs-materials/src/index.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy";
-export { materials };
-export default materials;
+import "materials/legacy/legacy";
+export * from "materials/legacy/legacy";

--- a/packages/public/umd/babylonjs-materials/src/lava.ts
+++ b/packages/public/umd/babylonjs-materials/src/lava.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-lava";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-lava";
+export * from "materials/legacy/legacy-lava";

--- a/packages/public/umd/babylonjs-materials/src/mix.ts
+++ b/packages/public/umd/babylonjs-materials/src/mix.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-mix";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-mix";
+export * from "materials/legacy/legacy-mix";

--- a/packages/public/umd/babylonjs-materials/src/normal.ts
+++ b/packages/public/umd/babylonjs-materials/src/normal.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-normal";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-normal";
+export * from "materials/legacy/legacy-normal";

--- a/packages/public/umd/babylonjs-materials/src/shadowOnly.ts
+++ b/packages/public/umd/babylonjs-materials/src/shadowOnly.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-shadowOnly";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-shadowOnly";
+export * from "materials/legacy/legacy-shadowOnly";

--- a/packages/public/umd/babylonjs-materials/src/simple.ts
+++ b/packages/public/umd/babylonjs-materials/src/simple.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-simple";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-simple";
+export * from "materials/legacy/legacy-simple";

--- a/packages/public/umd/babylonjs-materials/src/sky.ts
+++ b/packages/public/umd/babylonjs-materials/src/sky.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-sky";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-sky";
+export * from "materials/legacy/legacy-sky";

--- a/packages/public/umd/babylonjs-materials/src/terrain.ts
+++ b/packages/public/umd/babylonjs-materials/src/terrain.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-terrain";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-terrain";
+export * from "materials/legacy/legacy-terrain";

--- a/packages/public/umd/babylonjs-materials/src/triPlanar.ts
+++ b/packages/public/umd/babylonjs-materials/src/triPlanar.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-triPlanar";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-triPlanar";
+export * from "materials/legacy/legacy-triPlanar";

--- a/packages/public/umd/babylonjs-materials/src/water.ts
+++ b/packages/public/umd/babylonjs-materials/src/water.ts
@@ -1,3 +1,2 @@
-import * as materials from "materials/legacy/legacy-water";
-export { materials };
-export default materials;
+import "materials/legacy/legacy-water";
+export * from "materials/legacy/legacy-water";

--- a/packages/public/umd/babylonjs-node-editor/src/index.ts
+++ b/packages/public/umd/babylonjs-node-editor/src/index.ts
@@ -1,3 +1,2 @@
-import * as nodeEditor from "node-editor/legacy/legacy";
-export { nodeEditor };
-export default nodeEditor;
+import "node-editor/legacy/legacy";
+export * from "node-editor/legacy/legacy";

--- a/packages/public/umd/babylonjs-node-geometry-editor/src/index.ts
+++ b/packages/public/umd/babylonjs-node-geometry-editor/src/index.ts
@@ -1,3 +1,2 @@
-import * as nodeGeometryEditor from "node-geometry-editor/legacy/legacy";
-export { nodeGeometryEditor };
-export default nodeGeometryEditor;
+import "node-geometry-editor/legacy/legacy";
+export * from "node-geometry-editor/legacy/legacy";

--- a/packages/public/umd/babylonjs-node-particle-editor/src/index.ts
+++ b/packages/public/umd/babylonjs-node-particle-editor/src/index.ts
@@ -1,3 +1,2 @@
-import * as nodeParticleEditor from "node-particle-editor/legacy/legacy";
-export { nodeParticleEditor };
-export default nodeParticleEditor;
+import "node-particle-editor/legacy/legacy";
+export * from "node-particle-editor/legacy/legacy";

--- a/packages/public/umd/babylonjs-node-render-graph-editor/src/index.ts
+++ b/packages/public/umd/babylonjs-node-render-graph-editor/src/index.ts
@@ -1,3 +1,2 @@
-import * as nodeRenderGraphEditor from "node-render-graph-editor/legacy/legacy";
-export { nodeRenderGraphEditor };
-export default nodeRenderGraphEditor;
+import "node-render-graph-editor/legacy/legacy";
+export * from "node-render-graph-editor/legacy/legacy";

--- a/packages/public/umd/babylonjs-post-process/src/asciiArt.ts
+++ b/packages/public/umd/babylonjs-post-process/src/asciiArt.ts
@@ -1,3 +1,2 @@
-import * as postProcess from "post-processes/legacy/legacy-asciiArt";
-export { postProcess };
-export default postProcess;
+import "post-processes/legacy/legacy-asciiArt";
+export * from "post-processes/legacy/legacy-asciiArt";

--- a/packages/public/umd/babylonjs-post-process/src/digitalRain.ts
+++ b/packages/public/umd/babylonjs-post-process/src/digitalRain.ts
@@ -1,3 +1,2 @@
-import * as postProcess from "post-processes/legacy/legacy-digitalRain";
-export { postProcess };
-export default postProcess;
+import "post-processes/legacy/legacy-digitalRain";
+export * from "post-processes/legacy/legacy-digitalRain";

--- a/packages/public/umd/babylonjs-post-process/src/index.ts
+++ b/packages/public/umd/babylonjs-post-process/src/index.ts
@@ -1,3 +1,2 @@
-import * as postProcess from "post-processes/legacy/legacy";
-export { postProcess };
-export default postProcess;
+import "post-processes/legacy/legacy";
+export * from "post-processes/legacy/legacy";

--- a/packages/public/umd/babylonjs-procedural-textures/src/brick.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/brick.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-brick";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-brick";
+export * from "procedural-textures/legacy/legacy-brick";

--- a/packages/public/umd/babylonjs-procedural-textures/src/cloud.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/cloud.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-cloud";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-cloud";
+export * from "procedural-textures/legacy/legacy-cloud";

--- a/packages/public/umd/babylonjs-procedural-textures/src/fire.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/fire.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-fire";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-fire";
+export * from "procedural-textures/legacy/legacy-fire";

--- a/packages/public/umd/babylonjs-procedural-textures/src/grass.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/grass.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-grass";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-grass";
+export * from "procedural-textures/legacy/legacy-grass";

--- a/packages/public/umd/babylonjs-procedural-textures/src/index.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/index.ts
@@ -1,3 +1,2 @@
-import * as proceduralTextures from "procedural-textures/legacy/legacy";
-export { proceduralTextures };
-export default proceduralTextures;
+import "procedural-textures/legacy/legacy";
+export * from "procedural-textures/legacy/legacy";

--- a/packages/public/umd/babylonjs-procedural-textures/src/marble.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/marble.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-marble";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-marble";
+export * from "procedural-textures/legacy/legacy-marble";

--- a/packages/public/umd/babylonjs-procedural-textures/src/normalMap.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/normalMap.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-normalMap";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-normalMap";
+export * from "procedural-textures/legacy/legacy-normalMap";

--- a/packages/public/umd/babylonjs-procedural-textures/src/perlinNoise.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/perlinNoise.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-perlinNoise";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-perlinNoise";
+export * from "procedural-textures/legacy/legacy-perlinNoise";

--- a/packages/public/umd/babylonjs-procedural-textures/src/road.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/road.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-road";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-road";
+export * from "procedural-textures/legacy/legacy-road";

--- a/packages/public/umd/babylonjs-procedural-textures/src/starfield.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/starfield.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-starfield";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-starfield";
+export * from "procedural-textures/legacy/legacy-starfield";

--- a/packages/public/umd/babylonjs-procedural-textures/src/wood.ts
+++ b/packages/public/umd/babylonjs-procedural-textures/src/wood.ts
@@ -1,4 +1,3 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
-import * as proceduralTexture from "procedural-textures/legacy/legacy-wood";
-export { proceduralTexture };
-export default proceduralTexture;
+import "procedural-textures/legacy/legacy-wood";
+export * from "procedural-textures/legacy/legacy-wood";

--- a/packages/public/umd/babylonjs-serializers/src/3mf.ts
+++ b/packages/public/umd/babylonjs-serializers/src/3mf.ts
@@ -1,3 +1,2 @@
-import * as serializers from "serializers/legacy/legacy-3mfSerializer";
-export { serializers };
-export default serializers;
+import "serializers/legacy/legacy-3mfSerializer";
+export * from "serializers/legacy/legacy-3mfSerializer";

--- a/packages/public/umd/babylonjs-serializers/src/USDZ.ts
+++ b/packages/public/umd/babylonjs-serializers/src/USDZ.ts
@@ -1,3 +1,2 @@
-import * as serializers from "serializers/legacy/legacy-usdzSerializer";
-export { serializers };
-export default serializers;
+import "serializers/legacy/legacy-usdzSerializer";
+export * from "serializers/legacy/legacy-usdzSerializer";

--- a/packages/public/umd/babylonjs-serializers/src/glTF2.ts
+++ b/packages/public/umd/babylonjs-serializers/src/glTF2.ts
@@ -1,3 +1,2 @@
-import * as serializers from "serializers/legacy/legacy-glTF2Serializer";
-export { serializers };
-export default serializers;
+import "serializers/legacy/legacy-glTF2Serializer";
+export * from "serializers/legacy/legacy-glTF2Serializer";

--- a/packages/public/umd/babylonjs-serializers/src/index.ts
+++ b/packages/public/umd/babylonjs-serializers/src/index.ts
@@ -1,3 +1,2 @@
-import * as serializers from "serializers/legacy/legacy";
-export { serializers };
-export default serializers;
+import "serializers/legacy/legacy";
+export * from "serializers/legacy/legacy";

--- a/packages/public/umd/babylonjs-serializers/src/obj.ts
+++ b/packages/public/umd/babylonjs-serializers/src/obj.ts
@@ -1,3 +1,2 @@
-import * as serializers from "serializers/legacy/legacy-objSerializer";
-export { serializers };
-export default serializers;
+import "serializers/legacy/legacy-objSerializer";
+export * from "serializers/legacy/legacy-objSerializer";

--- a/packages/public/umd/babylonjs-serializers/src/stl.ts
+++ b/packages/public/umd/babylonjs-serializers/src/stl.ts
@@ -1,3 +1,2 @@
-import * as serializers from "serializers/legacy/legacy-stlSerializer";
-export { serializers };
-export default serializers;
+import "serializers/legacy/legacy-stlSerializer";
+export * from "serializers/legacy/legacy-stlSerializer";

--- a/packages/public/umd/babylonjs/src/index.ts
+++ b/packages/public/umd/babylonjs/src/index.ts
@@ -1,4 +1,2 @@
-import * as core from "core/Legacy/legacy";
-
-export { core };
-export default core;
+import "core/Legacy/legacy";
+export * from "core/Legacy/legacy";

--- a/packages/public/umd/test/unit/umdRollupCompatibility.test.ts
+++ b/packages/public/umd/test/unit/umdRollupCompatibility.test.ts
@@ -56,4 +56,15 @@ describe("UMD Rollup compatibility", () => {
         expect(multiEntryConfig).toHaveLength(2);
         expect(multiEntryConfig.every((config) => config.treeshake === false)).toBe(true);
     });
+
+    it("keeps the glTF2 legacy export compatible with nested UMD namespaces", async () => {
+        const { GLTF2: glTF2EntryNamespace } = await import("../../../../dev/loaders/src/legacy/legacy-glTF2");
+        const { GLTF2: fullLoadersNamespace } = await import("../../../../dev/loaders/src/legacy/legacy");
+
+        for (const GLTF2 of [glTF2EntryNamespace, fullLoadersNamespace]) {
+            expect(GLTF2.Loader).toBeDefined();
+            expect(GLTF2.Loader.Extensions).toBeDefined();
+            expect(GLTF2.Loader.Extensions.KHR_lights).toBeDefined();
+        }
+    });
 });

--- a/packages/public/umd/test/unit/umdRollupCompatibility.test.ts
+++ b/packages/public/umd/test/unit/umdRollupCompatibility.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../../..");
+const umdRoot = path.join(repoRoot, "packages/public/umd");
+
+function collectEntryFiles(dir: string): string[] {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const files: string[] = [];
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...collectEntryFiles(fullPath));
+        } else if (entry.isFile() && fullPath.includes(`${path.sep}src${path.sep}`) && fullPath.endsWith(".ts")) {
+            files.push(fullPath);
+        }
+    }
+    return files;
+}
+
+describe("UMD Rollup compatibility", () => {
+    it("keeps UMD entry points compatible with webpack libraryExport default", () => {
+        const entryFiles = collectEntryFiles(umdRoot);
+        expect(entryFiles.length).toBeGreaterThan(0);
+
+        for (const filePath of entryFiles) {
+            const source = fs.readFileSync(filePath, "utf8");
+            if (!source.includes("export * from")) {
+                continue;
+            }
+
+            expect(source, filePath).not.toMatch(/export default\b/);
+            expect(source, filePath).not.toMatch(/export \{ [^}]+ \};/);
+
+            const exportSpecifier = source.match(/export \* from (["'][^"']+["']);/)?.[1];
+            expect(exportSpecifier, filePath).toBeDefined();
+            expect(source, filePath).toContain(`import ${exportSpecifier};`);
+        }
+    });
+
+    it("does not tree-shake legacy UMD side effects", async () => {
+        const { commonUMDRollupConfiguration } = await import("../../../rollupUMDHelper.mjs");
+
+        const singleEntryConfig = commonUMDRollupConfiguration({ devPackageName: "core" });
+        expect(singleEntryConfig.treeshake).toBe(false);
+
+        const multiEntryConfig = commonUMDRollupConfiguration({
+            devPackageName: "loaders",
+            entryPoints: {
+                loaders: "./src/index.ts",
+                glTFFileLoader: "./src/glTFFileLoader.ts",
+            },
+        });
+        expect(multiEntryConfig).toHaveLength(2);
+        expect(multiEntryConfig.every((config) => config.treeshake === false)).toBe(true);
+    });
+});

--- a/packages/public/umd/test/unit/umdRollupCompatibility.test.ts
+++ b/packages/public/umd/test/unit/umdRollupCompatibility.test.ts
@@ -62,9 +62,10 @@ describe("UMD Rollup compatibility", () => {
         const { GLTF2: fullLoadersNamespace } = await import("../../../../dev/loaders/src/legacy/legacy");
 
         for (const GLTF2 of [glTF2EntryNamespace, fullLoadersNamespace]) {
-            expect(GLTF2.Loader).toBeDefined();
-            expect(GLTF2.Loader.Extensions).toBeDefined();
-            expect(GLTF2.Loader.Extensions.KHR_lights).toBeDefined();
+            const legacyGLTF2 = GLTF2 as typeof GLTF2 & { Loader: { Extensions: { KHR_lights: unknown } } };
+            expect(legacyGLTF2.Loader).toBeDefined();
+            expect(legacyGLTF2.Loader.Extensions).toBeDefined();
+            expect(legacyGLTF2.Loader.Extensions.KHR_lights).toBeDefined();
         }
     });
 });


### PR DESCRIPTION
## Summary

Fixes UMD package compatibility regressions introduced by the webpack-to-Rollup migration.

The previous webpack UMD build used `libraryExport: "default"`, so legacy public packages effectively exposed the legacy namespace itself. The Rollup entries were exporting namespace wrapper objects such as `{ core, default, __esModule }` instead, which broke both browser-global and bundler/CommonJS consumption patterns.

This PR updates the UMD entry points to:

```ts
import "package/legacy/legacy";
export * from "package/legacy/legacy";
```

That preserves legacy global attachment side effects and exposes named exports directly. It also disables Rollup tree-shaking for UMD builds so legacy side-effect modules are not removed because several dev packages declare `sideEffects: false`.

## Related forum reports

- https://forum.babylonjs.com/t/issues-with-loading-babylonjs-packages
- https://forum.babylonjs.com/t/cdn-for-gltffileloader-missing-changed-starting-in-v9-5-0
- https://forum.babylonjs.com/t/new-step-for-loading-babylon-in-webworker-starting-in-v9-5-0

## Behavior restored

- `import * as BABYLON from "babylonjs"` exposes `BABYLON.Vector3` at the root again.
- Dependent UMD packages receive the expected Babylon namespace rather than a `{ core, default }` wrapper.
- `babylonjs-procedural-textures` named imports work again, such as `WoodProceduralTexture`.
- Script-tag/global usage keeps attaching symbols like `BABYLON.GLTF2.GLTFLoader` and `BABYLON.WoodProceduralTexture`.
- Production builds continue to generate the non-min copied glTF loader artifact locally via the existing `minToMax` copy path.

## Validation

- Added `packages/public/umd/test/unit/umdRollupCompatibility.test.ts`.
- Ran the new unit test: 2 passed.
- Ran production UMD builds for `babylonjs`, `babylonjs-loaders`, and `babylonjs-procedural-textures`.
- Smoke-tested production artifacts for browser globals and CommonJS exports.
- Ran ES checks for the rebuilt UMD packages.
- Ran Prettier check and `npm run lint:changed`.

## Note

The live `v9.5.0` CDN 404 for `loaders/babylon.glTFFileLoader.js` appears to require a republish/redeploy or hotfix CDN upload. The local production build does generate the file, so this code change fixes the build output for the next publish.