### PR TITLE
Use POST for CDN purge requests

### DIFF
--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -234,7 +234,7 @@ jobs:
           #       -F "storageAccount=$(TOOLS_STORAGE_ACCOUNT)" \
           #       -F "zip=@public.zip"
           #
-          #     curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_SFE)&profileName=$(CDN_PROFILE_TOOLS)&wait=true" -i -H "Authorization: $(BASIC_AUTH)"
+          #     curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_SFE)&profileName=$(CDN_PROFILE_TOOLS)&wait=true" -i -X POST -H "Authorization: $(BASIC_AUTH)"
           #   displayName: 'SFE deployment'
 
           # DISABLED in classic pipeline - Azure CLI upload and purge steps:

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -1049,7 +1049,7 @@ jobs:
 
           - script: |
                 # Async purge: don't block CI on the CDN purge completing.
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -H "Authorization: $(BASIC_AUTH)"
+                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: $(BASIC_AUTH)"
 
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_PREVIEW_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -H "Authorization: $(BASIC_AUTH)"
+                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_PREVIEW_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: $(BASIC_AUTH)"
             displayName: "Purge CDN"

--- a/.azure-pipelines/templates/deploy-tool.yml
+++ b/.azure-pipelines/templates/deploy-tool.yml
@@ -55,5 +55,5 @@ steps:
                 # Async purge: don't wait for the CDN to finish purging.
                 # The deployment server has a much shorter timeout than Azure's
                 # purge operation, so blocking on it always times out in CI.
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}&wait=false" -i -H "Authorization: $(BASIC_AUTH)"
+                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}&wait=false" -i -X POST -H "Authorization: $(BASIC_AUTH)"
             displayName: "Purge CDN (${{ parameters.purgeEndpoint }})"


### PR DESCRIPTION
## Summary
- Explicitly send CDN purge requests to the deployment server with `POST`
- Update both the monorepo CDN purge step and the shared tool deployment template
- Update the disabled SFE example to avoid reintroducing implicit GET by copy/paste

## Validation
- `git --no-pager diff --check`
- VS Code diagnostics for edited YAML files