### PR TITLE
fix(build): output ES6 bundles to dist/ instead of package root

### DIFF
--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -471,7 +471,7 @@ function camelize(str) {
  * @param {string} [options.namespace]
  *   UMD global name for this bundle (e.g. "BABYLON.GUI").
  *   Defaults to the value in umdGlobals.
- * @param {string} [options.outputPath]        Output directory; defaults to process.cwd().
+ * @param {string} [options.outputPath]        Output directory; defaults to "./dist".
  * @param {Record<string,string>} [options.alias]  Additional alias entries.
  * @param {string[]} [options.optionalExternalFunctionSkip]
  *   Extra dev package names to bundle (not externalize).
@@ -495,7 +495,7 @@ export function commonUMDRollupConfiguration(options) {
         devPackageAliasPath,
         mode = "development",
         namespace,
-        outputPath = process.cwd(),
+        outputPath = resolve("./dist"),
         alias: aliasMap = {},
         optionalExternalFunctionSkip = [],
         maxMode = false,


### PR DESCRIPTION
The webpack-to-rollup migration (https://github.com/BabylonJS/Babylon.js/pull/18415) left the outputPath option unset for @babylonjs/* ES6 packages. The rollup helper defaults to process.cwd() (root), but package.json declares main/files in dist/.
Result: npm publish ships only the .d.ts — no JS bundle.

Affected packages (broken since 9.5.1):
- [@babylonjs/gui-editor](https://www.npmjs.com/package/@babylonjs/gui-editor)
- [@babylonjs/node-editor](https://www.npmjs.com/package/@babylonjs/node-editor)
- [@babylonjs/node-geometry-editor](https://www.npmjs.com/package/@babylonjs/node-geometry-editor)
- [@babylonjs/node-particle-editor](https://www.npmjs.com/package/@babylonjs/node-particle-editor)
- [@babylonjs/node-render-graph-editor](https://www.npmjs.com/package/@babylonjs/node-render-graph-editor)
- [@babylonjs/accessibility](https://www.npmjs.com/package/@babylonjs/accessibility)

Fix: change the helper default to resolve('./dist'). All UMD packages already override with path.resolve('.') and are unaffected.

An alternative per-config fix (adding outputPath to each of the 7 ES6 rollup configs) was considered but rejected as it wouldn't prevent the same omission in future packages.