### PR TITLE
Fix Flow Graph Editor serialization and snippet loading

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphMeshPickEventBlock.ts
@@ -1,6 +1,7 @@
 import { type AbstractMesh } from "../../../Meshes/abstractMesh";
 import { FlowGraphEventBlock } from "../../flowGraphEventBlock";
 import { type PointerInfo, PointerEventTypes } from "../../../Events/pointerEvents";
+import { type IPointerEvent } from "../../../Events/deviceInputEvents";
 import { type FlowGraphContext } from "../../flowGraphContext";
 import { type IFlowGraphBlockConfiguration } from "../../flowGraphBlock";
 import { RegisterClass } from "../../../Misc/typeStore";
@@ -99,7 +100,7 @@ export class FlowGraphMeshPickEventBlock extends FlowGraphEventBlock {
         // stable across reloads).
         const meshMatches = !mesh ? !!pickedMesh : !!(pickedMesh && (pickedMesh === mesh || _IsDescendantOf(pickedMesh, mesh) || pickedMesh.name === mesh.name));
         if (meshMatches && pickedMesh) {
-            this.pointerId.setValue((pickedInfo.event as PointerEvent).pointerId, context);
+            this.pointerId.setValue((pickedInfo.event as IPointerEvent).pointerId, context);
             this.pickOrigin.setValue(pickedInfo.pickInfo!.ray?.origin!, context);
             this.pickedPoint.setValue(pickedInfo.pickInfo!.pickedPoint!, context);
             this.pickedMesh.setValue(pickedMesh, context);

--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphPointerDownEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphPointerDownEventBlock.ts
@@ -1,6 +1,7 @@
 import { type AbstractMesh } from "core/Meshes/abstractMesh";
 import { FlowGraphEventBlock } from "core/FlowGraph/flowGraphEventBlock";
 import { type PointerInfo } from "core/Events/pointerEvents";
+import { type IPointerEvent } from "core/Events/deviceInputEvents";
 import { type FlowGraphContext } from "core/FlowGraph/flowGraphContext";
 import { type IFlowGraphBlockConfiguration } from "core/FlowGraph/flowGraphBlock";
 import { RegisterClass } from "core/Misc/typeStore";
@@ -80,7 +81,7 @@ export class FlowGraphPointerDownEventBlock extends FlowGraphEventBlock {
             return true;
         }
 
-        this.pointerId.setValue((pointerInfo.event as PointerEvent).pointerId, context);
+        this.pointerId.setValue((pointerInfo.event as IPointerEvent).pointerId, context);
         this.pickedMesh.setValue(pickedMesh ?? null, context);
         this.pickedPoint.setValue(pointerInfo.pickInfo?.pickedPoint ?? null, context);
         this._execute(context);

--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphPointerMoveEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphPointerMoveEventBlock.ts
@@ -1,6 +1,7 @@
 import { type AbstractMesh } from "core/Meshes/abstractMesh";
 import { FlowGraphEventBlock } from "core/FlowGraph/flowGraphEventBlock";
 import { type PointerInfo } from "core/Events/pointerEvents";
+import { type IPointerEvent } from "core/Events/deviceInputEvents";
 import { type FlowGraphContext } from "core/FlowGraph/flowGraphContext";
 import { type IFlowGraphBlockConfiguration } from "core/FlowGraph/flowGraphBlock";
 import { RegisterClass } from "core/Misc/typeStore";
@@ -80,7 +81,7 @@ export class FlowGraphPointerMoveEventBlock extends FlowGraphEventBlock {
             return true;
         }
 
-        this.pointerId.setValue((pointerInfo.event as PointerEvent).pointerId, context);
+        this.pointerId.setValue((pointerInfo.event as IPointerEvent).pointerId, context);
         this.meshUnderPointer.setValue(pickedMesh ?? null, context);
         this.pickedPoint.setValue(pointerInfo.pickInfo?.pickedPoint ?? null, context);
         this._execute(context);

--- a/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphPointerUpEventBlock.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Event/flowGraphPointerUpEventBlock.ts
@@ -1,6 +1,7 @@
 import { type AbstractMesh } from "core/Meshes/abstractMesh";
 import { FlowGraphEventBlock } from "core/FlowGraph/flowGraphEventBlock";
 import { type PointerInfo } from "core/Events/pointerEvents";
+import { type IPointerEvent } from "core/Events/deviceInputEvents";
 import { type FlowGraphContext } from "core/FlowGraph/flowGraphContext";
 import { type IFlowGraphBlockConfiguration } from "core/FlowGraph/flowGraphBlock";
 import { RegisterClass } from "core/Misc/typeStore";
@@ -80,7 +81,7 @@ export class FlowGraphPointerUpEventBlock extends FlowGraphEventBlock {
             return true;
         }
 
-        this.pointerId.setValue((pointerInfo.event as PointerEvent).pointerId, context);
+        this.pointerId.setValue((pointerInfo.event as IPointerEvent).pointerId, context);
         this.pickedMesh.setValue(pickedMesh ?? null, context);
         this.pickedPoint.setValue(pointerInfo.pickInfo?.pickedPoint ?? null, context);
         this._execute(context);

--- a/packages/dev/core/src/FlowGraph/flowGraphCoordinator.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphCoordinator.ts
@@ -31,7 +31,7 @@ export interface IFlowGraphCoordinatorParseOptions {
     /**
      * The path converter to use to convert the path to an object accessor.
      */
-    pathConverter: IPathToObjectConverter<IObjectAccessor>;
+    pathConverter?: IPathToObjectConverter<IObjectAccessor>;
     /**
      * The scene that the flow graph coordinator belongs to.
      */

--- a/packages/dev/core/src/FlowGraph/flowGraphParser.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphParser.ts
@@ -14,6 +14,37 @@ import { type ISerializedFlowGraph, type ISerializedFlowGraphBlock, type ISerial
 import { type Node } from "core/node";
 import { getRichTypeByFlowGraphType, RichType } from "./flowGraphRichTypes";
 import { type FlowGraphConnection } from "./flowGraphConnection";
+import { Constants } from "core/Engines/constants";
+import { WebRequest } from "core/Misc/webRequest";
+
+async function GetSerializedFlowGraphFromSnippetAsync(snippetId: string): Promise<any> {
+    const response = await WebRequest.FetchAsync(Constants.SnippetUrl + "/" + snippetId.replace(/#/g, "/"));
+    if (!response.ok) {
+        throw new Error("Unable to load the snippet " + snippetId);
+    }
+
+    const text = new TextDecoder().decode(await response.arrayBuffer());
+    const snippet = JSON.parse(text);
+    const snippetPayload = JSON.parse(snippet.jsonPayload);
+    const flowGraphPayload = snippetPayload.flowGraph;
+    if (!flowGraphPayload) {
+        throw new Error("Snippet " + snippetId + " does not contain a flow graph");
+    }
+
+    return typeof flowGraphPayload === "string" ? JSON.parse(flowGraphPayload) : flowGraphPayload;
+}
+
+function ApplyCoordinatorSerializationSettings(serializedObject: any, coordinator: FlowGraphCoordinator): void {
+    if (serializedObject.dispatchEventsSynchronously) {
+        coordinator.dispatchEventsSynchronously = serializedObject.dispatchEventsSynchronously;
+    }
+
+    if (serializedObject._defaultValues) {
+        for (const key in serializedObject._defaultValues) {
+            getRichTypeByFlowGraphType(key).defaultValue = serializedObject._defaultValues[key];
+        }
+    }
+}
 
 /**
  * Given a list of blocks, find an output data connection that has a specific unique id
@@ -61,19 +92,9 @@ export async function ParseCoordinatorAsync(serializedObject: any, options: IFlo
     const valueParseFunction = options.valueParseFunction ?? defaultValueParseFunction;
     const coordinator = new FlowGraphCoordinator({ scene: options.scene });
 
-    if (serializedObject.dispatchEventsSynchronously) {
-        coordinator.dispatchEventsSynchronously = serializedObject.dispatchEventsSynchronously;
-    }
+    ApplyCoordinatorSerializationSettings(serializedObject, coordinator);
 
     await options.scene.whenReadyAsync();
-    // if custom default values are defined, set them in the global context
-    if (serializedObject._defaultValues) {
-        for (const key in serializedObject._defaultValues) {
-            // key is the FlowGraphType, value is the default value
-            const value = serializedObject._defaultValues[key];
-            getRichTypeByFlowGraphType(key).defaultValue = value;
-        }
-    }
     // async-parse the flow graphs. This can be done in parallel
     await Promise.all(
         serializedObject._flowGraphs?.map(
@@ -81,6 +102,51 @@ export async function ParseCoordinatorAsync(serializedObject: any, options: IFlo
         )
     );
     return coordinator;
+}
+
+/**
+ * Parses a flow graph coordinator from a snippet saved by the Flow Graph Editor.
+ * @param snippetId the snippet id to load. Versioned ids such as "ABC123#4" are supported.
+ * @param options options for parsing the coordinator.
+ * @returns the parsed flow graph coordinator.
+ */
+export async function ParseFlowGraphCoordinatorFromSnippetAsync(snippetId: string, options: IFlowGraphCoordinatorParseOptions): Promise<FlowGraphCoordinator> {
+    const serializedObject = await GetSerializedFlowGraphFromSnippetAsync(snippetId);
+    if (serializedObject._flowGraphs) {
+        return await ParseCoordinatorAsync(serializedObject, options);
+    }
+
+    const valueParseFunction = options.valueParseFunction ?? defaultValueParseFunction;
+    const coordinator = new FlowGraphCoordinator({ scene: options.scene });
+    await options.scene.whenReadyAsync();
+    await ParseFlowGraphAsync(serializedObject, { coordinator, valueParseFunction, pathConverter: options.pathConverter });
+    return coordinator;
+}
+
+/**
+ * Parses a flow graph from a snippet saved by the Flow Graph Editor.
+ * If the snippet contains multiple graphs, all graphs are parsed into the provided coordinator and the active graph is returned.
+ * @param snippetId the snippet id to load. Versioned ids such as "ABC123#4" are supported.
+ * @param options options for parsing the graph.
+ * @returns the parsed flow graph.
+ */
+export async function ParseFlowGraphFromSnippetAsync(snippetId: string, options: IFlowGraphParseOptions): Promise<FlowGraph> {
+    const serializedObject = await GetSerializedFlowGraphFromSnippetAsync(snippetId);
+    const valueParseFunction = options.valueParseFunction ?? defaultValueParseFunction;
+
+    if (!serializedObject._flowGraphs) {
+        return await ParseFlowGraphAsync(serializedObject, options);
+    }
+
+    ApplyCoordinatorSerializationSettings(serializedObject, options.coordinator);
+    const parsedGraphs: FlowGraph[] = [];
+    for (const serializedGraph of serializedObject._flowGraphs) {
+        // eslint-disable-next-line no-await-in-loop -- graph order matters for the active graph index.
+        parsedGraphs.push(await ParseFlowGraphAsync(serializedGraph, { coordinator: options.coordinator, valueParseFunction, pathConverter: options.pathConverter }));
+    }
+
+    const activeGraphIndex = serializedObject.activeGraphIndex ?? 0;
+    return parsedGraphs[activeGraphIndex] ?? parsedGraphs[0];
 }
 
 /**
@@ -136,9 +202,14 @@ export function ParseFlowGraph(serializationObject: ISerializedFlowGraph, option
     }
     // After parsing all blocks, connect them.
     // Build lookup maps for O(1) connection resolution instead of O(B*P) linear scans.
+    const dataInMap = new Map<string, FlowGraphDataConnection<any>>();
     const dataOutMap = new Map<string, FlowGraphDataConnection<any>>();
     const signalInMap = new Map<string, FlowGraphSignalConnection>();
+    const signalOutMap = new Map<string, FlowGraphSignalConnection>();
     for (const block of blocks) {
+        for (const dataIn of block.dataInputs) {
+            dataInMap.set(dataIn.uniqueId, dataIn);
+        }
         for (const dataOut of block.dataOutputs) {
             dataOutMap.set(dataOut.uniqueId, dataOut);
         }
@@ -146,8 +217,17 @@ export function ParseFlowGraph(serializationObject: ISerializedFlowGraph, option
             for (const signalIn of block.signalInputs) {
                 signalInMap.set(signalIn.uniqueId, signalIn);
             }
+            for (const signalOut of block.signalOutputs) {
+                signalOutMap.set(signalOut.uniqueId, signalOut);
+            }
         }
     }
+    const connectIfNeeded = <ConnectionT extends FlowGraphConnection<any, any>>(connection: ConnectionT, connectedConnection: ConnectionT) => {
+        if (connection._connectedPoint.indexOf(connectedConnection) !== -1) {
+            return;
+        }
+        connection.connectTo(connectedConnection);
+    };
     for (const block of blocks) {
         for (const dataIn of block.dataInputs) {
             for (const serializedConnection of dataIn.connectedPointIds) {
@@ -155,7 +235,16 @@ export function ParseFlowGraph(serializationObject: ISerializedFlowGraph, option
                 if (!connection) {
                     throw new Error("Could not find data out connection with unique id " + serializedConnection);
                 }
-                dataIn.connectTo(connection);
+                connectIfNeeded(dataIn, connection);
+            }
+        }
+        for (const dataOut of block.dataOutputs) {
+            for (const serializedConnection of dataOut.connectedPointIds) {
+                const connection = dataInMap.get(serializedConnection);
+                if (!connection) {
+                    throw new Error("Could not find data in connection with unique id " + serializedConnection);
+                }
+                connectIfNeeded(dataOut, connection);
             }
         }
         if (block instanceof FlowGraphExecutionBlock) {
@@ -165,12 +254,21 @@ export function ParseFlowGraph(serializationObject: ISerializedFlowGraph, option
                     if (!connection) {
                         throw new Error("Could not find signal in connection with unique id " + serializedConnection);
                     }
-                    signalOut.connectTo(connection);
+                    connectIfNeeded(signalOut, connection);
+                }
+            }
+            for (const signalIn of block.signalInputs) {
+                for (const serializedConnection of signalIn.connectedPointIds) {
+                    const connection = signalOutMap.get(serializedConnection);
+                    if (!connection) {
+                        throw new Error("Could not find signal out connection with unique id " + serializedConnection);
+                    }
+                    connectIfNeeded(connection, signalIn);
                 }
             }
         }
     }
-    for (const serializedContext of serializationObject.executionContexts) {
+    for (const serializedContext of serializationObject.executionContexts ?? []) {
         ParseFlowGraphContext(serializedContext, { graph, valueParseFunction }, serializationObject.rightHanded);
     }
     return graph;

--- a/packages/dev/core/src/FlowGraph/flowGraphParser.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphParser.ts
@@ -35,7 +35,7 @@ async function GetSerializedFlowGraphFromSnippetAsync(snippetId: string): Promis
 }
 
 function ApplyCoordinatorSerializationSettings(serializedObject: any, coordinator: FlowGraphCoordinator): void {
-    if (serializedObject.dispatchEventsSynchronously) {
+    if (serializedObject.dispatchEventsSynchronously !== undefined) {
         coordinator.dispatchEventsSynchronously = serializedObject.dispatchEventsSynchronously;
     }
 

--- a/packages/dev/core/src/FlowGraph/serialization.ts
+++ b/packages/dev/core/src/FlowGraph/serialization.ts
@@ -6,23 +6,8 @@ import { type Scene } from "../scene";
 import { FlowGraphBlockNames } from "./Blocks/flowGraphBlockNames";
 import { FlowGraphInteger } from "./CustomTypes/flowGraphInteger";
 import { FlowGraphTypes, getRichTypeByFlowGraphType } from "./flowGraphRichTypes";
-import { type TransformNode } from "core/Meshes/transformNode";
+import { type Node } from "core/node";
 import { FlowGraphMatrix2D, FlowGraphMatrix3D } from "./CustomTypes/flowGraphMatrix";
-
-function IsMeshClassName(className: string) {
-    return (
-        className === "Mesh" ||
-        className === "AbstractMesh" ||
-        className === "TransformNode" ||
-        className === "GroundMesh" ||
-        className === "InstancedMesh" ||
-        className === "InstanceMesh" ||
-        className === "LinesMesh" ||
-        className === "GoldbergMesh" ||
-        className === "GreasedLineMesh" ||
-        className === "TrailMesh"
-    );
-}
 
 function IsVectorClassName(className: string) {
     return (
@@ -41,6 +26,22 @@ function IsMatrixClassName(className: string) {
 
 function IsAnimationGroupClassName(className: string) {
     return className === "AnimationGroup";
+}
+
+function GetSceneNodeFromSerializedReference(serializedReference: any, scene: Scene): Node | undefined {
+    if (!serializedReference || (!serializedReference.id && !serializedReference.name)) {
+        return undefined;
+    }
+
+    const nodes = scene.getNodes().filter((node) => (serializedReference.id ? node.id === serializedReference.id : node.name === serializedReference.name));
+    if (nodes.length === 0) {
+        return undefined;
+    }
+
+    const className = serializedReference.type ?? serializedReference.className;
+    const classMatches = className ? nodes.filter((node) => node.getClassName() === className) : [];
+    const candidates = classMatches.length > 0 ? classMatches : nodes;
+    return (serializedReference.uniqueId ? candidates.find((node) => node.uniqueId === serializedReference.uniqueId) : undefined) ?? candidates[0];
 }
 
 function ParseVector(className: string, value: Array<number>, flipHandedness = false) {
@@ -135,12 +136,9 @@ export function defaultValueParseFunction(key: string, serializationObject: any,
     const intermediateValue = serializationObject[key];
     let finalValue;
     const className = intermediateValue?.type ?? intermediateValue?.className;
-    if (IsMeshClassName(className)) {
-        let nodes: TransformNode[] = scene.meshes.filter((m) => (intermediateValue.id ? m.id === intermediateValue.id : m.name === intermediateValue.name));
-        if (nodes.length === 0) {
-            nodes = scene.transformNodes.filter((m) => (intermediateValue.id ? m.id === intermediateValue.id : m.name === intermediateValue.name));
-        }
-        finalValue = intermediateValue.uniqueId ? nodes.find((m) => m.uniqueId === intermediateValue.uniqueId) : nodes[0];
+    const sceneNode = GetSceneNodeFromSerializedReference(intermediateValue, scene);
+    if (sceneNode) {
+        finalValue = sceneNode;
     } else if (IsVectorClassName(className)) {
         finalValue = ParseVector(className, intermediateValue.value);
     } else if (IsAnimationGroupClassName(className)) {

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
@@ -1,4 +1,5 @@
 import { type Engine, NullEngine } from "core/Engines";
+import { Constants } from "core/Engines/constants";
 import {
     type FlowGraphAssetType,
     type FlowGraphExecutionBlock,
@@ -21,6 +22,8 @@ import {
     ParseFlowGraphContext,
     ParseFlowGraph,
     ParseFlowGraphAsync,
+    ParseFlowGraphCoordinatorFromSnippetAsync,
+    ParseFlowGraphFromSnippetAsync,
 } from "core/FlowGraph";
 import { FlowGraphConnectionType } from "core/FlowGraph/flowGraphConnection";
 import { FlowGraphDataConnection } from "core/FlowGraph/flowGraphDataConnection";
@@ -33,6 +36,16 @@ import { Mesh } from "core/Meshes";
 import { TransformNode } from "core/Meshes/transformNode";
 import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
+import { afterEach, vi } from "vitest";
+import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
+
+function MockFlowGraphSnippet(serializedFlowGraph: any) {
+    const fetchMock = vi.fn(async () => {
+        return new Response(JSON.stringify({ jsonPayload: JSON.stringify({ flowGraph: JSON.stringify(serializedFlowGraph) }) }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+}
 
 describe("Flow Graph Serialization", () => {
     let engine: Engine;
@@ -48,6 +61,10 @@ describe("Flow Graph Serialization", () => {
         Logger.Log = vi.fn();
 
         scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
     });
     it("Serializes and Parses a connection", () => {
         const block = {} as any;
@@ -206,6 +223,74 @@ describe("Flow Graph Serialization", () => {
         expect(Logger.Log).toHaveBeenCalledWith(42);
     });
 
+    it("parses connections from either side of serialized connection ids", async () => {
+        const mockContext: any = {};
+        const pathConverter = new FlowGraphPathConverter(mockContext);
+
+        const coordinator = new FlowGraphCoordinator({ scene });
+        const graph = coordinator.createGraph();
+        const context = graph.createContext();
+        context.setVariable("test", 42);
+
+        const sceneReadyBlock = new FlowGraphSceneReadyEventBlock();
+        graph.addEventBlock(sceneReadyBlock);
+
+        const logBlock = new FlowGraphConsoleLogBlock();
+        sceneReadyBlock.out.connectTo(logBlock.in);
+
+        const getVariableBlock = new FlowGraphGetVariableBlock({ variable: "test" });
+        logBlock.message.connectTo(getVariableBlock.value);
+
+        const serialized: any = {};
+        graph.serialize(serialized);
+
+        const sceneReadyJson = serialized.allBlocks.find((block: any) => block.className === "FlowGraphSceneReadyEventBlock");
+        sceneReadyJson.signalOutputs.find((signalOutput: any) => signalOutput.name === "out").connectedPointIds = [];
+
+        const logJson = serialized.allBlocks.find((block: any) => block.className === "FlowGraphConsoleLogBlock");
+        logJson.dataInputs.find((dataInput: any) => dataInput.name === "message").connectedPointIds = [];
+
+        const parsed = await ParseFlowGraphAsync(serialized, { coordinator, pathConverter });
+        parsed.start();
+
+        expect(Logger.Log).toHaveBeenCalledWith(42);
+    });
+
+    it("parses a flow graph coordinator from a snippet", async () => {
+        const coordinator = new FlowGraphCoordinator({ scene });
+        const graph = coordinator.createGraph("Snippet Graph");
+        graph.addEventBlock(new FlowGraphSceneReadyEventBlock());
+
+        const serializedGraph: any = {};
+        graph.serialize(serializedGraph);
+        const serializedCoordinator = { _flowGraphs: [serializedGraph], activeGraphIndex: 0 };
+        const fetchMock = MockFlowGraphSnippet(serializedCoordinator);
+
+        const parsedCoordinator = await ParseFlowGraphCoordinatorFromSnippetAsync("ABC123#4", { scene });
+
+        expect(fetchMock.mock.calls[0][0]).toBe(Constants.SnippetUrl + "/ABC123/4");
+        expect(parsedCoordinator.flowGraphs.length).toBe(1);
+        expect(parsedCoordinator.flowGraphs[0].name).toBe("Snippet Graph");
+    });
+
+    it("returns the active flow graph from a snippet", async () => {
+        const coordinator = new FlowGraphCoordinator({ scene });
+        const firstGraph = coordinator.createGraph("First Graph");
+        const activeGraph = coordinator.createGraph("Active Graph");
+
+        const firstSerializedGraph: any = {};
+        firstGraph.serialize(firstSerializedGraph);
+        const activeSerializedGraph: any = {};
+        activeGraph.serialize(activeSerializedGraph);
+        MockFlowGraphSnippet({ _flowGraphs: [firstSerializedGraph, activeSerializedGraph], activeGraphIndex: 1 });
+
+        const targetCoordinator = new FlowGraphCoordinator({ scene });
+        const parsedActiveGraph = await ParseFlowGraphFromSnippetAsync("ABC123#4", { coordinator: targetCoordinator });
+
+        expect(targetCoordinator.flowGraphs.length).toBe(2);
+        expect(parsedActiveGraph.name).toBe("Active Graph");
+    });
+
     it("Preserves name and uniqueId across serialize/parse roundtrip", async () => {
         const coordinator = new FlowGraphCoordinator({ scene });
         const graph = coordinator.createGraph("My Custom Graph");
@@ -264,6 +349,35 @@ describe("Flow Graph Serialization", () => {
 
         scene.onReadyObservable.notifyObservers(scene);
         expect(mesh.position.asArray()).toEqual([1, 2, 3]);
+    });
+
+    it("parses scene node references by id when unique ids differ", async () => {
+        const coordinator = new FlowGraphCoordinator({ scene });
+        const graph = coordinator.createGraph();
+        const camera = new ArcRotateCamera("camera1", 0, 0, 10, Vector3.Zero(), scene);
+
+        const flowGraphSceneReadyBlock = new FlowGraphSceneReadyEventBlock();
+        graph.addEventBlock(flowGraphSceneReadyBlock);
+
+        const setPropertyBlock = new FlowGraphSetPropertyBlock<number, FlowGraphAssetType.Camera>({ propertyName: "alpha" });
+        flowGraphSceneReadyBlock.out.connectTo(setPropertyBlock.in);
+
+        const cameraBlock = new FlowGraphConstantBlock<ArcRotateCamera>({ value: camera });
+        cameraBlock.output.connectTo(setPropertyBlock.object);
+
+        const valueBlock = new FlowGraphConstantBlock<number>({ value: 1 });
+        valueBlock.output.connectTo(setPropertyBlock.value);
+
+        const serialized: any = {};
+        graph.serialize(serialized);
+        const cameraBlockJson = serialized.allBlocks.find((block: any) => block.uniqueId === cameraBlock.uniqueId);
+        cameraBlockJson.config.value.uniqueId = -1;
+
+        const parsed = await ParseFlowGraphAsync(serialized, { coordinator });
+        parsed.start();
+
+        scene.onReadyObservable.notifyObservers(scene);
+        expect(camera.alpha).toBe(1);
     });
 
     it("Event block fires both out and done signals after round-trip", async () => {

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
@@ -22,6 +22,7 @@ import {
     ParseFlowGraphContext,
     ParseFlowGraph,
     ParseFlowGraphAsync,
+    ParseCoordinatorAsync,
     ParseFlowGraphCoordinatorFromSnippetAsync,
     ParseFlowGraphFromSnippetAsync,
 } from "core/FlowGraph";
@@ -271,6 +272,19 @@ describe("Flow Graph Serialization", () => {
         expect(fetchMock.mock.calls[0][0]).toBe(Constants.SnippetUrl + "/ABC123/4");
         expect(parsedCoordinator.flowGraphs.length).toBe(1);
         expect(parsedCoordinator.flowGraphs[0].name).toBe("Snippet Graph");
+    });
+
+    it("preserves false dispatch settings when parsing a coordinator", async () => {
+        const coordinator = new FlowGraphCoordinator({ scene });
+        coordinator.dispatchEventsSynchronously = false;
+        coordinator.createGraph("Async Events Graph");
+
+        const serializedCoordinator: any = {};
+        coordinator.serialize(serializedCoordinator);
+
+        const parsedCoordinator = await ParseCoordinatorAsync(serializedCoordinator, { scene });
+
+        expect(parsedCoordinator.dispatchEventsSynchronously).toBe(false);
     });
 
     it("returns the active flow graph from a snippet", async () => {

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.module.scss
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.module.scss
@@ -420,7 +420,7 @@
     border-radius: 50%;
     z-index: 20;
     pointer-events: auto;
-    cursor: help;
+    cursor: pointer;
     border: 2px solid black;
     box-sizing: border-box;
 

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -88,15 +88,22 @@ export class GraphNode {
         if (!severity) {
             this._validationBadge.style.display = "none";
             this._validationBadge.title = "";
+            this._validationBadge.removeAttribute("role");
+            this._validationBadge.removeAttribute("tabindex");
+            this._validationBadge.removeAttribute("aria-label");
             this._validationBadge.onclick = null;
             this._validationBadge.onpointerdown = null;
             this._validationBadge.onpointermove = null;
             this._validationBadge.onpointerup = null;
+            this._validationBadge.onkeydown = null;
             return;
         }
         this._validationBadge.style.display = "";
         this._validationBadge.classList.add(severity === "error" ? localStyles["validationError"] : localStyles["validationWarning"]);
         this._validationBadge.title = tooltip ?? "";
+        this._validationBadge.setAttribute("role", "button");
+        this._validationBadge.tabIndex = 0;
+        this._validationBadge.setAttribute("aria-label", severity === "error" ? "Show validation errors" : "Show validation warnings");
         this._validationBadge.onclick = null;
         this._validationBadge.onpointerdown = (e) => {
             e.stopPropagation();
@@ -105,6 +112,14 @@ export class GraphNode {
             e.stopPropagation();
         };
         this._validationBadge.onpointerup = (e) => {
+            e.stopPropagation();
+            onClick?.();
+        };
+        this._validationBadge.onkeydown = (e) => {
+            if (e.key !== "Enter" && e.key !== " ") {
+                return;
+            }
+            e.preventDefault();
             e.stopPropagation();
             onClick?.();
         };

--- a/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
+++ b/packages/dev/sharedUiComponents/src/nodeGraphSystem/graphNode.ts
@@ -78,8 +78,9 @@ export class GraphNode {
      * Shows a validation badge on the node header.
      * @param severity - "error" | "warning" | null. Pass null to hide the badge.
      * @param tooltip - tooltip text shown on hover.
+     * @param onClick - optional callback invoked when the badge is clicked.
      */
-    public setValidationState(severity: "error" | "warning" | null, tooltip?: string): void {
+    public setValidationState(severity: "error" | "warning" | null, tooltip?: string, onClick?: () => void): void {
         if (!this._validationBadge) {
             return;
         }
@@ -87,11 +88,26 @@ export class GraphNode {
         if (!severity) {
             this._validationBadge.style.display = "none";
             this._validationBadge.title = "";
+            this._validationBadge.onclick = null;
+            this._validationBadge.onpointerdown = null;
+            this._validationBadge.onpointermove = null;
+            this._validationBadge.onpointerup = null;
             return;
         }
         this._validationBadge.style.display = "";
         this._validationBadge.classList.add(severity === "error" ? localStyles["validationError"] : localStyles["validationWarning"]);
         this._validationBadge.title = tooltip ?? "";
+        this._validationBadge.onclick = null;
+        this._validationBadge.onpointerdown = (e) => {
+            e.stopPropagation();
+        };
+        this._validationBadge.onpointermove = (e) => {
+            e.stopPropagation();
+        };
+        this._validationBadge.onpointerup = (e) => {
+            e.stopPropagation();
+            onClick?.();
+        };
     }
 
     /**

--- a/packages/tools/flowGraphEditor/src/components/graphControls/graphControlsComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/graphControls/graphControlsComponent.tsx
@@ -152,18 +152,6 @@ export class GraphControlsComponent extends React.Component<IGraphControlsProps,
 
     private _onStart() {
         try {
-            // Stop all auto-playing animation groups on the scene so the flow
-            // graph has exclusive control over which animations run.  Without
-            // this, the glTF auto-started animation keeps running and masks
-            // whatever the PlayAnimation block tries to start.
-            const scene = this.props.globalState.sceneContext?.scene;
-            if (scene) {
-                for (const ag of scene.animationGroups) {
-                    if (ag.isPlaying) {
-                        ag.stop();
-                    }
-                }
-            }
             // Wire the flow graph to the preview scene so events (pick, tick, etc.)
             // fire on the visible scene, not the editor's hidden host scene.
             // setScene() clears stale execution contexts so start() creates

--- a/packages/tools/flowGraphEditor/src/components/howToUse/howToUseDialogComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/howToUse/howToUseDialogComponent.tsx
@@ -53,40 +53,21 @@ export class HowToUseDialogComponent extends React.Component<IHowToUseDialogProp
     override render() {
         const snippetId = this.props.globalState.flowGraphSnippetId;
 
-        const snippetCode = `import { FlowGraphCoordinator } from "@babylonjs/core/FlowGraph/flowGraphCoordinator";
-import { ParseFlowGraphAsync } from "@babylonjs/core/FlowGraph/flowGraphParser";
+        const snippetCode = `import { ParseFlowGraphCoordinatorFromSnippetAsync } from "@babylonjs/core/FlowGraph/flowGraphParser";
 
 // After creating your scene:
-const coordinator = new FlowGraphCoordinator({ scene });
+    const coordinator = await ParseFlowGraphCoordinatorFromSnippetAsync("${snippetId || "<your-snippet-id>"}", { scene });
+    coordinator.start();`;
 
-// Fetch the snippet from the Babylon.js snippet server:
-const response = await fetch(
-    "https://snippet.babylonjs.com/${snippetId || "<your-snippet-id>"}"
-);
-const snippet = await response.json();
-const data = JSON.parse(snippet.jsonPayload);
-
-// Parse and start the flow graph:
-const flowGraph = await ParseFlowGraphAsync(
-    JSON.parse(data.flowGraph),
-    { coordinator }
-);
-flowGraph.start();`;
-
-        const fileCode = `import { FlowGraphCoordinator } from "@babylonjs/core/FlowGraph/flowGraphCoordinator";
-import { ParseFlowGraphAsync } from "@babylonjs/core/FlowGraph/flowGraphParser";
+        const fileCode = `import { ParseCoordinatorAsync } from "@babylonjs/core/FlowGraph/flowGraphParser";
 
 // Load the saved JSON file:
 const response = await fetch("./flowGraph.json");
 const data = await response.json();
 
 // After creating your scene:
-const coordinator = new FlowGraphCoordinator({ scene });
-const flowGraph = await ParseFlowGraphAsync(
-    data,
-    { coordinator }
-);
-flowGraph.start();`;
+    const coordinator = await ParseCoordinatorAsync(data, { scene });
+    coordinator.start();`;
 
         return (
             <div className="fge-howto-overlay" onPointerDown={() => this.props.onClose()}>

--- a/packages/tools/flowGraphEditor/src/components/preview/scenePreviewComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/preview/scenePreviewComponent.tsx
@@ -352,7 +352,6 @@ export class ScenePreviewComponent extends React.Component<IScenePreviewComponen
             }
         }
 
-        this.props.globalState.onResetRequiredObservable.notifyObservers(false);
         this.props.globalState.stateManager.onSelectionChangedObservable.notifyObservers(null);
         this.props.globalState.onClearUndoStack.notifyObservers();
         this.props.globalState.onLogRequiredObservable.notifyObservers(

--- a/packages/tools/flowGraphEditor/src/components/propertyTab/propertyTabComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/propertyTab/propertyTabComponent.tsx
@@ -43,6 +43,9 @@ interface IPropertyTabComponentState {
 
 export class PropertyTabComponent extends React.Component<IPropertyTabComponentProps, IPropertyTabComponentState> {
     private _onBuiltObserver: Nullable<Observer<void>>;
+    private _onHashChange = () => {
+        void this._loadSnippetFromHashAsync();
+    };
 
     constructor(props: IPropertyTabComponentProps) {
         super(props);
@@ -69,10 +72,40 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
         this._onBuiltObserver = this.props.globalState.onBuiltObservable.add(() => {
             this.forceUpdate();
         });
+
+        this.props.globalState.hostDocument.defaultView?.addEventListener("hashchange", this._onHashChange);
+        void this._loadSnippetFromHashAsync();
     }
 
     override componentWillUnmount() {
         this.props.globalState.onBuiltObservable.remove(this._onBuiltObserver);
+        this.props.globalState.hostDocument.defaultView?.removeEventListener("hashchange", this._onHashChange);
+    }
+
+    private _getSnippetIdFromHash(): string {
+        const hash = this.props.globalState.hostDocument.defaultView?.location.hash.substring(1) ?? "";
+        try {
+            return decodeURIComponent(hash);
+        } catch {
+            return hash;
+        }
+    }
+
+    private _setSnippetIdInHash(snippetId: string): void {
+        const hostWindow = this.props.globalState.hostDocument.defaultView;
+        if (!hostWindow) {
+            return;
+        }
+        const { pathname, search } = hostWindow.location;
+        hostWindow.history.replaceState(null, "", `${pathname}${search}#${snippetId}`);
+    }
+
+    private async _loadSnippetFromHashAsync(): Promise<void> {
+        const snippetId = this._getSnippetIdFromHash();
+        if (!snippetId || snippetId === this.props.globalState.flowGraphSnippetId) {
+            return;
+        }
+        await this.loadFromSnippetAsync(snippetId);
     }
 
     load(file: File) {
@@ -82,7 +115,6 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                 const decoder = new TextDecoder("utf-8");
                 const doLoadAsync = async () => {
                     await SerializationTools.DeserializeAsync(JSON.parse(decoder.decode(data)), this.props.globalState);
-                    this.props.globalState.onResetRequiredObservable.notifyObservers(false);
                     this.props.globalState.stateManager.onSelectionChangedObservable.notifyObservers(null);
                     this.props.globalState.onClearUndoStack.notifyObservers();
                     ShowToast(this.props.globalState, "Flow graph loaded from file", "success");
@@ -179,6 +211,7 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                     newId += "#" + snippet.version;
                 }
                 this.props.globalState.flowGraphSnippetId = newId;
+                this._setSnippetIdInHash(newId);
                 this.forceUpdate();
 
                 if (navigator.clipboard) {
@@ -227,7 +260,7 @@ export class PropertyTabComponent extends React.Component<IPropertyTabComponentP
                 try {
                     await SerializationTools.DeserializeAsync(serializationObject, this.props.globalState);
                     this.props.globalState.flowGraphSnippetId = id;
-                    this.props.globalState.onResetRequiredObservable.notifyObservers(false);
+                    this._setSnippetIdInHash(id);
                     this.props.globalState.stateManager.onSelectionChangedObservable.notifyObservers(null);
                     this.props.globalState.onClearUndoStack.notifyObservers();
                     this.props.globalState.onLogRequiredObservable.notifyObservers(new LogEntry("Flow graph loaded from snippet " + id, false));

--- a/packages/tools/flowGraphEditor/src/components/toast/toast.scss
+++ b/packages/tools/flowGraphEditor/src/components/toast/toast.scss
@@ -48,6 +48,7 @@
 
     .fge-toast-message {
         flex: 1;
+        white-space: pre-line;
     }
 
     .fge-toast-close {

--- a/packages/tools/flowGraphEditor/src/components/toast/toastComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/toast/toastComponent.tsx
@@ -11,7 +11,9 @@ interface IToastEntry {
     id: number;
     message: string;
     severity: ToastSeverity;
-    timerId: ReturnType<typeof setTimeout>;
+    timerId: Nullable<ReturnType<typeof setTimeout>>;
+    startedAt: number;
+    remainingDuration: number;
 }
 
 interface IToastContainerProps {
@@ -50,9 +52,9 @@ export class ToastContainerComponent extends React.Component<IToastContainerProp
     override componentDidMount() {
         this._observer = this.props.globalState.onToastNotification.add((data) => {
             const id = this._nextId++;
-            const timerId = setTimeout(() => this._dismiss(id), TOAST_DURATION_MS);
+            const timerId = this._createDismissTimer(id, TOAST_DURATION_MS);
             this.setState((prev) => ({
-                toasts: [...prev.toasts, { id, message: data.message, severity: data.severity, timerId }],
+                toasts: [...prev.toasts, { id, message: data.message, severity: data.severity, timerId, startedAt: Date.now(), remainingDuration: TOAST_DURATION_MS }],
             }));
         });
     }
@@ -63,15 +65,57 @@ export class ToastContainerComponent extends React.Component<IToastContainerProp
         this._observer = null;
         // Clear all pending timers
         for (const t of this.state.toasts) {
-            clearTimeout(t.timerId);
+            if (t.timerId) {
+                clearTimeout(t.timerId);
+            }
         }
+    }
+
+    private _createDismissTimer(id: number, duration: number) {
+        return setTimeout(() => this._dismiss(id), duration);
+    }
+
+    private _pauseDismiss(id: number) {
+        this.setState((prev) => ({
+            toasts: prev.toasts.map((toast) => {
+                if (toast.id !== id || !toast.timerId) {
+                    return toast;
+                }
+                clearTimeout(toast.timerId);
+                const elapsed = Date.now() - toast.startedAt;
+                return {
+                    ...toast,
+                    timerId: null,
+                    remainingDuration: Math.max(0, toast.remainingDuration - elapsed),
+                };
+            }),
+        }));
+    }
+
+    private _resumeDismiss(id: number) {
+        this.setState((prev) => ({
+            toasts: prev.toasts.map((toast) => {
+                if (toast.id !== id || toast.timerId) {
+                    return toast;
+                }
+                const remainingDuration = Math.max(1, toast.remainingDuration);
+                return {
+                    ...toast,
+                    timerId: this._createDismissTimer(id, remainingDuration),
+                    startedAt: Date.now(),
+                    remainingDuration,
+                };
+            }),
+        }));
     }
 
     private _dismiss(id: number) {
         this.setState((prev) => ({
             toasts: prev.toasts.filter((t) => {
                 if (t.id === id) {
-                    clearTimeout(t.timerId);
+                    if (t.timerId) {
+                        clearTimeout(t.timerId);
+                    }
                     return false;
                 }
                 return true;
@@ -84,7 +128,14 @@ export class ToastContainerComponent extends React.Component<IToastContainerProp
         return (
             <div className="fge-toast-container">
                 {this.state.toasts.map((toast) => (
-                    <div key={toast.id} className={`fge-toast fge-toast-${toast.severity}`} role="status" aria-live="polite">
+                    <div
+                        key={toast.id}
+                        className={`fge-toast fge-toast-${toast.severity}`}
+                        role="status"
+                        aria-live="polite"
+                        onMouseEnter={() => this._pauseDismiss(toast.id)}
+                        onMouseLeave={() => this._resumeDismiss(toast.id)}
+                    >
                         <span className="fge-toast-icon">{SEVERITY_ICONS[toast.severity]}</span>
                         <span className="fge-toast-message">{toast.message}</span>
                         <button className="fge-toast-close" aria-label="Dismiss" onClick={() => this._dismiss(toast.id)}>

--- a/packages/tools/flowGraphEditor/src/flowGraphEditor.ts
+++ b/packages/tools/flowGraphEditor/src/flowGraphEditor.ts
@@ -92,8 +92,6 @@ export class FlowGraphEditor {
             options.customLoadObservable.add((data) => {
                 const doLoadAsync = async () => {
                     await SerializationTools.DeserializeAsync(data, globalState);
-                    globalState.onResetRequiredObservable.notifyObservers(false);
-                    globalState.onBuiltObservable.notifyObservers();
                 };
                 void doLoadAsync();
             });

--- a/packages/tools/flowGraphEditor/src/globalState.ts
+++ b/packages/tools/flowGraphEditor/src/globalState.ts
@@ -57,8 +57,8 @@ export class GlobalState {
     onImportFrameObservable = new Observable<any>();
     /** Observable triggered when popup is closed */
     onPopupClosedObservable = new Observable<void>();
-    /** Callback to get a graph node from a flow graph block */
-    onGetNodeFromBlock: (block: FlowGraphBlock) => GraphNode;
+    /** Callback to get a graph node from a flow graph block. Set by GraphEditor after mount. */
+    onGetNodeFromBlock: Nullable<(block: FlowGraphBlock) => GraphNode> = null;
     // eslint-disable-next-line jsdoc/require-returns
     /** Callback that returns true if the given graph node is within the visible viewport.
      *  Used by the debug highlighter to skip offscreen nodes and save DOM work. */

--- a/packages/tools/flowGraphEditor/src/graphEditor.tsx
+++ b/packages/tools/flowGraphEditor/src/graphEditor.tsx
@@ -294,7 +294,6 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
 
         if (globalState.hostDocument) {
             globalState.hostDocument.removeEventListener("keydown", this._onDocumentKeyDown, false);
-            globalState.hostDocument.addEventListener("keydown", this._onDocumentKeyDown, false);
             globalState.hostDocument.removeEventListener("keyup", this._onWidgetKeyUpPointer, false);
         }
 
@@ -520,7 +519,20 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             }
             const hasError = issues.some((i) => i.severity === FlowGraphValidationSeverity.Error);
             const tooltip = issues.map((i) => (i.severity === FlowGraphValidationSeverity.Error ? "[Error] " : "[Warn] ") + i.message).join("\n");
-            node.setValidationState(hasError ? "error" : "warning", tooltip);
+            const onClick = () => {
+                for (const issue of issues) {
+                    const prefix = issue.severity === FlowGraphValidationSeverity.Error ? "[Error]" : "[Warn]";
+                    const blockName = issue.block?.name ?? "Graph";
+                    this.props.globalState.onLogRequiredObservable.notifyObservers(
+                        new LogEntry(`${prefix} ${blockName}: ${issue.message}`, issue.severity === FlowGraphValidationSeverity.Error, issue.block)
+                    );
+                }
+                this.props.globalState.onToastNotification.notifyObservers({
+                    message: tooltip,
+                    severity: hasError ? "error" : "warning",
+                });
+            };
+            node.setValidationState(hasError ? "error" : "warning", tooltip, onClick);
         }
     }
 

--- a/packages/tools/flowGraphEditor/src/serializationTools.ts
+++ b/packages/tools/flowGraphEditor/src/serializationTools.ts
@@ -33,7 +33,7 @@ export class SerializationTools {
         }
 
         for (const block of blocks) {
-            const node = globalState.onGetNodeFromBlock(block);
+            const node = globalState.onGetNodeFromBlock?.(block);
 
             editorData.locations.push({
                 blockId: block.uniqueId,
@@ -453,7 +453,6 @@ export class SerializationTools {
 
         // Deserialize the flow graph
         await SerializationTools.DeserializeAsync(ext.flowGraph, globalState);
-        globalState.onResetRequiredObservable.notifyObservers(false);
         globalState.stateManager.onSelectionChangedObservable.notifyObservers(null);
         globalState.onClearUndoStack.notifyObservers();
         return true;

--- a/packages/tools/flowGraphEditor/test/playwright/fge.utils.ts
+++ b/packages/tools/flowGraphEditor/test/playwright/fge.utils.ts
@@ -240,14 +240,6 @@ export class FlowGraphEditorPage {
     }
 
     /**
-     * Find a port icon element within a node by port name and direction.
-     */
-    private async _findPortIcon(blockClass: string, portName: string, direction: "input" | "output"): Promise<Locator> {
-        const node = this.nodeOnCanvas(blockClass);
-        return this._findPortIconOnNode(node, portName, direction);
-    }
-
-    /**
      * Find a port icon on a specific node locator.
      */
     private _findPortIconOnNode(node: Locator, portName: string, direction: "input" | "output"): Locator {
@@ -358,7 +350,13 @@ export class FlowGraphEditorPage {
      * Useful for verifying that multi-block graphs are wired correctly.
      */
     async getGraphTopology(): Promise<{
-        blocks: { className: string; signalOuts: { name: string; connectedIds: string[] }[]; signalIns: { name: string; connectedIds: string[] }[] }[];
+        blocks: {
+            className: string;
+            signalOuts: { name: string; connectedIds: string[] }[];
+            signalIns: { name: string; connectedIds: string[] }[];
+            dataOuts: { name: string; connectedIds: string[] }[];
+            dataIns: { name: string; connectedIds: string[] }[];
+        }[];
         totalConnections: number;
     }> {
         const serialized = await this.serializeGraph();
@@ -374,7 +372,16 @@ export class FlowGraphEditorPage {
                 const ids = p.connectedPointIds || [];
                 return { name: p.name, connectedIds: ids };
             });
-            return { className: b.className, signalOuts, signalIns };
+            const dataOuts = (b.dataOutputs || []).map((p: any) => {
+                const ids = p.connectedPointIds || [];
+                totalConnections += ids.length;
+                return { name: p.name, connectedIds: ids };
+            });
+            const dataIns = (b.dataInputs || []).map((p: any) => {
+                const ids = p.connectedPointIds || [];
+                return { name: p.name, connectedIds: ids };
+            });
+            return { className: b.className, signalOuts, signalIns, dataOuts, dataIns };
         });
         return { blocks, totalConnections };
     }

--- a/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
+++ b/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
@@ -223,6 +223,42 @@ test.describe("Flow Graph Editor — Node List Filter", () => {
 });
 
 test.describe("Flow Graph Editor — Graph Construction", () => {
+    test("starting the graph does not stop existing scene animation groups", async ({ page }) => {
+        const fge = new FlowGraphEditorPage(page);
+        await fge.goto();
+        await fge.assertEditorReady();
+
+        await page.evaluate(() => {
+            const editor = (globalThis as any).BABYLON?.FlowGraphEditor;
+            const args = (globalThis as any).__viteFlowGraphEditorArgs;
+            const sceneCandidates = [editor?._CurrentState?.sceneContext?.scene, args?.[0]?.flowGraph?.scene, (globalThis as any).BABYLON?.EngineStore?.LastCreatedScene].filter(
+                Boolean
+            );
+            const scenes = Array.from(new Set(sceneCandidates));
+            if (scenes.length === 0) {
+                throw new Error("Flow Graph Editor scene not found");
+            }
+            (globalThis as any).__fgeAnimationStopCalled = false;
+            for (const scene of scenes) {
+                scene.animationGroups.push({
+                    name: "alreadyPlaying",
+                    uniqueId: 999999,
+                    isPlaying: true,
+                    targetedAnimations: [],
+                    stop: () => {
+                        (globalThis as any).__fgeAnimationStopCalled = true;
+                    },
+                    dispose: () => {},
+                });
+            }
+        });
+
+        await page.locator("button[title='Start']").click();
+
+        await expect.poll(async () => page.locator(".fge-ctrl-state").textContent()).toContain("Running");
+        expect(await page.evaluate(() => (globalThis as any).__fgeAnimationStopCalled)).toBe(false);
+    });
+
     test("build a SceneReady → ConsoleLog graph", async ({ page }) => {
         const fge = new FlowGraphEditorPage(page);
         await fge.goto();

--- a/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
+++ b/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
@@ -339,6 +339,9 @@ test.describe("Flow Graph Editor — Graph Construction", () => {
 
         const badge = fge.nodeOnCanvas("FlowGraphConsoleLogBlock").locator("[class*='validationBadge']");
         await expect(badge).toBeVisible();
+        await expect(badge).toHaveAttribute("role", "button");
+        await expect(badge).toHaveAttribute("tabindex", "0");
+        await expect(badge).toHaveAttribute("aria-label", "Show validation errors");
 
         const logEntries = page.locator("#fge-log-console .log");
         const beforeCount = await logEntries.count();
@@ -347,6 +350,12 @@ test.describe("Flow Graph Editor — Graph Construction", () => {
 
         await expect.poll(async () => await logEntries.count()).toBeGreaterThan(beforeCount);
         await expect(page.locator("#fge-log-console")).toContainText("FlowGraphConsoleLogBlock");
+
+        const afterClickCount = await logEntries.count();
+        await badge.focus();
+        await page.keyboard.press("Enter");
+
+        await expect.poll(async () => await logEntries.count()).toBeGreaterThan(afterClickCount);
 
         const toast = page.locator(".fge-toast").last();
         await expect(toast).toBeVisible();

--- a/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
+++ b/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
@@ -1,7 +1,21 @@
 import { test, expect } from "@playwright/test";
+import { readFileSync } from "fs";
 import { FlowGraphEditorPage } from "./fge.utils";
 
 // The FGE starts with an empty graph — no default blocks on the canvas.
+
+function CountSerializedConnections(serializedGraph: any): number {
+    let totalConnections = 0;
+    for (const block of serializedGraph.allBlocks ?? []) {
+        for (const port of block.signalOutputs ?? []) {
+            totalConnections += port.connectedPointIds?.length ?? 0;
+        }
+        for (const port of block.dataOutputs ?? []) {
+            totalConnections += port.connectedPointIds?.length ?? 0;
+        }
+    }
+    return totalConnections;
+}
 
 test.describe("Flow Graph Editor — Loading", () => {
     test("editor loads with all panels visible", async ({ page }) => {
@@ -17,6 +31,30 @@ test.describe("Flow Graph Editor — Loading", () => {
 
         const count = await fge.getNodeCount();
         expect(count).toBe(0);
+    });
+
+    test("loads a flow graph snippet from the URL hash", async ({ page }) => {
+        const fge = new FlowGraphEditorPage(page);
+        await fge.goto();
+        await fge.assertEditorReady();
+
+        await fge.addBlockFromPalette("SceneReadyEvent");
+        const serializedGraph = await fge.serializeGraph();
+        const snippetId = "FGEHASH";
+        const version = "7";
+
+        await page.route(`https://snippet.babylonjs.com/${snippetId}/${version}`, async (route) => {
+            await route.fulfill({
+                contentType: "application/json",
+                body: JSON.stringify({ jsonPayload: JSON.stringify({ flowGraph: serializedGraph }) }),
+            });
+        });
+
+        await page.goto(`${fge.baseUrl}#${snippetId}#${version}`, { waitUntil: "load" });
+        await fge.assertEditorReady();
+
+        await expect(page.locator(".fge-toast").last()).toContainText(`Flow graph loaded from snippet ${snippetId}#${version}`);
+        await expect(fge.nodeOnCanvas("FlowGraphSceneReadyEventBlock")).toBeVisible();
     });
 
     test("node list palette contains expected categories", async ({ page }) => {
@@ -220,6 +258,72 @@ test.describe("Flow Graph Editor — Graph Construction", () => {
         expect(topology.totalConnections).toBe(1);
         expect(blockNames).toContain("FlowGraphSceneReadyEventBlock");
         expect(blockNames).toContain("FlowGraphConsoleLogBlock");
+    });
+
+    test("save and load JSON preserves visual connections", async ({ page }) => {
+        const fge = new FlowGraphEditorPage(page);
+        await fge.goto();
+        await fge.assertEditorReady();
+
+        await fge.addBlockFromPalette("SceneReadyEvent");
+        await fge.addBlockFromPalette("ConsoleLog");
+        await fge.addBlockFromPalette("GetVariable");
+
+        await fge.connectPorts("FlowGraphSceneReadyEventBlock", "out", "FlowGraphConsoleLogBlock", "in");
+        await fge.connectPorts("FlowGraphGetVariableBlock", "value", "FlowGraphConsoleLogBlock", "message");
+
+        await expect.poll(async () => await fge.getLinkCount()).toBeGreaterThanOrEqual(2);
+        expect((await fge.getGraphTopology()).totalConnections).toBe(2);
+
+        const downloadPromise = page.waitForEvent("download");
+        await fge.rightPanel.getByRole("button", { name: "Save", exact: true }).click();
+        const download = await downloadPromise;
+        const downloadPath = await download.path();
+        if (!downloadPath) {
+            throw new Error("Saved flow graph download did not produce a local file path");
+        }
+        const savedJson = JSON.parse(readFileSync(downloadPath, "utf8"));
+        const savedGraph = savedJson._flowGraphs?.[savedJson.activeGraphIndex ?? 0] ?? savedJson;
+        expect(CountSerializedConnections(savedGraph)).toBe(2);
+
+        await page.locator("input[type='file'][accept='.json']").setInputFiles(downloadPath);
+
+        await expect(page.locator(".fge-toast").last()).toContainText("Flow graph loaded from file");
+        await expect.poll(async () => await fge.getNodeCount()).toBe(3);
+        await expect.poll(async () => await fge.getLinkCount()).toBeGreaterThanOrEqual(2);
+    });
+
+    test("clicking a validation badge logs its block issues", async ({ page }) => {
+        const fge = new FlowGraphEditorPage(page);
+        await fge.goto();
+        await fge.assertEditorReady();
+
+        await fge.addBlockFromPalette("ConsoleLog");
+        await page.locator("button[title='Validate graph']").click();
+
+        const badge = fge.nodeOnCanvas("FlowGraphConsoleLogBlock").locator("[class*='validationBadge']");
+        await expect(badge).toBeVisible();
+
+        const logEntries = page.locator("#fge-log-console .log");
+        const beforeCount = await logEntries.count();
+
+        await badge.click();
+
+        await expect.poll(async () => await logEntries.count()).toBeGreaterThan(beforeCount);
+        await expect(page.locator("#fge-log-console")).toContainText("FlowGraphConsoleLogBlock");
+
+        const toast = page.locator(".fge-toast").last();
+        await expect(toast).toBeVisible();
+
+        const toastMessage = toast.locator(".fge-toast-message");
+        await expect(toastMessage).toHaveCSS("white-space", "pre-line");
+        await expect(toastMessage).toContainText("[Error]");
+        await expect(toastMessage).toContainText("[Warn]");
+        expect(await toastMessage.textContent()).toContain("\n");
+
+        await toast.hover();
+        await page.waitForTimeout(4300);
+        await expect(toast).toBeVisible();
     });
 
     test("SceneReady → Branch with both true/false paths wired to ConsoleLog", async ({ page }) => {

--- a/packages/tools/flowGraphEditor/test/unit/variableUtils.test.ts
+++ b/packages/tools/flowGraphEditor/test/unit/variableUtils.test.ts
@@ -21,7 +21,6 @@ import {
     BuildFromComponents,
     GetDefaultValueForType,
     InferVariableType,
-    type IVariableEntry,
     type VariableTypeName,
 } from "flow-graph-editor/variableUtils";
 import { CONSTRUCTOR_CONFIG } from "flow-graph-editor/graphSystem/properties/constructorConfigRegistry";


### PR DESCRIPTION
## Summary
- Preserve Flow Graph Editor visual/runtime connections across JSON and snippet round-trips.
- Add Flow Graph snippet parser helpers for Playground/runtime use and resolve serialized scene node references such as cameras by id/name when unique ids differ.
- Make validation badges log their issues, show multiline toast details, and keep toasts visible while hovered.
- Add FGE URL-hash snippet loading and update the editor usage examples for saved snippets/files.

## Soft launch validation
- `runTests` for `packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts` and `packages/tools/flowGraphEditor/test/unit/variableUtils.test.ts`: 133 passed.
- `npx playwright test -c playwright.config.ts --project=flowGraphEditor --reporter=line`: 55 passed.
- `npm run lint:check`: passed.
- `npm run compile -w @dev/core && npm run compile -w @dev/shared-ui-components && npm run compile -w @tools/flow-graph-editor`: passed.
- `git diff --check`: passed.