### PR TITLE
fix: refresh Babylon server declarations in watch mode

### DIFF
--- a/packages/dev/buildTools/src/devWatcher.ts
+++ b/packages/dev/buildTools/src/devWatcher.ts
@@ -62,11 +62,11 @@ export const devWatch = () => {
 
     if (watchDeclarations) {
         const filter = processedPackages.join(",");
-        const filterAddition = processedPackages.length === 0 ? [] : ["--", "--filter", filter];
+        const declarationScriptArgs = [...(skipCompilation ? ["--watch-inputs"] : []), ...(processedPackages.length === 0 ? [] : ["--filter", filter])];
         processes.push({
             // npm run watch:declaration -w @tools/babylon-server
             command: "npm",
-            arguments: ["run", "watch:declaration:dev", "-w", "@tools/babylon-server", ...filterAddition],
+            arguments: ["run", "watch:declaration:dev", "-w", "@tools/babylon-server", ...(declarationScriptArgs.length === 0 ? [] : ["--", ...declarationScriptArgs])],
             name: "declaration",
         });
     }

--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -656,18 +656,34 @@ export function generateDeclaration() {
                 shell: true,
             });
 
-            child.on("close", (code) => {
+            let inputBuildCompleted = false;
+            const completeInputBuild = (code: number, error?: Error) => {
+                if (inputBuildCompleted) {
+                    return;
+                }
+
+                inputBuildCompleted = true;
                 inputBuildInProgress = false;
                 if (code === 0) {
                     debounced();
+                } else if (error) {
+                    console.error(`declaration input build failed to start`, config.declarationLibs, error.message);
                 } else {
-                    console.error(`declaration input build failed`, config.declarationLibs, `(exit ${code ?? 1})`);
+                    console.error(`declaration input build failed`, config.declarationLibs, `(exit ${code})`);
                 }
 
                 if (inputBuildQueued) {
                     inputBuildQueued = false;
                     buildDeclarationInputs();
                 }
+            };
+
+            child.on("error", (error) => {
+                completeInputBuild(1, error);
+            });
+
+            child.on("close", (code) => {
+                completeInputBuild(code ?? 1);
             });
         };
 

--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -4,6 +4,7 @@ import { globSync } from "glob";
 import * as fs from "fs";
 import * as path from "path";
 import * as chokidar from "chokidar";
+import { spawn } from "child_process";
 
 import { camelize, checkArgs, checkDirectorySync, debounce, findRootDirectory, getHashOfContent, getHashOfFile, kebabize } from "./utils.js";
 import { type BuildType, type DevPackageName, getAllPackageMappingsByDevNames, getPackageMappingByDevName, getPublicPackageName, isValidDevPackageName } from "./packageMapping.js";
@@ -598,6 +599,7 @@ export function generateDeclaration() {
         throw new Error("--config path to config file is required");
     }
     const asJSON = checkArgs("--json", true) as boolean;
+    const watchInputs = checkArgs("--watch-inputs", true) as boolean;
     const rootDir = findRootDirectory();
     // import { createRequire } from "module";
     // const requireRequest = createRequire(import.meta.url);
@@ -627,7 +629,47 @@ export function generateDeclaration() {
             return camelize(lib).replace(/@/g, "");
         });
         const directoriesToWatch = sourceDirs.map((dir: string) => path.join(rootDir, "packages", `${dir}/dist/**/*.d.ts`));
+        const sourceDirectoriesToWatch = sourceDirs.map((dir: string) => path.join(rootDir, "packages", `${dir}/src/**/*.{ts,tsx}`));
+        const declarationInputProjects = sourceDirs
+            .map((dir: string) => path.join("packages", dir, "tsconfig.build.json"))
+            .filter((project: string) => fs.existsSync(path.join(rootDir, project)));
         const looseDeclarations = sourceDirs.map((dir: string) => path.join(rootDir, "packages", `${dir}/**/LibDeclarations/**/*.d.ts`));
+
+        let inputBuildInProgress = false;
+        let inputBuildQueued = false;
+
+        const buildDeclarationInputs = () => {
+            if (!declarationInputProjects.length) {
+                debounced();
+                return;
+            }
+
+            if (inputBuildInProgress) {
+                inputBuildQueued = true;
+                return;
+            }
+
+            inputBuildInProgress = true;
+            const child = spawn("npx", ["tsc", "-b", ...declarationInputProjects, "--emitDeclarationOnly", "--pretty", "false"], {
+                cwd: rootDir,
+                stdio: "inherit",
+                shell: true,
+            });
+
+            child.on("close", (code) => {
+                inputBuildInProgress = false;
+                if (code === 0) {
+                    debounced();
+                } else {
+                    console.error(`declaration input build failed`, config.declarationLibs, `(exit ${code ?? 1})`);
+                }
+
+                if (inputBuildQueued) {
+                    inputBuildQueued = false;
+                    buildDeclarationInputs();
+                }
+            });
+        };
 
         const debounced = debounce(() => {
             const { output, namespaceDeclaration, looseDeclarationsString } = generateCombinedDeclaration(
@@ -706,6 +748,19 @@ ${looseDeclarationsString || ""}`
                     }
                     debounced();
                 });
+            if (watchInputs) {
+                chokidar
+                    .watch(sourceDirectoriesToWatch, {
+                        ignoreInitial: true,
+                        awaitWriteFinish: {
+                            stabilityThreshold: 300,
+                            pollInterval: 100,
+                        },
+                    })
+                    .on("all", () => {
+                        buildDeclarationInputs();
+                    });
+            }
         } else {
             debounced();
         }

--- a/packages/tools/babylonServer/vite.config.ts
+++ b/packages/tools/babylonServer/vite.config.ts
@@ -132,6 +132,17 @@ const staticDeclarationRewrites: Record<string, string> = {
     "glTF2Interface/babylon.glTF2Interface.d.ts": path.resolve(REPO_ROOT, "packages/public/glTF2Interface/babylon.glTF2Interface.d.ts"),
 };
 
+function getUmdEntry(url: string) {
+    const directEntry = umdUrlMap[url];
+    if (directEntry) {
+        return directEntry;
+    }
+
+    const urlDir = path.posix.dirname(url);
+    const urlFile = path.posix.basename(url);
+    return Object.entries(umdUrlMap).find(([mappedUrl, entry]) => path.posix.dirname(mappedUrl) === urlDir && entry.file === urlFile)?.[1];
+}
+
 /**
  * Vite plugin that serves pre-built rollup UMD bundles and handles URL rewrites.
  * Replaces the old entry-point compilation and dev-server configuration.
@@ -336,7 +347,7 @@ function babylonServerPlugin(): Plugin {
                 const url = req.url?.split("?")[0]?.replace(/^\//, "") ?? "";
 
                 // --- UMD bundle serving ---
-                const umdEntry = umdUrlMap[url];
+                const umdEntry = getUmdEntry(url);
                 if (umdEntry) {
                     const filePath = path.join(UMD_ROOT, umdEntry.dir, umdEntry.file);
                     if (fs.existsSync(filePath)) {
@@ -355,7 +366,7 @@ function babylonServerPlugin(): Plugin {
                 // --- Sourcemap serving (same dir as the UMD bundle) ---
                 if (url.endsWith(".js.map")) {
                     const jsUrl = url.replace(/\.map$/, "");
-                    const jsEntry = umdUrlMap[jsUrl];
+                    const jsEntry = getUmdEntry(jsUrl);
                     if (jsEntry) {
                         // The map file may be named after the served file (e.g. babylon.max.js.map)
                         // OR after the original rollup output (e.g. babylon.js.map / babylon.min.js.map),


### PR DESCRIPTION
## Summary
- Refresh Babylon server declaration inputs when the CDN watcher runs with `--skip-compilation`, so source-only API changes regenerate `dist/**/*.d.ts` before the combined server declarations are rebuilt.
- Keep declaration input rebuilds serialized and queue another pass when changes arrive during an in-flight declaration-only `tsc` run.
- Resolve UMD sourcemap requests by either the public CDN route or the actual emitted bundle filename, fixing `.max.js.map` requests that previously fell through to Vite's HTML fallback.

## Validation
- `npm run build -w @dev/build-tools`
- `npx eslint packages/dev/buildTools/src/devWatcher.ts packages/dev/buildTools/src/generateDeclaration.ts packages/tools/babylonServer/vite.config.ts --quiet`
- Smoke-tested declaration watch flow with `npm run watch:declaration:dev -w @tools/babylon-server -- --watch-inputs --filter @dev/core` by temporarily adding/removing a static `Color3` method and confirming `packages/tools/babylonServer/declarations/core.d.ts` updated both ways.
- Started Babylon server on `CDN_PORT=1338` and verified affected `.max.js.map` URLs return `200 application/json` instead of Vite HTML fallback.