### PR TITLE
Fix TypeDoc documentation CI check

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -401,12 +401,10 @@ jobs:
           - script: |
                 git branch
                 git fetch origin "+refs/heads/*:refs/remotes/origin/*"
-                git checkout -B master origin/master
                 git branch
 
-                GIT_CHANGES_COMMAND="git diff $(Build.SourceVersion) --name-only --relative" npm run test:docs
+                GIT_CHANGES_COMMAND="git diff origin/master...HEAD --name-only --relative" npm run test:docs
             displayName: "Run TypeDoc test"
-            continueOnError: true
             env:
                 CI: "true"
 
@@ -416,6 +414,7 @@ jobs:
             inputs:
                 testResultsFormat: JUnit
                 testResultsFiles: "./junit.xml"
+                failTaskOnFailedTests: true
 
     # ============================================================================
     # UNIT TESTS

--- a/scripts/comment-analyzer.mjs
+++ b/scripts/comment-analyzer.mjs
@@ -63,13 +63,18 @@ function traverseChildrenLookingForComments(child, parent, isSignature = false) 
     if (!child) {
         return;
     }
+    const source = child.sources?.[0] ?? parent?.sources?.[0];
     const result = {
         componentName: child.name,
         componentType: getKind(child),
         parentName: parent?.name,
-        fileName: child.sources[0]?.fileName + ":" + child.sources[0]?.line + ":" + child.sources[0]?.character,
-        url: child.sources[0]?.url,
+        fileName: source ? `${source.fileName}:${source.line}:${source.character}` : undefined,
+        url: source?.url,
     };
+    if (!source) {
+        result.result = TestResultType.PASS;
+        return result;
+    }
     // underscored names are ignored
     if (child.name.startsWith("_")) {
         result.result = TestResultType.PASS;

--- a/scripts/typedoc-generator.mjs
+++ b/scripts/typedoc-generator.mjs
@@ -33,6 +33,19 @@ function generateMessageFromError(error) {
     }]`;
 }
 
+function getSourceFileName(error) {
+    return error.url?.match(/\/(packages\/dev\/[^#]+)#L\d+$/)?.[1] ?? error.fileName?.replace(/:\d+:\d+$/, "");
+}
+
+function isInChangedFiles(error, filesChanged) {
+    const sourceFileName = getSourceFileName(error);
+    if (!sourceFileName) {
+        return false;
+    }
+
+    return filesChanged.some((file) => file === sourceFileName || file.endsWith(`/${sourceFileName}`));
+}
+
 async function generateTypedocAndAnalyze(entryPoints, filesChanged) {
     const app = await Application.bootstrapWithPlugins(
         {
@@ -68,7 +81,7 @@ async function generateTypedocAndAnalyze(entryPoints, filesChanged) {
         msgs.forEach((msg) => {
             const filePath = msg.fileName;
             if (filesChanged) {
-                if (!filesChanged.includes(filePath)) {
+                if (!isInChangedFiles(msg, filesChanged)) {
                     return;
                 }
             }
@@ -80,7 +93,7 @@ async function generateTypedocAndAnalyze(entryPoints, filesChanged) {
 async function main() {
     const packages = process.argv.includes("--packages") ? process.argv[process.argv.indexOf("--packages") + 1].split(",") : ["core", "loaders", "materials", "gui", "serializers"];
     const full = process.argv.includes("--full");
-    const filesChanged = (await runCommand(process.env.GIT_CHANGES_COMMAND || "git diff --name-only master")).split("\n");
+    const filesChanged = full ? undefined : (await runCommand(process.env.GIT_CHANGES_COMMAND || "git diff --name-only master")).split("\n").filter(Boolean);
     const files = globSync(`packages/dev/@(${packages.join("|")})/src/index.ts`).filter((f) => /*!f.endsWith("index.ts") && */ !f.endsWith(".d.ts"));
     console.log(files);
     const dirList = files.filter((file) => {
@@ -114,7 +127,7 @@ async function main() {
         // if in CI, save to errors.txt
         if (process.env.CI) {
             const messages = Object.keys(warnings)
-                .map((w) => `${w} ${generateMessageFromError(Object.keys(warnings)[w])}`)
+                .map((w) => `${w} ${generateMessageFromError(warnings[w])}`)
                 .join("\n");
             writeFileSync("errors.txt", messages);
             // log to the console
@@ -127,4 +140,7 @@ ${messages}`);
     }
 }
 
-main().catch(console.error);
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/typedoc-generator.mjs
+++ b/scripts/typedoc-generator.mjs
@@ -33,8 +33,20 @@ function generateMessageFromError(error) {
     }]`;
 }
 
+function normalizeFileName(fileName) {
+    const normalizedFileName = fileName
+        ?.replace(/\\/g, "/")
+        .replace(/:\d+:\d+$/, "")
+        .replace(/^\.\//, "");
+    return normalizedFileName?.match(/(?:^|\/)(packages\/[^#]+)$/)?.[1] ?? normalizedFileName;
+}
+
 function getSourceFileName(error) {
-    return error.url?.match(/\/(packages\/dev\/[^#]+)#L\d+$/)?.[1] ?? error.fileName?.replace(/:\d+:\d+$/, "");
+    return normalizeFileName(error.url?.match(/\/(packages\/[^#]+)#L\d+$/)?.[1] ?? error.fileName);
+}
+
+function isSameOrNestedPath(firstFileName, secondFileName) {
+    return firstFileName === secondFileName || firstFileName.endsWith(`/${secondFileName}`) || secondFileName.endsWith(`/${firstFileName}`);
 }
 
 function isInChangedFiles(error, filesChanged) {
@@ -43,7 +55,10 @@ function isInChangedFiles(error, filesChanged) {
         return false;
     }
 
-    return filesChanged.some((file) => file === sourceFileName || file.endsWith(`/${sourceFileName}`));
+    return filesChanged.some((file) => {
+        const changedFileName = normalizeFileName(file);
+        return changedFileName ? isSameOrNestedPath(sourceFileName, changedFileName) : false;
+    });
 }
 
 async function generateTypedocAndAnalyze(entryPoints, filesChanged) {


### PR DESCRIPTION
## Summary
- Fix the TypeDoc changed-file filter so analyzer warnings match Git paths from PR diffs.
- Keep the Azure TypeDoc job on the PR checkout and diff against `origin/master...HEAD`.
- Make missing documentation findings fail the job and publish failed JUnit results.
- Fix CI `errors.txt` generation to use warning objects instead of warning keys.

## Validation
- `GIT_CHANGES_COMMAND="printf '%s\n' packages/dev/serializers/src/BVH/bvhSerializer.ts" npm run test:docs -- --packages serializers` exits `1` for a known missing-doc changed file.
- `GIT_CHANGES_COMMAND="printf '%s\n' packages/dev/serializers/src/not-a-real.ts" npm run test:docs -- --packages serializers` exits `0` for an unrelated changed file.
- `npx prettier --check scripts/typedoc-generator.mjs .azure-pipelines/ci-monorepo.yml` passes.