### PR TITLE
Add ES6 package smoke tests

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -313,6 +313,12 @@ jobs:
             continueOnError: true
 
           - task: Npm@1
+            displayName: "Test ES6 packages"
+            inputs:
+                command: custom
+                customCommand: "run test:es6-packages -w @tools/tests"
+
+          - task: Npm@1
             displayName: "npm build modules size"
             inputs:
                 command: custom

--- a/packages/tools/tests/build.mjs
+++ b/packages/tools/tests/build.mjs
@@ -9,6 +9,10 @@ const shouldAnalyze = process.argv.includes("--analyze");
 
 const files = readdirSync(join(__dirname, "src"));
 for (const file of files) {
+    if (!file.endsWith(".ts")) {
+        continue;
+    }
+
     // TODO: Figure out why this entry uses so much memory when bundling sceneWithInspector.js
     if (file !== "sceneWithInspector.ts") {
         console.log();

--- a/packages/tools/tests/package.json
+++ b/packages/tools/tests/package.json
@@ -14,6 +14,7 @@
         "test:debug": "set DEBUG=true && npm run test",
         "update": "vitest run -u",
         "build": "node ./build.mjs",
+        "test:es6-packages": "tsc -p ./tsconfig.es6-smoke.json && node ./scripts/buildEs6SmokeTests.mjs",
         "analyse": "node ./build.mjs --analyze > stats.txt",
         "generate-file-size-report": "node ./scripts/generateFileSizes.js",
         "test:playwright": "playwright test --config ../../../playwright.config.ts"

--- a/packages/tools/tests/scripts/buildEs6SmokeTests.mjs
+++ b/packages/tools/tests/scripts/buildEs6SmokeTests.mjs
@@ -7,7 +7,7 @@ import { build } from "esbuild";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = join(__dirname, "..");
-const outputRoot = join(packageRoot, "dist", "es6Smoke");
+const outputRoot = join(packageRoot, "temp", "es6Smoke");
 const require = createRequire(import.meta.url);
 
 mkdirSync(outputRoot, { recursive: true });

--- a/packages/tools/tests/scripts/buildEs6SmokeTests.mjs
+++ b/packages/tools/tests/scripts/buildEs6SmokeTests.mjs
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, readFileSync } from "fs";
+import { createRequire } from "module";
+import { dirname, join } from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import chalk from "chalk";
+import { build } from "esbuild";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(__dirname, "..");
+const outputRoot = join(packageRoot, "dist", "es6Smoke");
+const require = createRequire(import.meta.url);
+
+mkdirSync(outputRoot, { recursive: true });
+
+const entries = [
+    {
+        name: "runtime",
+        entryPoint: join(packageRoot, "src", "es6Smoke", "runtimeSmoke.ts"),
+        outfile: join(outputRoot, "runtime.mjs"),
+        platform: "node",
+        format: "esm",
+        execute: true,
+    },
+    {
+        name: "packages",
+        entryPoint: join(packageRoot, "src", "es6Smoke", "packageImportSmoke.ts"),
+        outfile: join(outputRoot, "packages.mjs"),
+        platform: "browser",
+        format: "esm",
+    },
+];
+
+const editorPackages = [
+    "@babylonjs/gui-editor",
+    "@babylonjs/inspector",
+    "@babylonjs/inspector-legacy",
+    "@babylonjs/node-editor",
+    "@babylonjs/node-geometry-editor",
+    "@babylonjs/node-particle-editor",
+    "@babylonjs/node-render-graph-editor",
+];
+
+for (const entry of entries) {
+    console.log(chalk.bold(chalk.blue(`===== Building ES6 smoke test: ${entry.name} =====`)));
+
+    await build({
+        entryPoints: [entry.entryPoint],
+        bundle: true,
+        sourcemap: true,
+        platform: entry.platform,
+        format: entry.format,
+        outfile: entry.outfile,
+        logLevel: "info",
+        target: "es2022",
+        loader: {
+            ".gif": "dataurl",
+            ".jpg": "dataurl",
+            ".png": "dataurl",
+            ".svg": "dataurl",
+            ".wasm": "file",
+        },
+    });
+
+    if (entry.execute) {
+        console.log(chalk.bold(chalk.blue(`===== Running ES6 smoke test: ${entry.name} =====`)));
+        await import(pathToFileURL(entry.outfile).href);
+    }
+}
+
+console.log(chalk.bold(chalk.blue("===== Validating ES6 editor package entries =====")));
+
+for (const packageName of editorPackages) {
+    const packageJsonPath = require.resolve(`${packageName}/package.json`);
+    const packageDirectory = dirname(packageJsonPath);
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const runtimeEntry = packageJson.module ?? packageJson.main;
+    const typesEntry = packageJson.types ?? packageJson.typings;
+
+    if (!runtimeEntry || !existsSync(join(packageDirectory, runtimeEntry))) {
+        throw new Error(`${packageName} does not have a generated runtime entry file.`);
+    }
+
+    if (!typesEntry || !existsSync(join(packageDirectory, typesEntry))) {
+        throw new Error(`${packageName} does not have a generated declaration entry file.`);
+    }
+
+    console.log(`${packageName}: ${runtimeEntry}, ${typesEntry}`);
+}

--- a/packages/tools/tests/src/es6Smoke/editorImportSmoke.ts
+++ b/packages/tools/tests/src/es6Smoke/editorImportSmoke.ts
@@ -1,0 +1,24 @@
+import * as GuiEditor from "@babylonjs/gui-editor";
+import * as Inspector from "@babylonjs/inspector";
+import * as InspectorLegacy from "@babylonjs/inspector-legacy";
+import * as NodeEditor from "@babylonjs/node-editor";
+import * as NodeGeometryEditor from "@babylonjs/node-geometry-editor";
+import * as NodeParticleEditor from "@babylonjs/node-particle-editor";
+import * as NodeRenderGraphEditor from "@babylonjs/node-render-graph-editor";
+
+const editorNamespaces = {
+    GuiEditor,
+    Inspector,
+    InspectorLegacy,
+    NodeEditor,
+    NodeGeometryEditor,
+    NodeParticleEditor,
+    NodeRenderGraphEditor,
+};
+
+const globalObject = globalThis as typeof globalThis & { __babylonEs6EditorImportSmoke?: typeof editorNamespaces };
+globalObject.__babylonEs6EditorImportSmoke = editorNamespaces;
+
+if (Object.keys(editorNamespaces).length !== 7) {
+    throw new Error("The ES6 editor import smoke test is missing an editor namespace.");
+}

--- a/packages/tools/tests/src/es6Smoke/packageImportSmoke.ts
+++ b/packages/tools/tests/src/es6Smoke/packageImportSmoke.ts
@@ -1,0 +1,43 @@
+import * as Accessibility from "@babylonjs/accessibility";
+import * as Addons from "@babylonjs/addons";
+import * as Core from "@babylonjs/core";
+import * as GUI from "@babylonjs/gui";
+import * as Ktx2Decoder from "@babylonjs/ktx2decoder";
+import * as Loaders from "@babylonjs/loaders";
+import "@babylonjs/loaders/glTF";
+import "@babylonjs/loaders/OBJ";
+import "@babylonjs/loaders/STL";
+import * as LottiePlayer from "@babylonjs/lottie-player";
+import * as Materials from "@babylonjs/materials";
+import * as PostProcesses from "@babylonjs/post-processes";
+import * as ProceduralTextures from "@babylonjs/procedural-textures";
+import * as Serializers from "@babylonjs/serializers";
+import * as SharedUiComponents from "@babylonjs/shared-ui-components/fluent/primitives/button";
+import * as SmartFilterBlocks from "@babylonjs/smart-filters-blocks";
+import * as SmartFilters from "@babylonjs/smart-filters";
+import * as Viewer from "@babylonjs/viewer";
+
+const packageNamespaces = {
+    Accessibility,
+    Addons,
+    Core,
+    GUI,
+    Ktx2Decoder,
+    Loaders,
+    LottiePlayer,
+    Materials,
+    PostProcesses,
+    ProceduralTextures,
+    Serializers,
+    SharedUiComponents,
+    SmartFilterBlocks,
+    SmartFilters,
+    Viewer,
+};
+
+const globalObject = globalThis as typeof globalThis & { __babylonEs6PackageImportSmoke?: typeof packageNamespaces };
+globalObject.__babylonEs6PackageImportSmoke = packageNamespaces;
+
+if (Object.keys(packageNamespaces).length !== 15) {
+    throw new Error("The ES6 package import smoke test is missing a package namespace.");
+}

--- a/packages/tools/tests/src/es6Smoke/runtimeSmoke.ts
+++ b/packages/tools/tests/src/es6Smoke/runtimeSmoke.ts
@@ -1,0 +1,35 @@
+import { FreeCamera, HemisphericLight, MeshBuilder, NullEngine, PBRMaterial, Scene, SceneLoader, StandardMaterial, Vector3 } from "@babylonjs/core";
+import "@babylonjs/loaders/glTF";
+import { GridMaterial } from "@babylonjs/materials/grid/gridMaterial";
+
+const engine = new NullEngine();
+const scene = new Scene(engine);
+
+const camera = new FreeCamera("camera", new Vector3(0, 2, -8), scene);
+camera.setTarget(Vector3.Zero());
+scene.activeCamera = camera;
+
+const light = new HemisphericLight("light", Vector3.Up(), scene);
+light.intensity = 0.8;
+
+const box = MeshBuilder.CreateBox("box", { size: 2 }, scene);
+box.material = new StandardMaterial("standard", scene);
+
+const sphere = MeshBuilder.CreateSphere("sphere", { diameter: 1, segments: 8 }, scene);
+sphere.position.x = 2;
+sphere.material = new PBRMaterial("pbr", scene);
+
+const ground = MeshBuilder.CreateGround("ground", { width: 4, height: 4 }, scene);
+ground.material = new GridMaterial("grid", scene);
+
+if (!SceneLoader.IsPluginForExtensionAvailable(".gltf")) {
+    throw new Error("The glTF loader was not registered by the ES6 loaders package.");
+}
+
+scene.render();
+
+if (scene.meshes.length < 3 || !scene.activeCamera) {
+    throw new Error("The ES6 runtime smoke scene did not initialize correctly.");
+}
+
+engine.dispose();

--- a/packages/tools/tests/tsconfig.es6-smoke.json
+++ b/packages/tools/tests/tsconfig.es6-smoke.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "module": "esnext",
+        "moduleResolution": "bundler"
+    },
+    "include": ["./src/es6Smoke/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add a `test:es6-packages` script to `@tools/tests` that validates the built public ES6 packages after `build:es6`.
- Type-check import smoke entries for the framework and editor packages using the generated `@babylonjs/*` package outputs.
- Bundle broad public ES6 package imports with esbuild and run a runtime-safe `NullEngine` scene smoke test.
- Validate editor release packages by checking their generated runtime and declaration entry files without running the editors.
- Run the new ES6 package test in the ES6 CI job before the module-size report.

## Why
The ES6 CI job previously proved that the ES6 packages could be built, but it did not prove that the generated packages were consumable by downstream applications. This adds a lightweight consumer-style test for the built ES6 package outputs, including editor package import coverage.

## Validation
- `npm run test:es6-packages -w @tools/tests`
- `npm run build -w @tools/tests`
- `npx prettier --check .azure-pipelines/ci-monorepo.yml packages/tools/tests/build.mjs packages/tools/tests/package.json packages/tools/tests/scripts/buildEs6SmokeTests.mjs packages/tools/tests/src/es6Smoke/runtimeSmoke.ts packages/tools/tests/src/es6Smoke/packageImportSmoke.ts packages/tools/tests/src/es6Smoke/editorImportSmoke.ts packages/tools/tests/tsconfig.es6-smoke.json`