### PR TITLE
Clean up observers when parsing Node Materials

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.ts
@@ -2375,7 +2375,17 @@ export class NodeMaterial extends NodeMaterialBase {
         const id = this.id;
         const uniqueId = this.uniqueId;
 
+        const previousImageProcessingConfiguration = this._imageProcessingConfiguration;
+        const previousImageProcessingObserver = this._imageProcessingObserver;
+        const hasSerializedImageProcessingConfiguration = Object.prototype.hasOwnProperty.call(source, "_imageProcessingConfiguration");
+
         SerializationHelper.ParseProperties(source, this, this.getScene(), rootUrl);
+        const parsedImageProcessingConfiguration = this._imageProcessingConfiguration;
+        if (hasSerializedImageProcessingConfiguration) {
+            this._imageProcessingConfiguration = previousImageProcessingConfiguration;
+            this._imageProcessingObserver = previousImageProcessingObserver;
+            this._attachImageProcessingConfiguration(parsedImageProcessingConfiguration);
+        }
 
         this.id = id;
         this.uniqueId = uniqueId;

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts
@@ -1,0 +1,71 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
+import { Scene } from "core/scene";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const _getActiveImageProcessingObserverCount = (scene: Scene): number => {
+    return scene.imageProcessingConfiguration.onUpdateParameters.observers.filter((observer) => !observer._willBeUnregistered).length;
+};
+
+describe("Babylon NodeMaterial image processing observer lifecycle", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("does not accumulate scene image processing observers when parsing serialized node materials", () => {
+        const template = new NodeMaterial("template", scene);
+        const serialized = template.serialize();
+        template.dispose();
+
+        const initialObserverCount = _getActiveImageProcessingObserverCount(scene);
+
+        for (let i = 0; i < 25; i++) {
+            const material = new NodeMaterial(`nodeMaterial_${i}`, scene);
+            material.parseSerializedObject(serialized);
+            material.dispose();
+        }
+
+        const finalObserverCount = _getActiveImageProcessingObserverCount(scene);
+
+        expect(finalObserverCount).toBe(initialObserverCount);
+    });
+
+    it("does not accumulate observers when serialized image processing payload is omitted", () => {
+        const template = new NodeMaterial("template", scene);
+        const serialized = template.serialize();
+        template.dispose();
+
+        // This approximates the no-invocation behavior where image processing metadata
+        // is not part of the serialized property store.
+        expect(serialized._imageProcessingConfiguration).toBeDefined();
+        delete serialized._imageProcessingConfiguration;
+
+        const initialObserverCount = _getActiveImageProcessingObserverCount(scene);
+
+        for (let i = 0; i < 25; i++) {
+            const material = new NodeMaterial(`nodeMaterial_noIpc_${i}`, scene);
+            material.parseSerializedObject(serialized);
+            material.dispose();
+        }
+
+        const finalObserverCount = _getActiveImageProcessingObserverCount(scene);
+
+        expect(finalObserverCount).toBe(initialObserverCount);
+    });
+});


### PR DESCRIPTION
Before this change, repeatedly parsing NodeMaterial attached a new image-processing observer each time without rebinding through the normal attach/detach path. Over time, those observers accumulated and caused a memory leak.

This change preserves the existing observer/configuration state across ParseProperties and reattaches the parsed configuration through _attachImageProcessingConfiguration, so only one active observer is kept per material lifecycle.

A unit regression test was added to verify observer count remains stable across repeated parse + dispose cycles.