### PR TITLE
Fix draco3dgltf ReferenceError in local UMD builds and update playground references

### DIFF
--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -306,6 +306,50 @@ export function babylonUMDExternalsPlugin(excludePackages = [], opts = {}) {
 }
 
 /**
+ * Rollup plugin that stubs optional peer dependencies (e.g. draco3dgltf) that
+ * are not installed in the dev workspace.  Without this, rollup externalizes
+ * the import and the UMD wrapper tries to read `global.draco3dgltf` — the
+ * factory receives `undefined`, and property access on it throws at runtime.
+ *
+ * The plugin rewrites import statements at transform time so the named bindings
+ * become `const X = undefined;`, matching the expected "module not available"
+ * semantics that the consuming code already guards against (e.g.
+ * `typeof DracoDecoderModule !== "undefined"`).
+ */
+function stubOptionalPeerDepsPlugin() {
+    const optionals = ["draco3dgltf"];
+    const q = optionals.map((p) => p.replace(".", "\\.")).join("|");
+    // Erase ALL import forms — type-only, named, star, default, side-effect.
+    // Unlike the devHost Vite plugin, we do NOT create `const X = undefined`
+    // stubs because rollup would rename them (e.g. `DracoDecoderModule$1`),
+    // breaking worker functions that are stringified via `.toString()` and
+    // expect the original global name.  The consuming code already uses
+    // `declare let` for the global and guards with `typeof X !== "undefined"`.
+    const importRe = new RegExp(
+        `import\\s+(?:` +
+            `type\\s+\\{[^}]*\\}|` + // import type { … }
+            `\\{[^}]*\\}|` + // import { … }
+            `(?:type\\s+)?\\*\\s+as\\s+\\w+|` + // import * as ns / import type * as ns
+            `(?:type\\s+)?\\w+|` + // import Default / import type Default
+            `` + // (empty — side-effect)
+            `)\\s*from\\s+['"](?:${q})['"];?|` +
+            `import\\s+['"](?:${q})['"];?`, // import "pkg"
+        "g"
+    );
+
+    return {
+        name: "stub-optional-peer-deps",
+        transform(code, id) {
+            if (!/\.[tj]sx?$/.test(id)) return null;
+            if (!optionals.some((p) => code.includes(`"${p}"`) || code.includes(`'${p}'`))) return null;
+
+            const newCode = code.replace(importRe, "");
+            return newCode !== code ? { code: newCode, map: null } : null;
+        },
+    };
+}
+
+/**
  * Rollup renderChunk plugin that replaces any dynamic `import("umdId")` calls
  * that survive inlineDynamicImports (i.e. imports of external packages) with
  * `Promise.resolve(GLOBAL)` so the output remains ES5/ES6-compatible.
@@ -588,6 +632,7 @@ export function commonUMDRollupConfiguration(options) {
           ];
 
     const plugins = [
+        stubOptionalPeerDepsPlugin(),
         externalsPlugin,
         aliasPlugin({ entries: aliasEntries }),
         // Rewrite `import * as styles from "*.module.scss"` to a default import

--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -311,10 +311,10 @@ export function babylonUMDExternalsPlugin(excludePackages = [], opts = {}) {
  * the import and the UMD wrapper tries to read `global.draco3dgltf` — the
  * factory receives `undefined`, and property access on it throws at runtime.
  *
- * The plugin rewrites import statements at transform time so the named bindings
- * become `const X = undefined;`, matching the expected "module not available"
- * semantics that the consuming code already guards against (e.g.
- * `typeof DracoDecoderModule !== "undefined"`).
+ * The plugin erases import statements at transform time so the module is never
+ * seen by rollup's external resolution.  The consuming code already uses
+ * `declare let` for the global and guards with `typeof X !== "undefined"`,
+ * falling back to loading the decoder from a CDN URL.
  */
 function stubOptionalPeerDepsPlugin() {
     const optionals = ["draco3dgltf"];

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -375,7 +375,7 @@
         },
         {
             "title": "Volumetric Light Scattering Post Process with Morph Targets",
-            "playgroundId": "#5E318S#5",
+            "playgroundId": "#5E318S#7",
             "referenceImage": "volumetricLightScatteringMorphTargets.png",
             "dependsOn": ["Lights", "Materials", "Morph", "PostProcesses"]
         },
@@ -550,7 +550,7 @@
         },
         {
             "title": "Particle subemitters",
-            "playgroundId": "#1LK70I#40",
+            "playgroundId": "#1LK70I#41",
             "renderCount": 50,
             "referenceImage": "subemitters.png",
             "dependsOn": ["Animations", "Lights", "PBR", "Particles", "PostProcesses", "Textures"],


### PR DESCRIPTION
## Problem

When testing locally with the Vite-based dev server (babylon-server), playgrounds that trigger Draco decoding fail with:

```
ReferenceError: draco3dgltf is not defined
```

This started after the port to Vite. Rollup externalizes the `draco3dgltf` import (an optional peer dependency not installed in the workspace), generating a UMD wrapper that reads `global.draco3dgltf` — which is `undefined` in the browser. The factory then crashes on property access.

## Fix

Added a `stubOptionalPeerDepsPlugin` to the rollup UMD helper (`rollupUMDHelper.mjs`) that erases `draco3dgltf` import statements at transform time, before rollup's external resolution sees them. The consuming code already guards usage with `typeof DracoDecoderModule !== "undefined"` and falls back to loading the decoder from the CDN URL, so erasing the module import is safe.

The plugin erases imports entirely rather than creating `const X = undefined` stubs, because rollup would rename the bindings (e.g. `DracoDecoderModule$1`), which breaks worker functions that are stringified via `.toString()` and expect the original global name.

## Playground reference updates

Updated two visualization test playground snippet IDs to ES6-friendly versions:
- `#5E318S#5` → `#5E318S#7`
- `#1LK70I#40` → `#1LK70I#41`
