### PR TITLE
Fix UMD secondary aliases for multi-entry builds

### DIFF
--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -773,7 +773,7 @@ export function commonUMDRollupConfiguration(options) {
                           }),
                       ]
                     : []),
-                ...(minToMax && production && i === 0 ? [copyMinToMaxPlugin(resolve(outputPath), primaryFilename, chunkNames)] : []),
+                ...(minToMax && production ? [copyMinToMaxPlugin(resolve(outputPath), primaryFilename, [chunkName])] : []),
             ];
             return {
                 input: inputFile,


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Fixes the UMD production build helper so multi-entry packages copy the secondary filename alias for each entry after that entry's output exists.

Previously, the `copyMinToMaxPlugin` was attached only to the first Rollup config for multi-entry packages, but it attempted to copy aliases for every entry. Because later entry outputs had not been written yet, only the first/main package bundle received both published names.

## Motivation

A forum report noted that the versioned CDN URL for the regular glTF loader alias was missing starting in 9.5.x:

https://forum.babylonjs.com/t/cdn-for-gltffileloader-missing-changed-starting-in-v9-5-0/63314/5?u=raananw

For example, `v9.5.2/loaders/babylon.glTFFileLoader.min.js` exists, but `v9.5.2/loaders/babylon.glTFFileLoader.js` returns 404.

## What was missing

The issue was broader than the glTF loader. In versioned CDN releases, the individual entry aliases were missing for multi-entry UMD packages while their `.min.js` files existed:

- `loaders`: individual loader aliases such as `babylon.glTFFileLoader.js`
- `materialsLibrary`: individual material aliases such as `babylon.gridMaterial.js`
- `proceduralTexturesLibrary`: individual procedural texture aliases
- `postProcessesLibrary`: individual post-process aliases
- `serializers`: individual serializer aliases

The package-level bundles, such as `babylonjs.loaders.js` and `babylonjs.loaders.min.js`, were still present.

## Fix

In multi-entry mode, attach `copyMinToMaxPlugin` to every per-entry Rollup config and scope it to the current `chunkName`. This ensures the secondary alias is copied after the corresponding output file exists.

Single-entry packages, including the main `babylonjs` package (`babylon.js` / `babylon.max.js`), continue through the unchanged single-config path.

## Validation

Ran:

```bash
npm run build:prod -w babylonjs-loaders
```

Confirmed the build now emits both names for every loader entry, including:

```text
babylon.glTFFileLoader.min.js
babylon.glTFFileLoader.js
babylon.objFileLoader.min.js
babylon.objFileLoader.js
babylonjs.loaders.min.js
babylonjs.loaders.js
```