### PR TITLE
Fix snapshot rendering permanently falling back to STANDARD mode when disable interrupts an in-progress recording

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuSnapshotRendering.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuSnapshotRendering.ts
@@ -42,6 +42,13 @@ export class WebGPUSnapshotRendering {
         this._log("enabled", `activate=${activate}, mode=${this._mode}`);
 
         this._allBundleLists.length = 0;
+        if (this._record) {
+            // A recording pass is in flight: _mode is temporarily SNAPSHOTRENDERING_STANDARD and is normally
+            // restored to _modeSaved at the next endFrame(). Restore it now so that flipping _record off
+            // doesn't leave _mode stuck on STANDARD — otherwise the next "enabled = true" would save STANDARD
+            // as the user-requested mode and the engine would permanently fall back to STANDARD (forum #63365).
+            this._mode = this._modeSaved;
+        }
         this._record = this._enabled = activate;
         this._play = false;
         if (activate) {
@@ -113,9 +120,6 @@ export class WebGPUSnapshotRendering {
 
     public reset(): void {
         this._log("reset", "called");
-        if (this._record) {
-            this._mode = this._modeSaved;
-        }
         this.enabled = false;
         this.enabled = true;
     }

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuSnapshotRendering.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuSnapshotRendering.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Constants } from "core/Engines/constants";
+import { WebGPUSnapshotRendering } from "core/Engines/WebGPU/webgpuSnapshotRendering";
+import { type WebGPUEngine } from "core/Engines/webgpuEngine";
+import { type WebGPUBundleList } from "core/Engines/WebGPU/webgpuBundleList";
+
+describe("WebGPUSnapshotRendering", () => {
+    let snapshot: WebGPUSnapshotRendering;
+
+    beforeEach(() => {
+        const engine = { frameId: 0 } as unknown as WebGPUEngine;
+        const bundleList = {} as unknown as WebGPUBundleList;
+        snapshot = new WebGPUSnapshotRendering(engine, Constants.SNAPSHOTRENDERING_FAST, bundleList);
+    });
+
+    it("completes a normal record/play cycle in the requested mode", () => {
+        snapshot.enabled = true;
+        // Recording pass uses STANDARD mode internally.
+        expect(snapshot.record).toBe(true);
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_STANDARD);
+
+        snapshot.endFrame();
+        // After endFrame, mode is restored to the user-requested value and we are in playback.
+        expect(snapshot.record).toBe(false);
+        expect(snapshot.play).toBe(true);
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_FAST);
+    });
+
+    it("preserves the requested mode when disable interrupts an in-progress recording", () => {
+        // Start a recording pass (regression for forum #63365).
+        snapshot.enabled = true;
+        expect(snapshot.record).toBe(true);
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_STANDARD);
+
+        // Disable while still recording — without the fix, _mode is stuck at STANDARD.
+        snapshot.enabled = false;
+        expect(snapshot.record).toBe(false);
+        expect(snapshot.enabled).toBe(false);
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_FAST);
+
+        // Re-enable and complete the cycle. Mode must end at FAST, not STANDARD.
+        snapshot.enabled = true;
+        snapshot.endFrame();
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_FAST);
+    });
+
+    it("preserves the requested mode across a reset() that interrupts recording", () => {
+        snapshot.enabled = true;
+        expect(snapshot.record).toBe(true);
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_STANDARD);
+
+        snapshot.reset();
+        // reset() = enabled=false; enabled=true; we should be recording again, in the original mode.
+        expect(snapshot.record).toBe(true);
+        snapshot.endFrame();
+        expect(snapshot.mode).toBe(Constants.SNAPSHOTRENDERING_FAST);
+    });
+});


### PR DESCRIPTION
### Forum issue
https://forum.babylonjs.com/t/snapshot-rendering-stops-under-certain-conditions/63365

### Root cause
`WebGPUSnapshotRendering` temporarily sets `_mode = SNAPSHOTRENDERING_STANDARD` while a recording pass is in progress, and restores `_mode = _modeSaved` at the next `endFrame()`. If `enabled = false` is called between the start of recording and `endFrame()` (for example, from `disableSnapshotRendering` during a rapid resize storm), `_mode` is left stuck at `STANDARD`. The next `enabled = true` then runs `_modeSaved = _mode`, permanently clobbering the user-requested mode (`FAST`) with `STANDARD`. After that, `engine.snapshotRendering === true` but `engine.snapshotRenderingMode === 0`, and the engine never returns to FAST mode.

The same race had previously been fixed for `reset()` in #15633, but the protection wasn't applied to the underlying `enabled` setter.

### Repro
https://playground.babylonjs.com/#JCB9JF#0 — continuously resize the window. The cube is supposed to stay still (because snapshot rendering is on); eventually it starts animating again because snapshot rendering has silently fallen back to STANDARD mode and `disableSnapshotRendering` / `enableSnapshotRendering` no longer brings it back.

### Fix
Move the mode-restore guard into the `enabled` setter so that flipping `_record` off restores `_mode = _modeSaved` first. This mirrors the protection already in `reset()`. The now-duplicated guard in `reset()` is removed.

### Tests
New unit tests in `packages/dev/core/test/unit/Engines/WebGPU/webgpuSnapshotRendering.test.ts`:
- normal record/play cycle ends with the user-requested mode
- disable mid-recording preserves the user-requested mode (regression test for this bug)
- `reset()` mid-recording also preserves the user-requested mode

The mid-recording disable test fails on the unfixed code (`expected 0 to be 1` — STANDARD instead of FAST) and passes after the fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
