### PR TITLE
Fix Lottie worker in Vite dev host

### DIFF
--- a/packages/dev/lottiePlayer/src/player.ts
+++ b/packages/dev/lottiePlayer/src/player.ts
@@ -12,7 +12,7 @@ import {
 } from "./messageTypes";
 import { type RawLottieAnimation } from "./parsing/rawTypes";
 import { CalculateScaleFactors, type ScaleFactors } from "./rendering/calculateScaleFactor";
-import { BlobWorkerWrapper as Worker } from "./blobWorkerWrapper";
+import { BlobWorkerWrapper } from "./blobWorkerWrapper";
 
 /**
  * Allows you to play Lottie animations using Babylon.js.
@@ -184,7 +184,7 @@ export class Player {
 
     private _getOrCreateWorker(): globalThis.Worker {
         if (!this._worker) {
-            const wrapperWorker = new Worker(new URL("./worker", import.meta.url));
+            const wrapperWorker = new BlobWorkerWrapper(new URL("./worker", import.meta.url));
             this._worker = wrapperWorker.getWorker();
             this._worker.onmessage = (evt: MessageEvent) => {
                 this._handleWorkerMessage(evt);

--- a/packages/tools/devHost/vite.config.ts
+++ b/packages/tools/devHost/vite.config.ts
@@ -1,11 +1,12 @@
 import path from "path";
-import { defineConfig, type Plugin, type UserConfig } from "vite";
+import { defineConfig, normalizePath, type Plugin, type UserConfig } from "vite";
 // @ts-ignore -- untyped JS helper
 import { commonDevViteConfiguration } from "../../public/viteToolsHelper.mjs";
 
 const OptionalPeerDependencies = ["draco3dgltf", "ammo.js", "cannon", "oimo", "recast", "havok", "basis_transcoder"];
 const OptionalPeerDependencyPattern = OptionalPeerDependencies.map((p) => p.replace(".", "\\.")).join("|");
 const LottieWorkerEntry = path.resolve("../../dev/lottiePlayer/src/worker.ts");
+const LottiePlayerEntry = normalizePath(path.resolve("../../dev/lottiePlayer/src/player.ts"));
 const LottieWorkerDevUrl = "/__lottie-worker.js";
 const LottieWorkerUrlExpression = /new URL\(["']\.\/worker(?:\.[jt]s)?["'],\s*import\.meta\.url\)/g;
 
@@ -46,24 +47,31 @@ function stubOptionalPeerDependencyImports(code: string): string {
 function lottieClassicWorkerPlugin(aliases: Record<string, string>): Plugin {
     let bundlePromise: Promise<string> | undefined;
     let command: "build" | "serve" = "serve";
+    let mode = "development";
+    let sourcemap: boolean | "inline" = "inline";
 
     const bundleWorker = async (): Promise<string> => {
-        bundlePromise ??= import("esbuild").then(async ({ build }) => {
-            const result = await build({
-                entryPoints: [LottieWorkerEntry],
-                bundle: true,
-                write: false,
-                format: "iife",
-                platform: "browser",
-                target: "es2020",
-                sourcemap: "inline",
-                alias: aliases,
-                define: {
-                    "process.env.NODE_ENV": '"development"',
-                },
+        bundlePromise ??= import("esbuild")
+            .then(async ({ build }) => {
+                const result = await build({
+                    entryPoints: [LottieWorkerEntry],
+                    bundle: true,
+                    write: false,
+                    format: "iife",
+                    platform: "browser",
+                    target: "es2020",
+                    sourcemap,
+                    alias: aliases,
+                    define: {
+                        "process.env.NODE_ENV": JSON.stringify(mode),
+                    },
+                });
+                return result.outputFiles[0].text;
+            })
+            .catch((error: unknown) => {
+                bundlePromise = undefined;
+                throw error;
             });
-            return result.outputFiles[0].text;
-        });
 
         return bundlePromise;
     };
@@ -73,9 +81,11 @@ function lottieClassicWorkerPlugin(aliases: Record<string, string>): Plugin {
         enforce: "pre",
         configResolved(config) {
             command = config.command;
+            mode = config.mode;
+            sourcemap = command === "serve" ? "inline" : config.build.sourcemap === "inline" ? "inline" : Boolean(config.build.sourcemap);
         },
         async transform(code, id) {
-            if (!id.split("?")[0].endsWith("/packages/dev/lottiePlayer/src/player.ts") || !code.includes("./worker")) {
+            if (normalizePath(id.split("?")[0]) !== LottiePlayerEntry || !code.includes("./worker")) {
                 return null;
             }
 

--- a/packages/tools/devHost/vite.config.ts
+++ b/packages/tools/devHost/vite.config.ts
@@ -1,7 +1,116 @@
-import { defineConfig, type Plugin } from "vite";
 import path from "path";
+import { defineConfig, type Plugin, type UserConfig } from "vite";
 // @ts-ignore -- untyped JS helper
 import { commonDevViteConfiguration } from "../../public/viteToolsHelper.mjs";
+
+const OptionalPeerDependencies = ["draco3dgltf", "ammo.js", "cannon", "oimo", "recast", "havok", "basis_transcoder"];
+const OptionalPeerDependencyPattern = OptionalPeerDependencies.map((p) => p.replace(".", "\\.")).join("|");
+const LottieWorkerEntry = path.resolve("../../dev/lottiePlayer/src/worker.ts");
+const LottieWorkerDevUrl = "/__lottie-worker.js";
+const LottieWorkerUrlExpression = /new URL\(["']\.\/worker(?:\.[jt]s)?["'],\s*import\.meta\.url\)/g;
+
+function stubNamedOptionalPeerDependencyImport(bindings: string): string {
+    return bindings
+        .split(",")
+        .map((s) =>
+            s
+                .trim()
+                .split(/\s+as\s+/)
+                .pop()!
+                .trim()
+        )
+        .filter((n) => Boolean(n) && !n.startsWith("type "))
+        .map((n) => `const ${n} = undefined;`)
+        .join(" ");
+}
+
+function stubOptionalPeerDependencyImports(code: string): string {
+    if (!OptionalPeerDependencies.some((p) => code.includes(`"${p}"`) || code.includes(`'${p}'`))) {
+        return code;
+    }
+
+    const typeNamedRe = new RegExp(`import\\s+type\\s+\\{[^}]*\\}\\s+from\\s+['"](?:${OptionalPeerDependencyPattern})['"];?`, "g");
+    const namedRe = new RegExp(`import\\s+\\{([^}]*)\\}\\s+from\\s+['"](?:${OptionalPeerDependencyPattern})['"];?`, "g");
+    const starRe = new RegExp(`import\\s+(?:type\\s+)?\\*\\s+as\\s+(\\w+)\\s+from\\s+['"](?:${OptionalPeerDependencyPattern})['"];?`, "g");
+    const defaultRe = new RegExp(`import\\s+(?:type\\s+)?(\\w+)\\s+from\\s+['"](?:${OptionalPeerDependencyPattern})['"];?`, "g");
+    const sideEffectRe = new RegExp(`import\\s+['"](?:${OptionalPeerDependencyPattern})['"];?`, "g");
+
+    return code
+        .replace(typeNamedRe, "")
+        .replace(namedRe, (_m, bindings: string) => stubNamedOptionalPeerDependencyImport(bindings))
+        .replace(starRe, (_m, ns: string) => `const ${ns} = {};`)
+        .replace(defaultRe, (_m, def: string) => `const ${def} = undefined;`)
+        .replace(sideEffectRe, "");
+}
+
+function lottieClassicWorkerPlugin(aliases: Record<string, string>): Plugin {
+    let bundlePromise: Promise<string> | undefined;
+    let command: "build" | "serve" = "serve";
+
+    const bundleWorker = async (): Promise<string> => {
+        bundlePromise ??= import("esbuild").then(async ({ build }) => {
+            const result = await build({
+                entryPoints: [LottieWorkerEntry],
+                bundle: true,
+                write: false,
+                format: "iife",
+                platform: "browser",
+                target: "es2020",
+                sourcemap: "inline",
+                alias: aliases,
+                define: {
+                    "process.env.NODE_ENV": '"development"',
+                },
+            });
+            return result.outputFiles[0].text;
+        });
+
+        return bundlePromise;
+    };
+
+    return {
+        name: "lottie-classic-worker",
+        enforce: "pre",
+        configResolved(config) {
+            command = config.command;
+        },
+        async transform(code, id) {
+            if (!id.split("?")[0].endsWith("/packages/dev/lottiePlayer/src/player.ts") || !code.includes("./worker")) {
+                return null;
+            }
+
+            const workerUrl =
+                command === "serve"
+                    ? `new URL("${LottieWorkerDevUrl}", globalThis.location.href)`
+                    : `new URL(import.meta.ROLLUP_FILE_URL_${this.emitFile({ type: "asset", fileName: "assets/lottieWorker.js", source: await bundleWorker() })}, import.meta.url)`;
+            const transformedCode = code.replace(LottieWorkerUrlExpression, workerUrl);
+            if (transformedCode === code) {
+                return null;
+            }
+
+            return { code: transformedCode, map: null };
+        },
+        configureServer(server) {
+            server.watcher.on("change", () => (bundlePromise = undefined));
+
+            server.middlewares.use(async (req, res, next) => {
+                const pathname = req.url?.split(/[?#]/)[0] ?? "";
+                if (pathname !== LottieWorkerDevUrl) {
+                    next();
+                    return;
+                }
+
+                try {
+                    const workerCode = await bundleWorker();
+                    res.setHeader("Content-Type", "application/javascript; charset=utf-8");
+                    res.end(workerCode);
+                } catch (error) {
+                    next(error);
+                }
+            });
+        },
+    };
+}
 
 /**
  * Stub optional peer dependencies that core/src references but that are not
@@ -16,48 +125,16 @@ import { commonDevViteConfiguration } from "../../public/viteToolsHelper.mjs";
  *   → const DracoDecoderModule = undefined;
  */
 function stubOptionalPeerDepsPlugin(): Plugin {
-    const optionals = ["draco3dgltf", "ammo.js", "cannon", "oimo", "recast", "havok", "basis_transcoder"];
-    const q = optionals.map((p) => p.replace(".", "\\.")).join("|");
-    // Handle: import type { A, B } from "pkg"  — erase entirely (type-only)
-    const typeNamedRe = new RegExp(`import\\s+type\\s+\\{[^}]*\\}\\s+from\\s+['"](?:${q})['"];?`, "g");
-    // Handle: import { A, B } from "pkg"   (single or multi-line braces, runtime)
-    const namedRe = new RegExp(`import\\s+\\{([^}]*)\\}\\s+from\\s+['"](?:${q})['"];?`, "g");
-    // Handle: import * as ns from "pkg"
-    const starRe = new RegExp(`import\\s+(?:type\\s+)?\\*\\s+as\\s+(\\w+)\\s+from\\s+['"](?:${q})['"];?`, "g");
-    // Handle: import Default from "pkg"
-    const defaultRe = new RegExp(`import\\s+(?:type\\s+)?(\\w+)\\s+from\\s+['"](?:${q})['"];?`, "g");
-    // Handle: import "pkg"  (side-effect only)
-    const sideEffectRe = new RegExp(`import\\s+['"](?:${q})['"];?`, "g");
-
-    function stubNamed(bindings: string) {
-        return bindings
-            .split(",")
-            .map((s) =>
-                s
-                    .trim()
-                    .split(/\s+as\s+/)
-                    .pop()!
-                    .trim()
-            )
-            .filter((n) => Boolean(n) && !n.startsWith("type "))
-            .map((n) => `const ${n} = undefined;`)
-            .join(" ");
-    }
-
     return {
         name: "stub-optional-peer-deps",
         enforce: "pre",
         transform(code, id) {
             if (!/\.[tj]sx?$/.test(id)) return null;
-            if (!optionals.some((p) => code.includes(`"${p}"`) || code.includes(`'${p}'`))) return null;
+            const transformedCode = stubOptionalPeerDependencyImports(code);
+            if (transformedCode === code) return null;
 
             return {
-                code: code
-                    .replace(typeNamedRe, "")
-                    .replace(namedRe, (_m, bindings: string) => stubNamed(bindings))
-                    .replace(starRe, (_m, ns: string) => `const ${ns} = {};`)
-                    .replace(defaultRe, (_m, def: string) => `const ${def} = undefined;`)
-                    .replace(sideEffectRe, ""),
+                code: transformedCode,
                 map: null,
             };
         },
@@ -65,31 +142,33 @@ function stubOptionalPeerDepsPlugin(): Plugin {
 }
 
 export default defineConfig((_env) => {
+    const aliases = {
+        core: path.resolve("../../dev/core/src"),
+        gui: path.resolve("../../dev/gui/src"),
+        serializers: path.resolve("../../dev/serializers/src"),
+        loaders: path.resolve("../../dev/loaders/src"),
+        materials: path.resolve("../../dev/materials/src"),
+        "lottie-player": path.resolve("../../dev/lottiePlayer/src"),
+        inspector: path.resolve("../../dev/inspector/src"),
+        "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
+        "post-processes": path.resolve("../../dev/postProcesses/src"),
+        "procedural-textures": path.resolve("../../dev/proceduralTextures/src"),
+        "node-editor": path.resolve("../../tools/nodeEditor/src"),
+        "node-geometry-editor": path.resolve("../../tools/nodeGeometryEditor/src"),
+        "node-render-graph-editor": path.resolve("../../tools/nodeRenderGraphEditor/src"),
+        "node-particle-editor": path.resolve("../../tools/nodeParticleEditor/src"),
+        "gui-editor": path.resolve("../../tools/guiEditor/src"),
+        accessibility: path.resolve("../../tools/accessibility/src"),
+        "babylonjs-gltf2interface": path.resolve("./src/babylon.glTF2Interface.ts"),
+    };
+
     const base = commonDevViteConfiguration({
         port: parseInt(process.env.TOOLS_PORT ?? "1338"),
-        aliases: {
-            core: path.resolve("../../dev/core/src"),
-            gui: path.resolve("../../dev/gui/src"),
-            serializers: path.resolve("../../dev/serializers/src"),
-            loaders: path.resolve("../../dev/loaders/src"),
-            materials: path.resolve("../../dev/materials/src"),
-            "lottie-player": path.resolve("../../dev/lottiePlayer/src"),
-            inspector: path.resolve("../../dev/inspector/src"),
-            "shared-ui-components": path.resolve("../../dev/sharedUiComponents/src"),
-            "post-processes": path.resolve("../../dev/postProcesses/src"),
-            "procedural-textures": path.resolve("../../dev/proceduralTextures/src"),
-            "node-editor": path.resolve("../../tools/nodeEditor/src"),
-            "node-geometry-editor": path.resolve("../../tools/nodeGeometryEditor/src"),
-            "node-render-graph-editor": path.resolve("../../tools/nodeRenderGraphEditor/src"),
-            "node-particle-editor": path.resolve("../../tools/nodeParticleEditor/src"),
-            "gui-editor": path.resolve("../../tools/guiEditor/src"),
-            accessibility: path.resolve("../../tools/accessibility/src"),
-            "babylonjs-gltf2interface": path.resolve("./src/babylon.glTF2Interface.ts"),
-        },
-    });
+        aliases,
+    }) as unknown as UserConfig;
 
     return {
         ...base,
-        plugins: [...(base.plugins ?? []), stubOptionalPeerDepsPlugin()],
+        plugins: [...(base.plugins ?? []), lottieClassicWorkerPlugin(aliases), stubOptionalPeerDepsPlugin()],
     };
 });


### PR DESCRIPTION
## Summary
- Rename the Lottie worker wrapper usage so it is not mistaken for the native `Worker` constructor pattern.
- Add a focused dev-host Vite plugin that serves the Lottie worker as an esbuild-bundled classic script for `BlobWorkerWrapper` / `importScripts()`.
- Emit the same classic worker script during dev-host production builds.

## Validation
- `npm run build -w @tools/dev-host`
- `npm run lint:changed`
- Vite dev host smoke test for `?exp=lottie&useprewarm=true` produced a canvas and `#lottie-ready`.