### PR TITLE
fix(GaussianSplatting): preserve plugin defines with ShadowGenerator and invoke prepareDefines events

### DIFF
--- a/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
+++ b/packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts
@@ -295,8 +295,16 @@ export class GaussianSplattingMaterial extends PushMaterial {
         // Values that need to be evaluated on every frame
         PrepareDefinesForFrameBoundValues(scene, engine, this, defines, useInstances, null, true);
 
+        // External config
+        this._eventInfo.defines = defines;
+        this._eventInfo.mesh = mesh;
+        this._callbackPluginEventPrepareDefinesBeforeAttributes(this._eventInfo);
+
         // Attribs
         PrepareDefinesForAttributes(mesh, defines, false, false);
+
+        // External config
+        this._callbackPluginEventPrepareDefines(this._eventInfo);
 
         // SH is disabled for webGL1
         if (engine.version > 1 || engine.isWebGPU) {

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts
@@ -808,17 +808,38 @@ export class GaussianSplattingMeshBase extends Mesh {
         // each subMesh against the scene's shadow generators. Otherwise the first shadow pass
         // would be skipped (ShadowGenerator.isReady would return false) and we'd miss the shadow
         // on a renderCount=1 capture.
+        // The shadow generator's depth wrapper is standalone (it wraps a ShaderMaterial), so its
+        // isReadyForSubMesh path stamps an effect on subMesh._drawWrappers[engine.currentRenderPassId].
+        // If we leave currentRenderPassId set to the main pass while doing this, we'd overwrite the
+        // GS material's defines on the main draw wrapper, causing the GS material to recreate its
+        // defines on the next call and lose any plugin-driven define state (e.g. defines toggled
+        // by a MaterialPluginBase.isReadyForSubMesh override). Temporarily switch to each shadow
+        // generator's render pass id while preparing it (matches the pattern used in Mesh.isReady).
         if (this.material && this.material.shadowDepthWrapper) {
-            for (const light of this._scene.lights) {
-                const shadowGenerator = light.getShadowGenerator();
-                if (!shadowGenerator) {
-                    continue;
-                }
-                for (const subMesh of this.subMeshes) {
-                    if (!shadowGenerator.isReady(subMesh, true, false)) {
-                        return false;
+            const engine = this._scene.getEngine();
+            const previousRenderPassId = engine.currentRenderPassId;
+            try {
+                for (const light of this._scene.lights) {
+                    const shadowGenerator = light.getShadowGenerator();
+                    if (!shadowGenerator) {
+                        continue;
+                    }
+                    const shadowMap = shadowGenerator.getShadowMap();
+                    const renderPassIds = shadowMap?.renderPassIds;
+                    if (!renderPassIds || renderPassIds.length === 0) {
+                        continue;
+                    }
+                    for (let p = 0; p < renderPassIds.length; ++p) {
+                        engine.currentRenderPassId = renderPassIds[p];
+                        for (const subMesh of this.subMeshes) {
+                            if (!shadowGenerator.isReady(subMesh, true, false)) {
+                                return false;
+                            }
+                        }
                     }
                 }
+            } finally {
+                engine.currentRenderPassId = previousRenderPassId;
             }
         }
 


### PR DESCRIPTION
Two related fixes around MaterialPluginBase support on GaussianSplattingMaterial, both surfaced by https://forum.babylonjs.com/t/issue-updating-defines-on-material-plugin-for-gaussian-material/63369.

Repro playground: https://playground.babylonjs.com/#CID4NN#393

### (1) Plugin defines wiped when a ShadowGenerator is added to the scene

A recent change in `GaussianSplattingMeshBase.isReady()` (PR #18345) calls `shadowGenerator.isReady(subMesh, true, false)` on the main render pass to make sure shadow casting is ready on the very first frame.

Because the GS material's shadow depth wrapper is **standalone** (it wraps a private `ShaderMaterial`), the wrapper's `isReadyForSubMesh` path eventually writes its defines string to `subMesh._drawWrappers[engine.currentRenderPassId]` — overwriting the GS material's `MaterialDefines` object on the **main** draw wrapper.

Next call to `GaussianSplattingMaterial.isReadyForSubMesh` then sees no defines (the `subMesh.materialDefines` getter returns `null` when the underlying defines is a string), recreates them from scratch and loses any state previously stamped by a `MaterialPluginBase` — e.g. the user's `HUE_ENABLED` flag.

**Fix:** swap `engine.currentRenderPassId` to each shadow map's render pass id around the readiness check, then restore it in a `finally`. This matches the canonical pattern used in `Mesh.isReady` (`mesh.ts:1530-1555`).

### (2) `MaterialPluginBase.prepareDefines()` was never called from `GaussianSplattingMaterial`

Standard/PBR materials invoke `MaterialPluginEvent.PrepareDefinesBeforeAttributes` and `PrepareDefines` from their `isReadyForSubMesh`. The GS material did not, so plugin authors were forced to use `isReadyForSubMesh` even when `prepareDefines` would have been the more idiomatic hook.

**Fix:** add the two missing event invocations to `GaussianSplattingMaterial.isReadyForSubMesh`, in the same positions used by `StandardMaterial` (before/after `PrepareDefinesForAttributes`).

### Verification

- TypeScript diagnostics clean
- `prettier --check` passing
- `eslint` passing
- Existing GS unit tests (`babylon.gaussianSplatting.serialization.test.ts`): 5/5 passing
- Manually verified in-browser via Playwright by patching `mesh.isReady` to do exactly what the source fix now does — toggle correctly updates `HUE_ENABLED` with a `ShadowGenerator` present.

### Files changed

- `packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.ts`
- `packages/dev/core/src/Materials/GaussianSplatting/gaussianSplattingMaterial.ts`