### PR TITLE
Fix AnimatorAvatar.retargetAnimationGroup clobbering active animations

### DIFF
--- a/packages/dev/core/src/Animations/animatorAvatar.ts
+++ b/packages/dev/core/src/Animations/animatorAvatar.ts
@@ -274,198 +274,201 @@ export class AnimatorAvatar {
         // optional _fixRootPosition / _fixGroundReference helpers further drive the bones via
         // an internal play / goToFrame loop. Without restoring afterwards, any animation
         // already playing on the avatar gets clobbered (typically visible as a snap to the
-        // rest pose the moment that animation is later stopped).
+        // rest pose the moment that animation is later stopped). The restore is wrapped in
+        // a try/finally so the avatar is also reset if the body throws.
         const avatarSkeletonStates = this._captureAvatarSkeletonStates();
 
-        // Make sure that all world matrices are up to date, both in the bone hierarchy and in the animation transform node hierarchy
-        this._computeBoneWorldMatrices();
+        try {
+            // Make sure that all world matrices are up to date, both in the bone hierarchy and in the animation transform node hierarchy
+            this._computeBoneWorldMatrices();
 
-        const mapNodeNames = localOptions.mapNodeNames ?? new Map();
-        const lstSourceTransformNodes = new Set<TransformNode>();
-        const sourceTransformNodeNameToNode: TransformNodeNameToNode = new Map();
+            const mapNodeNames = localOptions.mapNodeNames ?? new Map();
+            const lstSourceTransformNodes = new Set<TransformNode>();
+            const sourceTransformNodeNameToNode: TransformNodeNameToNode = new Map();
 
-        for (let i = 0; i < sourceAnimationGroup.targetedAnimations.length; ++i) {
-            const ta = sourceAnimationGroup.targetedAnimations[i];
-            if (ta.target.getClassName?.() === "TransformNode" && !lstSourceTransformNodes.has(ta.target)) {
-                const tn = ta.target as TransformNode;
+            for (let i = 0; i < sourceAnimationGroup.targetedAnimations.length; ++i) {
+                const ta = sourceAnimationGroup.targetedAnimations[i];
+                if (ta.target.getClassName?.() === "TransformNode" && !lstSourceTransformNodes.has(ta.target)) {
+                    const tn = ta.target as TransformNode;
 
-                lstSourceTransformNodes.add(tn);
+                    lstSourceTransformNodes.add(tn);
 
-                sourceTransformNodeNameToNode.set(mapNodeNames.get(tn.name) ?? tn.name, {
-                    node: tn,
-                    initialTransformations: {
-                        position: tn.position.clone(),
-                        scaling: tn.scaling.clone(),
-                        quaternion: tn.rotationQuaternion?.clone(),
-                        rotation: tn.rotation.clone(),
-                    },
-                });
+                    sourceTransformNodeNameToNode.set(mapNodeNames.get(tn.name) ?? tn.name, {
+                        node: tn,
+                        initialTransformations: {
+                            position: tn.position.clone(),
+                            scaling: tn.scaling.clone(),
+                            quaternion: tn.rotationQuaternion?.clone(),
+                            rotation: tn.rotation.clone(),
+                        },
+                    });
 
-                if (!tn.rotationQuaternion) {
-                    tn.rotationQuaternion = Quaternion.FromEulerAngles(tn.rotation.x, tn.rotation.y, tn.rotation.z);
-                    tn.rotation.setAll(0);
-                }
-            }
-        }
-
-        lstSourceTransformNodes.forEach((node) => {
-            node.computeWorldMatrix(true);
-        });
-
-        // Clone the source animation and retarget it
-        const animationGroup = sourceAnimationGroup.clone(localOptions.animationGroupName!, undefined, true, true);
-
-        const mapTransformNodeToRootNode: Map<TransformNode, Node> = new Map<TransformNode, Node>();
-        const lstAnims = new Set<Animation>();
-
-        for (let i = 0; i < animationGroup.targetedAnimations.length; ++i) {
-            const ta = animationGroup.targetedAnimations[i];
-            const animation = ta.animation;
-
-            if (lstAnims.has(animation)) {
-                if (this.showWarnings) {
-                    Logger.Warn(
-                        `RetargetAnimationGroup - Avatar '${this.name}', AnimationGroup '${animationGroup.name}': animation '${animation.name}' is used multiple times in the same animation group: duplicated animations are not supported, the retargeted animation may not work as expected.`
-                    );
+                    if (!tn.rotationQuaternion) {
+                        tn.rotationQuaternion = Quaternion.FromEulerAngles(tn.rotation.x, tn.rotation.y, tn.rotation.z);
+                        tn.rotation.setAll(0);
+                    }
                 }
             }
 
-            lstAnims.add(animation);
+            lstSourceTransformNodes.forEach((node) => {
+                node.computeWorldMatrix(true);
+            });
 
-            switch (animation.targetProperty) {
-                case "influence": {
-                    if (!this._retargetMorphTarget(ta, animationGroup.name)) {
-                        animationGroup.targetedAnimations.splice(i, 1);
-                        i--;
+            // Clone the source animation and retarget it
+            const animationGroup = sourceAnimationGroup.clone(localOptions.animationGroupName!, undefined, true, true);
+
+            const mapTransformNodeToRootNode: Map<TransformNode, Node> = new Map<TransformNode, Node>();
+            const lstAnims = new Set<Animation>();
+
+            for (let i = 0; i < animationGroup.targetedAnimations.length; ++i) {
+                const ta = animationGroup.targetedAnimations[i];
+                const animation = ta.animation;
+
+                if (lstAnims.has(animation)) {
+                    if (this.showWarnings) {
+                        Logger.Warn(
+                            `RetargetAnimationGroup - Avatar '${this.name}', AnimationGroup '${animationGroup.name}': animation '${animation.name}' is used multiple times in the same animation group: duplicated animations are not supported, the retargeted animation may not work as expected.`
+                        );
                     }
-                    break;
                 }
-                case "position":
-                case "rotationQuaternion":
-                case "scaling": {
-                    if (ta.target.getClassName?.() !== "TransformNode") {
-                        break;
-                    }
 
-                    const sourceTransformNode = ta.target as TransformNode;
-                    const sourceTransformNodeName = mapNodeNames.get(sourceTransformNode.name) ?? sourceTransformNode.name;
-                    let targetBone = this.findBoneByTransformNode(sourceTransformNodeName);
+                lstAnims.add(animation);
 
-                    if (!targetBone) {
-                        targetBone = this.findBoneByName(sourceTransformNodeName);
-                    }
-
-                    if (!targetBone) {
-                        if (this.showWarnings) {
-                            Logger.Warn(
-                                `RetargetAnimationGroup - Avatar '${this.name}', AnimationGroup '${animationGroup.name}': "${sourceTransformNodeName}" bone not found in any skeleton of avatar: animation removed.`
-                            );
+                switch (animation.targetProperty) {
+                    case "influence": {
+                        if (!this._retargetMorphTarget(ta, animationGroup.name)) {
+                            animationGroup.targetedAnimations.splice(i, 1);
+                            i--;
                         }
-                        animationGroup.targetedAnimations.splice(i, 1);
-                        i--;
                         break;
                     }
+                    case "position":
+                    case "rotationQuaternion":
+                    case "scaling": {
+                        if (ta.target.getClassName?.() !== "TransformNode") {
+                            break;
+                        }
 
-                    if (
-                        !this._retargetTransformNodeToBone(
-                            ta,
-                            sourceTransformNode,
-                            targetBone,
-                            animationGroup.name,
-                            mapTransformNodeToRootNode,
-                            mapNodeNames,
-                            !!localOptions.checkHierarchy
-                        )
-                    ) {
-                        animationGroup.targetedAnimations.splice(i, 1);
-                        i--;
-                    } else if (localOptions.retargetAnimationKeys) {
-                        this._retargetAnimationKeys(ta.animation, sourceTransformNode, targetBone);
+                        const sourceTransformNode = ta.target as TransformNode;
+                        const sourceTransformNodeName = mapNodeNames.get(sourceTransformNode.name) ?? sourceTransformNode.name;
+                        let targetBone = this.findBoneByTransformNode(sourceTransformNodeName);
+
+                        if (!targetBone) {
+                            targetBone = this.findBoneByName(sourceTransformNodeName);
+                        }
+
+                        if (!targetBone) {
+                            if (this.showWarnings) {
+                                Logger.Warn(
+                                    `RetargetAnimationGroup - Avatar '${this.name}', AnimationGroup '${animationGroup.name}': "${sourceTransformNodeName}" bone not found in any skeleton of avatar: animation removed.`
+                                );
+                            }
+                            animationGroup.targetedAnimations.splice(i, 1);
+                            i--;
+                            break;
+                        }
+
+                        if (
+                            !this._retargetTransformNodeToBone(
+                                ta,
+                                sourceTransformNode,
+                                targetBone,
+                                animationGroup.name,
+                                mapTransformNodeToRootNode,
+                                mapNodeNames,
+                                !!localOptions.checkHierarchy
+                            )
+                        ) {
+                            animationGroup.targetedAnimations.splice(i, 1);
+                            i--;
+                        } else if (localOptions.retargetAnimationKeys) {
+                            this._retargetAnimationKeys(ta.animation, sourceTransformNode, targetBone);
+                        }
+
+                        break;
                     }
-
-                    break;
                 }
             }
-        }
 
-        if (localOptions.fixAnimations) {
-            this._fixAnimationGroup(animationGroup);
-        }
+            if (localOptions.fixAnimations) {
+                this._fixAnimationGroup(animationGroup);
+            }
 
-        if (localOptions.fixGroundReference || localOptions.fixRootPosition) {
-            const msg =
-                localOptions.fixGroundReference && localOptions.fixRootPosition
-                    ? "Ground reference and root position fixing processes skipped."
-                    : localOptions.fixGroundReference
-                      ? "Ground reference fixing process skipped."
-                      : "Root position fixing process skipped.";
+            if (localOptions.fixGroundReference || localOptions.fixRootPosition) {
+                const msg =
+                    localOptions.fixGroundReference && localOptions.fixRootPosition
+                        ? "Ground reference and root position fixing processes skipped."
+                        : localOptions.fixGroundReference
+                          ? "Ground reference fixing process skipped."
+                          : "Root position fixing process skipped.";
 
-            const res = this._findVerticalAxis(
-                msg,
-                animationGroup,
-                mapNodeNames.get(localOptions.rootNodeName) ?? localOptions.rootNodeName,
-                sourceTransformNodeNameToNode,
-                mapNodeNames.get(localOptions.groundReferenceNodeName) ?? localOptions.groundReferenceNodeName,
-                localOptions.groundReferenceVerticalAxis
-            );
+                const res = this._findVerticalAxis(
+                    msg,
+                    animationGroup,
+                    mapNodeNames.get(localOptions.rootNodeName) ?? localOptions.rootNodeName,
+                    sourceTransformNodeNameToNode,
+                    mapNodeNames.get(localOptions.groundReferenceNodeName) ?? localOptions.groundReferenceNodeName,
+                    localOptions.groundReferenceVerticalAxis
+                );
 
-            if (res) {
-                const {
-                    verticalAxis,
-                    sourceRootTransformNode,
-                    targetRootTransformNodeOrBone,
-                    targetRootPositionAnimation,
-                    sourceGroundReferenceTransformNode,
-                    targetGroundReferenceTransformNodeOrBone,
-                    proportionRatio,
-                } = res;
-
-                if (localOptions.fixRootPosition) {
-                    this._fixRootPosition(
-                        sourceAnimationGroup,
-                        animationGroup,
-                        sourceRootTransformNode,
-                        targetRootTransformNodeOrBone,
-                        targetRootPositionAnimation,
-                        proportionRatio
-                    );
-                    this._resetStates(sourceTransformNodeNameToNode);
-                }
-
-                const fixGroundReferenceDynamicRefNode = !!localOptions.fixGroundReferenceDynamicRefNode;
-
-                if (localOptions.fixGroundReference) {
-                    this._fixGroundReference(
-                        sourceAnimationGroup,
-                        animationGroup,
+                if (res) {
+                    const {
                         verticalAxis,
+                        sourceRootTransformNode,
                         targetRootTransformNodeOrBone,
                         targetRootPositionAnimation,
                         sourceGroundReferenceTransformNode,
                         targetGroundReferenceTransformNodeOrBone,
-                        lstSourceTransformNodes,
-                        mapNodeNames,
-                        fixGroundReferenceDynamicRefNode
-                    );
-                    this._resetStates(sourceTransformNodeNameToNode);
-                } else if (fixGroundReferenceDynamicRefNode) {
-                    if (this.showWarnings) {
-                        Logger.Warn(
-                            `RetargetAnimationGroup - Avatar '${this.name}', AnimationGroup '${animationGroup.name}': fixGroundReferenceDynamicRefNode option is set to true but fixGroundReference is false: dynamic ground reference node fixing process skipped.`
+                        proportionRatio,
+                    } = res;
+
+                    if (localOptions.fixRootPosition) {
+                        this._fixRootPosition(
+                            sourceAnimationGroup,
+                            animationGroup,
+                            sourceRootTransformNode,
+                            targetRootTransformNodeOrBone,
+                            targetRootPositionAnimation,
+                            proportionRatio
                         );
+                        this._resetStates(sourceTransformNodeNameToNode);
+                    }
+
+                    const fixGroundReferenceDynamicRefNode = !!localOptions.fixGroundReferenceDynamicRefNode;
+
+                    if (localOptions.fixGroundReference) {
+                        this._fixGroundReference(
+                            sourceAnimationGroup,
+                            animationGroup,
+                            verticalAxis,
+                            targetRootTransformNodeOrBone,
+                            targetRootPositionAnimation,
+                            sourceGroundReferenceTransformNode,
+                            targetGroundReferenceTransformNodeOrBone,
+                            lstSourceTransformNodes,
+                            mapNodeNames,
+                            fixGroundReferenceDynamicRefNode
+                        );
+                        this._resetStates(sourceTransformNodeNameToNode);
+                    } else if (fixGroundReferenceDynamicRefNode) {
+                        if (this.showWarnings) {
+                            Logger.Warn(
+                                `RetargetAnimationGroup - Avatar '${this.name}', AnimationGroup '${animationGroup.name}': fixGroundReferenceDynamicRefNode option is set to true but fixGroundReference is false: dynamic ground reference node fixing process skipped.`
+                            );
+                        }
                     }
                 }
             }
+
+            return animationGroup;
+        } finally {
+            // Restore the avatar's bones to their pre-call state. The internal helpers above
+            // (_computeBoneWorldMatrices and, when enabled, _fixRootPosition / _fixGroundReference)
+            // overwrite the bone transforms; without restoring, any animation already driving the
+            // avatar appears clobbered (visible as a snap to rest pose the moment that animation
+            // is later stopped). Running in finally also makes sure we restore on exception.
+            this._restoreAvatarSkeletonStates(avatarSkeletonStates);
         }
-
-        // Restore the avatar's bones to their pre-call state. The internal helpers above
-        // (_computeBoneWorldMatrices and, when enabled, _fixRootPosition / _fixGroundReference)
-        // overwrite the bone transforms; without restoring, any animation already driving the
-        // avatar appears clobbered (visible as a snap to rest pose the moment that animation
-        // is later stopped).
-        this._restoreAvatarSkeletonStates(avatarSkeletonStates);
-
-        return animationGroup;
     }
 
     /**
@@ -893,19 +896,35 @@ export class AnimatorAvatar {
         states.transformNodeStates.forEach((data, node) => {
             node.position.copyFrom(data.position);
             node.scaling.copyFrom(data.scaling);
-            if (data.quaternion && node.rotationQuaternion) {
-                node.rotationQuaternion.copyFrom(data.quaternion);
+            if (data.quaternion) {
+                // Snapshot was using a quaternion: ensure the node still has one and restore it.
+                // _computeBoneWorldMatrices() can null/replace it via Bone.returnToRest, so we can't
+                // assume node.rotationQuaternion is the same instance (or non-null) we captured.
+                if (node.rotationQuaternion) {
+                    node.rotationQuaternion.copyFrom(data.quaternion);
+                } else {
+                    node.rotationQuaternion = data.quaternion.clone();
+                }
             } else {
+                // Snapshot was using Euler rotation: clear any quaternion that may have been
+                // assigned in the meantime (Babylon ignores rotation when rotationQuaternion is set).
+                node.rotationQuaternion = null;
                 node.rotation.copyFrom(data.rotation);
             }
+            node.computeWorldMatrix(true);
         });
 
         states.boneMatrices.forEach((matrix, bone) => {
             bone._matrix = matrix;
         });
+
+        // Re-prepare each skeleton so the restored bone state takes effect immediately
+        // rather than being left as stale world/final matrices until the next frame.
+        this.skeletons.forEach((skeleton) => skeleton.prepare(true));
     }
 
     private _resetStates(sourceTransformNodeNameToNode: TransformNodeNameToNode) {
+        this.skeletons.forEach((skeleton) => skeleton.returnToRest());
         sourceTransformNodeNameToNode.forEach((data) => {
             const { node, initialTransformations } = data;
             node.position.copyFrom(initialTransformations.position);

--- a/packages/dev/core/src/Animations/animatorAvatar.ts
+++ b/packages/dev/core/src/Animations/animatorAvatar.ts
@@ -103,6 +103,11 @@ export interface IRetargetOptions {
 
 type TransformNodeNameToNode = Map<string, { node: TransformNode; initialTransformations: { position: Vector3; scaling: Vector3; quaternion?: Quaternion; rotation: Vector3 } }>;
 
+type AvatarSkeletonStates = {
+    transformNodeStates: Map<TransformNode, { position: Vector3; scaling: Vector3; quaternion?: Quaternion; rotation: Vector3 }>;
+    boneMatrices: Map<Bone, Matrix>;
+};
+
 /**
  * Represents an animator avatar that manages meshes, skeletons and morph target managers for a hierarchical transform node and mesh structure.
  * This class is used to group and manage animation-related resources (meshes, skeletons and morph targets) associated with a root transform node and its descendants.
@@ -263,6 +268,14 @@ export class AnimatorAvatar {
             fixRootPosition: true,
             ...options,
         };
+
+        // Capture the avatar's current bone state so we can restore it before returning.
+        // _computeBoneWorldMatrices() (called next) returns the skeletons to rest, and the
+        // optional _fixRootPosition / _fixGroundReference helpers further drive the bones via
+        // an internal play / goToFrame loop. Without restoring afterwards, any animation
+        // already playing on the avatar gets clobbered (typically visible as a snap to the
+        // rest pose the moment that animation is later stopped).
+        const avatarSkeletonStates = this._captureAvatarSkeletonStates();
 
         // Make sure that all world matrices are up to date, both in the bone hierarchy and in the animation transform node hierarchy
         this._computeBoneWorldMatrices();
@@ -444,6 +457,13 @@ export class AnimatorAvatar {
                 }
             }
         }
+
+        // Restore the avatar's bones to their pre-call state. The internal helpers above
+        // (_computeBoneWorldMatrices and, when enabled, _fixRootPosition / _fixGroundReference)
+        // overwrite the bone transforms; without restoring, any animation already driving the
+        // avatar appears clobbered (visible as a snap to rest pose the moment that animation
+        // is later stopped).
+        this._restoreAvatarSkeletonStates(avatarSkeletonStates);
 
         return animationGroup;
     }
@@ -846,9 +866,46 @@ export class AnimatorAvatar {
         };
     }
 
-    private _resetStates(sourceTransformNodeNameToNode: TransformNodeNameToNode) {
-        this.skeletons.forEach((skeleton) => skeleton.returnToRest());
+    private _captureAvatarSkeletonStates(): AvatarSkeletonStates {
+        const transformNodeStates = new Map<TransformNode, { position: Vector3; scaling: Vector3; quaternion?: Quaternion; rotation: Vector3 }>();
+        const boneMatrices = new Map<Bone, Matrix>();
 
+        this.skeletons.forEach((skeleton) => {
+            for (const bone of skeleton.bones) {
+                const linkedNode = bone._linkedTransformNode;
+                if (linkedNode) {
+                    transformNodeStates.set(linkedNode, {
+                        position: linkedNode.position.clone(),
+                        scaling: linkedNode.scaling.clone(),
+                        quaternion: linkedNode.rotationQuaternion?.clone(),
+                        rotation: linkedNode.rotation.clone(),
+                    });
+                } else {
+                    boneMatrices.set(bone, bone.getLocalMatrix().clone());
+                }
+            }
+        });
+
+        return { transformNodeStates, boneMatrices };
+    }
+
+    private _restoreAvatarSkeletonStates(states: AvatarSkeletonStates): void {
+        states.transformNodeStates.forEach((data, node) => {
+            node.position.copyFrom(data.position);
+            node.scaling.copyFrom(data.scaling);
+            if (data.quaternion && node.rotationQuaternion) {
+                node.rotationQuaternion.copyFrom(data.quaternion);
+            } else {
+                node.rotation.copyFrom(data.rotation);
+            }
+        });
+
+        states.boneMatrices.forEach((matrix, bone) => {
+            bone._matrix = matrix;
+        });
+    }
+
+    private _resetStates(sourceTransformNodeNameToNode: TransformNodeNameToNode) {
         sourceTransformNodeNameToNode.forEach((data) => {
             const { node, initialTransformations } = data;
             node.position.copyFrom(initialTransformations.position);


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Fixes the bug reported on the forum: [After Anim Retarget Stopping Current Animation Jumps to Rest Pose](https://forum.babylonjs.com/t/after-anim-retarget-stopping-current-animation-jumps-to-rest-pose/63379).

Repro: <https://playground.babylonjs.com/#K1QFZD#9>

## Root cause

`AnimatorAvatar.retargetAnimationGroup` was returning every avatar skeleton to its rest pose internally:

- `_computeBoneWorldMatrices()` (called unconditionally near the top) calls `skeleton.returnToRest()` on every skeleton.
- `_resetStates()` (called after `_fixRootPosition` / `_fixGroundReference` when those flags are enabled) does the same.

While another animation was driving the avatar, those resets were overwritten every frame, so visually nothing looked wrong. But the moment that animation was stopped (`testAnim.stop()`), nothing was overwriting the rest pose anymore and the avatar visibly snapped to T-pose.

The bug reproduces regardless of the `fixRootPosition` / `fixGroundReference` flags, since `_computeBoneWorldMatrices` runs unconditionally.

## Fix

Capture the avatar's bone state once at the top of `retargetAnimationGroup` and restore it once before returning. The internal helpers (`_computeBoneWorldMatrices`, `_fixRootPosition`, `_fixGroundReference`, `_resetStates`) are unchanged — the call no longer clobbers any animation already playing on the avatar.

Two new private helpers do the work:

- `_captureAvatarSkeletonStates()` — clones each bone's linked transform node values (or local matrix for unlinked bones) into a snapshot.
- `_restoreAvatarSkeletonStates(states)` — writes the snapshot back.

## Verification

Verified locally with the original repro playground (`#K1QFZD#9`, with both fix flags off) and the earlier variant (`#K1QFZD#8`, with `fixRootPosition: true`): in both cases the avatar now holds the clap pose after `testAnim.stop()` instead of snapping to T-pose.
