### PR TITLE
fix: PBR specular lobes use vLightSpecular instead of vLightDiffuse

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightFragment.fx
@@ -170,9 +170,9 @@
                         }
                     #endif
                     #ifdef ANISOTROPIC
-                        info.specular = computeAnisotropicSpecularLighting(preInfo, viewDirectionW, normalW, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, clearcoatOut.specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactors.x, diffuse{X}.rgb);
+                        info.specular = computeAnisotropicSpecularLighting(preInfo, viewDirectionW, normalW, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, clearcoatOut.specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactors.x, light{X}.vLightSpecular.rgb);
                     #else
-                        info.specular = computeSpecularLighting(preInfo, normalW, clearcoatOut.specularEnvironmentR0, coloredFresnel, AARoughnessFactors.x, diffuse{X}.rgb);
+                        info.specular = computeSpecularLighting(preInfo, normalW, clearcoatOut.specularEnvironmentR0, coloredFresnel, AARoughnessFactors.x, light{X}.vLightSpecular.rgb);
                     #endif
                 #endif
             #endif
@@ -202,7 +202,7 @@
                         preInfo.roughness = adjustRoughnessFromLightProperties(clearcoatOut.clearCoatRoughness, light{X}.vLightSpecular.a, preInfo.lightDistance);
                     #endif
 
-                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, diffuse{X}.rgb);
+                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, light{X}.vLightSpecular.rgb);
 
                     #ifdef CLEARCOAT_TINT
                         // Absorption

--- a/packages/dev/core/src/Shaders/ShadersInclude/pbrClusteredLightingFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/pbrClusteredLightingFunctions.fx
@@ -108,9 +108,9 @@
                         info.diffuse *= (vec3(1.0) - fresnel);
                     #endif
                     #ifdef ANISOTROPIC
-                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightDiffuse.rgb);
+                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightSpecular.rgb);
                     #else
-                        info.specular = computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightDiffuse.rgb);
+                        info.specular = computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightSpecular.rgb);
                     #endif
                 #endif
 
@@ -127,7 +127,7 @@
                 // Clear Coat contribution
                 #ifdef CLEARCOAT
                     preInfo.roughness = adjustRoughnessFromLightProperties(clearcoatOut.clearCoatRoughness, light.vLightSpecular.a, preInfo.lightDistance);
-                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, light.vLightDiffuse.rgb);
+                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, light.vLightSpecular.rgb);
 
                     #ifdef CLEARCOAT_TINT
                         // Absorption

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightFragment.fx
@@ -170,9 +170,9 @@
                         }
                     #endif
                     #ifdef ANISOTROPIC
-                        info.specular = computeAnisotropicSpecularLighting(preInfo, viewDirectionW, normalW, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, clearcoatOut.specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactors.x, diffuse{X}.rgb);
+                        info.specular = computeAnisotropicSpecularLighting(preInfo, viewDirectionW, normalW, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, clearcoatOut.specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactors.x, light{X}.vLightSpecular.rgb);
                     #else
-                        info.specular = computeSpecularLighting(preInfo, normalW, clearcoatOut.specularEnvironmentR0, coloredFresnel, AARoughnessFactors.x, diffuse{X}.rgb);
+                        info.specular = computeSpecularLighting(preInfo, normalW, clearcoatOut.specularEnvironmentR0, coloredFresnel, AARoughnessFactors.x, light{X}.vLightSpecular.rgb);
                     #endif
                 #endif
             #endif
@@ -202,7 +202,7 @@
                         preInfo.roughness = adjustRoughnessFromLightProperties(clearcoatOut.clearCoatRoughness, light{X}.vLightSpecular.a, preInfo.lightDistance);
                     #endif
 
-                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, diffuse{X}.rgb);
+                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, light{X}.vLightSpecular.rgb);
 
                     #ifdef CLEARCOAT_TINT
                         // Absorption

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions.fx
@@ -360,9 +360,9 @@ fn evalFuzz(L: vec3f, NdotL: f32, NdotV: f32, T: vec3f, B: vec3f, ltcLut: vec3f)
                         info.diffuse *= (vec3(1.0) - fresnel);
                     #endif
                     #ifdef ANISOTROPIC
-                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightDiffuse.rgb);
+                        info.specular = computeAnisotropicSpecularLighting(preInfo, V, N, anisotropicOut.anisotropicTangent, anisotropicOut.anisotropicBitangent, anisotropicOut.anisotropy, specularEnvironmentR0, specularEnvironmentR90, AARoughnessFactor, light.vLightSpecular.rgb);
                     #else
-                        info.specular = computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightDiffuse.rgb);
+                        info.specular = computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightSpecular.rgb);
                     #endif
                 #endif
 
@@ -379,7 +379,7 @@ fn evalFuzz(L: vec3f, NdotL: f32, NdotV: f32, T: vec3f, B: vec3f, ltcLut: vec3f)
                 // Clear Coat contribution
                 #ifdef CLEARCOAT
                     preInfo.roughness = adjustRoughnessFromLightProperties(clearcoatOut.clearCoatRoughness, light.vLightSpecular.a, preInfo.lightDistance);
-                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, light.vLightDiffuse.rgb);
+                    info.clearCoat = computeClearCoatLighting(preInfo, clearcoatOut.clearCoatNormalW, clearcoatOut.clearCoatAARoughnessFactors.x, clearcoatOut.clearCoatIntensity, light.vLightSpecular.rgb);
 
                     #ifdef CLEARCOAT_TINT
                         // Absorption

--- a/packages/dev/core/test/unit/Lights/babylon.hemisphericLight.test.ts
+++ b/packages/dev/core/test/unit/Lights/babylon.hemisphericLight.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { ShaderStore } from "core/Engines/shaderStore";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
+
+import "core/Shaders/ShadersInclude/lightFragment";
+import "core/Shaders/ShadersInclude/pbrClusteredLightingFunctions";
+import "core/ShadersWGSL/ShadersInclude/lightFragment";
+import "core/ShadersWGSL/ShadersInclude/pbrDirectLightingFunctions";
+
+describe("HemisphericLight", () => {
+    it("uses the light specular color for PBR specular lobes", () => {
+        const glslLightFragment = ShaderStore.GetIncludesShadersStore()[`lightFragment`];
+        const wgslLightFragment = ShaderStore.GetIncludesShadersStore(ShaderLanguage.WGSL)[`lightFragment`];
+        const glslClusteredLightingFunctions = ShaderStore.GetIncludesShadersStore()[`pbrClusteredLightingFunctions`];
+        const wgslDirectLightingFunctions = ShaderStore.GetIncludesShadersStore(ShaderLanguage.WGSL)[`pbrDirectLightingFunctions`];
+
+        for (const lightFragment of [glslLightFragment, wgslLightFragment, glslClusteredLightingFunctions, wgslDirectLightingFunctions]) {
+            // Specular lobe must now use vLightSpecular.rgb
+            expect(lightFragment).toMatch(/computeSpecularLighting\([^)]*vLightSpecular\.rgb\)/);
+            // Sheen must keep using the diffuse light color (sheen is diffuse-like)
+            expect(lightFragment).not.toMatch(/computeSheenLighting\([^)]*vLightSpecular\.rgb\)/);
+            expect(lightFragment).not.toContain("computeSpecularLighting(preInfo,normalW,clearcoatOut.specularEnvironmentR0,coloredFresnel,AARoughnessFactors.x,diffuse{X}.rgb)");
+            expect(lightFragment).not.toContain(
+                "computeSpecularLighting(preInfo, normalW, clearcoatOut.specularEnvironmentR0, coloredFresnel, AARoughnessFactors.x, diffuse{X}.rgb)"
+            );
+            expect(lightFragment).not.toContain("computeSpecularLighting(preInfo,N,specularEnvironmentR0,coloredFresnel,AARoughnessFactor,light.vLightDiffuse.rgb)");
+            expect(lightFragment).not.toContain("computeSpecularLighting(preInfo, N, specularEnvironmentR0, coloredFresnel, AARoughnessFactor, light.vLightDiffuse.rgb)");
+        }
+    });
+});

--- a/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/KHR_lights_punctual.ts
@@ -116,6 +116,10 @@ export class KHR_lights implements IGLTFLoaderExtension {
 
                 babylonLight.falloffType = Light.FALLOFF_GLTF;
                 babylonLight.diffuse = light.color ? Color3.FromArray(light.color) : Color3.White();
+                // glTF lights only define a single color (KHR_lights_punctual). We mirror it to the specular color
+                // so that PBR specular/anisotropic/clearcoat lobes (which now use vLightSpecular) stay tinted by
+                // the glTF light color and don't unexpectedly turn white on existing scenes.
+                babylonLight.specular = babylonLight.diffuse;
                 babylonLight.intensity = light.intensity == undefined ? 1 : light.intensity;
                 babylonLight.range = light.range == undefined ? Number.MAX_VALUE : light.range;
                 babylonLight.parent = babylonMesh;

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -3512,13 +3512,13 @@
         },
         {
             "title": "Sponza Clustered Lighting",
-            "playgroundId": "#CSCJO2#17",
+            "playgroundId": "#CSCJO2#100",
             "referenceImage": "sponza-clustered-lighting.png",
             "dependsOn": ["Lights", "Loaders", "glTF"]
         },
         {
             "title": "Sponza Clustered Lighting (2 viewports)",
-            "playgroundId": "#CSCJO2#20",
+            "playgroundId": "#CSCJO2#101",
             "referenceImage": "sponza-clustered-lighting-viewports.png",
             "dependsOn": ["Cameras", "Lights", "Loaders", "glTF"]
         },
@@ -3534,7 +3534,7 @@
         },
         {
             "title": "Sponza Clustered Lighting (node material pbr)",
-            "playgroundId": "#QY98Z3#17",
+            "playgroundId": "#QY98Z3#23",
             "dependsOn": ["Cameras", "Lights", "Loaders", "NodeMaterial", "glTF"]
         },
         {
@@ -3544,7 +3544,7 @@
         },
         {
             "title": "Clustered Lighting (lhs pbr material)",
-            "playgroundId": "#CSCJO2#60",
+            "playgroundId": "#CSCJO2#102",
             "dependsOn": ["Lights", "Materials", "Meshes", "NodeMaterial", "PBR"]
         },
         {
@@ -3554,7 +3554,7 @@
         },
         {
             "title": "Clustered Lighting (lhs pbr nodematerial)",
-            "playgroundId": "#CSCJO2#62",
+            "playgroundId": "#CSCJO2#103",
             "dependsOn": ["Lights", "Materials", "Meshes", "NodeMaterial", "PBR"]
         },
         {
@@ -3564,7 +3564,7 @@
         },
         {
             "title": "Clustered Lighting (rhs pbr material)",
-            "playgroundId": "#CSCJO2#70",
+            "playgroundId": "#CSCJO2#104",
             "dependsOn": ["Lights", "Materials", "Meshes", "NodeMaterial", "PBR"]
         },
         {
@@ -3574,7 +3574,7 @@
         },
         {
             "title": "Clustered Lighting (rhs pbr nodematerial)",
-            "playgroundId": "#CSCJO2#72",
+            "playgroundId": "#CSCJO2#105",
             "dependsOn": ["Lights", "Materials", "Meshes", "NodeMaterial", "PBR"]
         },
         {


### PR DESCRIPTION
## Summary

Fixes PBR specular lobes (specular, anisotropic specular, and clear coat) to correctly use the light's `vLightSpecular` color instead of `vLightDiffuse`. Sheen continues to use `vLightDiffuse` since it is conceptually a diffuse-like (broad, near-omnidirectional) lobe.

Forum thread: https://forum.babylonjs.com/t/directional-and-hemispheric-light-interaction/63448

## Changes

- `lightFragment.fx` (GLSL and WGSL): specular, anisotropic, and clear coat lobes now sample `light{X}.vLightSpecular.rgb`; sheen keeps `diffuse{X}.rgb`.
- `pbrClusteredLightingFunctions.fx` (GLSL) and `pbrDirectLightingFunctions.fx` (WGSL): same fix in the clustered lighting path.
- `KHR_lights_punctual.ts` (glTF loader): mirror the glTF light color into both diffuse and specular slots, with a comment explaining the rationale.
- New unit test asserting the specular lobe uses `vLightSpecular.rgb` and that sheen does NOT.

## Breaking change notice

This is a **breaking change** for users who create lights manually (i.e. not from a glTF file) and use them with **PBR materials**, in either of these cases:

1. The light's `specular` color is left at the default white but the `diffuse` color is set to a non-white value. Previously, PBR specular highlights followed the (non-white) `diffuse` color; they will now be white (the default `specular`).
2. The light's `specular` color is explicitly set to a value different from `diffuse`. Previously this had no effect on PBR; PBR specular highlights will now follow the `specular` color.

To avoid a visual regression on existing glTF scenes, the `KHR_lights_punctual` loader now sets `babylonLight.specular = babylonLight.diffuse`, so loaded glTF scenes are unaffected.

`StandardMaterial` is **not** affected by this change.

