### PR TITLE
[Materials] Fix PBRCustomMaterial shader source cleanup on dispose

### DIFF
--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -325,6 +325,18 @@ export class PBRCustomMaterial extends PBRMaterial {
         this._createdShaderName = "custompbr_" + PBRCustomMaterial.ShaderIndexer;
     }
 
+    /**
+     * Disposes the material
+     * @param forceDisposeEffect specifies if effects should be forcefully disposed
+     * @param forceDisposeTextures specifies if textures should be forcefully disposed
+     */
+    public override dispose(forceDisposeEffect?: boolean, forceDisposeTextures?: boolean): void {
+        delete Effect.ShadersStore[this._createdShaderName + "VertexShader"];
+        delete Effect.ShadersStore[this._createdShaderName + "PixelShader"];
+
+        super.dispose(forceDisposeEffect, forceDisposeTextures);
+    }
+
     protected override _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null, subMesh?: SubMesh): void {
         if (!effect) {
             return;

--- a/packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts
+++ b/packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts
@@ -1,0 +1,36 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import { Effect } from "core/Materials/effect";
+import { Scene } from "core/scene";
+import { PBRCustomMaterial } from "materials/custom/pbrCustomMaterial";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("PBRCustomMaterial", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let material: PBRCustomMaterial;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+        material = new PBRCustomMaterial("custom", scene);
+    });
+
+    afterEach(() => {
+        delete Effect.ShadersStore[material._createdShaderName + "VertexShader"];
+        delete Effect.ShadersStore[material._createdShaderName + "PixelShader"];
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("removes generated shader source entries when disposed", () => {
+        const shaderName = material.Builder("", [], [], [], []);
+
+        expect(Effect.ShadersStore[shaderName + "VertexShader"]).toBeDefined();
+        expect(Effect.ShadersStore[shaderName + "PixelShader"]).toBeDefined();
+
+        material.dispose(true, true);
+
+        expect(Effect.ShadersStore[shaderName + "VertexShader"]).toBeUndefined();
+        expect(Effect.ShadersStore[shaderName + "PixelShader"]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
`PBRCustomMaterial` generates per-instance shader names and stores generated vertex/pixel shader source strings in `Effect.ShadersStore`. These keys are not reused by future material instances, so disposing the material left unreachable shader source strings behind.

This change deletes the generated `custompbr_*VertexShader` and `custompbr_*PixelShader` entries when the material is disposed, then delegates to the base PBR material disposal path.

Fixes the memory leak reported at https://forum.babylonjs.com/t/pbrcustommaterial-shadersstore-memory-leak-on-dispose/63452.

Test coverage: added a unit regression test that builds a `PBRCustomMaterial`, verifies the generated shader entries exist, disposes the material, and verifies the generated entries are removed.

Validation:
- `npx vitest run --project=unit packages\dev\materials\test\unit\custom\pbrCustomMaterial.test.ts`
- `npx prettier --check "packages/dev/materials/src/custom/pbrCustomMaterial.ts" "packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts"`
- `npx eslint "packages/dev/materials/src/custom/pbrCustomMaterial.ts" "packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts" --quiet --no-warn-ignored`
- `npm run compile -w @dev/materials`

Note: `npm run lint:check` currently fails on unrelated upstream curly-rule errors in `packages/tools/babylonServer/src/createScene.js`.