### PR TITLE
fix(buildTools): handle file deletion in asset watcher gracefully

### DIFF
--- a/packages/dev/buildTools/src/copyAssets.ts
+++ b/packages/dev/buildTools/src/copyAssets.ts
@@ -58,7 +58,7 @@ export const processAssets = (options: { extensions: string[] } = { extensions: 
             })
             .on("all", (event, file) => {
                 // don't track directory changes
-                if (event === "addDir" || event === "unlinkDir") {
+                if (event === "addDir" || event === "unlinkDir" || event === "unlink") {
                     return;
                 }
                 let verb: string;
@@ -69,12 +69,24 @@ export const processAssets = (options: { extensions: string[] } = { extensions: 
                     case "change":
                         verb = "Changing";
                         break;
-                    case "unlink":
-                        verb = "Removing";
-                        break;
                 }
                 verbose && console.log(`${verb} asset: ${file}`);
-                ProcessFile(file, processOptions);
+                try {
+                    ProcessFile(file, processOptions);
+                } catch (e: any) {
+                    if (e.code === "ENOENT") {
+                        verbose && console.log(`File no longer exists, skipping: ${file}`);
+                    } else {
+                        console.error(`Error processing asset ${file}:`, e.message);
+                    }
+                }
+            })
+            .on("error", (error: NodeJS.ErrnoException) => {
+                if (error.code === "ENOENT") {
+                    verbose && console.log(`Watcher target no longer exists: ${error.path}`);
+                } else {
+                    console.error("Watcher error:", error.message);
+                }
             });
         console.log("watching for asset changes...");
     } else {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Problem

When switching git branches in VS Code, the **"Watch all for CDN (Dev)"** task crashes with a "no such file or directory" error. This happens because files that existed on the old branch but not the new one trigger chokidar file watcher events, and `ProcessFile` attempts to copy a source file that no longer exists — throwing an unhandled ENOENT exception that kills the watcher process.

## Fix

Three defensive changes in `packages/dev/buildTools/src/copyAssets.ts`:

1. **Skip `unlink` events** — `ProcessFile` only copies/builds files; it never actually handled deletions (the old code just crashed trying to copy a nonexistent file). Skipping the event is the correct behavior.
2. **Wrap `ProcessFile` in try-catch** — handles the race condition where a file disappears between the chokidar event firing and the actual copy attempt (e.g., rapid branch switching or rebasing).
3. **Add `.on("error")` handler** — chokidar itself can emit errors when watched paths vanish; without a handler these become unhandled exceptions that kill the process.

## Testing

- Verified no new lint errors or TypeScript errors introduced.
- Pre-existing lint warnings (missing JSDoc on `processAssets`) are unchanged.
