### PR TITLE
Upload Babylon Native visualization-test images as pipeline artifacts

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -800,17 +800,22 @@ jobs:
             retryCountOnTaskFailure: 3
 
           # validation_native.js writes its output (rendered PNGs to Results/,
-          # diff overlays to Errors/) next to Playground.exe. Mirror BabylonNative's
-          # own win32 workflow (.github/workflows/build-win32.yml) by uploading
-          # both as pipeline artifacts so failures are debuggable without re-running
-          # the test against a matching native binary locally.
+          # diff overlays to Errors/) next to Playground.exe's parent directory:
+          # `TestUtils.getOutputDirectory()` on Win32 returns the parent of the
+          # module directory. With Playground.exe under
+          # ..\BabylonNativeNightlyPlayground\RelWithDebInfo\, the output lands
+          # in ..\BabylonNativeNightlyPlayground\Results\ (not under
+          # RelWithDebInfo\). Mirror BabylonNative's own win32 workflow
+          # (.github/workflows/build-win32.yml) by uploading both as pipeline
+          # artifacts so failures are debuggable without re-running the test
+          # against a matching native binary locally.
           - pwsh: |
                 # PublishPipelineArtifact@1 has no "ignore if missing" option, so
                 # make sure both directories exist before publishing. Results/ may
                 # be missing if Playground.exe crashed before writing anything;
                 # Errors/ is only created on actual pixel diffs.
-                New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\RelWithDebInfo\Results" | Out-Null
-                New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\RelWithDebInfo\Errors" | Out-Null
+                New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\Results" | Out-Null
+                New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\Errors" | Out-Null
             displayName: "Ensure native visualization output dirs"
             condition: not(canceled())
 
@@ -818,7 +823,7 @@ jobs:
             displayName: "Upload Rendered Pictures"
             condition: not(canceled())
             inputs:
-                targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\RelWithDebInfo\\Results"
+                targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\Results"
                 artifact: "native-rendered-pictures"
                 publishLocation: "pipeline"
 
@@ -826,7 +831,7 @@ jobs:
             displayName: "Upload Error Pictures"
             condition: failed()
             inputs:
-                targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\RelWithDebInfo\\Errors"
+                targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\Errors"
                 artifact: "native-error-pictures"
                 publishLocation: "pipeline"
 

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -799,21 +799,7 @@ jobs:
             displayName: "Run visualization tests"
             retryCountOnTaskFailure: 3
 
-          # validation_native.js writes its output (rendered PNGs to Results/,
-          # diff overlays to Errors/) next to Playground.exe's parent directory:
-          # `TestUtils.getOutputDirectory()` on Win32 returns the parent of the
-          # module directory. With Playground.exe under
-          # ..\BabylonNativeNightlyPlayground\RelWithDebInfo\, the output lands
-          # in ..\BabylonNativeNightlyPlayground\Results\ (not under
-          # RelWithDebInfo\). Mirror BabylonNative's own win32 workflow
-          # (.github/workflows/build-win32.yml) by uploading both as pipeline
-          # artifacts so failures are debuggable without re-running the test
-          # against a matching native binary locally.
           - pwsh: |
-                # PublishPipelineArtifact@1 has no "ignore if missing" option, so
-                # make sure both directories exist before publishing. Results/ may
-                # be missing if Playground.exe crashed before writing anything;
-                # Errors/ is only created on actual pixel diffs.
                 New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\Results" | Out-Null
                 New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\Errors" | Out-Null
             displayName: "Ensure native visualization output dirs"

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -799,6 +799,37 @@ jobs:
             displayName: "Run visualization tests"
             retryCountOnTaskFailure: 3
 
+          # validation_native.js writes its output (rendered PNGs to Results/,
+          # diff overlays to Errors/) next to Playground.exe. Mirror BabylonNative's
+          # own win32 workflow (.github/workflows/build-win32.yml) by uploading
+          # both as pipeline artifacts so failures are debuggable without re-running
+          # the test against a matching native binary locally.
+          - pwsh: |
+                # PublishPipelineArtifact@1 has no "ignore if missing" option, so
+                # make sure both directories exist before publishing. Results/ may
+                # be missing if Playground.exe crashed before writing anything;
+                # Errors/ is only created on actual pixel diffs.
+                New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\RelWithDebInfo\Results" | Out-Null
+                New-Item -ItemType Directory -Force -Path "..\BabylonNativeNightlyPlayground\RelWithDebInfo\Errors" | Out-Null
+            displayName: "Ensure native visualization output dirs"
+            condition: not(canceled())
+
+          - task: PublishPipelineArtifact@1
+            displayName: "Upload Rendered Pictures"
+            condition: not(canceled())
+            inputs:
+                targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\RelWithDebInfo\\Results"
+                artifact: "native-rendered-pictures"
+                publishLocation: "pipeline"
+
+          - task: PublishPipelineArtifact@1
+            displayName: "Upload Error Pictures"
+            condition: failed()
+            inputs:
+                targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\RelWithDebInfo\\Errors"
+                artifact: "native-error-pictures"
+                publishLocation: "pipeline"
+
     # ============================================================================
     # PERFORMANCE TESTS
     # Depends on: Build, FormatLint


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Context

The `NativeTests` job in `ci-monorepo.yml` downloads BabylonNative nightly test artifacts (pipeline 36), replaces their bundled `babylon*.js` with the freshly built snapshot, and runs `Playground.exe app:///Scripts/validation_native.js` plus `UnitTests.exe`.

When pixel-diff regressions occur (e.g. the recent OpenPBR/glTF surface-tinting regression in #18430), `validation_native.js` writes the rendered PNG to `Results/<reference>.png` and a red-overlay diff to `Errors/<reference>.png` next to `Playground.exe` -- but nothing in the pipeline uploaded those directories. The failure log was the only visible signal, making it impossible to tell whether a regression is a real visual change vs. a threshold blip without re-running the test locally against a matching native binary.

## Change

Mirror the upload pattern from BabylonNative's own win32 workflow ([`.github/workflows/build-win32.yml`](https://github.com/BabylonJS/BabylonNative/blob/master/.github/workflows/build-win32.yml), `actions/upload-artifact@v6` twice) using the ADO equivalent `PublishPipelineArtifact@1`:

- **`native-rendered-pictures`** -- `Results/`, uploaded on `not(canceled())`. Matches `saveResult = true` in `validation_native.js`: every test always writes its render, so green runs upload too and give a baseline.
- **`native-error-pictures`** -- `Errors/`, uploaded only on `failed()`. Matches when `validation_native.js` actually writes diff overlays.

`PublishPipelineArtifact@1` has no `if-no-files-found: ignore` flag, so a one-off `New-Item -Force` step ensures both directories exist before publish (`Errors/` legitimately won't exist on a fully-green run).

## Verification

Can be verified end-to-end only after merge: the next native-test failure runs through this job and surfaces the diff PNGs as a downloadable artifact on the build. Until then, the green-run path is exercised by every passing build of this PR itself -- `native-rendered-pictures` should appear on the ADO run for this PR's CI.
