### PR TITLE
glTF loader: simplify material adapter finalizeAsync

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -214,9 +214,7 @@ export class GLTFLoader implements IGLTFLoader {
 
     private readonly _parent: GLTFFileLoader;
     private readonly _extensions = new Array<IGLTFLoaderExtension>();
-    /**
-     * @internal
-     */
+    /** @internal */
     public _disposed = false;
     private _rootUrl: Nullable<string> = null;
     private _fileName: Nullable<string> = null;

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -530,10 +530,7 @@ export class GLTFLoader implements IGLTFLoader {
                     // work (e.g. GPU texture processing); any returned Promise is pushed into
                     // _completePromises so it is awaited before the COMPLETE state is reached.
                     for (const adapter of Array.from(this._materialAdapters)) {
-                        const result = adapter.finalizeAsync?.();
-                        if (result) {
-                            this._completePromises.push(result);
-                        }
+                        this._completePromises.push(adapter.finalizeAsync());
                     }
 
                     this._extensionsOnReady();

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -214,7 +214,10 @@ export class GLTFLoader implements IGLTFLoader {
 
     private readonly _parent: GLTFFileLoader;
     private readonly _extensions = new Array<IGLTFLoaderExtension>();
-    private _disposed = false;
+    /**
+     * @internal
+     */
+    public _disposed = false;
     private _rootUrl: Nullable<string> = null;
     private _fileName: Nullable<string> = null;
     private _uniqueRootUrl: Nullable<string> = null;
@@ -530,7 +533,7 @@ export class GLTFLoader implements IGLTFLoader {
                     // work (e.g. GPU texture processing); any returned Promise is pushed into
                     // _completePromises so it is awaited before the COMPLETE state is reached.
                     for (const adapter of Array.from(this._materialAdapters)) {
-                        this._completePromises.push(adapter.finalizeAsync());
+                        this._completePromises.push(adapter.finalizeAsync(this));
                     }
 
                     this._extensionsOnReady();

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -197,9 +197,6 @@ export class GLTFLoader implements IGLTFLoader {
     /** @internal */
     public readonly _completePromises = new Array<Promise<unknown>>();
 
-    /** AbortController used to cancel in-flight finalizeAsync() calls when dispose() is called. */
-    private _finalizeController: AbortController | null = null;
-
     /** @internal */
     public _assetContainer: Nullable<AssetContainer> = null;
 
@@ -355,9 +352,6 @@ export class GLTFLoader implements IGLTFLoader {
         }
 
         this._disposed = true;
-
-        this._finalizeController?.abort();
-        this._finalizeController = null;
 
         this._completePromises.length = 0;
 
@@ -533,23 +527,12 @@ export class GLTFLoader implements IGLTFLoader {
                     }
 
                     // Finalize all material adapters. finalizeAsync() may return a Promise for async
-                    // work (e.g. GPU texture processing); push any such promises into
-                    // _completePromises so they are awaited before the COMPLETE state is reached.
-                    // Fall back to the deprecated finalize() for third-party adapters that have not
-                    // yet migrated, logging a warning so authors know to update.
-                    // An AbortController is created here and aborted in dispose() so that adapters
-                    // can detect mid-flight disposal and clean up intermediate resources early.
-                    this._finalizeController = new AbortController();
-                    const finalizeSignal = this._finalizeController.signal;
+                    // work (e.g. GPU texture processing); any returned Promise is pushed into
+                    // _completePromises so it is awaited before the COMPLETE state is reached.
                     for (const adapter of Array.from(this._materialAdapters)) {
-                        if (adapter.finalizeAsync) {
-                            const finalizePromise = adapter.finalizeAsync(finalizeSignal);
-                            if (finalizePromise) {
-                                this._completePromises.push(finalizePromise);
-                            }
-                        } else if (adapter.finalize) {
-                            Logger.Warn("GLTFLoader: IMaterialLoadingAdapter.finalize() is deprecated. Implement finalizeAsync() instead.");
-                            adapter.finalize();
+                        const result = adapter.finalizeAsync?.();
+                        if (result) {
+                            this._completePromises.push(result);
                         }
                     }
 

--- a/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
@@ -15,11 +15,11 @@ export interface IMaterialLoadingAdapter {
 
     /**
      * Finalizes material properties after all loading is complete.
-     * May return a Promise for async work (e.g. GPU texture processing). Any returned
-     * Promise is tracked by the loader and awaited before the COMPLETE state is reached,
-     * so callers can rely on onCompleteObservable for fully processed materials.
+     * May do async work (e.g. GPU texture processing); the returned Promise is tracked
+     * by the loader and awaited before the COMPLETE state is reached, so callers can rely
+     * on onCompleteObservable for fully processed materials.
      */
-    finalizeAsync?(): void | Promise<void>;
+    finalizeAsync?(): Promise<void>;
 
     /**
      * Whether the material should be treated as unlit

--- a/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
@@ -2,6 +2,7 @@ import { type Material } from "core/Materials/material";
 import { type BaseTexture } from "core/Materials/Textures/baseTexture";
 import { type Nullable } from "core/types";
 import { type Color3 } from "core/Maths/math.color";
+import { type GLTFLoader } from "./glTFLoader";
 
 /**
  * Interface for material loading adapters that provides a unified OpenPBR-like interface
@@ -18,8 +19,12 @@ export interface IMaterialLoadingAdapter {
      * May do async work (e.g. GPU texture processing); the returned Promise is tracked
      * by the loader and awaited before the COMPLETE state is reached, so callers can rely
      * on onCompleteObservable for fully processed materials.
+     *
+     * Implementations should check `loader._disposed` between awaits to bail out early
+     * when the loader is disposed mid-flight.
+     * @param loader The glTF loader driving the finalize step.
      */
-    finalizeAsync(): Promise<void>;
+    finalizeAsync(loader: GLTFLoader): Promise<void>;
 
     /**
      * Whether the material should be treated as unlit

--- a/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
@@ -19,7 +19,7 @@ export interface IMaterialLoadingAdapter {
      * by the loader and awaited before the COMPLETE state is reached, so callers can rely
      * on onCompleteObservable for fully processed materials.
      */
-    finalizeAsync?(): Promise<void>;
+    finalizeAsync(): Promise<void>;
 
     /**
      * Whether the material should be treated as unlit

--- a/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/materialLoadingAdapter.ts
@@ -13,21 +13,13 @@ export interface IMaterialLoadingAdapter {
      */
     readonly material: Material;
 
-    /** @deprecated Use finalizeAsync instead. */
-    finalize?(): void;
-
     /**
      * Finalizes material properties after all loading is complete.
      * May return a Promise for async work (e.g. GPU texture processing). Any returned
      * Promise is tracked by the loader and awaited before the COMPLETE state is reached,
      * so callers can rely on onCompleteObservable for fully processed materials.
-     *
-     * The loader passes an AbortSignal that is aborted when the loader is disposed.
-     * Implementations should check `signal.aborted` after each await point and, if
-     * aborted, release any intermediate resources and return early.
-     * @param signal An AbortSignal that fires when the loader is disposed mid-flight.
      */
-    finalizeAsync?(signal: AbortSignal): Promise<void> | void;
+    finalizeAsync?(): void | Promise<void>;
 
     /**
      * Whether the material should be treated as unlit

--- a/packages/dev/loaders/src/glTF/2.0/openpbrMaterialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/openpbrMaterialLoadingAdapter.ts
@@ -1258,10 +1258,8 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
 
     /**
      * Finalizes material properties after all loading is complete.
-     * @param signal An AbortSignal that fires when the loader is disposed. Intermediate
-     *   textures are disposed and the method returns early when aborted.
      */
-    public async finalizeAsync(signal: AbortSignal): Promise<void> {
+    public async finalizeAsync(): Promise<void> {
         // Do final configuration for the material to handle any interactions/dependencies between properties that we had to defer until all properties were loaded.
 
         // If the material is volumetric, we may need to create a coat layer to handle the surface tint.
@@ -1278,12 +1276,8 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                     TextureChannel.A,
                     this._diffuseTransmissionTint,
                     this._diffuseTransmissionTintTexture,
-                    true,
-                    signal
+                    true
                 );
-                if (signal.aborted) {
-                    return;
-                }
             }
         }
         // If the material has transmission, we need to use the base color to tint the transmission.
@@ -1294,10 +1288,7 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 this._material.transmissionColorTexture = this._material.baseColorTexture;
             } else if (!this.baseColor.equals(Color3.White()) || this.baseColorTexture !== null) {
                 // Otherwise, we have volumetric attenuation so we need to use the coat layer to preserve the base color tinting of glTF.
-                await this.copySurfaceToCoatAsync(this.transmissionWeight, this.transmissionWeightTexture, TextureChannel.R, this.baseColor, this.baseColorTexture, false, signal);
-                if (signal.aborted) {
-                    return;
-                }
+                await this.copySurfaceToCoatAsync(this.transmissionWeight, this.transmissionWeightTexture, TextureChannel.R, this.baseColor, this.baseColorTexture, false);
             }
         }
 
@@ -1324,10 +1315,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 TextureColorSpace.Linear,
                 ChannelMask.R
             );
-            if (signal.aborted) {
-                newRoughnessTexture.texture?.dispose();
-                return;
-            }
             this.specularRoughnessTexture = newRoughnessTexture.texture;
             this.specularRoughness = newRoughnessTexture.factor ? newRoughnessTexture.factor.r : 1.0;
 
@@ -1343,10 +1330,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 TextureColorSpace.SRGB,
                 ChannelMask.RGB
             );
-            if (signal.aborted) {
-                newMetallic.texture?.dispose();
-                return;
-            }
             this.baseMetalnessTexture = newMetallic.texture;
             this.baseMetalness = newMetallic.factor ? newMetallic.factor.r : 1.0;
 
@@ -1362,10 +1345,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 TextureColorSpace.SRGB,
                 ChannelMask.RGB
             );
-            if (signal.aborted) {
-                newBaseColor.texture?.dispose();
-                return;
-            }
             const oldBaseColorTexture = this.baseColorTexture;
             oldBaseColorTexture?.dispose();
             this.baseColorTexture = newBaseColor.texture;
@@ -1383,8 +1362,7 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
         weightTextureChannel: TextureChannel,
         color: Color3,
         colorTexture: Nullable<BaseTexture>,
-        diffuseTransmission: boolean = false,
-        signal: AbortSignal = new AbortController().signal
+        diffuseTransmission: boolean = false
     ): Promise<void> {
         // Blend coat properties using:
         // New coat will cover all areas that previously had coat or transmission.
@@ -1437,11 +1415,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
         const [lerpCoatColor, lerpSurfaceColor] = results.map(
             (r) => (r as PromiseFulfilledResult<(typeof results)[number] extends PromiseSettledResult<infer T> ? T : never>).value
         );
-        if (signal.aborted) {
-            lerpCoatColor.texture?.dispose();
-            lerpSurfaceColor.texture?.dispose();
-            return;
-        }
 
         const newCoatColor = await MultiplyTexturesAsync(
             "newCoatColor (" + this._material.name + ")",
@@ -1450,10 +1423,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             this._material.getScene(),
             TextureColorSpace.SRGB
         );
-        if (signal.aborted) {
-            newCoatColor.texture?.dispose();
-            return;
-        }
 
         if (newCoatColor.texture) {
             this.coatColorTexture = newCoatColor.texture;
@@ -1470,10 +1439,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
             this._material.getScene()
         );
-        if (signal.aborted) {
-            newCoatIor.texture?.dispose();
-            return;
-        }
         this.coatIor = newCoatIor.factor ? newCoatIor.factor.r : this.coatIor;
 
         const newCoatRoughness = await LerpTexturesAsync(
@@ -1487,10 +1452,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
             this._material.getScene()
         );
-        if (signal.aborted) {
-            newCoatRoughness.texture?.dispose();
-            return;
-        }
         this.coatRoughness = newCoatRoughness.factor ? newCoatRoughness.factor.r : 1.0;
         this.coatRoughnessTexture = newCoatRoughness.texture;
 
@@ -1501,10 +1462,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
             this._material.getScene()
         );
-        if (signal.aborted) {
-            newCoatDarkening.texture?.dispose();
-            return;
-        }
         this.coatDarkening = newCoatDarkening.factor ? newCoatDarkening.factor.r : this.coatDarkening;
 
         if (diffuseTransmission) {
@@ -1519,10 +1476,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 CreateTextureWithFactorOperand(weightTexture, weightCol4, weightTextureChannel),
                 this._material.getScene()
             );
-            if (signal.aborted) {
-                newSpecularRoughness.texture?.dispose();
-                return;
-            }
             this.specularRoughness = newSpecularRoughness.factor ? newSpecularRoughness.factor.r : 1.0;
             this.specularRoughnessTexture = newSpecularRoughness.texture;
         }
@@ -1539,10 +1492,6 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
                 this._material.getScene()
             );
-            if (signal.aborted) {
-                newCoatNormal.texture?.dispose();
-                return;
-            }
             if (newCoatNormal.texture) {
                 this.geometryCoatNormalTexture = newCoatNormal.texture;
             }

--- a/packages/dev/loaders/src/glTF/2.0/openpbrMaterialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/openpbrMaterialLoadingAdapter.ts
@@ -4,6 +4,7 @@ import { type BaseTexture } from "core/Materials/Textures/baseTexture";
 import { type Nullable } from "core/types";
 import { Color3, Color4 } from "core/Maths/math.color";
 import { type IMaterialLoadingAdapter } from "./materialLoadingAdapter";
+import { type GLTFLoader } from "./glTFLoader";
 import {
     MultiplyTexturesAsync,
     LerpTexturesAsync,
@@ -1258,8 +1259,9 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
 
     /**
      * Finalizes material properties after all loading is complete.
+     * @param loader The glTF loader; `loader._disposed` is polled between texture passes to bail early on dispose.
      */
-    public async finalizeAsync(): Promise<void> {
+    public async finalizeAsync(loader: GLTFLoader): Promise<void> {
         // Do final configuration for the material to handle any interactions/dependencies between properties that we had to defer until all properties were loaded.
 
         // If the material is volumetric, we may need to create a coat layer to handle the surface tint.
@@ -1271,6 +1273,7 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             } else {
                 // Otherwise, we have volumetric attenuation so we need to use the coat layer to preserve the base color tinting of glTF.
                 await this.copySurfaceToCoatAsync(
+                    loader,
                     this.subsurfaceWeight,
                     this.subsurfaceWeightTexture,
                     TextureChannel.A,
@@ -1278,6 +1281,9 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                     this._diffuseTransmissionTintTexture,
                     true
                 );
+                if (loader._disposed) {
+                    return;
+                }
             }
         }
         // If the material has transmission, we need to use the base color to tint the transmission.
@@ -1288,7 +1294,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 this._material.transmissionColorTexture = this._material.baseColorTexture;
             } else if (!this.baseColor.equals(Color3.White()) || this.baseColorTexture !== null) {
                 // Otherwise, we have volumetric attenuation so we need to use the coat layer to preserve the base color tinting of glTF.
-                await this.copySurfaceToCoatAsync(this.transmissionWeight, this.transmissionWeightTexture, TextureChannel.R, this.baseColor, this.baseColorTexture, false);
+                await this.copySurfaceToCoatAsync(loader, this.transmissionWeight, this.transmissionWeightTexture, TextureChannel.R, this.baseColor, this.baseColorTexture, false);
+                if (loader._disposed) {
+                    return;
+                }
             }
         }
 
@@ -1315,6 +1324,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 TextureColorSpace.Linear,
                 ChannelMask.R
             );
+            if (loader._disposed) {
+                newRoughnessTexture.texture?.dispose();
+                return;
+            }
             this.specularRoughnessTexture = newRoughnessTexture.texture;
             this.specularRoughness = newRoughnessTexture.factor ? newRoughnessTexture.factor.r : 1.0;
 
@@ -1330,6 +1343,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 TextureColorSpace.SRGB,
                 ChannelMask.RGB
             );
+            if (loader._disposed) {
+                newMetallic.texture?.dispose();
+                return;
+            }
             this.baseMetalnessTexture = newMetallic.texture;
             this.baseMetalness = newMetallic.factor ? newMetallic.factor.r : 1.0;
 
@@ -1345,6 +1362,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 TextureColorSpace.SRGB,
                 ChannelMask.RGB
             );
+            if (loader._disposed) {
+                newBaseColor.texture?.dispose();
+                return;
+            }
             const oldBaseColorTexture = this.baseColorTexture;
             oldBaseColorTexture?.dispose();
             this.baseColorTexture = newBaseColor.texture;
@@ -1357,6 +1378,7 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
     }
 
     private async copySurfaceToCoatAsync(
+        loader: GLTFLoader,
         weight: number,
         weightTexture: Nullable<BaseTexture>,
         weightTextureChannel: TextureChannel,
@@ -1415,6 +1437,11 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
         const [lerpCoatColor, lerpSurfaceColor] = results.map(
             (r) => (r as PromiseFulfilledResult<(typeof results)[number] extends PromiseSettledResult<infer T> ? T : never>).value
         );
+        if (loader._disposed) {
+            lerpCoatColor.texture?.dispose();
+            lerpSurfaceColor.texture?.dispose();
+            return;
+        }
 
         const newCoatColor = await MultiplyTexturesAsync(
             "newCoatColor (" + this._material.name + ")",
@@ -1423,6 +1450,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             this._material.getScene(),
             TextureColorSpace.SRGB
         );
+        if (loader._disposed) {
+            newCoatColor.texture?.dispose();
+            return;
+        }
 
         if (newCoatColor.texture) {
             this.coatColorTexture = newCoatColor.texture;
@@ -1439,6 +1470,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
             this._material.getScene()
         );
+        if (loader._disposed) {
+            newCoatIor.texture?.dispose();
+            return;
+        }
         this.coatIor = newCoatIor.factor ? newCoatIor.factor.r : this.coatIor;
 
         const newCoatRoughness = await LerpTexturesAsync(
@@ -1452,6 +1487,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
             this._material.getScene()
         );
+        if (loader._disposed) {
+            newCoatRoughness.texture?.dispose();
+            return;
+        }
         this.coatRoughness = newCoatRoughness.factor ? newCoatRoughness.factor.r : 1.0;
         this.coatRoughnessTexture = newCoatRoughness.texture;
 
@@ -1462,6 +1501,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
             CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
             this._material.getScene()
         );
+        if (loader._disposed) {
+            newCoatDarkening.texture?.dispose();
+            return;
+        }
         this.coatDarkening = newCoatDarkening.factor ? newCoatDarkening.factor.r : this.coatDarkening;
 
         if (diffuseTransmission) {
@@ -1476,6 +1519,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 CreateTextureWithFactorOperand(weightTexture, weightCol4, weightTextureChannel),
                 this._material.getScene()
             );
+            if (loader._disposed) {
+                newSpecularRoughness.texture?.dispose();
+                return;
+            }
             this.specularRoughness = newSpecularRoughness.factor ? newSpecularRoughness.factor.r : 1.0;
             this.specularRoughnessTexture = newSpecularRoughness.texture;
         }
@@ -1492,6 +1539,10 @@ export class OpenPBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
                 CreateTextureWithFactorOperand(origCoatWeightTexture, origCoatWeightCol4, TextureChannel.R),
                 this._material.getScene()
             );
+            if (loader._disposed) {
+                newCoatNormal.texture?.dispose();
+                return;
+            }
             if (newCoatNormal.texture) {
                 this.geometryCoatNormalTexture = newCoatNormal.texture;
             }

--- a/packages/dev/loaders/src/glTF/2.0/pbrMaterialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/pbrMaterialLoadingAdapter.ts
@@ -30,6 +30,11 @@ export class PBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
     }
 
     /**
+     * No-op: PBRMaterial has no deferred finalization.
+     */
+    public async finalizeAsync(): Promise<void> {}
+
+    /**
      * Whether the material should be treated as unlit
      */
     public get isUnlit(): boolean {

--- a/packages/dev/loaders/src/glTF/2.0/pbrMaterialLoadingAdapter.ts
+++ b/packages/dev/loaders/src/glTF/2.0/pbrMaterialLoadingAdapter.ts
@@ -5,6 +5,7 @@ import { type Nullable } from "core/types";
 import { Color3 } from "core/Maths/math.color";
 import { Constants } from "core/Engines/constants";
 import { type IMaterialLoadingAdapter } from "./materialLoadingAdapter";
+import { type GLTFLoader } from "./glTFLoader";
 import { Vector3 } from "core/Maths/math.vector";
 
 /**
@@ -31,8 +32,9 @@ export class PBRMaterialLoadingAdapter implements IMaterialLoadingAdapter {
 
     /**
      * No-op: PBRMaterial has no deferred finalization.
+     * @param _loader Unused.
      */
-    public async finalizeAsync(): Promise<void> {}
+    public async finalizeAsync(_loader: GLTFLoader): Promise<void> {}
 
     /**
      * Whether the material should be treated as unlit


### PR DESCRIPTION
## Context

PR #18430 added a `finalizeAsync(signal: AbortSignal)` method to `IMaterialLoadingAdapter` (alongside a deprecated `finalize?()`) and unconditionally allocated an `AbortController` on every glTF load. The signal is consumed only by `signal.aborted` polling in `OpenPBRMaterialLoadingAdapter` between awaits. It is never propagated into the texture helpers (`LerpTexturesAsync`, `MultiplyTexturesAsync`, `InvertTextureAsync`, etc.), so the underlying GPU passes always run to completion regardless.

Because JS is single-threaded, an `AbortSignal` that is not handed to a host API that respects it (`fetch`, web streams, `EventTarget.addEventListener(..., { signal })`, etc.) is functionally equivalent to a boolean flag polled at each `await` boundary. That is exactly how it is being used here — at the cost of an extra interface method, an `AbortController` allocation on every load, and a hard runtime dependency on the `AbortController` global.

`IMaterialLoadingAdapter` is an internal loader detail — no need to keep both shapes for backward compatibility.

## Changes

- Collapse the API into a single required `finalizeAsync(loader: GLTFLoader): Promise<void>`
- Drop `_finalizeController` (`AbortController`) from `GLTFLoader`
- Drop the `signal: AbortSignal` parameter from `OpenPBRMaterialLoadingAdapter.finalizeAsync` and from its private `copySurfaceToCoatAsync` helper
- Expose `GLTFLoader._disposed` as `@internal` so adapters can poll it between awaits to bail early on mid-load dispose — same semantics as the original `signal.aborted` checks, but using the loader's own state instead of an AbortSignal
- Add a no-op `finalizeAsync` to `PBRMaterialLoadingAdapter` (it had no deferred work)

Net: **4 files changed, ~40 insertions(+), ~55 deletions(-)**.

## Behavior

Unchanged. The OpenPBR adapter still short-circuits on each `await` if the loader is disposed mid-flight — the polling state is now `loader._disposed` instead of `signal.aborted`.

## Side-benefit: unblocks Babylon Native

Babylon Native does not initialize the AbortController polyfill in its JS host (the polyfill exists in `JsRuntimeHost` but is never wired into any BN app). After #18430, every glTF load on BN was throwing `ReferenceError: AbortController is not defined` inside the new `.then(...)` callback in `GLTFLoader.loadAsync`. The rejection prevented `_extensionsOnReady()` / `_setState(READY)` from running, so the loader never reached the READY state. This manifested as the `EXT_mesh_gpu_instancing` visualization test rendering the base mesh **without its instances** (205,438 px diff vs reference) in `BabylonNative` CI.

| Variant | AbortController in loader | BN polyfill | Pixel diff vs reference | Result |
|---|---|---|---|---|
| Master HEAD (#18430) | yes (broken on BN) | none | 205,438 | ❌ failed |
| Master + JS `AbortController` polyfill shim | yes (works) | injected via JS | 13,507 | ✅ validated |
| This PR | **removed** | none | 13,507 | ✅ validated |

Reproduced locally using `BabylonNative` nightly build #53343's `Playground.exe` + freshly-built UMD bundles from each variant.

We can still separately wire up the AbortController polyfill in BN — there are latent uses in `lightingVolume.ts` and `audioEngine.ts` that will hit the same wall when those code paths are exercised — but that's a defense-in-depth issue, not a blocker for this fix.

[Created by Copilot on behalf of @bghgary]