### PR TITLE
 Add distance-only spatial mode to Audio Engine V2

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/components/spatialAudioAttacherComponent.ts
@@ -82,7 +82,9 @@ export class _SpatialAudioAttacherComponent {
      * This is called automatically by default and only needs to be called manually if automatic updates are disabled.
      */
     public update() {
-        if (this._attachmentType & SpatialAudioAttachmentType.Position) {
+        const updatesPosition = !!(this._attachmentType & SpatialAudioAttachmentType.Position);
+
+        if (updatesPosition) {
             if (this._useBoundingBox && (this._sceneNode as AbstractMesh).getBoundingInfo) {
                 this._position.copyFrom((this._sceneNode as AbstractMesh).getBoundingInfo().boundingBox.centerWorld);
             } else {
@@ -98,6 +100,10 @@ export class _SpatialAudioAttacherComponent {
 
             this._spatialAudioNode.rotationQuaternion.copyFrom(this._rotationQuaternion);
             this._spatialAudioNode._updateRotation();
+        }
+
+        if (!updatesPosition && "panningEnabled" in this._spatialAudioNode && !this._spatialAudioNode.panningEnabled) {
+            this._spatialAudioNode._updatePosition();
         }
     }
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subNodes/spatialAudioSubNode.ts
@@ -24,6 +24,7 @@ export abstract class _SpatialAudioSubNode extends _AbstractAudioSubNode {
     public abstract maxDistance: number;
     public abstract minDistance: number;
     public abstract orientation: Vector3;
+    public abstract panningEnabled: boolean;
     public abstract panningModel: PanningModelType;
     public abstract position: Vector3;
     public abstract rolloffFactor: number;
@@ -69,6 +70,7 @@ export abstract class _SpatialAudioSubNode extends _AbstractAudioSubNode {
         this.maxDistance = options.spatialMaxDistance ?? _SpatialAudioDefaults.maxDistance;
         this.minDistance = options.spatialMinDistance ?? _SpatialAudioDefaults.minDistance;
         this.orientation = options.spatialOrientation ?? _SpatialAudioDefaults.orientation;
+        this.panningEnabled = options.spatialPanningEnabled ?? _SpatialAudioDefaults.panningEnabled;
         this.panningModel = options.spatialPanningModel ?? _SpatialAudioDefaults.panningModel;
         this.rolloffFactor = options.spatialRolloffFactor ?? _SpatialAudioDefaults.rolloffFactor;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -86,6 +86,7 @@ export interface ISpatialAudioOptions {
      * Whether to spatially pan the audio source. Defaults to `true`.
      *
      * When set to `false`, the source keeps distance attenuation but does not pan between the left and right channels.
+     * Sound cone attenuation is not applied while panning is disabled.
      */
     spatialPanningEnabled: boolean;
     /**
@@ -217,6 +218,7 @@ export abstract class AbstractSpatialAudio {
      * Whether to spatially pan the audio source. Defaults to `true`.
      *
      * When set to `false`, the source keeps distance attenuation but does not pan between the left and right channels.
+     * Sound cone attenuation is not applied while panning is disabled.
      */
     public abstract panningEnabled: boolean;
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -277,5 +277,8 @@ export abstract class AbstractSpatialAudio {
      */
     public abstract update(): void;
 
+    /**
+     * Releases associated resources.
+     */
     public abstract dispose(): void;
 }

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/abstractSpatialAudio.ts
@@ -11,6 +11,7 @@ export const _SpatialAudioDefaults = {
     maxDistance: 10000 as number,
     minDistance: 1 as number,
     orientation: Vector3.Right(),
+    panningEnabled: true as boolean,
     panningModel: "equalpower" as PanningModelType,
     position: Vector3.Zero(),
     rolloffFactor: 1 as number,
@@ -82,6 +83,12 @@ export interface ISpatialAudioOptions {
      */
     spatialOrientation: Vector3;
     /**
+     * Whether to spatially pan the audio source. Defaults to `true`.
+     *
+     * When set to `false`, the source keeps distance attenuation but does not pan between the left and right channels.
+     */
+    spatialPanningEnabled: boolean;
+    /**
      * Possible values are:
      * - `"equalpower"`: Represents the equal-power panning algorithm, generally regarded as simple and efficient.
      * - `"HRTF"`: Renders a stereo output of higher quality than `"equalpower"` — it uses a convolution with measured impulse responses from human subjects.
@@ -129,6 +136,7 @@ export function _HasSpatialAudioOptions(options: Partial<ISpatialAudioOptions>):
         options.spatialMinDistance !== undefined ||
         options.spatialMinUpdateTime !== undefined ||
         options.spatialOrientation !== undefined ||
+        options.spatialPanningEnabled !== undefined ||
         options.spatialPanningModel !== undefined ||
         options.spatialPosition !== undefined ||
         options.spatialRolloffFactor !== undefined ||
@@ -204,6 +212,13 @@ export abstract class AbstractSpatialAudio {
      * The spatial orientation used to determine the direction of the audio source. Defaults to (0, 0, -1).
      */
     public abstract orientation: Vector3;
+
+    /**
+     * Whether to spatially pan the audio source. Defaults to `true`.
+     *
+     * When set to `false`, the source keeps distance attenuation but does not pan between the left and right channels.
+     */
+    public abstract panningEnabled: boolean;
 
     /**
      * The spatial panning model. Defaults to "equalpower".

--- a/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/subProperties/spatialAudio.ts
@@ -16,6 +16,7 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
     private _maxDistance: number = _SpatialAudioDefaults.maxDistance;
     private _minDistance: number = _SpatialAudioDefaults.minDistance;
     private _orientation: Vector3;
+    private _panningEnabled: boolean = _SpatialAudioDefaults.panningEnabled;
     private _panningModel: PanningModelType = _SpatialAudioDefaults.panningModel;
     private _position: Vector3;
     private _rolloffFactor: number = _SpatialAudioDefaults.rolloffFactor;
@@ -30,6 +31,7 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
         const subNode = _GetSpatialAudioSubNode(subGraph);
         if (subNode) {
             this._orientation = subNode.orientation.clone();
+            this._panningEnabled = subNode.panningEnabled;
             this._position = subNode.position.clone();
             this._rotation = subNode.rotation.clone();
             this._rotationQuaternion = subNode.rotationQuaternion.clone();
@@ -132,6 +134,16 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
     }
 
     /** @internal */
+    public get panningEnabled(): boolean {
+        return this._panningEnabled;
+    }
+
+    public set panningEnabled(value: boolean) {
+        this._panningEnabled = value;
+        _SetSpatialAudioProperty(this._subGraph, "panningEnabled", value);
+    }
+
+    /** @internal */
     public get panningModel(): PanningModelType {
         return this._panningModel;
     }
@@ -230,6 +242,8 @@ export abstract class _SpatialAudio extends AbstractSpatialAudio {
         const position = subNode.position;
         if (!position.equalsWithEpsilon(this._position)) {
             subNode.position.copyFrom(this._position);
+            subNode._updatePosition();
+        } else if (!subNode.panningEnabled) {
             subNode._updatePosition();
         }
     }

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
@@ -296,20 +296,33 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         const deltaZ = this.position.z - listenerPosition.z;
         const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
         const minDistance = Math.max(this.minDistance, 0);
-        const maxDistance = Math.max(this.maxDistance, minDistance);
-        const clampedDistance = Math.min(Math.max(distance, minDistance), maxDistance);
         let attenuation = 1;
 
         switch (this.distanceModel) {
             case "linear":
-                attenuation =
-                    maxDistance === minDistance ? (distance <= minDistance ? 1 : 0) : 1 - (this.rolloffFactor * (clampedDistance - minDistance)) / (maxDistance - minDistance);
+                {
+                    const maxDistance = Math.max(this.maxDistance, minDistance);
+                    const clampedDistance = Math.min(Math.max(distance, minDistance), maxDistance);
+
+                    attenuation =
+                        maxDistance === minDistance ? (distance <= minDistance ? 1 : 0) : 1 - (this.rolloffFactor * (clampedDistance - minDistance)) / (maxDistance - minDistance);
+                }
                 break;
             case "inverse":
-                attenuation = minDistance === 0 && clampedDistance === 0 ? 1 : minDistance / (minDistance + this.rolloffFactor * (clampedDistance - minDistance));
+                if (minDistance === 0) {
+                    attenuation = 0;
+                    break;
+                }
+
+                attenuation = minDistance / (minDistance + this.rolloffFactor * (Math.max(distance, minDistance) - minDistance));
                 break;
             case "exponential":
-                attenuation = minDistance === 0 && clampedDistance === 0 ? 1 : Math.pow(clampedDistance / minDistance, -this.rolloffFactor);
+                if (minDistance === 0) {
+                    attenuation = 0;
+                    break;
+                }
+
+                attenuation = Math.pow(Math.max(distance, minDistance) / minDistance, -this.rolloffFactor);
                 break;
         }
 

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/spatialWebAudioSubNode.ts
@@ -24,6 +24,9 @@ export async function _CreateSpatialAudioSubNodeAsync(engine: _WebAudioEngine): 
 
 /** @internal */
 export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
+    private _attenuation: _WebAudioParameterComponent;
+    private readonly _attenuationNode: GainNode;
+    private readonly _inputNode: GainNode;
     private _lastOrientation: Vector3 = Vector3.Zero();
     private _lastPosition: Vector3 = Vector3.Zero();
     private _lastRotation: Vector3 = Vector3.Zero();
@@ -31,6 +34,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     private _orientationX: _WebAudioParameterComponent;
     private _orientationY: _WebAudioParameterComponent;
     private _orientationZ: _WebAudioParameterComponent;
+    private _panningEnabled = _SpatialAudioDefaults.panningEnabled;
     private _positionX: _WebAudioParameterComponent;
     private _positionY: _WebAudioParameterComponent;
     private _positionZ: _WebAudioParameterComponent;
@@ -54,6 +58,9 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     public constructor(engine: _WebAudioEngine) {
         super(engine);
 
+        this._inputNode = new GainNode(engine._audioContext);
+        this._attenuationNode = new GainNode(engine._audioContext);
+        this._attenuation = new _WebAudioParameterComponent(engine, this._attenuationNode.gain);
         this.node = new PannerNode(engine._audioContext);
 
         this._orientationX = new _WebAudioParameterComponent(engine, this.node.orientationX);
@@ -63,12 +70,15 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         this._positionX = new _WebAudioParameterComponent(engine, this.node.positionX);
         this._positionY = new _WebAudioParameterComponent(engine, this.node.positionY);
         this._positionZ = new _WebAudioParameterComponent(engine, this.node.positionZ);
+
+        this._connectActiveInput();
     }
 
     /** @internal */
     public override dispose(): void {
         super.dispose();
 
+        this._attenuation.dispose();
         this._orientationX.dispose();
         this._orientationY.dispose();
         this._orientationZ.dispose();
@@ -76,6 +86,8 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         this._positionY.dispose();
         this._positionZ.dispose();
 
+        this._inputNode.disconnect();
+        this._attenuationNode.disconnect();
         this.node.disconnect();
     }
 
@@ -118,6 +130,8 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         const maxDistance = this.node.maxDistance;
         this.node.maxDistance = maxDistance + 0.001;
         this.node.maxDistance = maxDistance;
+
+        this._updateAttenuation();
     }
 
     /** @internal */
@@ -127,6 +141,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
 
     public set minDistance(value: number) {
         this.node.refDistance = value;
+        this._updateAttenuation();
     }
 
     /** @internal */
@@ -136,6 +151,22 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
 
     public set maxDistance(value: number) {
         this.node.maxDistance = value;
+        this._updateAttenuation();
+    }
+
+    /** @internal */
+    public get panningEnabled(): boolean {
+        return this._panningEnabled;
+    }
+
+    public set panningEnabled(value: boolean) {
+        if (this._panningEnabled === value) {
+            return;
+        }
+
+        this._panningEnabled = value;
+        this._connectActiveInput();
+        this._updateAttenuation();
     }
 
     /** @internal */
@@ -154,21 +185,23 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
 
     public set rolloffFactor(value: number) {
         this.node.rolloffFactor = value;
+        this._updateAttenuation();
     }
 
     /** @internal */
     public get _inNode(): AudioNode {
-        return this.node;
+        return this._inputNode;
     }
 
     /** @internal */
     public get _outNode(): AudioNode {
-        return this.node;
+        return this._panningEnabled ? this.node : this._attenuationNode;
     }
 
     /** @internal */
     public _updatePosition(): void {
         if (this._lastPosition.equalsWithEpsilon(this.position)) {
+            this._updateAttenuation();
             return;
         }
 
@@ -177,6 +210,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         this._positionZ.targetValue = this.position.z;
 
         this._lastPosition.copyFrom(this.position);
+        this._updateAttenuation();
     }
 
     /** @internal */
@@ -214,6 +248,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
         // If the wrapped node is not available now, it will be connected later by the subgraph.
         if (node._inNode) {
             this.node.connect(node._inNode);
+            this._attenuationNode.connect(node._inNode);
         }
 
         return true;
@@ -228,6 +263,7 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
 
         if (node._inNode) {
             this.node.disconnect(node._inNode);
+            this._attenuationNode.disconnect(node._inNode);
         }
 
         return true;
@@ -236,5 +272,47 @@ export class _SpatialWebAudioSubNode extends _SpatialAudioSubNode {
     /** @internal */
     public getClassName(): string {
         return "_SpatialWebAudioSubNode";
+    }
+
+    private _connectActiveInput(): void {
+        this._inputNode.disconnect();
+
+        if (this._panningEnabled) {
+            this._inputNode.connect(this.node);
+        } else {
+            this._inputNode.connect(this._attenuationNode);
+        }
+    }
+
+    private _updateAttenuation(): void {
+        if (this._panningEnabled) {
+            this._attenuation.targetValue = 1;
+            return;
+        }
+
+        const listenerPosition = this.engine.listener.position;
+        const deltaX = this.position.x - listenerPosition.x;
+        const deltaY = this.position.y - listenerPosition.y;
+        const deltaZ = this.position.z - listenerPosition.z;
+        const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
+        const minDistance = Math.max(this.minDistance, 0);
+        const maxDistance = Math.max(this.maxDistance, minDistance);
+        const clampedDistance = Math.min(Math.max(distance, minDistance), maxDistance);
+        let attenuation = 1;
+
+        switch (this.distanceModel) {
+            case "linear":
+                attenuation =
+                    maxDistance === minDistance ? (distance <= minDistance ? 1 : 0) : 1 - (this.rolloffFactor * (clampedDistance - minDistance)) / (maxDistance - minDistance);
+                break;
+            case "inverse":
+                attenuation = minDistance === 0 && clampedDistance === 0 ? 1 : minDistance / (minDistance + this.rolloffFactor * (clampedDistance - minDistance));
+                break;
+            case "exponential":
+                attenuation = minDistance === 0 && clampedDistance === 0 ? 1 : Math.pow(clampedDistance / minDistance, -this.rolloffFactor);
+                break;
+        }
+
+        this._attenuation.targetValue = Math.min(Math.max(attenuation, 0), 1);
     }
 }

--- a/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/subNodes/webAudioBusAndSoundSubGraph.ts
@@ -7,7 +7,7 @@ import { _GetStereoAudioSubNode } from "../../abstractAudio/subNodes/stereoAudio
 import { type IVolumeAudioOptions, _GetVolumeAudioSubNode } from "../../abstractAudio/subNodes/volumeAudioSubNode";
 import { type ISpatialAudioOptions, _HasSpatialAudioOptions } from "../../abstractAudio/subProperties/abstractSpatialAudio";
 import { type IStereoAudioOptions, _HasStereoAudioOptions } from "../../abstractAudio/subProperties/abstractStereoAudio";
-import { type IWebAudioOutNode, type IWebAudioSubNode } from "../webAudioNode";
+import { type IWebAudioInNode, type IWebAudioOutNode } from "../webAudioNode";
 import { type _SpatialWebAudioSubNode, _CreateSpatialAudioSubNodeAsync } from "./spatialWebAudioSubNode";
 import { type _StereoWebAudioSubNode, _CreateStereoAudioSubNodeAsync } from "./stereoWebAudioSubNode";
 import { type _VolumeWebAudioSubNode } from "./volumeWebAudioSubNode";
@@ -105,14 +105,14 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
 
         if (spatialNode && stereoNode) {
             this._rootNode = new GainNode(this._owner.engine._audioContext);
-            this._rootNode.connect((spatialNode as _SpatialWebAudioSubNode)._outNode);
-            this._rootNode.connect((stereoNode as _StereoWebAudioSubNode)._outNode);
+            this._rootNode.connect((spatialNode as _SpatialWebAudioSubNode)._inNode);
+            this._rootNode.connect((stereoNode as _StereoWebAudioSubNode)._inNode);
         } else {
             this._rootNode?.disconnect();
             this._rootNode = null;
         }
 
-        let inSubNode: Nullable<IWebAudioSubNode> = null;
+        let inSubNode: Nullable<IWebAudioInNode> = null;
 
         let inNode: Nullable<AudioNode>;
 
@@ -127,7 +127,7 @@ export abstract class _WebAudioBusAndSoundSubGraph extends _WebAudioBaseSubGraph
                 inSubNode = volumeNode as _VolumeWebAudioSubNode;
             }
 
-            inNode = inSubNode?.node ?? null;
+            inNode = inSubNode?._inNode ?? null;
         }
 
         if (this._inputNode !== inNode) {

--- a/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
+++ b/packages/dev/core/test/unit/Audio/helpers/mockedAudioObjects.ts
@@ -1,4 +1,5 @@
-import { Engine } from "core/Engines";
+import { Engine } from "core/Engines/engine";
+import { vi } from "vitest";
 
 import { AudioBuffer, AudioTestSamples } from "./audioTestSamples";
 
@@ -109,6 +110,21 @@ class AudioBufferSourceNodeMock extends AudioNodeMock {
         });
 }
 
+class AudioListenerMock {
+    forwardX = new AudioParamMock();
+    forwardY = new AudioParamMock();
+    forwardZ = new AudioParamMock();
+    positionX = new AudioParamMock();
+    positionY = new AudioParamMock();
+    positionZ = new AudioParamMock();
+    upX = new AudioParamMock();
+    upY = new AudioParamMock();
+    upZ = new AudioParamMock();
+
+    setOrientation = vi.fn().mockName("setOrientation");
+    setPosition = vi.fn().mockName("setPosition");
+}
+
 class GainNodeMock extends AudioNodeMock {
     gain = new AudioParamMock();
 }
@@ -116,15 +132,20 @@ class GainNodeMock extends AudioNodeMock {
 class MediaElementAudioSourceNodeMock extends AudioNodeMock {}
 
 class PannerNodeMock extends AudioNodeMock {
-    coneInnerAngle = new AudioParamMock();
-    coneOuterAngle = new AudioParamMock();
-    coneOuterGain = new AudioParamMock();
+    coneInnerAngle = 360;
+    coneOuterAngle = 360;
+    coneOuterGain = 0;
+    distanceModel = "inverse";
+    maxDistance = 10000;
     orientationX = new AudioParamMock();
     orientationY = new AudioParamMock();
     orientationZ = new AudioParamMock();
+    panningModel = "equalpower";
     positionX = new AudioParamMock();
     positionY = new AudioParamMock();
     positionZ = new AudioParamMock();
+    refDistance = 1;
+    rolloffFactor = 1;
 
     setOrientation = vi.fn().mockName("setOrientation");
 }
@@ -138,6 +159,7 @@ export class AudioContextMock {
 
     currentTime = 0;
     destination = new AudioNodeMock();
+    listener = new AudioListenerMock();
     state = "running";
 
     requireUserInteraction = false;
@@ -295,7 +317,7 @@ export class MockedAudioObjects {
                 statusText: "",
                 response: null as any,
                 responseText: "",
-                responseType: "" as XMLHttpRequestResponseType,
+                responseType: "",
                 responseURL: "",
                 timeout: 0,
                 onprogress: null,

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -11,6 +11,7 @@ import { type Nullable } from "core/types";
 import { AbstractEngine } from "core/Engines/abstractEngine";
 import { NullEngine } from "core/Engines/nullEngine";
 import { Vector3 } from "core/Maths/math.vector";
+import { TransformNode } from "core/Meshes/transformNode";
 import { Scene } from "core/scene";
 
 import { AudioTestHelper } from "./helpers/audioTestHelper";
@@ -20,6 +21,7 @@ import { CreateSoundAsync as CreateSoundV2Async } from "../../../src/AudioV2/abs
 import { SoundState } from "../../../src/AudioV2/soundState";
 import { StaticSound } from "../../../src/AudioV2/abstractAudio/staticSound";
 import { StreamingSound } from "../../../src/AudioV2/abstractAudio/streamingSound";
+import { SpatialAudioAttachmentType } from "../../../src/AudioV2/spatialAudioAttachmentType";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Required for timers (eg. setTimeout) to work.
@@ -518,6 +520,136 @@ describe("Sound", () => {
         sound.spatial.update();
 
         expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.7);
+    });
+
+    it("matches WebAudio inverse and exponential distance attenuation when spatial panning is disabled in audio engine v2", async () => {
+        const sound = await CreateSoundV2Async(
+            expect.getState().currentTestName!,
+            AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz").audioBuffer as unknown as AudioBuffer,
+            {
+                spatialEnabled: true,
+                spatialMaxDistance: 10,
+                spatialMinDistance: 1,
+                spatialPanningEnabled: false,
+                spatialRolloffFactor: 1,
+            },
+            (audioEngine as AudioEngine)._v2
+        );
+
+        sound.spatial.position = new Vector3(20, 0, 0);
+        sound.spatial.distanceModel = "inverse";
+        sound.spatial.update();
+
+        const spatialSubNode = (sound as any)._subGraph.getSubNode("Spatial");
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.05);
+
+        sound.spatial.distanceModel = "exponential";
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.05);
+
+        sound.spatial.minDistance = 0;
+        sound.spatial.distanceModel = "inverse";
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBe(0);
+
+        sound.spatial.position = new Vector3(0, 0, 0);
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBe(0);
+
+        sound.spatial.distanceModel = "exponential";
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBe(0);
+
+        sound.spatial.position = new Vector3(20, 0, 0);
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBe(0);
+    });
+
+    it("refreshes distance attenuation for rotation-only attached sources when spatial panning is disabled in audio engine v2", async () => {
+        const sound = await CreateSoundV2Async(
+            expect.getState().currentTestName!,
+            AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz").audioBuffer as unknown as AudioBuffer,
+            {
+                spatialEnabled: true,
+                spatialMaxDistance: 11,
+                spatialMinDistance: 1,
+                spatialPanningEnabled: false,
+            },
+            (audioEngine as AudioEngine)._v2
+        );
+
+        const sourceNode = new TransformNode("source", scene);
+        sound.spatial.attach(sourceNode, false, SpatialAudioAttachmentType.Rotation);
+        sound.spatial.update();
+
+        const spatialSubNode = (sound as any)._subGraph.getSubNode("Spatial");
+        expect(spatialSubNode._attenuation.targetValue).toBe(1);
+
+        (audioEngine as AudioEngine)._v2.listener.position.copyFromFloats(2, 0, 0);
+        (audioEngine as AudioEngine)._v2.listener.update();
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.9);
+    });
+
+    it("updates connections and attenuation when spatial panning is toggled in audio engine v2", async () => {
+        const sound = await CreateSoundV2Async(
+            expect.getState().currentTestName!,
+            AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz").audioBuffer as unknown as AudioBuffer,
+            {
+                spatialEnabled: true,
+                spatialMaxDistance: 11,
+                spatialMinDistance: 1,
+            },
+            (audioEngine as AudioEngine)._v2
+        );
+
+        sound.spatial.position = new Vector3(6, 0, 0);
+        sound.spatial.update();
+        sound.play();
+
+        const spatialSubNode = (sound as any)._subGraph.getSubNode("Spatial");
+        expect(sound.spatial.panningEnabled).toBe(true);
+        expect(mock.connectsToPannerNode(mock.audioBufferSource)).toBe(true);
+
+        sound.spatial.panningEnabled = false;
+
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.5);
+        expect(mock.connectsToPannerNode(mock.audioBufferSource)).toBe(false);
+
+        sound.spatial.panningEnabled = true;
+
+        expect(spatialSubNode._attenuation.targetValue).toBe(1);
+        expect(mock.connectsToPannerNode(mock.audioBufferSource)).toBe(true);
+    });
+
+    it("does not apply cone attenuation when spatial panning is disabled in audio engine v2", async () => {
+        const sound = await CreateSoundV2Async(
+            expect.getState().currentTestName!,
+            AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz").audioBuffer as unknown as AudioBuffer,
+            {
+                spatialConeInnerAngle: 0,
+                spatialConeOuterAngle: 0,
+                spatialConeOuterVolume: 0,
+                spatialEnabled: true,
+                spatialMaxDistance: 11,
+                spatialMinDistance: 1,
+                spatialPanningEnabled: false,
+            },
+            (audioEngine as AudioEngine)._v2
+        );
+
+        sound.spatial.position = new Vector3(6, 0, 0);
+        sound.spatial.rotation = new Vector3(0, Math.PI, 0);
+        sound.spatial.update();
+
+        const spatialSubNode = (sound as any)._subGraph.getSubNode("Spatial");
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.5);
     });
 
     it("connects to panner node when spatialized via property", async () => {

--- a/packages/dev/core/test/unit/Audio/sound.test.ts
+++ b/packages/dev/core/test/unit/Audio/sound.test.ts
@@ -2,18 +2,25 @@
  * @vitest-environment jsdom
  */
 
-import { type ISoundOptions, AudioEngine, Sound } from "core/Audio";
+import { type ISoundOptions } from "core/Audio/Interfaces/ISoundOptions";
+import { AudioEngine } from "core/Audio/audioEngine";
+import "core/Audio/audioSceneComponent";
+import { Sound } from "core/Audio/sound";
 import { type Nullable } from "core/types";
 
-import { AbstractEngine, NullEngine } from "core/Engines";
+import { AbstractEngine } from "core/Engines/abstractEngine";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Vector3 } from "core/Maths/math.vector";
 import { Scene } from "core/scene";
 
 import { AudioTestHelper } from "./helpers/audioTestHelper";
 import { AudioTestSamples } from "./helpers/audioTestSamples";
 import { MockedAudioObjects } from "./helpers/mockedAudioObjects";
+import { CreateSoundAsync as CreateSoundV2Async } from "../../../src/AudioV2/abstractAudio/audioEngineV2";
 import { SoundState } from "../../../src/AudioV2/soundState";
 import { StaticSound } from "../../../src/AudioV2/abstractAudio/staticSound";
 import { StreamingSound } from "../../../src/AudioV2/abstractAudio/streamingSound";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Required for timers (eg. setTimeout) to work.
 // Store real timers before vi.useFakeTimers() replaces them
@@ -482,6 +489,35 @@ describe("Sound", () => {
         sound.play();
 
         expect(mock.connectsToPannerNode(mock.audioBufferSource)).toBe(true);
+    });
+
+    it("does not connect to panner node when spatial panning is disabled in audio engine v2", async () => {
+        const sound = await CreateSoundV2Async(
+            expect.getState().currentTestName!,
+            AudioTestSamples.Get("silence, 1 second, 1 channel, 48000 kHz").audioBuffer as unknown as AudioBuffer,
+            {
+                spatialEnabled: true,
+                spatialMaxDistance: 11,
+                spatialMinDistance: 1,
+                spatialPanningEnabled: false,
+            },
+            (audioEngine as AudioEngine)._v2
+        );
+
+        sound.spatial.position = new Vector3(6, 0, 0);
+        sound.spatial.update();
+        sound.play();
+
+        const spatialSubNode = (sound as any)._subGraph.getSubNode("Spatial");
+        expect(sound.spatial.panningEnabled).toBe(false);
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.5);
+        expect(mock.connectsToPannerNode(mock.audioBufferSource)).toBe(false);
+
+        (audioEngine as AudioEngine)._v2.listener.position.copyFromFloats(2, 0, 0);
+        (audioEngine as AudioEngine)._v2.listener.update();
+        sound.spatial.update();
+
+        expect(spatialSubNode._attenuation.targetValue).toBeCloseTo(0.7);
     });
 
     it("connects to panner node when spatialized via property", async () => {


### PR DESCRIPTION
## Summary

This PR adds an Audio Engine V2 spatial panning toggle so spatial sounds can keep distance attenuation without being panned between the left and right channels.

The new API is available both at creation time and at runtime:

- `spatialPanningEnabled: false`
- `sound.spatial.panningEnabled = false`

When panning is disabled, the WebAudio implementation bypasses `PannerNode` for directional panning and applies distance attenuation manually. This allows mono/centered spatial audio behavior while preserving distance-based volume falloff.

## Details

- Adds `spatialPanningEnabled` / `panningEnabled` to the Audio V2 spatial APIs.
- Adds a WebAudio no-panning signal path using a gain node for manual attenuation.
- Matches WebAudio distance attenuation behavior for `linear`, `inverse`, and `exponential` distance models.
- Supports runtime toggling between panned and non-panned spatial output.
- Keeps attenuation refreshed when source or listener position changes, including attached-source cases.
- Documents that sound cone attenuation is not applied while panning is disabled, because cone handling is tied to `PannerNode`.

## Playground

Saved Playground snippet:

https://playground.babylonjs.com/#ETXRJU

For PR testing, load it against the PR snapshot build once available:

https://playground.babylonjs.com/?snapshot=refs/pull/18462/merge#ETXRJU

The demo moves a mono tone around the listener while sweeping from near to far. With spatial panning ON, the tone moves between ears and changes volume with distance. With spatial panning OFF, the tone stays centered while still changing volume with distance.

## Validation

- `npm run build:dev`
- `npx vitest run --project=unit packages/dev/core/test/unit/Audio`