### PR TITLE
Fix Inspector v2 Havok wasm serving

### DIFF
--- a/packages/dev/inspector-v2/vite.config.ts
+++ b/packages/dev/inspector-v2/vite.config.ts
@@ -1,26 +1,62 @@
-import { defineConfig } from "vite";
+import { readFile } from "fs";
+import { fileURLToPath } from "url";
+import { defineConfig, mergeConfig, type Plugin } from "vite";
 import path from "path";
 // @ts-ignore -- untyped JS helper
 import { commonDevViteConfiguration } from "../../public/viteToolsHelper.mjs";
 
-export default defineConfig(
-    commonDevViteConfiguration({
-        port: parseInt(process.env.INSPECTOR_TEST_PORT ?? "9001"),
-        aliases: {
-            addons: path.resolve("../addons/dist"),
-            core: path.resolve("../core/dist"),
-            gui: path.resolve("../gui/dist"),
-            loaders: path.resolve("../loaders/dist"),
-            materials: path.resolve("../materials/dist"),
-            "shared-ui-components": path.resolve("../sharedUiComponents/src"),
-            inspector: path.resolve("./src"),
-            serializers: path.resolve("../serializers/dist"),
-            "node-editor": path.resolve("../../tools/nodeEditor/dist"),
-            "node-geometry-editor": path.resolve("../../tools/nodeGeometryEditor/dist"),
-            "node-particle-editor": path.resolve("../../tools/nodeParticleEditor/dist"),
-            "node-render-graph-editor": path.resolve("../../tools/nodeRenderGraphEditor/dist"),
-            "gui-editor": path.resolve("../../tools/guiEditor/dist"),
+const havokWasmFilePath = fileURLToPath(new URL("../../../node_modules/@babylonjs/havok/lib/esm/HavokPhysics.wasm", import.meta.url));
+
+function serveHavokWasmPlugin(): Plugin {
+    return {
+        name: "serve-havok-wasm",
+        configureServer(server) {
+            server.middlewares.use((request, response, next) => {
+                const requestPath = request.url?.split("?", 1)[0];
+                if (!requestPath?.endsWith("/HavokPhysics.wasm")) {
+                    next();
+                    return;
+                }
+
+                readFile(havokWasmFilePath, (error, wasm) => {
+                    if (error) {
+                        next(error);
+                        return;
+                    }
+
+                    response.statusCode = 200;
+                    response.setHeader("Content-Type", "application/wasm");
+                    response.setHeader("Cache-Control", "no-cache");
+                    response.end(wasm);
+                });
+            });
         },
-        productionExternals: {},
-    })
+    };
+}
+
+export default defineConfig(
+    mergeConfig(
+        commonDevViteConfiguration({
+            port: parseInt(process.env.INSPECTOR_TEST_PORT ?? "9001"),
+            aliases: {
+                addons: path.resolve("../addons/dist"),
+                core: path.resolve("../core/dist"),
+                gui: path.resolve("../gui/dist"),
+                loaders: path.resolve("../loaders/dist"),
+                materials: path.resolve("../materials/dist"),
+                "shared-ui-components": path.resolve("../sharedUiComponents/src"),
+                inspector: path.resolve("./src"),
+                serializers: path.resolve("../serializers/dist"),
+                "node-editor": path.resolve("../../tools/nodeEditor/dist"),
+                "node-geometry-editor": path.resolve("../../tools/nodeGeometryEditor/dist"),
+                "node-particle-editor": path.resolve("../../tools/nodeParticleEditor/dist"),
+                "node-render-graph-editor": path.resolve("../../tools/nodeRenderGraphEditor/dist"),
+                "gui-editor": path.resolve("../../tools/guiEditor/dist"),
+            },
+            productionExternals: {},
+        }),
+        {
+            plugins: [serveHavokWasmPlugin()],
+        }
+    )
 );


### PR DESCRIPTION
> 🤖 *This PR was created by GitHub Copilot.*

## Summary
- Add an Inspector v2 Vite dev-server middleware that serves `HavokPhysics.wasm` with `application/wasm`.
- Prevent Vite's SPA fallback from returning `index.html` for the generated Havok wasm dependency URL.

## Validation
- `get_errors` on `packages/dev/inspector-v2/vite.config.ts`: no errors
- `npx prettier --check packages/dev/inspector-v2/vite.config.ts`
- `curl http://localhost:9001/node_modules/.vite/deps/HavokPhysics.wasm`: returns `200`, `Content-Type: application/wasm`, and a WebAssembly binary