### PR TITLE
Fix PBRCustomMaterial compiled effect cleanup

### DIFF
--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -323,6 +323,18 @@ export class PBRCustomMaterial extends PBRMaterial {
 
         PBRCustomMaterial.ShaderIndexer++;
         this._createdShaderName = "custompbr_" + PBRCustomMaterial.ShaderIndexer;
+
+        this.onEffectCreatedObservable.add(({ effect, subMesh }) => {
+            const previousEffect = subMesh?.effect;
+            if (
+                (!this.allowShaderHotSwapping || effect.isReady()) &&
+                previousEffect &&
+                previousEffect !== effect &&
+                previousEffect._key.startsWith(this._createdShaderName + "+")
+            ) {
+                previousEffect.dispose();
+            }
+        });
     }
 
     /**

--- a/packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts
+++ b/packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts
@@ -1,5 +1,6 @@
 import { NullEngine } from "core/Engines/nullEngine";
 import { Effect } from "core/Materials/effect";
+import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { Scene } from "core/scene";
 import { PBRCustomMaterial } from "materials/custom/pbrCustomMaterial";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -32,5 +33,49 @@ describe("PBRCustomMaterial", () => {
 
         expect(Effect.ShadersStore[shaderName + "VertexShader"]).toBeUndefined();
         expect(Effect.ShadersStore[shaderName + "PixelShader"]).toBeUndefined();
+    });
+
+    it("releases a previous custom effect when a new custom effect is created for the same submesh", () => {
+        const shaderName = material.Builder("", [], [], [], []);
+        const mesh = MeshBuilder.CreateBox("box", {}, scene);
+        const subMesh = mesh.subMeshes[0];
+        const shaderSource = {
+            vertexSource: "void main(void) { gl_Position = vec4(0.0); }",
+            fragmentSource: "void main(void) { gl_FragColor = vec4(1.0); }",
+            vertexToken: shaderName,
+            fragmentToken: shaderName,
+        };
+        const firstEffect = engine.createEffect(
+            shaderSource,
+            {
+                attributes: [],
+                uniformsNames: [],
+                samplers: [],
+                defines: "#define FIRST",
+                fallbacks: null,
+                onCompiled: null,
+                onError: null,
+            },
+            engine
+        );
+        const secondEffect = engine.createEffect(
+            shaderSource,
+            {
+                attributes: [],
+                uniformsNames: [],
+                samplers: [],
+                defines: "#define SECOND",
+                fallbacks: null,
+                onCompiled: null,
+                onError: null,
+            },
+            engine
+        );
+
+        subMesh.setEffect(firstEffect);
+        material.onEffectCreatedObservable.notifyObservers({ effect: secondEffect, subMesh });
+
+        expect(firstEffect.isDisposed).toBe(true);
+        expect(secondEffect.isDisposed).toBe(false);
     });
 });


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Release the previous `PBRCustomMaterial` custom effect when a new ready custom effect replaces it for the same submesh.
- Keep the global compiled effect cache behavior intact for other materials and shared effects.
- Add unit coverage for the custom material effect replacement cleanup path.

## Motivation
`PBRCustomMaterial` uses unique shader names such as `custompbr_N`. When material defines change and a new effect is compiled, the previous effect can become orphaned in `engine._compiledEffects` because its unique key will not be reused by another material instance.

Forum report: https://forum.babylonjs.com/t/pbrcustommaterial-compiledeffects-memory-leak/63468
Related prerequisite PR: https://github.com/BabylonJS/Babylon.js/pull/18441

## Validation
- `npx vitest run --project=unit "packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts"`
- `npm run format:check`
