### PR TITLE
Normalize tree-shaking manifest paths to POSIX

### DIFF
--- a/scripts/treeshaking/auditSideEffects.mjs
+++ b/scripts/treeshaking/auditSideEffects.mjs
@@ -34,6 +34,14 @@ const __dirname = dirname(__filename);
 const REPO_ROOT = resolve(__dirname, "../..");
 const CORE_SRC = join(REPO_ROOT, "packages/dev/core/src");
 
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function toPosixPath(filePath) {
+    return filePath.split(/[/\\]+/).join("/");
+}
+
 // ---------------------------------------------------------------------------
 // File collection
 // ---------------------------------------------------------------------------
@@ -67,7 +75,7 @@ function collectTsFiles(dir) {
  * @returns {boolean}
  */
 function isStaleGeneratedShader(filePath) {
-    const relPath = relative(CORE_SRC, filePath);
+    const relPath = toPosixPath(relative(CORE_SRC, filePath));
     if (!relPath.startsWith("Shaders/") && !relPath.startsWith("ShadersWGSL/")) {
         return false;
     }
@@ -128,7 +136,7 @@ function isEscaped(text, index) {
 function analyzeFile(filePath) {
     const source = readFileSync(filePath, "utf-8");
     const lines = source.split("\n");
-    const relPath = relative(CORE_SRC, filePath);
+    const relPath = toPosixPath(relative(CORE_SRC, filePath));
     const sideEffects = [];
 
     // Track brace depth to distinguish top-level from nested scope.

--- a/scripts/treeshaking/syncSideEffects.mjs
+++ b/scripts/treeshaking/syncSideEffects.mjs
@@ -42,6 +42,24 @@ const MANIFEST_PATH = join(__dirname, "side-effects-manifest.json");
 // ---------------------------------------------------------------------------
 
 /**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function toPosixPath(filePath) {
+    return filePath.split(/[/\\]+/).join("/");
+}
+
+/**
+ * @param {string} filePath
+ * @returns {string}
+ */
+function getTopDir(filePath) {
+    const normalizedPath = toPosixPath(filePath);
+    const slashIndex = normalizedPath.indexOf("/");
+    return slashIndex === -1 ? normalizedPath : normalizedPath.substring(0, slashIndex);
+}
+
+/**
  * Recursively count all .ts files (excluding .d.ts, .test.ts, .spec.ts) per
  * top-level directory.
  * @returns {Record<string, number>}
@@ -54,8 +72,7 @@ function countTsFilesByTopDir() {
             if (entry.isDirectory()) {
                 walk(fullPath);
             } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts") && !entry.name.endsWith(".test.ts") && !entry.name.endsWith(".spec.ts")) {
-                const rel = relative(CORE_SRC, fullPath);
-                const topDir = rel.includes("/") ? rel.split("/")[0] : rel;
+                const topDir = getTopDir(relative(CORE_SRC, fullPath));
                 counts[topDir] = (counts[topDir] || 0) + 1;
             }
         }
@@ -89,12 +106,12 @@ function main() {
 
     // Read manifest
     const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf-8"));
-    const seFiles = manifest.manifest.map((r) => r.file);
+    const seFiles = manifest.manifest.map((r) => toPosixPath(r.file));
 
     // Count side-effectful files per top-level directory
     const seByTopDir = {};
     for (const file of seFiles) {
-        const topDir = file.includes("/") ? file.split("/")[0] : file;
+        const topDir = getTopDir(file);
         seByTopDir[topDir] = (seByTopDir[topDir] || 0) + 1;
     }
 
@@ -128,7 +145,7 @@ function main() {
 
     // 2. Individual file entries for everything else
     for (const file of seFiles.sort()) {
-        const topDir = file.includes("/") ? file.split("/")[0] : file;
+        const topDir = getTopDir(file);
         if (globDirs.has(topDir)) {
             continue; // Already covered by glob
         }


### PR DESCRIPTION
## Summary
- normalize relative paths emitted by the side-effects audit to POSIX separators
- normalize manifest paths consumed by sideEffects sync so Windows-generated manifests still produce Unix-style package entries

## Verification
- npm run check:manifest-drift
- npm run check:side-effects-sync

Generated JSON/package artifacts are intentionally not included in this PR.