### PR TITLE
Drop hardcoded field list in InputMapper._entryCoversAllConditionsOf

### DIFF
--- a/packages/dev/core/src/Cameras/inputMapper.ts
+++ b/packages/dev/core/src/Cameras/inputMapper.ts
@@ -352,17 +352,20 @@ export class InputMapper<THandlers extends Record<string, unknown>> {
         // from a string-keyed loop. The runtime check is harmless: irrelevant-for-this-source
         // fields are undefined on both entry and conditions and skip the early return.
         const e = entry as any;
-        for (const field of ["button", "key", "touchCount"] as const) {
-            if (conditions[field] !== undefined && e[field] === undefined) {
-                return false;
+        for (const key of Object.keys(conditions) as (keyof InputConditions)[]) {
+            const condValue = conditions[key];
+            if (condValue === undefined) {
+                continue;
             }
-        }
-        if (conditions.modifiers) {
-            const entryMods = e.modifiers ?? {};
-            for (const key of Object.keys(conditions.modifiers) as (keyof InputModifiers)[]) {
-                if (conditions.modifiers[key] !== undefined && entryMods[key] === undefined) {
-                    return false;
+            if (key === "modifiers") {
+                const entryMods = (e.modifiers ?? {}) as InputModifiers;
+                for (const modKey of Object.keys(condValue) as (keyof InputModifiers)[]) {
+                    if ((condValue as InputModifiers)[modKey] !== undefined && entryMods[modKey] === undefined) {
+                        return false;
+                    }
                 }
+            } else if (e[key] === undefined) {
+                return false;
             }
         }
         return true;


### PR DESCRIPTION
## Summary
Follow-up to #18461 (now merged). Replaces the hardcoded `["button", "key", "touchCount"]` array inside `InputMapper._entryCoversAllConditionsOf` with an `Object.keys(conditions)` loop so that any new top-level field added to `InputConditions` is automatically covered without having to remember to update this helper too.

## Why
@georginahalpern raised this on the original PR: the hardcoded list is brittle and has no compile-time guarantee against drift. If a new top-level condition field is added (e.g. a hypothetical `wheel` delta or similar), this helper would silently skip it and `setInteraction` could mutate broader entries it shouldn't.

## Behavior
No behavioral change. The new loop checks the same set of conditions for the existing `InputConditions` fields. Modifiers remain a nested special case (they're inherently a sub-object), but it's now one explicit branch rather than a parallel hardcoded list.

## Validation
- `npx vitest run packages/dev/core/test/unit/Cameras/cameraMovement.test.ts`: 33/33 pass (including the Kevin stricter-entry test added in #18461)
- `npx eslint packages/dev/core/src/Cameras/inputMapper.ts`: clean
- `npx prettier --check packages/dev/core/src/Cameras/inputMapper.ts`: clean
