### PR TITLE
[Collisions] Fix GPUPicker GLSL integer precision

### DIFF
--- a/packages/dev/core/src/Shaders/picking.fragment.fx
+++ b/packages/dev/core/src/Shaders/picking.fragment.fx
@@ -1,4 +1,8 @@
 ﻿
+#if defined(WEBGL2) || defined(WEBGPU) || defined(NATIVE)
+precision highp int;
+#endif
+
 #if defined(INSTANCES)
 flat varying float vMeshID;
 #else

--- a/packages/dev/core/test/unit/Collisions/babylon.gpuPicker.test.ts
+++ b/packages/dev/core/test/unit/Collisions/babylon.gpuPicker.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { pickingPixelShader } from "core/Shaders/picking.fragment";
+
+describe("GPUPicker", () => {
+    it("uses high precision integers for WebGL2 picking ID bit shifts", () => {
+        expect(pickingPixelShader.shader).toContain("precision highp int;");
+    });
+});

--- a/scripts/treeshaking/side-effects-manifest.json
+++ b/scripts/treeshaking/side-effects-manifest.json
@@ -9691,7 +9691,7 @@
       "sideEffects": [
         {
           "type": "shader-store-write",
-          "line": 32,
+          "line": 35,
           "text": "if (!ShaderStore.ShadersStore[name]) {"
         }
       ]


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Adds an explicit `precision highp int;` declaration to the GLSL GPUPicker fragment shader for WebGL2/native bit-shift ID packing.
- Covers the generated picking shader with a regression test so the precision declaration is not dropped.

## Context
Forum report: https://forum.babylonjs.com/t/bitshift-in-glsl-picker-fragment-shader-assumes-32-bit-of-mediump-int-on-device/63503

On some mobile devices, fragment `mediump int` can be too small for the GPUPicker path that packs 24-bit mesh IDs with `>> 16` and `>> 8`. This can leak the blue byte into red and make GPU picking resolve the wrong ID.

## Testing
- `npx vitest run --project=unit "packages/dev/core/test/unit/Collisions/babylon.gpuPicker.test.ts"`
- `npm run format:check`
- `npm run lint:check -w @dev/core`

Full repo `npm run lint:check` and `npm run test:unit` were attempted locally but are currently blocked by unrelated existing failures outside this change.