### PR TITLE
Fix SpinButton number expression parsing under strict CSP

### DIFF
--- a/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
@@ -25,11 +25,19 @@ function CoerceStepValue(step: number, isFineKeyPressed: boolean, isCourseKeyPre
     return step;
 }
 
-// Allow arbitrary expressions, primarily for math operations (e.g. 10*60 for 10 minutes in seconds).
-// Use Function constructor to safely evaluate the expression without allowing access to scope.
+// Parse the raw input into a number, supporting plain numeric values and arbitrary math expressions
+// (e.g. "10*60" for 10 minutes in seconds).
+// First, try Number() so plain numeric input works even under a strict Content-Security-Policy that
+// disallows eval/Function. Only fall back to the Function constructor for non-numeric inputs that may
+// be expressions. Empty/whitespace input returns NaN so validateValue rejects it rather than committing
+// 0 (which is what Number("") would otherwise return).
 // If the expression is invalid, fallback to NaN which will be caught by validateValue and prevent committing.
 function EvaluateExpression(rawValue: string): number {
     rawValue = rawValue.trim();
+    if (rawValue.length === 0) {
+        return NaN;
+    }
+
     const value = Number(rawValue);
     if (!isNaN(value)) {
         return value;

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
@@ -31,7 +31,7 @@ function CoerceStepValue(step: number, isFineKeyPressed: boolean, isCourseKeyPre
 // disallows eval/Function. Only fall back to the Function constructor for non-numeric inputs that may
 // be expressions. Empty/whitespace input returns NaN so validateValue rejects it rather than committing
 // 0 (which is what Number("") would otherwise return).
-// If the expression is invalid, fallback to NaN which will be caught by validateValue and prevent committing.
+// Non-finite results (NaN, +/-Infinity) are rejected from both paths so callers don't have to handle them.
 function EvaluateExpression(rawValue: string): number {
     rawValue = rawValue.trim();
     if (rawValue.length === 0) {
@@ -39,12 +39,13 @@ function EvaluateExpression(rawValue: string): number {
     }
 
     const value = Number(rawValue);
-    if (!isNaN(value)) {
+    if (Number.isFinite(value)) {
         return value;
     }
 
     try {
-        return Number(Function(`"use strict";return (${rawValue})`)());
+        const result = Number(Function(`"use strict";return (${rawValue})`)());
+        return Number.isFinite(result) ? result : NaN;
     } catch {
         return NaN;
     }

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
@@ -29,9 +29,14 @@ function CoerceStepValue(step: number, isFineKeyPressed: boolean, isCourseKeyPre
 // Use Function constructor to safely evaluate the expression without allowing access to scope.
 // If the expression is invalid, fallback to NaN which will be caught by validateValue and prevent committing.
 function EvaluateExpression(rawValue: string): number {
-    const val = rawValue.trim();
+    rawValue = rawValue.trim();
+    const value = Number(rawValue);
+    if (!isNaN(value)) {
+        return value;
+    }
+
     try {
-        return Number(Function(`"use strict";return (${val})`)());
+        return Number(Function(`"use strict";return (${rawValue})`)());
     } catch {
         return NaN;
     }


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

The `SpinButton` Fluent primitive evaluates user input through `Function(...)` so users can type math expressions (e.g. `10*60`). Under a strict Content-Security-Policy that disallows `eval`/`Function`, this throws, and the fallback returned `NaN` — making the input field unusable even for plain numbers.

This change makes plain numeric input work without invoking `Function`:

1. Trim the raw value.
2. Try `Number(rawValue)` first — if it parses as a finite number, return it.
3. Only fall back to the `Function(...)` evaluator for non-numeric inputs (i.e. actual expressions like `10*60`).

Under a strict CSP, step 2 returns immediately and expressions still fail gracefully (caught → `NaN` → rejected by the existing validator), so behavior for non-CSP environments is unchanged for normal numeric input.

Reported on the forum: https://forum.babylonjs.com/t/inspector-v2-number-expression-parsing-not-safe/63504
