### PR TITLE
Fix adaptToDeviceRatio option state

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -2077,9 +2077,6 @@ export abstract class AbstractEngine {
             this._badDesktopOS = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
         }
 
-        // Save this off for use in resize().
-        this.adaptToDeviceRatio = adaptToDeviceRatio ?? false;
-
         options.antialias = antialias ?? options.antialias;
         options.deterministicLockstep = options.deterministicLockstep ?? false;
         options.lockstepMaxSteps = options.lockstepMaxSteps ?? 4;
@@ -2098,6 +2095,8 @@ export abstract class AbstractEngine {
         const limitDeviceRatio = options.limitDeviceRatio || devicePixelRatio;
         // Viewport
         adaptToDeviceRatio = adaptToDeviceRatio || options.adaptToDeviceRatio || false;
+        // Save this off for use in resize().
+        this.adaptToDeviceRatio = adaptToDeviceRatio;
         this._hardwareScalingLevel = adaptToDeviceRatio ? 1.0 / Math.min(limitDeviceRatio, devicePixelRatio) : 1.0;
         this._lastDevicePixelRatio = devicePixelRatio;
 

--- a/packages/dev/core/test/unit/Engines/thinEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinEngine.test.ts
@@ -1,4 +1,19 @@
 import { Engine, ThinEngine } from "core/Engines";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("Engine", () => {
+    describe("constructor", () => {
+        it("sets adaptToDeviceRatio from engine options", () => {
+            const engine = new Engine(null, undefined, { adaptToDeviceRatio: true });
+
+            try {
+                expect(engine.adaptToDeviceRatio).toBe(true);
+            } finally {
+                engine.dispose();
+            }
+        });
+    });
+});
 
 describe("ThinEngine", () => {
     describe("getTexImageParametersForCreateTexture", () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Motivation

Fixes https://forum.babylonjs.com/t/when-initializing-the-engine-with-adapttodeviceratio-true-the-value-of-engine-adapttodeviceratio-logs-as-false/63512

When `adaptToDeviceRatio` was supplied through the `EngineOptions` object, the engine used it for the initial hardware scaling calculation, but `engine.adaptToDeviceRatio` stayed `false` because the public flag was assigned before the option-object value was merged.

## Changes

- Store `this.adaptToDeviceRatio` after merging the positional constructor argument with `options.adaptToDeviceRatio`.
- Add a unit regression test for `new Engine(null, undefined, { adaptToDeviceRatio: true })`.

## Validation

- `npx vitest run --project=unit "packages/dev/core/test/unit/Engines/thinEngine.test.ts"`
- `npx prettier --check "packages/dev/core/src/Engines/abstractEngine.pure.ts" "packages/dev/core/test/unit/Engines/thinEngine.test.ts"`
- `npm run format:check`
- Targeted visualization tests in WebGL2 and WebGPU for `Node Material 0`, `Texture Repetition - Standard Material`, `Texture Repetition - PBR Material`, and `Texture Repetition - OpenPBR Material`