### PR TITLE
[Materials] Fix PBRCustomMaterial cached effect cleanup

### DIFF
--- a/packages/dev/materials/src/custom/pbrCustomMaterial.ts
+++ b/packages/dev/materials/src/custom/pbrCustomMaterial.ts
@@ -144,6 +144,8 @@ export class PBRCustomMaterial extends PBRMaterial {
      */
     _customAttributes: string[];
 
+    private readonly _customEffects = new Set<Effect>();
+
     /**
      * Fragment shader string
      */
@@ -326,15 +328,20 @@ export class PBRCustomMaterial extends PBRMaterial {
 
         this.onEffectCreatedObservable.add(({ effect, subMesh }) => {
             const previousEffect = subMesh?.effect;
-            if (
-                (!this.allowShaderHotSwapping || effect.isReady()) &&
-                previousEffect &&
-                previousEffect !== effect &&
-                previousEffect._key.startsWith(this._createdShaderName + "+")
-            ) {
+            if (this._isCreatedShaderEffect(effect)) {
+                this._customEffects.add(effect);
+            }
+            if ((!this.allowShaderHotSwapping || effect.isReady()) && previousEffect && previousEffect !== effect && this._isCreatedShaderEffect(previousEffect)) {
                 previousEffect.dispose();
+                if (previousEffect.isDisposed) {
+                    this._customEffects.delete(previousEffect);
+                }
             }
         });
+    }
+
+    private _isCreatedShaderEffect(effect: Effect): boolean {
+        return effect._key.startsWith(this._createdShaderName + "+");
     }
 
     /**
@@ -347,6 +354,11 @@ export class PBRCustomMaterial extends PBRMaterial {
         delete Effect.ShadersStore[this._createdShaderName + "PixelShader"];
 
         super.dispose(forceDisposeEffect, forceDisposeTextures);
+
+        this._customEffects.forEach((effect) => {
+            effect.dispose(true);
+        });
+        this._customEffects.clear();
     }
 
     protected override _afterBind(mesh?: Mesh, effect: Nullable<Effect> = null, subMesh?: SubMesh): void {

--- a/packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts
+++ b/packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts
@@ -5,13 +5,19 @@ import { Scene } from "core/scene";
 import { PBRCustomMaterial } from "materials/custom/pbrCustomMaterial";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+class TestNullEngine extends NullEngine {
+    public getCompiledEffects(): Record<string, Effect> {
+        return this._compiledEffects;
+    }
+}
+
 describe("PBRCustomMaterial", () => {
-    let engine: NullEngine;
+    let engine: TestNullEngine;
     let scene: Scene;
     let material: PBRCustomMaterial;
 
     beforeEach(() => {
-        engine = new NullEngine();
+        engine = new TestNullEngine();
         scene = new Scene(engine);
         material = new PBRCustomMaterial("custom", scene);
     });
@@ -77,5 +83,71 @@ describe("PBRCustomMaterial", () => {
 
         expect(firstEffect.isDisposed).toBe(true);
         expect(secondEffect.isDisposed).toBe(false);
+    });
+
+    it("releases custom effects on dispose even if the effect was retrieved from the cache more than once", () => {
+        const compiledEffects = engine.getCompiledEffects();
+        const getCustomEffectCount = (shaderName: string) => Object.keys(compiledEffects).filter((key) => key.startsWith(shaderName + "+")).length;
+        const shaderName = material.Builder("", [], [], [], []);
+        const mesh = MeshBuilder.CreateBox("box", {}, scene);
+        const subMesh = mesh.subMeshes[0];
+        mesh.material = material;
+        const shaderSource = {
+            vertexSource: "void main(void) { gl_Position = vec4(0.0); }",
+            fragmentSource: "void main(void) { gl_FragColor = vec4(1.0); }",
+            vertexToken: shaderName,
+            fragmentToken: shaderName,
+        };
+        const firstEffect = engine.createEffect(
+            shaderSource,
+            {
+                attributes: [],
+                uniformsNames: [],
+                samplers: [],
+                defines: "#define FIRST",
+                fallbacks: null,
+                onCompiled: null,
+                onError: null,
+            },
+            engine
+        );
+        const secondEffect = engine.createEffect(
+            shaderSource,
+            {
+                attributes: [],
+                uniformsNames: [],
+                samplers: [],
+                defines: "#define SECOND",
+                fallbacks: null,
+                onCompiled: null,
+                onError: null,
+            },
+            engine
+        );
+        const cachedSecondEffect = engine.createEffect(
+            shaderSource,
+            {
+                attributes: [],
+                uniformsNames: [],
+                samplers: [],
+                defines: "#define SECOND",
+                fallbacks: null,
+                onCompiled: null,
+                onError: null,
+            },
+            engine
+        );
+
+        expect(cachedSecondEffect).toBe(secondEffect);
+        expect(secondEffect._refCount).toBe(2);
+
+        subMesh.setEffect(firstEffect);
+        material.onEffectCreatedObservable.notifyObservers({ effect: secondEffect, subMesh });
+        subMesh.setEffect(secondEffect);
+        material.dispose(true, true);
+
+        expect(firstEffect.isDisposed).toBe(true);
+        expect(secondEffect.isDisposed).toBe(true);
+        expect(getCustomEffectCount(shaderName)).toBe(0);
     });
 });


### PR DESCRIPTION
> 🤖 *This PR was created by Copilot.*

Forum report: https://forum.babylonjs.com/t/pbrcustommaterial-compiledeffects-memory-leak/63468

## Summary
- Track compiled effects generated for each `PBRCustomMaterial` shader key.
- Force-release remaining tracked custom effects when the material is disposed, covering cached effects with extra ref counts.
- Add unit coverage for the cached/ref-counted effect cleanup path.

## Root cause
`PBRCustomMaterial` uses unique shader names such as `custompbr_N`. If the engine cache returns the same custom effect more than once, its ref count can be greater than one. The base material disposal path releases one reference, leaving the unique compiled effect cached forever.

## Validation
- `npx vitest run --project=unit "packages/dev/materials/test/unit/custom/pbrCustomMaterial.test.ts"`
- `npx eslint "packages/dev/materials/src/custom/pbrCustomMaterial.ts" --quiet --cache`
- `npm run format:check`

Note: `npm run lint:check` is currently blocked by unrelated existing side-effect-import lint errors in core `.pure.ts` files.