### PR TITLE
Inspector V2: add material texture debug toggle and improve scene explorer tooltips

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/materials/materialTextureDebugPropertyLine.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/materialTextureDebugPropertyLine.tsx
@@ -1,5 +1,5 @@
 import { makeStyles, tokens } from "@fluentui/react-components";
-import { type FunctionComponent, useCallback } from "react";
+import { type FunctionComponent, useCallback, useEffect, useRef } from "react";
 
 import { type Material } from "core/Materials/material";
 import { type BaseTexture } from "core/Materials/Textures/baseTexture";
@@ -112,6 +112,23 @@ export const MaterialTextureDebugPropertyLine: FunctionComponent<MaterialTexture
     const reservedDataStore = useProperty(material, "reservedDataStore") as Partial<DebugTextureStore> | null | undefined;
     const debugTexture = useProperty(reservedDataStore, "debugTexture");
     const isDebugEnabled = !!texture && debugTexture === texture;
+
+    // Track the texture this slot last rendered with so we can detect when its value changes away
+    // from the texture currently being debugged. Without this, reassigning the slot's texture (or
+    // setting it to null) while debug is active would leave the scene stuck in debug view with no
+    // visible toggle to turn it off (the toggle for that slot is keyed off texture-instance
+    // equality and would just appear off).
+    const prevTextureRef = useRef(texture);
+    useEffect(() => {
+        const prevTexture = prevTextureRef.current;
+        prevTextureRef.current = texture;
+        if (prevTexture && prevTexture !== texture) {
+            const store = material.reservedDataStore as Partial<DebugTextureStore> | undefined;
+            if (store?.debugTexture === prevTexture) {
+                ToggleTextureDebug(material, prevTexture, false);
+            }
+        }
+    }, [texture]);
 
     const handleDebugToggle = useCallback(
         (checked: boolean) => {

--- a/packages/dev/inspector-v2/src/components/properties/materials/materialTextureDebugPropertyLine.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/materialTextureDebugPropertyLine.tsx
@@ -1,0 +1,145 @@
+import { makeStyles, tokens } from "@fluentui/react-components";
+import { type FunctionComponent, useCallback } from "react";
+
+import { type Material } from "core/Materials/material";
+import { type BaseTexture } from "core/Materials/Textures/baseTexture";
+import { type Nullable } from "core/types";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+
+import { type PropertyLineProps, PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
+import { type TextureSelectorProps, TextureSelector } from "shared-ui-components/fluent/primitives/textureSelector";
+import { Switch } from "shared-ui-components/fluent/primitives/switch";
+
+import { useProperty } from "../../../hooks/compoundPropertyHooks";
+
+type MaterialTextureDebugPropertyLineProps = PropertyLineProps<Nullable<BaseTexture>> & TextureSelectorProps & { material: Material };
+
+type DebugTextureStore = {
+    debugTexture: Nullable<BaseTexture>;
+    debugMaterial: Nullable<Material>;
+    level: number;
+};
+
+const useStyles = makeStyles({
+    expandedDebugContainer: {
+        display: "flex",
+        alignItems: "center",
+        marginTop: tokens.spacingVerticalXS,
+    },
+    debugLabel: {
+        flex: 1,
+    },
+});
+
+/**
+ * Toggles debug mode for a texture on a material.
+ * When enabled, creates a debug material with the texture as emissive and swaps it on all meshes using the original material.
+ * Enabling debug for one texture on a material disables it for any other texture on that material (mutually exclusive).
+ * @param material - The material to debug
+ * @param texture - The texture to debug
+ * @param enable - Whether to enable or disable debug mode
+ */
+function ToggleTextureDebug(material: Material, texture: Nullable<BaseTexture>, enable: boolean): void {
+    if (!material || !texture) {
+        return;
+    }
+
+    const scene = material.getScene();
+    const store = (material.reservedDataStore ?? (material.reservedDataStore = {})) as Partial<DebugTextureStore>;
+    store.debugTexture ??= null;
+    store.debugMaterial ??= null;
+    store.level ??= texture.level;
+
+    const isCurrentlyDebugging = store.debugTexture === texture;
+
+    if (enable && !isCurrentlyDebugging) {
+        // If we were debugging a different texture, clean it up first.
+        if (store.debugTexture) {
+            ToggleTextureDebug(material, store.debugTexture, false);
+        }
+
+        const debugMaterial = new StandardMaterial("debugMaterial", scene);
+        debugMaterial.disableLighting = true;
+        debugMaterial.sideOrientation = material.sideOrientation;
+        debugMaterial.emissiveTexture = texture;
+        debugMaterial.forceDepthWrite = true;
+        debugMaterial.reservedDataStore = { hidden: true };
+
+        let checkMaterial: Material = material;
+        let needToDisposeCheckMaterial = false;
+        if (store.debugTexture && store.debugMaterial) {
+            checkMaterial = store.debugMaterial;
+            needToDisposeCheckMaterial = true;
+        }
+
+        for (const mesh of scene.meshes) {
+            if (mesh.material === checkMaterial) {
+                mesh.material = debugMaterial;
+            }
+        }
+
+        store.debugMaterial = debugMaterial;
+        store.level = texture.level;
+        texture.level = 1.0;
+        // Assign debugTexture LAST so observers see a fully-populated store.
+        store.debugTexture = texture;
+
+        if (needToDisposeCheckMaterial) {
+            checkMaterial.dispose();
+        }
+    } else if (!enable && isCurrentlyDebugging) {
+        const debugMaterial: Nullable<Material> = store.debugMaterial;
+        if (debugMaterial) {
+            texture.level = store.level;
+
+            for (const mesh of scene.meshes) {
+                if (mesh.material === debugMaterial) {
+                    mesh.material = material;
+                }
+            }
+
+            debugMaterial.dispose();
+            store.debugMaterial = null;
+        }
+        store.debugTexture = null;
+    }
+}
+
+/**
+ * A texture selector property line with material texture debug capability.
+ * Displays a debug toggle in expanded content to render the selected texture as emissive on the material.
+ * Enabling debug on one texture for a given material disables it for any other texture on that material.
+ * @param props - The texture selector property line props plus material reference
+ * @returns The property line element with debug toggle
+ */
+export const MaterialTextureDebugPropertyLine: FunctionComponent<MaterialTextureDebugPropertyLineProps> = (props) => {
+    const classes = useStyles();
+    const { material, ...textureProps } = props;
+    const texture = props.value;
+
+    const reservedDataStore = useProperty(material, "reservedDataStore") as Partial<DebugTextureStore> | null | undefined;
+    const debugTexture = useProperty(reservedDataStore, "debugTexture");
+    const isDebugEnabled = !!texture && debugTexture === texture;
+
+    const handleDebugToggle = useCallback(
+        (checked: boolean) => {
+            if (texture) {
+                ToggleTextureDebug(material, texture, checked);
+            }
+        },
+        [material, texture]
+    );
+
+    const expandedContent = texture ? (
+        <div className={classes.expandedDebugContainer}>
+            <span className={classes.debugLabel}>Display Texture for Debug</span>
+            <Switch value={isDebugEnabled} onChange={handleDebugToggle} />
+        </div>
+    ) : undefined;
+
+    return (
+        <PropertyLine {...textureProps} expandedContent={expandedContent}>
+            <TextureSelector {...textureProps} />
+        </PropertyLine>
+    );
+};

--- a/packages/dev/inspector-v2/src/components/properties/materials/materialTextureDebugPropertyLine.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/materialTextureDebugPropertyLine.tsx
@@ -17,7 +17,6 @@ type MaterialTextureDebugPropertyLineProps = PropertyLineProps<Nullable<BaseText
 type DebugTextureStore = {
     debugTexture: Nullable<BaseTexture>;
     debugMaterial: Nullable<Material>;
-    level: number;
 };
 
 const useStyles = makeStyles({
@@ -33,8 +32,16 @@ const useStyles = makeStyles({
 
 /**
  * Toggles debug mode for a texture on a material.
- * When enabled, creates a debug material with the texture as emissive and swaps it on all meshes using the original material.
- * Enabling debug for one texture on a material disables it for any other texture on that material (mutually exclusive).
+ * When enabled, creates a debug `StandardMaterial` with the texture wired as `emissiveTexture` and swaps it onto every
+ * mesh that currently uses the original material. Enabling debug for one texture on a material disables it for any
+ * other texture on that material (mutually exclusive).
+ *
+ * Notes:
+ * - The texture is rendered using its current `level`. Textures whose level is not 1 will appear modulated; this is
+ *   intentional so that no global state on the source texture is mutated (a level mutation would affect every other
+ *   material that references the same texture instance).
+ * - Only meshes referencing the original material at toggle time receive the debug material. Meshes added or
+ *   reassigned to the original material afterwards are not affected until the next toggle cycle.
  * @param material - The material to debug
  * @param texture - The texture to debug
  * @param enable - Whether to enable or disable debug mode
@@ -45,10 +52,10 @@ function ToggleTextureDebug(material: Material, texture: Nullable<BaseTexture>, 
     }
 
     const scene = material.getScene();
-    const store = (material.reservedDataStore ?? (material.reservedDataStore = {})) as Partial<DebugTextureStore>;
+    material.reservedDataStore ??= {};
+    const store = material.reservedDataStore as Partial<DebugTextureStore>;
     store.debugTexture ??= null;
     store.debugMaterial ??= null;
-    store.level ??= texture.level;
 
     const isCurrentlyDebugging = store.debugTexture === texture;
 
@@ -65,33 +72,18 @@ function ToggleTextureDebug(material: Material, texture: Nullable<BaseTexture>, 
         debugMaterial.forceDepthWrite = true;
         debugMaterial.reservedDataStore = { hidden: true };
 
-        let checkMaterial: Material = material;
-        let needToDisposeCheckMaterial = false;
-        if (store.debugTexture && store.debugMaterial) {
-            checkMaterial = store.debugMaterial;
-            needToDisposeCheckMaterial = true;
-        }
-
         for (const mesh of scene.meshes) {
-            if (mesh.material === checkMaterial) {
+            if (mesh.material === material) {
                 mesh.material = debugMaterial;
             }
         }
 
         store.debugMaterial = debugMaterial;
-        store.level = texture.level;
-        texture.level = 1.0;
         // Assign debugTexture LAST so observers see a fully-populated store.
         store.debugTexture = texture;
-
-        if (needToDisposeCheckMaterial) {
-            checkMaterial.dispose();
-        }
     } else if (!enable && isCurrentlyDebugging) {
         const debugMaterial: Nullable<Material> = store.debugMaterial;
         if (debugMaterial) {
-            texture.level = store.level;
-
             for (const mesh of scene.meshes) {
                 if (mesh.material === debugMaterial) {
                     mesh.material = material;

--- a/packages/dev/inspector-v2/src/components/properties/materials/openpbrMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/openpbrMaterialProperties.tsx
@@ -5,7 +5,7 @@ import { BoundProperty } from "../boundProperty";
 import { Color3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
 import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
 import { CheckboxPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/checkboxPropertyLine";
-import { TextureSelectorPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/entitySelectorPropertyLine";
+import { MaterialTextureDebugPropertyLine } from "./materialTextureDebugPropertyLine";
 import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/dropdownPropertyLine";
 import { RealTimeFilteringQualityOptions } from "./pbrBaseMaterialProperties";
 
@@ -31,13 +31,14 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Base Weight"
                 target={material}
                 propertyKey="baseWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -49,13 +50,14 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Base Color"
                 target={material}
                 propertyKey="baseColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -69,13 +71,14 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Base Metalness"
                 target={material}
                 propertyKey="baseMetalnessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -89,22 +92,24 @@ export const OpenPBRMaterialBaseProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Base Diffuse Roughness"
                 target={material}
                 propertyKey="baseDiffuseRoughnessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Ambient Occlusion"
                 target={material}
                 propertyKey="ambientOcclusionTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
         </>
     );
@@ -132,13 +137,14 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Specular Weight"
                 target={material}
                 propertyKey="specularWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -150,13 +156,14 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Specular Color"
                 target={material}
                 propertyKey="specularColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -170,13 +177,14 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Specular Roughness"
                 target={material}
                 propertyKey="specularRoughnessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -190,13 +198,14 @@ export const OpenPBRMaterialSpecularProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/microfacetmodel"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Specular Roughness Anisotropy"
                 target={material}
                 propertyKey="specularRoughnessAnisotropyTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -230,13 +239,14 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/translucentbase"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Transmission Weight"
                 target={material}
                 propertyKey="transmissionWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -248,13 +258,14 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/translucentbase"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Transmission Color"
                 target={material}
                 propertyKey="transmissionColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -270,13 +281,14 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/translucentbase"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Transmission Depth"
                 target={material}
                 propertyKey="transmissionDepthTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -288,13 +300,14 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/translucentbase"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Transmission Scatter"
                 target={material}
                 propertyKey="transmissionScatterTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -330,13 +343,14 @@ export const OpenPBRMaterialTransmissionProperties: FunctionComponent<{ material
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/translucentbase"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Transmission Dispersion Scale"
                 target={material}
                 propertyKey="transmissionDispersionScaleTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
         </>
     );
@@ -359,13 +373,14 @@ export const OpenPBRMaterialSubsurfaceProperties: FunctionComponent<{ material: 
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/subsurface"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Subsurface Weight"
                 target={material}
                 propertyKey="subsurfaceWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -377,13 +392,14 @@ export const OpenPBRMaterialSubsurfaceProperties: FunctionComponent<{ material: 
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/subsurface"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Subsurface Color"
                 target={material}
                 propertyKey="subsurfaceColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -408,13 +424,14 @@ export const OpenPBRMaterialSubsurfaceProperties: FunctionComponent<{ material: 
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/basesubstrate/subsurface"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Subsurface Radius Scale"
                 target={material}
                 propertyKey="subsurfaceRadiusScaleTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -453,13 +470,14 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/coat"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Coat Weight"
                 target={material}
                 propertyKey="coatWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -471,13 +489,14 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/coat"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Coat Color"
                 target={material}
                 propertyKey="coatColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -491,13 +510,14 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/coat/roughening"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Coat Roughness"
                 target={material}
                 propertyKey="coatRoughnessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -511,13 +531,14 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/coat"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Coat Roughness Anisotropy"
                 target={material}
                 propertyKey="coatRoughnessAnisotropyTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -542,13 +563,14 @@ export const OpenPBRMaterialCoatProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/coat/darkening"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Coat Darkening"
                 target={material}
                 propertyKey="coatDarkeningTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
         </>
     );
@@ -576,13 +598,14 @@ export const OpenPBRMaterialFuzzProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/fuzz"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Fuzz Weight"
                 target={material}
                 propertyKey="fuzzWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={Color3PropertyLine}
@@ -594,13 +617,14 @@ export const OpenPBRMaterialFuzzProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/fuzz"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Fuzz Color"
                 target={material}
                 propertyKey="fuzzColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -614,13 +638,14 @@ export const OpenPBRMaterialFuzzProperties: FunctionComponent<{ material: OpenPB
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/fuzz"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Fuzz Roughness"
                 target={material}
                 propertyKey="fuzzRoughnessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
         </>
     );
@@ -646,13 +671,14 @@ export const OpenPBRMaterialEmissionProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/emission"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Emission Color"
                 target={material}
                 propertyKey="emissionColorTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -691,13 +717,14 @@ export const OpenPBRMaterialThinFilmProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/thin-filmiridescence"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Thin Film Weight"
                 target={material}
                 propertyKey="thinFilmWeightTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -711,13 +738,14 @@ export const OpenPBRMaterialThinFilmProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/thin-filmiridescence"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Thin Film Thickness"
                 target={material}
                 propertyKey="thinFilmThicknessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -756,13 +784,14 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/opacity/transparency"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Geometry Opacity"
                 target={material}
                 propertyKey="geometryOpacityTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={CheckboxPropertyLine}
@@ -773,13 +802,14 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/thin-walledcase"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Geometry Normal"
                 target={material}
                 propertyKey="geometryNormalTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -793,13 +823,14 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/geometry/tangent"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Geometry Tangent"
                 target={material}
                 propertyKey="geometryTangentTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -813,22 +844,24 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/geometry/coat-tangent"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Geometry Coat Normal"
                 target={material}
                 propertyKey="geometryCoatNormalTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Geometry Coat Tangent"
                 target={material}
                 propertyKey="geometryCoatTangentTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
             <BoundProperty
                 component={SyncedSliderPropertyLine}
@@ -841,13 +874,14 @@ export const OpenPBRMaterialGeometryProperties: FunctionComponent<{ material: Op
                 docLink="https://academysoftwarefoundation.github.io/OpenPBR/index.html#model/thickness"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Geometry Thickness"
                 target={material}
                 propertyKey="geometryThicknessTexture"
                 scene={material.getScene()}
                 defaultValue={null}
                 onLink={(texture) => void texture}
+                material={material}
             />
         </>
     );

--- a/packages/dev/inspector-v2/src/components/properties/materials/pbrBaseMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/pbrBaseMaterialProperties.tsx
@@ -15,6 +15,7 @@ import { NumberDropdownPropertyLine } from "shared-ui-components/fluent/hoc/prop
 import { type DropdownOption } from "shared-ui-components/fluent/primitives/dropdown";
 import { Constants } from "core/Engines/constants";
 import { TextureSelectorPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/entitySelectorPropertyLine";
+import { MaterialTextureDebugPropertyLine } from "./materialTextureDebugPropertyLine";
 import { type ISelectionService } from "../../../services/selectionService";
 import { Color3 } from "core/Maths/math.color";
 
@@ -163,43 +164,47 @@ export const PBRBaseMaterialChannelsProperties: FunctionComponent<{ material: PB
     return (
         <>
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Albedo"
                 target={material}
                 propertyKey="_albedoTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Base Weight"
                 target={material}
                 propertyKey="_baseWeightTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Base Diffuse Roughness"
                 target={material}
                 propertyKey="_baseDiffuseRoughnessTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Metallic Roughness"
                 target={material}
                 propertyKey="_metallicTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 uniqueId="PBRBaseMaterialChannels_Reflection"
                 label="Reflection"
                 target={material}
@@ -208,9 +213,10 @@ export const PBRBaseMaterialChannelsProperties: FunctionComponent<{ material: PB
                 cubeOnly
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Refraction"
                 target={material.subSurface}
                 propertyKey="refractionTexture"
@@ -218,72 +224,80 @@ export const PBRBaseMaterialChannelsProperties: FunctionComponent<{ material: PB
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Reflectivity"
                 target={material}
                 propertyKey="_reflectivityTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Micro Surface"
                 target={material}
                 propertyKey="_microSurfaceTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Bump"
                 target={material}
                 propertyKey="_bumpTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Emissive"
                 target={material}
                 propertyKey="_emissiveTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Opacity"
                 target={material}
                 propertyKey="_opacityTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Ambient"
                 target={material}
                 propertyKey="_ambientTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Lightmap"
                 target={material}
                 propertyKey="_lightmapTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Detailmap"
                 target={material.detailMap}
                 propertyKey="texture"
@@ -291,6 +305,7 @@ export const PBRBaseMaterialChannelsProperties: FunctionComponent<{ material: PB
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty component={SwitchPropertyLine} label="Use Lightmap as Shadowmap" target={material} propertyKey="_useLightmapAsShadowmap" />
             <BoundProperty component={SwitchPropertyLine} label="Use Detailmap" target={material.detailMap} propertyKey="isEnabled" propertyPath="detailMap.isEnabled" />
@@ -367,19 +382,21 @@ export const PBRBaseMaterialMetallicWorkflowProperties: FunctionComponent<{ mate
                 propertyKey="_useOnlyMetallicFromMetallicReflectanceTexture"
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Metallic Reflectance"
                 target={material}
                 propertyKey="_metallicReflectanceTexture"
+                material={material}
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Reflectance"
                 target={material}
                 propertyKey="_reflectanceTexture"
+                material={material}
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}

--- a/packages/dev/inspector-v2/src/components/properties/materials/standardMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/standardMaterialProperties.tsx
@@ -8,7 +8,7 @@ import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/proper
 import { Collapse } from "shared-ui-components/fluent/primitives/collapse";
 import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
-import { TextureSelectorPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/entitySelectorPropertyLine";
+import { MaterialTextureDebugPropertyLine } from "./materialTextureDebugPropertyLine";
 import { type ISelectionService } from "../../../services/selectionService";
 
 export const StandardMaterialGeneralProperties: FunctionComponent<{ material: StandardMaterial }> = (props) => {
@@ -51,25 +51,27 @@ export const StandardMaterialTexturesProperties: FunctionComponent<{ material: S
     return (
         <>
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Diffuse"
                 target={material}
                 propertyKey="diffuseTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Specular"
                 target={material}
                 propertyKey="specularTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 uniqueId="StandardMaterialTextures_Reflection"
                 label="Reflection"
                 target={material}
@@ -77,63 +79,70 @@ export const StandardMaterialTexturesProperties: FunctionComponent<{ material: S
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Refraction"
                 target={material}
                 propertyKey="refractionTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Emissive"
                 target={material}
                 propertyKey="emissiveTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Bump"
                 target={material}
                 propertyKey="bumpTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Opacity"
                 target={material}
                 propertyKey="opacityTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Ambient"
                 target={material}
                 propertyKey="ambientTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Lightmap"
                 target={material}
                 propertyKey="lightmapTexture"
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty
-                component={TextureSelectorPropertyLine}
+                component={MaterialTextureDebugPropertyLine}
                 label="Detailmap"
                 target={material.detailMap}
                 propertyKey="texture"
@@ -141,6 +150,7 @@ export const StandardMaterialTexturesProperties: FunctionComponent<{ material: S
                 scene={scene}
                 onLink={selectEntity}
                 defaultValue={null}
+                material={material}
             />
             <BoundProperty component={SwitchPropertyLine} label="Use Lightmap as Shadowmap" target={material} propertyKey="useLightmapAsShadowmap" />
             <BoundProperty component={SwitchPropertyLine} label="Use Detailmap" target={material.detailMap} propertyKey="isEnabled" propertyPath="detailMap.isEnabled" />

--- a/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
+++ b/packages/dev/inspector-v2/src/components/scene/sceneExplorer.tsx
@@ -24,6 +24,7 @@ import {
     Tooltip,
     TreeItemLayout,
     treeItemLevelToken,
+    typographyStyles,
 } from "@fluentui/react-components";
 import {
     type FluentIcon,
@@ -483,6 +484,57 @@ function GetCommandDescription(command: SceneExplorerCommand): string {
     return command.hotKey ? `${command.displayName} (${GetCommandHotKeyDescription(command)})` : command.displayName;
 }
 
+const useTruncatingBody1Styles = makeStyles({
+    container: {
+        display: "block",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+        minWidth: 0,
+        ...typographyStyles.body1,
+    },
+});
+
+const TruncatingBody1: FunctionComponent<{ text: string }> = (props) => {
+    const { text } = props;
+    const classes = useTruncatingBody1Styles();
+    const ref = useRef<HTMLSpanElement | null>(null);
+    const [isTruncated, setIsTruncated] = useState(false);
+    const [isHovered, setIsHovered] = useState(false);
+
+    useEffect(() => {
+        const element = ref.current;
+        if (!element) {
+            return undefined;
+        }
+
+        const update = () => {
+            setIsTruncated(element.scrollWidth > element.clientWidth);
+        };
+
+        update();
+
+        const observer = new ResizeObserver(update);
+        observer.observe(element);
+        return () => observer.disconnect();
+    }, [text]);
+
+    return (
+        <Tooltip content={text} positioning="after" relationship="description" visible={isTruncated && isHovered} onVisibleChange={(_, data) => setIsHovered(data.visible)}>
+            {/*
+              Body1 isn't used here: it doesn't forward refs (so we can't measure the rendered element)
+              and it reapplies its own white-space styling that overrides ours when wrapped, which would
+              break truncation for names containing spaces. Instead, render a single ref'd <span> styled
+              with Fluent typography tokens so we get the same look while keeping full control over
+              truncation and overflow measurement.
+            */}
+            <span ref={ref} className={classes.container}>
+                {text}
+            </span>
+        </Tooltip>
+    );
+};
+
 const ActionCommand: FunctionComponent<{ command: SceneExplorerCommand<"inline", "action"> }> = (props) => {
     const { command } = props;
 
@@ -493,7 +545,7 @@ const ActionCommand: FunctionComponent<{ command: SceneExplorerCommand<"inline",
     );
 
     return (
-        <Tooltip content={GetCommandDescription(command)} relationship="label" positioning={"after"}>
+        <Tooltip content={GetCommandDescription(command)} relationship="label" positioning="after">
             <Button icon={<Icon />} appearance="subtle" onClick={() => execute()} />
         </Tooltip>
     );
@@ -513,6 +565,7 @@ const ToggleCommand: FunctionComponent<{ command: SceneExplorerCommand<"inline",
         <ToggleButton
             appearance="transparent"
             title={GetCommandDescription(command)}
+            titlePositioning="after"
             checkedIcon={Icon as FluentIcon}
             value={isEnabled}
             onChange={(val: boolean) => (command.isEnabled = val)}
@@ -844,11 +897,7 @@ const EntityTreeItem: FunctionComponent<
                             className: classes.treeItemLayoutMain,
                         }}
                     >
-                        <Tooltip content={name} relationship="description">
-                            <Body1 wrap={false} truncate>
-                                {name}
-                            </Body1>
-                        </Tooltip>
+                        <TruncatingBody1 text={name} />
                     </TreeItemLayout>
                 </FlatTreeItem>
             </MenuTrigger>

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/toggleButton.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/toggleButton.tsx
@@ -1,4 +1,4 @@
-import { ToggleButton as FluentToggleButton, makeStyles } from "@fluentui/react-components";
+import { ToggleButton as FluentToggleButton, makeStyles, type TooltipProps } from "@fluentui/react-components";
 import { type ButtonProps } from "./button";
 import { useCallback, useContext, useEffect, useState, type FunctionComponent } from "react";
 import { type FluentIcon } from "@fluentui/react-icons";
@@ -18,6 +18,7 @@ type ToggleButtonProps = Omit<ButtonProps, "icon" | "onClick"> & {
     checkedIcon: FluentIcon;
     uncheckedIcon?: FluentIcon;
     onChange: (checked: boolean) => void;
+    titlePositioning?: TooltipProps["positioning"];
 };
 
 /**
@@ -46,7 +47,7 @@ export const ToggleButton: FunctionComponent<ToggleButtonProps> = (props) => {
     }, [props.value]);
 
     return (
-        <Tooltip content={title ?? ""}>
+        <Tooltip content={title ?? ""} positioning={props.titlePositioning}>
             <FluentToggleButton
                 className={classes.button}
                 size={size}

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/tooltip.tsx
@@ -2,21 +2,31 @@ import { type Nullable } from "core/index";
 
 import { type ReactElement, forwardRef } from "react";
 
-import { Tooltip as FluentTooltip } from "@fluentui/react-components";
+import { Tooltip as FluentTooltip, type TooltipProps as FluentTooltipProps } from "@fluentui/react-components";
 
-export type TooltipProps = { content?: Nullable<string | ReactElement>; children: ReactElement };
+/**
+ * Props for the Tooltip primitive.
+ */
+export type TooltipProps = {
+    /** The tooltip content. If null/empty, the tooltip is not rendered. */
+    content?: Nullable<string | ReactElement>;
+    /** Optional positioning passed through to the underlying FluentTooltip. */
+    positioning?: FluentTooltipProps["positioning"];
+    /** The element that the tooltip is attached to. */
+    children: ReactElement;
+};
 
 // forwardRef wrapper to avoid "function components cannot be given refs" warning
 // FluentTooltip handles ref forwarding to children internally via applyTriggerPropsToChildren
 export const Tooltip = forwardRef<HTMLElement, TooltipProps>((props, _ref) => {
-    const { content, children } = props;
+    const { content, positioning, children } = props;
 
     if (!content) {
         return children;
     }
 
     return (
-        <FluentTooltip relationship="description" content={content}>
+        <FluentTooltip relationship="description" content={content} positioning={positioning}>
             {children}
         </FluentTooltip>
     );


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Two Inspector V2 improvements bundled together:

1. **Material texture debug toggle.** Adds a new `MaterialTextureDebugPropertyLine` that renders an inline "Display Texture for Debug" switch in the expanded content of each texture picker on `StandardMaterial`, `PBRMaterial`, and `OpenPBRMaterial` panels. When enabled, a `StandardMaterial` debug material is swapped onto all meshes using the original material, with the selected texture wired as `emissiveTexture` (and `disableLighting = true`), so the raw texture is rendered to screen. Enabling debug for one texture on a material disables it for any other texture on that material (mutually exclusive). Debug state is tracked on `material.reservedDataStore` so it survives selection changes, and the debug material is marked `hidden` so it doesn't appear in the scene explorer.

2. **Better scene explorer tooltips.** Replaces the always-on tooltip on entity tree item names with a `TruncatingBody1` component that only shows the tooltip when the text is actually truncated (measured via `ResizeObserver` + `scrollWidth > clientWidth`). Also adds `positioning="after"` on action and toggle command tooltips so they appear next to the buttons instead of overlapping the tree.

To support that, the shared `Tooltip` primitive gains an optional `positioning` prop pass-through, and `ToggleButton` gains an optional `titlePositioning` prop.

## Files changed

- New: `inspector-v2/.../materials/materialTextureDebugPropertyLine.tsx`
- Wired into: `openpbrMaterialProperties.tsx`, `pbrBaseMaterialProperties.tsx`, `standardMaterialProperties.tsx`
- Scene explorer tooltip improvements: `inspector-v2/.../scene/sceneExplorer.tsx`
- Shared primitive enhancements: `sharedUiComponents/.../primitives/{tooltip.tsx, toggleButton.tsx}`

<img width="1029" height="547" alt="image" src="https://github.com/user-attachments/assets/c90e5bbf-2fbf-46dd-8e5e-8c4d09852a2f" />
<img width="563" height="226" alt="image" src="https://github.com/user-attachments/assets/035472ec-4bd4-4c1a-ba06-97cc50e53ba4" />
