### PR TITLE
Prevent render target camera swaps from notifying active camera observers

### DIFF
--- a/packages/dev/core/src/Rendering/objectRenderer.ts
+++ b/packages/dev/core/src/Rendering/objectRenderer.ts
@@ -676,7 +676,8 @@ export class ObjectRenderer {
             if (!this.dontSetTransformationMatrix) {
                 this._scene.setTransformMatrix(camera.getViewMatrix(), camera.getProjectionMatrix(true));
             }
-            this._scene.activeCamera = camera;
+            // Use _activeCamera instead of activeCamera to avoid onActiveCameraChanged for this internal render pass.
+            this._scene._activeCamera = camera;
             this._engine.setViewport(camera.rigParent ? camera.rigParent.viewport : camera.viewport, viewportWidth, viewportHeight);
         }
 
@@ -701,7 +702,8 @@ export class ObjectRenderer {
             scene.imageProcessingConfiguration._applyByPostProcess = this._currentApplyByPostProcessSetting;
         }
 
-        scene.activeCamera = this._currentSceneCamera;
+        // Use _activeCamera instead of activeCamera to avoid onActiveCameraChanged for this internal render pass.
+        scene._activeCamera = this._currentSceneCamera;
         if (this._currentSceneCamera) {
             if (this.activeCamera && this.activeCamera !== scene.activeCamera) {
                 scene.setTransformMatrix(this._currentSceneCamera.getViewMatrix(), this._currentSceneCamera.getProjectionMatrix(true));

--- a/packages/dev/core/test/unit/Rendering/objectRenderer.shouldRender.test.ts
+++ b/packages/dev/core/test/unit/Rendering/objectRenderer.shouldRender.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NullEngine } from "core/Engines/nullEngine";
 import { type Engine } from "core/Engines/engine";
 import { Scene } from "core/scene";
 import { ObjectRenderer } from "core/Rendering/objectRenderer";
+import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
+import { Vector3 } from "core/Maths/math.vector";
 
 describe("ObjectRenderer.shouldRender", () => {
     let engine: Engine;
@@ -88,6 +90,25 @@ describe("ObjectRenderer.shouldRender", () => {
         expect(renderer.shouldRender()).toBe(false);
         expect(renderer.shouldRender()).toBe(false);
         expect(renderer.shouldRender()).toBe(true);
+
+        renderer.dispose();
+    });
+
+    it("should not notify active camera observers while using a render target camera", () => {
+        const sceneCamera = new ArcRotateCamera("sceneCamera", 0, 0, 10, Vector3.Zero(), scene);
+        const renderTargetCamera = new ArcRotateCamera("renderTargetCamera", 0, 0, 10, Vector3.Zero(), scene);
+        const renderer = new ObjectRenderer("test", scene);
+        const activeCameraChanged = vi.fn();
+
+        renderer.activeCamera = renderTargetCamera;
+        scene.onActiveCameraChanged.add(activeCameraChanged);
+
+        renderer.initRender(256, 256);
+        expect(scene.activeCamera).toBe(renderTargetCamera);
+
+        renderer.finishRender();
+        expect(scene.activeCamera).toBe(sceneCamera);
+        expect(activeCameraChanged).not.toHaveBeenCalled();
 
         renderer.dispose();
     });


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Motivation
Fixes a forum-reported issue where enabling `CascadedShadowGenerator.autoCalcDepthBounds` could trigger `Scene.onActiveCameraChanged` during internal depth/render-target passes. In affected scenes, user code that detaches and reattaches camera controls on active-camera changes caused FlyCamera controls to be churned during rendering.

Forum: https://forum.babylonjs.com/t/shadow-autocalcdepthbounds-will-affect-the-flight-speed-of-the-fly-camera/63525

## Changes
- Updates `ObjectRenderer` to use the internal `_activeCamera` field while temporarily switching cameras for render-target rendering, matching the existing internal scene camera rendering pattern.
- Restores the original scene camera without firing `onActiveCameraChanged` for the internal render pass.
- Adds a unit regression test covering render-target camera usage without active-camera observer notifications.

## Validation
- `npx vitest run --project=unit packages\dev\core\test\unit\Rendering\objectRenderer.shouldRender.test.ts`
- `npx prettier --check packages\dev\core\src\Rendering\objectRenderer.ts packages\dev\core\test\unit\Rendering\objectRenderer.shouldRender.test.ts`
- `npx eslint packages\dev\core\src\Rendering\objectRenderer.ts packages\dev\core\test\unit\Rendering\objectRenderer.shouldRender.test.ts --quiet --cache --no-warn-ignored`

Note: Full `npm run lint:check` and `npm run test:unit` currently fail on unrelated existing baseline issues outside this change.