### PR TITLE
Fix Playground loading with older framework versions

### DIFF
--- a/packages/tools/playground/src/components/rendererComponent.tsx
+++ b/packages/tools/playground/src/components/rendererComponent.tsx
@@ -144,11 +144,13 @@ export class RenderingComponent extends React.Component<IRenderingComponentProps
         // SAMs created asynchronously - after runner.run() returns, e.g. from
         // a setTimeout, deferred load, or user interaction - still get bridged.
         // The `if (!manager.onAssetNotFound)` guard makes re-fires across runs safe.
-        this._smartAssetManagerCreatedObserver = AddSmartAssetManagerCreatedObserver((manager: SmartAssetManager) => {
-            if (!manager.onAssetNotFound) {
-                manager.onAssetNotFound = async (key, expectedUrl) => await this._resolveMissingSmartAssetWithInspectorAsync(manager.scene, key, expectedUrl);
-            }
-        });
+        if (typeof AddSmartAssetManagerCreatedObserver === "function") {
+            this._smartAssetManagerCreatedObserver = AddSmartAssetManagerCreatedObserver((manager: SmartAssetManager) => {
+                if (!manager.onAssetNotFound) {
+                    manager.onAssetNotFound = async (key, expectedUrl) => await this._resolveMissingSmartAssetWithInspectorAsync(manager.scene, key, expectedUrl);
+                }
+            });
+        }
     }
 
     /**

--- a/packages/tools/playground/test/unit/rendererComponent.test.ts
+++ b/packages/tools/playground/test/unit/rendererComponent.test.ts
@@ -14,6 +14,14 @@ vi.mock("../../src/tools/utilities", () => ({
     },
 }));
 
+vi.mock("@dev/core", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@dev/core")>();
+    return {
+        ...actual,
+        AddSmartAssetManagerCreatedObserver: undefined,
+    };
+});
+
 import { Observable } from "@dev/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RenderingComponent } from "../../src/components/rendererComponent";
@@ -70,6 +78,12 @@ describe("RenderingComponent", () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+    });
+
+    it("constructs when the loaded framework does not expose Smart Asset observer registration", () => {
+        const globalState = createMockGlobalState();
+
+        expect(() => new RenderingComponent({ globalState })).not.toThrow();
     });
 
     it("does not close Inspector when Smart Assets already reopened it during a run", async () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Guard Playground Smart Asset observer registration when the loaded Babylon.js framework version does not expose `AddSmartAssetManagerCreatedObserver`.
- Add unit coverage for constructing `RenderingComponent` against older framework globals.

## Motivation
The Playground still rewrites framework bundles for `?version=...`, but the current React Playground bundle can run against older Babylon.js versions. For example, `?version=8.56.2` loads Babylon.js 8.56.2 successfully, but the UI crashes before mounting because that framework version does not include the newer Smart Asset observer registration API.

## Behavior
Older framework versions can mount and run normally again. Smart Asset missing-file Inspector bridging remains enabled for framework versions that expose the observer API.
