### PR TITLE
fix(eslint): make require-pure-annotation autofix conservative

### DIFF
--- a/packages/tools/eslintBabylonPlugin/src/index.ts
+++ b/packages/tools/eslintBabylonPlugin/src/index.ts
@@ -945,30 +945,6 @@ const plugin: IPlugin = {
                     return node;
                 }
 
-                function getCalleeName(node: any): string | undefined {
-                    node = unwrapExpression(node);
-                    if (node?.type === "Identifier") {
-                        return node.name;
-                    }
-                    if (node?.type === "MemberExpression" && !node.computed) {
-                        return getCalleeName(node.property);
-                    }
-                    return undefined;
-                }
-
-                function getCalleePath(node: any): string | undefined {
-                    node = unwrapExpression(node);
-                    if (node?.type === "Identifier") {
-                        return node.name;
-                    }
-                    if (node?.type === "MemberExpression" && !node.computed) {
-                        const objectPath = getCalleePath(node.object);
-                        const propertyName = getCalleeName(node.property);
-                        return objectPath && propertyName ? `${objectPath}.${propertyName}` : undefined;
-                    }
-                    return undefined;
-                }
-
                 function isSimplePureArgument(node: any): boolean {
                     node = unwrapExpression(node);
                     if (!node) {
@@ -982,6 +958,10 @@ const plugin: IPlugin = {
                         case "TemplateLiteral":
                             return node.expressions.length === 0;
                         case "UnaryExpression":
+                            // Reject side-effecting unary operators; allow safe ones.
+                            if (node.operator === "delete") {
+                                return false;
+                            }
                             return isSimplePureArgument(node.argument);
                         case "ArrayExpression":
                             return node.elements.every((element: any) => element !== null && element.type !== "SpreadElement" && isSimplePureArgument(element));
@@ -1003,13 +983,31 @@ const plugin: IPlugin = {
 
                 function isSafelyAutofixablePureExpression(node: any): boolean {
                     if (node.type === "NewExpression") {
-                        const calleeName = getCalleeName(node.callee);
-                        return !!calleeName && safelyAutofixablePureConstructors.has(calleeName) && hasOnlySimplePureArguments(node);
+                        // Only accept a plain Identifier callee (e.g. `new Vector3()`).
+                        // Member-expression callees like `new SomeNamespace.Vector3()` are
+                        // rejected because the trailing name alone cannot confirm the type.
+                        const calleeNode = unwrapExpression(node.callee);
+                        if (!calleeNode || calleeNode.type !== "Identifier") {
+                            return false;
+                        }
+                        return safelyAutofixablePureConstructors.has(calleeNode.name) && hasOnlySimplePureArguments(node);
                     }
 
                     if (node.type === "CallExpression") {
-                        const calleePath = getCalleePath(node.callee);
-                        return !!calleePath && calleePath.startsWith("Math.") && hasOnlySimplePureArguments(node);
+                        // Only accept a direct `Math.<identifier>(...)` call —
+                        // not chains like `Math.abs.call(...)` / `Math.max.bind(...)`.
+                        const calleeNode = unwrapExpression(node.callee);
+                        if (
+                            !calleeNode ||
+                            calleeNode.type !== "MemberExpression" ||
+                            calleeNode.computed ||
+                            calleeNode.object?.type !== "Identifier" ||
+                            calleeNode.object.name !== "Math" ||
+                            calleeNode.property?.type !== "Identifier"
+                        ) {
+                            return false;
+                        }
+                        return hasOnlySimplePureArguments(node);
                     }
 
                     return false;

--- a/packages/tools/eslintBabylonPlugin/src/index.ts
+++ b/packages/tools/eslintBabylonPlugin/src/index.ts
@@ -869,13 +869,21 @@ const plugin: IPlugin = {
                         "Call/new expression in a .pure.ts file must be annotated with /*#__PURE__*/. " + "Without it, bundlers cannot tree-shake this code. Expression: {{expr}}",
                 },
             },
-            create(context: { filename?: string; getFilename?: () => string; sourceCode?: any; getSourceCode?: () => any; report: (desc: any) => void }) {
-                const filename = context.filename ?? context.getFilename?.() ?? "";
+            create(context: eslint.Rule.RuleContext) {
+                const filename = context.filename;
                 if (!filename.endsWith(".pure.ts")) {
                     return {};
                 }
 
-                const sourceCode = context.sourceCode ?? context.getSourceCode?.();
+                const sourceCode = context.sourceCode;
+
+                type TypeScriptExpressionWrapper = ESTree.BaseExpression & {
+                    type: "TSAsExpression" | "TSTypeAssertion" | "TSSatisfiesExpression" | "TSNonNullExpression";
+                    expression: PureAnnotationNode;
+                };
+
+                type PureAnnotationNode = ESTree.Node | TypeScriptExpressionWrapper;
+                type PureAnnotationCallOrNewExpression = ESTree.SimpleCallExpression | ESTree.NewExpression;
 
                 /**
                  * Unwrap TS type assertions (e.g. `new Foo() as Bar`) to find the
@@ -883,14 +891,14 @@ const plugin: IPlugin = {
                  * @param node - The AST node to unwrap.
                  * @returns The unwrapped CallExpression/NewExpression, or null.
                  */
-                function findCallOrNew(node: any): any {
+                function findCallOrNew(node: PureAnnotationNode | null | undefined): PureAnnotationCallOrNewExpression | null {
                     if (!node) {
                         return null;
                     }
                     if (node.type === "NewExpression" || node.type === "CallExpression") {
                         return node;
                     }
-                    if (node.type === "TSAsExpression" || node.type === "TSTypeAssertion" || node.type === "TSSatisfiesExpression") {
+                    if (node.type === "TSAsExpression" || node.type === "TSTypeAssertion" || node.type === "TSSatisfiesExpression" || node.type === "TSNonNullExpression") {
                         return findCallOrNew(node.expression);
                     }
                     return null;
@@ -901,9 +909,9 @@ const plugin: IPlugin = {
                  * @param node - The AST node to check.
                  * @returns True if a #__PURE__ annotation precedes the node.
                  */
-                function hasPureAnnotation(node: any): boolean {
+                function hasPureAnnotation(node: PureAnnotationCallOrNewExpression): boolean {
                     // getCommentsBefore returns leading comments attached to the node
-                    const comments = sourceCode.getCommentsBefore?.(node) ?? [];
+                    const comments = sourceCode.getCommentsBefore(node);
                     for (const c of comments) {
                         if (c.type === "Block" && c.value.trim() === "#__PURE__") {
                             return true;
@@ -911,14 +919,14 @@ const plugin: IPlugin = {
                     }
                     // Also check the immediately preceding token (comment) in case
                     // ESLint attached it differently
-                    const prev = sourceCode.getTokenBefore?.(node, { includeComments: true });
+                    const prev = sourceCode.getTokenBefore(node, { includeComments: true });
                     if (prev && prev.type === "Block" && prev.value?.trim() === "#__PURE__") {
                         return true;
                     }
                     return false;
                 }
 
-                const safelyAutofixablePureConstructors = new Set([
+                const safelyAutofixablePureConstructors = new Set<string>([
                     "Map",
                     "Set",
                     "WeakMap",
@@ -935,7 +943,7 @@ const plugin: IPlugin = {
                     "Viewport",
                 ]);
 
-                function unwrapExpression(node: any): any {
+                function unwrapExpression(node: PureAnnotationNode | null | undefined): PureAnnotationNode | null | undefined {
                     if (!node) {
                         return node;
                     }
@@ -945,28 +953,28 @@ const plugin: IPlugin = {
                     return node;
                 }
 
-                function isSimplePureArgument(node: any): boolean {
-                    node = unwrapExpression(node);
-                    if (!node) {
+                function isSimplePureArgument(node: PureAnnotationNode | null | undefined): boolean {
+                    const unwrappedNode = unwrapExpression(node);
+                    if (!unwrappedNode) {
                         return true;
                     }
-                    switch (node.type) {
+                    switch (unwrappedNode.type) {
                         case "Identifier":
                         case "Literal":
                         case "ThisExpression":
                             return true;
                         case "TemplateLiteral":
-                            return node.expressions.length === 0;
+                            return unwrappedNode.expressions.length === 0;
                         case "UnaryExpression":
                             // Reject side-effecting unary operators; allow safe ones.
-                            if (node.operator === "delete") {
+                            if (unwrappedNode.operator === "delete") {
                                 return false;
                             }
-                            return isSimplePureArgument(node.argument);
+                            return isSimplePureArgument(unwrappedNode.argument);
                         case "ArrayExpression":
-                            return node.elements.every((element: any) => element !== null && element.type !== "SpreadElement" && isSimplePureArgument(element));
+                            return unwrappedNode.elements.every((element) => element !== null && element.type !== "SpreadElement" && isSimplePureArgument(element));
                         case "ObjectExpression":
-                            return node.properties.every((property: any) => {
+                            return unwrappedNode.properties.every((property) => {
                                 if (property.type === "SpreadElement" || property.computed) {
                                     return false;
                                 }
@@ -977,11 +985,14 @@ const plugin: IPlugin = {
                     }
                 }
 
-                function hasOnlySimplePureArguments(node: any): boolean {
-                    return (node.arguments ?? []).every((argument: any) => isSimplePureArgument(argument));
+                function hasOnlySimplePureArguments(node: PureAnnotationCallOrNewExpression): boolean {
+                    // Keep autofix limited to arguments that are already values or literal containers.
+                    // For example, `new Vector3(GetXValue(), 0, 0)` still needs manual review because
+                    // the argument call may have side effects even though `Vector3` itself is safe.
+                    return node.arguments.every((argument) => isSimplePureArgument(argument));
                 }
 
-                function isSafelyAutofixablePureExpression(node: any): boolean {
+                function isSafelyAutofixablePureExpression(node: PureAnnotationCallOrNewExpression): boolean {
                     if (node.type === "NewExpression") {
                         // Only accept a plain Identifier callee (e.g. `new Vector3()`).
                         // Member-expression callees like `new SomeNamespace.Vector3()` are
@@ -1013,14 +1024,14 @@ const plugin: IPlugin = {
                     return false;
                 }
 
-                function reportMissing(callOrNew: any) {
+                function reportMissing(callOrNew: PureAnnotationCallOrNewExpression) {
                     const text = sourceCode.getText(callOrNew);
                     const canAutofix = isSafelyAutofixablePureExpression(callOrNew);
                     context.report({
                         node: callOrNew,
                         messageId: "missing-pure-annotation",
                         data: { expr: text.length > 60 ? text.slice(0, 57) + "..." : text },
-                        fix: canAutofix ? (fixer: any) => fixer.insertTextBefore(callOrNew, "/*#__PURE__*/ ") : undefined,
+                        fix: canAutofix ? (fixer: eslint.Rule.RuleFixer) => fixer.insertTextBefore(callOrNew, "/*#__PURE__*/ ") : undefined,
                     });
                 }
 

--- a/packages/tools/eslintBabylonPlugin/src/index.ts
+++ b/packages/tools/eslintBabylonPlugin/src/index.ts
@@ -918,15 +918,111 @@ const plugin: IPlugin = {
                     return false;
                 }
 
+                const safelyAutofixablePureConstructors = new Set([
+                    "Map",
+                    "Set",
+                    "WeakMap",
+                    "WeakSet",
+                    "Color3",
+                    "Color4",
+                    "Matrix",
+                    "Plane",
+                    "Quaternion",
+                    "Size",
+                    "Vector2",
+                    "Vector3",
+                    "Vector4",
+                    "Viewport",
+                ]);
+
+                function unwrapExpression(node: any): any {
+                    if (!node) {
+                        return node;
+                    }
+                    if (node.type === "TSAsExpression" || node.type === "TSTypeAssertion" || node.type === "TSSatisfiesExpression" || node.type === "TSNonNullExpression") {
+                        return unwrapExpression(node.expression);
+                    }
+                    return node;
+                }
+
+                function getCalleeName(node: any): string | undefined {
+                    node = unwrapExpression(node);
+                    if (node?.type === "Identifier") {
+                        return node.name;
+                    }
+                    if (node?.type === "MemberExpression" && !node.computed) {
+                        return getCalleeName(node.property);
+                    }
+                    return undefined;
+                }
+
+                function getCalleePath(node: any): string | undefined {
+                    node = unwrapExpression(node);
+                    if (node?.type === "Identifier") {
+                        return node.name;
+                    }
+                    if (node?.type === "MemberExpression" && !node.computed) {
+                        const objectPath = getCalleePath(node.object);
+                        const propertyName = getCalleeName(node.property);
+                        return objectPath && propertyName ? `${objectPath}.${propertyName}` : undefined;
+                    }
+                    return undefined;
+                }
+
+                function isSimplePureArgument(node: any): boolean {
+                    node = unwrapExpression(node);
+                    if (!node) {
+                        return true;
+                    }
+                    switch (node.type) {
+                        case "Identifier":
+                        case "Literal":
+                        case "ThisExpression":
+                            return true;
+                        case "TemplateLiteral":
+                            return node.expressions.length === 0;
+                        case "UnaryExpression":
+                            return isSimplePureArgument(node.argument);
+                        case "ArrayExpression":
+                            return node.elements.every((element: any) => element !== null && element.type !== "SpreadElement" && isSimplePureArgument(element));
+                        case "ObjectExpression":
+                            return node.properties.every((property: any) => {
+                                if (property.type === "SpreadElement" || property.computed) {
+                                    return false;
+                                }
+                                return isSimplePureArgument(property.value);
+                            });
+                        default:
+                            return false;
+                    }
+                }
+
+                function hasOnlySimplePureArguments(node: any): boolean {
+                    return (node.arguments ?? []).every((argument: any) => isSimplePureArgument(argument));
+                }
+
+                function isSafelyAutofixablePureExpression(node: any): boolean {
+                    if (node.type === "NewExpression") {
+                        const calleeName = getCalleeName(node.callee);
+                        return !!calleeName && safelyAutofixablePureConstructors.has(calleeName) && hasOnlySimplePureArguments(node);
+                    }
+
+                    if (node.type === "CallExpression") {
+                        const calleePath = getCalleePath(node.callee);
+                        return !!calleePath && calleePath.startsWith("Math.") && hasOnlySimplePureArguments(node);
+                    }
+
+                    return false;
+                }
+
                 function reportMissing(callOrNew: any) {
                     const text = sourceCode.getText(callOrNew);
+                    const canAutofix = isSafelyAutofixablePureExpression(callOrNew);
                     context.report({
                         node: callOrNew,
                         messageId: "missing-pure-annotation",
                         data: { expr: text.length > 60 ? text.slice(0, 57) + "..." : text },
-                        fix(fixer: any) {
-                            return fixer.insertTextBefore(callOrNew, "/*#__PURE__*/ ");
-                        },
+                        fix: canAutofix ? (fixer: any) => fixer.insertTextBefore(callOrNew, "/*#__PURE__*/ ") : undefined,
                     });
                 }
 


### PR DESCRIPTION
## Summary

The `require-pure-annotation` ESLint rule previously offered an automatic `/*#__PURE__*/` fix for **every** top-level call/new expression in `.pure.ts` files — including unknown constructors that might genuinely have runtime side effects.

This changes the autofix to be **conservative**:

- The fix is still applied automatically for a safe-listed set of known side-effect-free constructors:
  - JS builtins: `Map`, `Set`, `WeakMap`, `WeakSet`
  - Babylon math value types: `Vector2`, `Vector3`, `Vector4`, `Color3`, `Color4`, `Matrix`, `Plane`, `Quaternion`, `Size`, `Viewport`
  - `Math.*` calls (e.g. `Math.abs(...)`, `Math.sqrt(...)`)
- Arguments are also checked — autofix only applies when all arguments are simple literals, identifiers, or static object/array literals (no nested calls, no spread, no computed properties).
- For **unknown** constructors, factory calls, or expressions with non-trivial arguments, the rule still reports the missing annotation as an **error** but provides **no autofix**. The developer must consciously add `/*#__PURE__*/` after verifying purity.

## Before

```ts
// eslint --fix would silently annotate this as pure:
const x = new SomeUnknownClass(); // → /*#__PURE__*/ new SomeUnknownClass()
```

Even if `SomeUnknownClass` registers globals, mutates prototypes, etc.

## After

| Expression | Reported | Autofixed |
|---|---|---|
| `new WeakMap<K,V>()` | only if unannotated | ✅ |
| `new Vector3(1, 2, 3)` | only if unannotated | ✅ |
| `new SomeUnknownClass()` | ✅ always | ❌ manual |
| `new WeakMap(getEntries())` | ✅ always | ❌ manual |
| `createSomething()` | ✅ always | ❌ manual |