### PR TITLE
Properly await async GUI playground setup in visual tests

### DIFF
--- a/packages/tools/testTools/src/visualizationUtils.ts
+++ b/packages/tools/testTools/src/visualizationUtils.ts
@@ -215,6 +215,7 @@ export const evaluateRenderSceneForVisualization = async (renderCount: number) =
                             window.engine && window.engine.stopRenderLoop();
                             return resolve(true);
                         } else {
+                            window.engine && window.engine.stopRenderLoop();
                             console.error("Scene is not ready after rendering is done");
                             return resolve(false);
                         }

--- a/packages/tools/testTools/src/visualizationUtils.ts
+++ b/packages/tools/testTools/src/visualizationUtils.ts
@@ -211,14 +211,12 @@ export const evaluateRenderSceneForVisualization = async (renderCount: number) =
             window.engine.runRenderLoop(function () {
                 try {
                     if (renderCount <= 0) {
-                        if (window.scene!.isReady()) {
-                            window.engine && window.engine.stopRenderLoop();
-                            return resolve(true);
-                        } else {
-                            window.engine && window.engine.stopRenderLoop();
+                        window.engine && window.engine.stopRenderLoop();
+                        const ready = window.scene!.isReady();
+                        if (!ready) {
                             console.error("Scene is not ready after rendering is done");
-                            return resolve(false);
                         }
+                        return resolve(ready);
                     } else {
                         window.scene && window.scene.render();
                         renderCount--;

--- a/packages/tools/testTools/src/visualizationUtils.ts
+++ b/packages/tools/testTools/src/visualizationUtils.ts
@@ -208,14 +208,9 @@ export const evaluateRenderSceneForVisualization = async (renderCount: number) =
             if (window.scene.activeCamera && (window.scene.activeCamera as any).useAutoRotationBehavior) {
                 (window.scene.activeCamera as any).useAutoRotationBehavior = false;
             }
-            const sceneAdts: any[] = window.scene.textures.filter((t: any) => t.getClassName() === "AdvancedDynamicTexture");
-            const adtsAreReady = () => {
-                return sceneAdts.every((adt: any) => adt.guiIsReady());
-            };
-            let renderAfterGuiIsReadyCount = 1;
             window.engine.runRenderLoop(function () {
                 try {
-                    if (renderCount <= 0 && renderAfterGuiIsReadyCount <= 0) {
+                    if (renderCount <= 0) {
                         if (window.scene!.isReady()) {
                             window.engine && window.engine.stopRenderLoop();
                             return resolve(true);
@@ -226,9 +221,6 @@ export const evaluateRenderSceneForVisualization = async (renderCount: number) =
                     } else {
                         window.scene && window.scene.render();
                         renderCount--;
-                        if (adtsAreReady()) {
-                            renderAfterGuiIsReadyCount--;
-                        }
                     }
                 } catch (e) {
                     window.engine && window.engine.stopRenderLoop();

--- a/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
+++ b/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
@@ -598,14 +598,9 @@ export const evaluateRenderSceneForVisualization = async ({ renderCount, continu
             if (window.scene.activeCamera && (window.scene.activeCamera as any).useAutoRotationBehavior) {
                 (window.scene.activeCamera as any).useAutoRotationBehavior = false;
             }
-            const sceneAdts: any[] = window.scene!.textures.filter((t: any) => t.getClassName() === "AdvancedDynamicTexture");
-            const adtsAreReady = () => {
-                return sceneAdts.every((adt: any) => adt.guiIsReady());
-            };
-            let renderAfterGuiIsReadyCount = 1;
             window.engine.runRenderLoop(function () {
                 try {
-                    if (renderCount <= 0 && renderAfterGuiIsReadyCount <= 0) {
+                    if (renderCount <= 0) {
                         if (window.scene!.isReady()) {
                             if (continueRenderingOnDone) {
                                 window.scene && window.scene.render();
@@ -621,9 +616,6 @@ export const evaluateRenderSceneForVisualization = async ({ renderCount, continu
                         (window as any).onRenderCallback && (window as any).onRenderCallback();
                         window.scene && window.scene.render();
                         renderCount--;
-                        if (adtsAreReady()) {
-                            renderAfterGuiIsReadyCount--;
-                        }
                     }
                 } catch (e) {
                     window.engine && window.engine.stopRenderLoop();

--- a/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
+++ b/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
@@ -601,18 +601,18 @@ export const evaluateRenderSceneForVisualization = async ({ renderCount, continu
             window.engine.runRenderLoop(function () {
                 try {
                     if (renderCount <= 0) {
-                        if (window.scene!.isReady()) {
+                        const ready = window.scene!.isReady();
+                        if (!ready || !continueRenderingOnDone) {
+                            window.engine && window.engine.stopRenderLoop();
+                        }
+                        if (ready) {
                             if (continueRenderingOnDone) {
                                 window.scene && window.scene.render();
-                            } else {
-                                window.engine && window.engine.stopRenderLoop();
                             }
-                            return resolve(true);
                         } else {
-                            window.engine && window.engine.stopRenderLoop();
                             console.error("Scene is not ready after rendering is done");
-                            return resolve(false);
                         }
+                        return resolve(ready);
                     } else {
                         (window as any).onRenderCallback && (window as any).onRenderCallback();
                         window.scene && window.scene.render();

--- a/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
+++ b/packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts
@@ -609,6 +609,7 @@ export const evaluateRenderSceneForVisualization = async ({ renderCount, continu
                             }
                             return resolve(true);
                         } else {
+                            window.engine && window.engine.stopRenderLoop();
                             console.error("Scene is not ready after rendering is done");
                             return resolve(false);
                         }

--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -2604,14 +2604,14 @@
         },
         {
             "title": "Load GUI snippet with unicode",
-            "playgroundId": "#YS93KY",
+            "playgroundId": "#YS93KY#1",
             "referenceImage": "loadGuiSnippetWithUnicode.png",
             "errorRatio": 4,
             "dependsOn": ["GUI", "Textures"]
         },
         {
             "title": "Parse GUI json with unicode",
-            "playgroundId": "#ERVGT5",
+            "playgroundId": "#ERVGT5#1",
             "referenceImage": "parseGuiJsonWithUnicode.png",
             "errorRatio": 4,
             "dependsOn": ["GUI", "Textures"]


### PR DESCRIPTION
## Context

The visualization test runner has special-case logic that, after the per-test `renderCount` is exhausted, keeps rendering until every `AdvancedDynamicTexture` reports `guiIsReady()` and then renders one more frame. This was [introduced in #13475](https://github.com/BabylonJS/Babylon.js/pull/13475) to give GUI-based PGs time to finish loading before the screenshot is captured.

It doesn't actually solve the race for PGs that fire-and-forget `parseFromSnippetAsync` / `parseFromURLAsync`: while the snippet fetch is still in flight, the ADT root container has zero children, `Container.isReady()` iterates an empty array and returns `true`, so `guiIsReady()` is satisfied immediately. The gate only adds a settle frame for image loads on controls that are *already* in the tree.

It also bakes GUI-specific knowledge into a generic test runner. The correct contract is: a PG whose setup is async returns `Promise<Scene>` from `createScene` and the runner awaits it. The runner already does `await (createScene(engine, canvas) ?? createScene())`, so no runner-side framework change is needed beyond removing the gate.

## Changes

- Drop the `guiIsReady()` gate from both viz runners:
  - `packages/tools/tests/test/playwright/visualizationPlaywright.utils.ts`
  - `packages/tools/testTools/src/visualizationUtils.ts`
- Update the two PGs that needed the workaround to actually follow the `Promise<Scene>` contract, by saving new revisions:
  - `#YS93KY#0` → `#YS93KY#1` (Load GUI snippet with unicode) — `return adv.parseFromSnippetAsync("#KHPNS9").then(() => scene);`
  - `#ERVGT5#0` → `#ERVGT5#1` (Parse GUI json with unicode) — `return adv.parseFromURLAsync(...).then(() => scene);`
- Pin the BJS viz config to the new revisions.

## Notes

- The `AdvancedDynamicTexture.guiIsReady()` / `onGuiReadyObservable` API itself is **not** removed — only its usage in the test runner. It is still used internally by `FrameGraph/guiTask.ts` and remains available to anyone who wants it.
- BabylonNative was hitting the same flake on slow CI runners ([BabylonNative#1716](https://github.com/BabylonJS/BabylonNative/pull/1716) carries a temporary BN-side workaround). Once this PR lands and a fresh nightly UMD ships, that workaround will be removed in BN.

[Created by Copilot on behalf of @bghgary]
