### PR TITLE
Add an option to disable teaching moments

### DIFF
--- a/packages/dev/inspector-v2/src/inspector.tsx
+++ b/packages/dev/inspector-v2/src/inspector.tsx
@@ -430,6 +430,7 @@ export function ShowInspector(scene: Scene, options: Partial<InspectorOptions> =
             sidePaneRemapper: options.sidePaneRemapper,
             leftPaneDefaultCollapsed: options.leftPaneDefaultCollapsed,
             rightPaneDefaultCollapsed: options.rightPaneDefaultCollapsed,
+            disableTeachingMoments: options.disableTeachingMoments,
         });
         disposeActions.push(async () => await modularTool.dispose());
 

--- a/packages/dev/sharedUiComponents/src/modularTool/contexts/teachingMomentsContext.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/contexts/teachingMomentsContext.ts
@@ -2,7 +2,9 @@ import { createContext, useContext } from "react";
 
 type TeachingMomentsContext = {
     /**
-     * When true, all teaching moments are suppressed regardless of their individual state.
+     * When true, all teaching moments are suppressed regardless of any caller-supplied
+     * `suppress` argument and regardless of whether the user has previously dismissed
+     * the teaching moment.
      */
     disabled: boolean;
 };

--- a/packages/dev/sharedUiComponents/src/modularTool/contexts/teachingMomentsContext.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/contexts/teachingMomentsContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+type TeachingMomentsContext = {
+    /**
+     * When true, all teaching moments are suppressed regardless of their individual state.
+     */
+    disabled: boolean;
+};
+
+export const TeachingMomentsContext = createContext<TeachingMomentsContext>({ disabled: false });
+
+/**
+ * Returns the teaching moments context provided by the surrounding modular tool framework.
+ * @returns The current teaching moments context.
+ */
+export function useTeachingMomentsContext(): TeachingMomentsContext {
+    return useContext(TeachingMomentsContext);
+}

--- a/packages/dev/sharedUiComponents/src/modularTool/hooks/teachingMomentHooks.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/hooks/teachingMomentHooks.ts
@@ -4,6 +4,7 @@ import { type OnOpenChangeData, type PositioningImperativeRef } from "@fluentui/
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSetting } from "./settingsHooks";
+import { useTeachingMomentsContext } from "../contexts/teachingMomentsContext";
 
 import { AsyncLock } from "core/Misc/asyncLock";
 import { Deferred } from "core/Misc/deferred";
@@ -17,6 +18,8 @@ const SequencerLock = new AsyncLock();
  */
 export function MakeTeachingMoment(name: string) {
     return (suppress?: boolean) => {
+        const { disabled } = useTeachingMomentsContext();
+        suppress = suppress || disabled;
         const [hasDisplayed, setHasDisplayed, resetDisplayed] = useSetting({ key: `TeachingMoments/${name}`, defaultValue: false });
         const [shouldDisplay, setShouldDisplay] = useState(false);
 

--- a/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
+++ b/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
@@ -252,14 +252,13 @@ export function MakeModularTool(options: ModularToolOptions) {
                     produces: [ReactContextServiceIdentity],
                     factory: (): IReactContextService => ({
                         addContext<T>(provider: Context<T>["Provider"], initialValue: T, options?: { order?: number }): ReactContextHandle<T> {
-                            const typedProvider = provider;
-                            updateContexts({ type: "add", entry: { provider: typedProvider, value: initialValue, order: options?.order ?? 0 } });
+                            updateContexts({ type: "add", entry: { provider: provider, value: initialValue, order: options?.order ?? 0 } });
                             return {
                                 updateValue: (newValue: T) => {
-                                    updateContexts({ type: "update", provider: typedProvider, value: newValue });
+                                    updateContexts({ type: "update", provider: provider, value: newValue });
                                 },
                                 dispose: () => {
-                                    updateContexts({ type: "remove", provider: typedProvider });
+                                    updateContexts({ type: "remove", provider: provider });
                                 },
                             };
                         },

--- a/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
+++ b/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
@@ -96,15 +96,15 @@ const useStyles = makeStyles({
 });
 
 type ReactContextEntry = {
-    provider: Context<unknown>["Provider"];
+    provider: Context<any>["Provider"];
     value: unknown;
     order: number;
 };
 
 type ReactContextAction =
     | { type: "add"; entry: ReactContextEntry }
-    | { type: "remove"; provider: Context<unknown>["Provider"] }
-    | { type: "update"; provider: Context<unknown>["Provider"]; value: unknown };
+    | { type: "remove"; provider: Context<any>["Provider"] }
+    | { type: "update"; provider: Context<any>["Provider"]; value: unknown };
 
 type DialogQueueAction = { type: "enqueue"; options: DialogOptions } | { type: "dequeue" };
 
@@ -178,7 +178,6 @@ export function MakeModularTool(options: ModularToolOptions) {
 
     const modularToolRootComponent: FunctionComponent = () => {
         const classes = useStyles();
-        const [extensionManagerContext, setExtensionManagerContext] = useState<ExtensionManagerContext>();
         const [requiredExtensions, setRequiredExtensions] = useState<string[]>();
         const [requiredExtensionsDeferred, setRequiredExtensionsDeferred] = useState<Deferred<boolean>>();
         const [extensionInstallError, setExtensionInstallError] = useState<InstallFailedInfo>();
@@ -215,16 +214,25 @@ export function MakeModularTool(options: ModularToolOptions) {
 
         const [rootComponentService, setRootComponentService] = useState<IRootComponentService>();
 
-        const [contexts, updateContexts] = useReducer((state: ReactContextEntry[], action: ReactContextAction): ReactContextEntry[] => {
-            switch (action.type) {
-                case "add":
-                    return [...state, action.entry].sort((a, b) => a.order - b.order);
-                case "remove":
-                    return state.filter((e) => e.provider !== action.provider);
-                case "update":
-                    return state.map((e) => (e.provider === action.provider ? { ...e, value: action.value } : e));
-            }
-        }, []);
+        const [contexts, updateContexts] = useReducer(
+            (state: ReactContextEntry[], action: ReactContextAction): ReactContextEntry[] => {
+                switch (action.type) {
+                    case "add":
+                        return [...state, action.entry].sort((a, b) => a.order - b.order);
+                    case "remove":
+                        return state.filter((e) => e.provider !== action.provider);
+                    case "update":
+                        return state.map((e) => (e.provider === action.provider ? { ...e, value: action.value } : e));
+                }
+            },
+            [
+                // Static contexts seeded into the wrapper so they don't add JSX nesting below.
+                // Negative orders keep them as the outermost providers (lowest order = outermost via reduceRight).
+                { provider: TeachingMomentsContext.Provider, value: teachingMomentsContextValue, order: -2 },
+                { provider: SettingsStoreContext.Provider, value: settingsStore, order: -1 },
+                { provider: ExtensionManagerContext.Provider, value: undefined, order: 0 },
+            ]
+        );
 
         // This is the main async initialization.
         useEffect(() => {
@@ -244,7 +252,7 @@ export function MakeModularTool(options: ModularToolOptions) {
                     produces: [ReactContextServiceIdentity],
                     factory: (): IReactContextService => ({
                         addContext<T>(provider: Context<T>["Provider"], initialValue: T, options?: { order?: number }): ReactContextHandle<T> {
-                            const typedProvider = provider as Context<unknown>["Provider"];
+                            const typedProvider = provider;
                             updateContexts({ type: "add", entry: { provider: typedProvider, value: initialValue, order: options?.order ?? 0 } });
                             return {
                                 updateValue: (newValue: T) => {
@@ -344,7 +352,7 @@ export function MakeModularTool(options: ModularToolOptions) {
                 }
 
                 // Set the contexts.
-                setExtensionManagerContext({ extensionManager });
+                updateContexts({ type: "update", provider: ExtensionManagerContext.Provider, value: { extensionManager } });
 
                 return () => {
                     extensionManager.dispose();
@@ -401,13 +409,9 @@ export function MakeModularTool(options: ModularToolOptions) {
         if (!rootComponentService) {
             return (
                 <ReactContextsWrapper contexts={contexts}>
-                    <TeachingMomentsContext.Provider value={teachingMomentsContextValue}>
-                        <SettingsStoreContext.Provider value={settingsStore}>
-                            <Theme className={classes.app} targetDocument={targetDocument}>
-                                <Spinner className={classes.spinner} />
-                            </Theme>
-                        </SettingsStoreContext.Provider>
-                    </TeachingMomentsContext.Provider>
+                    <Theme className={classes.app} targetDocument={targetDocument}>
+                        <Spinner className={classes.spinner} />
+                    </Theme>
                 </ReactContextsWrapper>
             );
         } else {
@@ -416,91 +420,83 @@ export function MakeModularTool(options: ModularToolOptions) {
 
             return (
                 <ReactContextsWrapper contexts={contexts}>
-                    <TeachingMomentsContext.Provider value={teachingMomentsContextValue}>
-                        {/* Expose the settings store as a React context so that UI components can read/write
-                        settings without the ISettingsService needing to be explicitly passed around. */}
-                        <SettingsStoreContext.Provider value={settingsStore}>
-                            <ExtensionManagerContext.Provider value={extensionManagerContext}>
-                                <Theme className={classes.app} targetDocument={targetDocument}>
-                                    <ToastProvider imperativeRef={setToastHandle}>
-                                        <Dialog open={!!requiredExtensions} modalType="alert">
-                                            <DialogSurface>
-                                                <DialogBody>
-                                                    <DialogTitle>Required Extensions</DialogTitle>
-                                                    <DialogContent>
-                                                        Opening this URL requires the following extensions to be installed and enabled:
-                                                        <ul>
-                                                            {requiredExtensions?.map((name) => (
-                                                                <li key={name}>{name}</li>
-                                                            ))}
-                                                        </ul>
-                                                    </DialogContent>
-                                                    <DialogActions>
-                                                        <Button appearance="primary" onClick={onAcceptRequiredExtensions}>
-                                                            Install & Enable
-                                                        </Button>
-                                                        <Button appearance="secondary" onClick={onRejectRequiredExtensions}>
-                                                            No Thanks
-                                                        </Button>
-                                                    </DialogActions>
-                                                </DialogBody>
-                                            </DialogSurface>
-                                        </Dialog>
-                                        <Dialog open={!!extensionInstallError} modalType="alert">
-                                            <DialogSurface>
-                                                <DialogBody>
-                                                    <DialogTitle>
-                                                        <div className={classes.extensionErrorTitleDiv}>
-                                                            Extension Install Error
-                                                            <ErrorCircleRegular className={classes.extensionErrorIcon} />
-                                                        </div>
-                                                    </DialogTitle>
-                                                    <DialogContent>
-                                                        <List>
-                                                            <ListItem>
-                                                                <Body1>{`Extension "${extensionInstallError?.extension.name}" failed to install and was removed.`}</Body1>
-                                                            </ListItem>
-                                                            <ListItem>
-                                                                <Body1>{`${extensionInstallError?.error}`}</Body1>
-                                                            </ListItem>
-                                                        </List>
-                                                    </DialogContent>
-                                                    <DialogActions>
-                                                        <Button appearance="primary" onClick={onAcknowledgedExtensionInstallError}>
-                                                            Close
-                                                        </Button>
-                                                    </DialogActions>
-                                                </DialogBody>
-                                            </DialogSurface>
-                                        </Dialog>
-                                        <Dialog open={!!currentDialog} modalType="alert">
-                                            <DialogSurface>
-                                                <DialogBody>
-                                                    <DialogTitle>
-                                                        <div className={classes.dialogTitle}>
-                                                            {currentDialogIcon}
-                                                            {currentDialog?.title}
-                                                        </div>
-                                                    </DialogTitle>
-                                                    {currentDialog?.content && <DialogContent>{currentDialog.content}</DialogContent>}
-                                                    <DialogActions>
-                                                        <Button appearance="primary" onClick={onDismissDialog}>
-                                                            OK
-                                                        </Button>
-                                                    </DialogActions>
-                                                </DialogBody>
-                                            </DialogSurface>
-                                        </Dialog>
-                                        <Suspense fallback={<Spinner className={classes.spinner} />}>
-                                            <DialogContext.Provider value={{ showDialog }}>
-                                                <Content />
-                                            </DialogContext.Provider>
-                                        </Suspense>
-                                    </ToastProvider>
-                                </Theme>
-                            </ExtensionManagerContext.Provider>
-                        </SettingsStoreContext.Provider>
-                    </TeachingMomentsContext.Provider>
+                    <Theme className={classes.app} targetDocument={targetDocument}>
+                        <ToastProvider imperativeRef={setToastHandle}>
+                            <Dialog open={!!requiredExtensions} modalType="alert">
+                                <DialogSurface>
+                                    <DialogBody>
+                                        <DialogTitle>Required Extensions</DialogTitle>
+                                        <DialogContent>
+                                            Opening this URL requires the following extensions to be installed and enabled:
+                                            <ul>
+                                                {requiredExtensions?.map((name) => (
+                                                    <li key={name}>{name}</li>
+                                                ))}
+                                            </ul>
+                                        </DialogContent>
+                                        <DialogActions>
+                                            <Button appearance="primary" onClick={onAcceptRequiredExtensions}>
+                                                Install & Enable
+                                            </Button>
+                                            <Button appearance="secondary" onClick={onRejectRequiredExtensions}>
+                                                No Thanks
+                                            </Button>
+                                        </DialogActions>
+                                    </DialogBody>
+                                </DialogSurface>
+                            </Dialog>
+                            <Dialog open={!!extensionInstallError} modalType="alert">
+                                <DialogSurface>
+                                    <DialogBody>
+                                        <DialogTitle>
+                                            <div className={classes.extensionErrorTitleDiv}>
+                                                Extension Install Error
+                                                <ErrorCircleRegular className={classes.extensionErrorIcon} />
+                                            </div>
+                                        </DialogTitle>
+                                        <DialogContent>
+                                            <List>
+                                                <ListItem>
+                                                    <Body1>{`Extension "${extensionInstallError?.extension.name}" failed to install and was removed.`}</Body1>
+                                                </ListItem>
+                                                <ListItem>
+                                                    <Body1>{`${extensionInstallError?.error}`}</Body1>
+                                                </ListItem>
+                                            </List>
+                                        </DialogContent>
+                                        <DialogActions>
+                                            <Button appearance="primary" onClick={onAcknowledgedExtensionInstallError}>
+                                                Close
+                                            </Button>
+                                        </DialogActions>
+                                    </DialogBody>
+                                </DialogSurface>
+                            </Dialog>
+                            <Dialog open={!!currentDialog} modalType="alert">
+                                <DialogSurface>
+                                    <DialogBody>
+                                        <DialogTitle>
+                                            <div className={classes.dialogTitle}>
+                                                {currentDialogIcon}
+                                                {currentDialog?.title}
+                                            </div>
+                                        </DialogTitle>
+                                        {currentDialog?.content && <DialogContent>{currentDialog.content}</DialogContent>}
+                                        <DialogActions>
+                                            <Button appearance="primary" onClick={onDismissDialog}>
+                                                OK
+                                            </Button>
+                                        </DialogActions>
+                                    </DialogBody>
+                                </DialogSurface>
+                            </Dialog>
+                            <Suspense fallback={<Spinner className={classes.spinner} />}>
+                                <DialogContext.Provider value={{ showDialog }}>
+                                    <Content />
+                                </DialogContext.Provider>
+                            </Suspense>
+                        </ToastProvider>
+                    </Theme>
                 </ReactContextsWrapper>
             );
         }

--- a/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
+++ b/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
@@ -400,15 +400,15 @@ export function MakeModularTool(options: ModularToolOptions) {
         // Show a spinner until a main view has been set.
         if (!rootComponentService) {
             return (
-                <TeachingMomentsContext.Provider value={teachingMomentsContextValue}>
-                    <ReactContextsWrapper contexts={contexts}>
+                <ReactContextsWrapper contexts={contexts}>
+                    <TeachingMomentsContext.Provider value={teachingMomentsContextValue}>
                         <SettingsStoreContext.Provider value={settingsStore}>
                             <Theme className={classes.app} targetDocument={targetDocument}>
                                 <Spinner className={classes.spinner} />
                             </Theme>
                         </SettingsStoreContext.Provider>
-                    </ReactContextsWrapper>
-                </TeachingMomentsContext.Provider>
+                    </TeachingMomentsContext.Provider>
+                </ReactContextsWrapper>
             );
         } else {
             // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
+++ b/packages/dev/sharedUiComponents/src/modularTool/modularTool.tsx
@@ -46,6 +46,7 @@ import { Theme } from "./components/theme";
 import { DialogContext } from "./contexts/dialogContext";
 import { ExtensionManagerContext } from "./contexts/extensionManagerContext";
 import { SettingsStoreContext } from "./contexts/settingsContext";
+import { TeachingMomentsContext } from "./contexts/teachingMomentsContext";
 import { type IReactContextService, type ReactContextHandle, ReactContextServiceIdentity } from "./services/reactContextService";
 import { ThemeSelectorServiceDefinition } from "./services/themeSelectorService";
 
@@ -147,6 +148,11 @@ export type ModularToolOptions = {
      * will be resolved from this parent.
      */
     parentContainer?: ServiceContainer;
+
+    /**
+     * When true, all teaching moments are disabled and will not be shown.
+     */
+    disableTeachingMoments?: boolean;
 } & ShellServiceOptions;
 
 /**
@@ -155,7 +161,9 @@ export type ModularToolOptions = {
  * @returns A token that can be used to dispose of the tool.
  */
 export function MakeModularTool(options: ModularToolOptions) {
-    const { namespace, containerElement, serviceDefinitions, themeMode, showThemeSelector = true, extensionFeeds = [], parentContainer } = options;
+    const { namespace, containerElement, serviceDefinitions, themeMode, showThemeSelector = true, extensionFeeds = [], parentContainer, disableTeachingMoments = false } = options;
+
+    const teachingMomentsContextValue = { disabled: disableTeachingMoments };
 
     // Create the settings store immediately as it will be exposed to services and through React context.
     const settingsStore = new SettingsStore(namespace);
@@ -392,13 +400,15 @@ export function MakeModularTool(options: ModularToolOptions) {
         // Show a spinner until a main view has been set.
         if (!rootComponentService) {
             return (
-                <ReactContextsWrapper contexts={contexts}>
-                    <SettingsStoreContext.Provider value={settingsStore}>
-                        <Theme className={classes.app} targetDocument={targetDocument}>
-                            <Spinner className={classes.spinner} />
-                        </Theme>
-                    </SettingsStoreContext.Provider>
-                </ReactContextsWrapper>
+                <TeachingMomentsContext.Provider value={teachingMomentsContextValue}>
+                    <ReactContextsWrapper contexts={contexts}>
+                        <SettingsStoreContext.Provider value={settingsStore}>
+                            <Theme className={classes.app} targetDocument={targetDocument}>
+                                <Spinner className={classes.spinner} />
+                            </Theme>
+                        </SettingsStoreContext.Provider>
+                    </ReactContextsWrapper>
+                </TeachingMomentsContext.Provider>
             );
         } else {
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -406,89 +416,91 @@ export function MakeModularTool(options: ModularToolOptions) {
 
             return (
                 <ReactContextsWrapper contexts={contexts}>
-                    {/* Expose the settings store as a React context so that UI components can read/write
+                    <TeachingMomentsContext.Provider value={teachingMomentsContextValue}>
+                        {/* Expose the settings store as a React context so that UI components can read/write
                         settings without the ISettingsService needing to be explicitly passed around. */}
-                    <SettingsStoreContext.Provider value={settingsStore}>
-                        <ExtensionManagerContext.Provider value={extensionManagerContext}>
-                            <Theme className={classes.app} targetDocument={targetDocument}>
-                                <ToastProvider imperativeRef={setToastHandle}>
-                                    <Dialog open={!!requiredExtensions} modalType="alert">
-                                        <DialogSurface>
-                                            <DialogBody>
-                                                <DialogTitle>Required Extensions</DialogTitle>
-                                                <DialogContent>
-                                                    Opening this URL requires the following extensions to be installed and enabled:
-                                                    <ul>
-                                                        {requiredExtensions?.map((name) => (
-                                                            <li key={name}>{name}</li>
-                                                        ))}
-                                                    </ul>
-                                                </DialogContent>
-                                                <DialogActions>
-                                                    <Button appearance="primary" onClick={onAcceptRequiredExtensions}>
-                                                        Install & Enable
-                                                    </Button>
-                                                    <Button appearance="secondary" onClick={onRejectRequiredExtensions}>
-                                                        No Thanks
-                                                    </Button>
-                                                </DialogActions>
-                                            </DialogBody>
-                                        </DialogSurface>
-                                    </Dialog>
-                                    <Dialog open={!!extensionInstallError} modalType="alert">
-                                        <DialogSurface>
-                                            <DialogBody>
-                                                <DialogTitle>
-                                                    <div className={classes.extensionErrorTitleDiv}>
-                                                        Extension Install Error
-                                                        <ErrorCircleRegular className={classes.extensionErrorIcon} />
-                                                    </div>
-                                                </DialogTitle>
-                                                <DialogContent>
-                                                    <List>
-                                                        <ListItem>
-                                                            <Body1>{`Extension "${extensionInstallError?.extension.name}" failed to install and was removed.`}</Body1>
-                                                        </ListItem>
-                                                        <ListItem>
-                                                            <Body1>{`${extensionInstallError?.error}`}</Body1>
-                                                        </ListItem>
-                                                    </List>
-                                                </DialogContent>
-                                                <DialogActions>
-                                                    <Button appearance="primary" onClick={onAcknowledgedExtensionInstallError}>
-                                                        Close
-                                                    </Button>
-                                                </DialogActions>
-                                            </DialogBody>
-                                        </DialogSurface>
-                                    </Dialog>
-                                    <Dialog open={!!currentDialog} modalType="alert">
-                                        <DialogSurface>
-                                            <DialogBody>
-                                                <DialogTitle>
-                                                    <div className={classes.dialogTitle}>
-                                                        {currentDialogIcon}
-                                                        {currentDialog?.title}
-                                                    </div>
-                                                </DialogTitle>
-                                                {currentDialog?.content && <DialogContent>{currentDialog.content}</DialogContent>}
-                                                <DialogActions>
-                                                    <Button appearance="primary" onClick={onDismissDialog}>
-                                                        OK
-                                                    </Button>
-                                                </DialogActions>
-                                            </DialogBody>
-                                        </DialogSurface>
-                                    </Dialog>
-                                    <Suspense fallback={<Spinner className={classes.spinner} />}>
-                                        <DialogContext.Provider value={{ showDialog }}>
-                                            <Content />
-                                        </DialogContext.Provider>
-                                    </Suspense>
-                                </ToastProvider>
-                            </Theme>
-                        </ExtensionManagerContext.Provider>
-                    </SettingsStoreContext.Provider>
+                        <SettingsStoreContext.Provider value={settingsStore}>
+                            <ExtensionManagerContext.Provider value={extensionManagerContext}>
+                                <Theme className={classes.app} targetDocument={targetDocument}>
+                                    <ToastProvider imperativeRef={setToastHandle}>
+                                        <Dialog open={!!requiredExtensions} modalType="alert">
+                                            <DialogSurface>
+                                                <DialogBody>
+                                                    <DialogTitle>Required Extensions</DialogTitle>
+                                                    <DialogContent>
+                                                        Opening this URL requires the following extensions to be installed and enabled:
+                                                        <ul>
+                                                            {requiredExtensions?.map((name) => (
+                                                                <li key={name}>{name}</li>
+                                                            ))}
+                                                        </ul>
+                                                    </DialogContent>
+                                                    <DialogActions>
+                                                        <Button appearance="primary" onClick={onAcceptRequiredExtensions}>
+                                                            Install & Enable
+                                                        </Button>
+                                                        <Button appearance="secondary" onClick={onRejectRequiredExtensions}>
+                                                            No Thanks
+                                                        </Button>
+                                                    </DialogActions>
+                                                </DialogBody>
+                                            </DialogSurface>
+                                        </Dialog>
+                                        <Dialog open={!!extensionInstallError} modalType="alert">
+                                            <DialogSurface>
+                                                <DialogBody>
+                                                    <DialogTitle>
+                                                        <div className={classes.extensionErrorTitleDiv}>
+                                                            Extension Install Error
+                                                            <ErrorCircleRegular className={classes.extensionErrorIcon} />
+                                                        </div>
+                                                    </DialogTitle>
+                                                    <DialogContent>
+                                                        <List>
+                                                            <ListItem>
+                                                                <Body1>{`Extension "${extensionInstallError?.extension.name}" failed to install and was removed.`}</Body1>
+                                                            </ListItem>
+                                                            <ListItem>
+                                                                <Body1>{`${extensionInstallError?.error}`}</Body1>
+                                                            </ListItem>
+                                                        </List>
+                                                    </DialogContent>
+                                                    <DialogActions>
+                                                        <Button appearance="primary" onClick={onAcknowledgedExtensionInstallError}>
+                                                            Close
+                                                        </Button>
+                                                    </DialogActions>
+                                                </DialogBody>
+                                            </DialogSurface>
+                                        </Dialog>
+                                        <Dialog open={!!currentDialog} modalType="alert">
+                                            <DialogSurface>
+                                                <DialogBody>
+                                                    <DialogTitle>
+                                                        <div className={classes.dialogTitle}>
+                                                            {currentDialogIcon}
+                                                            {currentDialog?.title}
+                                                        </div>
+                                                    </DialogTitle>
+                                                    {currentDialog?.content && <DialogContent>{currentDialog.content}</DialogContent>}
+                                                    <DialogActions>
+                                                        <Button appearance="primary" onClick={onDismissDialog}>
+                                                            OK
+                                                        </Button>
+                                                    </DialogActions>
+                                                </DialogBody>
+                                            </DialogSurface>
+                                        </Dialog>
+                                        <Suspense fallback={<Spinner className={classes.spinner} />}>
+                                            <DialogContext.Provider value={{ showDialog }}>
+                                                <Content />
+                                            </DialogContext.Provider>
+                                        </Suspense>
+                                    </ToastProvider>
+                                </Theme>
+                            </ExtensionManagerContext.Provider>
+                        </SettingsStoreContext.Provider>
+                    </TeachingMomentsContext.Provider>
                 </ReactContextsWrapper>
             );
         }


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Adds a new `disableTeachingMoments` option to `ModularToolOptions` (and therefore `InspectorOptions`) that suppresses all teaching moments rendered by the modular tool, regardless of each teaching moment's individual `suppress` state.

## Changes

- New `TeachingMomentsContext` (in `sharedUiComponents/src/modularTool/contexts/teachingMomentsContext.ts`) exposing a `disabled` flag.
- `MakeModularTool` now accepts a `disableTeachingMoments?: boolean` option and wraps the rendered tree in a `TeachingMomentsContext.Provider`.
- `MakeTeachingMoment` consumes the context and ORs the context's `disabled` flag with the caller-provided `suppress` flag.
- `ShowInspector` forwards `options.disableTeachingMoments` through to `MakeModularTool` so inspector hosts can opt out of teaching moments.

## Motivation

Addresses a forum request from a user embedding the inspector in their own app who wants a parameter in `ShowInspector` to turn off the teaching-moment "bubbles" that appear the first time the inspector opens in a session: https://forum.babylonjs.com/t/introducing-inspector-v2/60937/223

With this option, host apps can call `ShowInspector(scene, { disableTeachingMoments: true })` to globally suppress teaching moments.
