### PR TITLE
Fix thin-instance bounds for baked vertex animation

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.pure.ts
@@ -4,7 +4,7 @@ import { Observable } from "../Misc/observable.pure";
 import { type Nullable, type FloatArray, type IndicesArray, type DeepImmutable } from "../types";
 import { type Camera } from "../Cameras/camera.pure";
 import { type Scene, type IDisposable, ScenePerformancePriority } from "../scene.pure";
-import { type Vector2, Quaternion, Matrix, Vector3, TmpVectors } from "../Maths/math.vector.pure";
+import { type Vector2, type Vector4, Quaternion, Matrix, Vector3, TmpVectors } from "../Maths/math.vector.pure";
 import { type Node } from "../node";
 import { VertexBuffer } from "../Buffers/buffer.pure";
 import { type IGetSetVerticesData, VertexData } from "../Meshes/mesh.vertexData";
@@ -33,6 +33,7 @@ import { Epsilon } from "../Maths/math.constants";
 import { type Plane } from "../Maths/math.plane";
 import { Axis } from "../Maths/math.axis";
 import { type IParticleSystem } from "../Particles/IParticleSystem";
+import { Logger } from "../Misc/logger";
 
 import { type Ray, type TrianglePickingPredicate } from "../Culling/ray.pure";
 import { type Collider } from "../Collisions/collider";
@@ -126,6 +127,123 @@ function ApplySkeleton(
     }
 }
 
+function BakedVertexAnimationModulo(value: number, divisor: number): number {
+    return value - Math.floor(value / divisor) * divisor;
+}
+
+function BakedVertexAnimationHalfFloatToNumber(value: number): number {
+    const sign = value & 0x8000 ? -1 : 1;
+    const exponent = (value & 0x7c00) >> 10;
+    const fraction = value & 0x03ff;
+
+    if (exponent === 0) {
+        return sign * Math.pow(2, -14) * (fraction / Math.pow(2, 10));
+    } else if (exponent === 0x1f) {
+        return fraction ? NaN : sign * Infinity;
+    }
+
+    return sign * Math.pow(2, exponent - 15) * (1 + fraction / Math.pow(2, 10));
+}
+
+function GetBakedVertexAnimationFrame(animationSettings: DeepImmutable<Vector4>, time: number): number {
+    const totalFrames = animationSettings.y - animationSettings.x + 1;
+    const normalizedTime = (time * animationSettings.w) / totalFrames;
+    const frameCorrection = normalizedTime < 1 ? 0 : 1;
+    const numOfFrames = totalFrames - frameCorrection;
+
+    let frameNum = BakedVertexAnimationModulo(normalizedTime - Math.floor(normalizedTime), 1) * numOfFrames;
+    frameNum = BakedVertexAnimationModulo(frameNum + animationSettings.z, numOfFrames);
+    return Math.floor(frameNum) + animationSettings.x + frameCorrection;
+}
+
+function ReadBakedVertexAnimationMatrixToRef(data: Float32Array | Uint16Array, offset: number, matrix: Matrix): void {
+    if (data instanceof Float32Array) {
+        Matrix.FromArrayToRef(data, offset, matrix);
+        return;
+    }
+
+    matrix.copyFromFloats(
+        BakedVertexAnimationHalfFloatToNumber(data[offset]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 1]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 2]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 3]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 4]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 5]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 6]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 7]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 8]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 9]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 10]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 11]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 12]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 13]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 14]),
+        BakedVertexAnimationHalfFloatToNumber(data[offset + 15])
+    );
+}
+
+function ApplyBakedVertexAnimation(
+    data: FloatArray,
+    kind: string,
+    bakedVertexAnimationManager: IBakedVertexAnimationManager,
+    animationSettings: DeepImmutable<Vector4>,
+    matricesIndicesData: FloatArray,
+    matricesWeightsData: FloatArray,
+    matricesIndicesExtraData: Nullable<FloatArray>,
+    matricesWeightsExtraData: Nullable<FloatArray>,
+    numBoneInfluencers: number
+): boolean {
+    const texture = bakedVertexAnimationManager.texture;
+    const internalTexture = texture?.getInternalTexture();
+    const textureData = internalTexture?._bufferView;
+
+    if (!(textureData instanceof Float32Array) && !(textureData instanceof Uint16Array)) {
+        Logger.Warn("Baked vertex animation bounding info requires CPU-readable Float32Array or Uint16Array texture data.", 1);
+        return false;
+    }
+
+    const textureSize = texture!.getSize();
+    const frame = GetBakedVertexAnimationFrame(animationSettings, bakedVertexAnimationManager.time);
+    if (!isFinite(frame) || frame < 0 || frame >= textureSize.height) {
+        Logger.Warn("Baked vertex animation bounding info could not be refreshed because the computed frame is outside the texture.", 1);
+        return false;
+    }
+
+    const tempVector = TmpVectors.Vector3[0];
+    const finalMatrix = TmpVectors.Matrix[0];
+    const tempMatrix = TmpVectors.Matrix[1];
+    const textureFrameOffset = frame * textureSize.width * 4;
+    const transformFromFloatsToRef = kind === VertexBuffer.NormalKind ? Vector3.TransformNormalFromFloatsToRef : Vector3.TransformCoordinatesFromFloatsToRef;
+
+    for (let index = 0, matWeightIdx = 0; index < data.length; index += 3, matWeightIdx += 4) {
+        finalMatrix.reset();
+
+        let inf: number;
+        let weight: number;
+        for (inf = 0; inf < 4 && inf < numBoneInfluencers; inf++) {
+            weight = matricesWeightsData[matWeightIdx + inf];
+            if (weight > 0) {
+                ReadBakedVertexAnimationMatrixToRef(textureData, textureFrameOffset + Math.floor(matricesIndicesData[matWeightIdx + inf]) * 16, tempMatrix);
+                tempMatrix.scaleAndAddToRef(weight, finalMatrix);
+            }
+        }
+        if (matricesIndicesExtraData && matricesWeightsExtraData) {
+            for (inf = 0; inf < 4 && inf + 4 < numBoneInfluencers; inf++) {
+                weight = matricesWeightsExtraData[matWeightIdx + inf];
+                if (weight > 0) {
+                    ReadBakedVertexAnimationMatrixToRef(textureData, textureFrameOffset + Math.floor(matricesIndicesExtraData[matWeightIdx + inf]) * 16, tempMatrix);
+                    tempMatrix.scaleAndAddToRef(weight, finalMatrix);
+                }
+            }
+        }
+
+        transformFromFloatsToRef(data[index], data[index + 1], data[index + 2], finalMatrix, tempVector);
+        tempVector.toArray(data, index);
+    }
+
+    return true;
+}
+
 /**
  * Opaque cache when computing data about a mesh
  */
@@ -146,6 +264,12 @@ export interface IMeshDataOptions {
 
     /** Apply morph when computing the bounding info. Defaults to false. */
     applyMorph?: boolean;
+
+    /** Apply baked vertex animation when computing data. Defaults to false. */
+    applyBakedVertexAnimation?: boolean;
+
+    /** Baked vertex animation settings to use instead of the manager's animationParameters. */
+    bakedVertexAnimationSettings?: DeepImmutable<Vector4>;
 
     /** Update the cached positions stored as a Vector3 array. Defaults to true. */
     updatePositionsArray?: boolean;
@@ -1739,7 +1863,11 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
             }
 
             data = cache._outputData;
-        } else if ((options.applyMorph && this.morphTargetManager) || (options.applySkeleton && this.skeleton)) {
+        } else if (
+            (options.applyMorph && this.morphTargetManager) ||
+            (options.applySkeleton && this.skeleton) ||
+            (options.applyBakedVertexAnimation && this.bakedVertexAnimationManager?.isEnabled)
+        ) {
             data = data.slice();
         }
 
@@ -1747,7 +1875,30 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
             ApplyMorph(data, kind, this.morphTargetManager);
         }
 
-        if (options.applySkeleton && this.skeleton) {
+        const bakedVertexAnimationManager = this.bakedVertexAnimationManager;
+        let bakedVertexAnimationApplied = false;
+        if (options.applyBakedVertexAnimation && bakedVertexAnimationManager?.isEnabled) {
+            const matricesIndicesData = getVertexData(VertexBuffer.MatricesIndicesKind);
+            const matricesWeightsData = getVertexData(VertexBuffer.MatricesWeightsKind);
+            if (matricesWeightsData && matricesIndicesData) {
+                const needExtras = this.numBoneInfluencers > 4;
+                const matricesIndicesExtraData = needExtras ? getVertexData(VertexBuffer.MatricesIndicesExtraKind) : null;
+                const matricesWeightsExtraData = needExtras ? getVertexData(VertexBuffer.MatricesWeightsExtraKind) : null;
+                bakedVertexAnimationApplied = ApplyBakedVertexAnimation(
+                    data,
+                    kind,
+                    bakedVertexAnimationManager,
+                    options.bakedVertexAnimationSettings ?? bakedVertexAnimationManager.animationParameters,
+                    matricesIndicesData,
+                    matricesWeightsData,
+                    matricesIndicesExtraData,
+                    matricesWeightsExtraData,
+                    this.numBoneInfluencers
+                );
+            }
+        }
+
+        if (!bakedVertexAnimationApplied && options.applySkeleton && this.skeleton) {
             const matricesIndicesData = getVertexData(VertexBuffer.MatricesIndicesKind);
             const matricesWeightsData = getVertexData(VertexBuffer.MatricesWeightsKind);
             if (matricesWeightsData && matricesIndicesData) {

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.pure.ts
@@ -1,11 +1,178 @@
 /** This file must only contain pure code and pure imports */
 
-import { type Nullable, type DeepImmutableObject } from "../types";
-import { Vector3, TmpVectors, Matrix } from "../Maths/math.vector.pure";
+import { type Nullable, type DeepImmutableObject, type FloatArray } from "../types";
+import { type Vector2, Vector3, TmpVectors, Matrix } from "../Maths/math.vector.pure";
 import { Logger } from "../Misc/logger";
 import { BoundingInfo } from "core/Culling/boundingInfo";
 import { Mesh } from "../Meshes/mesh.pure";
 import { VertexBuffer, Buffer } from "../Buffers/buffer.pure";
+
+const BakedVertexAnimationSettingsInstancedKind = "bakedVertexAnimationSettingsInstanced";
+
+function HasCpuReadableBakedVertexAnimationData(mesh: Mesh): boolean {
+    const textureData = mesh.bakedVertexAnimationManager?.texture?.getInternalTexture()?._bufferView;
+
+    return textureData instanceof Float32Array || textureData instanceof Uint16Array;
+}
+
+function ExtractMinAndMaxToRef(data: FloatArray, count: number, minimum: Vector3, maximum: Vector3): void {
+    minimum.setAll(Number.POSITIVE_INFINITY);
+    maximum.setAll(Number.NEGATIVE_INFINITY);
+
+    for (let index = 0; index < count * 3; index += 3) {
+        const x = data[index];
+        const y = data[index + 1];
+        const z = data[index + 2];
+
+        if (x < minimum.x) {
+            minimum.x = x;
+        }
+        if (y < minimum.y) {
+            minimum.y = y;
+        }
+        if (z < minimum.z) {
+            minimum.z = z;
+        }
+        if (x > maximum.x) {
+            maximum.x = x;
+        }
+        if (y > maximum.y) {
+            maximum.y = y;
+        }
+        if (z > maximum.z) {
+            maximum.z = z;
+        }
+    }
+}
+
+function ApplyBoundingBiasToMinAndMax(minimum: Vector3, maximum: Vector3, bias: Nullable<Vector2>): void {
+    if (!bias) {
+        return;
+    }
+
+    minimum.x -= minimum.x * bias.x + bias.y;
+    minimum.y -= minimum.y * bias.x + bias.y;
+    minimum.z -= minimum.z * bias.x + bias.y;
+    maximum.x += maximum.x * bias.x + bias.y;
+    maximum.y += maximum.y * bias.x + bias.y;
+    maximum.z += maximum.z * bias.x + bias.y;
+}
+
+function UpdateTransformedMinAndMaxToRef(minimum: Vector3, maximum: Vector3, matrix: Matrix, globalMinimum: Vector3, globalMaximum: Vector3): void {
+    const corner = TmpVectors.Vector3[7];
+    const transformed = TmpVectors.Vector3[8];
+
+    for (let x = 0; x < 2; ++x) {
+        for (let y = 0; y < 2; ++y) {
+            for (let z = 0; z < 2; ++z) {
+                corner.set(x ? maximum.x : minimum.x, y ? maximum.y : minimum.y, z ? maximum.z : minimum.z);
+                Vector3.TransformCoordinatesToRef(corner, matrix, transformed);
+                globalMinimum.minimizeInPlace(transformed);
+                globalMaximum.maximizeInPlace(transformed);
+            }
+        }
+    }
+}
+
+function UpdateTransformedDataMinAndMaxToRef(data: FloatArray, count: number, matrix: Matrix, globalMinimum: Vector3, globalMaximum: Vector3): void {
+    const transformed = TmpVectors.Vector3[7];
+
+    for (let index = 0; index < count * 3; index += 3) {
+        Vector3.TransformCoordinatesFromFloatsToRef(data[index], data[index + 1], data[index + 2], matrix, transformed);
+        globalMinimum.minimizeInPlace(transformed);
+        globalMaximum.maximizeInPlace(transformed);
+    }
+}
+
+function UpdateRawBoundingVectors(vectors: Vector3[], rawBoundingInfo: BoundingInfo): void {
+    vectors.length = 0;
+
+    for (let v = 0; v < rawBoundingInfo.boundingBox.vectors.length; ++v) {
+        vectors.push(rawBoundingInfo.boundingBox.vectors[v].clone());
+    }
+}
+
+function TryUpdateBakedVertexAnimationThinInstanceBoundingInfo(mesh: Mesh, vectors: Vector3[], applyMorph: boolean): boolean {
+    const storage = mesh._userThinInstanceBuffersStorage;
+    const bakedVertexAnimationSettingsData = storage?.data[BakedVertexAnimationSettingsInstancedKind];
+    const bakedVertexAnimationSettingsStride = storage?.strides[BakedVertexAnimationSettingsInstancedKind];
+
+    if (!bakedVertexAnimationSettingsData || !bakedVertexAnimationSettingsStride || bakedVertexAnimationSettingsStride < 4 || !HasCpuReadableBakedVertexAnimationData(mesh)) {
+        return false;
+    }
+
+    const matrixData = mesh._thinInstanceDataStorage.matrixData;
+    if (!matrixData) {
+        return false;
+    }
+
+    const cache = {};
+    const settings = TmpVectors.Vector4[0];
+    const rawMinimum = TmpVectors.Vector3[0];
+    const rawMaximum = TmpVectors.Vector3[1];
+    const globalMinimum = TmpVectors.Vector3[2];
+    const globalMaximum = TmpVectors.Vector3[3];
+    const localMinimum = TmpVectors.Vector3[4];
+    const localMaximum = TmpVectors.Vector3[5];
+    const matrix = TmpVectors.Matrix[2];
+    const bias = mesh.geometry ? mesh.geometry.boundingBias : null;
+
+    rawMinimum.setAll(Number.POSITIVE_INFINITY);
+    rawMaximum.setAll(Number.NEGATIVE_INFINITY);
+    globalMinimum.setAll(Number.POSITIVE_INFINITY);
+    globalMaximum.setAll(Number.NEGATIVE_INFINITY);
+
+    for (let index = 0; index < mesh._thinInstanceDataStorage.instancesCount; ++index) {
+        const settingsOffset = index * bakedVertexAnimationSettingsStride;
+        settings.set(
+            bakedVertexAnimationSettingsData[settingsOffset],
+            bakedVertexAnimationSettingsData[settingsOffset + 1],
+            bakedVertexAnimationSettingsData[settingsOffset + 2],
+            bakedVertexAnimationSettingsData[settingsOffset + 3]
+        );
+
+        const positionData = mesh._getData(
+            {
+                applyMorph,
+                applyBakedVertexAnimation: true,
+                bakedVertexAnimationSettings: settings,
+                updatePositionsArray: false,
+                cache,
+            },
+            null,
+            VertexBuffer.PositionKind
+        );
+
+        if (!positionData) {
+            return false;
+        }
+
+        ExtractMinAndMaxToRef(positionData, mesh.getTotalVertices(), localMinimum, localMaximum);
+        ApplyBoundingBiasToMinAndMax(localMinimum, localMaximum, bias);
+        rawMinimum.minimizeInPlace(localMinimum);
+        rawMaximum.maximizeInPlace(localMaximum);
+
+        Matrix.FromArrayToRef(matrixData, index * 16, matrix);
+        if (bias) {
+            UpdateTransformedMinAndMaxToRef(localMinimum, localMaximum, matrix, globalMinimum, globalMaximum);
+        } else {
+            UpdateTransformedDataMinAndMaxToRef(positionData, mesh.getTotalVertices(), matrix, globalMinimum, globalMaximum);
+        }
+    }
+
+    if (!isFinite(rawMinimum.x) || !isFinite(globalMinimum.x)) {
+        return false;
+    }
+
+    const boundingInfo = mesh.getBoundingInfo();
+    boundingInfo.reConstruct(globalMinimum, globalMaximum);
+    mesh.rawBoundingInfo = new BoundingInfo(rawMinimum, rawMaximum);
+    UpdateRawBoundingVectors(vectors, mesh.rawBoundingInfo);
+
+    mesh._updateBoundingInfo();
+
+    return true;
+}
 
 let _Registered = false;
 /**
@@ -297,7 +464,12 @@ export function RegisterThinInstanceMesh(): void {
         return this._thinInstanceDataStorage.worldMatrices;
     };
 
-    Mesh.prototype.thinInstanceRefreshBoundingInfo = function (forceRefreshParentInfo: boolean = false, applySkeleton: boolean = false, applyMorph: boolean = false) {
+    Mesh.prototype.thinInstanceRefreshBoundingInfo = function (
+        forceRefreshParentInfo: boolean = false,
+        applySkeleton: boolean = false,
+        applyMorph: boolean = false,
+        applyBakedVertexAnimation: boolean = false
+    ) {
         if (!this._thinInstanceDataStorage.matrixData || !this._thinInstanceDataStorage.matrixBuffer) {
             return;
         }
@@ -306,7 +478,16 @@ export function RegisterThinInstanceMesh(): void {
 
         if (forceRefreshParentInfo || !this.rawBoundingInfo) {
             vectors.length = 0;
-            this.refreshBoundingInfo(applySkeleton, applyMorph);
+            if (applyBakedVertexAnimation && TryUpdateBakedVertexAnimationThinInstanceBoundingInfo(this, vectors, applyMorph)) {
+                return;
+            }
+
+            const useBakedVertexAnimation = applyBakedVertexAnimation && this.bakedVertexAnimationManager?.isEnabled && HasCpuReadableBakedVertexAnimationData(this);
+            if (useBakedVertexAnimation) {
+                this.refreshBoundingInfo({ applySkeleton, applyMorph, applyBakedVertexAnimation: true, updatePositionsArray: false });
+            } else {
+                this.refreshBoundingInfo(applySkeleton, applyMorph);
+            }
             const boundingInfo = this.getBoundingInfo();
             this.rawBoundingInfo = new BoundingInfo(boundingInfo.minimum, boundingInfo.maximum);
         }

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.pure.ts
@@ -108,14 +108,15 @@ function TryUpdateBakedVertexAnimationThinInstanceBoundingInfo(mesh: Mesh, vecto
 
     const cache = {};
     const settings = TmpVectors.Vector4[0];
-    const rawMinimum = TmpVectors.Vector3[0];
-    const rawMaximum = TmpVectors.Vector3[1];
-    const globalMinimum = TmpVectors.Vector3[2];
-    const globalMaximum = TmpVectors.Vector3[3];
-    const localMinimum = TmpVectors.Vector3[4];
-    const localMaximum = TmpVectors.Vector3[5];
+    const rawMinimum = TmpVectors.Vector3[1];
+    const rawMaximum = TmpVectors.Vector3[2];
+    const globalMinimum = TmpVectors.Vector3[3];
+    const globalMaximum = TmpVectors.Vector3[4];
+    const localMinimum = TmpVectors.Vector3[5];
+    const localMaximum = TmpVectors.Vector3[6];
     const matrix = TmpVectors.Matrix[2];
     const bias = mesh.geometry ? mesh.geometry.boundingBias : null;
+    const vertexCount = mesh.getTotalVertices();
 
     rawMinimum.setAll(Number.POSITIVE_INFINITY);
     rawMaximum.setAll(Number.NEGATIVE_INFINITY);
@@ -147,7 +148,7 @@ function TryUpdateBakedVertexAnimationThinInstanceBoundingInfo(mesh: Mesh, vecto
             return false;
         }
 
-        ExtractMinAndMaxToRef(positionData, mesh.getTotalVertices(), localMinimum, localMaximum);
+        ExtractMinAndMaxToRef(positionData, vertexCount, localMinimum, localMaximum);
         ApplyBoundingBiasToMinAndMax(localMinimum, localMaximum, bias);
         rawMinimum.minimizeInPlace(localMinimum);
         rawMaximum.maximizeInPlace(localMaximum);
@@ -156,7 +157,7 @@ function TryUpdateBakedVertexAnimationThinInstanceBoundingInfo(mesh: Mesh, vecto
         if (bias) {
             UpdateTransformedMinAndMaxToRef(localMinimum, localMaximum, matrix, globalMinimum, globalMaximum);
         } else {
-            UpdateTransformedDataMinAndMaxToRef(positionData, mesh.getTotalVertices(), matrix, globalMinimum, globalMaximum);
+            UpdateTransformedDataMinAndMaxToRef(positionData, vertexCount, matrix, globalMinimum, globalMaximum);
         }
     }
 

--- a/packages/dev/core/src/Meshes/thinInstanceMesh.types.ts
+++ b/packages/dev/core/src/Meshes/thinInstanceMesh.types.ts
@@ -101,8 +101,9 @@ declare module "./mesh.pure" {
          * @param forceRefreshParentInfo true to force recomputing the mesh bounding info and use it to compute the aggregated bounding info
          * @param applySkeleton defines whether to apply the skeleton before computing the bounding info
          * @param applyMorph  defines whether to apply the morph target before computing the bounding info
+         * @param applyBakedVertexAnimation defines whether to apply baked vertex animation before computing the bounding info
          */
-        thinInstanceRefreshBoundingInfo(forceRefreshParentInfo?: boolean, applySkeleton?: boolean, applyMorph?: boolean): void;
+        thinInstanceRefreshBoundingInfo(forceRefreshParentInfo?: boolean, applySkeleton?: boolean, applyMorph?: boolean, applyBakedVertexAnimation?: boolean): void;
 
         /** @internal */
         _thinInstanceInitializeUserStorage(): void;

--- a/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
@@ -126,6 +126,26 @@ describe("ThinInstance picking", () => {
             expect(box.rawBoundingInfo!.maximum.y).toBeCloseTo(10.5);
         });
 
+        it("aggregates bounds from multiple instanced baked vertex animation settings", () => {
+            const manager = createBakedVertexAnimationManager(box);
+
+            box.thinInstanceAdd(Matrix.Identity(), false);
+            box.thinInstanceAdd(Matrix.Translation(20, 0, 0), true);
+            box.thinInstanceSetBuffer("bakedVertexAnimationSettingsInstanced", new Float32Array([0, 1, 0, 30, 0, 1, 1, 30]), 4);
+
+            manager.time = 0;
+            box.thinInstanceRefreshBoundingInfo(true, false, false, true);
+
+            expect(box.getBoundingInfo().minimum.x).toBeCloseTo(-0.5);
+            expect(box.getBoundingInfo().maximum.x).toBeCloseTo(20.5);
+            expect(box.getBoundingInfo().minimum.y).toBeCloseTo(-0.5);
+            expect(box.getBoundingInfo().maximum.y).toBeCloseTo(10.5);
+            expect(box.rawBoundingInfo!.minimum.x).toBeCloseTo(-0.5);
+            expect(box.rawBoundingInfo!.maximum.x).toBeCloseTo(0.5);
+            expect(box.rawBoundingInfo!.minimum.y).toBeCloseTo(-0.5);
+            expect(box.rawBoundingInfo!.maximum.y).toBeCloseTo(10.5);
+        });
+
         it("uses animated vertices instead of local animated AABB corners for thin-instance bounds", () => {
             const diagonalMesh = new Mesh("diagonal", scene);
             diagonalMesh.setVerticesData(VertexBuffer.PositionKind, new Float32Array([0, 0, 0, 1, 1, 0]));

--- a/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.thinInstancePicking.test.ts
@@ -1,14 +1,21 @@
-import { type Engine, NullEngine } from "core/Engines";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Constants } from "core/Engines/constants";
 import { Matrix, Quaternion, Vector3 } from "core/Maths/math.vector";
-import { type Mesh, MeshBuilder } from "core/Meshes";
+import { Mesh } from "core/Meshes/mesh";
+import { MeshBuilder } from "core/Meshes/meshBuilder";
 import { Scene } from "core/scene";
 import { PickingInfo } from "core/Collisions/pickingInfo";
 import { PickingCustomization, Ray } from "core/Culling/ray";
-import "core/Culling/ray";
+import { VertexBuffer } from "core/Buffers/buffer";
+import { BakedVertexAnimationManager } from "core/BakedVertexAnimation/bakedVertexAnimationManager";
+import { RawTexture } from "core/Materials/Textures/rawTexture";
+import { Texture } from "core/Materials/Textures/texture";
+import "core/Materials/standardMaterial";
 import "core/Meshes/thinInstanceMesh";
 
 describe("ThinInstance picking", () => {
-    let engine: Engine;
+    let engine: NullEngine;
     let scene: Scene;
     let box: Mesh;
 
@@ -32,6 +39,41 @@ describe("ThinInstance picking", () => {
         box.thinInstanceEnablePicking = true;
     }
 
+    function setSingleBoneInfluence(mesh: Mesh) {
+        const vertexCount = mesh.getTotalVertices();
+        const matricesIndices = new Float32Array(vertexCount * 4);
+        const matricesWeights = new Float32Array(vertexCount * 4);
+
+        for (let index = 0; index < vertexCount; ++index) {
+            matricesWeights[index * 4] = 1;
+        }
+
+        mesh.setVerticesData(VertexBuffer.MatricesIndicesKind, matricesIndices);
+        mesh.setVerticesData(VertexBuffer.MatricesWeightsKind, matricesWeights);
+        mesh.numBoneInfluencers = 1;
+    }
+
+    function createBakedVertexAnimationTexture() {
+        const textureData = new Float32Array(64);
+
+        Matrix.Identity().copyToArray(textureData, 0);
+        Matrix.Identity().copyToArray(textureData, 16);
+        Matrix.Translation(0, 10, 0).copyToArray(textureData, 32);
+        Matrix.Identity().copyToArray(textureData, 48);
+
+        return RawTexture.CreateRGBATexture(textureData, 8, 2, scene, false, false, Texture.NEAREST_NEAREST, Constants.TEXTURETYPE_FLOAT);
+    }
+
+    function createBakedVertexAnimationManager(mesh: Mesh) {
+        setSingleBoneInfluence(mesh);
+
+        const manager = new BakedVertexAnimationManager(scene);
+        manager.texture = createBakedVertexAnimationTexture();
+        mesh.bakedVertexAnimationManager = manager;
+
+        return manager;
+    }
+
     beforeEach(() => {
         engine = new NullEngine({
             renderHeight: 256,
@@ -50,6 +92,53 @@ describe("ThinInstance picking", () => {
         PickingCustomization.internalPickerForMesh = undefined;
         scene.dispose();
         engine.dispose();
+    });
+
+    describe("refreshBoundingInfo", () => {
+        it("does not apply baked vertex animation unless requested", () => {
+            const manager = createBakedVertexAnimationManager(box);
+
+            box.thinInstanceAdd(Matrix.Identity(), true);
+            box.thinInstanceSetBuffer("bakedVertexAnimationSettingsInstanced", new Float32Array([0, 1, 0, 30]), 4);
+
+            manager.time = 1 / 30;
+            box.thinInstanceRefreshBoundingInfo(true);
+            expect(box.getBoundingInfo().minimum.y).toBeCloseTo(-0.5);
+            expect(box.getBoundingInfo().maximum.y).toBeCloseTo(0.5);
+        });
+
+        it("updates bounds from instanced baked vertex animation settings", () => {
+            const manager = createBakedVertexAnimationManager(box);
+
+            box.thinInstanceAdd(Matrix.Identity(), true);
+            box.thinInstanceSetBuffer("bakedVertexAnimationSettingsInstanced", new Float32Array([0, 1, 0, 30]), 4);
+
+            manager.time = 0;
+            box.thinInstanceRefreshBoundingInfo(true, false, false, true);
+            expect(box.getBoundingInfo().minimum.y).toBeCloseTo(-0.5);
+            expect(box.getBoundingInfo().maximum.y).toBeCloseTo(0.5);
+
+            manager.time = 1 / 30;
+            box.thinInstanceRefreshBoundingInfo(true, false, false, true);
+            expect(box.getBoundingInfo().minimum.y).toBeCloseTo(9.5);
+            expect(box.getBoundingInfo().maximum.y).toBeCloseTo(10.5);
+            expect(box.rawBoundingInfo!.minimum.y).toBeCloseTo(9.5);
+            expect(box.rawBoundingInfo!.maximum.y).toBeCloseTo(10.5);
+        });
+
+        it("uses animated vertices instead of local animated AABB corners for thin-instance bounds", () => {
+            const diagonalMesh = new Mesh("diagonal", scene);
+            diagonalMesh.setVerticesData(VertexBuffer.PositionKind, new Float32Array([0, 0, 0, 1, 1, 0]));
+            createBakedVertexAnimationManager(diagonalMesh);
+
+            diagonalMesh.thinInstanceAdd(Matrix.RotationZ(Math.PI / 4), true);
+            diagonalMesh.thinInstanceSetBuffer("bakedVertexAnimationSettingsInstanced", new Float32Array([0, 0, 0, 30]), 4);
+
+            diagonalMesh.thinInstanceRefreshBoundingInfo(true, false, false, true);
+            expect(diagonalMesh.getBoundingInfo().minimum.x).toBeCloseTo(0);
+            expect(diagonalMesh.getBoundingInfo().maximum.x).toBeCloseTo(0);
+            expect(diagonalMesh.getBoundingInfo().maximum.y).toBeCloseTo(Math.SQRT2);
+        });
     });
 
     describe("pickWithRay", () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Adds an opt-in baked vertex animation path to thin-instance bounding refresh so animated thin instances can recompute CPU bounds from the VAT texture and per-instance animation settings.

## What changed

- Adds `applyBakedVertexAnimation` as an optional fourth parameter on `thinInstanceRefreshBoundingInfo`, defaulting to `false` for backward compatibility.
- Applies baked vertex animation in the CPU mesh data path when explicitly requested.
- Uses per-thin-instance `bakedVertexAnimationSettingsInstanced` when refreshing thin-instance bounds.
- Adds regression coverage for default behavior, animated bounds refresh, and rotated thin-instance bounds.

## Related

Forum repro: https://forum.babylonjs.com/t/bounding-box-for-animated-thin-instances-are-not-updating/63540
Updated PG: https://playground.babylonjs.com/#T19S0U#5

## Validation

- `npx vitest run --project=unit packages\dev\core\test\unit\Meshes\babylon.thinInstancePicking.test.ts`
- `npx prettier --check packages\dev\core\src\Meshes\abstractMesh.pure.ts packages\dev\core\src\Meshes\thinInstanceMesh.pure.ts packages\dev\core\src\Meshes\thinInstanceMesh.types.ts packages\dev\core\test\unit\Meshes\babylon.thinInstancePicking.test.ts`
- `npx eslint packages\dev\core\src\Meshes\abstractMesh.pure.ts packages\dev\core\src\Meshes\thinInstanceMesh.pure.ts packages\dev\core\src\Meshes\thinInstanceMesh.types.ts packages\dev\core\test\unit\Meshes\babylon.thinInstancePicking.test.ts --quiet`
- `npx playwright test --config playwright.config.ts --project=webgl2 -g "Node Material 0|Texture Repetition - Standard Material|Texture Repetition - PBR Material|Texture Repetition - OpenPBR Material"`
- `npx playwright test --config playwright.config.ts --project=webgpu -g "Node Material 0|Texture Repetition - Standard Material|Texture Repetition - PBR Material|Texture Repetition - OpenPBR Material"`
