### PR TITLE
[DeviceInput] Fix: DSM detects modern Xbox controllers on Linux as Generic

### DIFF
--- a/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
+++ b/packages/dev/core/src/DeviceInput/webDeviceInputSystem.ts
@@ -898,7 +898,15 @@ export class WebDeviceInputSystem implements IDeviceInputSystem {
         if (deviceName.indexOf("054c") !== -1) {
             // DualShock 4 Gamepad
             return deviceName.indexOf("0ce6") !== -1 ? DeviceType.DualSense : DeviceType.DualShock;
-        } else if (deviceName.indexOf("Xbox One") !== -1 || deviceName.search("Xbox 360") !== -1 || deviceName.search("xinput") !== -1) {
+        } else if (
+            deviceName.indexOf("Xbox One") !== -1 ||
+            deviceName.search("Xbox 360") !== -1 ||
+            deviceName.search("xinput") !== -1 ||
+            // Microsoft vendor id covers Xbox Series/One/Elite controllers reported with various names
+            // (e.g. "Xbox Wireless Controller (... Vendor: 045e Product: 0b13)"). Excludes the
+            // Surface Dock Extender, which also reports vendor 045e. Mirrors GamepadManager.
+            (deviceName.indexOf("045e") !== -1 && deviceName.indexOf("Surface Dock") === -1)
+        ) {
             // Xbox Gamepad
             return DeviceType.Xbox;
         } else if (deviceName.indexOf("057e") !== -1) {


### PR DESCRIPTION
Forum thread: https://forum.babylonjs.com/t/xbox-gamepad-not-working-with-the-device-source-manager-on-linux/63536

### Root cause

`WebDeviceInputSystem._getGamepadDeviceType` only matched the substrings `"Xbox One"`, `"Xbox 360"`, or `"xinput"`. On Linux (xpadneo) Chromium reports newer Xbox controllers with id strings like `"Xbox Wireless Controller (STANDARD GAMEPAD Vendor: 045e Product: 0b13)"` and `"Microsoft Controller (... Vendor: 045e Product: 02ea)"`, none of which contain those substrings. The result: every Xbox Series / Xbox One / Xbox Elite controller falls through to `DeviceType.Generic` on Linux.

The legacy `GamepadManager._addNewGamepad` already handles this by additionally matching the Microsoft USB vendor id `"045e"` (excluding the Surface Dock Extender). DSM was simply missing the same check.

### Fix

Add the `"045e"` (Microsoft vendor) check to DSM's Xbox detection, mirroring the long-standing logic in `GamepadManager`. Strict superset of previous detection — no existing path regresses.

### Verification

Reporter ran a diagnostic playground and provided real `gamepad.id` strings from six Xbox-family controllers on Arch Linux + Chromium:

| Controller | id substring | Caught by `"045e"` check? |
|---|---|---|
| Xbox Series Wireless | `Xbox Wireless Controller … Vendor: 045e Product: 0b13` | ✅ |
| Xbox One Wired | `Microsoft Controller … Vendor: 045e Product: 02ea` | ✅ |
| Xbox Elite V2 Wired | `Microsoft Controller … Vendor: 045e Product: 0b00` | ✅ |
| Xbox Elite V2 Wireless | `Xbox Elite Wireless Controller … Vendor: 045e Product: 028e` | ✅ |
| 8BitDo SN30pro | `Microsoft X-Box 360 pad … Vendor: 045e Product: 028e` | ✅ |
| Steam Controller 2 | `Microsoft X-Box 360 pad 1 … Vendor: 28de Product: 11ff` | ❌ (Valve vendor — out of scope) |

### Test coverage

No existing unit tests cover `_getGamepadDeviceType` (private, string-based). Verified by inspection of the matched id strings against the new predicate.
