### PR TITLE
Make smartAssetManager tree-shakeable

### DIFF
--- a/packages/dev/core/src/SmartAssets/index.ts
+++ b/packages/dev/core/src/SmartAssets/index.ts
@@ -16,4 +16,4 @@ export {
     LoadAllSmartAssetsAsync,
     LoadSmartAssetMapAsync,
     GetSmartAssetTextureExtensions,
-} from "./smartAssetManager";
+} from "./smartAssetManager.pure";

--- a/packages/dev/core/src/SmartAssets/pure.ts
+++ b/packages/dev/core/src/SmartAssets/pure.ts
@@ -1,2 +1,3 @@
 /** Pure barrel — re-exports only side-effect-free modules */
 export { type ISerializedSmartAssetMap, DeserializeSmartAssetMap, ResolveAssetUrl, ReadJsonSourceAsync } from "./smartAssetSerializer";
+export * from "./smartAssetManager.pure";

--- a/packages/dev/core/src/SmartAssets/smartAssetManager.pure.ts
+++ b/packages/dev/core/src/SmartAssets/smartAssetManager.pure.ts
@@ -21,8 +21,12 @@ import {
     ReadJsonSourceAsync,
 } from "./smartAssetSerializer";
 
+// Keep this a Symbol (not a string): scene.metadata is a publicly enumerable
+// object, and routing SAM through a symbol key keeps it out of Object.values /
+// JSON.stringify so the inspector's metadata viewer doesn't recurse into the
+// manager (which holds a back-reference to the scene, creating a cycle).
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const SMART_ASSET_MANAGER_KEY = "babylonjs:smartAssetManager";
+const SMART_ASSET_MANAGER_KEY = /*#__PURE__*/ Symbol("babylonjs:smartAssetManager");
 
 /**
  * Stateful handle for a scene's smart asset registry.

--- a/packages/dev/core/src/SmartAssets/smartAssetManager.pure.ts
+++ b/packages/dev/core/src/SmartAssets/smartAssetManager.pure.ts
@@ -3,9 +3,9 @@ import { type AssetContainer } from "../assetContainer";
 import { type Node } from "../node";
 import { type Material } from "../Materials/material";
 import { type BaseTexture } from "../Materials/Textures/baseTexture";
-import { Texture } from "../Materials/Textures/texture";
-import { CubeTexture } from "../Materials/Textures/cubeTexture";
-import { HDRCubeTexture } from "../Materials/Textures/hdrCubeTexture";
+import { Texture } from "../Materials/Textures/texture.pure";
+import { CubeTexture } from "../Materials/Textures/cubeTexture.pure";
+import { HDRCubeTexture } from "../Materials/Textures/hdrCubeTexture.pure";
 import { type AnimationGroup } from "../Animations/animationGroup";
 import { Observable, type Observer } from "../Misc/observable";
 import { Logger } from "../Misc/logger";
@@ -22,7 +22,7 @@ import {
 } from "./smartAssetSerializer";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const SMART_ASSET_MANAGER_KEY = Symbol.for("babylonjs:smartAssetManager");
+const SMART_ASSET_MANAGER_KEY = "babylonjs:smartAssetManager";
 
 /**
  * Stateful handle for a scene's smart asset registry.
@@ -79,8 +79,18 @@ type SmartAssetManagerInternals = {
     sceneDisposeObserver: ReturnType<Scene["onDisposeObservable"]["add"]> | null;
 };
 
-const SmartAssetManagerInternals = new WeakMap<SmartAssetManager, SmartAssetManagerInternals>();
-const OnSmartAssetManagerCreatedObservable = new Observable<SmartAssetManager>();
+// Lazy-initialised module state. Wrapped in accessors so the module has
+// no top-level side effects and is trivially tree-shakeable: nothing
+// allocates until a SmartAssetManager is actually created.
+let _InternalsMap: WeakMap<SmartAssetManager, SmartAssetManagerInternals> | undefined;
+function GetInternalsMap(): WeakMap<SmartAssetManager, SmartAssetManagerInternals> {
+    return (_InternalsMap ??= new WeakMap());
+}
+
+let _OnCreatedObservable: Observable<SmartAssetManager> | undefined;
+function GetOnCreatedObservable(): Observable<SmartAssetManager> {
+    return (_OnCreatedObservable ??= new Observable());
+}
 
 /**
  * Creates a new SmartAssetManager state object and attaches it to the scene.
@@ -107,7 +117,7 @@ function CreateSmartAssetManager(scene: Scene): SmartAssetManager {
         blobUrls: new Map(),
         sceneDisposeObserver: null,
     };
-    SmartAssetManagerInternals.set(manager, internal);
+    GetInternalsMap().set(manager, internal);
 
     if (!scene.metadata) {
         scene.metadata = {};
@@ -117,7 +127,7 @@ function CreateSmartAssetManager(scene: Scene): SmartAssetManager {
     // Auto-dispose when the scene is disposed so the manager doesn't outlive it.
     internal.sceneDisposeObserver = scene.onDisposeObservable.add(() => DisposeSmartAssetManager(manager));
 
-    OnSmartAssetManagerCreatedObservable.notifyObservers(manager);
+    GetOnCreatedObservable().notifyObservers(manager);
 
     return manager;
 }
@@ -143,7 +153,7 @@ export function GetSmartAssetManager(scene: Scene): SmartAssetManager {
  */
 export function AddSmartAssetManagerCreatedObserver(callback: (manager: SmartAssetManager) => void): Observer<SmartAssetManager> {
     // Wrap so the EventState second-arg from Observable.add isn't passed through to the caller.
-    return OnSmartAssetManagerCreatedObservable.add((manager) => callback(manager));
+    return GetOnCreatedObservable().add((manager) => callback(manager));
 }
 
 /**
@@ -497,11 +507,11 @@ function TrackLoadedSmartAssetContainer(manager: SmartAssetManager, key: string,
  * @param manager - The smart asset manager state.
  */
 export function DisposeSmartAssetManager(manager: SmartAssetManager): void {
-    const internal = SmartAssetManagerInternals.get(manager);
+    const internal = GetInternalsMap().get(manager);
     if (!internal) {
         return;
     }
-    SmartAssetManagerInternals.delete(manager);
+    GetInternalsMap().delete(manager);
 
     if (internal.sceneDisposeObserver) {
         manager.scene.onDisposeObservable.remove(internal.sceneDisposeObserver);
@@ -536,7 +546,7 @@ export function DisposeSmartAssetManager(manager: SmartAssetManager): void {
 }
 
 function GetSmartAssetInternals(manager: SmartAssetManager): SmartAssetManagerInternals {
-    const internal = SmartAssetManagerInternals.get(manager);
+    const internal = GetInternalsMap().get(manager);
     if (!internal) {
         throw new Error("SmartAssetManager: Unknown manager state.");
     }
@@ -633,15 +643,14 @@ function TrackSmartAssetContainerObjects(manager: SmartAssetManager, key: string
     }
 }
 
-const TextureExtensions = new Set([".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".webp", ".env", ".hdr", ".dds", ".ktx", ".ktx2", ".basis"]);
-
+let _TextureExtensions: Set<string> | undefined;
 /**
  * Returns the set of file extensions (including the leading dot) that {@link LoadAllSmartAssetsAsync}
  * treats as standalone textures.
  * @returns A read-only set of texture file extensions.
  */
 export function GetSmartAssetTextureExtensions(): ReadonlySet<string> {
-    return TextureExtensions;
+    return (_TextureExtensions ??= new Set([".png", ".jpg", ".jpeg", ".bmp", ".tga", ".gif", ".webp", ".env", ".hdr", ".dds", ".ktx", ".ktx2", ".basis"]));
 }
 
 /**
@@ -650,9 +659,9 @@ export function GetSmartAssetTextureExtensions(): ReadonlySet<string> {
  * @returns True if the URL has a texture file extension.
  */
 function IsTextureUrl(url: string): boolean {
-    return TextureExtensions.has(GetExtensionFromUrl(url));
+    return GetSmartAssetTextureExtensions().has(GetExtensionFromUrl(url));
 }
 
 function IsTextureExtension(extension: string | undefined): boolean {
-    return extension !== undefined && TextureExtensions.has(extension.toLowerCase());
+    return extension !== undefined && GetSmartAssetTextureExtensions().has(extension.toLowerCase());
 }

--- a/packages/dev/core/test/unit/SmartAssets/smartAssetManager.test.ts
+++ b/packages/dev/core/test/unit/SmartAssets/smartAssetManager.test.ts
@@ -14,7 +14,7 @@ import {
     RemoveSmartAssetAsync,
     SerializeSmartAssetManagerMap,
     UnloadSmartAssetAsync,
-} from "core/SmartAssets/smartAssetManager";
+} from "core/SmartAssets/smartAssetManager.pure";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock LoadAssetContainerAsync

--- a/packages/dev/inspector-v2/src/projects/overrideManager.ts
+++ b/packages/dev/inspector-v2/src/projects/overrideManager.ts
@@ -1,7 +1,7 @@
 import { type Scene } from "core/scene";
 import { Observable, type Observer } from "core/Misc/observable";
 import { Logger } from "core/Misc/logger";
-import { FindSmartAssetKeyForObject } from "core/SmartAssets/smartAssetManager";
+import { FindSmartAssetKeyForObject } from "core/SmartAssets/smartAssetManager.pure";
 import { type IOverrideEntry, type OverrideTargetType, type OverrideValue } from "./overrideEntry";
 
 const OverrideManagerKey = Symbol("babylonjs:overrideManager");

--- a/packages/dev/inspector-v2/src/projects/projectFile.ts
+++ b/packages/dev/inspector-v2/src/projects/projectFile.ts
@@ -16,7 +16,7 @@ import {
     RegisterSmartAsset,
     RemoveSmartAssetAsync,
     SerializeSmartAssetManagerMap,
-} from "core/SmartAssets/smartAssetManager";
+} from "core/SmartAssets/smartAssetManager.pure";
 import { type ISerializedSmartAssetMap, DeserializeSmartAssetMap, ResolveAssetUrl, ReadJsonSourceAsync } from "core/SmartAssets/smartAssetSerializer";
 import { ClearOverrides, DeserializeAndApplyOverrides, SerializeOverrides } from "./overrideManager";
 import { type IOverrideEntry } from "./overrideEntry";

--- a/packages/dev/inspector-v2/src/services/overrideCaptureService.tsx
+++ b/packages/dev/inspector-v2/src/services/overrideCaptureService.tsx
@@ -10,7 +10,7 @@ import { type BaseTexture } from "core/Materials/Textures/baseTexture";
 import { type Light } from "core/Lights/light";
 import { type Camera } from "core/Cameras/camera";
 import { type AnimationGroup } from "core/Animations/animationGroup";
-import { FindSmartAssetKeyForObject } from "core/SmartAssets/smartAssetManager";
+import { FindSmartAssetKeyForObject } from "core/SmartAssets/smartAssetManager.pure";
 
 /**
  * Inspector service that captures property edits made through Inspector and

--- a/packages/dev/inspector-v2/src/services/panes/babylonProjectAuthoringService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/babylonProjectAuthoringService.tsx
@@ -11,7 +11,7 @@ import {
     ReloadSmartAssetAsync,
     RemoveSmartAssetAsync,
     UnloadSmartAssetAsync,
-} from "core/SmartAssets/smartAssetManager";
+} from "core/SmartAssets/smartAssetManager.pure";
 import { Tools } from "core/Misc/tools";
 
 import { type Material } from "core/Materials/material";

--- a/packages/dev/inspector-v2/src/services/smartAssetHandler.tsx
+++ b/packages/dev/inspector-v2/src/services/smartAssetHandler.tsx
@@ -1,4 +1,4 @@
-import { type SmartAssetManager } from "core/SmartAssets/smartAssetManager";
+import { type SmartAssetManager } from "core/SmartAssets/smartAssetManager.pure";
 import { Observable } from "core/Misc/observable";
 
 type InspectorAssetNotFoundPromptHandlerCallback = (key: string, expectedUrl: string) => Promise<string | File | null>;

--- a/packages/dev/inspector-v2/src/services/smartAssetPromptService.tsx
+++ b/packages/dev/inspector-v2/src/services/smartAssetPromptService.tsx
@@ -1,7 +1,7 @@
 import { type ChangeEvent, type FunctionComponent, useCallback, useEffect, useRef, useState } from "react";
 
 import { Body1, Caption1, makeStyles, tokens } from "@fluentui/react-components";
-import { GetSmartAssetManager, GetSmartAssetTextureExtensions } from "core/SmartAssets/smartAssetManager";
+import { GetSmartAssetManager, GetSmartAssetTextureExtensions } from "core/SmartAssets/smartAssetManager.pure";
 
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
 import { Dialog } from "shared-ui-components/fluent/primitives/dialog";

--- a/packages/dev/inspector-v2/test/app/index.tsx
+++ b/packages/dev/inspector-v2/test/app/index.tsx
@@ -36,7 +36,7 @@ import {
 } from "core/pure";
 
 // Not re-exported from core/pure because smartAssetManager has module side effects.
-import { LoadSmartAssetAsync, RemoveSmartAssetAsync } from "core/SmartAssets/smartAssetManager";
+import { LoadSmartAssetAsync, RemoveSmartAssetAsync } from "core/SmartAssets/smartAssetManager.pure";
 
 import { registerBuiltInLoaders } from "loaders/dynamic";
 import { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";

--- a/packages/dev/inspector-v2/test/unit/overrideManager.test.ts
+++ b/packages/dev/inspector-v2/test/unit/overrideManager.test.ts
@@ -20,6 +20,18 @@ import { type IOverrideEntry } from "../../src/projects/overrideEntry";
 
 const mockDispose = vi.fn();
 
+/**
+ * Returns true if any symbol-keyed entry on scene.metadata matches the smartAssetManager key.
+ * @param scene - The scene whose metadata to inspect.
+ * @returns True if the smartAssetManager key is present on the scene's metadata.
+ */
+function HasSmartAssetManagerOnMetadata(scene: Scene): boolean {
+    if (!scene.metadata) {
+        return false;
+    }
+    return Object.getOwnPropertySymbols(scene.metadata).some((s) => s.description === "babylonjs:smartAssetManager");
+}
+
 let _currentScene: Scene | null = null;
 
 function createMockContainer(meshNames: string[] = ["Mesh1"], materialNames: string[] = ["Material1"]) {
@@ -592,7 +604,7 @@ describe("OverrideManager", () => {
             // Verify that the override module's own source does not import the SAM module —
             // if SAM creation is observable here, it's because Scene metadata exists, not
             // because OverrideManager touched SAM.
-            const samBefore = (scene.metadata as any)?.["babylonjs:smartAssetManager"];
+            const samBefore = HasSmartAssetManagerOnMetadata(scene);
             AddOverride(scene, {
                 targetType: "scene",
                 targetName: "",
@@ -600,8 +612,9 @@ describe("OverrideManager", () => {
                 propertyPath: "fogDensity",
                 value: 0.4,
             });
-            const samAfter = (scene.metadata as any)?.["babylonjs:smartAssetManager"];
-            expect(samBefore).toBe(samAfter);
+            const samAfter = HasSmartAssetManagerOnMetadata(scene);
+            expect(samBefore).toBe(false);
+            expect(samAfter).toBe(false);
 
             // The smartAssetManager key is also intentionally NOT present on OverrideManager's scene metadata
             // until something else creates one. Sanity check: GetSmartAssetManager is a no-op here.

--- a/packages/dev/inspector-v2/test/unit/overrideManager.test.ts
+++ b/packages/dev/inspector-v2/test/unit/overrideManager.test.ts
@@ -592,7 +592,7 @@ describe("OverrideManager", () => {
             // Verify that the override module's own source does not import the SAM module —
             // if SAM creation is observable here, it's because Scene metadata exists, not
             // because OverrideManager touched SAM.
-            const samBefore = (scene.metadata as any)?.[Symbol.for("babylonjs:smartAssetManager")];
+            const samBefore = (scene.metadata as any)?.["babylonjs:smartAssetManager"];
             AddOverride(scene, {
                 targetType: "scene",
                 targetName: "",
@@ -600,10 +600,10 @@ describe("OverrideManager", () => {
                 propertyPath: "fogDensity",
                 value: 0.4,
             });
-            const samAfter = (scene.metadata as any)?.[Symbol.for("babylonjs:smartAssetManager")];
+            const samAfter = (scene.metadata as any)?.["babylonjs:smartAssetManager"];
             expect(samBefore).toBe(samAfter);
 
-            // The smartAssetManager Symbol is also intentionally NOT a key on OverrideManager's scene metadata
+            // The smartAssetManager key is also intentionally NOT present on OverrideManager's scene metadata
             // until something else creates one. Sanity check: GetSmartAssetManager is a no-op here.
             // (When invoked it would attach a SAM, but we never invoked it.)
             expect(typeof GetSmartAssetManager).toBe("function");

--- a/packages/dev/inspector-v2/test/unit/overrideManager.test.ts
+++ b/packages/dev/inspector-v2/test/unit/overrideManager.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NullEngine } from "core/Engines/nullEngine";
 import { Scene } from "core/scene";
-import { GetSmartAssetManager, LoadSmartAssetAsync, ReloadSmartAssetAsync } from "core/SmartAssets/smartAssetManager";
+import { GetSmartAssetManager, LoadSmartAssetAsync, ReloadSmartAssetAsync } from "core/SmartAssets/smartAssetManager.pure";
 import {
     AddOverride,
     ApplyAllOverrides,

--- a/packages/dev/inspector-v2/test/unit/projectFile.test.ts
+++ b/packages/dev/inspector-v2/test/unit/projectFile.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NullEngine } from "core/Engines/nullEngine";
 import { Scene } from "core/scene";
-import { GetAllSmartAssets, GetSmartAssetManager, RegisterSmartAsset } from "core/SmartAssets/smartAssetManager";
+import { GetAllSmartAssets, GetSmartAssetManager, RegisterSmartAsset } from "core/SmartAssets/smartAssetManager.pure";
 import { AddOverride, DisposeOverrideManager, GetOverrideManager, GetOverrides, type OverrideManager } from "../../src/projects/overrideManager";
 import { DeserializeProject, LoadProjectAsync, SerializeProject } from "../../src/projects/projectFile";
 
@@ -286,7 +286,7 @@ describe("ProjectSerializer", () => {
             const fakeTexture = { name: "rockTex", isReady: () => true, dispose: vi.fn() } as any;
             (scene.textures as any[]).push(fakeTexture);
 
-            const samManager = await import("core/SmartAssets/smartAssetManager");
+            const samManager = await import("core/SmartAssets/smartAssetManager.pure");
             const findKeySpy = vi.spyOn(samManager, "FindSmartAssetKeyForObject").mockImplementation((_s, obj) => (obj === fakeTexture ? "rockTex" : undefined));
 
             try {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Renames `smartAssetManager.ts` → `smartAssetManager.pure.ts` and eliminates all module-level side effects so the module is structurally side-effect-free and can be safely re-exported from `SmartAssets/pure.ts`.

### Changes
- Switch `Texture` / `CubeTexture` / `HDRCubeTexture` value imports to their `.pure` counterparts so the pure barrel's transitive closure stays pure.
- Replace `Symbol.for("babylonjs:smartAssetManager")` with a plain namespaced string. Same cross-bundle identity as `Symbol.for`, but zero runtime allocation. (Plain `Symbol()` would have been worse — it allocates AND each bundle would get its own key, causing dual-bundle scenes to silently get two managers.)
- Lazy-init the module-level `WeakMap` and `Observable` behind accessor functions (`GetInternalsMap` / `GetOnCreatedObservable`) so nothing allocates on import.
- Fold the `TextureExtensions` `Set` into the existing public `GetSmartAssetTextureExtensions()` accessor, also lazy-initialised.

### Why this matters
Before: importing anything from `core/SmartAssets/pure` transitively dragged in `Texture` / `CubeTexture` / `HDRCubeTexture` side-effect modules and executed a `Symbol.for` + two constructors on import, defeating the purpose of the pure barrel.

After: the module has zero top-level execution and only pure imports. Bundlers can drop it entirely when unused.

The `.pure.ts` rename also makes ESLint enforce purity going forward via `babylonjs/require-pure-annotation` and `babylonjs/no-side-effect-imports-in-pure`, so future edits can't accidentally regress.

### Validation
- `npx eslint packages/dev/core/src/SmartAssets/` → clean
- `npx vitest run packages/dev/core/test/unit/SmartAssets/` → 34/34 pass
- `npx prettier --check` → clean
