### PR TITLE
fix(FlowGraph): allow CancelDelay to cancel the first scheduled delay

### DIFF
--- a/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.pure.ts
+++ b/packages/dev/core/src/FlowGraph/Blocks/Execution/ControlFlow/flowGraphCancelDelayBlock.pure.ts
@@ -28,7 +28,7 @@ export class FlowGraphCancelDelayBlock extends FlowGraphExecutionBlockWithOutSig
 
     public _execute(context: FlowGraphContext, _callingSignal: FlowGraphSignalConnection): void {
         const delayIndex = getNumericValue(this.delayIndex.getValue(context));
-        if (delayIndex <= 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
+        if (delayIndex < 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
             return this._reportError(context, "Invalid delay index");
         }
         const timers = context._getGlobalContextVariable("pendingDelays", [] as AdvancedTimer[]);

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphExecutionNodes.test.ts
@@ -14,6 +14,7 @@ import {
     FlowGraphSwitchBlock,
     FlowGraphThrottleBlock,
     FlowGraphSetDelayBlock,
+    FlowGraphCancelDelayBlock,
 } from "core/FlowGraph";
 import { FlowGraphBranchBlock } from "core/FlowGraph/Blocks/Execution/ControlFlow/flowGraphBranchBlock";
 import { FlowGraphInteger } from "core/FlowGraph/CustomTypes/flowGraphInteger";
@@ -202,6 +203,37 @@ describe("Flow Graph Execution Nodes", () => {
         scene.render();
         expect(Logger.Log).toHaveBeenNthCalledWith(1, "custom");
         expect(Logger.Log).toHaveBeenNthCalledWith(2, "custom2");
+    });
+
+    it("Cancel Delay Block cancels the first scheduled delay (index 0)", async () => {
+        const sceneReady = new FlowGraphSceneReadyEventBlock();
+        flowGraph.addEventBlock(sceneReady);
+
+        const timeToWait = 1000;
+
+        // The first delay scheduled in a context is assigned lastDelayIndex 0.
+        const delay = new FlowGraphSetDelayBlock();
+        sceneReady.done.connectTo(delay.in);
+        delay.duration.setValue(timeToWait / 1000, flowGraphContext);
+
+        const onDone = new FlowGraphConsoleLogBlock();
+        onDone.message.setValue("done", flowGraphContext);
+        delay.done.connectTo(onDone.in);
+
+        // Cancel that delay by feeding its lastDelayIndex (0) into CancelDelay.
+        const cancel = new FlowGraphCancelDelayBlock();
+        delay.lastDelayIndex.connectTo(cancel.delayIndex);
+
+        flowGraph.start();
+
+        // The delay is now scheduled with index 0; cancel it before it elapses.
+        cancel._execute(flowGraphContext, cancel.in);
+
+        // Wait past the original duration — the cancelled delay's done must not fire.
+        await new Promise((resolve) => setTimeout(resolve, timeToWait + 30));
+        scene.render();
+
+        expect(Logger.Log).not.toHaveBeenCalledWith("done");
     });
 
     it("Flip Flop Block", () => {


### PR DESCRIPTION
## Bug

`FlowGraphSetDelayBlock` assigns the **first** scheduled delay index `0` (`lastDelayIndex` starts at `-1`, then `newIndex = lastDelayIndex + 1`). However `FlowGraphCancelDelayBlock` treats `delayIndex <= 0` as invalid and reports an error instead of canceling.

The practical effect: when there's only one pending delay (or you cancel the first one scheduled in a context), `flow/cancelDelay` silently fails — it fires the error flow and never disposes the timer, so the delay's `done` still activates.

## Fix

Change the guard from `delayIndex <= 0` to `delayIndex < 0`, so index `0` is a valid, cancellable delay. Negative / NaN / non-finite indices remain invalid, and the rest of the block is unchanged.

```diff
- if (delayIndex <= 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
+ if (delayIndex < 0 || isNaN(delayIndex) || !isFinite(delayIndex)) {
```

## Test

Added a unit test in `flowGraphExecutionNodes.test.ts` ("Cancel Delay Block cancels the first scheduled delay (index 0)") that schedules a delay, wires its `lastDelayIndex` (0) into a `FlowGraphCancelDelayBlock`, cancels before the duration elapses, and asserts the delay's `done` never fires. Verified the test fails on the old `<= 0` guard and passes with the fix; the full `flowGraphExecutionNodes` suite (10 tests) is green.