### PR TITLE
Native: prefer setRenderResetCallback with legacy setDeviceLostCallback fallback

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -24,7 +24,16 @@ export interface INativeEngine {
     dispose(): void;
 
     requestAnimationFrame(callback: () => void): void;
-    setDeviceLostCallback(callback: () => void): void;
+    /**
+     * Registers a callback fired after bgfx is (re)initialized on the graphics device, i.e. the
+     * device-restored edge. Preferred name; see BabylonNative #1722.
+     */
+    setRenderResetCallback?(callback: () => void): void;
+    /**
+     * @deprecated Use {@link setRenderResetCallback}. Kept for compatibility with older
+     * BabylonNative builds; despite the name, this fires on device restore, not loss.
+     */
+    setDeviceLostCallback?(callback: () => void): void;
 
     createVertexArray(): NativeData;
 

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -280,12 +280,18 @@ export class ThinNativeEngine extends ThinEngine {
             throw new Error(`Protocol version mismatch: ${_native.Engine.PROTOCOL_VERSION} (Native) !== ${ThinNativeEngine.PROTOCOL_VERSION} (JS)`);
         }
 
-        if (this._engine.setDeviceLostCallback) {
-            this._engine.setDeviceLostCallback(() => {
-                this.onContextLostObservable.notifyObservers(this);
-                this._contextWasLost = true;
-                this._restoreEngineAfterContextLost();
-            });
+        // Prefer setRenderResetCallback (accurate name -- fires when bgfx is (re)initialized,
+        // i.e. on device restore). Fall back to the legacy setDeviceLostCallback for backward
+        // compatibility with older BabylonNative builds. See BabylonNative #1722.
+        const renderResetCallback = () => {
+            this.onContextLostObservable.notifyObservers(this);
+            this._contextWasLost = true;
+            this._restoreEngineAfterContextLost();
+        };
+        if (this._engine.setRenderResetCallback) {
+            this._engine.setRenderResetCallback(renderResetCallback);
+        } else if (this._engine.setDeviceLostCallback) {
+            this._engine.setDeviceLostCallback(renderResetCallback);
         }
 
         this._webGLVersion = 2;


### PR DESCRIPTION
## Context

`INativeEngine.setDeviceLostCallback` actually fires on the device-**restored** edge (after bgfx re-initializes on a `DisableRendering` / `UpdateDevice` / re-`EnableRendering` cycle), not on device loss. BabylonNative #1722 adds `setRenderResetCallback` as the accurate name while keeping `setDeviceLostCallback` as an alias for backward compatibility.

## Change

Prefer `setRenderResetCallback`; fall back to `setDeviceLostCallback` when running against a pre-#1722 BabylonNative build.

Both methods are marked optional on `INativeEngine`, and `setDeviceLostCallback` is `@deprecated`.

## Compatibility

Works against any BabylonNative version. Independent of when BabylonNative #1722 lands.

[Created by Copilot on behalf of @bghgary]
