### PR TITLE
Add HALF_FLOAT vertex buffer type support

### DIFF
--- a/packages/dev/core/src/Buffers/buffer.align.pure.ts
+++ b/packages/dev/core/src/Buffers/buffer.align.pure.ts
@@ -101,6 +101,8 @@ export function RegisterBufferAlign(): void {
             alignedData = new Int16Array(totalLength);
         } else if (this.type === VertexBuffer.UNSIGNED_SHORT) {
             alignedData = new Uint16Array(totalLength);
+        } else if (this.type === VertexBuffer.HALF_FLOAT) {
+            alignedData = new Uint16Array(totalLength);
         } else if (this.type === VertexBuffer.INT) {
             alignedData = new Int32Array(totalLength);
         } else if (this.type === VertexBuffer.UNSIGNED_INT) {
@@ -126,6 +128,9 @@ export function RegisterBufferAlign(): void {
                         alignedData[i * alignedSize + j] = sourceData.getInt16(sourceOffset + j * 2, IsLittleEndian);
                         break;
                     case VertexBuffer.UNSIGNED_SHORT:
+                        alignedData[i * alignedSize + j] = sourceData.getUint16(sourceOffset + j * 2, IsLittleEndian);
+                        break;
+                    case VertexBuffer.HALF_FLOAT:
                         alignedData[i * alignedSize + j] = sourceData.getUint16(sourceOffset + j * 2, IsLittleEndian);
                         break;
                     case VertexBuffer.INT:

--- a/packages/dev/core/src/Buffers/buffer.nonFloatVertexBuffers.ts
+++ b/packages/dev/core/src/Buffers/buffer.nonFloatVertexBuffers.ts
@@ -33,6 +33,7 @@ function IsSignedType(type: number): boolean {
         case VertexBuffer.SHORT:
         case VertexBuffer.INT:
         case VertexBuffer.FLOAT:
+        case VertexBuffer.HALF_FLOAT:
             return true;
         case VertexBuffer.UNSIGNED_BYTE:
         case VertexBuffer.UNSIGNED_SHORT:
@@ -67,7 +68,7 @@ export function checkNonFloatVertexBuffers(vertexBuffers: { [key: string]: Nulla
             continue;
         }
 
-        const currentVertexBufferType = currentVertexBuffer.normalized ? VertexBuffer.FLOAT : currentVertexBuffer.type;
+        const currentVertexBufferType = currentVertexBuffer.normalized || currentVertexBuffer.type === VertexBuffer.HALF_FLOAT ? VertexBuffer.FLOAT : currentVertexBuffer.type;
         const vertexBufferType = pipelineContext.vertexBufferKindToType[kind];
 
         if (

--- a/packages/dev/core/src/Buffers/buffer.pure.ts
+++ b/packages/dev/core/src/Buffers/buffer.pure.ts
@@ -380,11 +380,13 @@ export class VertexBuffer {
 
     /**
      * The integer type.
+     * Note: supported as a vertex attribute type only on the WebGL and WebGPU engines, not on Babylon Native.
      */
     public static readonly INT = Constants.INT;
 
     /**
      * The unsigned integer type.
+     * Note: supported as a vertex attribute type only on the WebGL and WebGPU engines, not on Babylon Native.
      */
     public static readonly UNSIGNED_INT = Constants.UNSIGNED_INT;
 
@@ -395,6 +397,7 @@ export class VertexBuffer {
 
     /**
      * The half float type.
+     * Note: supported as a vertex attribute type only on the WebGL and WebGPU engines, not on Babylon Native.
      */
     public static readonly HALF_FLOAT = Constants.HALF_FLOAT;
 
@@ -625,7 +628,7 @@ export class VertexBuffer {
         (this.hashCode as any) =
             (VertexBuffer._GetTypeHashIndex(this.type) << 0) +
             ((this.normalized ? 1 : 0) << 3) +
-            (this._size << 4) +
+            ((this._size - 1) << 4) +
             ((this._instanced ? 1 : 0) << 6) +
             /* keep 5 bits free */
             (this.byteStride << 12);

--- a/packages/dev/core/src/Buffers/buffer.pure.ts
+++ b/packages/dev/core/src/Buffers/buffer.pure.ts
@@ -394,6 +394,11 @@ export class VertexBuffer {
     public static readonly FLOAT = Constants.FLOAT;
 
     /**
+     * The half float type.
+     */
+    public static readonly HALF_FLOAT = Constants.HALF_FLOAT;
+
+    /**
      * Gets a boolean indicating if the Buffer is disposed
      */
     public get isDisposed(): boolean {
@@ -592,10 +597,33 @@ export class VertexBuffer {
         this._computeHashCode();
     }
 
+    private static _GetTypeHashIndex(type: number): number {
+        switch (type) {
+            case VertexBuffer.BYTE:
+                return 0;
+            case VertexBuffer.UNSIGNED_BYTE:
+                return 1;
+            case VertexBuffer.SHORT:
+                return 2;
+            case VertexBuffer.UNSIGNED_SHORT:
+                return 3;
+            case VertexBuffer.INT:
+                return 4;
+            case VertexBuffer.UNSIGNED_INT:
+                return 5;
+            case VertexBuffer.FLOAT:
+                return 6;
+            case VertexBuffer.HALF_FLOAT:
+                return 7;
+            default:
+                throw new Error(`Invalid vertex buffer type '${type}'`);
+        }
+    }
+
     private _computeHashCode(): void {
         // note: cast to any because the property is declared readonly
         (this.hashCode as any) =
-            ((this.type - 5120) << 0) +
+            (VertexBuffer._GetTypeHashIndex(this.type) << 0) +
             ((this.normalized ? 1 : 0) << 3) +
             (this._size << 4) +
             ((this._instanced ? 1 : 0) << 6) +

--- a/packages/dev/core/src/Buffers/bufferUtils.ts
+++ b/packages/dev/core/src/Buffers/bufferUtils.ts
@@ -7,6 +7,55 @@ import { type DataArray, type FloatArray, type IndicesArray, type TypedArray, ty
  */
 export type VertexDataTypedArray = Exclude<TypedArray, Float64Array | BigInt64Array | BigUint64Array>;
 
+const FloatView = new Float32Array(1);
+const Int32View = new Int32Array(FloatView.buffer);
+
+/**
+ * Converts a half float to a number.
+ * @param value the half-float bit pattern to convert
+ * @returns the decoded number
+ */
+function FromHalfFloat(value: number): number {
+    const s = (value & 0x8000) >> 15;
+    const e = (value & 0x7c00) >> 10;
+    const f = value & 0x03ff;
+    if (e === 0) {
+        return (s ? -1 : 1) * Math.pow(2, -14) * (f / Math.pow(2, 10));
+    } else if (e === 0x1f) {
+        return f ? NaN : (s ? -1 : 1) * Infinity;
+    }
+    return (s ? -1 : 1) * Math.pow(2, e - 15) * (1 + f / Math.pow(2, 10));
+}
+
+/**
+ * Converts a number to a half float.
+ * @param value the number to convert
+ * @returns the half-float bit pattern
+ */
+function ToHalfFloat(value: number): number {
+    FloatView[0] = value;
+    const x = Int32View[0];
+    let bits = (x >> 16) & 0x8000;
+    let m = (x >> 12) & 0x07ff;
+    const e = (x >> 23) & 0xff;
+    if (e < 103) {
+        return bits;
+    }
+    if (e > 142) {
+        bits |= 0x7c00;
+        bits |= (e === 255 ? 0 : 1) && x & 0x007fffff;
+        return bits;
+    }
+    if (e < 113) {
+        m |= 0x0800;
+        bits |= (m >> (114 - e)) + ((m >> (113 - e)) & 1);
+        return bits;
+    }
+    bits |= ((e - 112) << 10) | (m >> 1);
+    bits += m & 1;
+    return bits;
+}
+
 function GetFloatValue(dataView: DataView, type: number, byteOffset: number, normalized: boolean): number {
     switch (type) {
         case Constants.BYTE: {
@@ -36,6 +85,9 @@ function GetFloatValue(dataView: DataView, type: number, byteOffset: number, nor
                 value = value / 65535;
             }
             return value;
+        }
+        case Constants.HALF_FLOAT: {
+            return FromHalfFloat(dataView.getUint16(byteOffset, true));
         }
         case Constants.INT: {
             return dataView.getInt32(byteOffset, true);
@@ -82,6 +134,10 @@ function SetFloatValue(dataView: DataView, type: number, byteOffset: number, nor
             dataView.setUint16(byteOffset, value, true);
             break;
         }
+        case Constants.HALF_FLOAT: {
+            dataView.setUint16(byteOffset, ToHalfFloat(value), true);
+            break;
+        }
         case Constants.INT: {
             dataView.setInt32(byteOffset, value, true);
             break;
@@ -112,6 +168,7 @@ export function GetTypeByteLength(type: number): number {
             return 1;
         case Constants.SHORT:
         case Constants.UNSIGNED_SHORT:
+        case Constants.HALF_FLOAT:
             return 2;
         case Constants.INT:
         case Constants.UNSIGNED_INT:
@@ -136,6 +193,8 @@ export function GetTypedArrayConstructor(componentType: number): TypedArrayConst
         case Constants.SHORT:
             return Int16Array;
         case Constants.UNSIGNED_SHORT:
+            return Uint16Array;
+        case Constants.HALF_FLOAT:
             return Uint16Array;
         case Constants.INT:
             return Int32Array;
@@ -351,11 +410,12 @@ export function GetTypedArrayData(
     }
     if (byteStride !== tightlyPackedByteStride) {
         const copy = new constructor(count);
-        EnumerateFloatValues(buffer, adjustedByteOffset, byteStride, size, type, count, false, (values, index) => {
-            for (let i = 0; i < size; i++) {
-                copy[index + i] = values[i];
-            }
-        });
+        const src = new Uint8Array(buffer, adjustedByteOffset);
+        const dst = new Uint8Array(copy.buffer);
+        const rowBytes = size * typeByteLength;
+        for (let v = 0, s = 0, d = 0; v < totalVertices; v++, s += byteStride, d += rowBytes) {
+            dst.set(src.subarray(s, s + rowBytes), d);
+        }
         return copy;
     }
 

--- a/packages/dev/core/src/Buffers/bufferUtils.ts
+++ b/packages/dev/core/src/Buffers/bufferUtils.ts
@@ -1,60 +1,12 @@
 import { Constants } from "../Engines/constants";
 import { Logger } from "../Misc/logger";
+import { FromHalfFloat, ToHalfFloat } from "../Misc/halfFloat";
 import { type DataArray, type FloatArray, type IndicesArray, type TypedArray, type TypedArrayConstructor } from "../types";
 
 /**
  * Union of TypedArrays that can be used for vertex data.
  */
 export type VertexDataTypedArray = Exclude<TypedArray, Float64Array | BigInt64Array | BigUint64Array>;
-
-const FloatView = new Float32Array(1);
-const Int32View = new Int32Array(FloatView.buffer);
-
-/**
- * Converts a half float to a number.
- * @param value the half-float bit pattern to convert
- * @returns the decoded number
- */
-function FromHalfFloat(value: number): number {
-    const s = (value & 0x8000) >> 15;
-    const e = (value & 0x7c00) >> 10;
-    const f = value & 0x03ff;
-    if (e === 0) {
-        return (s ? -1 : 1) * Math.pow(2, -14) * (f / Math.pow(2, 10));
-    } else if (e === 0x1f) {
-        return f ? NaN : (s ? -1 : 1) * Infinity;
-    }
-    return (s ? -1 : 1) * Math.pow(2, e - 15) * (1 + f / Math.pow(2, 10));
-}
-
-/**
- * Converts a number to a half float.
- * @param value the number to convert
- * @returns the half-float bit pattern
- */
-function ToHalfFloat(value: number): number {
-    FloatView[0] = value;
-    const x = Int32View[0];
-    let bits = (x >> 16) & 0x8000;
-    let m = (x >> 12) & 0x07ff;
-    const e = (x >> 23) & 0xff;
-    if (e < 103) {
-        return bits;
-    }
-    if (e > 142) {
-        bits |= 0x7c00;
-        bits |= (e === 255 ? 0 : 1) && x & 0x007fffff;
-        return bits;
-    }
-    if (e < 113) {
-        m |= 0x0800;
-        bits |= (m >> (114 - e)) + ((m >> (113 - e)) & 1);
-        return bits;
-    }
-    bits |= ((e - 112) << 10) | (m >> 1);
-    bits += m & 1;
-    return bits;
-}
 
 function GetFloatValue(dataView: DataView, type: number, byteOffset: number, normalized: boolean): number {
     switch (type) {

--- a/packages/dev/core/src/Engines/Native/nativeHelpers.ts
+++ b/packages/dev/core/src/Engines/Native/nativeHelpers.ts
@@ -340,6 +340,9 @@ export function getNativeAttribType(type: number): number {
             return _native.Engine.ATTRIB_TYPE_UINT16;
         case VertexBuffer.FLOAT:
             return _native.Engine.ATTRIB_TYPE_FLOAT;
+        // HALF_FLOAT (as well as INT and UNSIGNED_INT) has no equivalent in the native bindings, which only
+        // expose ATTRIB_TYPE_INT8/UINT8/INT16/UINT16/FLOAT. Those vertex attribute types are therefore
+        // WebGL/WebGPU only and intentionally fall through to the throw below on the Babylon Native engine.
         default:
             throw new Error(`Unsupported attribute type: ${type}.`);
     }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -703,6 +703,16 @@ export abstract class WebGPUCacheRenderPipeline {
                         return normalized ? WebGPUConstants.VertexFormat.Unorm16x4 : WebGPUConstants.VertexFormat.Uint16x4;
                 }
                 break;
+            case VertexBuffer.HALF_FLOAT:
+                switch (size) {
+                    case 1:
+                    case 2:
+                        return WebGPUConstants.VertexFormat.Float16x2;
+                    case 3:
+                    case 4:
+                        return WebGPUConstants.VertexFormat.Float16x4;
+                }
+                break;
             case VertexBuffer.INT:
                 switch (size) {
                     case 1:

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -1042,6 +1042,11 @@ export class Constants {
     public static FLOAT = 5126;
 
     /**
+     * The half float type.
+     */
+    public static HALF_FLOAT = 5131;
+
+    /**
      * Positions
      */
     public static PositionKind = "position";

--- a/packages/dev/core/src/Materials/Textures/Loaders/EXR/exrLoader.core.ts
+++ b/packages/dev/core/src/Materials/Textures/Loaders/EXR/exrLoader.core.ts
@@ -1,4 +1,5 @@
 import { Clamp } from "core/Maths/math.scalar.functions";
+import { FromHalfFloat, MaxHalfFloat, ToHalfFloat } from "core/Misc/halfFloat";
 import { FLOAT32_SIZE, INT16_SIZE, INT32_SIZE, INT8_SIZE, ULONG_SIZE } from "./exrLoader.interfaces";
 
 /**
@@ -93,115 +94,6 @@ enum LineOrders {
 export interface DataCursor {
     /** Curosr position */
     value: number;
-}
-
-const Tables = GenerateTables();
-
-// Fast Half Float Conversions, http://www.fox-toolkit.org/ftp/fasthalffloatconversion.pdf
-function GenerateTables() {
-    // float32 to float16 helpers
-
-    const buffer = new ArrayBuffer(4);
-    const floatView = new Float32Array(buffer);
-    const uint32View = new Uint32Array(buffer);
-
-    const baseTable = new Uint32Array(512);
-    const shiftTable = new Uint32Array(512);
-
-    for (let i = 0; i < 256; ++i) {
-        const e = i - 127;
-
-        // very small number (0, -0)
-
-        if (e < -27) {
-            baseTable[i] = 0x0000;
-            baseTable[i | 0x100] = 0x8000;
-            shiftTable[i] = 24;
-            shiftTable[i | 0x100] = 24;
-
-            // small number (denorm)
-        } else if (e < -14) {
-            baseTable[i] = 0x0400 >> (-e - 14);
-            baseTable[i | 0x100] = (0x0400 >> (-e - 14)) | 0x8000;
-            shiftTable[i] = -e - 1;
-            shiftTable[i | 0x100] = -e - 1;
-
-            // normal number
-        } else if (e <= 15) {
-            baseTable[i] = (e + 15) << 10;
-            baseTable[i | 0x100] = ((e + 15) << 10) | 0x8000;
-            shiftTable[i] = 13;
-            shiftTable[i | 0x100] = 13;
-
-            // large number (Infinity, -Infinity)
-        } else if (e < 128) {
-            baseTable[i] = 0x7c00;
-            baseTable[i | 0x100] = 0xfc00;
-            shiftTable[i] = 24;
-            shiftTable[i | 0x100] = 24;
-
-            // stay (NaN, Infinity, -Infinity)
-        } else {
-            baseTable[i] = 0x7c00;
-            baseTable[i | 0x100] = 0xfc00;
-            shiftTable[i] = 13;
-            shiftTable[i | 0x100] = 13;
-        }
-    }
-
-    // float16 to float32 helpers
-    const mantissaTable = new Uint32Array(2048);
-    const exponentTable = new Uint32Array(64);
-    const offsetTable = new Uint32Array(64);
-
-    for (let i = 1; i < 1024; ++i) {
-        let m = i << 13; // zero pad mantissa bits
-        let e = 0; // zero exponent
-
-        // normalized
-        while ((m & 0x00800000) === 0) {
-            m <<= 1;
-            e -= 0x00800000; // decrement exponent
-        }
-
-        m &= ~0x00800000; // clear leading 1 bit
-        e += 0x38800000; // adjust bias
-
-        mantissaTable[i] = m | e;
-    }
-
-    for (let i = 1024; i < 2048; ++i) {
-        mantissaTable[i] = 0x38000000 + ((i - 1024) << 13);
-    }
-
-    for (let i = 1; i < 31; ++i) {
-        exponentTable[i] = i << 23;
-    }
-
-    exponentTable[31] = 0x47800000;
-    exponentTable[32] = 0x80000000;
-
-    for (let i = 33; i < 63; ++i) {
-        exponentTable[i] = 0x80000000 + ((i - 32) << 23);
-    }
-
-    exponentTable[63] = 0xc7800000;
-
-    for (let i = 1; i < 64; ++i) {
-        if (i !== 32) {
-            offsetTable[i] = 1024;
-        }
-    }
-
-    return {
-        floatView: floatView,
-        uint32View: uint32View,
-        baseTable: baseTable,
-        shiftTable: shiftTable,
-        mantissaTable: mantissaTable,
-        exponentTable: exponentTable,
-        offsetTable: offsetTable,
-    };
 }
 
 /**
@@ -336,40 +228,18 @@ export function ParseFloat32(dataView: DataView, offset: DataCursor) {
  * @returns a float16
  */
 export function ParseFloat16(dataView: DataView, offset: DataCursor) {
-    return DecodeFloat16(ParseUint16(dataView, offset));
-}
-
-function DecodeFloat16(binary: number) {
-    const exponent = (binary & 0x7c00) >> 10;
-    const fraction = binary & 0x03ff;
-
-    return (
-        (binary >> 15 ? -1 : 1) *
-        (exponent ? (exponent === 0x1f ? (fraction ? NaN : Infinity) : Math.pow(2, exponent - 15) * (1 + fraction / 0x400)) : 6.103515625e-5 * (fraction / 0x400))
-    );
-}
-
-function ToHalfFloat(value: number) {
-    if (Math.abs(value) > 65504) {
-        throw new Error("Value out of range.Consider using float instead of half-float.");
-    }
-
-    value = Clamp(value, -65504, 65504);
-
-    Tables.floatView[0] = value;
-    const f = Tables.uint32View[0];
-    const e = (f >> 23) & 0x1ff;
-    return Tables.baseTable[e] + ((f & 0x007fffff) >> Tables.shiftTable[e]);
+    return FromHalfFloat(ParseUint16(dataView, offset));
 }
 
 /**
  * Decode a float32 from the buffer
  * @param dataView dataview on the data
  * @param offset current offset in the data view
- * @returns a float32
+ * @returns a float16
  */
 export function DecodeFloat32(dataView: DataView, offset: DataCursor) {
-    return ToHalfFloat(ParseFloat32(dataView, offset));
+    // EXR FLOAT channels are HDR and can exceed the half-float range. Clamp to the largest finite half
+    return ToHalfFloat(Clamp(ParseFloat32(dataView, offset), -MaxHalfFloat, MaxHalfFloat));
 }
 
 function ParseFixedLengthString(buffer: ArrayBufferLike, offset: DataCursor, size: number) {

--- a/packages/dev/core/src/Meshes/abstractMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.pure.ts
@@ -26,6 +26,7 @@ import { type AbstractActionManager } from "../Actions/abstractActionManager";
 import { UniformBuffer } from "../Materials/uniformBuffer";
 import { _MeshCollisionData } from "../Collisions/meshCollisionData";
 import { _WarnImport, _MissingSideEffect, _MissingSideEffectProperty } from "../Misc/devTools";
+import { FromHalfFloat } from "../Misc/halfFloat";
 import { type RawTexture } from "../Materials/Textures/rawTexture";
 import { extractMinAndMax } from "../Maths/math.functions";
 import { Color3, Color4 } from "../Maths/math.color.pure";
@@ -131,20 +132,6 @@ function BakedVertexAnimationModulo(value: number, divisor: number): number {
     return value - Math.floor(value / divisor) * divisor;
 }
 
-function BakedVertexAnimationHalfFloatToNumber(value: number): number {
-    const sign = value & 0x8000 ? -1 : 1;
-    const exponent = (value & 0x7c00) >> 10;
-    const fraction = value & 0x03ff;
-
-    if (exponent === 0) {
-        return sign * Math.pow(2, -14) * (fraction / Math.pow(2, 10));
-    } else if (exponent === 0x1f) {
-        return fraction ? NaN : sign * Infinity;
-    }
-
-    return sign * Math.pow(2, exponent - 15) * (1 + fraction / Math.pow(2, 10));
-}
-
 function GetBakedVertexAnimationFrame(animationSettings: DeepImmutable<Vector4>, time: number): number {
     const totalFrames = animationSettings.y - animationSettings.x + 1;
     const normalizedTime = (time * animationSettings.w) / totalFrames;
@@ -163,22 +150,22 @@ function ReadBakedVertexAnimationMatrixToRef(data: Float32Array | Uint16Array, o
     }
 
     matrix.copyFromFloats(
-        BakedVertexAnimationHalfFloatToNumber(data[offset]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 1]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 2]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 3]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 4]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 5]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 6]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 7]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 8]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 9]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 10]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 11]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 12]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 13]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 14]),
-        BakedVertexAnimationHalfFloatToNumber(data[offset + 15])
+        FromHalfFloat(data[offset]),
+        FromHalfFloat(data[offset + 1]),
+        FromHalfFloat(data[offset + 2]),
+        FromHalfFloat(data[offset + 3]),
+        FromHalfFloat(data[offset + 4]),
+        FromHalfFloat(data[offset + 5]),
+        FromHalfFloat(data[offset + 6]),
+        FromHalfFloat(data[offset + 7]),
+        FromHalfFloat(data[offset + 8]),
+        FromHalfFloat(data[offset + 9]),
+        FromHalfFloat(data[offset + 10]),
+        FromHalfFloat(data[offset + 11]),
+        FromHalfFloat(data[offset + 12]),
+        FromHalfFloat(data[offset + 13]),
+        FromHalfFloat(data[offset + 14]),
+        FromHalfFloat(data[offset + 15])
     );
 }
 

--- a/packages/dev/core/src/Misc/halfFloat.ts
+++ b/packages/dev/core/src/Misc/halfFloat.ts
@@ -1,0 +1,167 @@
+/**
+ * Lookup tables used for fast conversions between 32-bit floats and 16-bit (half) floats.
+ * @see Fast Half Float Conversions, http://www.fox-toolkit.org/ftp/fasthalffloatconversion.pdf
+ */
+interface IHalfFloatConversionTables {
+    floatView: Float32Array;
+    uint32View: Uint32Array;
+    baseTable: Uint32Array;
+    shiftTable: Uint32Array;
+    mantissaTable: Uint32Array;
+    exponentTable: Uint32Array;
+    offsetTable: Uint32Array;
+}
+
+let Tables: IHalfFloatConversionTables | null = null;
+
+/**
+ * Returns the conversion tables, building them lazily on first use.
+ * Generation is deferred so that importing this module allocates nothing: tree-shaken code paths
+ * that never convert a half float pay no cost, keeping the module side-effect free at import time.
+ * @returns the shared conversion tables
+ */
+// Fast Half Float Conversions, http://www.fox-toolkit.org/ftp/fasthalffloatconversion.pdf
+function GenerateTables(): IHalfFloatConversionTables {
+    if (Tables) {
+        return Tables;
+    }
+
+    const buffer = new ArrayBuffer(4);
+    const floatView = new Float32Array(buffer);
+    const uint32View = new Uint32Array(buffer);
+
+    // float32 to float16 helpers
+    const baseTable = new Uint32Array(512);
+    const shiftTable = new Uint32Array(512);
+
+    for (let i = 0; i < 256; ++i) {
+        const e = i - 127;
+
+        // very small number (0, -0)
+        if (e < -24) {
+            baseTable[i] = 0x0000;
+            baseTable[i | 0x100] = 0x8000;
+            shiftTable[i] = 24;
+            shiftTable[i | 0x100] = 24;
+
+            // small number (denorm)
+        } else if (e < -14) {
+            baseTable[i] = 0x0400 >> (-e - 14);
+            baseTable[i | 0x100] = (0x0400 >> (-e - 14)) | 0x8000;
+            shiftTable[i] = -e - 1;
+            shiftTable[i | 0x100] = -e - 1;
+
+            // normal number
+        } else if (e <= 15) {
+            baseTable[i] = (e + 15) << 10;
+            baseTable[i | 0x100] = ((e + 15) << 10) | 0x8000;
+            shiftTable[i] = 13;
+            shiftTable[i | 0x100] = 13;
+
+            // large number (Infinity, -Infinity)
+        } else if (e < 128) {
+            baseTable[i] = 0x7c00;
+            baseTable[i | 0x100] = 0xfc00;
+            shiftTable[i] = 24;
+            shiftTable[i | 0x100] = 24;
+
+            // stay (NaN, Infinity, -Infinity)
+        } else {
+            baseTable[i] = 0x7c00;
+            baseTable[i | 0x100] = 0xfc00;
+            shiftTable[i] = 13;
+            shiftTable[i | 0x100] = 13;
+        }
+    }
+
+    // float16 to float32 helpers
+    const mantissaTable = new Uint32Array(2048);
+    const exponentTable = new Uint32Array(64);
+    const offsetTable = new Uint32Array(64);
+
+    for (let i = 1; i < 1024; ++i) {
+        let m = i << 13; // zero pad mantissa bits
+        let e = 0; // zero exponent
+
+        // normalized
+        while ((m & 0x00800000) === 0) {
+            m <<= 1;
+            e -= 0x00800000; // decrement exponent
+        }
+
+        m &= ~0x00800000; // clear leading 1 bit
+        e += 0x38800000; // adjust bias
+
+        mantissaTable[i] = m | e;
+    }
+
+    for (let i = 1024; i < 2048; ++i) {
+        mantissaTable[i] = 0x38000000 + ((i - 1024) << 13);
+    }
+
+    for (let i = 1; i < 31; ++i) {
+        exponentTable[i] = i << 23;
+    }
+
+    exponentTable[31] = 0x47800000;
+    exponentTable[32] = 0x80000000;
+
+    for (let i = 33; i < 63; ++i) {
+        exponentTable[i] = 0x80000000 + ((i - 32) << 23);
+    }
+
+    exponentTable[63] = 0xc7800000;
+
+    for (let i = 1; i < 64; ++i) {
+        if (i !== 32) {
+            offsetTable[i] = 1024;
+        }
+    }
+
+    Tables = {
+        floatView,
+        uint32View,
+        baseTable,
+        shiftTable,
+        mantissaTable,
+        exponentTable,
+        offsetTable,
+    };
+
+    return Tables;
+}
+
+/**
+ * The largest finite magnitude representable by a 16-bit half-float (binary16): 65504.
+ * Use this to clamp values into the half-float range before conversion instead of hardcoding the literal.
+ */
+export const MaxHalfFloat = 65504;
+
+/**
+ * Converts a 32-bit float to its 16-bit half-float bit pattern.
+ * @param value the float to convert
+ * @returns the half-float bit pattern, in the range 0..65535
+ */
+export function ToHalfFloat(value: number): number {
+    // For now this truncates toward zero (drops the extra mantissa bits instead of rounding).
+    // TODO: replace with the native Float16Array / Math.f16round once Node 24 is the minimum version;
+    //       those round to nearest-even, so some results will change.
+    const tables = GenerateTables();
+
+    tables.floatView[0] = value;
+    const f = tables.uint32View[0];
+    const e = (f >> 23) & 0x1ff;
+    return tables.baseTable[e] + ((f & 0x007fffff) >> tables.shiftTable[e]);
+}
+
+/**
+ * Converts a 16-bit half-float bit pattern back to a 32-bit float.
+ * @param value the half-float bit pattern, in the range 0..65535
+ * @returns the decoded float
+ */
+export function FromHalfFloat(value: number): number {
+    const tables = GenerateTables();
+
+    tables.uint32View[0] = tables.mantissaTable[tables.offsetTable[value >> 10] + (value & 0x03ff)] + tables.exponentTable[value >> 10];
+    return tables.floatView[0];
+}

--- a/packages/dev/core/src/Misc/textureTools.ts
+++ b/packages/dev/core/src/Misc/textureTools.ts
@@ -11,6 +11,9 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { type Observable } from "./observable";
 import { type Nullable } from "../types";
 import { Clamp } from "../Maths/math.scalar.functions";
+import { FromHalfFloat, ToHalfFloat } from "./halfFloat";
+
+export { FromHalfFloat, ToHalfFloat };
 
 /**
  * Uses the GPU to create a copy texture rescaled at a given size
@@ -170,75 +173,6 @@ export function ApplyPostProcess(
             });
         });
     });
-}
-
-// ref: http://stackoverflow.com/questions/32633585/how-do-you-convert-to-half-floats-in-javascript
-let floatView: Float32Array;
-let int32View: Int32Array;
-/**
- * Converts a number to half float
- * @param value number to convert
- * @returns converted number
- */
-export function ToHalfFloat(value: number): number {
-    if (!floatView) {
-        floatView = new Float32Array(1);
-        int32View = new Int32Array(floatView.buffer);
-    }
-
-    floatView[0] = value;
-    const x = int32View[0];
-
-    let bits = (x >> 16) & 0x8000; /* Get the sign */
-    let m = (x >> 12) & 0x07ff; /* Keep one extra bit for rounding */
-    const e = (x >> 23) & 0xff; /* Using int is faster here */
-
-    /* If zero, or denormal, or exponent underflows too much for a denormal
-     * half, return signed zero. */
-    if (e < 103) {
-        return bits;
-    }
-
-    /* If NaN, return NaN. If Inf or exponent overflow, return Inf. */
-    if (e > 142) {
-        bits |= 0x7c00;
-        /* If exponent was 0xff and one mantissa bit was set, it means NaN,
-         * not Inf, so make sure we set one mantissa bit too. */
-        bits |= (e == 255 ? 0 : 1) && x & 0x007fffff;
-        return bits;
-    }
-
-    /* If exponent underflows but not too much, return a denormal */
-    if (e < 113) {
-        m |= 0x0800;
-        /* Extra rounding may overflow and set mantissa to 0 and exponent
-         * to 1, which is OK. */
-        bits |= (m >> (114 - e)) + ((m >> (113 - e)) & 1);
-        return bits;
-    }
-
-    bits |= ((e - 112) << 10) | (m >> 1);
-    bits += m & 1;
-    return bits;
-}
-
-/**
- * Converts a half float to a number
- * @param value half float to convert
- * @returns converted half float
- */
-export function FromHalfFloat(value: number): number {
-    const s = (value & 0x8000) >> 15;
-    const e = (value & 0x7c00) >> 10;
-    const f = value & 0x03ff;
-
-    if (e === 0) {
-        return (s ? -1 : 1) * Math.pow(2, -14) * (f / Math.pow(2, 10));
-    } else if (e == 0x1f) {
-        return f ? NaN : (s ? -1 : 1) * Infinity;
-    }
-
-    return (s ? -1 : 1) * Math.pow(2, e - 15) * (1 + f / Math.pow(2, 10));
 }
 
 function IsCompressedTextureFormat(format: number): boolean {

--- a/packages/dev/core/test/unit/Buffers/babylon.buffer.test.ts
+++ b/packages/dev/core/test/unit/Buffers/babylon.buffer.test.ts
@@ -271,5 +271,31 @@ describe("VertexBuffer", () => {
             const expected = new Uint8Array([102, 153, 204]);
             expect(result).toStrictEqual(expected);
         });
+        it("de-interleaves half-float data preserving exact bits", () => {
+            const source = new Uint16Array([10, 20, 30, 999, 40, 50, 60, 888]);
+            const vb = {
+                data: source,
+                size: 3,
+                type: Constants.HALF_FLOAT,
+                byteOffset: 0,
+                byteStride: 8,
+                totalVertices: 2,
+            };
+
+            const result = GetTypedArrayData(vb.data, vb.size, vb.type, vb.byteOffset, vb.byteStride, vb.totalVertices);
+
+            expect(result.constructor).toBe(source.constructor);
+            expect(result).toStrictEqual(new Uint16Array([10, 20, 30, 40, 50, 60]));
+            expect(result.buffer !== source.buffer).toBeTruthy();
+        });
+        it("returns a view for tightly packed half-float data", () => {
+            const source = new Uint16Array([10, 20, 30, 40, 50, 60]);
+
+            const result = GetTypedArrayData(source, 3, Constants.HALF_FLOAT, 0, 6, 2);
+
+            expect(result.constructor).toBe(source.constructor);
+            expect(result).toStrictEqual(source);
+            expect(result.buffer === source.buffer).toBeTruthy();
+        });
     });
 });

--- a/packages/dev/core/test/unit/Misc/babylon.halfFloat.test.ts
+++ b/packages/dev/core/test/unit/Misc/babylon.halfFloat.test.ts
@@ -1,0 +1,77 @@
+import { FromHalfFloat, ToHalfFloat } from "core/Misc/halfFloat";
+
+describe("HalfFloat", () => {
+    describe("ToHalfFloat", () => {
+        it("encodes exact bit patterns", () => {
+            expect(ToHalfFloat(0)).toBe(0x0000);
+            expect(ToHalfFloat(-0)).toBe(0x8000);
+            expect(ToHalfFloat(1)).toBe(0x3c00);
+            expect(ToHalfFloat(-1)).toBe(0xbc00);
+            expect(ToHalfFloat(0.5)).toBe(0x3800);
+            expect(ToHalfFloat(2)).toBe(0x4000);
+            expect(ToHalfFloat(65504)).toBe(0x7bff); // max finite half
+        });
+
+        it("encodes the smallest normal and a denormal", () => {
+            expect(ToHalfFloat(Math.pow(2, -14))).toBe(0x0400); // smallest positive normal
+            expect(ToHalfFloat(Math.pow(2, -24))).toBe(0x0001); // smallest positive denormal
+        });
+
+        it("overflows to +/-Infinity at and beyond 2^16 (no clamping)", () => {
+            // Mode-agnostic: 2^16+ exceeds the half exponent range under any rounding mode.
+            expect(ToHalfFloat(65536)).toBe(0x7c00);
+            expect(ToHalfFloat(70000)).toBe(0x7c00);
+            expect(ToHalfFloat(-70000)).toBe(0xfc00);
+        });
+
+        it("preserves Infinity and NaN", () => {
+            expect(ToHalfFloat(Infinity)).toBe(0x7c00);
+            expect(ToHalfFloat(-Infinity)).toBe(0xfc00);
+            // NaN stays NaN: exponent all ones with a non-zero mantissa
+            const half = ToHalfFloat(NaN);
+            expect((half & 0x7c00) === 0x7c00 && (half & 0x03ff) !== 0).toBe(true);
+        });
+
+        // These assertions are specific to the current round-toward-zero (truncation) algorithm.
+        // When ToHalfFloat moves to the native Float16Array / Math.f16round (round-to-nearest-even,
+        // e.g. Node 24+), they MUST be updated to the round-to-nearest-even results:
+        //   ToHalfFloat(65520)       0x7bff -> 0x7c00 (+Inf)
+        //   ToHalfFloat(1 + 3*2^-12) 0x3c00 -> 0x3c01
+        describe("round-toward-zero specific (changes under round-to-nearest-even)", () => {
+            it("keeps [65504, 65536) at the max finite half instead of rounding up to Infinity", () => {
+                expect(ToHalfFloat(65520)).toBe(0x7bff);
+            });
+            it("drops the surplus mantissa bits instead of rounding up", () => {
+                // 3/4 ULP above 1.0: truncation drops to 1.0 (0x3c00); round-to-nearest-even gives 0x3c01.
+                expect(ToHalfFloat(1 + 3 * Math.pow(2, -12))).toBe(0x3c00);
+            });
+        });
+    });
+
+    describe("FromHalfFloat", () => {
+        it("decodes special values", () => {
+            expect(FromHalfFloat(0x0000)).toBe(0);
+            expect(FromHalfFloat(0x7c00)).toBe(Infinity);
+            expect(FromHalfFloat(0xfc00)).toBe(-Infinity);
+            expect(Number.isNaN(FromHalfFloat(0x7e00))).toBe(true);
+        });
+
+        it("decodes the smallest normal and a denormal exactly", () => {
+            expect(FromHalfFloat(0x0400)).toBe(Math.pow(2, -14));
+            expect(FromHalfFloat(0x0001)).toBe(Math.pow(2, -24));
+        });
+    });
+
+    describe("round-trip", () => {
+        it("is exact for representable values", () => {
+            const values = [0, 1, -1, 0.5, -0.5, 2, 0.25, 65504, Math.pow(2, -14), Math.pow(2, -24)];
+            for (const value of values) {
+                expect(FromHalfFloat(ToHalfFloat(value))).toBe(value);
+            }
+        });
+
+        it("maps NaN back to NaN", () => {
+            expect(Number.isNaN(FromHalfFloat(ToHalfFloat(NaN)))).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Forum: https://forum.babylonjs.com/t/support-half-float-float16-vertex-attribute-type-float16x2-float16x4-on-webgpu/63574

Wire the HALF_FLOAT (5131) attribute type through the buffer utilities, alignment, non-float buffer handling, and the WebGPU pipeline cache.

- Add Constants.HALF_FLOAT and VertexBuffer.HALF_FLOAT
- Add half<->float conversion in bufferUtils get/set, byte length, and typed-array constructor lookup
- Map half-float attributes to WebGPU Float16x2/Float16x4 formats
- Treat half-float as signed and shader-typed as FLOAT
- Replace the type-based hash offset with a compact index lookup so HALF_FLOAT fits the 3-bit field instead of overflowing it
- De-interleave vertex data via a raw byte copy: faster and bit-exact (no lossy float round-trip), with unit tests covering half-float