### PR TITLE
Fix WebXR body tracking startup hand roll

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts
@@ -672,6 +672,15 @@ export interface IWebXRBodyTrackingOptions {
     useBoneOrientationOffsets?: boolean;
 
     /**
+     * Capture the first tracked frame as the rest pose for delta-from-bind retargeting.
+     *
+     * This is useful only when the user starts tracking in a known calibration pose. It is
+     * disabled by default because capturing an arbitrary startup pose can bake in a fixed
+     * hand or forearm roll offset for the rest of the session.
+     */
+    autoCaptureBindOnFirstFrame?: boolean;
+
+    /**
      * Rotation applied in each tracked joint's local frame to re-base the
      * XR joint axes. Some runtimes (e.g., some Meta Quest builds) emit body
      * joint poses whose +Z axis points along the bone (parent → child), while
@@ -1009,11 +1018,12 @@ export class WebXRTrackedBody implements IDisposable {
     private _hasTrackedBind = false;
 
     /**
-     * When `true` (default), the first tracked frame after the feature
-     * attaches is used as the "rest" pose for delta-from-bind retargeting.
-     * Set to `false` to require an explicit {@link captureTrackedBind} call.
+     * When `true`, the first tracked frame after the feature attaches is used
+     * as the "rest" pose for delta-from-bind retargeting. Set to `true` only
+     * when tracking starts in a known calibration pose; otherwise arbitrary
+     * startup hand/forearm roll can be captured as a fixed session offset.
      */
-    public autoCaptureBindOnFirstFrame = true;
+    public autoCaptureBindOnFirstFrame = false;
 
     /** Scratch quaternion for retarget delta composition. */
     private _tempDeltaQuat = new Quaternion();
@@ -1033,6 +1043,10 @@ export class WebXRTrackedBody implements IDisposable {
     private _computedBoneNewWorldRot = new Map<Bone, Quaternion>();
     /** Per-bone marker: frame id at which the pooled rotation above was last set. */
     private _computedBoneNewWorldRotFrameId = new Map<Bone, number>();
+    /** Per-frame world rotations used by the direct-retarget aim-correction path. */
+    private _computedDirectWorldRotations = new Map<Bone, Quaternion>();
+    /** Per-bone marker for direct-retarget world rotations. */
+    private _computedDirectWorldRotationsFrameId = new Map<Bone, number>();
     private _currentRetargetFrameId = 0;
     /** Scratch quaternion reused for the parent-world accumulation loop. */
     private _tempParentAccumRot = new Quaternion();
@@ -1275,6 +1289,8 @@ export class WebXRTrackedBody implements IDisposable {
         this._bindBoneWorldRotMeshLocal.clear();
         this._computedBoneNewWorldRot.clear();
         this._computedBoneNewWorldRotFrameId.clear();
+        this._computedDirectWorldRotations.clear();
+        this._computedDirectWorldRotationsFrameId.clear();
         this._trackedBindDesiredFinalRot = null;
         this._trackedBindDesiredFinalPos = null;
         this._hasTrackedBind = false;
@@ -1780,7 +1796,7 @@ export class WebXRTrackedBody implements IDisposable {
             const scaleFactor = this._jointScaleFactor;
             const useInitialSkinMatrix = this._skeleton.needInitialSkinMatrix;
             const useBoneOrientationOffsets = this._useBoneOrientationOffsets;
-            const computedWorldRotations = useBoneOrientationOffsets ? new Map<Bone, Quaternion>() : null;
+            const computedWorldRotations = useBoneOrientationOffsets ? this._computedDirectWorldRotations : null;
 
             if (useInitialSkinMatrix) {
                 this._skeletonMesh.getPoseMatrix().invertToRef(this._initialSkinMatrixInverse);
@@ -1896,8 +1912,8 @@ export class WebXRTrackedBody implements IDisposable {
      * avatar.
      *
      * Call this after the user assumes a known rest pose (e.g. T-pose,
-     * A-pose, arms-at-sides). By default the feature auto-captures on the
-     * first tracked frame — disable via {@link autoCaptureBindOnFirstFrame}.
+     * A-pose, arms-at-sides). Automatic first-frame capture is opt-in via
+     * {@link autoCaptureBindOnFirstFrame}.
      */
     public captureTrackedBind(): void {
         this._captureTrackedBindFromDesiredFinals();
@@ -2256,6 +2272,8 @@ export class WebXRTrackedBody implements IDisposable {
         if (!this._skeleton || !this._skeletonMesh) {
             return;
         }
+        this._currentRetargetFrameId++;
+
         for (const bone of this._skeleton.bones) {
             const parentBone = bone.getParent();
             const jointIdx = this._boneToJointIdx.get(bone);
@@ -2275,12 +2293,11 @@ export class WebXRTrackedBody implements IDisposable {
                 this._tempLocalMatrix.decompose(jointTransform.scaling, jointTransform.rotationQuaternion!, jointTransform.position);
 
                 if (useBoneOrientationOffsets) {
-                    const childBone = this._mappedChildBones.get(bone);
                     const bindLocalAimDirection = this._bindLocalAimDirections.get(bone);
-                    const childJointIdx = childBone ? this._boneToJointIdx.get(childBone) : undefined;
+                    const targetJointIdx = this._boneAimTargetJointIdx.get(bone);
 
-                    if (bindLocalAimDirection && childJointIdx !== undefined) {
-                        this._desiredFinalPositions[childJointIdx].subtractToRef(this._desiredFinalPositions[jointIdx], this._tempDirection);
+                    if (bindLocalAimDirection && targetJointIdx !== undefined) {
+                        this._desiredFinalPositions[targetJointIdx].subtractToRef(this._desiredFinalPositions[jointIdx], this._tempDirection);
                         if (this._tempDirection.lengthSquared() > 1e-8) {
                             this._tempDirection.normalize();
                             this._desiredFinals[jointIdx].decompose(this._tempScaleVector, this._tempRotQuat, this._tempPosVec);
@@ -2292,7 +2309,10 @@ export class WebXRTrackedBody implements IDisposable {
                                 this._tempRotQuat.multiplyToRef(this._tempRotQuat2, this._tempRotQuat);
 
                                 if (parentBone) {
-                                    const parentWorldRotation = computedWorldRotations?.get(parentBone);
+                                    const parentWorldRotation =
+                                        computedWorldRotations && this._computedDirectWorldRotationsFrameId.get(parentBone) === this._currentRetargetFrameId
+                                            ? computedWorldRotations.get(parentBone)
+                                            : undefined;
                                     if (parentWorldRotation) {
                                         Quaternion.InverseToRef(parentWorldRotation, this._tempRotQuat2);
                                         this._tempRotQuat.multiplyToRef(this._tempRotQuat2, jointTransform.rotationQuaternion!);
@@ -2336,7 +2356,13 @@ export class WebXRTrackedBody implements IDisposable {
 
                 if (computedWorldRotations) {
                     bone.getFinalMatrix().decompose(this._tempScaleVector, this._tempRotQuat, this._tempPosVec);
-                    computedWorldRotations.set(bone, this._tempRotQuat.clone());
+                    let computedWorldRotation = computedWorldRotations.get(bone);
+                    if (!computedWorldRotation) {
+                        computedWorldRotation = new Quaternion();
+                        computedWorldRotations.set(bone, computedWorldRotation);
+                    }
+                    computedWorldRotation.copyFrom(this._tempRotQuat);
+                    this._computedDirectWorldRotationsFrameId.set(bone, this._currentRetargetFrameId);
                 }
             } else {
                 // Unmapped bone: chain bind-pose local × parent final.
@@ -2420,6 +2446,8 @@ export class WebXRTrackedBody implements IDisposable {
         }
         this._unmappedBoneNodes = [];
         this._boneToJointIdx.clear();
+        this._computedDirectWorldRotations.clear();
+        this._computedDirectWorldRotationsFrameId.clear();
         this._skeleton = null;
         this._jointHasBone.fill(false);
         this._jointParentJointIdx.fill(-1);
@@ -2635,6 +2663,7 @@ export class WebXRBodyTracking extends WebXRAbstractFeature {
                 aimChildOverrides,
                 this.options.jointLocalRotationOffset
             );
+            this._trackedBody.autoCaptureBindOnFirstFrame = this.options.autoCaptureBindOnFirstFrame ?? false;
         } catch (e) {
             this._lastFrameDebugInfo = "ATTACH ERROR: " + e;
             Logger.Warn("WebXR Body Tracking: failed to create tracked body: " + e);

--- a/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
+++ b/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
@@ -2093,7 +2093,7 @@ describe("WebXRBodyTracking - _ResolveMixamoRigMapping", () => {
     });
 });
 
-describe("WebXRTrackedBody - hand twist correction", () => {
+describe("WebXRTrackedBody - hand retargeting", () => {
     let engine: Engine;
     let scene: Scene;
 
@@ -2156,6 +2156,89 @@ describe("WebXRTrackedBody - hand twist correction", () => {
 
         expect(Vector3.Dot(correctedTwistNormal, expectedTwistNormal)).toBeGreaterThan(0.999);
         expect(Vector3.Dot(correctedAim, Vector3.Right())).toBeGreaterThan(0.999);
+        trackedBody.dispose();
+    });
+
+    const leftWristIdx = JOINT_NAMES.indexOf(WebXRBodyJoint.LEFT_HAND_WRIST);
+    const leftMiddleMetacarpalIdx = JOINT_NAMES.indexOf(WebXRBodyJoint.LEFT_HAND_MIDDLE_METACARPAL);
+
+    const createIdentityJointMatrices = (): Float32Array => {
+        const matrices = new Float32Array(BODY_JOINT_COUNT * 16);
+        for (let i = 0; i < BODY_JOINT_COUNT; i++) {
+            const offset = i * 16;
+            matrices[offset] = 1;
+            matrices[offset + 5] = 1;
+            matrices[offset + 10] = 1;
+            matrices[offset + 15] = 1;
+        }
+        return matrices;
+    };
+
+    const setJointPose = (matrices: Float32Array, jointIdx: number, rotation: Quaternion, position: Vector3): void => {
+        const matrix = new Matrix();
+        Matrix.ComposeToRef(new Vector3(1, 1, 1), rotation, position, matrix);
+        matrix.copyToArray(matrices, jointIdx * 16);
+    };
+
+    const createHandFrame = (wristRollRadians: number): Float32Array => {
+        const matrices = createIdentityJointMatrices();
+        setJointPose(matrices, leftWristIdx, Quaternion.RotationAxis(new Vector3(0, 1, 0), wristRollRadians), Vector3.Zero());
+        setJointPose(matrices, leftMiddleMetacarpalIdx, Quaternion.Identity(), new Vector3(0, 1, 0));
+        return matrices;
+    };
+
+    const createTrackedHand = (): { trackedBody: WebXRTrackedBody; handBone: Bone } => {
+        const mesh = new Mesh("hand-mesh", scene);
+        const skeleton = new Skeleton("hand-skeleton", "hand-skeleton", scene);
+        mesh.skeleton = skeleton;
+
+        const handBone = new Bone("LeftHand", skeleton, null, Matrix.Identity(), null, Matrix.Identity(), 0);
+        new Bone("LeftMiddleMetacarpal", skeleton, handBone, Matrix.Translation(0, 1, 0), null, Matrix.Translation(0, 1, 0));
+        mesh.computeWorldMatrix(true);
+
+        const trackedBody = new WebXRTrackedBody(scene, mesh, { [WebXRBodyJoint.LEFT_HAND_WRIST]: "LeftHand" }, 1, false, true, {
+            [WebXRBodyJoint.LEFT_HAND_WRIST]: WebXRBodyJoint.LEFT_HAND_MIDDLE_METACARPAL,
+        });
+
+        return { trackedBody, handBone };
+    };
+
+    const getBoneWorldRotation = (bone: Bone): Quaternion => {
+        const rotation = new Quaternion();
+        bone.getFinalMatrix().decompose(undefined, rotation, undefined);
+        rotation.normalize();
+        return rotation;
+    };
+
+    it("does not bake first-frame wrist roll into later hand orientation", () => {
+        const currentFrame = createHandFrame(0);
+
+        const startsPalmUp = createTrackedHand();
+        startsPalmUp.trackedBody.replayRawJointMatrices(createHandFrame(Math.PI), true);
+        startsPalmUp.trackedBody.replayRawJointMatrices(currentFrame, true);
+        const afterPalmUpStart = getBoneWorldRotation(startsPalmUp.handBone);
+
+        const startsNeutral = createTrackedHand();
+        startsNeutral.trackedBody.replayRawJointMatrices(currentFrame, true);
+        const afterNeutralStart = getBoneWorldRotation(startsNeutral.handBone);
+
+        expect(Math.abs(Quaternion.Dot(afterPalmUpStart, afterNeutralStart))).toBeGreaterThan(0.9999);
+
+        startsPalmUp.trackedBody.dispose();
+        startsNeutral.trackedBody.dispose();
+    });
+
+    it("keeps first-frame bind capture opt-in for calibrated startup poses", () => {
+        const tracked = createTrackedHand();
+        tracked.trackedBody.autoCaptureBindOnFirstFrame = true;
+
+        tracked.trackedBody.replayRawJointMatrices(createHandFrame(Math.PI), true);
+        tracked.trackedBody.replayRawJointMatrices(createHandFrame(0), true);
+
+        const rotation = getBoneWorldRotation(tracked.handBone);
+        expect(Math.abs(Quaternion.Dot(rotation, Quaternion.Identity()))).toBeLessThan(0.01);
+
+        tracked.trackedBody.dispose();
     });
 });
 


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Avoids auto-capturing an arbitrary first body-tracking frame as the default retarget bind pose.
- Keeps first-frame bind capture available as an explicit opt-in for calibrated startup poses.
- Applies direct-retarget aim correction to unmapped hand aim targets so Mixamo hand orientation still uses tracked finger positions without startup-pose calibration.
- Adds offline regression coverage for palm-up startup hand roll and the opt-in capture behavior.

## Motivation
Quest 3 body tracking can initialize the avatar hand or forearm with a 180-degree roll offset when entering XR with palms up or sideways. The previous default first-frame bind capture could bake that startup pose into the session, so later neutral hand poses retained the wrong roll.

Related forum report: https://forum.babylonjs.com/t/quest-3-webxr-body-tracking-hand-forearm-orientation-can-initialize-incorrectly/63541/5?u=raananw

## Validation
- `npx prettier --check packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts`
- `npx eslint packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts --quiet --no-warn-ignored`
- `npx vitest run --project=unit packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts --silent`
- `npm run build:source -- --pretty false`
