### PR TITLE
Add RegisterPBRMaterial alias to RegisterPbrMaterial

### DIFF
--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.pure.ts
@@ -762,3 +762,12 @@ export function RegisterPbrMaterial(): void {
 
     RegisterClass("BABYLON.PBRMaterial", PBRMaterial);
 }
+
+/**
+ * Register side effects for PBRMaterial.
+ * Safe to call multiple times; only the first call has an effect.
+ * Alias for {@link RegisterPbrMaterial}.
+ */
+export function RegisterPBRMaterial(): void {
+    RegisterPbrMaterial();
+}


### PR DESCRIPTION
## Problem

The registration function for `PBRMaterial` in the pure barrel was exported as `RegisterPbrMaterial` (acronym normalized to `Pbr`), but users naturally reach for the all-caps variant `RegisterPBRMaterial`. Vite and other bundlers would emit:

> Warning: Import 'RegisterPBRMaterial' will always be undefined because there is no matching export

...and at runtime the function would indeed be `undefined`, causing the registration call to silently do nothing.

Reported by a user in the forum:
https://forum.babylonjs.com/t/pure-barrel-for-better-tree-shaking-in-babylonjs-core/63455/12

## Fix

Add `RegisterPBRMaterial` as a thin public alias that delegates to `RegisterPbrMaterial`. Both casing variants now work. `RegisterPbrMaterial` remains the canonical implementation; `RegisterPBRMaterial` is the discoverable alias for users following the `PBR` acronym convention.

## Change

One file, 9 lines added in `packages/dev/core/src/Materials/PBR/pbrMaterial.pure.ts`.

Since `pbrMaterial.pure.ts` is re-exported by both the pure barrel (`PBR/pure.ts`) and the side-effect wrapper (`pbrMaterial.ts`), both import paths automatically expose the new alias with no further changes needed.