### PR TITLE
Fix WebXR body tracking startup hand roll (ring metacarpal twist reference)

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts
@@ -672,6 +672,15 @@ export interface IWebXRBodyTrackingOptions {
     useBoneOrientationOffsets?: boolean;
 
     /**
+     * Capture the first tracked frame as the rest pose for delta-from-bind retargeting.
+     *
+     * Defaults to `true`. Set to `false` when you want to capture a specific calibration
+     * pose instead, and call {@link WebXRTrackedBody.captureTrackedBind} explicitly when
+     * the user is in the desired pose.
+     */
+    autoCaptureBindOnFirstFrame?: boolean;
+
+    /**
      * Rotation applied in each tracked joint's local frame to re-base the
      * XR joint axes. Some runtimes (e.g., some Meta Quest builds) emit body
      * joint poses whose +Z axis points along the bone (parent → child), while
@@ -813,11 +822,15 @@ export const MixamoAimChildOverrides: Partial<Record<WebXRBodyJoint, WebXRBodyJo
 const HandTwistReferenceJoints: Partial<Record<WebXRBodyJoint, { first: WebXRBodyJoint; second: WebXRBodyJoint }>> = {
     [WebXRBodyJoint.LEFT_HAND_WRIST]: {
         first: WebXRBodyJoint.LEFT_HAND_INDEX_METACARPAL,
-        second: WebXRBodyJoint.LEFT_HAND_LITTLE_METACARPAL,
+        // Ring metacarpal is used (not little/pinky) because common rig naming conventions
+        // (e.g. Mixamo "LeftHandRing1") match the token "ring", while "little" does not match
+        // the typical "Pinky" bone names. Using ring still gives a valid cross-hand spread for
+        // computing the palm-plane normal.
+        second: WebXRBodyJoint.LEFT_HAND_RING_METACARPAL,
     },
     [WebXRBodyJoint.RIGHT_HAND_WRIST]: {
         first: WebXRBodyJoint.RIGHT_HAND_INDEX_METACARPAL,
-        second: WebXRBodyJoint.RIGHT_HAND_LITTLE_METACARPAL,
+        second: WebXRBodyJoint.RIGHT_HAND_RING_METACARPAL,
     },
 };
 
@@ -1033,6 +1046,10 @@ export class WebXRTrackedBody implements IDisposable {
     private _computedBoneNewWorldRot = new Map<Bone, Quaternion>();
     /** Per-bone marker: frame id at which the pooled rotation above was last set. */
     private _computedBoneNewWorldRotFrameId = new Map<Bone, number>();
+    /** Per-frame world rotations used by the direct-retarget aim-correction path. */
+    private _computedDirectWorldRotations = new Map<Bone, Quaternion>();
+    /** Per-bone marker for direct-retarget world rotations. */
+    private _computedDirectWorldRotationsFrameId = new Map<Bone, number>();
     private _currentRetargetFrameId = 0;
     /** Scratch quaternion reused for the parent-world accumulation loop. */
     private _tempParentAccumRot = new Quaternion();
@@ -1275,6 +1292,8 @@ export class WebXRTrackedBody implements IDisposable {
         this._bindBoneWorldRotMeshLocal.clear();
         this._computedBoneNewWorldRot.clear();
         this._computedBoneNewWorldRotFrameId.clear();
+        this._computedDirectWorldRotations.clear();
+        this._computedDirectWorldRotationsFrameId.clear();
         this._trackedBindDesiredFinalRot = null;
         this._trackedBindDesiredFinalPos = null;
         this._hasTrackedBind = false;
@@ -1780,7 +1799,7 @@ export class WebXRTrackedBody implements IDisposable {
             const scaleFactor = this._jointScaleFactor;
             const useInitialSkinMatrix = this._skeleton.needInitialSkinMatrix;
             const useBoneOrientationOffsets = this._useBoneOrientationOffsets;
-            const computedWorldRotations = useBoneOrientationOffsets ? new Map<Bone, Quaternion>() : null;
+            const computedWorldRotations = useBoneOrientationOffsets ? this._computedDirectWorldRotations : null;
 
             if (useInitialSkinMatrix) {
                 this._skeletonMesh.getPoseMatrix().invertToRef(this._initialSkinMatrixInverse);
@@ -1897,7 +1916,7 @@ export class WebXRTrackedBody implements IDisposable {
      *
      * Call this after the user assumes a known rest pose (e.g. T-pose,
      * A-pose, arms-at-sides). By default the feature auto-captures on the
-     * first tracked frame — disable via {@link autoCaptureBindOnFirstFrame}.
+     * first tracked frame if {@link autoCaptureBindOnFirstFrame} is enabled.
      */
     public captureTrackedBind(): void {
         this._captureTrackedBindFromDesiredFinals();
@@ -2256,6 +2275,8 @@ export class WebXRTrackedBody implements IDisposable {
         if (!this._skeleton || !this._skeletonMesh) {
             return;
         }
+        this._currentRetargetFrameId++;
+
         for (const bone of this._skeleton.bones) {
             const parentBone = bone.getParent();
             const jointIdx = this._boneToJointIdx.get(bone);
@@ -2275,15 +2296,14 @@ export class WebXRTrackedBody implements IDisposable {
                 this._tempLocalMatrix.decompose(jointTransform.scaling, jointTransform.rotationQuaternion!, jointTransform.position);
 
                 if (useBoneOrientationOffsets) {
-                    const childBone = this._mappedChildBones.get(bone);
+                    this._desiredFinals[jointIdx].decompose(this._tempScaleVector, this._tempRotQuat, this._tempPosVec);
                     const bindLocalAimDirection = this._bindLocalAimDirections.get(bone);
-                    const childJointIdx = childBone ? this._boneToJointIdx.get(childBone) : undefined;
+                    const targetJointIdx = this._boneAimTargetJointIdx.get(bone);
 
-                    if (bindLocalAimDirection && childJointIdx !== undefined) {
-                        this._desiredFinalPositions[childJointIdx].subtractToRef(this._desiredFinalPositions[jointIdx], this._tempDirection);
+                    if (bindLocalAimDirection && targetJointIdx !== undefined) {
+                        this._desiredFinalPositions[targetJointIdx].subtractToRef(this._desiredFinalPositions[jointIdx], this._tempDirection);
                         if (this._tempDirection.lengthSquared() > 1e-8) {
                             this._tempDirection.normalize();
-                            this._desiredFinals[jointIdx].decompose(this._tempScaleVector, this._tempRotQuat, this._tempPosVec);
                             Quaternion.InverseToRef(this._tempRotQuat, this._tempRotQuat2);
                             this._tempDirection.rotateByQuaternionToRef(this._tempRotQuat2, this._tempLocalDirection);
                             if (this._tempLocalDirection.lengthSquared() > 1e-8) {
@@ -2292,7 +2312,61 @@ export class WebXRTrackedBody implements IDisposable {
                                 this._tempRotQuat.multiplyToRef(this._tempRotQuat2, this._tempRotQuat);
 
                                 if (parentBone) {
-                                    const parentWorldRotation = computedWorldRotations?.get(parentBone);
+                                    const parentWorldRotation =
+                                        computedWorldRotations && this._computedDirectWorldRotationsFrameId.get(parentBone) === this._currentRetargetFrameId
+                                            ? computedWorldRotations.get(parentBone)
+                                            : undefined;
+                                    if (parentWorldRotation) {
+                                        Quaternion.InverseToRef(parentWorldRotation, this._tempRotQuat2);
+                                        this._tempRotQuat.multiplyToRef(this._tempRotQuat2, jointTransform.rotationQuaternion!);
+                                    } else {
+                                        jointTransform.rotationQuaternion!.copyFrom(this._tempRotQuat);
+                                    }
+                                } else if (useInitialSkinMatrix) {
+                                    this._skeletonMesh.getPoseMatrix().decompose(this._tempScaleVector, this._tempRotQuat2, this._tempPosVec);
+                                    Quaternion.InverseToRef(this._tempRotQuat2, this._tempRotQuat2);
+                                    this._tempRotQuat.multiplyToRef(this._tempRotQuat2, jointTransform.rotationQuaternion!);
+                                } else {
+                                    jointTransform.rotationQuaternion!.copyFrom(this._tempRotQuat);
+                                }
+                                jointTransform.rotationQuaternion!.normalize();
+                            }
+                        }
+                    }
+
+                    const twistReferences = this._boneTwistReferenceJointIdx.get(bone);
+                    const bindLocalTwistNormal = this._bindLocalTwistNormals.get(bone);
+                    if (twistReferences && bindLocalTwistNormal && targetJointIdx !== undefined) {
+                        if (
+                            this._computeNormalFromJointPositions(
+                                this._desiredFinalPositions[jointIdx],
+                                this._desiredFinalPositions[targetJointIdx],
+                                this._desiredFinalPositions[twistReferences.first],
+                                this._desiredFinalPositions[twistReferences.second],
+                                this._tempTwistNormal,
+                                this._tempTwistAimAxis
+                            )
+                        ) {
+                            bindLocalTwistNormal.rotateByQuaternionToRef(this._tempRotQuat, this._tempCurrentTwistNormal);
+                            if (
+                                this._projectOnPlaneToRef(this._tempCurrentTwistNormal, this._tempTwistAimAxis, this._tempProjectedTwistNormal) &&
+                                this._projectOnPlaneToRef(this._tempTwistNormal, this._tempTwistAimAxis, this._tempProjectedDesiredTwistNormal)
+                            ) {
+                                const dot = Vector3.Dot(this._tempProjectedTwistNormal, this._tempProjectedDesiredTwistNormal);
+                                if (dot < -0.9999) {
+                                    Quaternion.RotationAxisToRef(this._tempTwistAimAxis, Math.PI, this._tempRotQuat2);
+                                } else {
+                                    Quaternion.FromUnitVectorsToRef(this._tempProjectedTwistNormal, this._tempProjectedDesiredTwistNormal, this._tempRotQuat2);
+                                }
+                                this._tempRotQuat2.multiplyToRef(this._tempRotQuat, this._tempDeltaQuat);
+                                this._tempRotQuat.copyFrom(this._tempDeltaQuat);
+                                this._tempRotQuat.normalize();
+
+                                if (parentBone) {
+                                    const parentWorldRotation =
+                                        computedWorldRotations && this._computedDirectWorldRotationsFrameId.get(parentBone) === this._currentRetargetFrameId
+                                            ? computedWorldRotations.get(parentBone)
+                                            : undefined;
                                     if (parentWorldRotation) {
                                         Quaternion.InverseToRef(parentWorldRotation, this._tempRotQuat2);
                                         this._tempRotQuat.multiplyToRef(this._tempRotQuat2, jointTransform.rotationQuaternion!);
@@ -2336,7 +2410,13 @@ export class WebXRTrackedBody implements IDisposable {
 
                 if (computedWorldRotations) {
                     bone.getFinalMatrix().decompose(this._tempScaleVector, this._tempRotQuat, this._tempPosVec);
-                    computedWorldRotations.set(bone, this._tempRotQuat.clone());
+                    let computedWorldRotation = computedWorldRotations.get(bone);
+                    if (!computedWorldRotation) {
+                        computedWorldRotation = new Quaternion();
+                        computedWorldRotations.set(bone, computedWorldRotation);
+                    }
+                    computedWorldRotation.copyFrom(this._tempRotQuat);
+                    this._computedDirectWorldRotationsFrameId.set(bone, this._currentRetargetFrameId);
                 }
             } else {
                 // Unmapped bone: chain bind-pose local × parent final.
@@ -2420,6 +2500,8 @@ export class WebXRTrackedBody implements IDisposable {
         }
         this._unmappedBoneNodes = [];
         this._boneToJointIdx.clear();
+        this._computedDirectWorldRotations.clear();
+        this._computedDirectWorldRotationsFrameId.clear();
         this._skeleton = null;
         this._jointHasBone.fill(false);
         this._jointParentJointIdx.fill(-1);
@@ -2635,6 +2717,7 @@ export class WebXRBodyTracking extends WebXRAbstractFeature {
                 aimChildOverrides,
                 this.options.jointLocalRotationOffset
             );
+            this._trackedBody.autoCaptureBindOnFirstFrame = this.options.autoCaptureBindOnFirstFrame ?? true;
         } catch (e) {
             this._lastFrameDebugInfo = "ATTACH ERROR: " + e;
             Logger.Warn("WebXR Body Tracking: failed to create tracked body: " + e);

--- a/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
+++ b/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
@@ -2159,6 +2159,123 @@ describe("WebXRTrackedBody - hand twist correction", () => {
     });
 });
 
+describe("WebXRTrackedBody - hand retargeting startup pose", () => {
+    let engine: Engine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({ renderHeight: 256, renderWidth: 256, textureSize: 256 });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    const jointIndex = (joint: WebXRBodyJoint): number => {
+        const idx = WebXRBodyTracking.AllBodyJoints.indexOf(joint);
+        expect(idx).toBeGreaterThanOrEqual(0);
+        return idx;
+    };
+
+    const leftWristIdx = jointIndex(WebXRBodyJoint.LEFT_HAND_WRIST);
+    const leftMiddleMetacarpalIdx = jointIndex(WebXRBodyJoint.LEFT_HAND_MIDDLE_METACARPAL);
+    const leftIndexMetacarpalIdx = jointIndex(WebXRBodyJoint.LEFT_HAND_INDEX_METACARPAL);
+    // Ring metacarpal is the second twist reference (not little/pinky) because common rigs
+    // name this bone "Ring1" which matches the token "ring", while "little" does not match
+    // the typical "Pinky" bone names used in rigs like Mixamo.
+    const leftRingMetacarpalIdx = jointIndex(WebXRBodyJoint.LEFT_HAND_RING_METACARPAL);
+
+    const createIdentityJointMatrices = (): Float32Array => {
+        const matrices = new Float32Array(BODY_JOINT_COUNT * 16);
+        for (let i = 0; i < BODY_JOINT_COUNT; i++) {
+            const offset = i * 16;
+            matrices[offset] = 1;
+            matrices[offset + 5] = 1;
+            matrices[offset + 10] = 1;
+            matrices[offset + 15] = 1;
+        }
+        return matrices;
+    };
+
+    const setJointPose = (matrices: Float32Array, jointIdx: number, rotation: Quaternion, position: Vector3): void => {
+        const matrix = new Matrix();
+        Matrix.ComposeToRef(Vector3.One(), rotation, position, matrix);
+        matrix.copyToArray(matrices, jointIdx * 16);
+    };
+
+    const createHandFrame = (wristRollRadians: number): Float32Array => {
+        const matrices = createIdentityJointMatrices();
+        setJointPose(matrices, leftWristIdx, Quaternion.RotationAxis(Vector3.Up(), wristRollRadians), Vector3.Zero());
+        setJointPose(matrices, leftMiddleMetacarpalIdx, Quaternion.Identity(), new Vector3(0, 1, 0));
+        setJointPose(matrices, leftIndexMetacarpalIdx, Quaternion.Identity(), new Vector3(-0.3, 0.8, 0));
+        setJointPose(matrices, leftRingMetacarpalIdx, Quaternion.Identity(), new Vector3(0.3, 0.8, 0));
+        return matrices;
+    };
+
+    const createTrackedHand = (): { trackedBody: WebXRTrackedBody; handBone: Bone } => {
+        const mesh = new Mesh("hand-mesh", scene);
+        const skeleton = new Skeleton("hand-skeleton", "hand-skeleton", scene);
+        mesh.skeleton = skeleton;
+
+        const handBone = new Bone("LeftHand", skeleton, null, Matrix.Identity(), null, Matrix.Identity(), 0);
+        new Bone("LeftMiddleMetacarpal", skeleton, handBone, Matrix.Translation(0, 1, 0), null, Matrix.Translation(0, 1, 0));
+        new Bone("LeftIndexMetacarpal", skeleton, handBone, Matrix.Translation(-0.3, 0.8, 0), null, Matrix.Translation(-0.3, 0.8, 0));
+        // "LeftRingMetacarpal" matches the "ring" token so findBestUnmappedDescendantForJoint
+        // succeeds for LEFT_HAND_RING_METACARPAL, allowing the twist normal to be derived from
+        // the avatar's bind pose (not the XR startup pose).
+        new Bone("LeftRingMetacarpal", skeleton, handBone, Matrix.Translation(0.3, 0.8, 0), null, Matrix.Translation(0.3, 0.8, 0));
+        mesh.computeWorldMatrix(true);
+
+        const trackedBody = new WebXRTrackedBody(scene, mesh, { [WebXRBodyJoint.LEFT_HAND_WRIST]: "LeftHand" }, 1, false, true, {
+            [WebXRBodyJoint.LEFT_HAND_WRIST]: WebXRBodyJoint.LEFT_HAND_MIDDLE_METACARPAL,
+        });
+
+        return { trackedBody, handBone };
+    };
+
+    const getBoneWorldRotation = (bone: Bone): Quaternion => {
+        const rotation = new Quaternion();
+        bone.getFinalMatrix().decompose(undefined, rotation, undefined);
+        rotation.normalize();
+        return rotation;
+    };
+
+    it("auto-captures first tracked frame as bind pose by default", () => {
+        const { trackedBody } = createTrackedHand();
+
+        expect(trackedBody.autoCaptureBindOnFirstFrame).toBe(true);
+
+        trackedBody.dispose();
+    });
+
+    it("does not bake first-frame wrist roll into later hand orientation", () => {
+        // The same live pose (neutral wrist, fixed metacarpal positions) should produce
+        // the same avatar orientation regardless of what startup pose was captured as bind.
+        // This tests that the twist correction uses the avatar's bind-pose palm-plane normal
+        // (derived from the rig's ring metacarpal bone) rather than the XR startup positions.
+        const currentFrame = createHandFrame(0);
+
+        const startsPalmUp = createTrackedHand();
+        // First frame: palm-up (180° roll) — captured as bind because autoCaptureBindOnFirstFrame = true.
+        startsPalmUp.trackedBody.replayRawJointMatrices(createHandFrame(Math.PI), true);
+        // Second frame: neutral pose — should converge to the same orientation as neutral-start below.
+        startsPalmUp.trackedBody.replayRawJointMatrices(currentFrame, true);
+        const afterPalmUpStart = getBoneWorldRotation(startsPalmUp.handBone);
+
+        const startsNeutral = createTrackedHand();
+        // First frame: neutral pose — captured as bind.
+        startsNeutral.trackedBody.replayRawJointMatrices(currentFrame, true);
+        const afterNeutralStart = getBoneWorldRotation(startsNeutral.handBone);
+
+        expect(Math.abs(Quaternion.Dot(afterPalmUpStart, afterNeutralStart))).toBeGreaterThan(0.9999);
+
+        startsPalmUp.trackedBody.dispose();
+        startsNeutral.trackedBody.dispose();
+    });
+});
+
 describe("WebXRBodyTracking - feature class", () => {
     let engine: Engine;
     let scene: Scene;

--- a/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
+++ b/packages/dev/core/test/unit/XR/babylon.webXRBodyTracking.test.ts
@@ -2186,6 +2186,7 @@ describe("WebXRTrackedBody - hand retargeting startup pose", () => {
     // name this bone "Ring1" which matches the token "ring", while "little" does not match
     // the typical "Pinky" bone names used in rigs like Mixamo.
     const leftRingMetacarpalIdx = jointIndex(WebXRBodyJoint.LEFT_HAND_RING_METACARPAL);
+    const leftLittleMetacarpalIdx = jointIndex(WebXRBodyJoint.LEFT_HAND_LITTLE_METACARPAL);
 
     const createIdentityJointMatrices = (): Float32Array => {
         const matrices = new Float32Array(BODY_JOINT_COUNT * 16);
@@ -2205,12 +2206,23 @@ describe("WebXRTrackedBody - hand retargeting startup pose", () => {
         matrix.copyToArray(matrices, jointIdx * 16);
     };
 
-    const createHandFrame = (wristRollRadians: number): Float32Array => {
+    // Build a hand frame whose palm plane is rolled by `palmRollRadians` around the aim axis
+    // (the wrist→middle direction, +Y). The wrist joint rotation stays identity so the only
+    // signal a roll-around-aim correction can pick up is the rolled finger *positions*. The
+    // middle metacarpal sits on the aim axis, so it is unaffected by the roll and the aim
+    // direction is identical across frames — isolating the twist (roll) correction.
+    const createHandFrame = (palmRollRadians: number): Float32Array => {
         const matrices = createIdentityJointMatrices();
-        setJointPose(matrices, leftWristIdx, Quaternion.RotationAxis(Vector3.Up(), wristRollRadians), Vector3.Zero());
+        const roll = Quaternion.RotationAxis(Vector3.Up(), palmRollRadians);
+        const rolled = (x: number, y: number, z: number): Vector3 => new Vector3(x, y, z).rotateByQuaternionToRef(roll, new Vector3());
+        setJointPose(matrices, leftWristIdx, Quaternion.Identity(), Vector3.Zero());
         setJointPose(matrices, leftMiddleMetacarpalIdx, Quaternion.Identity(), new Vector3(0, 1, 0));
-        setJointPose(matrices, leftIndexMetacarpalIdx, Quaternion.Identity(), new Vector3(-0.3, 0.8, 0));
-        setJointPose(matrices, leftRingMetacarpalIdx, Quaternion.Identity(), new Vector3(0.3, 0.8, 0));
+        setJointPose(matrices, leftIndexMetacarpalIdx, Quaternion.Identity(), rolled(-0.3, 0.8, 0));
+        setJointPose(matrices, leftRingMetacarpalIdx, Quaternion.Identity(), rolled(0.3, 0.8, 0));
+        // Little (pinky) joint is colinear with the ring spread so that, whichever joint the
+        // twist reference uses at runtime, the live palm normal is identical. This makes the
+        // test sensitive only to which *bind* normal is used (rig bind pose vs tracked startup).
+        setJointPose(matrices, leftLittleMetacarpalIdx, Quaternion.Identity(), rolled(0.6, 0.8, 0));
         return matrices;
     };
 
@@ -2219,13 +2231,17 @@ describe("WebXRTrackedBody - hand retargeting startup pose", () => {
         const skeleton = new Skeleton("hand-skeleton", "hand-skeleton", scene);
         mesh.skeleton = skeleton;
 
+        // Use real Mixamo-style finger bone names. Crucially, none of them contain the
+        // substring "metacarpal", and the little finger is named "Pinky" — so the twist
+        // reference must use the RING joint (token "ring" → "LeftHandRing1") to resolve a
+        // descendant. If the twist reference used LITTLE, its tokens ("little"/"metacarpal")
+        // would match no bone here and the palm-plane twist correction would be disabled,
+        // re-introducing the startup-roll bug this test guards against.
         const handBone = new Bone("LeftHand", skeleton, null, Matrix.Identity(), null, Matrix.Identity(), 0);
-        new Bone("LeftMiddleMetacarpal", skeleton, handBone, Matrix.Translation(0, 1, 0), null, Matrix.Translation(0, 1, 0));
-        new Bone("LeftIndexMetacarpal", skeleton, handBone, Matrix.Translation(-0.3, 0.8, 0), null, Matrix.Translation(-0.3, 0.8, 0));
-        // "LeftRingMetacarpal" matches the "ring" token so findBestUnmappedDescendantForJoint
-        // succeeds for LEFT_HAND_RING_METACARPAL, allowing the twist normal to be derived from
-        // the avatar's bind pose (not the XR startup pose).
-        new Bone("LeftRingMetacarpal", skeleton, handBone, Matrix.Translation(0.3, 0.8, 0), null, Matrix.Translation(0.3, 0.8, 0));
+        new Bone("LeftHandMiddle1", skeleton, handBone, Matrix.Translation(0, 1, 0), null, Matrix.Translation(0, 1, 0));
+        new Bone("LeftHandIndex1", skeleton, handBone, Matrix.Translation(-0.3, 0.8, 0), null, Matrix.Translation(-0.3, 0.8, 0));
+        new Bone("LeftHandRing1", skeleton, handBone, Matrix.Translation(0.3, 0.8, 0), null, Matrix.Translation(0.3, 0.8, 0));
+        new Bone("LeftHandPinky1", skeleton, handBone, Matrix.Translation(0.5, 0.7, 0), null, Matrix.Translation(0.5, 0.7, 0));
         mesh.computeWorldMatrix(true);
 
         const trackedBody = new WebXRTrackedBody(scene, mesh, { [WebXRBodyJoint.LEFT_HAND_WRIST]: "LeftHand" }, 1, false, true, {
@@ -2250,28 +2266,33 @@ describe("WebXRTrackedBody - hand retargeting startup pose", () => {
         trackedBody.dispose();
     });
 
-    it("does not bake first-frame wrist roll into later hand orientation", () => {
-        // The same live pose (neutral wrist, fixed metacarpal positions) should produce
-        // the same avatar orientation regardless of what startup pose was captured as bind.
-        // This tests that the twist correction uses the avatar's bind-pose palm-plane normal
-        // (derived from the rig's ring metacarpal bone) rather than the XR startup positions.
-        const currentFrame = createHandFrame(0);
+    it("does not bake the startup palm roll into later hand orientation", () => {
+        // The same live pose (neutral palm) must produce the same avatar orientation no matter
+        // how the user's palm was rolled around the aim axis on the captured bind frame.
+        //
+        // The twist correction must derive its reference palm-plane normal from the AVATAR's
+        // bind pose (the ring metacarpal bone resolved by name), NOT from the tracked startup
+        // positions. If the second twist reference used LITTLE, it would not resolve to a bone
+        // on a Mixamo-style rig (named "...Pinky1"), the reference normal would fall back to the
+        // tracked startup palm, and a startup roll would be baked in permanently — diverging the
+        // two scenarios below.
+        const neutralLiveFrame = createHandFrame(0);
 
-        const startsPalmUp = createTrackedHand();
-        // First frame: palm-up (180° roll) — captured as bind because autoCaptureBindOnFirstFrame = true.
-        startsPalmUp.trackedBody.replayRawJointMatrices(createHandFrame(Math.PI), true);
-        // Second frame: neutral pose — should converge to the same orientation as neutral-start below.
-        startsPalmUp.trackedBody.replayRawJointMatrices(currentFrame, true);
-        const afterPalmUpStart = getBoneWorldRotation(startsPalmUp.handBone);
+        const startsRolled = createTrackedHand();
+        // First frame: palm rolled 90° around the aim axis — captured as bind (auto-capture on).
+        startsRolled.trackedBody.replayRawJointMatrices(createHandFrame(Math.PI / 2), true);
+        // Second frame: neutral palm — should converge to the same orientation as the neutral start.
+        startsRolled.trackedBody.replayRawJointMatrices(neutralLiveFrame, true);
+        const afterRolledStart = getBoneWorldRotation(startsRolled.handBone);
 
         const startsNeutral = createTrackedHand();
-        // First frame: neutral pose — captured as bind.
-        startsNeutral.trackedBody.replayRawJointMatrices(currentFrame, true);
+        // First frame: neutral palm — captured as bind.
+        startsNeutral.trackedBody.replayRawJointMatrices(neutralLiveFrame, true);
         const afterNeutralStart = getBoneWorldRotation(startsNeutral.handBone);
 
-        expect(Math.abs(Quaternion.Dot(afterPalmUpStart, afterNeutralStart))).toBeGreaterThan(0.9999);
+        expect(Math.abs(Quaternion.Dot(afterRolledStart, afterNeutralStart))).toBeGreaterThan(0.9999);
 
-        startsPalmUp.trackedBody.dispose();
+        startsRolled.trackedBody.dispose();
         startsNeutral.trackedBody.dispose();
     });
 });


### PR DESCRIPTION
## Problem

Fixes https://forum.babylonjs.com/t/quest-3-webxr-body-tracking-hand-forearm-orientation-can-initialize-incorrectly/63541/5 (post #5 — the startup roll issue).

When entering WebXR body tracking with the palm facing up or sideways, the avatar's hand would have a permanent ~180° roll offset for the entire session. The first issue (asymmetric start-time behavior) was already fixed in a previous PR; this PR addresses the follow-up startup roll bug.

## Root Cause

The delta-from-bind retarget path uses an aim + twist correction to make joint orientation independent of the startup pose. The twist correction requires `_bindLocalTwistNormal` — a vector representing the "palm plane" direction in the avatar's bind-rotation space.

This vector is ideally derived from the **avatar's bind-pose skeleton** during `setBodyMesh`. `HandTwistReferenceJoints` listed `LEFT/RIGHT_HAND_LITTLE_METACARPAL` as the second spread point for the palm plane. `findBestUnmappedDescendantForJoint` tokenizes that name and looks for the token `"little"` — but Mixamo rigs name this bone **"Pinky"** (e.g. `mixamorig:LeftHandPinky1`), scoring 0. The bind computation falls back to the **XR startup positions**, which vary with the user's hand orientation at session entry, baking in a permanent roll offset for the whole session.

## Fix

Change the second twist-plane reference from `LEFT/RIGHT_HAND_LITTLE_METACARPAL` to `LEFT/RIGHT_HAND_RING_METACARPAL`. The token `"ring"` matches Mixamo's `LeftHandRing1` bones (score ≥ 1), so the avatar bind-pose computation succeeds and the twist normal is startup-pose independent.

## Other changes

- Pooled `_computedDirectWorldRotations` to avoid per-frame allocations in `_retargetDirect`
- Twist correction backported to the legacy `_retargetDirect` fallback path
- `IWebXRBodyTrackingOptions.autoCaptureBindOnFirstFrame` option (defaulting `true`) for apps that want an explicit calibration-pose workflow instead of auto-capture

## Testing

All 84 unit tests pass. New regression test: verifies that a palm-up startup and a neutral startup produce the same avatar orientation for the same live hand pose.