### PR TITLE
chore(deps): npm audit fix - 20260603

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17377,9 +17377,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
Automated by the morning-dev-briefing skill.

## Summary
`npm audit fix` resolved the following findings:
- Critical: 0
- High:     1
- Moderate: 0

Remaining audit findings after the fix:
- Critical: 0
- High:     0
- Moderate: 4

## Verification
- [ ] CI green
- [ ] No runtime regressions in dev host
- [ ] Lockfile diff reviewed

Run locally: `npm install && npm audit`