### PR TITLE
Add NullEngine multiview render-state testability

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.pure.ts
+++ b/packages/dev/core/src/Engines/nullEngine.pure.ts
@@ -77,11 +77,7 @@ export class NullEngineOptions {
  * This can be used in server side scenario or for testing purposes
  */
 export class NullEngine extends Engine {
-    private _options: NullEngineOptions = new NullEngineOptions();
-
-    private static readonly _MultiviewExtension = {
-        framebufferTextureMultiviewOVR: () => {},
-    };
+    private _options: NullEngineOptions;
 
     /**
      * Gets a boolean indicating that the engine is running in deterministic lock step mode
@@ -115,7 +111,7 @@ export class NullEngine extends Engine {
      * Gets a boolean indicating that the engine supports uniform buffers
      */
     public override get supportsUniformBuffers(): boolean {
-        return !!this._options.enableMultiview || super.supportsUniformBuffers;
+        return !!this._options?.enableMultiview || super.supportsUniformBuffers;
     }
 
     public constructor(options: NullEngineOptions = new NullEngineOptions()) {
@@ -198,7 +194,7 @@ export class NullEngine extends Engine {
         };
 
         if (options.enableMultiview) {
-            this._caps.multiview = NullEngine._MultiviewExtension;
+            this._caps.multiview = { framebufferTextureMultiviewOVR: () => {} };
         }
 
         this._features = {

--- a/packages/dev/core/src/Engines/nullEngine.pure.ts
+++ b/packages/dev/core/src/Engines/nullEngine.pure.ts
@@ -64,6 +64,12 @@ export class NullEngineOptions {
      * If supplied, the HTMLCanvasElement to use (e.g. as the inputElement)
      */
     renderingCanvas?: HTMLCanvasElement;
+
+    /**
+     * Enables headless multiview render target support for CPU-side render-state tests.
+     * This does not emulate GPU multiview rendering.
+     */
+    enableMultiview?: boolean;
 }
 
 /**
@@ -71,7 +77,11 @@ export class NullEngineOptions {
  * This can be used in server side scenario or for testing purposes
  */
 export class NullEngine extends Engine {
-    private _options: NullEngineOptions;
+    private _options: NullEngineOptions = new NullEngineOptions();
+
+    private static readonly _MultiviewExtension = {
+        framebufferTextureMultiviewOVR: () => {},
+    };
 
     /**
      * Gets a boolean indicating that the engine is running in deterministic lock step mode
@@ -99,6 +109,13 @@ export class NullEngine extends Engine {
      */
     public override getHardwareScalingLevel(): number {
         return 1.0;
+    }
+
+    /**
+     * Gets a boolean indicating that the engine supports uniform buffers
+     */
+    public override get supportsUniformBuffers(): boolean {
+        return !!this._options.enableMultiview || super.supportsUniformBuffers;
     }
 
     public constructor(options: NullEngineOptions = new NullEngineOptions()) {
@@ -179,6 +196,10 @@ export class NullEngine extends Engine {
             dualSourceBlending: false,
             supportReadWriteStorageTextures: false,
         };
+
+        if (options.enableMultiview) {
+            this._caps.multiview = NullEngine._MultiviewExtension;
+        }
 
         this._features = {
             forceBitmapOverHTMLImageElement: false,
@@ -294,6 +315,52 @@ export class NullEngine extends Engine {
     public override setViewport(viewport: IViewportLike, requiredWidth?: number, requiredHeight?: number): void {
         this._cachedViewport = viewport;
     }
+
+    /**
+     * Creates a uniform buffer.
+     * @param elements defines the content of the uniform buffer
+     * @returns a new data buffer
+     */
+    public override createUniformBuffer(elements: FloatArray): DataBuffer {
+        const buffer = new DataBuffer();
+        buffer.references = 1;
+        buffer.capacity = elements.length;
+        return buffer;
+    }
+
+    /**
+     * Creates a dynamic uniform buffer.
+     * @param elements defines the content of the dynamic uniform buffer
+     * @returns a new data buffer
+     */
+    public override createDynamicUniformBuffer(elements: FloatArray): DataBuffer {
+        return this.createUniformBuffer(elements);
+    }
+
+    /**
+     * Updates a uniform buffer.
+     * @param _uniformBuffer defines the target uniform buffer
+     * @param _elements defines the content to update
+     * @param _offset defines the offset in the uniform buffer where update should start
+     * @param _count defines the size of the data to update
+     */
+    public override updateUniformBuffer(_uniformBuffer: DataBuffer, _elements: FloatArray, _offset?: number, _count?: number): void {}
+
+    /**
+     * Binds a uniform buffer to the current draw context.
+     * @param _buffer defines the buffer to bind
+     * @param _location not used in NullEngine
+     * @param _name name of the uniform variable to bind
+     */
+    public override bindUniformBufferBase(_buffer: DataBuffer, _location: number, _name: string): void {}
+
+    /**
+     * Binds a uniform block to a specific index.
+     * @param _pipelineContext defines the pipeline context to use
+     * @param _blockName defines the block name
+     * @param _index defines the index where to bind the block
+     */
+    public override bindUniformBlock(_pipelineContext: IPipelineContext, _blockName: string, _index: number): void {}
 
     public override createShaderProgram(
         pipelineContext: IPipelineContext,
@@ -799,6 +866,44 @@ export class NullEngine extends Engine {
         this._internalTexturesCache.push(texture);
 
         return rtWrapper;
+    }
+
+    /**
+     * Creates a new multiview render target wrapper for headless render-state tests.
+     * @param width defines the width of the texture
+     * @param height defines the height of the texture
+     * @returns a new multiview render target wrapper
+     */
+    public override createMultiviewRenderTargetTexture(width: number, height: number): RenderTargetWrapper {
+        if (!this.getCaps().multiview) {
+            // eslint-disable-next-line no-throw-literal
+            throw "Multiview is not supported";
+        }
+
+        const rtWrapper = this._createHardwareRenderTargetWrapper(false, false, { width, height });
+        const texture = new InternalTexture(this, InternalTextureSource.Unknown, true);
+
+        texture.baseWidth = width;
+        texture.baseHeight = height;
+        texture.width = width;
+        texture.height = height;
+        texture.isMultiview = true;
+        texture.isReady = true;
+        texture.format = Constants.TEXTUREFORMAT_RGBA;
+        texture.samples = 1;
+
+        rtWrapper.setTextures(texture);
+        rtWrapper._depthStencilTexture = texture;
+
+        return rtWrapper;
+    }
+
+    /**
+     * Binds a multiview framebuffer for headless render-state tests.
+     * @param multiviewTexture render target wrapper to bind
+     */
+    public override bindMultiviewFramebuffer(multiviewTexture: RenderTargetWrapper): void {
+        this.bindFramebuffer(multiviewTexture, undefined, undefined, undefined, true);
     }
 
     /**

--- a/packages/dev/core/src/Engines/nullEngine.pure.ts
+++ b/packages/dev/core/src/Engines/nullEngine.pure.ts
@@ -324,7 +324,7 @@ export class NullEngine extends Engine {
     public override createUniformBuffer(elements: FloatArray): DataBuffer {
         const buffer = new DataBuffer();
         buffer.references = 1;
-        buffer.capacity = elements.length;
+        buffer.capacity = elements instanceof Array ? elements.length * Float32Array.BYTES_PER_ELEMENT : elements.byteLength;
         return buffer;
     }
 
@@ -876,12 +876,11 @@ export class NullEngine extends Engine {
      */
     public override createMultiviewRenderTargetTexture(width: number, height: number): RenderTargetWrapper {
         if (!this.getCaps().multiview) {
-            // eslint-disable-next-line no-throw-literal
-            throw "Multiview is not supported";
+            throw new Error("Multiview is not supported");
         }
 
         const rtWrapper = this._createHardwareRenderTargetWrapper(false, false, { width, height });
-        const texture = new InternalTexture(this, InternalTextureSource.Unknown, true);
+        const texture = new InternalTexture(this, InternalTextureSource.RenderTarget, true);
 
         texture.baseWidth = width;
         texture.baseHeight = height;
@@ -893,7 +892,6 @@ export class NullEngine extends Engine {
         texture.samples = 1;
 
         rtWrapper.setTextures(texture);
-        rtWrapper._depthStencilTexture = texture;
 
         return rtWrapper;
     }

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -1751,6 +1751,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
     private _viewUpdateFlag = -1;
     private _projectionUpdateFlag = -1;
+    private _transformMatrixIsFromActiveCamera = false;
 
     /** @internal */
     public _toBeDisposed = new Array<Nullable<IDisposable>>(256);
@@ -2832,21 +2833,22 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         return this._transformMatrix;
     }
 
-    /**
-     * Sets the current transform matrix
-     * @param viewL defines the View matrix to use
-     * @param projectionL defines the Projection matrix to use
-     * @param viewR defines the right View matrix to use (if provided)
-     * @param projectionR defines the right Projection matrix to use (if provided)
-     */
-    public setTransformMatrix(viewL: Matrix, projectionL: Matrix, viewR?: Matrix, projectionR?: Matrix): void {
+    /** @internal */
+    private _setTransformMatrix(viewL: Matrix, projectionL: Matrix, viewR: Matrix | undefined, projectionR: Matrix | undefined, transformMatrixIsFromActiveCamera: boolean): void {
         // Toggle the multiview flag based on whether stereo matrices are provided.
         // The multiview UBO itself is kept alive for the XR session lifetime to avoid per-frame GPU alloc/dealloc.
-        this._multiviewSceneUboIsActive = !!(viewR && projectionR && this._multiviewSceneUbo);
-        if (this._viewUpdateFlag === viewL.updateFlag && this._projectionUpdateFlag === projectionL.updateFlag) {
+        const multiviewSceneUboIsActive = !!(viewR && projectionR && this._multiviewSceneUbo);
+        if (
+            this._transformMatrixIsFromActiveCamera === transformMatrixIsFromActiveCamera &&
+            this._multiviewSceneUboIsActive === multiviewSceneUboIsActive &&
+            this._viewUpdateFlag === viewL.updateFlag &&
+            this._projectionUpdateFlag === projectionL.updateFlag
+        ) {
             return;
         }
 
+        this._transformMatrixIsFromActiveCamera = transformMatrixIsFromActiveCamera;
+        this._multiviewSceneUboIsActive = multiviewSceneUboIsActive;
         this._viewUpdateFlag = viewL.updateFlag;
         this._projectionUpdateFlag = projectionL.updateFlag;
         this._viewMatrix = viewL;
@@ -2873,6 +2875,17 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             this._sceneUbo.updateMatrix("projection", this._projectionMatrix);
             this._sceneUbo.updateMatrix("inverseProjection", this._inverseProjectionMatrix);
         }
+    }
+
+    /**
+     * Sets the current transform matrix
+     * @param viewL defines the View matrix to use
+     * @param projectionL defines the Projection matrix to use
+     * @param viewR defines the right View matrix to use (if provided)
+     * @param projectionR defines the right Projection matrix to use (if provided)
+     */
+    public setTransformMatrix(viewL: Matrix, projectionL: Matrix, viewR?: Matrix, projectionR?: Matrix): void {
+        this._setTransformMatrix(viewL, projectionL, viewR, projectionR, false);
     }
 
     /**
@@ -2916,6 +2929,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         this._sceneUbo = ubo;
         this._viewUpdateFlag = -1;
         this._projectionUpdateFlag = -1;
+        this._transformMatrixIsFromActiveCamera = false;
     }
 
     private _floatingOriginScene: Scene | undefined = undefined;
@@ -4949,9 +4963,15 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         if (activeCamera._renderingMultiview) {
             const leftCamera = activeCamera._rigCameras[0];
             const rightCamera = activeCamera._rigCameras[1];
-            this.setTransformMatrix(leftCamera.getViewMatrix(), leftCamera.getProjectionMatrix(force), rightCamera.getViewMatrix(), rightCamera.getProjectionMatrix(force));
+            this._setTransformMatrix(
+                leftCamera.getViewMatrix(force),
+                leftCamera.getProjectionMatrix(force),
+                rightCamera.getViewMatrix(force),
+                rightCamera.getProjectionMatrix(force),
+                true
+            );
         } else {
-            this.setTransformMatrix(activeCamera.getViewMatrix(), activeCamera.getProjectionMatrix(force));
+            this._setTransformMatrix(activeCamera.getViewMatrix(force), activeCamera.getProjectionMatrix(force), undefined, undefined, true);
         }
     }
 

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -4963,15 +4963,9 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         if (activeCamera._renderingMultiview) {
             const leftCamera = activeCamera._rigCameras[0];
             const rightCamera = activeCamera._rigCameras[1];
-            this._setTransformMatrix(
-                leftCamera.getViewMatrix(force),
-                leftCamera.getProjectionMatrix(force),
-                rightCamera.getViewMatrix(force),
-                rightCamera.getProjectionMatrix(force),
-                true
-            );
+            this._setTransformMatrix(leftCamera.getViewMatrix(), leftCamera.getProjectionMatrix(force), rightCamera.getViewMatrix(), rightCamera.getProjectionMatrix(force), true);
         } else {
-            this._setTransformMatrix(activeCamera.getViewMatrix(force), activeCamera.getProjectionMatrix(force), undefined, undefined, true);
+            this._setTransformMatrix(activeCamera.getViewMatrix(), activeCamera.getProjectionMatrix(force), undefined, undefined, true);
         }
     }
 

--- a/packages/dev/core/test/unit/Engines/nullEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/nullEngine.test.ts
@@ -185,6 +185,67 @@ describe("NullEngine", () => {
                 engine.dispose();
             }
         });
+
+        it("restores the active-camera scene transform after a direct narrowed transform (multiview)", () => {
+            const { engine, scene, leftCamera } = createMultiviewScene();
+
+            try {
+                // A capture/RTT path narrows the scene transform mid-frame via a direct
+                // setTransformMatrix; the projection updateFlag is forced to collide with the left
+                // camera's so the pre-fix guard (view/proj flags only) would early-return.
+                const view = leftCamera.getViewMatrix(true);
+                const wideProjection = leftCamera.getProjectionMatrix(true);
+                const narrowedProjection = Matrix.OrthoOffCenterLH(-1, 1, -1, 1, leftCamera.minZ, leftCamera.maxZ, engine.isNDCHalfZRange);
+                narrowedProjection.updateFlag = wideProjection.updateFlag;
+
+                scene.setTransformMatrix(view, narrowedProjection);
+                const narrowedTransform = scene.getTransformMatrix().clone();
+                expectMatrixToBeCloseTo(narrowedTransform, view.multiply(narrowedProjection));
+
+                scene.render();
+
+                // The active-camera render must hand the scene transform back at full FOV, not
+                // early-return on the matching flags and leave it narrowed. (Asserts the transform
+                // directly, where the existing test asserts the downstream culling consequence.)
+                const restoredTransform = scene.getTransformMatrix();
+                expect(restoredTransform.equals(narrowedTransform)).toBe(false);
+                expectMatrixToBeCloseTo(restoredTransform, leftCamera.getViewMatrix().multiply(leftCamera.getProjectionMatrix()));
+            } finally {
+                scene.dispose();
+                engine.dispose();
+            }
+        });
+
+        it("refreshes the right-eye view-projection when a mono transform precedes a multiview render", () => {
+            const { engine, scene, leftCamera, rightCamera } = createMultiviewScene();
+
+            try {
+                scene.render(); // establish the initial right-eye transform
+
+                // The right eye moves; its multiview-UBO transform must be re-derived next render.
+                rightCamera.position.set(4, 0, 0);
+                rightCamera.setTarget(new Vector3(4, 0, 1));
+                const movedRightViewProjection = rightCamera.getViewMatrix(true).multiply(rightCamera.getProjectionMatrix(true));
+
+                // A direct mono setTransformMatrix using the LEFT eye's view flips the multiview UBO
+                // inactive; the projection updateFlag is forced to the left camera's so the pre-fix
+                // guard would early-return the next render and leave the right eye stale. Covers the
+                // _multiviewSceneUboIsActive consequence the frustum test does not.
+                const leftView = leftCamera.getViewMatrix(true);
+                const monoProjection = leftCamera.getProjectionMatrix(true).clone();
+                monoProjection.updateFlag = leftCamera.getProjectionMatrix().updateFlag;
+                scene.setTransformMatrix(leftView, monoProjection);
+                expect(scene._multiviewSceneUboIsActive).toBe(false);
+
+                scene.render();
+
+                expect(scene._multiviewSceneUboIsActive).toBe(true);
+                expectMatrixToBeCloseTo(scene._transformMatrixR, movedRightViewProjection);
+            } finally {
+                scene.dispose();
+                engine.dispose();
+            }
+        });
     });
 
     describe("render loop", () => {

--- a/packages/dev/core/test/unit/Engines/nullEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/nullEngine.test.ts
@@ -1,6 +1,7 @@
 import { NullEngine } from "core/Engines/nullEngine";
 import { Camera } from "core/Cameras/camera";
 import { FreeCamera } from "core/Cameras/freeCamera";
+import { InternalTextureSource } from "core/Materials/Textures/internalTexture";
 import { MultiviewRenderTarget } from "core/Materials/Textures/MultiviewRenderTarget";
 import { Matrix, Vector3 } from "core/Maths/math.vector";
 import { MeshBuilder } from "core/Meshes/meshBuilder";
@@ -49,6 +50,8 @@ function createMultiviewScene(): {
     configureOrthographicCamera(leftCamera, -0.5);
     configureOrthographicCamera(rightCamera, 0.5);
 
+    // WebXR sets this internal multiview state from XR view/render-target data. There is no public
+    // NullEngine setup API that reaches this exact branch without a live XRSession.
     parentCamera._rigCameras = [leftCamera, rightCamera];
     parentCamera._renderingMultiview = true;
     parentCamera.outputRenderTarget = renderTarget;
@@ -113,9 +116,43 @@ describe("NullEngine", () => {
             defaultEngine.dispose();
             multiviewEngine.dispose();
         });
+
+        it("reports uniform buffer capacity in bytes", () => {
+            const engine = new NullEngine({
+                enableMultiview: true,
+            });
+
+            try {
+                expect(engine.createUniformBuffer([0, 1, 2, 3]).capacity).toBe(16);
+                expect(engine.createUniformBuffer(new Float32Array(6)).capacity).toBe(24);
+                expect(engine.createDynamicUniformBuffer(new Float32Array(2)).capacity).toBe(8);
+            } finally {
+                engine.dispose();
+            }
+        });
     });
 
     describe("multiview", () => {
+        it("throws an Error when multiview render targets are requested without opt-in", () => {
+            const engine = new NullEngine();
+            const scene = new Scene(engine);
+            let thrownError: unknown;
+
+            try {
+                try {
+                    new MultiviewRenderTarget(scene, { width: 64, height: 64 });
+                } catch (error) {
+                    thrownError = error;
+                }
+
+                expect(thrownError).toBeInstanceOf(Error);
+                expect((thrownError as Error).message).toBe("Multiview is not supported");
+            } finally {
+                scene.dispose();
+                engine.dispose();
+            }
+        });
+
         it("creates inspectable multiview render targets when enabled", () => {
             const engine = new NullEngine({
                 enableMultiview: true,
@@ -128,6 +165,8 @@ describe("NullEngine", () => {
                 expect(renderTarget.getRenderWidth()).toBe(64);
                 expect(renderTarget.getRenderHeight()).toBe(32);
                 expect(renderTarget.renderTarget?.texture?.isMultiview).toBe(true);
+                expect(renderTarget.renderTarget?.texture?.source).toBe(InternalTextureSource.RenderTarget);
+                expect(renderTarget.renderTarget?.depthStencilTexture).toBeNull();
                 expect(() => renderTarget._bindFrameBuffer()).not.toThrow();
                 expect((engine as any)._currentRenderTarget).toBe(renderTarget.renderTarget);
             } finally {

--- a/packages/dev/core/test/unit/Engines/nullEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/nullEngine.test.ts
@@ -1,7 +1,67 @@
 import { NullEngine } from "core/Engines/nullEngine";
+import { Camera } from "core/Cameras/camera";
+import { FreeCamera } from "core/Cameras/freeCamera";
+import { MultiviewRenderTarget } from "core/Materials/Textures/MultiviewRenderTarget";
+import { Matrix, Vector3 } from "core/Maths/math.vector";
+import { MeshBuilder } from "core/Meshes/meshBuilder";
+import { Scene } from "core/scene";
 import { describe, expect, it } from "vitest";
 
+import "core/Engines/Extensions/engine.multiview";
+
 type RenderFrameCallback = (timestamp: number) => void;
+
+function configureOrthographicCamera(camera: FreeCamera, x: number): void {
+    camera.mode = Camera.ORTHOGRAPHIC_CAMERA;
+    camera.minZ = 0.1;
+    camera.maxZ = 100;
+    camera.orthoLeft = -10;
+    camera.orthoRight = 10;
+    camera.orthoBottom = -10;
+    camera.orthoTop = 10;
+    camera.position.set(x, 0, 0);
+    camera.setTarget(new Vector3(x, 0, 1));
+    camera.getViewMatrix(true);
+    camera.getProjectionMatrix(true);
+}
+
+function createMultiviewScene(): {
+    engine: NullEngine;
+    scene: Scene;
+    parentCamera: FreeCamera;
+    leftCamera: FreeCamera;
+    rightCamera: FreeCamera;
+    renderTarget: MultiviewRenderTarget;
+} {
+    const engine = new NullEngine({
+        renderHeight: 128,
+        renderWidth: 128,
+        textureSize: 128,
+        enableMultiview: true,
+    });
+    const scene = new Scene(engine);
+    const parentCamera = new FreeCamera("parent", Vector3.Zero(), scene);
+    const leftCamera = new FreeCamera("left", Vector3.Zero(), scene);
+    const rightCamera = new FreeCamera("right", Vector3.Zero(), scene);
+    const renderTarget = new MultiviewRenderTarget(scene, { width: 128, height: 128 });
+
+    configureOrthographicCamera(parentCamera, 0);
+    configureOrthographicCamera(leftCamera, -0.5);
+    configureOrthographicCamera(rightCamera, 0.5);
+
+    parentCamera._rigCameras = [leftCamera, rightCamera];
+    parentCamera._renderingMultiview = true;
+    parentCamera.outputRenderTarget = renderTarget;
+    scene.activeCamera = parentCamera;
+
+    return { engine, scene, parentCamera, leftCamera, rightCamera, renderTarget };
+}
+
+function expectMatrixToBeCloseTo(actual: Matrix, expected: Matrix): void {
+    for (let index = 0; index < 16; index++) {
+        expect(actual.m[index]).toBeCloseTo(expected.m[index], 6);
+    }
+}
 
 describe("NullEngine", () => {
     describe("constructor", () => {
@@ -38,6 +98,92 @@ describe("NullEngine", () => {
             expect(nullEngine.isDeterministicLockStep()).toBe(true);
             expect(nullEngine.getTimeStep()).toBe(500); // 0.5 seconds in ms
             expect(nullEngine.getLockstepMaxSteps()).toBe(4);
+        });
+
+        it("advertises multiview only when enabled", () => {
+            const defaultEngine = new NullEngine();
+            const multiviewEngine = new NullEngine({
+                enableMultiview: true,
+            });
+
+            expect(defaultEngine.getCaps().multiview).toBeUndefined();
+            expect(multiviewEngine.getCaps().multiview).toBeTruthy();
+            expect(multiviewEngine.supportsUniformBuffers).toBe(true);
+
+            defaultEngine.dispose();
+            multiviewEngine.dispose();
+        });
+    });
+
+    describe("multiview", () => {
+        it("creates inspectable multiview render targets when enabled", () => {
+            const engine = new NullEngine({
+                enableMultiview: true,
+            });
+            const scene = new Scene(engine);
+            const renderTarget = new MultiviewRenderTarget(scene, { width: 64, height: 32 });
+
+            try {
+                expect(renderTarget.getViewCount()).toBe(2);
+                expect(renderTarget.getRenderWidth()).toBe(64);
+                expect(renderTarget.getRenderHeight()).toBe(32);
+                expect(renderTarget.renderTarget?.texture?.isMultiview).toBe(true);
+                expect(() => renderTarget._bindFrameBuffer()).not.toThrow();
+                expect((engine as any)._currentRenderTarget).toBe(renderTarget.renderTarget);
+            } finally {
+                scene.dispose();
+                engine.dispose();
+            }
+        });
+
+        it("updates left and right view-projection state when rendering multiview", () => {
+            const { engine, scene, parentCamera, leftCamera, rightCamera, renderTarget } = createMultiviewScene();
+
+            try {
+                scene.render();
+
+                const leftViewProjection = leftCamera.getViewMatrix().multiply(leftCamera.getProjectionMatrix());
+                const rightViewProjection = rightCamera.getViewMatrix().multiply(rightCamera.getProjectionMatrix());
+                const multiviewSceneUbo = scene._multiviewSceneUbo;
+
+                expect(parentCamera.outputRenderTarget).toBe(renderTarget);
+                expect(scene._multiviewSceneUboIsActive).toBe(true);
+                expect(multiviewSceneUbo).not.toBeNull();
+                expect(scene.getSceneUniformBuffer()).toBe(multiviewSceneUbo);
+                expect(multiviewSceneUbo!.useUbo).toBe(true);
+                expect(multiviewSceneUbo!.getUniformNames()).toContain("viewProjectionR");
+                expectMatrixToBeCloseTo(scene.getTransformMatrix(), leftViewProjection);
+                expectMatrixToBeCloseTo(scene._transformMatrixR, rightViewProjection);
+            } finally {
+                scene.dispose();
+                engine.dispose();
+            }
+        });
+
+        it("restores active-camera frustum planes after a direct narrowed transform before multiview render", () => {
+            const { engine, scene, leftCamera } = createMultiviewScene();
+            const visibleInWideFrustum = MeshBuilder.CreateBox("visibleInWideFrustum", { size: 1 }, scene);
+
+            try {
+                visibleInWideFrustum.position.set(5, 0, 10);
+                visibleInWideFrustum.computeWorldMatrix(true);
+
+                const view = leftCamera.getViewMatrix(true);
+                const wideProjection = leftCamera.getProjectionMatrix(true);
+                const narrowedProjection = Matrix.OrthoOffCenterLH(-1, 1, -10, 10, leftCamera.minZ, leftCamera.maxZ, engine.isNDCHalfZRange);
+
+                narrowedProjection.updateFlag = wideProjection.updateFlag;
+                scene.setTransformMatrix(view, narrowedProjection);
+
+                expect(visibleInWideFrustum.isInFrustum(scene.frustumPlanes)).toBe(false);
+
+                scene.render();
+
+                expect(visibleInWideFrustum.isInFrustum(scene.frustumPlanes)).toBe(true);
+            } finally {
+                scene.dispose();
+                engine.dispose();
+            }
         });
     });
 


### PR DESCRIPTION
## Summary
- Add an opt-in `NullEngineOptions.enableMultiview` path that reports `caps.multiview`, provides no-op uniform-buffer plumbing, and creates inspectable multiview render target wrappers for CPU-side render-state tests.
- Refresh scene transform state when an active-camera render follows a direct `scene.setTransformMatrix(...)` call with matching matrix update flags, so frustum planes and multiview UBO state cannot remain stale.
- Add NullEngine unit tests for opt-in multiview capability, multiview render target binding, left/right view-projection state, and the stale narrowed-frustum regression class.

## Scope
This does not emulate GPU multiview rasterization in NullEngine. It only makes Babylon's CPU-side multiview render-state path reachable and assertable headlessly: `caps.multiview`, `_renderingMultiview`, multiview render target bookkeeping, multiview scene UBO selection/update, transform matrices, and frustum planes.

## Root cause
`Scene.setTransformMatrix` cached only the left view/projection update flags. A direct transform update could therefore leave `Scene._frustumPlanes` based on a temporary narrowed projection, and a later multiview active-camera render could return early when the active camera matrices had matching update flags. In the multiview path there is one parent-camera pass, so it does not get the non-multiview per-eye reset behavior.

## Draft issue/forum context
NullEngine previously could not drive Babylon's multiview render-state path, so regressions in WebXR multiview culling/UBO state were only visible on devices that actually took the OVR multiview path. The motivating failure mode is a mid-frame direct `scene.setTransformMatrix(view, narrowedProjection)` used by a capture/RTT path: if it does not restore the transform, the main multiview render can cull with stale narrowed mono frustum planes even though the per-eye view-projection UBOs are otherwise populated. This PR closes that headless test gap while keeping the NullEngine behavior opt-in.

## Tests
- `npx vitest run --project=unit packages/dev/core/test/unit/Engines/nullEngine.test.ts`
- `npx eslint --quiet packages/dev/core/src/Engines/nullEngine.pure.ts packages/dev/core/src/scene.pure.ts packages/dev/core/test/unit/Engines/nullEngine.test.ts`
- `npm run compile:source -w @dev/core`
- `npm run lint:check`

Regression proof: temporarily restoring the previous cache guard (`viewUpdateFlag`/`projectionUpdateFlag` only) makes `restores active-camera frustum planes after a direct narrowed transform before multiview render` fail with `expected false to be true`, then the test passes again with this patch.

Also attempted full root validation locally:
- `npm run build:dev` is blocked before these touched files by existing local generated GUI declaration errors (`TS7016` against `packages/dev/gui/dist` imports).
- `npm run test:unit` runs the new NullEngine test successfully, but the full root suite has unrelated local/tooling failures around missing `zod`, missing `@tools/test-tools`, UMD declaration compatibility, and tree-shaking side-effect bundle checks.
