### PR TITLE
Warn when uniform-stored bone matrices risk overflowing the vertex-uniform budget

### DIFF
--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -1064,6 +1064,15 @@ export function PrepareDefinesForFrameBoundValues(
     }
 }
 
+// Sizing the bone-uniform budget reserves room for the rest of the vertex stage (base uniforms +
+// plugins + clip planes), mirroring GetGaussianSplattingMaxPartCount's reserve. Multiview duplicates
+// the per-eye view/projection, so it reserves more.
+const _BoneUniformBaseReserve = 40;
+const _BoneUniformMultiviewReserve = 64;
+// The budget-risk diagnostic logs once PER SKELETON: its message varies by skeleton/bone-count/caps/
+// multiview, so Logger's per-message limit would not dedupe it. A WeakSet lets disposed skeletons be GC'd.
+const _BoneUniformBudgetWarnedSkeletons = new WeakSet<object>();
+
 /**
  * Prepares the defines for bones
  * @param mesh The mesh containing the geometry data we will draw
@@ -1093,25 +1102,26 @@ export function PrepareDefinesForBones(mesh: AbstractMesh, defines: any) {
             // when a program exceeds that budget — the skinned mesh just never renders, with no error or
             // warning (see Babylon's "A Mysterious Case of Skinned Mesh Disappearances"). Multiview is the
             // common trigger: it duplicates per-eye matrices and adds driver overhead, shrinking the
-            // practical budget below what the device reports. Warn (once) when uniform bone storage is at
-            // risk so the failure is diagnosable; useTextureToStoreBoneMatrices removes bones from the budget.
+            // practical budget below what the device reports. Warn once per skeleton when uniform bone
+            // storage is at risk so the failure is diagnosable; useTextureToStoreBoneMatrices removes bones
+            // from the budget.
             const maxVertexUniformVectors = scene.getEngine().getCaps().maxVertexUniformVectors;
-            if (maxVertexUniformVectors) {
+            if (maxVertexUniformVectors && !_BoneUniformBudgetWarnedSkeletons.has(mesh.skeleton)) {
                 const boneUniformVectors = defines["BonesPerMesh"] * 4;
-                const isMultiview = !!scene.activeCamera?.outputRenderTarget && scene.activeCamera.outputRenderTarget.getViewCount() > 1;
-                // Mirror GaussianSplatting's reserve for the rest of the vertex stage (base uniforms +
-                // plugins/clip planes); reserve more under multiview for the second eye's matrices.
-                const reservedVertexUniforms = isMultiview ? 64 : 40;
+                // Optional-chain getViewCount so an output target without a view-count method can't throw
+                // on this path; mirrors PrepareDefinesForFrameBoundValues' own multiview test.
+                const isMultiview = (scene.activeCamera?.outputRenderTarget?.getViewCount?.() ?? 0) > 1;
+                const reservedVertexUniforms = isMultiview ? _BoneUniformMultiviewReserve : _BoneUniformBaseReserve;
                 const available = Math.max(maxVertexUniformVectors - reservedVertexUniforms, 0);
                 // Overflow the budget outright, or — under multiview, where the practical budget is
                 // smaller than reported — merely dominate it (bones alone are a third or more of nominal).
                 if (boneUniformVectors > available || (isMultiview && boneUniformVectors * 3 > maxVertexUniformVectors)) {
+                    _BoneUniformBudgetWarnedSkeletons.add(mesh.skeleton);
                     Logger.Warn(
                         `Skeleton "${mesh.skeleton.name}": ${mesh.skeleton.bones.length} bones stored as vertex uniforms use ` +
                             `${boneUniformVectors} of ~${available} usable uniform vectors${isMultiview ? " (multiview)" : ""} on a ` +
                             `device reporting ${maxVertexUniformVectors}. This can exceed the GPU vertex-uniform limit and make the ` +
-                            `mesh silently fail to render. Set skeleton.useTextureToStoreBoneMatrices = true to store bone matrices in a texture.`,
-                        1
+                            `mesh silently fail to render. Set skeleton.useTextureToStoreBoneMatrices = true to store bone matrices in a texture.`
                     );
                 }
             }

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -1069,8 +1069,12 @@ export function PrepareDefinesForFrameBoundValues(
 // the per-eye view/projection, so it reserves more.
 const _BoneUniformBaseReserve = 40;
 const _BoneUniformMultiviewReserve = 64;
-// The budget-risk diagnostic logs once PER SKELETON: its message varies by skeleton/bone-count/caps/
-// multiview, so Logger's per-message limit would not dedupe it. A WeakSet lets disposed skeletons be GC'd.
+// PrepareDefinesForBones is on the defines-evaluation hot path, so the budget diagnostic only
+// re-evaluates when its inputs change for a skeleton: the WeakMap stores the last-seen signature
+// (bone count + multiview bit) and the steady-state cost is one lookup plus an integer compare.
+const _BoneUniformBudgetCheckedSignature = new WeakMap<object, number>();
+// The diagnostic logs once PER SKELETON: its message varies by skeleton/bone-count/caps/multiview,
+// so Logger's per-message limit would not dedupe it. Weak collections let disposed skeletons be GC'd.
 const _BoneUniformBudgetWarnedSkeletons = new WeakSet<object>();
 
 /**
@@ -1102,27 +1106,32 @@ export function PrepareDefinesForBones(mesh: AbstractMesh, defines: any) {
             // when a program exceeds that budget — the skinned mesh just never renders, with no error or
             // warning (see Babylon's "A Mysterious Case of Skinned Mesh Disappearances"). Multiview is the
             // common trigger: it duplicates per-eye matrices and adds driver overhead, shrinking the
-            // practical budget below what the device reports. Warn once per skeleton when uniform bone
-            // storage is at risk so the failure is diagnosable; useTextureToStoreBoneMatrices removes bones
-            // from the budget.
-            const maxVertexUniformVectors = scene.getEngine().getCaps().maxVertexUniformVectors;
-            if (maxVertexUniformVectors && !_BoneUniformBudgetWarnedSkeletons.has(mesh.skeleton)) {
-                const boneUniformVectors = defines["BonesPerMesh"] * 4;
-                // Optional-chain getViewCount so an output target without a view-count method can't throw
-                // on this path; mirrors PrepareDefinesForFrameBoundValues' own multiview test.
-                const isMultiview = (scene.activeCamera?.outputRenderTarget?.getViewCount?.() ?? 0) > 1;
-                const reservedVertexUniforms = isMultiview ? _BoneUniformMultiviewReserve : _BoneUniformBaseReserve;
-                const available = Math.max(maxVertexUniformVectors - reservedVertexUniforms, 0);
-                // Overflow the budget outright, or — under multiview, where the practical budget is
-                // smaller than reported — merely dominate it (bones alone are a third or more of nominal).
-                if (boneUniformVectors > available || (isMultiview && boneUniformVectors * 3 > maxVertexUniformVectors)) {
-                    _BoneUniformBudgetWarnedSkeletons.add(mesh.skeleton);
-                    Logger.Warn(
-                        `Skeleton "${mesh.skeleton.name}": ${mesh.skeleton.bones.length} bones stored as vertex uniforms use ` +
-                            `${boneUniformVectors} of ~${available} usable uniform vectors${isMultiview ? " (multiview)" : ""} on a ` +
-                            `device reporting ${maxVertexUniformVectors}. This can exceed the GPU vertex-uniform limit and make the ` +
-                            `mesh silently fail to render. Set skeleton.useTextureToStoreBoneMatrices = true to store bone matrices in a texture.`
-                    );
+            // practical budget below what the device reports.
+            //
+            // Hot-path note: everything below the signature gate runs only when the inputs change for
+            // this skeleton (bone count or MULTIVIEW — already set on the defines by
+            // PrepareDefinesForFrameBoundValues, which materials run before the attributes/bones
+            // prepare). Steady-state cost: one WeakMap lookup and an integer compare.
+            const isMultiview = defines["MULTIVIEW"] === true;
+            const signature = defines["BonesPerMesh"] * 2 + (isMultiview ? 1 : 0);
+            if (_BoneUniformBudgetCheckedSignature.get(mesh.skeleton) !== signature) {
+                _BoneUniformBudgetCheckedSignature.set(mesh.skeleton, signature);
+                const maxVertexUniformVectors = scene.getEngine().getCaps().maxVertexUniformVectors;
+                if (maxVertexUniformVectors && !_BoneUniformBudgetWarnedSkeletons.has(mesh.skeleton)) {
+                    const boneUniformVectors = defines["BonesPerMesh"] * 4;
+                    const reservedVertexUniforms = isMultiview ? _BoneUniformMultiviewReserve : _BoneUniformBaseReserve;
+                    const available = Math.max(maxVertexUniformVectors - reservedVertexUniforms, 0);
+                    // Overflow the budget outright, or — under multiview, where the practical budget is
+                    // smaller than reported — merely dominate it (bones alone are a third or more of nominal).
+                    if (boneUniformVectors > available || (isMultiview && boneUniformVectors * 3 > maxVertexUniformVectors)) {
+                        _BoneUniformBudgetWarnedSkeletons.add(mesh.skeleton);
+                        Logger.Warn(
+                            `Skeleton "${mesh.skeleton.name}": ${mesh.skeleton.bones.length} bones stored as vertex uniforms use ` +
+                                `${boneUniformVectors} of ~${available} usable uniform vectors${isMultiview ? " (multiview)" : ""} on a ` +
+                                `device reporting ${maxVertexUniformVectors}. This can exceed the GPU vertex-uniform limit and make the ` +
+                                `mesh silently fail to render. Set skeleton.useTextureToStoreBoneMatrices = true to store bone matrices in a texture.`
+                        );
+                    }
                 }
             }
         }

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -1081,10 +1081,39 @@ export function PrepareDefinesForBones(mesh: AbstractMesh, defines: any) {
             defines["BonesPerMesh"] = mesh.skeleton.bones.length + 1;
             defines["BONETEXTURE"] = materialSupportsBoneTexture ? false : undefined;
 
-            const prePassRenderer = mesh.getScene().prePassRenderer;
+            const scene = mesh.getScene();
+            const prePassRenderer = scene.prePassRenderer;
             if (prePassRenderer && prePassRenderer.enabled) {
                 const nonExcluded = prePassRenderer.excludedSkinnedMesh.indexOf(mesh) === -1;
                 defines["BONES_VELOCITY_ENABLED"] = nonExcluded;
+            }
+
+            // Bones stored as vertex uniforms cost one mat4 (4 vectors) each, drawn from the same
+            // maxVertexUniformVectors budget as the rest of the vertex stage. Some drivers fail SILENTLY
+            // when a program exceeds that budget — the skinned mesh just never renders, with no error or
+            // warning (see Babylon's "A Mysterious Case of Skinned Mesh Disappearances"). Multiview is the
+            // common trigger: it duplicates per-eye matrices and adds driver overhead, shrinking the
+            // practical budget below what the device reports. Warn (once) when uniform bone storage is at
+            // risk so the failure is diagnosable; useTextureToStoreBoneMatrices removes bones from the budget.
+            const maxVertexUniformVectors = scene.getEngine().getCaps().maxVertexUniformVectors;
+            if (maxVertexUniformVectors) {
+                const boneUniformVectors = defines["BonesPerMesh"] * 4;
+                const isMultiview = !!scene.activeCamera?.outputRenderTarget && scene.activeCamera.outputRenderTarget.getViewCount() > 1;
+                // Mirror GaussianSplatting's reserve for the rest of the vertex stage (base uniforms +
+                // plugins/clip planes); reserve more under multiview for the second eye's matrices.
+                const reservedVertexUniforms = isMultiview ? 64 : 40;
+                const available = Math.max(maxVertexUniformVectors - reservedVertexUniforms, 0);
+                // Overflow the budget outright, or — under multiview, where the practical budget is
+                // smaller than reported — merely dominate it (bones alone are a third or more of nominal).
+                if (boneUniformVectors > available || (isMultiview && boneUniformVectors * 3 > maxVertexUniformVectors)) {
+                    Logger.Warn(
+                        `Skeleton "${mesh.skeleton.name}": ${mesh.skeleton.bones.length} bones stored as vertex uniforms use ` +
+                            `${boneUniformVectors} of ~${available} usable uniform vectors${isMultiview ? " (multiview)" : ""} on a ` +
+                            `device reporting ${maxVertexUniformVectors}. This can exceed the GPU vertex-uniform limit and make the ` +
+                            `mesh silently fail to render. Set skeleton.useTextureToStoreBoneMatrices = true to store bone matrices in a texture.`,
+                        1
+                    );
+                }
             }
         }
     } else {

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { PrepareUniformsAndSamplersForLight } from "core/Materials/materialHelper.functions";
+import { describe, it, expect, vi } from "vitest";
+import { PrepareUniformsAndSamplersForLight, PrepareDefinesForBones } from "core/Materials/materialHelper.functions";
+import { Logger } from "core/Misc/logger";
+import { type AbstractMesh } from "core/Meshes/abstractMesh";
 
 describe("PrepareUniformsAndSamplersForLight", () => {
     it("keeps clustered light tile masks as textures by default", () => {
@@ -20,5 +22,53 @@ describe("PrepareUniformsAndSamplersForLight", () => {
 
         expect(samplers).toContain("lightDataTexture0");
         expect(samplers).not.toContain("tileMaskTexture0");
+    });
+});
+
+describe("PrepareDefinesForBones uniform-budget warning", () => {
+    const makeSkinnedMesh = (boneCount: number, opts: { maxVertexUniformVectors?: number; isUsingTextureForMatrices?: boolean; multiview?: boolean } = {}): AbstractMesh => {
+        const { maxVertexUniformVectors = 16, isUsingTextureForMatrices = false, multiview = false } = opts;
+        return {
+            useBones: true,
+            computeBonesUsingShaders: true,
+            numBoneInfluencers: 4,
+            skeleton: { name: "test", bones: new Array(boneCount).fill({}), isUsingTextureForMatrices },
+            getScene: () => ({
+                prePassRenderer: null,
+                activeCamera: { outputRenderTarget: multiview ? { getViewCount: () => 2 } : null },
+                getEngine: () => ({ getCaps: () => ({ maxVertexUniformVectors }) }),
+            }),
+        } as unknown as AbstractMesh;
+    };
+
+    it("warns (once) and recommends a bone texture when uniform bones overflow the budget", () => {
+        const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        PrepareDefinesForBones(makeSkinnedMesh(30), { BONETEXTURE: false });
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain("useTextureToStoreBoneMatrices");
+        warn.mockRestore();
+    });
+
+    it("does not warn when bones are stored in a texture", () => {
+        const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        PrepareDefinesForBones(makeSkinnedMesh(30, { isUsingTextureForMatrices: true }), { BONETEXTURE: false });
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("does not warn for a small skeleton that comfortably fits", () => {
+        const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        PrepareDefinesForBones(makeSkinnedMesh(1, { maxVertexUniformVectors: 256 }), { BONETEXTURE: false });
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("flags a bone array that dominates the budget under multiview even when it would fit otherwise", () => {
+        const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        // 30 bones -> 124 vectors: fits 256 outright, but exceeds 256/3 once multiview shrinks the budget.
+        PrepareDefinesForBones(makeSkinnedMesh(30, { maxVertexUniformVectors: 256, multiview: true }), { BONETEXTURE: false });
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(String(warn.mock.calls[0][0])).toContain("multiview");
+        warn.mockRestore();
     });
 });

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -26,8 +26,8 @@ describe("PrepareUniformsAndSamplersForLight", () => {
 });
 
 describe("PrepareDefinesForBones uniform-budget warning", () => {
-    const makeSkinnedMesh = (boneCount: number, opts: { maxVertexUniformVectors?: number; isUsingTextureForMatrices?: boolean; multiview?: boolean } = {}): AbstractMesh => {
-        const { maxVertexUniformVectors = 16, isUsingTextureForMatrices = false, multiview = false } = opts;
+    const makeSkinnedMesh = (boneCount: number, opts: { maxVertexUniformVectors?: number; isUsingTextureForMatrices?: boolean } = {}): AbstractMesh => {
+        const { maxVertexUniformVectors = 16, isUsingTextureForMatrices = false } = opts;
         return {
             useBones: true,
             computeBonesUsingShaders: true,
@@ -35,7 +35,6 @@ describe("PrepareDefinesForBones uniform-budget warning", () => {
             skeleton: { name: "test", bones: new Array(boneCount).fill({}), isUsingTextureForMatrices },
             getScene: () => ({
                 prePassRenderer: null,
-                activeCamera: { outputRenderTarget: multiview ? { getViewCount: () => 2 } : null },
                 getEngine: () => ({ getCaps: () => ({ maxVertexUniformVectors }) }),
             }),
         } as unknown as AbstractMesh;
@@ -68,9 +67,24 @@ describe("PrepareDefinesForBones uniform-budget warning", () => {
     it("flags a bone array that dominates the budget under multiview even when it would fit otherwise", () => {
         const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
         // 30 bones -> 124 vectors: fits 256 outright, but exceeds 256/3 once multiview shrinks the budget.
-        PrepareDefinesForBones(makeSkinnedMesh(30, { maxVertexUniformVectors: 256, multiview: true }), { BONETEXTURE: false });
+        // MULTIVIEW is read from the defines (set by PrepareDefinesForFrameBoundValues, which materials
+        // run before the attributes/bones prepare) — no camera/render-target access on this path.
+        PrepareDefinesForBones(makeSkinnedMesh(30, { maxVertexUniformVectors: 256 }), { BONETEXTURE: false, MULTIVIEW: true });
         expect(warn).toHaveBeenCalledTimes(1);
         expect(String(warn.mock.calls[0][0])).toContain("multiview");
+        warn.mockRestore();
+    });
+
+    it("re-evaluates when MULTIVIEW flips for a skeleton that fit in mono (the 2D -> XR transition)", () => {
+        const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        const mesh = makeSkinnedMesh(30, { maxVertexUniformVectors: 256 });
+        // Mono: 124 vectors fit comfortably -> evaluated, no warn (and the signature is cached).
+        PrepareDefinesForBones(mesh, { BONETEXTURE: false, MULTIVIEW: false });
+        PrepareDefinesForBones(mesh, { BONETEXTURE: false, MULTIVIEW: false }); // same signature -> skipped
+        expect(warn).not.toHaveBeenCalled();
+        // Entering multiview changes the signature -> the budget re-evaluates and now warns.
+        PrepareDefinesForBones(mesh, { BONETEXTURE: false, MULTIVIEW: true });
+        expect(warn).toHaveBeenCalledTimes(1);
         warn.mockRestore();
     });
 });

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -41,9 +41,11 @@ describe("PrepareDefinesForBones uniform-budget warning", () => {
         } as unknown as AbstractMesh;
     };
 
-    it("warns (once) and recommends a bone texture when uniform bones overflow the budget", () => {
+    it("warns once per skeleton (deduped across calls) and recommends a bone texture on overflow", () => {
         const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
-        PrepareDefinesForBones(makeSkinnedMesh(30), { BONETEXTURE: false });
+        const mesh = makeSkinnedMesh(30);
+        PrepareDefinesForBones(mesh, { BONETEXTURE: false });
+        PrepareDefinesForBones(mesh, { BONETEXTURE: false }); // same skeleton -> deduped, no second warn
         expect(warn).toHaveBeenCalledTimes(1);
         expect(String(warn.mock.calls[0][0])).toContain("useTextureToStoreBoneMatrices");
         warn.mockRestore();


### PR DESCRIPTION
## Problem
`PrepareDefinesForBones` picks uniform vs texture bone storage from `skeleton.isUsingTextureForMatrices` alone — it never looks at `maxVertexUniformVectors`. When uniform-stored bones (a mat4 = 4 vectors each) push the vertex shader past the cap, some drivers fail *silently*: the skinned mesh just doesn't render. No error, no warning.

Lost a few days to this on Quest — a 25-bone WebXR hand under multiview vanished with a clean compile. `useTextureToStoreBoneMatrices = true` fixed it instantly, but nothing pointed there.

## Change
Warn once in the uniform-bones branch when storage is at risk, recommending bone textures:
- overflows the budget (`bones*4 > cap - reserve`), or
- under multiview *dominates* it (`bones*4 > cap/3`) — multiview duplicates per-eye matrices, so the practical budget is well below the reported cap.

Reserve mirrors `GetGaussianSplattingMaxPartCount` (the only other `maxVertexUniformVectors` consumer). `Logger.Warn(msg, 1)` fires once, not per-frame. Diagnostic only — no behavior change. The `cap/3` multiview cut is conservative; happy to tune.

## Test
`PrepareDefinesForBones` unit tests (NullEngine, cap 16): warns on overflow; silent when bones are in a texture or comfortably fit; fires on a bone array that only crosses the line under multiview.