### PR TITLE
FrameGraph Geometry Renderer: Fix screenspace texture clear in reverse Z mode

### DIFF
--- a/packages/dev/core/src/FrameGraph/Tasks/Rendering/geometryRendererTask.ts
+++ b/packages/dev/core/src/FrameGraph/Tasks/Rendering/geometryRendererTask.ts
@@ -471,17 +471,21 @@ export class FrameGraphGeometryRendererTask extends FrameGraphObjectRendererTask
             const index = MaterialHelperGeometryRendering.GeometryTextureDescriptions.findIndex((f) => f.type === description.type);
             const geometryDescription = MaterialHelperGeometryRendering.GeometryTextureDescriptions[index];
 
-            let layout = clearAttachmentsLayout.get(geometryDescription.clearType);
+            const clearType =
+                geometryDescription.type === Constants.PREPASS_SCREENSPACE_DEPTH_TEXTURE_TYPE && this._engine.useReverseDepthBuffer
+                    ? GeometryRenderingTextureClearType.Zero
+                    : geometryDescription.clearType;
+            let layout = clearAttachmentsLayout.get(clearType);
             if (layout === undefined) {
                 layout = [];
-                clearAttachmentsLayout.set(geometryDescription.clearType, layout);
+                clearAttachmentsLayout.set(clearType, layout);
                 for (let j = 0; j < i; j++) {
                     layout[j] = false;
                 }
             }
 
-            clearAttachmentsLayout.forEach((layout, clearType) => {
-                layout.push(clearType === geometryDescription.clearType);
+            clearAttachmentsLayout.forEach((layout, layoutClearType) => {
+                layout.push(layoutClearType === clearType);
             });
 
             allAttachmentsLayout.push(true);

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -128,6 +128,18 @@ export class NodeMaterialDefines extends ImageProcessingDefinesMixin(NodeMateria
     public PREPASS_SCREENSPACE_DEPTH = false;
     /** Clip-space depth index */
     public PREPASS_SCREENSPACE_DEPTH_INDEX = -1;
+    /** Reflectivity */
+    public PREPASS_REFLECTIVITY = false;
+    /** Reflectivity index */
+    public PREPASS_REFLECTIVITY_INDEX = -1;
+    /** Velocity */
+    public PREPASS_VELOCITY = false;
+    /** Velocity index */
+    public PREPASS_VELOCITY_INDEX = -1;
+    /** Velocity linear */
+    public PREPASS_VELOCITY_LINEAR = false;
+    /** Velocity linear index */
+    public PREPASS_VELOCITY_LINEAR_INDEX = -1;
     /** Scene MRT count */
     public SCENE_MRT_COUNT = 0;
 


### PR DESCRIPTION
I also added missing defines in `NodeMaterialDefines`.