### PR TITLE
Fix: inject PostProcessRenderPipelineManager class for tree-shaken builds (#18523)

### DIFF
--- a/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderPipeline.ts
+++ b/packages/dev/core/src/PostProcesses/RenderPipeline/postProcessRenderPipeline.ts
@@ -7,6 +7,7 @@ import { type AbstractEngine } from "../../Engines/abstractEngine";
 import { type PostProcessRenderEffect } from "./postProcessRenderEffect";
 import { type IInspectable } from "../../Misc/iInspectable";
 import { RegisterPostProcessRenderPipelineManagerSceneComponent } from "./postProcessRenderPipelineManagerSceneComponent.pure";
+import { PostProcessRenderPipelineManager } from "./postProcessRenderPipelineManager";
 
 import { type PrePassRenderer } from "../../Rendering/prePassRenderer";
 
@@ -66,7 +67,7 @@ export class PostProcessRenderPipeline {
         private _engine: AbstractEngine,
         name: string
     ) {
-        RegisterPostProcessRenderPipelineManagerSceneComponent();
+        RegisterPostProcessRenderPipelineManagerSceneComponent(PostProcessRenderPipelineManager);
         this._name = name;
 
         this._renderEffects = {};


### PR DESCRIPTION
## Fixes #18523

### Problem

With selective ES6 imports, constructing a rendering pipeline crashes:

```ts
import { Engine } from "@babylonjs/core/Engines/engine";
import { Scene } from "@babylonjs/core/scene";
import { DefaultRenderingPipeline } from "@babylonjs/core/PostProcesses/RenderPipeline/Pipelines/defaultRenderingPipeline";

const e = new Engine(document.createElement("canvas"));
const s = new Scene(e);
new DefaultRenderingPipeline("d", true, s);
// Uncaught TypeError: _PostProcessRenderPipelineManagerClass is not a constructor
```

### Cause

`PostProcessRenderPipeline`'s constructor called `RegisterPostProcessRenderPipelineManagerSceneComponent()` **without** the manager class. That registers the lazy `Scene.prototype.postProcessRenderPipelineManager` getter and sets the `_Registered` guard, but leaves the module-level `_PostProcessRenderPipelineManagerClass` undefined. The only callers that supply the concrete class (`PostProcessRenderPipelineManager`'s constructor and the `postProcessRenderPipelineManagerSceneComponent.ts` side-effect wrapper) don't run in a tree-shaken import path before the getter is hit, so the getter executes `new _PostProcessRenderPipelineManagerClass!()` on `undefined`.

It only works in the full `@babylonjs/core` bundle because the side-effect wrapper happens to load and set the class.

### Fix

`postProcessRenderPipeline.ts` already triggers registration and conceptually owns the manager (the getter instantiates it), so it now passes the concrete `PostProcessRenderPipelineManager` to the registration function. This guarantees the class is set before the getter runs, without pulling in the full side-effect module (preserving tree-shaking). The manager only imports types from `core/index`, so no runtime circular import is introduced.

This is preferable to the issue's suggested `import './postProcessRenderPipelineManagerSceneComponent'`, which would force the entire side-effect wrapper and undermine tree-shaking.

### Notes

The only other component using the same "inject class via registration fn + lazy `new`" pattern (`DepthPeelingSceneComponent`) is **not** affected: its registration parameter is required and always assigned before the guard, and both call sites pass the class.
