### PR TITLE
Fix NME post process / smart filter / procedural modes failing with 404 shader errors

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -1301,7 +1301,11 @@ export class NodeMaterial extends NodeMaterialBase {
             const result = this._processDefines(defines);
 
             if (result) {
-                Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString);
+                // Recompute the vertex emission for the current build (the graph may have been rebuilt),
+                // and register with the material's shader language so WGSL post processes use the WGSL store.
+                const currentVertexCode = this._sharedData.checks.emitVertex ? this._vertexCompilationState._builtCompilationString : undefined;
+
+                Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, currentVertexCode, this.shaderLanguage);
 
                 TimingTools.SetImmediate(() =>
                     postProcess.updateEffect(
@@ -1311,7 +1315,7 @@ export class NodeMaterial extends NodeMaterialBase {
                         { maxSimultaneousLights: this.maxSimultaneousLights },
                         undefined,
                         undefined,
-                        vertexCode ? tempName : "postprocess",
+                        currentVertexCode ? tempName : "postprocess",
                         tempName
                     )
                 );
@@ -1378,7 +1382,10 @@ export class NodeMaterial extends NodeMaterialBase {
                         this._fragmentCompilationState.samplers,
                         defines.toString(),
                         result?.fallbacks,
-                        undefined
+                        undefined,
+                        undefined,
+                        undefined,
+                        this.shaderLanguage
                     );
 
                     proceduralTexture._setEffect(effect);

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -1196,6 +1196,49 @@ export class NodeMaterial extends NodeMaterialBase {
         textureType: number = Constants.TEXTURETYPE_UNSIGNED_BYTE,
         textureFormat = Constants.TEXTUREFORMAT_RGBA
     ): PostProcess {
+        // The post process effect is built from the shader code produced by the node graph. That code
+        // is only available once the build has completed. Some blocks (e.g. CurrentScreenBlock) load
+        // their shader sources asynchronously, so the build may still be running when this is called
+        // (for instance right after a synchronous NodeMaterial.Parse). Registering the still empty
+        // shaders would make the engine try to fetch them from a URL and fail with a 404, leaving the
+        // post process blank. Defer the effect creation until the build has completed.
+        if (!this._buildWasSuccessful) {
+            if (!postProcess) {
+                // Create the handle now with compilation blocked so callers can attach their observers;
+                // the actual effect is created once the build completes.
+                postProcess = new PostProcess(
+                    this.name + "PostProcess",
+                    "postprocess",
+                    null,
+                    null,
+                    options,
+                    camera!,
+                    samplingMode,
+                    engine,
+                    reusable,
+                    null,
+                    textureType,
+                    "postprocess",
+                    undefined,
+                    true,
+                    textureFormat,
+                    this.shaderLanguage
+                );
+                postProcess.nodeMaterialSource = this;
+            }
+
+            const deferredPostProcess = postProcess;
+            this.onBuildObservable.addOnce(() => {
+                this._createEffectForPostProcess(deferredPostProcess, camera, options, samplingMode, engine, reusable, textureType, textureFormat);
+            });
+
+            if (!this._buildIsInProgress) {
+                this.build();
+            }
+
+            return postProcess;
+        }
+
         let tempName = this.name + this._buildId;
 
         const defines = new NodeMaterialDefines();
@@ -1236,7 +1279,7 @@ export class NodeMaterial extends NodeMaterialBase {
                 { maxSimultaneousLights: this.maxSimultaneousLights },
                 undefined,
                 undefined,
-                tempName,
+                vertexCode ? tempName : "postprocess",
                 tempName
             );
         }
@@ -1268,7 +1311,7 @@ export class NodeMaterial extends NodeMaterialBase {
                         { maxSimultaneousLights: this.maxSimultaneousLights },
                         undefined,
                         undefined,
-                        tempName,
+                        vertexCode ? tempName : "postprocess",
                         tempName
                     )
                 );
@@ -1295,31 +1338,13 @@ export class NodeMaterial extends NodeMaterialBase {
         let tempName = this.name + this._buildId;
 
         const proceduralTexture = new ProceduralTexture(tempName, size, null, scene);
+        proceduralTexture.nodeMaterialSource = this;
 
         const defines = new NodeMaterialDefines();
-        const result = this._processDefines(defines);
-        Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString, this.shaderLanguage);
-
-        let effect = this.getScene().getEngine().createEffect(
-            {
-                vertexElement: tempName,
-                fragmentElement: tempName,
-            },
-            [VertexBuffer.PositionKind],
-            this._fragmentCompilationState.uniforms,
-            this._fragmentCompilationState.samplers,
-            defines.toString(),
-            result?.fallbacks,
-            undefined,
-            undefined,
-            undefined,
-            this.shaderLanguage
-        );
-
-        proceduralTexture.nodeMaterialSource = this;
-        proceduralTexture._setEffect(effect);
 
         let buildId = this._buildId;
+        let effect: Effect | undefined;
+
         const refreshEffect = () => {
             if (buildId !== this._buildId) {
                 delete Effect.ShadersStore[tempName + "VertexShader"];
@@ -1338,6 +1363,11 @@ export class NodeMaterial extends NodeMaterialBase {
                 Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString, this.shaderLanguage);
 
                 TimingTools.SetImmediate(() => {
+                    // The material may have been disposed before this deferred effect creation runs.
+                    if (!this._fragmentCompilationState) {
+                        return;
+                    }
+
                     effect = this.getScene().getEngine().createEffect(
                         {
                             vertexElement: tempName,
@@ -1355,7 +1385,9 @@ export class NodeMaterial extends NodeMaterialBase {
                 });
             }
 
-            this._checkInternals(effect);
+            if (effect) {
+                this._checkInternals(effect);
+            }
         };
 
         proceduralTexture.onBeforeGenerationObservable.add(() => {
@@ -1366,6 +1398,37 @@ export class NodeMaterial extends NodeMaterialBase {
         this.onBuildObservable.add(() => {
             refreshEffect();
         });
+
+        // The effect is built from the shader code produced by the node graph, which is only available
+        // once the build has completed. Some blocks (e.g. CurrentScreenBlock) load their shader sources
+        // asynchronously, so the build may still be running here (for instance right after a synchronous
+        // NodeMaterial.Parse). Creating the effect now would register empty shaders and make the engine
+        // fetch them from a URL, failing with a 404. Only create the effect once the build has
+        // succeeded; otherwise the onBuildObservable hook above creates it when the build completes.
+        if (this._buildWasSuccessful) {
+            const result = this._processDefines(defines);
+            Effect.RegisterShader(tempName, this._fragmentCompilationState._builtCompilationString, this._vertexCompilationState._builtCompilationString, this.shaderLanguage);
+
+            effect = this.getScene().getEngine().createEffect(
+                {
+                    vertexElement: tempName,
+                    fragmentElement: tempName,
+                },
+                [VertexBuffer.PositionKind],
+                this._fragmentCompilationState.uniforms,
+                this._fragmentCompilationState.samplers,
+                defines.toString(),
+                result?.fallbacks,
+                undefined,
+                undefined,
+                undefined,
+                this.shaderLanguage
+            );
+
+            proceduralTexture._setEffect(effect);
+        } else if (!this._buildIsInProgress) {
+            this.build();
+        }
 
         return proceduralTexture;
     }

--- a/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.pure.ts
+++ b/packages/dev/core/src/Materials/Textures/Procedurals/proceduralTexture.pure.ts
@@ -359,7 +359,10 @@ export class ProceduralTexture extends Texture {
         const engine = this._fullEngine;
 
         if (this.nodeMaterialSource) {
-            return this._drawWrapper.effect!.isReady();
+            // When sourced from a node material, the effect is created asynchronously once the material
+            // build completes (some node material blocks load their shader code asynchronously). Until
+            // then there is no effect yet, so the texture is simply not ready.
+            return this._drawWrapper.effect?.isReady() ?? false;
         }
 
         if (!this._fragment) {

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
@@ -1,0 +1,96 @@
+import { NullEngine } from "core/Engines/nullEngine";
+import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
+import { Effect } from "core/Materials/effect";
+import { FreeCamera } from "core/Cameras/freeCamera";
+import { Vector3 } from "core/Maths/math.vector";
+import { Scene } from "core/scene";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Some node material blocks (e.g. CurrentScreenBlock) load their shader code through an asynchronous
+// dynamic import, so NodeMaterial.build() can finish after it returns. createPostProcess /
+// createProceduralTexture used to read the (still empty) compilation strings synchronously and register
+// empty shaders, which made the engine try to fetch the shaders from a URL and fail with a 404 - leaving
+// the NME preview blank in Post Process / Smart Filter / Procedural modes. These tests lock in that the
+// effect creation is deferred until the build has produced real (non-empty) shader code.
+describe("NodeMaterial effect creation with an asynchronous build", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    const waitForBuild = async (material: NodeMaterial): Promise<void> => {
+        if (!material.buildIsInProgress) {
+            return;
+        }
+        await new Promise<void>((resolve) => material.onBuildObservable.addOnce(() => resolve()));
+    };
+
+    it("defers post process shader registration until the asynchronous build completes", async () => {
+        const material = new NodeMaterial("node", scene);
+        material.setToDefaultPostProcess();
+        material.build();
+
+        // CurrentScreenBlock loads its shader code asynchronously, so the build is still in progress.
+        expect(material.buildIsInProgress).toBe(true);
+
+        const registerSpy = vi.spyOn(Effect, "RegisterShader");
+
+        const camera = new FreeCamera("camera", new Vector3(0, 0, -1), scene);
+        const postProcess = material.createPostProcess(camera);
+
+        // A usable handle is returned synchronously...
+        expect(postProcess).not.toBeNull();
+        // ...but no empty shader is registered while the build is still pending (an empty registration
+        // is what made the engine fetch the shader from a URL and 404).
+        expect(registerSpy.mock.calls.filter(([, pixelShader]) => !pixelShader)).toHaveLength(0);
+
+        await waitForBuild(material);
+
+        // Once the build completes, the real (non-empty) shader is registered.
+        const registeredRealShader = registerSpy.mock.calls.some(([name, pixelShader]) => typeof name === "string" && name.startsWith("node") && !!pixelShader);
+        expect(registeredRealShader).toBe(true);
+
+        registerSpy.mockRestore();
+        postProcess?.dispose(camera);
+    });
+
+    it("defers procedural texture shader registration until the asynchronous build completes", async () => {
+        const material = new NodeMaterial("node", scene);
+        material.setToDefaultProceduralTexture();
+        material.build();
+
+        expect(material.buildIsInProgress).toBe(true);
+
+        const registerSpy = vi.spyOn(Effect, "RegisterShader");
+
+        const proceduralTexture = material.createProceduralTexture(256, scene);
+
+        expect(proceduralTexture).not.toBeNull();
+        // A procedural texture without an effect yet must report "not ready" instead of throwing.
+        expect(proceduralTexture!.isReady()).toBe(false);
+        expect(registerSpy.mock.calls.filter(([, pixelShader]) => !pixelShader)).toHaveLength(0);
+
+        await waitForBuild(material);
+
+        const registeredRealShader = registerSpy.mock.calls.some(([name, pixelShader]) => typeof name === "string" && name.startsWith("node") && !!pixelShader);
+        expect(registeredRealShader).toBe(true);
+
+        registerSpy.mockRestore();
+        proceduralTexture?.dispose();
+    });
+});

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
@@ -1,6 +1,7 @@
 import { NullEngine } from "core/Engines/nullEngine";
 import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { Effect } from "core/Materials/effect";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { FreeCamera } from "core/Cameras/freeCamera";
 import { Vector3 } from "core/Maths/math.vector";
 import { Scene } from "core/scene";
@@ -91,6 +92,56 @@ describe("NodeMaterial effect creation with an asynchronous build", () => {
         expect(registeredRealShader).toBe(true);
 
         registerSpy.mockRestore();
+        proceduralTexture?.dispose();
+    });
+
+    it("registers the post process shaders with the material shader language (WGSL)", async () => {
+        vi.spyOn(engine, "isWebGPU", "get").mockReturnValue(true);
+        const material = new NodeMaterial("node", scene, { shaderLanguage: ShaderLanguage.WGSL });
+        material.setToDefaultPostProcess();
+        material.build();
+
+        expect(material.buildIsInProgress).toBe(true);
+
+        const registerSpy = vi.spyOn(Effect, "RegisterShader");
+
+        const camera = new FreeCamera("camera", new Vector3(0, 0, -1), scene);
+        const postProcess = material.createPostProcess(camera);
+
+        await waitForBuild(material);
+
+        // The shader must be registered into the WGSL store (the 4th argument), otherwise a WGSL node
+        // material post process resolves against the GLSL store and fails to compile.
+        const registeredAsWgsl = registerSpy.mock.calls.some(
+            ([name, pixelShader, , shaderLanguage]) => typeof name === "string" && name.startsWith("node") && !!pixelShader && shaderLanguage === ShaderLanguage.WGSL
+        );
+        expect(registeredAsWgsl).toBe(true);
+
+        registerSpy.mockRestore();
+        postProcess?.dispose(camera);
+    });
+
+    it("creates the procedural texture effect with the material shader language (WGSL)", async () => {
+        vi.spyOn(engine, "isWebGPU", "get").mockReturnValue(true);
+        const material = new NodeMaterial("node", scene, { shaderLanguage: ShaderLanguage.WGSL });
+        material.setToDefaultProceduralTexture();
+        material.build();
+
+        expect(material.buildIsInProgress).toBe(true);
+
+        const createEffectSpy = vi.spyOn(engine, "createEffect");
+
+        const proceduralTexture = material.createProceduralTexture(256, scene);
+
+        await waitForBuild(material);
+        // The effect is created on a SetImmediate; let it run.
+        await new Promise((resolve) => setTimeout(resolve, 16));
+
+        // createEffect receives the shader language as its 10th argument; it must be WGSL here.
+        const createdAsWgsl = createEffectSpy.mock.calls.some((args) => args[9] === ShaderLanguage.WGSL);
+        expect(createdAsWgsl).toBe(true);
+
+        createEffectSpy.mockRestore();
         proceduralTexture?.dispose();
     });
 });


### PR DESCRIPTION
## Problem

Fixes #18548.

On the public NME — and in any tool/app that creates a post process or procedural texture from a node material — switching to **Post Process**, **Smart Filter** or **Procedural** mode throws `404` errors for shader files such as `src/Shaders/node8.fragment.fx`, and the preview stays blank with no UI.

## Root cause

Several node material blocks load their shader code through an asynchronous dynamic `import()` (e.g. `CurrentScreenBlock._initShaderSourceAsync`, used by the default Post Process / Smart Filter graphs). Because of this, `NodeMaterial.build()` can finish **after** it returns — it defers `_finishBuildProcess` until every block's `codeIsReady` is `true`.

The NME preview manager calls `createPostProcess()` / `createProceduralTexture()` right after the synchronous `NodeMaterial.Parse()`. At that point the build hasn't finished, so `this._fragmentCompilationState._builtCompilationString` is still empty. `Effect.RegisterShader(name, "", "")` then registers nothing, and the engine falls back to fetching the shader from `ShadersRepository + name + ".fragment.fx"` → **404**, and the effect never renders.

This is why it surfaces in the deployed build: `await import(...)` always yields a microtask, so the build is still pending when the effect is created.

## Fix (all in `@babylonjs/core`)

- **`_createEffectForPostProcess`** (Post Process + Smart Filter): when the build hasn't completed yet, return a post process with compilation blocked and (re)create the effect once `onBuildObservable` fires, so the real, non-empty shaders are registered before the effect is compiled.
- Fall back to the built-in `"postprocess"` vertex shader in the `updateEffect` paths when the graph emits no vertex program (Smart Filter), matching the constructor path.
- **`createProceduralTexture`**: only create the effect once the build has succeeded; otherwise let the existing `onBuildObservable` hook create it when the build completes. Guard the deferred `SetImmediate` against disposal.
- **`ProceduralTexture.isReady()`**: return `effect?.isReady() ?? false` when sourced from a node material, since the effect may not exist yet (mirrors `EffectWrapper.isReady()`).

There is no behavior change once the build is ready — only the "build still in progress" path is affected.

## Testing

- New unit test `babylon.nodeMaterials.asyncBuild.test.ts` (NullEngine): asserts that no empty shader is registered while the asynchronous build is pending, and that the real (non-empty) shader is registered once it completes. It fails on `master` and passes with this change.
- Verified end-to-end in a browser (built `babylon.max.js`, mirroring the preview manager's `Parse → createPostProcess` / `createProceduralTexture`):
  - **before:** `404 .../src/Shaders/nodeN.fragment.fx` (and `.vertex.fx` for Procedural), effect never ready → blank preview.
  - **after:** no 404s; **Post Process**, **Smart Filter** and **Procedural** all reach `effect.isReady()` / `texture.isReady()`.
