### PR TITLE
Fix PhysicsAggregate mutating caller's options object

### DIFF
--- a/packages/dev/core/src/Physics/v2/physicsAggregate.ts
+++ b/packages/dev/core/src/Physics/v2/physicsAggregate.ts
@@ -106,6 +106,8 @@ export class PhysicsAggregate {
 
     private _nodeDisposeObserver: Nullable<Observer<Node>>;
 
+    private _options: PhysicsAggregateParameters;
+
     constructor(
         /**
          * The physics-enabled object used as the physics aggregate
@@ -115,9 +117,15 @@ export class PhysicsAggregate {
          * The type of the physics aggregate
          */
         public type: PhysicsShapeType | PhysicsShape,
-        private _options: PhysicsAggregateParameters = { mass: 0 },
+        options: PhysicsAggregateParameters = { mass: 0 },
         private _scene?: Scene
     ) {
+        // Shallow-clone the options so we never mutate the caller's object.
+        // _addSizeOptions assigns to fields like .mesh, .center, .radius, etc.,
+        // which would otherwise leak stale references (e.g. a disposed mesh)
+        // into subsequent PhysicsAggregate constructions sharing the same options.
+        this._options = { ...options };
+
         //sanity check!
         if (!this.transformNode) {
             Logger.Error("No object was provided. A physics object is obligatory");
@@ -140,9 +148,9 @@ export class PhysicsAggregate {
         }
 
         //default options params
-        this._options.mass = _options.mass === void 0 ? 0 : _options.mass;
-        this._options.friction = _options.friction === void 0 ? 0.2 : _options.friction;
-        this._options.restitution = _options.restitution === void 0 ? 0.2 : _options.restitution;
+        this._options.mass = this._options.mass === void 0 ? 0 : this._options.mass;
+        this._options.friction = this._options.friction === void 0 ? 0.2 : this._options.friction;
+        this._options.restitution = this._options.restitution === void 0 ? 0.2 : this._options.restitution;
 
         const motionType = this._options.mass === 0 ? PhysicsMotionType.STATIC : PhysicsMotionType.DYNAMIC;
         const startAsleep = this._options.startAsleep ?? false;


### PR DESCRIPTION
Shallow-clone the options object in the `PhysicsAggregate` constructor so fields written by `_addSizeOptions` (`mesh`, `center`, `radius`, `pointA`/`B`, `extents`, `rotation`) don't leak between successive constructions sharing the same options instance.

Previously, reusing an options object after disposing a `MESH` / `CONVEX_HULL` / `HEIGHTFIELD` aggregate's mesh caused the next construction to throw `No valid mesh was provided` because the stale `.mesh` reference still pointed at the disposed mesh.

Forum report: https://forum.babylonjs.com/t/havok-creating-a-new-physicsaggregate-of-type-mesh-fails-once-a-mesh-has-been-disposed/63594