### PR TITLE
Accept AbstractEngine in ThinRenderTargetTexture constructor

### DIFF
--- a/packages/dev/core/src/Materials/Textures/thinRenderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/thinRenderTargetTexture.ts
@@ -1,7 +1,7 @@
 import { type Nullable } from "../../types";
 import { type InternalTexture } from "../../Materials/Textures/internalTexture";
 
-import { type ThinEngine } from "../../Engines/thinEngine";
+import { type AbstractEngine } from "../../Engines/abstractEngine";
 import { type IRenderTargetTexture, type RenderTargetWrapper } from "../../Engines/renderTargetWrapper";
 import { ThinTexture } from "./thinTexture";
 import { type TextureSize, type RenderTargetCreationOptions } from "./textureCreationOptions";
@@ -31,7 +31,7 @@ export class ThinRenderTargetTexture extends ThinTexture implements IRenderTarge
      * @param size Define the size of the RTT to create
      * @param options Define rendertarget options
      */
-    constructor(engine: ThinEngine, size: TextureSize, options: RenderTargetCreationOptions) {
+    constructor(engine: AbstractEngine, size: TextureSize, options: RenderTargetCreationOptions) {
         super(null);
         this._engine = engine;
         this._renderTargetOptions = options;

--- a/packages/dev/core/src/Materials/Textures/thinRenderTargetTexture.ts
+++ b/packages/dev/core/src/Materials/Textures/thinRenderTargetTexture.ts
@@ -26,8 +26,8 @@ export class ThinRenderTargetTexture extends ThinTexture implements IRenderTarge
     /**
      * Instantiates a new ThinRenderTargetTexture.
      * Tiny helper class to wrap a RenderTargetWrapper in a texture.
-     * This can be used as an internal texture wrapper in ThinEngine to benefit from the cache and to hold on the associated RTT
-     * @param engine Define the internalTexture to wrap
+     * This can be used as an internal texture wrapper to benefit from the cache and to hold on the associated RTT
+     * @param engine Define the engine used to create and host the render target
      * @param size Define the size of the RTT to create
      * @param options Define rendertarget options
      */


### PR DESCRIPTION
ThinRenderTargetTexture's constructor previously required a `ThinEngine`, but it only uses `createRenderTargetTexture`, which is available on `AbstractEngine`. This widens the constructor parameter to `AbstractEngine` so the helper can be used with any engine (e.g. WebGPU) without going through `ThinEngine`.

This is a backward-compatible widening:
- `createRenderTargetTexture` is already declared on `AbstractEngine`.
- The base `ThinTexture._engine` field is already typed `Nullable<AbstractEngine>`.
- Existing callers passing a `ThinEngine` remain valid (subtype).

Verified: core `tsc --noEmit` clean; eslint clean (only pre-existing unrelated TSDoc warnings).