### PR TITLE
Fix USDZ export for cached unsupported texture formats

### DIFF
--- a/packages/dev/serializers/src/USDZ/usdzExporter.ts
+++ b/packages/dev/serializers/src/USDZ/usdzExporter.ts
@@ -18,7 +18,8 @@ import { type Scene } from "core/scene";
 import { type FloatArray, type Nullable } from "core/types";
 import { IsNoopNode } from "../exportUtils";
 import { GetTextureDataAsync } from "core/Misc/textureTools";
-import { InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { ImageMimeType } from "babylonjs-gltf2interface";
+import { GetCachedImageAsync } from "../exportImageUtils";
 
 /**
  * Ported from https://github.com/mrdoob/three.js/blob/master/examples/jsm/exporters/USDZExporter.js
@@ -27,6 +28,9 @@ import { InternalTextureSource } from "core/Materials/Textures/internalTexture";
 
 // FFlate access
 declare const fflate: any;
+
+type USDZTextureMimeType = Extract<ImageMimeType, ImageMimeType.JPEG | ImageMimeType.PNG>;
+type TextureToExport = { texture: BaseTexture; mimeType: USDZTextureMimeType; ext: string };
 
 /**
  * Options for the USDZ export
@@ -264,7 +268,7 @@ function BuildXform(mesh: Mesh, matrix: Matrix) {
 `;
 }
 
-function BuildMaterials(materials: { [key: string]: Material }, textureToExports: { [key: string]: { texture: BaseTexture; ext: string } }, options: IUSDZExportOptions) {
+function BuildMaterials(materials: { [key: string]: Material }, textureToExports: { [key: string]: TextureToExport }, options: IUSDZExportOptions) {
     const array: string[] = [];
 
     for (const uuid in materials) {
@@ -306,19 +310,24 @@ function BuildColor(color: Color3) {
     return `(${color.r}, ${color.g}, ${color.b})`;
 }
 
+function IsUSDZTextureMimeType(mimeType: string | undefined): mimeType is USDZTextureMimeType {
+    return mimeType === ImageMimeType.JPEG || mimeType === ImageMimeType.PNG;
+}
+
 function BuildTexture(
     texture: Texture,
     material: Material,
     mapType: string,
     color: Nullable<Color3>,
-    textureToExports: { [key: string]: { texture: BaseTexture; ext: string } },
+    textureToExports: { [key: string]: TextureToExport },
     options: IUSDZExportOptions
 ) {
     const id = texture.getInternalTexture()!.uniqueId + "_" + texture.invertY;
-    const mimeType = texture.mimeType || GetMimeType(texture.getInternalTexture()?.url ?? "");
-    const ext = mimeType === "image/jpeg" ? "jpg" : "png";
+    const sourceMimeType = texture.mimeType || GetMimeType(texture.getInternalTexture()?.url ?? "");
+    const mimeType = IsUSDZTextureMimeType(sourceMimeType) ? sourceMimeType : ImageMimeType.PNG;
+    const ext = mimeType === ImageMimeType.JPEG ? "jpg" : "png";
 
-    textureToExports[id] = { texture, ext };
+    textureToExports[id] = { texture, mimeType, ext };
 
     const uv = texture.coordinatesIndex > 0 ? "st" + texture.coordinatesIndex : "st";
     const repeat = new Vector2(texture.uScale, texture.vScale);
@@ -439,7 +448,7 @@ function ExtractTextureInformations(material: Material) {
     return defaults;
 }
 
-function BuildMaterial(material: Material, textureToExports: { [key: string]: { texture: BaseTexture; ext: string } }, options: IUSDZExportOptions) {
+function BuildMaterial(material: Material, textureToExports: { [key: string]: TextureToExport }, options: IUSDZExportOptions) {
     // https://graphics.pixar.com/usd/docs/UsdPreviewSurface-Proposal.html
 
     const pad = "			";
@@ -655,57 +664,6 @@ function ExtractMeshInformations(mesh: Mesh) {
 }
 
 /**
- * Gets cached image data from a texture's internal buffer, if available.
- * This allows texture export without requiring a WebGL or canvas rendering context,
- * enabling server-side (Node.js) export with NullEngine.
- * @param babylonTexture texture to check for cached image data
- * @returns image data and mime type if found and directly usable; null otherwise
- */
-async function GetCachedImageAsync(babylonTexture: BaseTexture): Promise<Nullable<{ data: ArrayBuffer; mimeType: string }>> {
-    const internalTexture = babylonTexture.getInternalTexture();
-    if (!internalTexture || internalTexture.source !== InternalTextureSource.Url) {
-        return null;
-    }
-    const buffer = internalTexture._buffer;
-
-    let data;
-    let mimeType = (babylonTexture as Texture).mimeType;
-
-    try {
-        if (!buffer) {
-            data = await Tools.LoadFileAsync(internalTexture.url);
-            mimeType = GetMimeType(internalTexture.url) || mimeType;
-        } else if (ArrayBuffer.isView(buffer)) {
-            data = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer;
-        } else if (buffer instanceof ArrayBuffer) {
-            data = buffer;
-        } else if (buffer instanceof Blob) {
-            data = await buffer.arrayBuffer();
-            mimeType = buffer.type || mimeType;
-        } else if (typeof buffer === "string") {
-            data = await Tools.LoadFileAsync(buffer);
-            mimeType = GetMimeType(buffer) || mimeType;
-        } else if (typeof HTMLImageElement !== "undefined" && buffer instanceof HTMLImageElement) {
-            data = await Tools.LoadFileAsync(buffer.src);
-            mimeType = GetMimeType(buffer.src) || mimeType;
-        }
-    } catch {
-        return null;
-    }
-
-    if (data && !mimeType && internalTexture.url) {
-        const dataUriMatch = internalTexture.url.match(/^data:([^;,]+)/);
-        mimeType = dataUriMatch ? dataUriMatch[1] : GetMimeType(internalTexture.url);
-    }
-
-    if (data && mimeType) {
-        return { data, mimeType };
-    }
-
-    return null;
-}
-
-/**
  *
  * @param scene scene to export
  * @param options options to configure the export
@@ -787,7 +745,7 @@ export async function USDZExportAsync(scene: Scene, options: Partial<IUSDZExport
     output += BuildSceneEnd();
 
     // Materials
-    const textureToExports: { [key: string]: { texture: BaseTexture; ext: string } } = {};
+    const textureToExports: { [key: string]: TextureToExport } = {};
     output += BuildMaterials(materialToExports, textureToExports, localOptions);
 
     // Close root
@@ -798,12 +756,12 @@ export async function USDZExportAsync(scene: Scene, options: Partial<IUSDZExport
 
     // Textures
     for (const id in textureToExports) {
-        const { texture, ext } = textureToExports[id];
+        const { texture, ext, mimeType } = textureToExports[id];
 
         // Try to get the image directly from the internal texture buffer (works without WebGL/canvas)
         // eslint-disable-next-line no-await-in-loop
         const cachedImage = await GetCachedImageAsync(texture);
-        if (cachedImage) {
+        if (cachedImage && IsUSDZTextureMimeType(cachedImage.mimeType) && cachedImage.mimeType === mimeType) {
             files[`textures/Texture_${id}.${ext}`] = new Uint8Array(cachedImage.data);
         } else {
             // Fall back to GPU texture read + DumpTools (requires WebGL/canvas context)
@@ -812,7 +770,7 @@ export async function USDZExportAsync(scene: Scene, options: Partial<IUSDZExport
             const textureData = await GetTextureDataAsync(texture);
 
             // eslint-disable-next-line no-await-in-loop
-            const fileContent = await DumpTools.DumpDataAsync(size.width, size.height, textureData, "image/png", undefined, false, true);
+            const fileContent = await DumpTools.DumpDataAsync(size.width, size.height, textureData, mimeType, undefined, false, true);
 
             files[`textures/Texture_${id}.${ext}`] = new Uint8Array(fileContent as ArrayBuffer).slice(); // This is to avoid getting a link and not a copy
         }

--- a/packages/dev/serializers/src/exportImageUtils.ts
+++ b/packages/dev/serializers/src/exportImageUtils.ts
@@ -1,0 +1,83 @@
+import { ImageMimeType } from "babylonjs-gltf2interface";
+import { NullEngine } from "core/Engines/nullEngine";
+import { type BaseTexture } from "core/Materials/Textures/baseTexture";
+import { InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { type Texture } from "core/Materials/Textures/texture";
+import { GetMimeType } from "core/Misc/fileTools";
+import { Tools } from "core/Misc/tools";
+import { type Nullable } from "core/types";
+
+export function GetFileExtensionFromMimeType(mimeType: ImageMimeType): string {
+    switch (mimeType) {
+        case ImageMimeType.JPEG:
+            return ".jpg";
+        case ImageMimeType.PNG:
+            return ".png";
+        case ImageMimeType.WEBP:
+            return ".webp";
+        case ImageMimeType.AVIF:
+            return ".avif";
+        case ImageMimeType.KTX2:
+            return ".ktx2";
+    }
+}
+
+/**
+ * Gets cached image data from a texture's internal buffer, if available.
+ * @param babylonTexture texture to check for cached image data
+ * @returns image data and mime type if found; null otherwise
+ */
+export async function GetCachedImageAsync(babylonTexture: BaseTexture): Promise<Nullable<{ data: ArrayBuffer; mimeType: string }>> {
+    const internalTexture = babylonTexture.getInternalTexture();
+    if (!internalTexture || internalTexture.source !== InternalTextureSource.Url) {
+        return null;
+    }
+    if (internalTexture.invertY) {
+        // On a real engine, the GPU has the texture stored flipped (UNPACK_FLIP_Y_WEBGL),
+        // while the glTF loader uploads with invertY=false. Falling back to GPU readback
+        // produces bytes that round-trip correctly. NullEngine has no GPU readback path,
+        // so the cached URL bytes are the only option.
+        const engine = babylonTexture.getScene()?.getEngine();
+        if (!(engine instanceof NullEngine)) {
+            return null;
+        }
+    }
+
+    const buffer = internalTexture._buffer;
+
+    let data;
+    let mimeType = (babylonTexture as Texture).mimeType;
+
+    try {
+        if (!buffer) {
+            data = await Tools.LoadFileAsync(internalTexture.url);
+            mimeType = GetMimeType(internalTexture.url) || mimeType;
+        } else if (ArrayBuffer.isView(buffer)) {
+            data = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer;
+        } else if (buffer instanceof ArrayBuffer) {
+            data = buffer;
+        } else if (buffer instanceof Blob) {
+            data = await buffer.arrayBuffer();
+            mimeType = buffer.type || mimeType;
+        } else if (typeof buffer === "string") {
+            data = await Tools.LoadFileAsync(buffer);
+            mimeType = GetMimeType(buffer) || mimeType;
+        } else if (typeof HTMLImageElement !== "undefined" && buffer instanceof HTMLImageElement) {
+            data = await Tools.LoadFileAsync(buffer.src);
+            mimeType = GetMimeType(buffer.src) || mimeType;
+        }
+    } catch {
+        return null;
+    }
+
+    if (data && !mimeType && internalTexture.url) {
+        const dataUriMatch = internalTexture.url.match(/^data:([^;,]+)/);
+        mimeType = dataUriMatch ? dataUriMatch[1] : GetMimeType(internalTexture.url);
+    }
+
+    if (data && mimeType) {
+        return { data, mimeType };
+    }
+
+    return null;
+}

--- a/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
+++ b/packages/dev/serializers/src/glTF/2.0/glTFMaterialExporter.ts
@@ -29,17 +29,15 @@ import { type Scene } from "core/scene";
 
 import { type GLTFExporter } from "./glTFExporter";
 import { Constants } from "core/Engines/constants";
-import { NullEngine } from "core/Engines/nullEngine";
 import { EncodeImageAsync } from "core/Misc/dumpTools";
 
 import { type Material } from "core/Materials/material";
 import { type StandardMaterial } from "core/Materials/standardMaterial";
 import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";
 import { SpecularPowerToRoughness } from "core/Helpers/materialConversionHelper";
-import { InternalTextureSource } from "core/Materials/Textures/internalTexture";
-import { GetMimeType } from "core/Misc/fileTools";
 import { OpenPBRMaterial } from "core/Materials/PBR/openpbrMaterial";
 import { MergeTexturesAsync, CreateRGBAConfiguration, CreateTextureInput, CreateConstantInput } from "core/Materials/Textures/textureMerger";
+import { GetCachedImageAsync, GetFileExtensionFromMimeType } from "../../exportImageUtils";
 
 const Epsilon = 1e-6;
 const DielectricSpecular = new Color3(0.04, 0.04, 0.04) as DeepImmutable<Color3>;
@@ -68,21 +66,6 @@ interface IPBRMetallicRoughness {
     baseColorTextureData?: Nullable<Blob>;
 }
 
-function GetFileExtensionFromMimeType(mimeType: ImageMimeType): string {
-    switch (mimeType) {
-        case ImageMimeType.JPEG:
-            return ".jpg";
-        case ImageMimeType.PNG:
-            return ".png";
-        case ImageMimeType.WEBP:
-            return ".webp";
-        case ImageMimeType.AVIF:
-            return ".avif";
-        case ImageMimeType.KTX2:
-            return ".ktx2";
-    }
-}
-
 /**
  * @param mimeType the MIME type requested by the user
  * @returns true if the given mime type is compatible with glTF
@@ -98,67 +81,6 @@ function IsSupportedMimeType(mimeType?: string): mimeType is ImageMimeType {
         default:
             return false;
     }
-}
-
-/**
- * Gets cached image from a texture, if available.
- * @param babylonTexture texture to check for cached image
- * @returns image data if found and directly usable; null otherwise
- */
-async function GetCachedImageAsync(babylonTexture: BaseTexture): Promise<Nullable<Blob>> {
-    const internalTexture = babylonTexture.getInternalTexture();
-    if (!internalTexture || internalTexture.source !== InternalTextureSource.Url) {
-        return null;
-    }
-    if (internalTexture.invertY) {
-        // On a real engine, the GPU has the texture stored flipped (UNPACK_FLIP_Y_WEBGL),
-        // while the glTF loader uploads with invertY=false. Falling back to GPU readback
-        // produces bytes that round-trip correctly. NullEngine has no GPU readback path,
-        // so the cached URL bytes are the only option.
-        const engine = babylonTexture.getScene()?.getEngine();
-        if (!(engine instanceof NullEngine)) {
-            return null;
-        }
-    }
-
-    const buffer = internalTexture._buffer;
-
-    let data;
-    let mimeType = (babylonTexture as Texture).mimeType;
-
-    try {
-        if (!buffer) {
-            data = await Tools.LoadFileAsync(internalTexture.url);
-            mimeType = GetMimeType(internalTexture.url) || mimeType;
-        } else if (ArrayBuffer.isView(buffer)) {
-            data = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer;
-        } else if (buffer instanceof ArrayBuffer) {
-            data = buffer;
-        } else if (buffer instanceof Blob) {
-            data = await buffer.arrayBuffer();
-            mimeType = buffer.type || mimeType;
-        } else if (typeof buffer === "string") {
-            data = await Tools.LoadFileAsync(buffer);
-            mimeType = GetMimeType(buffer) || mimeType;
-        } else if (typeof HTMLImageElement !== "undefined" && buffer instanceof HTMLImageElement) {
-            data = await Tools.LoadFileAsync(buffer.src);
-            mimeType = GetMimeType(buffer.src) || mimeType;
-        }
-    } catch {
-        // Failed to load texture data, fall back to GPU texture read via GetTextureDataAsync
-        return null;
-    }
-
-    if (data && !mimeType && internalTexture.url) {
-        const dataUriMatch = internalTexture.url.match(/^data:([^;,]+)/);
-        mimeType = dataUriMatch ? dataUriMatch[1] : GetMimeType(internalTexture.url);
-    }
-
-    if (data && IsSupportedMimeType(mimeType)) {
-        return new Blob([data], { type: mimeType });
-    }
-
-    return null;
 }
 
 /**
@@ -1099,8 +1021,8 @@ export class GLTFMaterialExporter {
             imageIndexPromise = (async () => {
                 // Try to get the image from memory first, if applicable
                 const cache = await GetCachedImageAsync(babylonTexture);
-                if (cache && (requestedMimeType === "none" || cache.type === requestedMimeType)) {
-                    return await this._exportImageAsync(babylonTexture.name, cache);
+                if (cache && IsSupportedMimeType(cache.mimeType) && (requestedMimeType === "none" || cache.mimeType === requestedMimeType)) {
+                    return await this._exportImageAsync(babylonTexture.name, new Blob([cache.data], { type: cache.mimeType }));
                 }
 
                 // Preserve texture mime type if defined


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Fixes USDZ export when a texture has cached source bytes in a format USDZ does not support, such as KTX2.

The previous USDZ path could copy cached source bytes directly into the archive even when the texture entry was emitted as PNG/JPEG. This made KTX2-backed textures produce invalid USDZ image payloads. This PR keeps cached-byte export for USDZ-supported image MIME types, but falls back to the existing decoded/readback image export path for unsupported source MIME types.

The cached-image extraction logic is shared with the glTF exporter so the NullEngine/cached-byte behavior stays consistent, while each exporter keeps its own supported-MIME policy.

Validation:
- `npm run format:check`
- `npm run build:dev`
- `npm run lint:check`
- `npm run test:unit`
- CI visualization jobs passed on the PR branch