### PR TITLE
[Native] Load single-file .dds/.ktx/.ktx2 cubemaps on the native engine

### DIFF
--- a/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
+++ b/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
@@ -4,6 +4,7 @@ import { InternalTextureSource, InternalTexture } from "../../../Materials/Textu
 import { Texture } from "../../../Materials/Textures/texture.pure";
 import { CreateRadianceImageDataArrayBufferViews, GetEnvInfo, UploadEnvSpherical } from "../../../Misc/environmentTextureTools.pure";
 import { type IWebRequest } from "../../../Misc/interfaces/iWebRequest";
+import { SphericalPolynomial } from "../../../Maths/sphericalPolynomial";
 import { type Scene } from "../../../scene.pure";
 import { type Nullable } from "../../../types";
 import { Constants } from "../../constants";
@@ -118,34 +119,94 @@ export function RegisterNativeEngineCubeTexture(): void {
                 );
             }
         } else {
-            if (!files || files.length !== 6) {
+            if (files && files.length === 6) {
+                // Reorder from [+X, +Y, +Z, -X, -Y, -Z] to [+X, -X, +Y, -Y, +Z, -Z].
+                const reorderedFiles = [files[0], files[3], files[1], files[4], files[2], files[5]];
+                // eslint-disable-next-line github/no-then
+                Promise.all(reorderedFiles.map(async (file) => await this._loadFileAsync(file, undefined, true).then((data) => new Uint8Array(data, 0, data.byteLength))))
+                    // eslint-disable-next-line github/no-then
+                    .then(async (data) => {
+                        return await new Promise<void>((resolve, reject) => {
+                            this._engine.loadCubeTexture(texture._hardwareTexture!.underlyingResource, data, !noMipmap, true, texture._useSRGBBuffer, resolve, reject);
+                        });
+                    })
+                    // eslint-disable-next-line github/no-then
+                    .then(
+                        () => {
+                            texture.isReady = true;
+                            if (onLoad) {
+                                onLoad();
+                            }
+                        },
+                        (error) => {
+                            if (onError) {
+                                onError(`Failed to load cubemap: ${error.message}`, error);
+                            }
+                        }
+                    );
+            } else if (files) {
                 throw new Error("Cannot load cubemap because 6 files were not defined");
-            }
+            } else {
+                // Single self-contained cubemap container (.dds / .ktx / .ktx2) holding all six
+                // faces and their mip chain. The native engine decodes it with bimg and, when
+                // polynomials are requested, returns the spherical harmonics it computed from the
+                // top mip (native cannot read cube faces back from the GPU to derive them lazily).
+                const onContainerLoaded = (data: ArrayBufferView) => {
+                    this._engine.loadCubeTexture(
+                        texture._hardwareTexture!.underlyingResource,
+                        [data],
+                        !noMipmap,
+                        true,
+                        texture._useSRGBBuffer,
+                        (sphericalPolynomialCoefficients?: Float32Array) => {
+                            if (createPolynomials && sphericalPolynomialCoefficients && sphericalPolynomialCoefficients.length === 27) {
+                                const c = sphericalPolynomialCoefficients;
+                                texture._sphericalPolynomial = SphericalPolynomial.FromArray([
+                                    [c[0], c[1], c[2]],
+                                    [c[3], c[4], c[5]],
+                                    [c[6], c[7], c[8]],
+                                    [c[9], c[10], c[11]],
+                                    [c[12], c[13], c[14]],
+                                    [c[15], c[16], c[17]],
+                                    [c[18], c[19], c[20]],
+                                    [c[21], c[22], c[23]],
+                                    [c[24], c[25], c[26]],
+                                ]);
+                            }
+                            texture.isReady = true;
+                            if (onLoad) {
+                                onLoad();
+                            }
+                        },
+                        () => {
+                            if (onError) {
+                                onError("Could not load a native cube texture.");
+                            }
+                        }
+                    );
+                };
 
-            // Reorder from [+X, +Y, +Z, -X, -Y, -Z] to [+X, -X, +Y, -Y, +Z, -Z].
-            const reorderedFiles = [files[0], files[3], files[1], files[4], files[2], files[5]];
-            // eslint-disable-next-line github/no-then
-            Promise.all(reorderedFiles.map(async (file) => await this._loadFileAsync(file, undefined, true).then((data) => new Uint8Array(data, 0, data.byteLength))))
-                // eslint-disable-next-line github/no-then
-                .then(async (data) => {
-                    return await new Promise<void>((resolve, reject) => {
-                        this._engine.loadCubeTexture(texture._hardwareTexture!.underlyingResource, data, !noMipmap, true, texture._useSRGBBuffer, resolve, reject);
-                    });
-                })
-                // eslint-disable-next-line github/no-then
-                .then(
-                    () => {
-                        texture.isReady = true;
-                        if (onLoad) {
-                            onLoad();
+                if (buffer) {
+                    onContainerLoaded(buffer);
+                } else {
+                    const onInternalError = (request?: IWebRequest, exception?: any) => {
+                        if (onError && request) {
+                            onError(request.status + " " + request.statusText, exception);
                         }
-                    },
-                    (error) => {
-                        if (onError) {
-                            onError(`Failed to load cubemap: ${error.message}`, error);
-                        }
-                    }
-                );
+                    };
+
+                    this._loadFile(
+                        rootUrl,
+                        (data) => {
+                            onContainerLoaded(new Uint8Array(data as ArrayBuffer, 0, (data as ArrayBuffer).byteLength));
+                        },
+                        undefined,
+                        undefined,
+                        true,
+                        onInternalError
+                    );
+                }
+            }
         }
 
         this._internalTexturesCache.push(texture);

--- a/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
+++ b/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
@@ -127,7 +127,15 @@ export function RegisterNativeEngineCubeTexture(): void {
                     // eslint-disable-next-line github/no-then
                     .then(async (data) => {
                         return await new Promise<void>((resolve, reject) => {
-                            this._engine.loadCubeTexture(texture._hardwareTexture!.underlyingResource, data, !noMipmap, true, texture._useSRGBBuffer, resolve, reject);
+                            this._engine.loadCubeTexture(
+                                texture._hardwareTexture!.underlyingResource,
+                                data,
+                                !noMipmap,
+                                true,
+                                texture._useSRGBBuffer,
+                                () => resolve(),
+                                () => reject(new Error("Failed to load native cubemap"))
+                            );
                         });
                     })
                     // eslint-disable-next-line github/no-then

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -74,7 +74,15 @@ export interface INativeEngine {
         generateMipMaps: boolean,
         invertY: boolean
     ): void;
-    loadCubeTexture(texture: NativeTexture, data: Array<ArrayBufferView>, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
+    loadCubeTexture(
+        texture: NativeTexture,
+        data: Array<ArrayBufferView>,
+        generateMips: boolean,
+        invertY: boolean,
+        srgb: boolean,
+        onSuccess: (sphericalPolynomial?: Float32Array) => void,
+        onError: () => void
+    ): void;
     loadCubeTextureWithMips(texture: NativeTexture, data: Array<Array<ArrayBufferView>>, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     getTextureWidth(texture: NativeTexture): number;
     getTextureHeight(texture: NativeTexture): number;
@@ -433,21 +441,45 @@ export const enum NativeTraceLevel {
 /** @internal */
 export interface INative {
     // NativeEngine plugin
+    /**
+     *
+     */
     Engine: INativeEngineConstructor;
+    /**
+     *
+     */
     NativeDataStream: INativeDataStreamConstructor;
 
     // NativeCamera plugin
+    /**
+     *
+     */
     Camera?: INativeCameraConstructor;
 
     // NativeCanvas plugin
+    /**
+     *
+     */
     Canvas?: INativeCanvasConstructor;
+    /**
+     *
+     */
     Image?: INativeImageConstructor;
+    /**
+     *
+     */
     Path2D?: INativePath2DConstructor;
 
     // Native XMLHttpRequest polyfill
+    /**
+     *
+     */
     XMLHttpRequest?: typeof XMLHttpRequest;
 
     // NativeInput plugin
+    /**
+     *
+     */
     DeviceInputSystem?: IDeviceInputSystemConstructor;
 
     // NativeTracing plugin


### PR DESCRIPTION
# [Native] Load single-file `.dds`/`.ktx`/`.ktx2` cubemaps on the native engine

## Problem

The native engine overrides `createCubeTexture` (`nativeEngine.cubeTexture.pure.ts`) and only
handles two cases: a single `.env` file, and an array of six face files. A single self-contained
cubemap container — `.dds` / `.ktx` / `.ktx2`, the format produced by
`CubeTexture.CreateFromPrefilteredData(...)` — falls through to:

```ts
throw new Error("Cannot load cubemap because 6 files were not defined");
```

So prefiltered-environment scenes (PBR IBL) that reference a single `.dds` cannot load it on
native at all.

This path was never wired because the generic WebGL loader route isn't usable on native: the
engine's `_uploadDataToTextureDirectly` / `_uploadCompressedDataToTextureDirectly` (and cube
`_readTexturePixels`) are unimplemented there — native uploads via its own command path, and the
`.env` branch worked only because `.env` ships pre-split faces plus baked spherical harmonics.

## Fix

Route a single-URL container cubemap to the native engine, which decodes it (bimg already supports
DDS/KTX/KTX2 cube containers) and, when polynomials are requested, returns the spherical-harmonics
coefficients it computed from the top mip. The diffuse-IBL spherical polynomial is then set on the
texture from those coefficients.

- `nativeEngine.cubeTexture.pure.ts`: in the non-`.env` branch, keep the existing six-file path,
  and add a branch for a single-URL container — fetch the bytes (or use the provided `buffer`),
  call `engine.loadCubeTexture(resource, [buffer], ...)`, and on success set
  `_sphericalPolynomial` from the returned coefficients (when `createPolynomials` was requested).
- `nativeInterfaces.ts`: `loadCubeTexture`'s `onSuccess` now optionally carries the spherical
  polynomial coefficients (`(sphericalPolynomial?: Float32Array) => void`); the existing six-file
  caller ignores them.

No change to the `.env` or six-file paths.

> Pairs with a Babylon Native `NativeEngine` change that implements the single-buffer cube decode
> (via bimg) and the spherical-harmonics computation from the top mip. This JS change requires that
> native support to be present.

## Testing

Validated on Babylon Native (Win32 / D3D11) with the Playground validation suite: six previously
unloadable prefiltered-environment `.dds` PBR scenes now load and render correctly, matching their
reference images. The computed spherical-harmonics integration is correct (total solid angle = 4π).

---

## Related PRs & landing order

- **Babylon.js (engine / TS):** https://github.com/BabylonJS/Babylon.js/pull/18560
- **BabylonNative (C++ engine + test re-enable):** https://github.com/BabylonJS/BabylonNative/pull/1748

Co-dependent; land in this order:
1. **Babylon.js #18560 first** — adds the single-URL container cube dispatch + spherical-harmonics wiring; no WebGL behavior change.
2. A **`babylonjs` npm release** ships that TS change.
3. **BabylonNative #1748 last** — bumps the bundled `babylonjs` and re-enables the 6 prefiltered-`.dds` PBR validation tests, which only pass once the paired JS is present in the bundled engine. The folded-in `blur-cube-with-the-effect-renderer` test additionally requires https://github.com/BabylonJS/Babylon.js/pull/18558 to be in the same `babylonjs` release.
