### PR TITLE
Fix lighting volume WGSL depth texture binding

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/lightingVolume.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/lightingVolume.compute.fx
@@ -8,7 +8,7 @@ struct Params {
     orthoMax: vec3f,
 };
 
-@group(0) @binding(0) var shadowMap : texture_2d<f32>;
+@group(0) @binding(0) var shadowMap : texture_depth_2d;
 @group(0) @binding(1) var<uniform> params : Params;
 @group(0) @binding(2) var<storage,read_write> positions : array<f32>;
 
@@ -27,7 +27,7 @@ fn updateFarPlaneVertices(@builtin(global_invocation_id) global_id : vec3u) {
     let stepY = floor(params.step * f32(coord.y));
     let depthCoord = vec2u(u32(floor(f32(coord.x) * params.step)), u32(stepY));
 
-    var depth = textureLoad(shadowMap, depthCoord, 0).r;
+    var depth = textureLoad(shadowMap, depthCoord, 0);
 #ifdef MOVE_FAR_DEPTH_TO_NEAR
     if (depth == 1.0) {
         depth = 0.0;


### PR DESCRIPTION
## Summary

 Declare the `shadowMap` binding of `lightingVolume.compute.fx` as `texture_depth_2d` instead of `texture_2d<f32>`, and drop the `.r` swizzle since `textureLoad` on `texture_depth_2d` returns a scalar `f32`.

## Why

`LightingVolume` binds the shadow generator's shadow map `depthStencilTexture` — a depth-format texture (`TEXTUREFORMAT_DEPTH32_FLOAT`) — as the `shadowMap` input of this compute shader (`lightingVolume.pure.ts`).

This completes the compute depth sample-type support introduced in BabylonJS/Babylon.js#18460: `_GetComputeTextureSampleType` classifies that texture as bind group layout sampleType `"depth"`, and WebGPU pipeline validation requires a `texture_depth_2d` WGSL declaration to match a `"depth"` layout entry. With the current `texture_2d<f32>` declaration, `createComputePipeline` fails validation (observed in Chromium and wgpu-native) as soon as the lighting volume compute shaders run with an explicit pipeline layout.

Under the default auto layout the current declaration only works by accident: `texture_2d<f32>` used with `textureLoad` derives sampleType `"unfilterable-float"`, which a depth-aspect view happens to be compatible with. The fix is the semantically correct binding for a depth texture and is equally valid under the auto layout (`texture_depth_2d` derives sampleType `"depth"`), and the loaded scalar is the same depth value `.r` previously carried, so far-plane fitting results are unchanged.

## Repro

Playground (run with the WebGPU engine): https://playground.babylonjs.com/#JE6IH3

It dispatches the lightingVolume far-plane kernel against a shadow generator's `depthStencilTexture` four ways (shipped/fixed WGSL x auto/explicit layout). On Babylon.js 9.12.0 + Chrome Canary, the shipped `texture_2d<f32>` declaration under the explicit pipeline layout fails `createComputePipeline` with:

```
The shader's texture sample type (TextureSampleType::4294967294) isn't compatible with the layout's texture sample type (TextureSampleType::Depth) (it is only compatible with TextureSampleType::Depth for the shader texture sample type).
 - While validating that the entry-point's declaration for @group(0) @binding(0) matches [BindGroupLayoutInternal (unlabeled)]
 - While validating the entry-point's compatibility for group 0 with [BindGroupLayoutInternal (unlabeled)]
 - While validating compute stage ([ShaderModule (unlabeled)], entryPoint: "updateFarPlaneVertices").
 - While calling [Device "BabylonWebGPUDevice5"].CreateComputePipeline([ComputePipelineDescriptor]).
```

With `texture_depth_2d`, the pipeline builds under both explicit and auto layouts, and the storage-buffer readback is bit-identical to the previous `.r` path (the playground compares the two outputs element by element), verifying far-plane fitting depths are unchanged. The snippet inspects the running build's shader store and self-reports once a build ships the fix, so it can be re-run post-merge as confirmation.

## Device context

This came from the Hill Valley GLTF/NativeXR AR Portal validation pass.

## Validation

- Playground repro above on Babylon.js 9.12.0 + Chrome Canary:
  - shipped WGSL + auto layout: pipeline + dispatch succeed (current behavior preserved)
  - shipped WGSL + explicit layout: `createComputePipeline` validation error (the bug)
  - fixed WGSL + explicit layout: pipeline + dispatch succeed
  - fixed WGSL + auto layout: pipeline + dispatch succeed
  - depth readback of the fixed shader is bit-identical to the `texture_2d<f32>.r` output, with real geometry depths present (min depth < 1.0)
- HIll Vallet AR Portal in our WebGPU fork of BabylonNative on iPhone XS and iPhone 12
- Shader-only change: the generated `lightingVolume.compute.ts` is produced at build time, and `.prettierignore` excludes `ShadersWGSL`, so no other source files change.