### PR TITLE
[Native] Report engine.name "Native" and implement updateTextureData

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -74,6 +74,17 @@ export interface INativeEngine {
     ): void;
     loadTexture(texture: NativeTexture, data: ArrayBufferView, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadRawTexture(texture: NativeTexture, data: ArrayBufferView, width: number, height: number, format: number, generateMips: boolean, invertY: boolean): void;
+    updateTextureData(
+        texture: NativeTexture,
+        data: ArrayBufferView,
+        xOffset: number,
+        yOffset: number,
+        width: number,
+        height: number,
+        faceIndex: number,
+        lod: number,
+        invertY: boolean
+    ): void;
     loadRawTexture2DArray(
         texture: NativeTexture,
         data: Nullable<ArrayBufferView>,

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -74,7 +74,7 @@ export interface INativeEngine {
     ): void;
     loadTexture(texture: NativeTexture, data: ArrayBufferView, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     loadRawTexture(texture: NativeTexture, data: ArrayBufferView, width: number, height: number, format: number, generateMips: boolean, invertY: boolean): void;
-    updateTextureData(
+    updateTextureData?(
         texture: NativeTexture,
         data: ArrayBufferView,
         xOffset: number,

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -307,6 +307,10 @@ export class ThinNativeEngine extends ThinEngine {
         this._webGLVersion = 2;
         this.disableUniformBuffers = true;
         this._shaderPlatformName = "NATIVE";
+        // Babylon Native is not WebGL and has no _gl context. Report a distinct engine name (like
+        // WebGPU reports "WebGPU") so application/feature code that branches on engine.name === "WebGL"
+        // to touch the WebGL-only _gl context skips the native engine instead of dereferencing null.
+        this._name = "Native";
 
         // TODO: Initialize this more correctly based on the hardware capabilities.
         // Init caps
@@ -2821,7 +2825,15 @@ export class ThinNativeEngine extends ThinEngine {
         lod: number = 0,
         generateMipMaps = false
     ): void {
-        throw new Error("updateTextureData not implemented.");
+        if (!texture._hardwareTexture) {
+            return;
+        }
+
+        // bgfx updates the requested sub-rectangle of the existing texture (faceIndex selects the cube
+        // face / array layer, lod selects the mip level). invertY is forwarded so the native side can match
+        // the vertical orientation the base texture upload uses. Mip regeneration after a partial update is
+        // not supported on Native, so generateMipMaps is ignored (consistent with the other raw-texture paths).
+        this._engine.updateTextureData(texture._hardwareTexture.underlyingResource, imageData, xOffset, yOffset, width, height, faceIndex, lod, texture.invertY);
     }
 
     /**

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -2829,6 +2829,10 @@ export class ThinNativeEngine extends ThinEngine {
             return;
         }
 
+        if (!this._engine.updateTextureData) {
+            throw new Error("updateTextureData not implemented.");
+        }
+
         // bgfx updates the requested sub-rectangle of the existing texture (faceIndex selects the cube
         // face / array layer, lod selects the mip level). invertY is forwarded so the native side can match
         // the vertical orientation the base texture upload uses. Mip regeneration after a partial update is


### PR DESCRIPTION
Paired native PR: BabylonJS/BabylonNative#1751

## What

1. **`engine.name` → `"Native"`.** The native engine inherited `"WebGL"` from `ThinEngine`, so external code gating WebGL-only `_gl` access on `engine.name === "WebGL"` ran on native and dereferenced the null `_gl` (e.g. `TypeError: ... 'TEXTURE_2D' of null`). It now reports `"Native"` (as WebGPU reports `"WebGPU"`). No internal `=== "WebGL"` checks exist (selection uses `_shaderPlatformName`/`isWebGPU`), so only external name-branching code is affected — exactly the code already broken on native.

2. **`updateTextureData` implemented** (was throwing "not implemented"). Forwards the sub-rectangle with `invertY`; ignores `generateMipMaps` (no partial-update mip regen on Native). The native binding is optional + existence-checked, so old native binaries get the explicit `"updateTextureData not implemented."` instead of `... is not a function`.

## Changes (`packages/dev/core/src/Engines`)

- `thinNativeEngine.pure.ts`: set `_name = "Native"`; implement `updateTextureData` (early-return without `_hardwareTexture`, existence-check before forwarding).
- `Native/nativeInterfaces.ts`: add optional `updateTextureData?` signature (matching `setRenderResetCallback?` / `sortSplats?`).

## Testing

Built `babylon.max.js` + ran the BabylonNative Playground validation suite (D3D11): the "Test updateTextureData" scene (previously crashed on `_gl.TEXTURE_2D`) renders and passes pixel comparison, stable across runs.

## Landing order

Co-dependent with `NativeEngine::UpdateTextureData` in BabylonJS/BabylonNative#1751:
1. **This PR first** — TS overrides (no WebGL behavior change).
2. A **`babylonjs` npm release** ships them.
3. **BabylonJS/BabylonNative#1751 last** — bumps bundled `babylonjs` + re-enables the validation test (passes only with the paired JS).
