### PR TITLE
[Native] MultiRenderTarget, reverse-Z clear, applyStates, OIT alpha modes

### DIFF
--- a/packages/dev/core/src/Engines/Native/nativeHelpers.ts
+++ b/packages/dev/core/src/Engines/Native/nativeHelpers.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { ErrorCodes, RuntimeError } from "core/Misc/error";
+import { Logger } from "core/Misc/logger";
 import { Constants } from "../constants";
 import { type INative } from "./nativeInterfaces";
 import { VertexBuffer } from "core/Buffers/buffer.pure";
@@ -299,6 +300,18 @@ export function getNativeStencilDepthPass(opPass: number): number {
     }
 }
 
+const _warnedUnsupportedAlphaModes = new Set<number>();
+
+// Some alpha modes were introduced alongside newer Babylon Native features. When running against an older
+// native binary the corresponding _native.Engine constant is undefined; warn once and fall back to ALPHA_ONEONE.
+function _getFallbackAlphaMode(mode: number, unsupportedName: string): number {
+    if (!_warnedUnsupportedAlphaModes.has(mode)) {
+        _warnedUnsupportedAlphaModes.add(mode);
+        Logger.Warn(`Alpha mode ${unsupportedName} is not supported by this version of Babylon Native; falling back to ALPHA_ONEONE.`);
+    }
+    return _native.Engine.ALPHA_ONEONE;
+}
+
 export function getNativeAlphaMode(mode: number): number {
     switch (mode) {
         case Constants.ALPHA_DISABLE:
@@ -316,9 +329,9 @@ export function getNativeAlphaMode(mode: number): number {
         case Constants.ALPHA_ONEONE:
             return _native.Engine.ALPHA_ONEONE;
         case Constants.ALPHA_ONEONE_ONEONE:
-            return _native.Engine.ALPHA_ONEONE_ONEONE;
+            return _native.Engine.ALPHA_ONEONE_ONEONE ?? _getFallbackAlphaMode(mode, "ALPHA_ONEONE_ONEONE");
         case Constants.ALPHA_LAYER_ACCUMULATE:
-            return _native.Engine.ALPHA_LAYER_ACCUMULATE;
+            return _native.Engine.ALPHA_LAYER_ACCUMULATE ?? _getFallbackAlphaMode(mode, "ALPHA_LAYER_ACCUMULATE");
         case Constants.ALPHA_PREMULTIPLIED:
             return _native.Engine.ALPHA_PREMULTIPLIED;
         case Constants.ALPHA_PREMULTIPLIED_PORTERDUFF:

--- a/packages/dev/core/src/Engines/Native/nativeHelpers.ts
+++ b/packages/dev/core/src/Engines/Native/nativeHelpers.ts
@@ -315,6 +315,10 @@ export function getNativeAlphaMode(mode: number): number {
             return _native.Engine.ALPHA_MAXIMIZED;
         case Constants.ALPHA_ONEONE:
             return _native.Engine.ALPHA_ONEONE;
+        case Constants.ALPHA_ONEONE_ONEONE:
+            return _native.Engine.ALPHA_ONEONE_ONEONE;
+        case Constants.ALPHA_LAYER_ACCUMULATE:
+            return _native.Engine.ALPHA_LAYER_ACCUMULATE;
         case Constants.ALPHA_PREMULTIPLIED:
             return _native.Engine.ALPHA_PREMULTIPLIED;
         case Constants.ALPHA_PREMULTIPLIED_PORTERDUFF:

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -102,6 +102,14 @@ export interface INativeEngine {
         generateDepthBuffer: boolean,
         samples: number
     ): NativeFramebuffer;
+    createMultiFrameBuffer(
+        textures: NativeTexture[],
+        width: number,
+        height: number,
+        generateStencilBuffer: boolean,
+        generateDepthBuffer: boolean,
+        samples: number
+    ): NativeFramebuffer;
 
     getRenderWidth(): number;
     getRenderHeight(): number;
@@ -270,6 +278,8 @@ interface INativeEngineConstructor {
     readonly ALPHA_MULTIPLY: number;
     readonly ALPHA_MAXIMIZED: number;
     readonly ALPHA_ONEONE: number;
+    readonly ALPHA_ONEONE_ONEONE: number;
+    readonly ALPHA_LAYER_ACCUMULATE: number;
     readonly ALPHA_PREMULTIPLIED: number;
     readonly ALPHA_PREMULTIPLIED_PORTERDUFF: number;
     readonly ALPHA_INTERPOLATE: number;

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -125,6 +125,14 @@ export interface INativeEngine {
         samples: number,
         layer?: number
     ): NativeFramebuffer;
+    createMultiFrameBuffer(
+        textures: NativeTexture[],
+        width: number,
+        height: number,
+        generateStencilBuffer: boolean,
+        generateDepthBuffer: boolean,
+        samples: number
+    ): NativeFramebuffer;
 
     getRenderWidth(): number;
     getRenderHeight(): number;
@@ -293,6 +301,8 @@ interface INativeEngineConstructor {
     readonly ALPHA_MULTIPLY: number;
     readonly ALPHA_MAXIMIZED: number;
     readonly ALPHA_ONEONE: number;
+    readonly ALPHA_ONEONE_ONEONE: number;
+    readonly ALPHA_LAYER_ACCUMULATE: number;
     readonly ALPHA_PREMULTIPLIED: number;
     readonly ALPHA_PREMULTIPLIED_PORTERDUFF: number;
     readonly ALPHA_INTERPOLATE: number;

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -125,7 +125,7 @@ export interface INativeEngine {
         samples: number,
         layer?: number
     ): NativeFramebuffer;
-    createMultiFrameBuffer(
+    createMultiFrameBuffer?(
         textures: NativeTexture[],
         width: number,
         height: number,
@@ -301,8 +301,8 @@ interface INativeEngineConstructor {
     readonly ALPHA_MULTIPLY: number;
     readonly ALPHA_MAXIMIZED: number;
     readonly ALPHA_ONEONE: number;
-    readonly ALPHA_ONEONE_ONEONE: number;
-    readonly ALPHA_LAYER_ACCUMULATE: number;
+    readonly ALPHA_ONEONE_ONEONE?: number;
+    readonly ALPHA_LAYER_ACCUMULATE?: number;
     readonly ALPHA_PREMULTIPLIED: number;
     readonly ALPHA_PREMULTIPLIED_PORTERDUFF: number;
     readonly ALPHA_INTERPOLATE: number;

--- a/packages/dev/core/src/Engines/Native/nativeRenderTargetWrapper.ts
+++ b/packages/dev/core/src/Engines/Native/nativeRenderTargetWrapper.ts
@@ -1,4 +1,5 @@
 import { type Nullable } from "../../types";
+import { type InternalTexture } from "../../Materials/Textures/internalTexture";
 import { type TextureSize } from "../../Materials/Textures/textureCreationOptions";
 import { RenderTargetWrapper } from "../renderTargetWrapper";
 import { type NativeFramebuffer } from "./nativeInterfaces";
@@ -55,6 +56,19 @@ export class NativeRenderTargetWrapper extends RenderTargetWrapper {
     constructor(isMulti: boolean, isCube: boolean, size: TextureSize, engine: ThinNativeEngine) {
         super(isMulti, isCube, size, engine);
         this._engine = engine;
+    }
+
+    public override setTexture(texture: InternalTexture, index: number = 0, disposePrevious: boolean = true): void {
+        const previous = this.textures?.[index];
+        super.setTexture(texture, index, disposePrevious);
+
+        // bgfx binds a fixed attachment set when a framebuffer is created and cannot re-point an individual
+        // attachment the way GL's framebufferTexture2D can. When a multi render target attachment is swapped
+        // after creation (e.g. the OIT depth-peeling renderer replaces every attachment via
+        // MultiRenderTarget.setInternalTexture), recreate the whole framebuffer from the new attachment set.
+        if (this.isMulti && this.textures?.[index] !== previous) {
+            this._engine._createMultiRenderTargetFramebuffer(this);
+        }
     }
 
     public override dispose(disposeOnlyFramebuffers = false): void {

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -19,6 +19,7 @@ import {
     type InternalTextureCreationOptions,
 } from "../Materials/Textures/textureCreationOptions";
 import { type IPipelineContext } from "./IPipelineContext";
+import { type IMultiRenderTargetOptions } from "../Materials/Textures/multiRenderTarget.pure";
 import { type IColor3Like, type IColor4Like, type IViewportLike } from "../Maths/math.like";
 import { Logger } from "../Misc/logger";
 import { Constants } from "./constants";
@@ -344,7 +345,7 @@ export class ThinNativeEngine extends ThinEngine {
             textureHalfFloatRender: true,
             textureLOD: true,
             texelFetch: false,
-            drawBuffersExtension: false,
+            drawBuffersExtension: true,
             depthTextureExtension: false,
             vertexArrayObject: true,
             instancedArrays: true,
@@ -570,8 +571,11 @@ export class ThinNativeEngine extends ThinEngine {
     }
 
     public override clear(color: Nullable<IColor4Like>, backBuffer: boolean, depth: boolean, stencil: boolean = false, stencilClearValue = 0): void {
-        if (this.useReverseDepthBuffer) {
-            throw new Error("reverse depth buffer is not currently implemented");
+        if (depth && this.useReverseDepthBuffer) {
+            // Reverse-Z: the scene is rendered with a flipped projection (near maps to 1, far to 0), so the
+            // depth buffer is cleared to 0 and the comparison must accept greater values. Mirror the WebGL
+            // engine, which sets the depth-culling comparison to GEQUAL here and clears depth to 0.
+            this._depthCullingState.depthFunc = Constants.GEQUAL;
         }
 
         this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_CLEAR);
@@ -581,7 +585,7 @@ export class ThinNativeEngine extends ThinEngine {
         this._commandBufferEncoder.encodeCommandArgAsFloat32(color ? color.b : 0);
         this._commandBufferEncoder.encodeCommandArgAsFloat32(color ? color.a : 1);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(depth ? 1 : 0);
-        this._commandBufferEncoder.encodeCommandArgAsFloat32(1);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(depth && this.useReverseDepthBuffer ? 0 : 1);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(stencil ? 1 : 0);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(stencilClearValue);
         this._commandBufferEncoder.finishEncodingCommand();
@@ -1072,6 +1076,20 @@ export class ThinNativeEngine extends ThinEngine {
         this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_SETDEPTHTEST);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(enable ? this._currentDepthTest : _native.Engine.DEPTH_TEST_ALWAYS);
         this._commandBufferEncoder.finishEncodingCommand();
+    }
+
+    public override applyStates(): void {
+        // The base ThinEngine.applyStates() drives the WebGL context (this._gl) directly, which is null on
+        // Native. Flush the depth-culling state through the native command path instead, so callers that
+        // mutate engine.depthCullingState directly and then call applyStates() (e.g. the depth-peeling / OIT
+        // renderer) take effect. Alpha and stencil state are applied on Native via their dedicated setters
+        // (setAlphaMode / setStencil*), which encode their commands when called.
+        const depthCullingState = this._depthCullingState;
+        if (depthCullingState.depthFunc !== null && depthCullingState.depthFunc !== undefined) {
+            this.setDepthFunction(depthCullingState.depthFunc);
+        }
+        this.setDepthBuffer(depthCullingState.depthTest);
+        this.setDepthWrite(depthCullingState.depthMask);
     }
 
     /**
@@ -2315,6 +2333,161 @@ export class ThinNativeEngine extends ThinEngine {
         rtWrapper.setTextures(texture);
 
         return rtWrapper;
+    }
+
+    public override createMultipleRenderTarget(size: TextureSize, options: IMultiRenderTargetOptions, _initializeBuffers = true): RenderTargetWrapper {
+        const rtWrapper = this._createHardwareRenderTargetWrapper(true, false, size) as NativeRenderTargetWrapper;
+
+        let generateMipMaps = false;
+        let generateDepthBuffer = true;
+        let generateStencilBuffer = false;
+        let generateDepthTexture = false;
+        let textureCount = 1;
+        let samples = 1;
+        let types: number[] = [];
+        let samplingModes: number[] = [];
+        let formats: number[] = [];
+        let targets: number[] = [];
+        let faceIndex: number[] = [];
+        let layerIndex: number[] = [];
+        let labels: string[] = [];
+        let dontCreateTextures = false;
+
+        if (options !== undefined) {
+            generateMipMaps = options.generateMipMaps ?? false;
+            generateDepthBuffer = options.generateDepthBuffer ?? true;
+            generateStencilBuffer = options.generateStencilBuffer ?? false;
+            generateDepthTexture = options.generateDepthTexture ?? false;
+            textureCount = options.textureCount ?? 1;
+            samples = options.samples ?? 1;
+            types = options.types || types;
+            samplingModes = options.samplingModes || samplingModes;
+            formats = options.formats || formats;
+            targets = options.targetTypes || targets;
+            faceIndex = options.faceIndex || faceIndex;
+            layerIndex = options.layerIndex || layerIndex;
+            labels = options.labels || labels;
+            dontCreateTextures = options.dontCreateTextures ?? false;
+        }
+
+        rtWrapper.label = options?.label ?? "MultiRenderTargetWrapper";
+
+        const width = (<{ width: number; height: number }>size).width ?? <number>size;
+        const height = (<{ width: number; height: number }>size).height ?? <number>size;
+
+        const textures: InternalTexture[] = [];
+        const attachments: number[] = [];
+        const colorHandles: NativeTexture[] = [];
+
+        for (let i = 0; i < textureCount; i++) {
+            const samplingMode = samplingModes[i] || Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
+            let type = types[i] || Constants.TEXTURETYPE_UNSIGNED_BYTE;
+            const format = formats[i] || Constants.TEXTUREFORMAT_RGBA;
+            const target = targets[i] || Constants.TEXTURE_2D;
+
+            attachments.push(i);
+
+            // target === -1 marks an attachment with no engine-created texture; dontCreateTextures defers them.
+            if (target === -1 || dontCreateTextures) {
+                continue;
+            }
+
+            if (type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
+                type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
+                Logger.Warn("Float textures are not supported. Multi render target attachment forced to TEXTURETYPE_UNSIGNED_BYTE type");
+            }
+
+            const texture = new InternalTexture(this, InternalTextureSource.MultiRenderTarget);
+            const nativeTexture = texture._hardwareTexture!.underlyingResource;
+            if (target !== Constants.TEXTURE_2D) {
+                // Native multi render targets currently only attach 2D color textures; cube / 2D-array
+                // attachments are created as 2D so the attachment still exists and mrt.textures[i] is populated.
+                Logger.Warn("Multi render target attachment target " + target + " is not supported on Native; using a 2D texture.");
+            }
+            // bgfx auto-generates the mip chain on resolve; avoid the mips + MSAA combo (see createRenderTargetTexture).
+            const hasMips = samples > 1 ? false : generateMipMaps;
+            this._engine.initializeTexture(nativeTexture, width, height, hasMips, getNativeTextureFormat(format, type), /*renderTarget*/ true, /*srgb*/ false, samples);
+            this._setTextureSampling(nativeTexture, getNativeSamplingMode(samplingMode));
+
+            texture.baseWidth = width;
+            texture.baseHeight = height;
+            texture.width = width;
+            texture.height = height;
+            texture.isReady = true;
+            texture.samples = samples;
+            texture.generateMipMaps = generateMipMaps;
+            texture.samplingMode = samplingMode;
+            texture.type = type;
+            texture.format = format;
+            texture.label = labels[i] ?? rtWrapper.label + "-Texture" + i;
+
+            textures[i] = texture;
+            colorHandles.push(nativeTexture);
+            this._internalTexturesCache.push(texture);
+        }
+
+        // The native engine creates one framebuffer with all the color attachments (bgfx writes to every
+        // attachment of the bound framebuffer, so there is no drawBuffers equivalent to issue per draw).
+        if (colorHandles.length > 0) {
+            rtWrapper._framebuffer = this._engine.createMultiFrameBuffer(colorHandles, width, height, generateStencilBuffer, generateDepthBuffer || generateDepthTexture, samples);
+        }
+
+        rtWrapper._generateDepthBuffer = generateDepthBuffer || generateDepthTexture;
+        rtWrapper._generateStencilBuffer = generateStencilBuffer;
+        rtWrapper._samples = samples;
+        rtWrapper._attachments = attachments;
+
+        rtWrapper.setTextures(textures);
+        rtWrapper.setLayerAndFaceIndices(layerIndex, faceIndex);
+
+        return rtWrapper;
+    }
+
+    public override bindAttachments(_attachments: number[]): void {
+        // No-op on Native: bgfx renders to every color attachment of the bound framebuffer, so there is
+        // no gl.drawBuffers equivalent to select a subset.
+    }
+
+    public override buildTextureLayout(textureStatus: boolean[], _backBufferLayout = false): number[] {
+        // Native has no gl draw-buffer enums; return a per-attachment index list (consumers only use the
+        // length/order, and bindAttachments is a no-op).
+        const result: number[] = [];
+        for (let i = 0; i < textureStatus.length; i++) {
+            result.push(textureStatus[i] ? i : -1);
+        }
+        return result;
+    }
+
+    public override restoreSingleAttachment(): void {
+        // No-op on Native (see bindAttachments).
+    }
+
+    public override restoreSingleAttachmentForRenderTarget(): void {
+        // No-op on Native (see bindAttachments).
+    }
+
+    public override generateMipMapsMultiFramebuffer(_texture: RenderTargetWrapper): void {
+        // No-op on Native: bgfx auto-generates mips on render-target resolve (as for 2D/cube RTTs).
+    }
+
+    public override resolveMultiFramebuffer(_texture: RenderTargetWrapper): void {
+        // No-op on Native: bgfx resolves MSAA render targets automatically.
+    }
+
+    public override unBindMultiColorAttachmentFramebuffer(_rtWrapper: RenderTargetWrapper, _disableGenerateMipMaps = false, onBeforeUnbind?: () => void): void {
+        this._currentRenderTarget = null;
+        if (onBeforeUnbind) {
+            onBeforeUnbind();
+        }
+        this._bindUnboundFramebuffer(null);
+    }
+
+    public override updateMultipleRenderTargetTextureSampleCount(rtWrapper: Nullable<RenderTargetWrapper>, samples: number, _initializeBuffers = true): number {
+        // Native MSAA is configured at texture creation; just record the requested sample count.
+        if (rtWrapper) {
+            (rtWrapper as NativeRenderTargetWrapper)._samples = samples;
+        }
+        return samples;
     }
 
     public override updateRenderTargetTextureSampleCount(rtWrapper: RenderTargetWrapper, samples: number): number {

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -579,9 +579,14 @@ export class ThinNativeEngine extends ThinEngine {
     public override clear(color: Nullable<IColor4Like>, backBuffer: boolean, depth: boolean, stencil: boolean = false, stencilClearValue = 0): void {
         if (depth && this.useReverseDepthBuffer) {
             // Reverse-Z: the scene is rendered with a flipped projection (near maps to 1, far to 0), so the
-            // depth buffer is cleared to 0 and the comparison must accept greater values. Mirror the WebGL
-            // engine, which sets the depth-culling comparison to GEQUAL here and clears depth to 0.
+            // depth buffer is cleared to 0 and the comparison must accept greater values. The WebGL engine
+            // sets depthCullingState.depthFunc = GEQUAL here and relies on applyStates() running the depth
+            // comparison to the GL context before each draw. The native draw path does not call applyStates()
+            // (only depth-test enable/disable is reconciled in _flushDepthTestState()), so setting the shared
+            // state alone would never reach the backend. Route the comparison through the native command path
+            // as well -- mirroring the WebGPU engine's clear path, which calls setDepthFunctionToGreaterOrEqual().
             this._depthCullingState.depthFunc = Constants.GEQUAL;
+            this.setDepthFunction(Constants.GEQUAL);
         }
 
         this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_CLEAR);

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -19,6 +19,7 @@ import {
     type InternalTextureCreationOptions,
 } from "../Materials/Textures/textureCreationOptions";
 import { type IPipelineContext } from "./IPipelineContext";
+import { type IMultiRenderTargetOptions } from "../Materials/Textures/multiRenderTarget.pure";
 import { type IColor3Like, type IColor4Like, type IViewportLike } from "../Maths/math.like";
 import { Logger } from "../Misc/logger";
 import { Constants } from "./constants";
@@ -350,7 +351,7 @@ export class ThinNativeEngine extends ThinEngine {
             textureHalfFloatRender: true,
             textureLOD: true,
             texelFetch: false,
-            drawBuffersExtension: false,
+            drawBuffersExtension: true,
             depthTextureExtension: false,
             vertexArrayObject: true,
             instancedArrays: true,
@@ -576,8 +577,11 @@ export class ThinNativeEngine extends ThinEngine {
     }
 
     public override clear(color: Nullable<IColor4Like>, backBuffer: boolean, depth: boolean, stencil: boolean = false, stencilClearValue = 0): void {
-        if (this.useReverseDepthBuffer) {
-            throw new Error("reverse depth buffer is not currently implemented");
+        if (depth && this.useReverseDepthBuffer) {
+            // Reverse-Z: the scene is rendered with a flipped projection (near maps to 1, far to 0), so the
+            // depth buffer is cleared to 0 and the comparison must accept greater values. Mirror the WebGL
+            // engine, which sets the depth-culling comparison to GEQUAL here and clears depth to 0.
+            this._depthCullingState.depthFunc = Constants.GEQUAL;
         }
 
         this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_CLEAR);
@@ -587,7 +591,7 @@ export class ThinNativeEngine extends ThinEngine {
         this._commandBufferEncoder.encodeCommandArgAsFloat32(color ? color.b : 0);
         this._commandBufferEncoder.encodeCommandArgAsFloat32(color ? color.a : 1);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(depth ? 1 : 0);
-        this._commandBufferEncoder.encodeCommandArgAsFloat32(1);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(depth && this.useReverseDepthBuffer ? 0 : 1);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(stencil ? 1 : 0);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(stencilClearValue);
         this._commandBufferEncoder.finishEncodingCommand();
@@ -1100,6 +1104,20 @@ export class ThinNativeEngine extends ThinEngine {
         if (this._depthCullingState.depthTest !== this._depthTestEnabled) {
             this._encodeDepthTest(this._depthCullingState.depthTest);
         }
+    }
+
+    public override applyStates(): void {
+        // The base ThinEngine.applyStates() drives the WebGL context (this._gl) directly, which is null on
+        // Native. Flush the depth-culling state through the native command path instead, so callers that
+        // mutate engine.depthCullingState directly and then call applyStates() (e.g. the depth-peeling / OIT
+        // renderer) take effect. Alpha and stencil state are applied on Native via their dedicated setters
+        // (setAlphaMode / setStencil*), which encode their commands when called.
+        const depthCullingState = this._depthCullingState;
+        if (depthCullingState.depthFunc !== null && depthCullingState.depthFunc !== undefined) {
+            this.setDepthFunction(depthCullingState.depthFunc);
+        }
+        this.setDepthBuffer(depthCullingState.depthTest);
+        this.setDepthWrite(depthCullingState.depthMask);
     }
 
     /**
@@ -2440,11 +2458,166 @@ export class ThinNativeEngine extends ThinEngine {
         return rtWrapper;
     }
 
+    public override createMultipleRenderTarget(size: TextureSize, options: IMultiRenderTargetOptions, _initializeBuffers = true): RenderTargetWrapper {
+        const rtWrapper = this._createHardwareRenderTargetWrapper(true, false, size) as NativeRenderTargetWrapper;
+
+        let generateMipMaps = false;
+        let generateDepthBuffer = true;
+        let generateStencilBuffer = false;
+        let generateDepthTexture = false;
+        let textureCount = 1;
+        let samples = 1;
+        let types: number[] = [];
+        let samplingModes: number[] = [];
+        let formats: number[] = [];
+        let targets: number[] = [];
+        let faceIndex: number[] = [];
+        let layerIndex: number[] = [];
+        let labels: string[] = [];
+        let dontCreateTextures = false;
+
+        if (options !== undefined) {
+            generateMipMaps = options.generateMipMaps ?? false;
+            generateDepthBuffer = options.generateDepthBuffer ?? true;
+            generateStencilBuffer = options.generateStencilBuffer ?? false;
+            generateDepthTexture = options.generateDepthTexture ?? false;
+            textureCount = options.textureCount ?? 1;
+            samples = options.samples ?? 1;
+            types = options.types || types;
+            samplingModes = options.samplingModes || samplingModes;
+            formats = options.formats || formats;
+            targets = options.targetTypes || targets;
+            faceIndex = options.faceIndex || faceIndex;
+            layerIndex = options.layerIndex || layerIndex;
+            labels = options.labels || labels;
+            dontCreateTextures = options.dontCreateTextures ?? false;
+        }
+
+        rtWrapper.label = options?.label ?? "MultiRenderTargetWrapper";
+
+        const width = (<{ width: number; height: number }>size).width ?? <number>size;
+        const height = (<{ width: number; height: number }>size).height ?? <number>size;
+
+        const textures: InternalTexture[] = [];
+        const attachments: number[] = [];
+        const colorHandles: NativeTexture[] = [];
+
+        for (let i = 0; i < textureCount; i++) {
+            const samplingMode = samplingModes[i] || Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
+            let type = types[i] || Constants.TEXTURETYPE_UNSIGNED_BYTE;
+            const format = formats[i] || Constants.TEXTUREFORMAT_RGBA;
+            const target = targets[i] || Constants.TEXTURE_2D;
+
+            attachments.push(i);
+
+            // target === -1 marks an attachment with no engine-created texture; dontCreateTextures defers them.
+            if (target === -1 || dontCreateTextures) {
+                continue;
+            }
+
+            if (type === Constants.TEXTURETYPE_FLOAT && !this._caps.textureFloat) {
+                type = Constants.TEXTURETYPE_UNSIGNED_BYTE;
+                Logger.Warn("Float textures are not supported. Multi render target attachment forced to TEXTURETYPE_UNSIGNED_BYTE type");
+            }
+
+            const texture = new InternalTexture(this, InternalTextureSource.MultiRenderTarget);
+            const nativeTexture = texture._hardwareTexture!.underlyingResource;
+            if (target !== Constants.TEXTURE_2D) {
+                // Native multi render targets currently only attach 2D color textures; cube / 2D-array
+                // attachments are created as 2D so the attachment still exists and mrt.textures[i] is populated.
+                Logger.Warn("Multi render target attachment target " + target + " is not supported on Native; using a 2D texture.");
+            }
+            // bgfx auto-generates the mip chain on resolve; avoid the mips + MSAA combo (see createRenderTargetTexture).
+            const hasMips = samples > 1 ? false : generateMipMaps;
+            this._engine.initializeTexture(nativeTexture, width, height, hasMips, getNativeTextureFormat(format, type), /*renderTarget*/ true, /*srgb*/ false, samples);
+            this._setTextureSampling(nativeTexture, getNativeSamplingMode(samplingMode));
+
+            texture.baseWidth = width;
+            texture.baseHeight = height;
+            texture.width = width;
+            texture.height = height;
+            texture.isReady = true;
+            texture.samples = samples;
+            texture.generateMipMaps = generateMipMaps;
+            texture.samplingMode = samplingMode;
+            texture.type = type;
+            texture.format = format;
+            texture.label = labels[i] ?? rtWrapper.label + "-Texture" + i;
+
+            textures[i] = texture;
+            colorHandles.push(nativeTexture);
+            this._internalTexturesCache.push(texture);
+        }
+
+        // The native engine creates one framebuffer with all the color attachments (bgfx writes to every
+        // attachment of the bound framebuffer, so there is no drawBuffers equivalent to issue per draw).
+        if (colorHandles.length > 0) {
+            rtWrapper._framebuffer = this._engine.createMultiFrameBuffer(colorHandles, width, height, generateStencilBuffer, generateDepthBuffer || generateDepthTexture, samples);
+        }
+
+        rtWrapper._generateDepthBuffer = generateDepthBuffer || generateDepthTexture;
+        rtWrapper._generateStencilBuffer = generateStencilBuffer;
+        rtWrapper._samples = samples;
+        rtWrapper._attachments = attachments;
+
+        rtWrapper.setTextures(textures);
+        rtWrapper.setLayerAndFaceIndices(layerIndex, faceIndex);
+
+        return rtWrapper;
+    }
+
     public override generateMipMapsForCubemap(_texture: InternalTexture, _unbind = true): void {
         // The WebGL path rebinds gl.TEXTURE_CUBE_MAP and calls gl.generateMipmap; both deref _gl, which is
         // null on Native. bgfx auto-generates the mip chain when a render target texture created with mips is
         // resolved (the same way 2D RTTs get their mips here -- unBindFramebuffer issues no explicit mipgen),
         // so this is a no-op on Native.
+    }
+
+    public override bindAttachments(_attachments: number[]): void {
+        // No-op on Native: bgfx renders to every color attachment of the bound framebuffer, so there is
+        // no gl.drawBuffers equivalent to select a subset.
+    }
+
+    public override buildTextureLayout(textureStatus: boolean[], _backBufferLayout = false): number[] {
+        // Native has no gl draw-buffer enums; return a per-attachment index list (consumers only use the
+        // length/order, and bindAttachments is a no-op).
+        const result: number[] = [];
+        for (let i = 0; i < textureStatus.length; i++) {
+            result.push(textureStatus[i] ? i : -1);
+        }
+        return result;
+    }
+
+    public override restoreSingleAttachment(): void {
+        // No-op on Native (see bindAttachments).
+    }
+
+    public override restoreSingleAttachmentForRenderTarget(): void {
+        // No-op on Native (see bindAttachments).
+    }
+
+    public override generateMipMapsMultiFramebuffer(_texture: RenderTargetWrapper): void {
+        // No-op on Native: bgfx auto-generates mips on render-target resolve (as for 2D/cube RTTs).
+    }
+
+    public override resolveMultiFramebuffer(_texture: RenderTargetWrapper): void {
+        // No-op on Native: bgfx resolves MSAA render targets automatically.
+    }
+
+    public override unBindMultiColorAttachmentFramebuffer(_rtWrapper: RenderTargetWrapper, _disableGenerateMipMaps = false, onBeforeUnbind?: () => void): void {
+        this._currentRenderTarget = null;
+        if (onBeforeUnbind) {
+            onBeforeUnbind();
+        }
+        this._bindUnboundFramebuffer(null);
+    }
+
+    public override updateMultipleRenderTargetTextureSampleCount(rtWrapper: Nullable<RenderTargetWrapper>, samples: number, _initializeBuffers = true): number {
+        // Native MSAA is configured at texture creation; just record the requested sample count.
+        if (rtWrapper) {
+            (rtWrapper as NativeRenderTargetWrapper)._samples = samples;
+        }
+        return samples;
     }
 
     public override updateRenderTargetTextureSampleCount(rtWrapper: RenderTargetWrapper, samples: number): number {

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -2615,8 +2615,10 @@ export class ThinNativeEngine extends ThinEngine {
         } else {
             // Older Babylon Native binaries (predating multi render target support) do not expose createMultiFrameBuffer.
             // Fall back to a single-attachment framebuffer bound to the first color target so the scene keeps rendering.
+            // Warn once (limit 1): the framebuffer can be rebuilt many times during attachment setup/swaps.
             Logger.Warn(
-                "createMultiFrameBuffer is not supported by this version of Babylon Native; multi render targets are unavailable. Falling back to a single-attachment framebuffer bound to the first color target."
+                "createMultiFrameBuffer is not supported by this version of Babylon Native; multi render targets are unavailable. Falling back to a single-attachment framebuffer bound to the first color target.",
+                1
             );
             rtWrapper._framebuffer = this._engine.createFrameBuffer(
                 colorHandles[0],
@@ -2676,10 +2678,48 @@ export class ThinNativeEngine extends ThinEngine {
     }
 
     public override updateMultipleRenderTargetTextureSampleCount(rtWrapper: Nullable<RenderTargetWrapper>, samples: number, _initializeBuffers = true): number {
-        // Native MSAA is configured at texture creation; just record the requested sample count.
-        if (rtWrapper) {
-            (rtWrapper as NativeRenderTargetWrapper)._samples = samples;
+        if (!rtWrapper || rtWrapper.samples === samples) {
+            return samples;
         }
+
+        const textures = rtWrapper.textures;
+        if (!textures) {
+            return rtWrapper.samples;
+        }
+
+        const nativeRTWrapper = rtWrapper as NativeRenderTargetWrapper;
+
+        // bgfx couples MSAA to the texture creation flags (see updateRenderTargetTextureSampleCount), so
+        // changing the sample count after the fact requires reissuing every color attachment's underlying
+        // bgfx handle with the new MSAA flag. initializeTexture disposes the old handle and allocates a fresh
+        // one while preserving the InternalTexture / Graphics::Texture identity; only the internal bgfx handle
+        // rotates. Afterwards the framebuffer is recreated so its attachment list refers to the new handles.
+        for (const texture of textures) {
+            // Wrapped (External-source) textures own an opaque external handle (format=-1); reinitializing
+            // would destroy it and getNativeTextureFormat would throw, so leave those attachments untouched.
+            if (!texture?._hardwareTexture || texture.source === InternalTextureSource.External) {
+                continue;
+            }
+
+            const nativeTexture = texture._hardwareTexture.underlyingResource;
+            // See the bgfx-msaa-mips workaround in updateRenderTargetTextureSampleCount (BabylonNative#1714).
+            const hasMips = samples > 1 ? false : texture.generateMipMaps;
+            this._engine.initializeTexture(
+                nativeTexture,
+                texture.baseWidth,
+                texture.baseHeight,
+                hasMips,
+                getNativeTextureFormat(texture.format, texture.type),
+                /*renderTarget*/ true,
+                texture._useSRGBBuffer,
+                samples
+            );
+            texture.samples = samples;
+        }
+
+        nativeRTWrapper._samples = samples;
+        this._createMultiRenderTargetFramebuffer(nativeRTWrapper);
+
         return samples;
     }
 

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -2590,7 +2590,13 @@ export class ThinNativeEngine extends ThinEngine {
             }
         }
 
-        if (colorHandles.length === 0) {
+        // bgfx framebuffers use a dense, ordered attachment list, so only (re)build once every expected color
+        // attachment is present. Building from a partial set (e.g. attachments deferred via dontCreateTextures /
+        // targetTypes[i] === -1, or filled out of order) would compress the attachment indices -- attachment 2
+        // would become attachment 1, etc. -- and produce a framebuffer that does not match the MRT layout. The
+        // count match guarantees the collected handles are contiguous and in attachment order.
+        const expectedCount = rtWrapper._attachments ? rtWrapper._attachments.length : colorHandles.length;
+        if (colorHandles.length === 0 || colorHandles.length !== expectedCount) {
             return;
         }
 

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -2505,7 +2505,6 @@ export class ThinNativeEngine extends ThinEngine {
 
         const textures: InternalTexture[] = [];
         const attachments: number[] = [];
-        const colorHandles: NativeTexture[] = [];
 
         for (let i = 0; i < textureCount; i++) {
             const samplingMode = samplingModes[i] || Constants.TEXTURE_TRILINEAR_SAMPLINGMODE;
@@ -2550,37 +2549,7 @@ export class ThinNativeEngine extends ThinEngine {
             texture.label = labels[i] ?? rtWrapper.label + "-Texture" + i;
 
             textures[i] = texture;
-            colorHandles.push(nativeTexture);
             this._internalTexturesCache.push(texture);
-        }
-
-        // The native engine creates one framebuffer with all the color attachments (bgfx writes to every
-        // attachment of the bound framebuffer, so there is no drawBuffers equivalent to issue per draw).
-        if (colorHandles.length > 0) {
-            if (this._engine.createMultiFrameBuffer) {
-                rtWrapper._framebuffer = this._engine.createMultiFrameBuffer(
-                    colorHandles,
-                    width,
-                    height,
-                    generateStencilBuffer,
-                    generateDepthBuffer || generateDepthTexture,
-                    samples
-                );
-            } else {
-                // Older Babylon Native binaries (predating multi render target support) do not expose createMultiFrameBuffer.
-                // Fall back to a single-attachment framebuffer bound to the first color target so the scene keeps rendering.
-                Logger.Warn(
-                    "createMultiFrameBuffer is not supported by this version of Babylon Native; multi render targets are unavailable. Falling back to a single-attachment framebuffer bound to the first color target."
-                );
-                rtWrapper._framebuffer = this._engine.createFrameBuffer(
-                    colorHandles[0],
-                    width,
-                    height,
-                    generateStencilBuffer,
-                    generateDepthBuffer || generateDepthTexture,
-                    samples
-                );
-            }
         }
 
         rtWrapper._generateDepthBuffer = generateDepthBuffer || generateDepthTexture;
@@ -2591,7 +2560,67 @@ export class ThinNativeEngine extends ThinEngine {
         rtWrapper.setTextures(textures);
         rtWrapper.setLayerAndFaceIndices(layerIndex, faceIndex);
 
+        // The native engine creates one framebuffer with all the color attachments (bgfx writes to every
+        // attachment of the bound framebuffer, so there is no drawBuffers equivalent to issue per draw).
+        this._createMultiRenderTargetFramebuffer(rtWrapper);
+
         return rtWrapper;
+    }
+
+    /**
+     * Creates (or recreates) the native framebuffer of a multi render target from the color attachment
+     * textures currently held by the wrapper. bgfx binds a fixed attachment set when a framebuffer is
+     * created and cannot re-point an individual attachment the way GL's framebufferTexture2D can, so the
+     * whole framebuffer has to be recreated whenever an attachment is swapped after creation (e.g. the OIT
+     * depth-peeling renderer replaces every attachment via MultiRenderTarget.setInternalTexture).
+     * @param rtWrapper The multi render target wrapper to build the framebuffer for.
+     * @internal
+     */
+    public _createMultiRenderTargetFramebuffer(rtWrapper: NativeRenderTargetWrapper): void {
+        const textures = rtWrapper.textures;
+        if (!textures) {
+            return;
+        }
+
+        const colorHandles: NativeTexture[] = [];
+        for (const texture of textures) {
+            const handle = texture?._hardwareTexture?.underlyingResource;
+            if (handle) {
+                colorHandles.push(handle);
+            }
+        }
+
+        if (colorHandles.length === 0) {
+            return;
+        }
+
+        const width = rtWrapper.width;
+        const height = rtWrapper.height;
+
+        if (this._engine.createMultiFrameBuffer) {
+            rtWrapper._framebuffer = this._engine.createMultiFrameBuffer(
+                colorHandles,
+                width,
+                height,
+                rtWrapper._generateStencilBuffer,
+                rtWrapper._generateDepthBuffer,
+                rtWrapper._samples
+            );
+        } else {
+            // Older Babylon Native binaries (predating multi render target support) do not expose createMultiFrameBuffer.
+            // Fall back to a single-attachment framebuffer bound to the first color target so the scene keeps rendering.
+            Logger.Warn(
+                "createMultiFrameBuffer is not supported by this version of Babylon Native; multi render targets are unavailable. Falling back to a single-attachment framebuffer bound to the first color target."
+            );
+            rtWrapper._framebuffer = this._engine.createFrameBuffer(
+                colorHandles[0],
+                width,
+                height,
+                rtWrapper._generateStencilBuffer,
+                rtWrapper._generateDepthBuffer,
+                rtWrapper._samples
+            );
+        }
     }
 
     public override generateMipMapsForCubemap(_texture: InternalTexture, _unbind = true): void {

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -2552,7 +2552,30 @@ export class ThinNativeEngine extends ThinEngine {
         // The native engine creates one framebuffer with all the color attachments (bgfx writes to every
         // attachment of the bound framebuffer, so there is no drawBuffers equivalent to issue per draw).
         if (colorHandles.length > 0) {
-            rtWrapper._framebuffer = this._engine.createMultiFrameBuffer(colorHandles, width, height, generateStencilBuffer, generateDepthBuffer || generateDepthTexture, samples);
+            if (this._engine.createMultiFrameBuffer) {
+                rtWrapper._framebuffer = this._engine.createMultiFrameBuffer(
+                    colorHandles,
+                    width,
+                    height,
+                    generateStencilBuffer,
+                    generateDepthBuffer || generateDepthTexture,
+                    samples
+                );
+            } else {
+                // Older Babylon Native binaries (predating multi render target support) do not expose createMultiFrameBuffer.
+                // Fall back to a single-attachment framebuffer bound to the first color target so the scene keeps rendering.
+                Logger.Warn(
+                    "createMultiFrameBuffer is not supported by this version of Babylon Native; multi render targets are unavailable. Falling back to a single-attachment framebuffer bound to the first color target."
+                );
+                rtWrapper._framebuffer = this._engine.createFrameBuffer(
+                    colorHandles[0],
+                    width,
+                    height,
+                    generateStencilBuffer,
+                    generateDepthBuffer || generateDepthTexture,
+                    samples
+                );
+            }
         }
 
         rtWrapper._generateDepthBuffer = generateDepthBuffer || generateDepthTexture;


### PR DESCRIPTION
Paired native PR: BabylonJS/BabylonNative#1754

## What

Foundational native-engine surface so `MultiRenderTarget`, the reverse depth buffer, and the
order-independent-transparency (depth-peeling) renderer stop dereferencing the null `_gl` context.
This removes several distinct crash classes. It does **not** by itself turn the MRT/OIT/FrameGraph
validation tests green — those need further work (see Follow-ups).

## Changes (`packages/dev/core/src/Engines`)

- **`thinNativeEngine.pure.ts`**
  - `createMultipleRenderTarget` + the MRT helper overrides: `bindAttachments`, `buildTextureLayout`,
    `restoreSingleAttachment`/`restoreSingleAttachmentForRenderTarget`, `generateMipMapsMultiFramebuffer`,
    `resolveMultiFramebuffer`, `unBindMultiColorAttachmentFramebuffer`,
    `updateMultipleRenderTargetTextureSampleCount`. bgfx writes every color attachment of the bound
    framebuffer, so the WebGL `drawBuffers` / MSAA-resolve plumbing becomes no-ops on Native. Reports
    `drawBuffersExtension = true`.
  - `clear()`: implement the reverse depth buffer (clear depth to 0 + `GEQUAL`) instead of throwing.
  - `applyStates()`: override so it flushes the depth-culling state through the native command path —
    the base implementation drives the null `_gl` directly, which crashed callers that mutate
    `engine.depthCullingState` then call `applyStates()` (e.g. the OIT depth-peeling renderer).
- **`Native/nativeHelpers.ts` / `nativeInterfaces.ts`**: map alpha modes `ALPHA_ONEONE_ONEONE` and
  `ALPHA_LAYER_ACCUMULATE` to the native engine, and declare `createMultiFrameBuffer`.

## Backward compatibility (feature detection)

`createMultiFrameBuffer` and the two OIT alpha constants only exist on a Babylon Native binary that
carries the paired #1754. They are declared **optional** on the native interface and feature-detected
at runtime, so this PR runs against the currently-published native **without** a protocol/version bump:

- `createMultiFrameBuffer` absent → `Logger.Warn` + fall back to a single-attachment `createFrameBuffer`
  bound to the first color target.
- `ALPHA_ONEONE_ONEONE` / `ALPHA_LAYER_ACCUMULATE` absent → warn once + fall back to `ALPHA_ONEONE`.

This is also what fixes the previously-red **"Native tests (experimental)"** CI job, which pulls the
BabylonNative *master* Playground (no #1754): before the guards it hit `createMultiFrameBuffer is not a
function` / an `undefined` alpha mode, the harness exited on the first failure, and the step's retries
blew the job timeout. With the guards the MRT/OIT scenes degrade gracefully instead of crashing.

## Paired native PR

Pairs with the BabylonNative C++ change (the shared `CreateFrameBufferImpl` framebuffer helper + the two
alpha blend modes). Thanks to the feature detection above, this JS PR can land **before** #1754.

## Follow-ups (not in this PR)

- OIT depth-peeling (`thinDepthPeelingRenderer`) still faults inside the D3D11 driver on `submit`
  (a multi-output / SRV↔RTV ping-pong state the driver rejects); needs interactive GPU debugging.
- The blend **equation** (e.g. `MAX`) is not yet applied on Native (`setAlphaEquation` is a no-op),
  so OIT blending would still be incorrect once the crash is resolved.

## Testing

- `nx run babylonjs:build` (full `tsc -b` + rollup + declaration) and ESLint pass.
- Against native **with** #1754: built `babylon.max.js` and ran the BabylonNative Playground suite
  (D3D11). MRT, reverse-Z, and the depth-peeling setup no longer crash with `COLOR_ATTACHMENT0` /
  `reverse depth buffer` / `depthMask of undefined` / `Unsupported alpha mode`. No regressions in
  existing 2D render-target tests.
- Against native **without** #1754: the feature-detection guards keep those same scenes from throwing —
  they warn and degrade to a single-attachment framebuffer + `ALPHA_ONEONE`.

---

## Related PRs & landing order

- **Babylon.js (engine / TS):** https://github.com/BabylonJS/Babylon.js/pull/18568
- **BabylonNative (C++ engine):** https://github.com/BabylonJS/BabylonNative/pull/1754

These two are co-dependent. With the feature-detection guards, **#18568 no longer hard-requires the
native side** and can merge independently:
1. **Babylon.js #18568 first** — adds native-engine TS overrides, changes no WebGL behavior, re-enables
   no validation tests on its own, and degrades gracefully on native that predates #1754.
2. A **`babylonjs` npm release** ships that TS change.
3. **BabylonNative #1754 last** — after bumping the bundled `babylonjs` to that release. (This
   foundational pair does not yet turn the MRT/OIT/FrameGraph tests green — that is separate follow-up
   work.)
