### PR TITLE
Visualization: in-memory round-trip for Serialize-without-materials test

### DIFF
--- a/packages/tools/tests/test/visualization/config.json
+++ b/packages/tools/tests/test/visualization/config.json
@@ -2603,7 +2603,7 @@
         },
         {
             "title": "Serialize scene without materials",
-            "playgroundId": "#PH4DEZ#1",
+            "playgroundId": "#PH4DEZ#4",
             "referenceImage": "serializeWithoutMaterials.png",
             "dependsOn": ["Meshes", "Serializers"]
         },


### PR DESCRIPTION
## Summary

Repoints the **Serialize scene without materials** visualization test (`#PH4DEZ#1` -> `#PH4DEZ#4`).

The previous revision's only DOM usage was a file *download* (`createElement('a')` + `createEvent` + `link.dispatchEvent`) with no visual effect. `#PH4DEZ#4` instead performs a real in-memory serialization round-trip:

1. serialize the sphere hierarchy with `SceneSerializer.SerializeMesh`;
2. reload it via `SceneLoader.ImportMeshAsync(null, "", "data:" + json, scene)`;
3. render the **deserialized** scene.

This actually validates serialization correctness (not just that it doesn't throw), modeled on the glTF serializer round-trip `#KU72PX`. The browser-only `.babylon` download is kept but guarded on `document.createEvent`, so it is skipped where the DOM isn't available.

Motivation: the same shared snippet is used by BabylonNative's visual suite, which has no DOM. The round-trip lets both web and native run the test without faking DOM APIs. Mirrors BabylonNative PR BabylonJS/BabylonNative#1708.

## Visual impact

The rendered scene is unchanged (same sphere hierarchy), so the `serializeWithoutMaterials.png` reference is expected to still match — the BabylonNative side validates against the same reference with the new revision (248 px diff, well within tolerance). No reference image regeneration is included; CI's Playwright run will confirm.