### PR TITLE
Fix(GreasedLine): guard grl_offsets behind GREASED_LINE_USE_OFFSETS in GLSL shaders (match WGSL)

### DIFF
--- a/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts
+++ b/packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts
@@ -13,7 +13,9 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
         const obj: any = {
             CUSTOM_VERTEX_DEFINITIONS: `
                 attribute float grl_widths;
-                attribute vec3 grl_offsets;
+                #ifdef GREASED_LINE_USE_OFFSETS
+                    attribute vec3 grl_offsets;
+                #endif
                 attribute float grl_colorPointers;
                 varying float grlCounters;
                 varying float grlColorPointer;
@@ -33,11 +35,16 @@ export function GetCustomCode(shaderType: string, cameraFacing: boolean): Nullab
                 #endif
                 `,
             CUSTOM_VERTEX_UPDATE_POSITION: `
-                #ifdef GREASED_LINE_CAMERA_FACING
+                #ifdef GREASED_LINE_USE_OFFSETS
                     vec3 grlPositionOffset = grl_offsets;
+                #else
+                    vec3 grlPositionOffset = vec3(0.);
+                #endif
+
+                #ifdef GREASED_LINE_CAMERA_FACING
                     positionUpdated += grlPositionOffset;
                 #else
-                    positionUpdated = (positionUpdated + grl_offsets) + (grl_slopes * grl_widths);
+                    positionUpdated = (positionUpdated + grlPositionOffset) + (grl_slopes * grl_widths);
                 #endif
                 `,
             CUSTOM_VERTEX_MAIN_END: `

--- a/packages/dev/core/src/Shaders/greasedLine.vertex.fx
+++ b/packages/dev/core/src/Shaders/greasedLine.vertex.fx
@@ -2,7 +2,9 @@ precision highp float;
 #include<instancesDeclaration>
 
 attribute float grl_widths;
+#ifdef GREASED_LINE_USE_OFFSETS
 attribute vec3 grl_offsets;
+#endif
 attribute float grl_colorPointers;
 attribute vec3 position;
 uniform mat4 viewProjection;
@@ -44,7 +46,12 @@ void main() {
         grlCounters = grl_nextAndCounters.w;
         float grlWidth = grlBaseWidth * grl_widths;
 
-        vec3 positionUpdated = position + grl_offsets;
+        #ifdef GREASED_LINE_USE_OFFSETS
+            vec3 grlPositionOffset = grl_offsets;
+        #else
+            vec3 grlPositionOffset = vec3(0.);
+        #endif
+        vec3 positionUpdated = position + grlPositionOffset;
         vec3 worldDir = normalize(grlNext - grlPrevious);
         vec3 nearPosition = positionUpdated + (worldDir * 0.01);
         vec4 grlFinalPosition = grlMatrix * vec4( positionUpdated , 1.0);
@@ -69,7 +76,12 @@ void main() {
         gl_Position = grlFinalPosition;
     #else
         grlCounters = grl_counters;
-        vec4 grlFinalPosition = grlMatrix * vec4( (position + grl_offsets) + grl_slopes * grl_widths , 1.0 ) ;
+        #ifdef GREASED_LINE_USE_OFFSETS
+            vec3 grlPositionOffset = grl_offsets;
+        #else
+            vec3 grlPositionOffset = vec3(0.);
+        #endif
+        vec4 grlFinalPosition = grlMatrix * vec4( (position + grlPositionOffset) + grl_slopes * grl_widths , 1.0 ) ;
         gl_Position = grlFinalPosition;
     #endif
 }


### PR DESCRIPTION
## What

Guard the `grl_offsets` vertex attribute behind `#ifdef GREASED_LINE_USE_OFFSETS` in the **GLSL** GreasedLine shaders, so it is only declared/used when the line actually has offsets. This matches what the **WGSL** shaders already do.

Affected files:
- `packages/dev/core/src/Materials/GreasedLine/greasedLinePluginMaterialShadersGLSL.ts`
- `packages/dev/core/src/Shaders/greasedLine.vertex.fx`

## Why

The GLSL GreasedLine shaders declare and use `attribute vec3 grl_offsets` **unconditionally**, even though the `grl_offsets` buffer is only created when the mesh has offsets (`GreasedLineBaseMesh._createOffsetsBuffer`, called from `set offsets`). The `GREASED_LINE_USE_OFFSETS` define is already computed (`GreasedLinePluginMaterial.prepareDefines`: `defines.GREASED_LINE_USE_OFFSETS = !!mesh.offsets`, and the simple material sets it too) — the GLSL shaders just don't consume it.

The WGSL shaders **do** guard it, because WebGPU pipeline validation rejects a vertex attribute that is declared in the shader but not bound — i.e. WebGPU *requires* this guard:

```wgsl
// ShadersWGSL/greasedLine.vertex.fx  +  greasedLinePluginMaterialShadersWGSL.ts
#ifdef GREASED_LINE_USE_OFFSETS
    attribute grl_offsets: vec3f;
#endif
...
#ifdef GREASED_LINE_USE_OFFSETS
    var grlPositionOffset: vec3f = input.grl_offsets;
#else
    var grlPositionOffset = vec3f(0.);
#endif
positionUpdated += grlPositionOffset;
```

This PR brings the GLSL path in line with the WGSL path.

### Why it matters (the symptom)

When a GreasedLine has no offsets (the common case) the `grl_offsets` buffer is never created. On **WebGL** this happens to work, because an *unbound* vertex attribute reads the constant default `(0,0,0,1)`, so `position + grl_offsets == position`. But that behavior is not guaranteed elsewhere:

- **WebGPU**: can't even reach this state — declaring an unbound attribute fails pipeline validation (hence the existing guard).
- **Babylon Native (bgfx: D3D11 / Metal / Vulkan)**: an attribute declared by the shader but missing from all bound vertex streams is **not** zero-defaulted — bgfx aliases it to the last bound stream, so `grl_offsets` reads unrelated vertex data and corrupts `positionUpdated += grl_offsets`. The result is shifted lines and distorted/faceted wide lines.

Relying on WebGL's lenient unbound-attribute default is the underlying issue; guarding the attribute (as WGSL already does) is the correct, backend-agnostic fix.

## Validation

Reproduced with the GreasedLine validation tests on Babylon Native (D3D11), Playgrounds `#H1LRZ3#103` (basic) and `#H1LRZ3#101` (simple material). Pixel comparison vs the reference images (240,000 px, 2.5% tolerance ≈ 6,000 px):

| Test | Before (unconditional `grl_offsets`) | After (this guard) |
|---|---|---|
| GreasedLine - basic (plugin material) | 33,212 px differ ❌ | **2,361 px ✅** |
| GreasedLine - simple material | 20,494 px differ ❌ | **1,479 px ✅** |

No change expected on WebGL (already zero-defaults the unbound attribute) or WebGPU (already guarded).
