### PR TITLE
ci: raise native visualization tests timeout to 35 minutes

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -777,7 +777,7 @@ jobs:
       dependsOn:
           - Build
           - FormatLint
-      timeoutInMinutes: 15
+      timeoutInMinutes: 35
       pool:
           vmImage: windows-latest
       steps:


### PR DESCRIPTION
## What

Raise the `timeoutInMinutes` of the **Native tests (experimental)** job in `.azure-pipelines/ci-monorepo.yml` from **15** to **35**.

## Why

The job downloads the prebuilt BabylonNative nightly Playground and runs the full `validation_native.js` visualization suite (~290 active tests). On the CI agent each test runs roughly **~3x slower** than local hardware, so the suite needs about **14–16 minutes** of wall time plus ~1.5 min of script-load/startup.

With the old 15-minute budget, even a **clean, crash-free run** was cancelled mid-suite. In a recent run the suite reached **~285 of ~290 tests** (it was rendering "Particles - Helper - Sun") before the 15-minute timeout terminated the batch job — only a handful of tests short of finishing.

A use-after-free crash in the native texture upload path (fixed upstream in BabylonNative) previously masked this: the crash forced a full-suite relaunch that always blew the budget. Now that the crash is gone, the suite nearly fits — it just needs a slightly larger budget.

Raising the timeout to **35 minutes** provides comfortable headroom for CI variance. For reference, the sibling native unit-tests job already uses `timeoutInMinutes: 45`.

## Scope

One-line CI configuration change. No product/source code is affected.