### PR TITLE
Fix: strip type-only re-exports from generated namespace declarations

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -365,9 +365,13 @@ function GetPackageDeclaration(
 
         //Exclude import statements
         excludeLine = excludeLine || /^import[ (]/.test(line);
-        excludeLine = excludeLine || /export \{/.test(line);
+        // The optional "type " modifier covers type-only re-exports (e.g. `export type { Foo } from "..."`,
+        // `export type * from "..."`). These must be stripped from the namespace output: an `export ... from`
+        // statement left inside `declare namespace BABYLON` turns it into an export context, which breaks the
+        // declaration merging of augmented classes/interfaces (TS2395) and corrupts the public namespace types.
+        excludeLine = excludeLine || /export (?:type )?\{/.test(line);
         excludeLine = excludeLine || /export default/.test(line);
-        excludeLine = excludeLine || /export \* from "/.test(line);
+        excludeLine = excludeLine || /export (?:type )?\* from "/.test(line);
         excludeLine = excludeLine || /^declare type (.*) import/.test(line);
 
         const match = line.match(/(\s*)declare module "(.*)" \{/);

--- a/packages/dev/buildTools/test/unit/generateDeclaration.test.ts
+++ b/packages/dev/buildTools/test/unit/generateDeclaration.test.ts
@@ -1,0 +1,98 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { generateCombinedDeclaration } from "../../src/generateDeclaration";
+
+/**
+ * Regression coverage for the UMD/namespace declaration generation.
+ *
+ * The generator strips ES re-export statements out of the global `BABYLON`
+ * namespace declaration. A re-export left inside `declare namespace BABYLON`
+ * turns the namespace into an export context, which breaks declaration merging
+ * of augmented classes/interfaces (TS2395) and strips augmented members from
+ * the public namespace types (see forum report 63631).
+ *
+ * The tree-shaking refactor introduced type-only re-exports
+ * (`export type * from "..."` / `export type { ... } from "..."`) that the
+ * original exclusion regexes did not catch. These tests lock in that all
+ * re-export variants are excluded from the namespace output while real
+ * declarations are preserved.
+ */
+describe("generateCombinedDeclaration namespace re-export stripping", () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+        // The generator keys module naming off a "/dist" path segment.
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bjs-gendecl-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const writeDeclarationFile = (contents: string): string => {
+        const fileDir = path.join(tempDir, "core", "dist", "Meshes");
+        fs.mkdirSync(fileDir, { recursive: true });
+        const filePath = path.join(fileDir, "meshUVSpaceRenderer.d.ts");
+        fs.writeFileSync(filePath, contents);
+        return filePath;
+    };
+
+    it("excludes type-only re-exports from the namespace declaration", () => {
+        const filePath = writeDeclarationFile(
+            [
+                "export declare class MeshUVSpaceRenderer {",
+                "    isReady(): boolean;",
+                "}",
+                'export * from "./meshUVSpaceRenderer.pure";',
+                'export type * from "./meshUVSpaceRenderer.types";',
+                'export type { IMeshUVSpaceRendererOptions } from "./meshUVSpaceRenderer.types";',
+            ].join("\n")
+        );
+
+        const { namespaceDeclaration } = generateCombinedDeclaration([filePath], {
+            devPackageName: "core",
+            declarationLibs: ["@dev/core"],
+        });
+
+        // The real declaration must survive.
+        expect(namespaceDeclaration).toContain("class MeshUVSpaceRenderer");
+        // No re-export statement may leak into the ambient namespace.
+        expect(namespaceDeclaration).not.toContain("export * from");
+        expect(namespaceDeclaration).not.toContain("export type * from");
+        expect(namespaceDeclaration).not.toContain("export type {");
+        expect(namespaceDeclaration).not.toMatch(/from\s+["']\.\/meshUVSpaceRenderer/);
+    });
+
+    it("keeps augmented interfaces mergeable by not leaking a re-export between them", () => {
+        // Mirrors the real failure: an augmentation interface, a leaked type
+        // re-export, then another augmentation. The re-export must be removed so
+        // both interfaces stay in the same (mergeable) namespace context.
+        const filePath = writeDeclarationFile(
+            [
+                "export declare class MeshUVSpaceRenderer {",
+                "    isReady(): boolean;",
+                "}",
+                "interface Scene {",
+                "    firstAugmentation: number;",
+                "}",
+                'export type * from "./meshUVSpaceRenderer.types";',
+                "interface Scene {",
+                "    secondAugmentation: number;",
+                "}",
+            ].join("\n")
+        );
+
+        const { namespaceDeclaration } = generateCombinedDeclaration([filePath], {
+            devPackageName: "core",
+            declarationLibs: ["@dev/core"],
+        });
+
+        expect(namespaceDeclaration).toContain("firstAugmentation");
+        expect(namespaceDeclaration).toContain("secondAugmentation");
+        expect(namespaceDeclaration).not.toContain("export type * from");
+    });
+});


### PR DESCRIPTION
## Problem

Reported on the forum: [Version 9.12.0 Is Broken On Playground](https://forum.babylonjs.com/t/63631).

On 9.12.0, the default Playground shows a red TypeScript error on `new BABYLON.Scene(engine)`, and TypeScript library builds against `@babylonjs/core` fail with errors like:

- `Property 'physicsBody' does not exist on type 'TransformNode'`
- `Argument of type 'BABYLON.Scene' is not assignable to parameter of type 'Scene'. Type 'Scene' is missing the following properties from type 'Scene': _pointerOverSprite, _pickedDownSprite, ... and 86 more`
- The same pattern for `Engine` / `AbstractEngine`, `Effect`, `Mesh`, `Observable`, etc.

9.11.0 was fine, so this is a regression.

## Root cause

The declaration generator (`generateDeclaration.ts`) strips ES re-export statements out of the global `BABYLON` namespace declaration. Its exclusion list covered `export * from "..."`, `export { ... }`, and `export default`, but **not the type-only variants** `export type * from "..."` and `export type { ... } from "..."`.

Those type-only re-exports were introduced by the tree-shaking `.types.ts` refactor (e.g. `meshUVSpaceRenderer.ts` → `export type * from "./meshUVSpaceRenderer.types"`). When even one `export ... from` statement is left inside `declare namespace BABYLON`, it turns the namespace into an **export context**, which breaks TypeScript declaration merging of augmented classes/interfaces. The shipped `babylon.d.ts` (served as the Playground's namespace types and consumed via `@babylonjs/core`) ended up with **89 `TS2395` ("Individual declarations in merged declaration must be all exported or all local")** errors (0 on 9.11.0), causing `BABYLON.Scene`, `TransformNode`, `Engine`, etc. to lose all their augmented members.

## Fix

Broaden the two exclusion regexes in `GetPackageDeclaration` to also match the optional `type ` modifier:

- `/export \{/` → `/export (?:type )?\{/`
- `/export \* from "/` → `/export (?:type )?\* from "/`

## Validation

Against declarations regenerated from source:

- Namespace `TS2395` count: **89 → 0**
- `BABYLON.Scene` re-merges all 29 declarations; augmented members (`_pointerOverSprite`, `spriteManagers`, `createDefaultLight`, `TransformNode.physicsBody`, …) are present again
- Playground (namespace) and `import * as BABYLON` (module) consumer repros both type-check cleanly
- `gui` / `loaders` / `serializers` / `materials` namespace portions: 0 leaked re-exports

## Tests

Adds `packages/dev/buildTools/test/unit/generateDeclaration.test.ts` — a regression test that feeds a declaration file containing `export type * from "..."` / `export type { ... } from "..."` through `generateCombinedDeclaration` and asserts those re-exports are excluded from the namespace output while real declarations and augmentation interfaces are preserved. Confirmed to fail without the fix and pass with it.