### PR TITLE
chore(deps-dev): bump vite from 6.4.2 to 6.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21229,7 +21229,7 @@
                 "@dev/serializers": "1.0.0",
                 "@tools/accessibility": "1.0.0",
                 "@vitejs/plugin-react": "^4.4.1",
-                "vite": "^6.4.2"
+                "vite": "^6.4.3"
             }
         },
         "packages/tools/eslintBabylonPlugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "typedoc": "^0.28.16",
                 "typescript": "~6.0.2",
                 "typescript-eslint": "^8.58.2",
-                "vite": "6.4.2",
+                "vite": "6.4.3",
                 "vitest": "^4.1.3"
             },
             "engines": {
@@ -18723,9 +18723,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -20892,7 +20892,7 @@
                 "rollup-plugin-dts": "^6.1.1",
                 "rollup-plugin-minify-template-literals": "^1.1.7",
                 "sonda": "^0.11.1",
-                "vite": "6.4.2"
+                "vite": "6.4.3"
             },
             "peerDependencies": {
                 "@babylonjs/core": "^9.0.0",
@@ -22258,7 +22258,7 @@
                 "rollup": "^4.59.0",
                 "rollup-plugin-minify-template-literals": "^1.1.7",
                 "rollup-plugin-visualizer": "^5.12.0",
-                "vite": "6.4.2"
+                "vite": "6.4.3"
             }
         },
         "packages/tools/viewer-configurator": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "typedoc": "^0.28.16",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
-        "vite": "6.4.2",
+        "vite": "6.4.3",
         "vitest": "^4.1.3"
     },
     "workspaces": [

--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -49,7 +49,7 @@
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-minify-template-literals": "^1.1.7",
         "sonda": "^0.11.1",
-        "vite": "6.4.2"
+        "vite": "6.4.3"
     },
     "keywords": [
         "3D",

--- a/packages/tools/devHost/package.json
+++ b/packages/tools/devHost/package.json
@@ -25,7 +25,7 @@
         "@dev/serializers": "1.0.0",
         "@tools/accessibility": "1.0.0",
         "@vitejs/plugin-react": "^4.4.1",
-        "vite": "^6.4.2"
+        "vite": "^6.4.3"
     },
     "sideEffects": true
 }

--- a/packages/tools/viewer/package.json
+++ b/packages/tools/viewer/package.json
@@ -40,6 +40,6 @@
         "rollup": "^4.59.0",
         "rollup-plugin-minify-template-literals": "^1.1.7",
         "rollup-plugin-visualizer": "^5.12.0",
-        "vite": "6.4.2"
+        "vite": "6.4.3"
     }
 }


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Bumps `vite` from `6.4.2` to `6.4.3` across the viewer packages to address two security advisories flagged by `npm audit`:

- **vite: `server.fs.deny` bypass on Windows alternate paths** ([GHSA-fx2h-pf6j-xcff](https://github.com/advisories/GHSA-fx2h-pf6j-xcff))
- **launch-editor: NTLMv2 hash disclosure via UNC path handling on Windows** ([GHSA-v6wh-96g9-6wx3](https://github.com/advisories/GHSA-v6wh-96g9-6wx3))

### Changes
- `package.json`, `packages/tools/viewer/package.json`, `packages/public/@babylonjs/viewer/package.json`: bump `vite` devDependency to `6.4.3`
- `package-lock.json`: regenerated

### Validation
- `npm audit` no longer reports the two advisories above.
- Built `@tools/viewer` and `@babylonjs/viewer`; output is **byte-for-byte identical** to the 6.4.2 build (verified by SHA-256 hashing all 1669 `lib/` + `dist/` files before and after). Vite is only used by the dev `serve` script, not the build output.

> Note: a separate `esbuild` advisory remains on the Vite 6.x line and would require a major Vite 8 upgrade — out of scope for this patch.
