### PR TITLE
Reject shared scene loader failures

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -715,7 +715,7 @@ async function loadDataAsync(
         };
 
         const engine = scene.getEngine();
-        let canUseOfflineSupport = engine.enableOfflineSupport;
+        let canUseOfflineSupport = !fileInfo.file && !fileInfo.rawData && engine.enableOfflineSupport;
         if (canUseOfflineSupport) {
             // Also check for exceptions
             let exceptionFound = false;
@@ -1079,23 +1079,28 @@ async function loadSceneSharedAsync(
     pluginOptions?: PluginOptions
 ): Promise<Scene> {
     return await new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        loadSceneImplAsync(
-            rootUrl,
-            sceneFilename,
-            engine,
-            (scene) => {
-                resolve(scene);
-            },
-            onProgress,
-            (scene, message, exception) => {
-                // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                reject(exception || new Error(message));
-            },
-            pluginExtension,
-            name,
-            pluginOptions
-        );
+        try {
+            loadSceneImplAsync(
+                rootUrl,
+                sceneFilename,
+                engine,
+                (scene) => {
+                    resolve(scene);
+                },
+                onProgress,
+                (scene, message, exception) => {
+                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+                    reject(exception || new Error(message));
+                },
+                pluginExtension,
+                name,
+                pluginOptions
+                // eslint-disable-next-line github/no-then
+            ).catch(reject);
+        } catch (error) {
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+            reject(error);
+        }
     });
 }
 

--- a/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
+++ b/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
@@ -1172,6 +1172,34 @@ test.describe("Babylon Scene Loader", function () {
             expect(assertionData).toBe(true);
         });
 
+        test("File object bypasses offline provider", async () => {
+            const assertionData = await page.evaluate(async () => {
+                const glb = await BABYLON.Tools.LoadFileAsync("https://playground.babylonjs.com/scenes/BoomBox.glb", true);
+                const engine = window.engine!;
+                const oldEnableOfflineSupport = engine.enableOfflineSupport;
+                const oldOfflineProviderFactory = BABYLON.AbstractEngine.OfflineProviderFactory;
+                let offlineProviderFactoryCalls = 0;
+                let loadedScene: BABYLON.Scene | undefined;
+
+                BABYLON.AbstractEngine.OfflineProviderFactory = (() => {
+                    offlineProviderFactoryCalls++;
+                    throw new Error("Offline provider should not be used for File sources.");
+                }) as typeof BABYLON.AbstractEngine.OfflineProviderFactory;
+                engine.enableOfflineSupport = true;
+
+                try {
+                    loadedScene = await BABYLON.SceneLoader.LoadAsync("", new File([glb], "BoomBox.glb"), engine);
+                    return { loaded: !!loadedScene, offlineProviderFactoryCalls };
+                } finally {
+                    loadedScene?.dispose();
+                    BABYLON.AbstractEngine.OfflineProviderFactory = oldOfflineProviderFactory;
+                    engine.enableOfflineSupport = oldEnableOfflineSupport;
+                }
+            });
+            expect(assertionData.loaded).toBe(true);
+            expect(assertionData.offlineProviderFactoryCalls).toBe(0);
+        });
+
         test("File url (Babylon Native)", async () => {
             const assertionData = await page.evaluate(() => {
                 const urlRedirects = {


### PR DESCRIPTION
## Summary

This fixes two `LoadAsync` failure paths in the shared scene loader wrapper:

- `loadSceneSharedAsync` now rejects if `loadSceneImplAsync` throws synchronously or rejects asynchronously.
- `File` and raw-data scene sources bypass offline support setup.

The offline bypass is general, not Babylon Native-specific: offline providers are URL/request cache providers. A `File` object or raw data buffer is already supplied by the caller and is not a URL-backed request that should go through manifest/offline-cache lookup. Routing those in-memory inputs through the offline provider can throw or hang before the loader plugin gets the actual content.

## Validation

- `prettier --check packages/dev/core/src/Loading/sceneLoader.ts packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts`
- `nx build babylonjs --outputStyle=static`

I added an integration test that enables offline support, installs an offline provider factory that throws, and verifies loading a `File` object succeeds without invoking the factory.
