### PR TITLE
Fix NullEngine uniform-buffer accessor for UMD

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.pure.ts
+++ b/packages/dev/core/src/Engines/nullEngine.pure.ts
@@ -85,6 +85,7 @@ export class NullEngineOptions {
  */
 export class NullEngine extends Engine {
     private _options: NullEngineOptions;
+    private _supportsUniformBuffers = false;
 
     /**
      * Gets a boolean indicating that the engine is running in deterministic lock step mode
@@ -122,7 +123,7 @@ export class NullEngine extends Engine {
      * implies WebGL2, which always supports uniform buffers.
      */
     public override get supportsUniformBuffers(): boolean {
-        return !!this._options?.enableMultiview || super.supportsUniformBuffers;
+        return !!this._options?.enableMultiview || this._supportsUniformBuffers;
     }
 
     public constructor(options: NullEngineOptions = new NullEngineOptions()) {


### PR DESCRIPTION
Fixes the lint failure introduced after #18576 by removing `super.supportsUniformBuffers` from the `NullEngine.supportsUniformBuffers` accessor. The UMD ES5 target can miscompile `super` property reads inside accessors, and the new `babylonjs/no-super-in-accessor` rule correctly flags that pattern.

Validation:
- `npx eslint --quiet packages/dev/core/src/Engines/nullEngine.pure.ts packages/dev/core/test/unit/Engines/nullEngine.test.ts`
- `npm run check:treeshaking`
- `npm run compile:assets -w @dev/core && npm run compile:source -w @dev/core`
- `npx vitest run packages/dev/core/test/unit/Engines/nullEngine.test.ts`