### PR TITLE
NullEngine: avoid super in supportsUniformBuffers accessor (fix no-super-in-accessor lint)

### DIFF
--- a/packages/dev/core/src/Engines/nullEngine.pure.ts
+++ b/packages/dev/core/src/Engines/nullEngine.pure.ts
@@ -122,7 +122,11 @@ export class NullEngine extends Engine {
      * implies WebGL2, which always supports uniform buffers.
      */
     public override get supportsUniformBuffers(): boolean {
-        return !!this._options?.enableMultiview || super.supportsUniformBuffers;
+        // Inlined from the base ThinEngine getter (`this.webGLVersion > 1 && !this.disableUniformBuffers`)
+        // instead of reading `super.supportsUniformBuffers`: `super` inside a decorated accessor
+        // mis-compiles to `undefined` in the ES5 UMD bundle (it works in dev/ESM). See the
+        // `babylonjs/no-super-in-accessor` lint rule.
+        return !!this._options?.enableMultiview || (this.webGLVersion > 1 && !this.disableUniformBuffers);
     }
 
     public constructor(options: NullEngineOptions = new NullEngineOptions()) {


### PR DESCRIPTION
## What

Fixes the `babylonjs/no-super-in-accessor` lint error that is currently **red on `master`**:

```
packages/dev/core/src/Engines/nullEngine.pure.ts(125,52): error babylonjs/no-super-in-accessor:
super.supportsUniformBuffers inside a get/set accessor mis-compiles to `undefined` in the UMD build
```

The `NullEngine.supportsUniformBuffers` getter read `super.supportsUniformBuffers`. `super` inside a decorated accessor downlevels to `undefined` in the ES5 UMD bundle (it works in dev/ESM), which is exactly what the `no-super-in-accessor` rule guards against.

## Fix

Inline the base `ThinEngine` getter expression (`this.webGLVersion > 1 && !this.disableUniformBuffers`) instead of calling `super.supportsUniformBuffers`. Behavior is identical — it reads the same live properties the base getter reads — and it no longer uses `super` inside the accessor. (`super` in a normal method/constructor is fine; only accessors are affected.)

```ts
public override get supportsUniformBuffers(): boolean {
    return !!this._options?.enableMultiview || (this.webGLVersion > 1 && !this.disableUniformBuffers);
}
```

## How this reached `master` (root cause)

This is a **semantic merge skew** between two PRs that were open at the same time — neither PR's CI ever tested the combination:

| When (UTC) | Event |
|---|---|
| 2026-06-15 20:44 | **#18580** "Fix camera frozen in UMD build" merges — it **adds** the `no-super-in-accessor` rule (and fixes the then-existing violations, e.g. `TargetCamera`). |
| 2026-06-15 20:53–21:02 | **#18576** "Add NullEngine multiview render-state testability" runs its `Format, Lint, and more` check and **passes** ✅ — but its merge base **does not contain #18580's rule** (the two branches were diverged). So its lint ran *without* the new rule. |
| 2026-06-16 08:00 | **#18576** merges on that green-but-stale CI, introducing the `super.supportsUniformBuffers` getter. |
| now | `master` = rule (#18580) **+** violation (#18576) → lint **red**. |

Because the repo doesn't require a PR branch to be up to date with the absolute-latest `master` before merging, #18576 merged against a base snapshot that predated #18580. Re-running #18576 against post-#18580 `master` (e.g. `Update branch` / rebase) would have caught this before merge.

## Verification

- One-line behavior-preserving change; `super` removed from the accessor, so `no-super-in-accessor` no longer triggers.
- Unblocks `master` and every open PR currently inheriting this repo-wide lint failure.
