### PR TITLE
Rework SceneLoader and add unit tests

### DIFF
--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -325,13 +325,18 @@ interface ISceneLoaderPluginInternal {
 }
 
 /**
+ * A concrete (non-factory) SceneLoader plugin, which may be synchronous or asynchronous and may expose internal members.
+ */
+type SceneLoaderPlugin = (ISceneLoaderPlugin | ISceneLoaderPluginAsync) & Partial<ISceneLoaderPluginInternal>;
+
+/**
  * Defines a plugin registered by the SceneLoader
  */
 interface IRegisteredPlugin {
     /**
      * Defines the plugin to use
      */
-    plugin: ((ISceneLoaderPlugin | ISceneLoaderPluginAsync) & Partial<ISceneLoaderPluginInternal>) | ISceneLoaderPluginFactory;
+    plugin: SceneLoaderPlugin | ISceneLoaderPluginFactory;
     /**
      * Defines if the plugin supports binary data
      */
@@ -559,22 +564,105 @@ function formatErrorMessage(fileInfo: IFileInfo, message?: string, exception?: a
     return errorMessage;
 }
 
+/**
+ * The plugin instance and the loaded data produced by loadDataAsync.
+ */
+type LoadedPluginData = {
+    plugin: SceneLoaderPlugin;
+    data: unknown;
+    responseURL?: string;
+};
+
+function createLoadError(fileInfo: IFileInfo, message?: string, exception?: any): RuntimeError {
+    const errorMessage = formatErrorMessage(fileInfo, message, exception);
+    return new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception);
+}
+
+function getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+// Converts an error into a SceneLoader RuntimeError, leaving an already-wrapped SceneLoader error untouched
+// so that it is not double-wrapped (which would duplicate the "Unable to load from ..." prefix).
+function toLoadError(fileInfo: IFileInfo, error: unknown): RuntimeError {
+    return error instanceof RuntimeError && error.errorCode === ErrorCodes.SceneLoaderError ? error : createLoadError(fileInfo, getErrorMessage(error), error);
+}
+
+const loadAssetContainerNotSupportedMessage = "LoadAssetContainer is not supported by this plugin. Plugin did not provide a loadAssetContainer or loadAssetContainerAsync method.";
+
+// A synchronous plugin exposes the synchronous import/load methods; an asynchronous plugin exposes the *Async methods.
+function isSyncPlugin(plugin: SceneLoaderPlugin): plugin is ISceneLoaderPlugin & Partial<ISceneLoaderPluginInternal> {
+    const candidate = plugin as Partial<ISceneLoaderPlugin>;
+    return !!candidate.importMesh || !!candidate.load || !!candidate.loadAssetContainer;
+}
+
+// Adapts a synchronous ISceneLoaderPlugin into an ISceneLoaderPluginAsync so that callers can use a single
+// promise-based code path regardless of whether the underlying plugin is synchronous or asynchronous.
+// Asynchronous plugins are returned unchanged. The synchronous plugin reports failure via an onError callback
+// and/or a falsy return value; both are translated into a rejected promise.
+function toAsyncPlugin(plugin: SceneLoaderPlugin, fileInfo: IFileInfo): ISceneLoaderPluginAsync {
+    if (!isSyncPlugin(plugin)) {
+        return plugin;
+    }
+
+    const runSync = <T>(invoke: (onError: (message?: string, exception?: any) => void) => T): NonNullable<T> => {
+        let pluginError: { message?: string; exception?: any } | undefined;
+        const result = invoke((message, exception) => {
+            pluginError = { message, exception };
+        });
+        if (!result) {
+            throw createLoadError(fileInfo, pluginError?.message, pluginError?.exception);
+        }
+        return result;
+    };
+
+    return {
+        name: plugin.name,
+        extensions: plugin.extensions,
+        importMeshAsync: async (meshesNames, scene, data, rootUrl) => {
+            const meshes: AbstractMesh[] = [];
+            const particleSystems: IParticleSystem[] = [];
+            const skeletons: Skeleton[] = [];
+            runSync((onError) => plugin.importMesh(meshesNames, scene, data, rootUrl, meshes, particleSystems, skeletons, onError));
+            return { meshes, particleSystems, skeletons, animationGroups: [], transformNodes: [], geometries: [], lights: [], spriteManagers: [] };
+        },
+        loadAsync: async (scene, data, rootUrl) => {
+            runSync((onError) => plugin.load(scene, data, rootUrl, onError));
+        },
+        loadAssetContainerAsync: async (scene, data, rootUrl) => {
+            return runSync((onError) => plugin.loadAssetContainer(scene, data, rootUrl, onError));
+        },
+    };
+}
+
+// Wraps a user supplied progress callback so that an exception thrown by it is logged rather than
+// aborting the entire loading operation.
+function wrapProgress(onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined): ((event: ISceneLoaderProgressEvent) => void) | undefined {
+    if (!onProgress) {
+        return undefined;
+    }
+
+    return (event: ISceneLoaderProgressEvent) => {
+        try {
+            onProgress(event);
+        } catch (error) {
+            Logger.Warn("Error in onProgress callback: " + getErrorMessage(error));
+        }
+    };
+}
+
 async function loadDataAsync(
     fileInfo: IFileInfo,
     scene: Scene,
-    onSuccess: (plugin: ISceneLoaderPlugin | ISceneLoaderPluginAsync, data: unknown, responseURL?: string) => void,
     onProgress: ((event: ISceneLoaderProgressEvent) => void) | undefined,
-    onError: (message?: string, exception?: any) => void,
-    onDispose: () => void,
     pluginExtension: Nullable<string>,
     name: string,
     pluginOptions: PluginOptions
-): Promise<Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>> {
+): Promise<LoadedPluginData> {
     const directLoad = getDirectLoad(fileInfo.url);
 
     if (fileInfo.rawData && !pluginExtension) {
-        // eslint-disable-next-line no-throw-literal
-        throw "When using ArrayBufferView to load data the file extension must be provided.";
+        throw new Error("When using ArrayBufferView to load data the file extension must be provided.");
     }
 
     const fileExtension = !directLoad && !pluginExtension ? getFilenameExtension(fileInfo.url) : "";
@@ -591,7 +679,6 @@ async function loadDataAsync(
             const response = await _FetchAsync(fileInfo.url, { method: "HEAD", responseHeaders: ["Content-Type"] });
             const mimeType = response.headerValues ? response.headerValues["Content-Type"] : "";
             if (mimeType) {
-                // eslint-disable-next-line require-atomic-updates
                 registeredPlugin = getPluginForMimeType(mimeType);
             }
         }
@@ -610,78 +697,48 @@ async function loadDataAsync(
     }
 
     if (fileInfo.rawData && !registeredPlugin.isBinary) {
-        // eslint-disable-next-line no-throw-literal
-        throw "Loading from ArrayBufferView can not be used with plugins that don't support binary loading.";
+        throw new Error("Loading from ArrayBufferView can not be used with plugins that don't support binary loading.");
     }
 
-    const getPluginInstance = (callback: (plugin: (ISceneLoaderPlugin | ISceneLoaderPluginAsync) & Partial<ISceneLoaderPluginInternal>) => void) => {
-        // For plugin factories, the plugin is instantiated on each SceneLoader operation. This makes options handling
-        // much simpler as we can just pass the options to the factory, rather than passing options through to every possible
-        // plugin call. Given this, options are only supported for plugins that provide a factory function.
-        if (IsFactory(registeredPlugin.plugin)) {
-            const pluginFactory = registeredPlugin.plugin;
-            const partialPlugin = pluginFactory.createPlugin((pluginOptions ?? {}) as SceneLoaderPluginOptions);
-            if (partialPlugin instanceof Promise) {
-                // eslint-disable-next-line github/no-then
-                partialPlugin.then(callback).catch((error) => {
-                    onError("Error instantiating plugin.", error);
-                });
-                // When async factories are used, the plugin instance cannot be returned synchronously.
-                // In this case, the legacy loader functions will return null.
-                return null;
-            } else {
-                callback(partialPlugin);
-                return partialPlugin;
-            }
-        } else {
-            callback(registeredPlugin.plugin);
-            return registeredPlugin.plugin;
+    // For plugin factories, the plugin is instantiated on each SceneLoader operation. This makes options handling
+    // much simpler as we can just pass the options to the factory, rather than passing options through to every possible
+    // plugin call. Given this, options are only supported for plugins that provide a factory function.
+    let plugin: SceneLoaderPlugin;
+    if (IsFactory(registeredPlugin.plugin)) {
+        const pluginFactory = registeredPlugin.plugin;
+        try {
+            plugin = await pluginFactory.createPlugin((pluginOptions ?? {}) as SceneLoaderPluginOptions);
+        } catch (error) {
+            throw createLoadError(fileInfo, "Error instantiating plugin.", error);
         }
-    };
+    } else {
+        plugin = registeredPlugin.plugin;
+    }
 
-    return getPluginInstance((plugin) => {
-        if (!plugin) {
-            // eslint-disable-next-line no-throw-literal
-            throw `The loader plugin corresponding to the '${pluginExtension}' file type has not been found. If using es6, please import the plugin you wish to use before.`;
-        }
+    if (!plugin) {
+        throw new Error(`The loader plugin corresponding to the '${pluginExtension}' file type has not been found. If using es6, please import the plugin you wish to use before.`);
+    }
 
-        onPluginActivatedObservable.notifyObservers(plugin);
+    onPluginActivatedObservable.notifyObservers(plugin);
 
-        // Check if we have a direct load url. If the plugin is registered to handle
-        // it or it's not a base64 data url, then pass it through the direct load path.
-        if (directLoad && ((plugin.canDirectLoad && plugin.canDirectLoad(fileInfo.url)) || !IsBase64DataUrl(fileInfo.url))) {
-            if (plugin.directLoad) {
-                const result = plugin.directLoad(scene, directLoad);
-                if (result instanceof Promise) {
-                    result
-                        // eslint-disable-next-line github/no-then
-                        .then((data: unknown) => {
-                            onSuccess(plugin, data);
-                        })
-                        // eslint-disable-next-line github/no-then
-                        .catch((error: any) => {
-                            onError("Error in directLoad of _loadData: " + error, error);
-                        });
-                } else {
-                    onSuccess(plugin, result);
-                }
-            } else {
-                onSuccess(plugin, directLoad);
+    // Check if we have a direct load url. If the plugin is registered to handle
+    // it or it's not a base64 data url, then pass it through the direct load path.
+    if (directLoad && ((plugin.canDirectLoad && plugin.canDirectLoad(fileInfo.url)) || !IsBase64DataUrl(fileInfo.url))) {
+        if (plugin.directLoad) {
+            let data: unknown;
+            try {
+                data = await plugin.directLoad(scene, directLoad);
+            } catch (error) {
+                throw createLoadError(fileInfo, "Error in directLoad of _loadData: " + error, error);
             }
-            return;
+            return { plugin, data };
         }
+        return { plugin, data: directLoad };
+    }
 
-        const useArrayBuffer = registeredPlugin.isBinary;
+    const useArrayBuffer = registeredPlugin.isBinary;
 
-        const dataCallback = (data: unknown, responseURL?: string) => {
-            if (scene.isDisposed) {
-                onError("Scene has been disposed");
-                return;
-            }
-
-            onSuccess(plugin, data, responseURL);
-        };
-
+    return await new Promise<LoadedPluginData>((resolve, reject) => {
         let request: Nullable<IFileRequest> = null;
         let pluginDisposed = false;
         plugin.onDisposeObservable?.add(() => {
@@ -692,8 +749,17 @@ async function loadDataAsync(
                 request = null;
             }
 
-            onDispose();
+            reject(createLoadError(fileInfo, "Loading was aborted because the plugin was disposed."));
         });
+
+        const dataCallback = (data: unknown, responseURL?: string) => {
+            if (scene.isDisposed) {
+                reject(createLoadError(fileInfo, "Scene has been disposed"));
+                return;
+            }
+
+            resolve({ plugin, data, responseURL });
+        };
 
         const manifestChecked = () => {
             if (pluginDisposed) {
@@ -701,21 +767,27 @@ async function loadDataAsync(
             }
 
             const errorCallback = (request?: WebRequest, exception?: LoadFileError) => {
-                onError(request?.statusText, exception);
+                reject(createLoadError(fileInfo, request?.statusText, exception));
             };
 
             if (!plugin.loadFile && fileInfo.rawData) {
-                // eslint-disable-next-line no-throw-literal
-                throw "Plugin does not support loading ArrayBufferView.";
+                reject(createLoadError(fileInfo, "Plugin does not support loading ArrayBufferView."));
+                return;
             }
 
-            request = plugin.loadFile
-                ? plugin.loadFile(scene, fileInfo.rawData || fileInfo.file || fileInfo.url, fileInfo.rootUrl, dataCallback, onProgress, useArrayBuffer, errorCallback, name)
-                : scene._loadFile(fileInfo.file || fileInfo.url, dataCallback, onProgress, true, useArrayBuffer, errorCallback);
+            try {
+                request = plugin.loadFile
+                    ? plugin.loadFile(scene, fileInfo.rawData || fileInfo.file || fileInfo.url, fileInfo.rootUrl, dataCallback, onProgress, useArrayBuffer, errorCallback, name)
+                    : scene._loadFile(fileInfo.file || fileInfo.url, dataCallback, onProgress, true, useArrayBuffer, errorCallback);
+            } catch (error) {
+                reject(createLoadError(fileInfo, undefined, error));
+            }
         };
 
         const engine = scene.getEngine();
-        let canUseOfflineSupport = engine.enableOfflineSupport;
+        // File objects and raw data buffers are already in-memory and are not URL-backed requests, so they must
+        // not be routed through the offline (manifest/cache) provider.
+        let canUseOfflineSupport = !fileInfo.file && !fileInfo.rawData && engine.enableOfflineSupport;
         if (canUseOfflineSupport) {
             // Also check for exceptions
             let exceptionFound = false;
@@ -731,7 +803,11 @@ async function loadDataAsync(
 
         if (canUseOfflineSupport && AbstractEngine.OfflineProviderFactory) {
             // Checking if a manifest file has been set for this scene and if offline mode has been requested
-            scene.offlineProvider = AbstractEngine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
+            try {
+                scene.offlineProvider = AbstractEngine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
+            } catch (error) {
+                reject(createLoadError(fileInfo, undefined, error));
+            }
         } else {
             manifestChecked();
         }
@@ -856,192 +932,74 @@ export function GetRegisteredSceneLoaderPluginMetadata(): DeepImmutable<
  */
 export async function ImportMeshAsync(source: SceneSource, scene: Scene, options?: ImportMeshOptions): Promise<ISceneLoaderAsyncResult> {
     const { meshNames, rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return await importMeshAsyncCoreAsync(meshNames, rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+    return await importMeshCoreAsync(meshNames, rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
 }
 
-async function importMeshAsync(
+async function importMeshCoreAsync(
     meshNames: string | readonly string[] | null | undefined,
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-    onSuccess: Nullable<SceneLoaderSuccessCallback> = null,
-    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-    pluginExtension: Nullable<string> = null,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
     name = "",
     pluginOptions: PluginOptions = {}
-): Promise<Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>> {
+): Promise<ISceneLoaderAsyncResult> {
     if (!scene) {
-        Logger.Error("No scene available to import mesh to");
-        return null;
+        throw new Error("No scene available to import mesh to");
     }
 
     const fileInfo = GetFileInfo(rootUrl, sceneFilename);
     if (!fileInfo) {
-        return null;
+        throw new Error("Cannot load file: a valid scene filename or root url was not provided.");
     }
 
     const loadingToken = {};
     scene.addPendingData(loadingToken);
 
-    const disposeHandler = () => {
-        scene.removePendingData(loadingToken);
-    };
+    const progressHandler = wrapProgress(onProgress);
 
-    const errorHandler = (message?: string, exception?: any) => {
-        const errorMessage = formatErrorMessage(fileInfo, message, exception);
+    try {
+        const { plugin, data, responseURL } = await loadDataAsync(fileInfo, scene, progressHandler, pluginExtension ?? null, name, pluginOptions);
 
-        if (onError) {
-            onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
-        } else {
-            Logger.Error(errorMessage);
-            // should the exception be thrown?
+        if (plugin.rewriteRootURL) {
+            fileInfo.rootUrl = plugin.rewriteRootURL(fileInfo.rootUrl, responseURL);
         }
 
-        disposeHandler();
-    };
+        let result: ISceneLoaderAsyncResult;
+        try {
+            result = await toAsyncPlugin(plugin, fileInfo).importMeshAsync(meshNames, scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name);
+        } catch (error) {
+            throw toLoadError(fileInfo, error);
+        }
 
-    const progressHandler = onProgress
-        ? (event: ISceneLoaderProgressEvent) => {
-              try {
-                  onProgress(event);
-              } catch (e) {
-                  errorHandler("Error in onProgress callback: " + e, e);
-              }
-          }
-        : undefined;
-
-    const successHandler: SceneLoaderSuccessCallback = (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
+        // eslint-disable-next-line require-atomic-updates
+        scene.loadingPluginName = plugin.name;
         scene.importedMeshesFiles.push(fileInfo.url);
 
-        if (onSuccess) {
-            try {
-                onSuccess(meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers);
-            } catch (e) {
-                errorHandler("Error in onSuccess callback: " + e, e);
-            }
-        }
-
+        return result;
+    } finally {
         scene.removePendingData(loadingToken);
-    };
-
-    return await loadDataAsync(
-        fileInfo,
-        scene,
-        (plugin, data, responseURL) => {
-            if (plugin.rewriteRootURL) {
-                fileInfo.rootUrl = plugin.rewriteRootURL(fileInfo.rootUrl, responseURL);
-            }
-
-            if ((plugin as ISceneLoaderPlugin).importMesh) {
-                const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                const meshes: AbstractMesh[] = [];
-                const particleSystems: IParticleSystem[] = [];
-                const skeletons: Skeleton[] = [];
-
-                if (!syncedPlugin.importMesh(meshNames, scene, data, fileInfo.rootUrl, meshes, particleSystems, skeletons, errorHandler)) {
-                    return;
-                }
-
-                scene.loadingPluginName = plugin.name;
-                successHandler(meshes, particleSystems, skeletons, [], [], [], [], []);
-            } else {
-                const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
-                asyncedPlugin
-                    .importMeshAsync(meshNames, scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
-                    // eslint-disable-next-line github/no-then
-                    .then((result) => {
-                        scene.loadingPluginName = plugin.name;
-                        successHandler(
-                            result.meshes,
-                            result.particleSystems,
-                            result.skeletons,
-                            result.animationGroups,
-                            result.transformNodes,
-                            result.geometries,
-                            result.lights,
-                            result.spriteManagers
-                        );
-                    })
-                    // eslint-disable-next-line github/no-then
-                    .catch((error) => {
-                        errorHandler(error.message, error);
-                    });
-            }
-        },
-        progressHandler,
-        errorHandler,
-        disposeHandler,
-        pluginExtension,
-        name,
-        pluginOptions
-    );
-}
-
-async function importMeshAsyncCoreAsync(
-    meshNames: string | readonly string[] | null | undefined,
-    rootUrl: string,
-    sceneFilename?: SceneSource,
-    scene?: Nullable<Scene>,
-    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-    pluginExtension?: Nullable<string>,
-    name?: string,
-    pluginOptions?: PluginOptions
-): Promise<ISceneLoaderAsyncResult> {
-    return await new Promise((resolve, reject) => {
-        try {
-            importMeshAsync(
-                meshNames,
-                rootUrl,
-                sceneFilename,
-                scene,
-                (meshes, particleSystems, skeletons, animationGroups, transformNodes, geometries, lights, spriteManagers) => {
-                    resolve({
-                        meshes: meshes,
-                        particleSystems: particleSystems,
-                        skeletons: skeletons,
-                        animationGroups: animationGroups,
-                        transformNodes: transformNodes,
-                        geometries: geometries,
-                        lights: lights,
-                        spriteManagers: spriteManagers,
-                    });
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-                // eslint-disable-next-line github/no-then
-            ).catch(reject);
-        } catch (error) {
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-            reject(error);
-        }
-    });
+    }
 }
 
 // This is the core implementation of load scene
-async function loadSceneImplAsync(
+async function loadSceneCoreAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     engine: Nullable<AbstractEngine> = EngineStore.LastCreatedEngine,
-    onSuccess: Nullable<(scene: Scene) => void> = null,
-    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-    pluginExtension: Nullable<string> = null,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
     name = "",
     pluginOptions: PluginOptions = {}
-): Promise<void> {
+): Promise<Scene> {
     if (!engine) {
-        Tools.Error("No engine available");
-        return;
+        throw new Error("No engine available");
     }
 
-    await appendSceneImplAsync(rootUrl, sceneFilename, new Scene(engine), onSuccess, onProgress, onError, pluginExtension, name, pluginOptions);
+    const scene = new Scene(engine);
+    await appendSceneCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name, pluginOptions);
+    return scene;
 }
 
 /**
@@ -1053,7 +1011,7 @@ async function loadSceneImplAsync(
  */
 export async function LoadSceneAsync(source: SceneSource, engine: AbstractEngine, options?: LoadOptions): Promise<Scene> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return await loadSceneSharedAsync(rootUrl, source, engine, onProgress, pluginExtension, name, pluginOptions);
+    return await loadSceneCoreAsync(rootUrl, source, engine, onProgress, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1068,65 +1026,27 @@ export async function loadSceneAsync(source: SceneSource, engine: AbstractEngine
     return await LoadSceneAsync(source, engine, options);
 }
 
-// This function is shared between the new module level loadSceneAsync and the legacy SceneLoader.LoadAsync
-async function loadSceneSharedAsync(
-    rootUrl: string,
-    sceneFilename?: SceneSource,
-    engine?: Nullable<AbstractEngine>,
-    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-    pluginExtension?: Nullable<string>,
-    name?: string,
-    pluginOptions?: PluginOptions
-): Promise<Scene> {
-    return await new Promise((resolve, reject) => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        loadSceneImplAsync(
-            rootUrl,
-            sceneFilename,
-            engine,
-            (scene) => {
-                resolve(scene);
-            },
-            onProgress,
-            (scene, message, exception) => {
-                // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                reject(exception || new Error(message));
-            },
-            pluginExtension,
-            name,
-            pluginOptions
-        );
-    });
-}
-
 // This is the core implementation of append scene
-async function appendSceneImplAsync(
+async function appendSceneCoreAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-    onSuccess: Nullable<(scene: Scene) => void> = null,
-    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-    pluginExtension: Nullable<string> = null,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
     name = "",
     pluginOptions: PluginOptions = {}
-): Promise<Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>> {
+): Promise<Scene> {
     if (!scene) {
-        Logger.Error("No scene available to append to");
-        return null;
+        throw new Error("No scene available to append to");
     }
 
     const fileInfo = GetFileInfo(rootUrl, sceneFilename);
     if (!fileInfo) {
-        return null;
+        throw new Error("Cannot load file: a valid scene filename or root url was not provided.");
     }
 
     const loadingToken = {};
     scene.addPendingData(loadingToken);
-
-    const disposeHandler = () => {
-        scene.removePendingData(loadingToken);
-    };
 
     if (SceneLoaderFlags.ShowLoadingScreen && !showingLoadingScreen) {
         showingLoadingScreen = true;
@@ -1137,75 +1057,23 @@ async function appendSceneImplAsync(
         });
     }
 
-    const errorHandler = (message?: string, exception?: any) => {
-        const errorMessage = formatErrorMessage(fileInfo, message, exception);
+    const progressHandler = wrapProgress(onProgress);
 
-        if (onError) {
-            onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
-        } else {
-            Logger.Error(errorMessage);
-            // should the exception be thrown?
+    try {
+        const { plugin, data } = await loadDataAsync(fileInfo, scene, progressHandler, pluginExtension ?? null, name, pluginOptions);
+
+        try {
+            await toAsyncPlugin(plugin, fileInfo).loadAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name);
+        } catch (error) {
+            throw toLoadError(fileInfo, error);
         }
 
-        disposeHandler();
-    };
-
-    const progressHandler = onProgress
-        ? (event: ISceneLoaderProgressEvent) => {
-              try {
-                  onProgress(event);
-              } catch (e) {
-                  errorHandler("Error in onProgress callback", e);
-              }
-          }
-        : undefined;
-
-    const successHandler = () => {
-        if (onSuccess) {
-            try {
-                onSuccess(scene);
-            } catch (e) {
-                errorHandler("Error in onSuccess callback", e);
-            }
-        }
-
+        // eslint-disable-next-line require-atomic-updates
+        scene.loadingPluginName = plugin.name;
+        return scene;
+    } finally {
         scene.removePendingData(loadingToken);
-    };
-
-    return await loadDataAsync(
-        fileInfo,
-        scene,
-        (plugin, data) => {
-            if ((plugin as ISceneLoaderPlugin).load) {
-                const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                if (!syncedPlugin.load(scene, data, fileInfo.rootUrl, errorHandler)) {
-                    return;
-                }
-
-                scene.loadingPluginName = plugin.name;
-                successHandler();
-            } else {
-                const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
-                asyncedPlugin
-                    .loadAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
-                    // eslint-disable-next-line github/no-then
-                    .then(() => {
-                        scene.loadingPluginName = plugin.name;
-                        successHandler();
-                    })
-                    // eslint-disable-next-line github/no-then
-                    .catch((error) => {
-                        errorHandler(error.message, error);
-                    });
-            }
-        },
-        progressHandler,
-        errorHandler,
-        disposeHandler,
-        pluginExtension,
-        name,
-        pluginOptions
-    );
+    }
 }
 
 /**
@@ -1217,7 +1085,7 @@ async function appendSceneImplAsync(
  */
 export async function AppendSceneAsync(source: SceneSource, scene: Scene, options?: AppendOptions): Promise<void> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    await appendSceneSharedAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+    await appendSceneCoreAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1232,144 +1100,53 @@ export async function appendSceneAsync(source: SceneSource, scene: Scene, option
     return await AppendSceneAsync(source, scene, options);
 }
 
-// This function is shared between the new module level appendSceneAsync and the legacy SceneLoader.AppendAsync
-async function appendSceneSharedAsync(
-    rootUrl: string,
-    sceneFilename?: SceneSource,
-    scene?: Nullable<Scene>,
-    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-    pluginExtension?: Nullable<string>,
-    name?: string,
-    pluginOptions?: PluginOptions
-): Promise<Scene> {
-    return await new Promise((resolve, reject) => {
-        try {
-            appendSceneImplAsync(
-                rootUrl,
-                sceneFilename,
-                scene,
-                (scene) => {
-                    resolve(scene);
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-                // eslint-disable-next-line github/no-then
-            ).catch(reject);
-        } catch (error) {
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-            reject(error);
-        }
-    });
-}
-
 // This is the core implementation of load asset container
-async function loadAssetContainerImplAsync(
+async function loadAssetContainerCoreAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
-    onSuccess: Nullable<(assets: AssetContainer) => void> = null,
-    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-    pluginExtension: Nullable<string> = null,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
     name = "",
     pluginOptions: PluginOptions = {}
-): Promise<Nullable<ISceneLoaderPlugin | ISceneLoaderPluginAsync>> {
+): Promise<AssetContainer> {
     if (!scene) {
-        Logger.Error("No scene available to load asset container to");
-        return null;
+        throw new Error("No scene available to load asset container to");
     }
 
     const fileInfo = GetFileInfo(rootUrl, sceneFilename);
     if (!fileInfo) {
-        return null;
+        throw new Error("Cannot load file: a valid scene filename or root url was not provided.");
     }
 
     const loadingToken = {};
     scene.addPendingData(loadingToken);
 
-    const disposeHandler = () => {
-        scene.removePendingData(loadingToken);
-    };
+    const progressHandler = wrapProgress(onProgress);
 
-    const errorHandler = (message?: string, exception?: any) => {
-        const errorMessage = formatErrorMessage(fileInfo, message, exception);
+    try {
+        const { plugin, data } = await loadDataAsync(fileInfo, scene, progressHandler, pluginExtension ?? null, name, pluginOptions);
 
-        if (onError) {
-            onError(scene, errorMessage, new RuntimeError(errorMessage, ErrorCodes.SceneLoaderError, exception));
-        } else {
-            Logger.Error(errorMessage);
-            // should the exception be thrown?
+        const asyncPlugin = toAsyncPlugin(plugin, fileInfo);
+        if (!asyncPlugin.loadAssetContainerAsync) {
+            throw createLoadError(fileInfo, loadAssetContainerNotSupportedMessage);
         }
 
-        disposeHandler();
-    };
-
-    const progressHandler = onProgress
-        ? (event: ISceneLoaderProgressEvent) => {
-              try {
-                  onProgress(event);
-              } catch (e) {
-                  errorHandler("Error in onProgress callback", e);
-              }
-          }
-        : undefined;
-
-    const successHandler = (assets: AssetContainer) => {
-        if (onSuccess) {
-            try {
-                onSuccess(assets);
-            } catch (e) {
-                errorHandler("Error in onSuccess callback", e);
-            }
+        let assetContainer: AssetContainer;
+        try {
+            assetContainer = await asyncPlugin.loadAssetContainerAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name);
+        } catch (error) {
+            throw toLoadError(fileInfo, error);
         }
 
-        scene.removePendingData(loadingToken);
-    };
+        assetContainer.populateRootNodes();
+        // eslint-disable-next-line require-atomic-updates
+        scene.loadingPluginName = plugin.name;
 
-    return await loadDataAsync(
-        fileInfo,
-        scene,
-        (plugin, data) => {
-            if ((plugin as ISceneLoaderPlugin).loadAssetContainer) {
-                const syncedPlugin = <ISceneLoaderPlugin>plugin;
-                const assetContainer = syncedPlugin.loadAssetContainer(scene, data, fileInfo.rootUrl, errorHandler);
-                if (!assetContainer) {
-                    return;
-                }
-                assetContainer.populateRootNodes();
-                scene.loadingPluginName = plugin.name;
-                successHandler(assetContainer);
-            } else if ((plugin as ISceneLoaderPluginAsync).loadAssetContainerAsync) {
-                const asyncedPlugin = <ISceneLoaderPluginAsync>plugin;
-                asyncedPlugin
-                    .loadAssetContainerAsync(scene, data, fileInfo.rootUrl, progressHandler, fileInfo.name)
-                    // eslint-disable-next-line github/no-then
-                    .then((assetContainer) => {
-                        assetContainer.populateRootNodes();
-                        scene.loadingPluginName = plugin.name;
-                        successHandler(assetContainer);
-                    })
-                    // eslint-disable-next-line github/no-then
-                    .catch((error) => {
-                        errorHandler(error.message, error);
-                    });
-            } else {
-                errorHandler("LoadAssetContainer is not supported by this plugin. Plugin did not provide a loadAssetContainer or loadAssetContainerAsync method.");
-            }
-        },
-        progressHandler,
-        errorHandler,
-        disposeHandler,
-        pluginExtension,
-        name,
-        pluginOptions
-    );
+        return assetContainer;
+    } finally {
+        scene.removePendingData(loadingToken);
+    }
 }
 
 /**
@@ -1381,7 +1158,7 @@ async function loadAssetContainerImplAsync(
  */
 export async function LoadAssetContainerAsync(source: SceneSource, scene: Scene, options?: LoadAssetContainerOptions): Promise<AssetContainer> {
     const { rootUrl = "", onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    return await loadAssetContainerSharedAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
+    return await loadAssetContainerCoreAsync(rootUrl, source, scene, onProgress, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1396,60 +1173,21 @@ export async function loadAssetContainerAsync(source: SceneSource, scene: Scene,
     return await LoadAssetContainerAsync(source, scene, options);
 }
 
-// This function is shared between the new module level loadAssetContainerAsync and the legacy SceneLoader.LoadAssetContainerAsync
-async function loadAssetContainerSharedAsync(
-    rootUrl: string,
-    sceneFilename?: SceneSource,
-    scene?: Nullable<Scene>,
-    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-    pluginExtension?: Nullable<string>,
-    name?: string,
-    pluginOptions?: PluginOptions
-): Promise<AssetContainer> {
-    return await new Promise((resolve, reject) => {
-        try {
-            loadAssetContainerImplAsync(
-                rootUrl,
-                sceneFilename,
-                scene,
-                (assets) => {
-                    resolve(assets);
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-                // eslint-disable-next-line github/no-then
-            ).catch(reject);
-        } catch (error) {
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-            reject(error);
-        }
-    });
-}
-
 // This is the core implementation of import animations
-async function importAnimationsImplAsync(
+async function importAnimationsCoreAsync(
     rootUrl: string,
     sceneFilename: SceneSource = "",
     scene: Nullable<Scene> = EngineStore.LastCreatedScene,
     overwriteAnimations = true,
     animationGroupLoadingMode = SceneLoaderAnimationGroupLoadingMode.Clean,
     targetConverter: Nullable<(target: any) => any> = null,
-    onSuccess: Nullable<(scene: Scene) => void> = null,
-    onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> = null,
-    onError: Nullable<(scene: Scene, message: string, exception?: any) => void> = null,
-    pluginExtension: Nullable<string> = null,
+    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
+    pluginExtension?: Nullable<string>,
     name = "",
     pluginOptions: PluginOptions = {}
 ): Promise<void> {
     if (!scene) {
-        Logger.Error("No scene available to load animations to");
-        return;
+        throw new Error("No scene available to load animations to");
     }
 
     if (overwriteAnimations) {
@@ -1491,26 +1229,17 @@ async function importAnimationsImplAsync(
                 // nothing to do
                 break;
             default:
-                Logger.Error("Unknown animation group loading mode value '" + animationGroupLoadingMode + "'");
-                return;
+                throw new Error("Unknown animation group loading mode value '" + animationGroupLoadingMode + "'");
         }
     }
 
     const startingIndexForNewAnimatables = scene.animatables.length;
 
-    const onAssetContainerLoaded = (container: AssetContainer) => {
-        container.mergeAnimationsTo(scene, scene.animatables.slice(startingIndexForNewAnimatables), targetConverter);
+    const container = await loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name, pluginOptions);
 
-        container.dispose();
-
-        scene.onAnimationFileImportedObservable.notifyObservers(scene);
-
-        if (onSuccess) {
-            onSuccess(scene);
-        }
-    };
-
-    await loadAssetContainerImplAsync(rootUrl, sceneFilename, scene, onAssetContainerLoaded, onProgress, onError, pluginExtension, name, pluginOptions);
+    container.mergeAnimationsTo(scene, scene.animatables.slice(startingIndexForNewAnimatables), targetConverter);
+    container.dispose();
+    scene.onAnimationFileImportedObservable.notifyObservers(scene);
 }
 
 /**
@@ -1522,7 +1251,7 @@ async function importAnimationsImplAsync(
  */
 export async function ImportAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<void> {
     const { rootUrl = "", overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions } = options ?? {};
-    await importAnimationsSharedAsync(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
+    await importAnimationsCoreAsync(rootUrl, source, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name, pluginOptions);
 }
 
 /**
@@ -1535,48 +1264,6 @@ export async function ImportAnimationsAsync(source: SceneSource, scene: Scene, o
  */
 export async function importAnimationsAsync(source: SceneSource, scene: Scene, options?: ImportAnimationsOptions): Promise<void> {
     return await ImportAnimationsAsync(source, scene, options);
-}
-
-// This function is shared between the new module level importAnimationsAsync and the legacy SceneLoader.ImportAnimationsAsync
-async function importAnimationsSharedAsync(
-    rootUrl: string,
-    sceneFilename?: SceneSource,
-    scene?: Nullable<Scene>,
-    overwriteAnimations?: boolean,
-    animationGroupLoadingMode?: SceneLoaderAnimationGroupLoadingMode,
-    targetConverter?: Nullable<(target: any) => any>,
-    onProgress?: Nullable<(event: ISceneLoaderProgressEvent) => void>,
-    pluginExtension?: Nullable<string>,
-    name?: string,
-    pluginOptions?: PluginOptions
-): Promise<Scene> {
-    return await new Promise((resolve, reject) => {
-        try {
-            importAnimationsImplAsync(
-                rootUrl,
-                sceneFilename,
-                scene,
-                overwriteAnimations,
-                animationGroupLoadingMode,
-                targetConverter,
-                (scene) => {
-                    resolve(scene);
-                },
-                onProgress,
-                (scene, message, exception) => {
-                    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                    reject(exception || new Error(message));
-                },
-                pluginExtension,
-                name,
-                pluginOptions
-                // eslint-disable-next-line github/no-then
-            ).catch(reject);
-        } catch (error) {
-            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-            reject(error);
-        }
-    });
 }
 
 /**
@@ -1722,10 +1409,28 @@ export class SceneLoader {
         name?: string,
         pluginOptions?: PluginOptions
     ): void {
-        // eslint-disable-next-line github/no-then
-        importMeshAsync(meshNames, rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name, pluginOptions).catch((error) =>
-            onError?.(EngineStore.LastCreatedScene!, error?.message, error)
-        );
+        const reportScene = scene ?? EngineStore.LastCreatedScene;
+        void (async () => {
+            try {
+                const result = await importMeshCoreAsync(meshNames, rootUrl, sceneFilename, scene, onProgress, pluginExtension, name, pluginOptions);
+                onSuccess?.(
+                    result.meshes,
+                    result.particleSystems,
+                    result.skeletons,
+                    result.animationGroups,
+                    result.transformNodes,
+                    result.geometries,
+                    result.lights,
+                    result.spriteManagers
+                );
+            } catch (error) {
+                if (onError) {
+                    onError(reportScene!, getErrorMessage(error), error);
+                } else {
+                    Logger.Error(getErrorMessage(error));
+                }
+            }
+        })();
     }
 
     /**
@@ -1749,7 +1454,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<ISceneLoaderAsyncResult> {
-        return await importMeshAsyncCoreAsync(meshNames, rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+        return await importMeshCoreAsync(meshNames, rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1774,10 +1479,18 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        // eslint-disable-next-line github/no-then
-        loadSceneImplAsync(rootUrl, sceneFilename, engine, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
-            onError?.(EngineStore.LastCreatedScene!, error?.message, error)
-        );
+        void (async () => {
+            try {
+                const scene = await loadSceneCoreAsync(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
+                onSuccess?.(scene);
+            } catch (error) {
+                if (onError) {
+                    onError(EngineStore.LastCreatedScene!, getErrorMessage(error), error);
+                } else {
+                    Logger.Error(getErrorMessage(error));
+                }
+            }
+        })();
     }
 
     /**
@@ -1799,7 +1512,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<Scene> {
-        return await loadSceneSharedAsync(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
+        return await loadSceneCoreAsync(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1824,10 +1537,19 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        // eslint-disable-next-line github/no-then
-        appendSceneImplAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
-            onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error)
-        );
+        const reportScene = scene ?? EngineStore.LastCreatedScene;
+        void (async () => {
+            try {
+                const appendedScene = await appendSceneCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+                onSuccess?.(appendedScene);
+            } catch (error) {
+                if (onError) {
+                    onError(reportScene!, getErrorMessage(error), error);
+                } else {
+                    Logger.Error(getErrorMessage(error));
+                }
+            }
+        })();
     }
 
     /**
@@ -1849,7 +1571,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<Scene> {
-        return await appendSceneSharedAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+        return await appendSceneCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1874,10 +1596,19 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ) {
-        // eslint-disable-next-line github/no-then
-        loadAssetContainerImplAsync(rootUrl, sceneFilename, scene, onSuccess, onProgress, onError, pluginExtension, name).catch((error) =>
-            onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error)
-        );
+        const reportScene = scene ?? EngineStore.LastCreatedScene;
+        void (async () => {
+            try {
+                const assets = await loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+                onSuccess?.(assets);
+            } catch (error) {
+                if (onError) {
+                    onError(reportScene!, getErrorMessage(error), error);
+                } else {
+                    Logger.Error(getErrorMessage(error));
+                }
+            }
+        })();
     }
 
     /**
@@ -1899,7 +1630,7 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<AssetContainer> {
-        return await loadAssetContainerSharedAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
+        return await loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
     }
 
     /**
@@ -1930,20 +1661,19 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): void {
-        importAnimationsImplAsync(
-            rootUrl,
-            sceneFilename,
-            scene,
-            overwriteAnimations,
-            animationGroupLoadingMode,
-            targetConverter,
-            onSuccess,
-            onProgress,
-            onError,
-            pluginExtension,
-            name
-            // eslint-disable-next-line github/no-then
-        ).catch((error) => onError?.((scene ?? EngineStore.LastCreatedScene)!, error?.message, error));
+        const reportScene = scene ?? EngineStore.LastCreatedScene;
+        void (async () => {
+            try {
+                await importAnimationsCoreAsync(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
+                onSuccess?.(reportScene!);
+            } catch (error) {
+                if (onError) {
+                    onError(reportScene!, getErrorMessage(error), error);
+                } else {
+                    Logger.Error(getErrorMessage(error));
+                }
+            }
+        })();
     }
 
     /**
@@ -1977,6 +1707,8 @@ export class SceneLoader {
         pluginExtension?: Nullable<string>,
         name?: string
     ): Promise<Scene> {
-        return await importAnimationsSharedAsync(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
+        const targetScene = scene ?? EngineStore.LastCreatedScene;
+        await importAnimationsCoreAsync(rootUrl, sceneFilename, targetScene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
+        return targetScene!;
     }
 }

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -707,7 +707,10 @@ async function loadDataAsync(
     if (IsFactory(registeredPlugin.plugin)) {
         const pluginFactory = registeredPlugin.plugin;
         try {
-            plugin = await pluginFactory.createPlugin((pluginOptions ?? {}) as SceneLoaderPluginOptions);
+            // Only await when the factory is actually asynchronous, so that for synchronous factories the plugin is
+            // instantiated (and onPluginActivatedObservable is notified) synchronously within the calling load operation.
+            const createdPlugin = pluginFactory.createPlugin((pluginOptions ?? {}) as SceneLoaderPluginOptions);
+            plugin = createdPlugin instanceof Promise ? await createdPlugin : createdPlugin;
         } catch (error) {
             throw createLoadError(fileInfo, "Error instantiating plugin.", error);
         }

--- a/packages/dev/core/src/Loading/sceneLoader.ts
+++ b/packages/dev/core/src/Loading/sceneLoader.ts
@@ -635,6 +635,18 @@ function toAsyncPlugin(plugin: SceneLoaderPlugin, fileInfo: IFileInfo): ISceneLo
     };
 }
 
+// Reports a load failure to the legacy onError callback. The onError signature requires a Scene, but a scene
+// may not be available (e.g. the error occurred before any scene was created). In that case, fall back to
+// logging so the error handler does not throw a secondary error and mask the original failure.
+function reportLegacyLoadError(onError: Nullable<(scene: Scene, message: string, exception?: any) => void> | undefined, reportScene: Nullable<Scene>, error: unknown): void {
+    const message = getErrorMessage(error);
+    if (onError && reportScene) {
+        onError(reportScene, message, error);
+    } else {
+        Logger.Error(message);
+    }
+}
+
 // Wraps a user supplied progress callback so that an exception thrown by it is logged rather than
 // aborting the entire loading operation.
 function wrapProgress(onProgress: Nullable<(event: ISceneLoaderProgressEvent) => void> | undefined): ((event: ISceneLoaderProgressEvent) => void) | undefined {
@@ -744,7 +756,8 @@ async function loadDataAsync(
     return await new Promise<LoadedPluginData>((resolve, reject) => {
         let request: Nullable<IFileRequest> = null;
         let pluginDisposed = false;
-        plugin.onDisposeObservable?.add(() => {
+
+        const onDisposeObserver = plugin.onDisposeObservable?.add(() => {
             pluginDisposed = true;
 
             if (request) {
@@ -752,16 +765,31 @@ async function loadDataAsync(
                 request = null;
             }
 
-            reject(createLoadError(fileInfo, "Loading was aborted because the plugin was disposed."));
+            rejectAndCleanup(createLoadError(fileInfo, "Loading was aborted because the plugin was disposed."));
         });
+
+        // Ensure the onDispose observer is removed once the promise settles, so observers do not accumulate across loads.
+        const cleanup = () => {
+            if (onDisposeObserver) {
+                plugin.onDisposeObservable?.remove(onDisposeObserver);
+            }
+        };
+        const resolveAndCleanup = (value: LoadedPluginData) => {
+            cleanup();
+            resolve(value);
+        };
+        const rejectAndCleanup = (error: Error) => {
+            cleanup();
+            reject(error);
+        };
 
         const dataCallback = (data: unknown, responseURL?: string) => {
             if (scene.isDisposed) {
-                reject(createLoadError(fileInfo, "Scene has been disposed"));
+                rejectAndCleanup(createLoadError(fileInfo, "Scene has been disposed"));
                 return;
             }
 
-            resolve({ plugin, data, responseURL });
+            resolveAndCleanup({ plugin, data, responseURL });
         };
 
         const manifestChecked = () => {
@@ -770,11 +798,11 @@ async function loadDataAsync(
             }
 
             const errorCallback = (request?: WebRequest, exception?: LoadFileError) => {
-                reject(createLoadError(fileInfo, request?.statusText, exception));
+                rejectAndCleanup(createLoadError(fileInfo, request?.statusText, exception));
             };
 
             if (!plugin.loadFile && fileInfo.rawData) {
-                reject(createLoadError(fileInfo, "Plugin does not support loading ArrayBufferView."));
+                rejectAndCleanup(createLoadError(fileInfo, "Plugin does not support loading ArrayBufferView."));
                 return;
             }
 
@@ -783,7 +811,7 @@ async function loadDataAsync(
                     ? plugin.loadFile(scene, fileInfo.rawData || fileInfo.file || fileInfo.url, fileInfo.rootUrl, dataCallback, onProgress, useArrayBuffer, errorCallback, name)
                     : scene._loadFile(fileInfo.file || fileInfo.url, dataCallback, onProgress, true, useArrayBuffer, errorCallback);
             } catch (error) {
-                reject(createLoadError(fileInfo, undefined, error));
+                rejectAndCleanup(createLoadError(fileInfo, undefined, error));
             }
         };
 
@@ -809,7 +837,7 @@ async function loadDataAsync(
             try {
                 scene.offlineProvider = AbstractEngine.OfflineProviderFactory(fileInfo.url, manifestChecked, engine.disableManifestCheck);
             } catch (error) {
-                reject(createLoadError(fileInfo, undefined, error));
+                rejectAndCleanup(createLoadError(fileInfo, undefined, error));
             }
         } else {
             manifestChecked();
@@ -1001,7 +1029,13 @@ async function loadSceneCoreAsync(
     }
 
     const scene = new Scene(engine);
-    await appendSceneCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name, pluginOptions);
+    try {
+        await appendSceneCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name, pluginOptions);
+    } catch (error) {
+        // The scene was created here, so dispose it on failure to avoid leaking the partially loaded scene.
+        scene.dispose();
+        throw error;
+    }
     return scene;
 }
 
@@ -1427,11 +1461,7 @@ export class SceneLoader {
                     result.spriteManagers
                 );
             } catch (error) {
-                if (onError) {
-                    onError(reportScene!, getErrorMessage(error), error);
-                } else {
-                    Logger.Error(getErrorMessage(error));
-                }
+                reportLegacyLoadError(onError, reportScene, error);
             }
         })();
     }
@@ -1487,11 +1517,7 @@ export class SceneLoader {
                 const scene = await loadSceneCoreAsync(rootUrl, sceneFilename, engine, onProgress, pluginExtension, name);
                 onSuccess?.(scene);
             } catch (error) {
-                if (onError) {
-                    onError(EngineStore.LastCreatedScene!, getErrorMessage(error), error);
-                } else {
-                    Logger.Error(getErrorMessage(error));
-                }
+                reportLegacyLoadError(onError, EngineStore.LastCreatedScene, error);
             }
         })();
     }
@@ -1546,11 +1572,7 @@ export class SceneLoader {
                 const appendedScene = await appendSceneCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
                 onSuccess?.(appendedScene);
             } catch (error) {
-                if (onError) {
-                    onError(reportScene!, getErrorMessage(error), error);
-                } else {
-                    Logger.Error(getErrorMessage(error));
-                }
+                reportLegacyLoadError(onError, reportScene, error);
             }
         })();
     }
@@ -1605,11 +1627,7 @@ export class SceneLoader {
                 const assets = await loadAssetContainerCoreAsync(rootUrl, sceneFilename, scene, onProgress, pluginExtension, name);
                 onSuccess?.(assets);
             } catch (error) {
-                if (onError) {
-                    onError(reportScene!, getErrorMessage(error), error);
-                } else {
-                    Logger.Error(getErrorMessage(error));
-                }
+                reportLegacyLoadError(onError, reportScene, error);
             }
         })();
     }
@@ -1670,11 +1688,7 @@ export class SceneLoader {
                 await importAnimationsCoreAsync(rootUrl, sceneFilename, scene, overwriteAnimations, animationGroupLoadingMode, targetConverter, onProgress, pluginExtension, name);
                 onSuccess?.(reportScene!);
             } catch (error) {
-                if (onError) {
-                    onError(reportScene!, getErrorMessage(error), error);
-                } else {
-                    Logger.Error(getErrorMessage(error));
-                }
+                reportLegacyLoadError(onError, reportScene, error);
             }
         })();
     }

--- a/packages/dev/core/test/unit/Loading/sceneLoader.test.ts
+++ b/packages/dev/core/test/unit/Loading/sceneLoader.test.ts
@@ -441,6 +441,32 @@ describe("SceneLoader", () => {
             await promise.catch(() => {});
         });
 
+        // The scene created internally by LoadSceneAsync must be disposed when the load fails so that a
+        // partially loaded scene is not leaked.
+        it("disposes the newly created scene when the load fails", async () => {
+            const { name, extension } = nextPluginIdentity("loadscenedispose");
+            let createdScene: Scene | null = null;
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: (s) => {
+                    createdScene = s;
+                    return Promise.reject(new Error("load scene boom"));
+                },
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = LoadSceneAsync("data:dummy", engine, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+
+            expect(createdScene).not.toBeNull();
+            expect(createdScene!).not.toBe(scene);
+            expect(createdScene!.isDisposed).toBe(true);
+        });
+
         // Regression for https://github.com/BabylonJS/Babylon.js/pull/18584:
         // a disabled plugin causes loadDataAsync to throw, which loadSceneImplAsync rejects with.
         // loadSceneSharedAsync used a floating promise without a catch, so that rejection was swallowed
@@ -695,9 +721,8 @@ describe("SceneLoader", () => {
     });
 
     // A synchronous plugin can signal failure either by calling its onError argument or by returning false.
-    // When it returns false WITHOUT calling onError, the loading operation should still settle (reject) and
-    // must not leak pending data on the scene. These tests currently fail because the operation hangs forever
-    // and the pending data is never removed; they should pass once the loader is reworked.
+    // When it returns false WITHOUT calling onError, the loading operation still settles (reject) and must not
+    // leak pending data on the scene.
     describe("Sync plugin returns false without calling onError", () => {
         it("ImportMeshAsync rejects and clears pending data", async () => {
             const { name, extension } = nextPluginIdentity("importsilentfalse");
@@ -757,9 +782,7 @@ describe("SceneLoader", () => {
     });
 
     // When GetFileInfo returns null (for example, a rootUrl is set and the filename starts with "/"),
-    // the internal loader functions return early without ever invoking the success callback, so the
-    // promise-based public APIs never settle. They should reject on invalid input. These tests currently
-    // fail because the operation hangs forever; they should pass once the loader is reworked. Note that
+    // the operation rejects on the invalid input rather than leaving the promise unsettled. Note that
     // Tools.Error logs an error in this path, so it is silenced to keep the test output clean.
     describe("Invalid input (GetFileInfo returns null)", () => {
         beforeEach(() => {
@@ -791,9 +814,8 @@ describe("SceneLoader", () => {
         });
     });
 
-    // When a plugin is disposed mid-load (via its onDisposeObservable), the in-flight request is aborted and
-    // pending data is removed, but the loading promise is never settled. It should reject so callers are not
-    // left awaiting forever. This test currently fails because the operation hangs; it should pass once reworked.
+    // When a plugin is disposed mid-load (via its onDisposeObservable), the in-flight request is aborted,
+    // pending data is removed, and the loading promise rejects so callers are not left awaiting forever.
     describe("Plugin disposed mid-load", () => {
         it("AppendSceneAsync rejects and clears pending data when the plugin is disposed", async () => {
             const { name, extension } = nextPluginIdentity("appenddispose");
@@ -824,9 +846,8 @@ describe("SceneLoader", () => {
         });
     });
 
-    // An exception thrown by a user-supplied onProgress callback should not abort the whole load. Today the
-    // loader routes the exception to its error handler, which rejects the operation. The load should instead
-    // still succeed. This test currently fails (the operation rejects); it should pass once reworked.
+    // An exception thrown by a user-supplied onProgress callback does not abort the whole load. The loader
+    // (via wrapProgress) logs the exception and the load still succeeds.
     describe("Throwing onProgress callback", () => {
         it("ImportMeshAsync still resolves when onProgress throws", async () => {
             const { name, extension } = nextPluginIdentity("importprogressthrow");
@@ -876,9 +897,7 @@ describe("SceneLoader", () => {
             expect(onImported).toHaveBeenCalledWith(scene, expect.anything());
         });
 
-        // importAnimationsImplAsync returns early on an unrecognized animationGroupLoadingMode without ever
-        // calling onSuccess or onError, so the promise never settles. It should reject instead. This test
-        // currently fails (the operation hangs); it should pass once the loader is reworked.
+        // An unrecognized animationGroupLoadingMode rejects the operation instead of leaving the promise unsettled.
         it("rejects on an unknown animationGroupLoadingMode", async () => {
             vi.spyOn(console, "error").mockImplementation(() => {});
             const { name, extension } = nextPluginIdentity("animationsbadmode");
@@ -902,10 +921,9 @@ describe("SceneLoader", () => {
         });
     });
 
-    // Every internal loader function returns early (without settling) when no scene is available. Since scene
-    // defaults to EngineStore.LastCreatedScene, a null scene is a real runtime possibility. The operation
-    // should reject rather than hang. These tests currently fail (the operations hang); they should pass once
-    // the loader is reworked.
+    // Every internal loader function rejects when no scene is available. Since scene defaults to
+    // EngineStore.LastCreatedScene, a null scene is a real runtime possibility and the operation rejects
+    // rather than leaving the promise unsettled.
     describe("No scene available", () => {
         beforeEach(() => {
             vi.spyOn(console, "error").mockImplementation(() => {});
@@ -1089,10 +1107,8 @@ describe("SceneLoader", () => {
     });
 
     // The directLoad path can fail either by returning a rejected Promise or by throwing synchronously.
-    // Both should reject the operation AND clear pending data. Today the async rejection is routed through
-    // the loader's error handler (cleans up), but a synchronous throw propagates out of loadDataAsync
-    // bypassing the error handler, so pending data leaks. These two tests document that asymmetry: the
-    // async case passes today, the sync case fails until the loader is reworked.
+    // Both reject the operation AND clear pending data. These two tests cover both the asynchronous
+    // rejection and the synchronous throw, which are now handled consistently by loadDataAsync.
     describe("directLoad error timing", () => {
         it("rejects and clears pending data when directLoad rejects asynchronously", async () => {
             const { name, extension } = nextPluginIdentity("directloadasyncreject");
@@ -1131,7 +1147,7 @@ describe("SceneLoader", () => {
 
             const promise = AppendSceneAsync("data:payload", scene, { pluginExtension: extension });
             expect(await classifySettlement(promise)).toBe("rejected");
-            // Currently fails: the synchronous throw bypasses the error handler so pending data is leaked.
+            // The synchronous throw is handled by loadDataAsync, so pending data is cleared.
             expect(scene.getWaitingItemsCount()).toBe(0);
 
             await promise.catch(() => {});

--- a/packages/dev/core/test/unit/Loading/sceneLoader.test.ts
+++ b/packages/dev/core/test/unit/Loading/sceneLoader.test.ts
@@ -1,0 +1,1294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { AbstractEngine } from "core/Engines/abstractEngine";
+import { Scene } from "core/scene";
+import { Mesh } from "core/Meshes/mesh";
+import { AssetContainer } from "core/assetContainer";
+import { Observable } from "core/Misc/observable";
+
+import {
+    AppendSceneAsync,
+    GetRegisteredSceneLoaderPluginMetadata,
+    ImportAnimationsAsync,
+    ImportMeshAsync,
+    LoadAssetContainerAsync,
+    LoadSceneAsync,
+    RegisterSceneLoaderPlugin,
+    SceneLoader,
+    type ISceneLoaderAsyncResult,
+    type ISceneLoaderPlugin,
+    type ISceneLoaderPluginAsync,
+    type ISceneLoaderPluginFactory,
+    type ISceneLoaderProgressEvent,
+    type SceneLoaderPluginOptions,
+} from "core/Loading/sceneLoader";
+import { type IFileRequest } from "core/Misc/fileRequest";
+
+// A monotonically increasing counter so each test can register a plugin with a
+// unique extension/name. The SceneLoader keeps a module level registry that is
+// never cleared, so using unique identifiers keeps tests isolated from one another.
+let pluginCounter = 0;
+
+type TestPluginIdentity = {
+    name: string;
+    extension: string;
+};
+
+function nextPluginIdentity(prefix: string): TestPluginIdentity {
+    pluginCounter++;
+    return {
+        name: `${prefix}_${pluginCounter}`,
+        extension: `.${prefix}_${pluginCounter}`,
+    };
+}
+
+function createFileRequest(): IFileRequest {
+    return {
+        abort: () => {},
+        onCompleteObservable: new Observable<IFileRequest>(),
+    };
+}
+
+function createEmptyAsyncResult(overrides: Partial<ISceneLoaderAsyncResult> = {}): ISceneLoaderAsyncResult {
+    return {
+        meshes: [],
+        particleSystems: [],
+        skeletons: [],
+        animationGroups: [],
+        transformNodes: [],
+        geometries: [],
+        lights: [],
+        spriteManagers: [],
+        ...overrides,
+    };
+}
+
+// Classifies how a promise settles within a short window. Used to detect when a loading
+// operation hangs (never resolves nor rejects) instead of failing slowly via the test timeout.
+async function classifySettlement(promise: Promise<unknown>, timeoutMs = 250): Promise<"resolved" | "rejected" | "pending"> {
+    let timer: ReturnType<typeof setTimeout>;
+    const pending = new Promise<"pending">((resolve) => {
+        timer = setTimeout(() => resolve("pending"), timeoutMs);
+    });
+    const settled = promise.then(
+        () => "resolved" as const,
+        () => "rejected" as const
+    );
+    const result = await Promise.race([settled, pending]);
+    clearTimeout(timer!);
+    return result;
+}
+
+describe("SceneLoader", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+        vi.restoreAllMocks();
+    });
+
+    describe("Plugin registration", () => {
+        it("registers a plugin and reports availability by extension", () => {
+            const { name, extension } = nextPluginIdentity("reg");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+
+            RegisterSceneLoaderPlugin(plugin);
+
+            expect(SceneLoader.IsPluginForExtensionAvailable(extension)).toBe(true);
+            expect(SceneLoader.IsPluginForExtensionAvailable(".does-not-exist")).toBe(false);
+            expect(SceneLoader.GetPluginForExtension(extension)).toBe(plugin);
+        });
+
+        it("exposes registered plugin metadata", () => {
+            const { name, extension } = nextPluginIdentity("meta");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: { [extension]: { isBinary: false } },
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+
+            RegisterSceneLoaderPlugin(plugin);
+
+            const metadata = GetRegisteredSceneLoaderPluginMetadata();
+            const entry = metadata.find((m) => m.name === name);
+            expect(entry).toBeDefined();
+            expect(entry!.extensions).toEqual([{ extension, isBinary: false, mimeType: undefined }]);
+        });
+    });
+
+    describe("ImportMeshAsync", () => {
+        it("resolves with the results of an async plugin", async () => {
+            const { name, extension } = nextPluginIdentity("importasync");
+            const mesh = new Mesh("imported", scene);
+            const result = createEmptyAsyncResult({ meshes: [mesh] });
+
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(result),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loaded = await ImportMeshAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(loaded.meshes).toEqual([mesh]);
+            expect(scene.loadingPluginName).toBe(name);
+            expect(scene.importedMeshesFiles).toContain("data:dummy");
+        });
+
+        it("resolves with the results of a sync plugin", async () => {
+            const { name, extension } = nextPluginIdentity("importsync");
+
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: (_meshNames, s, _data, _rootUrl, meshes) => {
+                    meshes.push(new Mesh("syncImported", s));
+                    return true;
+                },
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loaded = await ImportMeshAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(loaded.meshes).toHaveLength(1);
+            expect(loaded.meshes[0].name).toBe("syncImported");
+            // The sync importMesh path supplies empty arrays for the remaining result fields.
+            expect(loaded.animationGroups).toEqual([]);
+        });
+
+        it("forwards progress events from the plugin to the caller", async () => {
+            const { name, extension } = nextPluginIdentity("importprogress");
+            const progressEvent: ISceneLoaderProgressEvent = { lengthComputable: true, loaded: 1, total: 2 };
+
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: (_meshNames, _s, _data, _rootUrl, onProgress) => {
+                    onProgress?.(progressEvent);
+                    return Promise.resolve(createEmptyAsyncResult());
+                },
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const onProgress = vi.fn();
+            await ImportMeshAsync("data:dummy", scene, { pluginExtension: extension, onProgress });
+
+            expect(onProgress).toHaveBeenCalledWith(progressEvent);
+        });
+
+        it("rejects when an async plugin rejects", async () => {
+            const { name, extension } = nextPluginIdentity("importreject");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.reject(new Error("boom")),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(ImportMeshAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("boom");
+        });
+
+        it("rejects when a sync plugin reports an error", async () => {
+            const { name, extension } = nextPluginIdentity("importsyncerror");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: (_meshNames, _s, _data, _rootUrl, _meshes, _ps, _sk, onError) => {
+                    onError?.("sync import failed");
+                    return false;
+                },
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(ImportMeshAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow(/sync import failed/);
+        });
+
+        it("rejects when an async plugin throws synchronously", async () => {
+            // The plugin method is declared to return a Promise but throws before returning one.
+            const { name, extension } = nextPluginIdentity("importsyncthrow");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => {
+                    throw new Error("sync throw from importMeshAsync");
+                },
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(ImportMeshAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("sync throw from importMeshAsync");
+        });
+
+        it("rejects when a sync plugin throws instead of calling onError", async () => {
+            const { name, extension } = nextPluginIdentity("importsyncpluginthrow");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => {
+                    throw new Error("sync throw from importMesh");
+                },
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(ImportMeshAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("sync throw from importMesh");
+        });
+    });
+
+    describe("AppendSceneAsync", () => {
+        it("appends using an async plugin", async () => {
+            const { name, extension } = nextPluginIdentity("appendasync");
+            const loadAsync = vi.fn(() => Promise.resolve());
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync,
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await AppendSceneAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(loadAsync).toHaveBeenCalledTimes(1);
+            expect(scene.loadingPluginName).toBe(name);
+        });
+
+        it("appends using a sync plugin", async () => {
+            const { name, extension } = nextPluginIdentity("appendsync");
+            const load = vi.fn(() => true);
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await AppendSceneAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(load).toHaveBeenCalledTimes(1);
+            expect(scene.loadingPluginName).toBe(name);
+        });
+
+        it("rejects when the async plugin rejects", async () => {
+            const { name, extension } = nextPluginIdentity("appendreject");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.reject(new Error("append boom")),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(AppendSceneAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("append boom");
+        });
+
+        it("rejects when the async plugin throws synchronously", async () => {
+            const { name, extension } = nextPluginIdentity("appendsyncthrow");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => {
+                    throw new Error("sync throw from loadAsync");
+                },
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(AppendSceneAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("sync throw from loadAsync");
+        });
+
+        it("rejects when a sync plugin throws instead of calling onError", async () => {
+            const { name, extension } = nextPluginIdentity("appendpluginthrow");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => {
+                    throw new Error("sync throw from load");
+                },
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(AppendSceneAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("sync throw from load");
+        });
+
+        it("rejects when the matched plugin is disabled", async () => {
+            // Guard for the asymmetry fixed in PR #18584: unlike LoadSceneAsync, the Append shared wrapper
+            // already rejects (rather than hangs) when loadDataAsync throws for a disabled plugin.
+            const { name, extension } = nextPluginIdentity("appenddisabled");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = AppendSceneAsync("data:dummy", scene, {
+                pluginExtension: extension,
+                pluginOptions: { [name]: { enabled: false } } as SceneLoaderPluginOptions,
+            });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("rejects with 'Scene has been disposed' when the scene is disposed mid load", async () => {
+            const { name, extension } = nextPluginIdentity("appenddisposed");
+            let deliverData: (() => void) | undefined;
+
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                loadFile: (_s, _fileOrUrl, _rootUrl, onSuccess) => {
+                    deliverData = () => onSuccess("dummy");
+                    return createFileRequest();
+                },
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            // Use a non data: url so the loadFile path (which checks for disposal) is exercised.
+            const promise = AppendSceneAsync("scene.bin", scene, { pluginExtension: extension });
+            expect(deliverData).toBeDefined();
+
+            scene.dispose();
+            deliverData!();
+
+            await expect(promise).rejects.toThrow(/Scene has been disposed/);
+        });
+    });
+
+    describe("LoadSceneAsync", () => {
+        it("creates and resolves a new scene", async () => {
+            const { name, extension } = nextPluginIdentity("loadscene");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loadedScene = await LoadSceneAsync("data:dummy", engine, { pluginExtension: extension });
+
+            expect(loadedScene).toBeInstanceOf(Scene);
+            expect(loadedScene).not.toBe(scene);
+            expect(loadedScene.loadingPluginName).toBe(name);
+
+            loadedScene.dispose();
+        });
+
+        // General coverage: LoadSceneAsync should reject when an async plugin rejects. This path already
+        // works today because the rejection flows through the loader's error handler.
+        it("rejects when the underlying load rejects", async () => {
+            const { name, extension } = nextPluginIdentity("loadscenereject");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.reject(new Error("load scene boom")),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = LoadSceneAsync("data:dummy", engine, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        // Regression for https://github.com/BabylonJS/Babylon.js/pull/18584:
+        // a disabled plugin causes loadDataAsync to throw, which loadSceneImplAsync rejects with.
+        // loadSceneSharedAsync used a floating promise without a catch, so that rejection was swallowed
+        // and the operation hung. It should propagate the rejection instead.
+        it("rejects when the matched plugin is disabled", async () => {
+            const { name, extension } = nextPluginIdentity("loadscenedisabled");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = LoadSceneAsync("data:dummy", engine, {
+                pluginExtension: extension,
+                pluginOptions: { [name]: { enabled: false } } as SceneLoaderPluginOptions,
+            });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+    });
+
+    // Regression for https://github.com/BabylonJS/Babylon.js/pull/18584:
+    // File and raw-data sources are already in-memory and must not be routed through the offline
+    // provider. With the bug present, the offline provider factory is invoked for these sources
+    // (and here, since the factory throws, the load also rejects).
+    describe("Offline provider bypass for in-memory sources", () => {
+        let previousFactory: typeof AbstractEngine.OfflineProviderFactory;
+
+        beforeEach(() => {
+            previousFactory = AbstractEngine.OfflineProviderFactory;
+            engine.enableOfflineSupport = true;
+        });
+
+        afterEach(() => {
+            AbstractEngine.OfflineProviderFactory = previousFactory;
+        });
+
+        it("does not invoke the offline provider factory for raw ArrayBufferView data", async () => {
+            const { name, extension } = nextPluginIdentity("offlinebypass");
+            const data = new Uint8Array([1, 2, 3, 4]);
+
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: { [extension]: { isBinary: true } },
+                loadFile: (_s, fileOrUrl, _rootUrl, onSuccess: (data: unknown) => void) => {
+                    onSuccess(fileOrUrl);
+                    return createFileRequest();
+                },
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const offlineProviderFactory = vi.fn(() => {
+                throw new Error("Offline provider should not be used for in-memory sources.");
+            });
+            AbstractEngine.OfflineProviderFactory = offlineProviderFactory as unknown as typeof AbstractEngine.OfflineProviderFactory;
+
+            const promise = AppendSceneAsync(data, scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("resolved");
+            expect(offlineProviderFactory).not.toHaveBeenCalled();
+
+            await promise.catch(() => {});
+        });
+
+        it("does not invoke the offline provider factory for a File source", async () => {
+            const { name, extension } = nextPluginIdentity("offlinebypassfile");
+            // A minimal File-like object: GetFileInfo only checks for a truthy `name`.
+            const file = { name: `scene${extension}` } as unknown as File;
+
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                loadFile: (_s, fileOrUrl, _rootUrl, onSuccess: (data: unknown) => void) => {
+                    onSuccess(fileOrUrl);
+                    return createFileRequest();
+                },
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const offlineProviderFactory = vi.fn(() => {
+                throw new Error("Offline provider should not be used for File sources.");
+            });
+            AbstractEngine.OfflineProviderFactory = offlineProviderFactory as unknown as typeof AbstractEngine.OfflineProviderFactory;
+
+            const promise = AppendSceneAsync(file, scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("resolved");
+            expect(offlineProviderFactory).not.toHaveBeenCalled();
+
+            await promise.catch(() => {});
+        });
+
+        it("still invokes the offline provider factory for URL string sources", async () => {
+            // Positive guard: the bypass must apply only to in-memory sources, not URL-backed loads.
+            const { name, extension } = nextPluginIdentity("offlineurl");
+
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                loadFile: (_s, fileOrUrl, _rootUrl, onSuccess: (data: unknown) => void) => {
+                    onSuccess(fileOrUrl);
+                    return createFileRequest();
+                },
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const offlineProviderFactory = vi.fn((_url: string, manifestChecked: () => void) => {
+                // Invoke the manifest-checked callback so the load proceeds to the plugin.
+                manifestChecked();
+                return {} as ReturnType<NonNullable<typeof AbstractEngine.OfflineProviderFactory>>;
+            });
+            AbstractEngine.OfflineProviderFactory = offlineProviderFactory as unknown as typeof AbstractEngine.OfflineProviderFactory;
+
+            const promise = AppendSceneAsync(`http://example.com/scene${extension}`, scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("resolved");
+            expect(offlineProviderFactory).toHaveBeenCalledTimes(1);
+
+            await promise.catch(() => {});
+        });
+    });
+
+    describe("LoadAssetContainerAsync", () => {
+        it("loads an asset container with an async plugin and populates root nodes", async () => {
+            const { name, extension } = nextPluginIdentity("containerasync");
+            const container = new AssetContainer(scene);
+            container.meshes.push(new Mesh("rootMesh", scene));
+
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: () => Promise.resolve(container),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loaded = await LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(loaded).toBe(container);
+            expect(loaded.rootNodes).toHaveLength(1);
+            expect(scene.loadingPluginName).toBe(name);
+        });
+
+        it("loads an asset container with a sync plugin", async () => {
+            const { name, extension } = nextPluginIdentity("containersync");
+            const container = new AssetContainer(scene);
+
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: () => container,
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loaded = await LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(loaded).toBe(container);
+        });
+
+        it("rejects when the plugin does not support loading an asset container", async () => {
+            const { name, extension } = nextPluginIdentity("containerunsupported");
+            // A plugin that only supports importing meshes, not asset containers.
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+            } as unknown as ISceneLoaderPluginAsync;
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow(/LoadAssetContainer is not supported/);
+        });
+
+        it("rejects when the matched plugin is disabled", async () => {
+            // Guard for the asymmetry fixed in PR #18584: the LoadAssetContainer shared wrapper already
+            // rejects (rather than hangs) when loadDataAsync throws for a disabled plugin.
+            const { name, extension } = nextPluginIdentity("containerdisabled");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = LoadAssetContainerAsync("data:dummy", scene, {
+                pluginExtension: extension,
+                pluginOptions: { [name]: { enabled: false } } as SceneLoaderPluginOptions,
+            });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("rejects when the async plugin rejects", async () => {
+            const { name, extension } = nextPluginIdentity("containerreject");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: () => Promise.reject(new Error("container boom")),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("container boom");
+        });
+
+        it("rejects when the async plugin throws synchronously", async () => {
+            const { name, extension } = nextPluginIdentity("containersyncthrow");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: () => {
+                    throw new Error("sync throw from loadAssetContainerAsync");
+                },
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("sync throw from loadAssetContainerAsync");
+        });
+
+        it("rejects when a sync plugin throws instead of calling onError", async () => {
+            const { name, extension } = nextPluginIdentity("containerpluginthrow");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: () => {
+                    throw new Error("sync throw from loadAssetContainer");
+                },
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension })).rejects.toThrow("sync throw from loadAssetContainer");
+        });
+    });
+
+    // A synchronous plugin can signal failure either by calling its onError argument or by returning false.
+    // When it returns false WITHOUT calling onError, the loading operation should still settle (reject) and
+    // must not leak pending data on the scene. These tests currently fail because the operation hangs forever
+    // and the pending data is never removed; they should pass once the loader is reworked.
+    describe("Sync plugin returns false without calling onError", () => {
+        it("ImportMeshAsync rejects and clears pending data", async () => {
+            const { name, extension } = nextPluginIdentity("importsilentfalse");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => false,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = ImportMeshAsync("data:dummy", scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            expect(scene.getWaitingItemsCount()).toBe(0);
+
+            // Avoid an unhandled rejection if the assertion above already failed.
+            await promise.catch(() => {});
+        });
+
+        it("AppendSceneAsync rejects and clears pending data", async () => {
+            const { name, extension } = nextPluginIdentity("appendsilentfalse");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => false,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = AppendSceneAsync("data:dummy", scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            expect(scene.getWaitingItemsCount()).toBe(0);
+
+            await promise.catch(() => {});
+        });
+
+        it("LoadAssetContainerAsync rejects and clears pending data", async () => {
+            const { name, extension } = nextPluginIdentity("containersilentfalse");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                // The loader treats a falsy asset container as a silent failure.
+                loadAssetContainer: () => null as unknown as AssetContainer,
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = LoadAssetContainerAsync("data:dummy", scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            expect(scene.getWaitingItemsCount()).toBe(0);
+
+            await promise.catch(() => {});
+        });
+    });
+
+    // When GetFileInfo returns null (for example, a rootUrl is set and the filename starts with "/"),
+    // the internal loader functions return early without ever invoking the success callback, so the
+    // promise-based public APIs never settle. They should reject on invalid input. These tests currently
+    // fail because the operation hangs forever; they should pass once the loader is reworked. Note that
+    // Tools.Error logs an error in this path, so it is silenced to keep the test output clean.
+    describe("Invalid input (GetFileInfo returns null)", () => {
+        beforeEach(() => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+        });
+
+        it("ImportMeshAsync rejects when the filename is invalid", async () => {
+            const promise = ImportMeshAsync("/invalid.babylon", scene, { rootUrl: "http://example.com/" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("AppendSceneAsync rejects when the filename is invalid", async () => {
+            const promise = AppendSceneAsync("/invalid.babylon", scene, { rootUrl: "http://example.com/" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("LoadAssetContainerAsync rejects when the filename is invalid", async () => {
+            const promise = LoadAssetContainerAsync("/invalid.babylon", scene, { rootUrl: "http://example.com/" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("LoadSceneAsync rejects when the filename is invalid", async () => {
+            const promise = LoadSceneAsync("/invalid.babylon", engine, { rootUrl: "http://example.com/" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+    });
+
+    // When a plugin is disposed mid-load (via its onDisposeObservable), the in-flight request is aborted and
+    // pending data is removed, but the loading promise is never settled. It should reject so callers are not
+    // left awaiting forever. This test currently fails because the operation hangs; it should pass once reworked.
+    describe("Plugin disposed mid-load", () => {
+        it("AppendSceneAsync rejects and clears pending data when the plugin is disposed", async () => {
+            const { name, extension } = nextPluginIdentity("appenddispose");
+            const onDisposeObservable = new Observable<void>();
+
+            const plugin: ISceneLoaderPlugin & { onDisposeObservable: Observable<void> } = {
+                name,
+                extensions: extension,
+                onDisposeObservable,
+                // Never call onSuccess so the load stays in-flight until the plugin is disposed.
+                loadFile: () => createFileRequest(),
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = AppendSceneAsync("scene.bin", scene, { pluginExtension: extension });
+
+            // Allow the loader to register its dispose handler and start the request.
+            await Promise.resolve();
+            onDisposeObservable.notifyObservers();
+
+            expect(await classifySettlement(promise)).toBe("rejected");
+            expect(scene.getWaitingItemsCount()).toBe(0);
+
+            await promise.catch(() => {});
+        });
+    });
+
+    // An exception thrown by a user-supplied onProgress callback should not abort the whole load. Today the
+    // loader routes the exception to its error handler, which rejects the operation. The load should instead
+    // still succeed. This test currently fails (the operation rejects); it should pass once reworked.
+    describe("Throwing onProgress callback", () => {
+        it("ImportMeshAsync still resolves when onProgress throws", async () => {
+            const { name, extension } = nextPluginIdentity("importprogressthrow");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: (_meshNames, _s, _data, _rootUrl, onProgress) => {
+                    onProgress?.({ lengthComputable: true, loaded: 1, total: 2 });
+                    return Promise.resolve(createEmptyAsyncResult());
+                },
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const onProgress = vi.fn(() => {
+                throw new Error("progress callback boom");
+            });
+
+            const promise = ImportMeshAsync("data:dummy", scene, { pluginExtension: extension, onProgress });
+
+            expect(await classifySettlement(promise)).toBe("resolved");
+            expect(onProgress).toHaveBeenCalledTimes(1);
+
+            await promise.catch(() => {});
+        });
+    });
+
+    describe("ImportAnimationsAsync", () => {
+        it("imports animations and notifies the scene observable", async () => {
+            const { name, extension } = nextPluginIdentity("animations");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const onImported = vi.fn();
+            scene.onAnimationFileImportedObservable.add(onImported);
+
+            await ImportAnimationsAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(onImported).toHaveBeenCalledTimes(1);
+            expect(onImported).toHaveBeenCalledWith(scene, expect.anything());
+        });
+
+        // importAnimationsImplAsync returns early on an unrecognized animationGroupLoadingMode without ever
+        // calling onSuccess or onError, so the promise never settles. It should reject instead. This test
+        // currently fails (the operation hangs); it should pass once the loader is reworked.
+        it("rejects on an unknown animationGroupLoadingMode", async () => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+            const { name, extension } = nextPluginIdentity("animationsbadmode");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = ImportAnimationsAsync("data:dummy", scene, {
+                pluginExtension: extension,
+                overwriteAnimations: false,
+                // 999 is not a valid SceneLoaderAnimationGroupLoadingMode value.
+                animationGroupLoadingMode: 999 as never,
+            });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+    });
+
+    // Every internal loader function returns early (without settling) when no scene is available. Since scene
+    // defaults to EngineStore.LastCreatedScene, a null scene is a real runtime possibility. The operation
+    // should reject rather than hang. These tests currently fail (the operations hang); they should pass once
+    // the loader is reworked.
+    describe("No scene available", () => {
+        beforeEach(() => {
+            vi.spyOn(console, "error").mockImplementation(() => {});
+        });
+
+        it("ImportMeshAsync rejects when the scene is null", async () => {
+            const promise = ImportMeshAsync("data:dummy", null as unknown as Scene, { pluginExtension: ".null" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("AppendSceneAsync rejects when the scene is null", async () => {
+            const promise = AppendSceneAsync("data:dummy", null as unknown as Scene, { pluginExtension: ".null" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+
+        it("LoadAssetContainerAsync rejects when the scene is null", async () => {
+            const promise = LoadAssetContainerAsync("data:dummy", null as unknown as Scene, { pluginExtension: ".null" });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            await promise.catch(() => {});
+        });
+    });
+
+    describe("Plugin options", () => {
+        it("rejects when the matched plugin is disabled via plugin options", async () => {
+            const { name, extension } = nextPluginIdentity("disabled");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await expect(
+                ImportMeshAsync("data:dummy", scene, {
+                    pluginExtension: extension,
+                    pluginOptions: { [name]: { enabled: false } } as SceneLoaderPluginOptions,
+                })
+            ).rejects.toThrow(/is disabled/);
+        });
+    });
+
+    describe("Plugin factories", () => {
+        it("instantiates a plugin from a synchronous factory", async () => {
+            const { name, extension } = nextPluginIdentity("factorysync");
+            const importMeshAsync = vi.fn(() => Promise.resolve(createEmptyAsyncResult()));
+            const createPlugin = vi.fn(
+                (): ISceneLoaderPluginAsync => ({
+                    name,
+                    extensions: extension,
+                    importMeshAsync,
+                    loadAsync: () => Promise.resolve(),
+                    loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+                })
+            );
+            const factory: ISceneLoaderPluginFactory = { name, extensions: extension, createPlugin };
+            RegisterSceneLoaderPlugin(factory);
+
+            await ImportMeshAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(createPlugin).toHaveBeenCalledTimes(1);
+            expect(importMeshAsync).toHaveBeenCalledTimes(1);
+        });
+
+        it("instantiates a plugin from an asynchronous factory", async () => {
+            const { name, extension } = nextPluginIdentity("factoryasync");
+            const importMeshAsync = vi.fn(() => Promise.resolve(createEmptyAsyncResult()));
+            const createPlugin = vi.fn(
+                (): Promise<ISceneLoaderPluginAsync> =>
+                    Promise.resolve({
+                        name,
+                        extensions: extension,
+                        importMeshAsync,
+                        loadAsync: () => Promise.resolve(),
+                        loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+                    })
+            );
+            const factory: ISceneLoaderPluginFactory = { name, extensions: extension, createPlugin };
+            RegisterSceneLoaderPlugin(factory);
+
+            await ImportMeshAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(createPlugin).toHaveBeenCalledTimes(1);
+            expect(importMeshAsync).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("OnPluginActivatedObservable", () => {
+        it("notifies observers with the activated plugin", async () => {
+            const { name, extension } = nextPluginIdentity("activated");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult()),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const observer = vi.fn();
+            const registration = SceneLoader.OnPluginActivatedObservable.add(observer);
+
+            await ImportMeshAsync("data:dummy", scene, { pluginExtension: extension });
+
+            expect(observer).toHaveBeenCalledWith(plugin, expect.anything());
+            SceneLoader.OnPluginActivatedObservable.remove(registration);
+        });
+    });
+
+    describe("Loading paths", () => {
+        it("loads via the plugin loadFile callback for non-direct sources", async () => {
+            const { name, extension } = nextPluginIdentity("loadfile");
+            const loadFile = vi.fn((_s, _fileOrUrl, _rootUrl, onSuccess: (data: unknown) => void) => {
+                onSuccess("file-data");
+                return createFileRequest();
+            });
+            const load = vi.fn(() => true);
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                loadFile,
+                importMesh: () => true,
+                load,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await AppendSceneAsync("scene.data", scene, { pluginExtension: extension });
+
+            expect(loadFile).toHaveBeenCalledTimes(1);
+            expect(load).toHaveBeenCalledWith(scene, "file-data", expect.any(String), expect.any(Function));
+        });
+
+        it("resolves a promise returned from the plugin directLoad", async () => {
+            const { name, extension } = nextPluginIdentity("directload");
+            const directLoad = vi.fn(() => Promise.resolve("resolved-data"));
+            const load = vi.fn(() => true);
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                canDirectLoad: () => true,
+                directLoad,
+                importMesh: () => true,
+                load,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await AppendSceneAsync("data:payload", scene, { pluginExtension: extension });
+
+            expect(directLoad).toHaveBeenCalledTimes(1);
+            expect(load).toHaveBeenCalledWith(scene, "resolved-data", expect.any(String), expect.any(Function));
+        });
+
+        it("loads binary data from an ArrayBufferView via loadFile", async () => {
+            const { name, extension } = nextPluginIdentity("binary");
+            const data = new Uint8Array([1, 2, 3, 4]);
+            const loadFile = vi.fn((_s, fileOrUrl, _rootUrl, onSuccess: (data: unknown) => void) => {
+                onSuccess(fileOrUrl);
+                return createFileRequest();
+            });
+            const load = vi.fn(() => true);
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: { [extension]: { isBinary: true } },
+                loadFile,
+                importMesh: () => true,
+                load,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            await AppendSceneAsync(data, scene, { pluginExtension: extension });
+
+            expect(loadFile).toHaveBeenCalledTimes(1);
+            expect(load).toHaveBeenCalledWith(scene, data, expect.any(String), expect.any(Function));
+        });
+    });
+
+    // The directLoad path can fail either by returning a rejected Promise or by throwing synchronously.
+    // Both should reject the operation AND clear pending data. Today the async rejection is routed through
+    // the loader's error handler (cleans up), but a synchronous throw propagates out of loadDataAsync
+    // bypassing the error handler, so pending data leaks. These two tests document that asymmetry: the
+    // async case passes today, the sync case fails until the loader is reworked.
+    describe("directLoad error timing", () => {
+        it("rejects and clears pending data when directLoad rejects asynchronously", async () => {
+            const { name, extension } = nextPluginIdentity("directloadasyncreject");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                canDirectLoad: () => true,
+                directLoad: () => Promise.reject(new Error("async directLoad boom")),
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = AppendSceneAsync("data:payload", scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            expect(scene.getWaitingItemsCount()).toBe(0);
+
+            await promise.catch(() => {});
+        });
+
+        it("rejects and clears pending data when directLoad throws synchronously", async () => {
+            const { name, extension } = nextPluginIdentity("directloadsyncthrow");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                canDirectLoad: () => true,
+                directLoad: () => {
+                    throw new Error("sync directLoad boom");
+                },
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const promise = AppendSceneAsync("data:payload", scene, { pluginExtension: extension });
+            expect(await classifySettlement(promise)).toBe("rejected");
+            // Currently fails: the synchronous throw bypasses the error handler so pending data is leaked.
+            expect(scene.getWaitingItemsCount()).toBe(0);
+
+            await promise.catch(() => {});
+        });
+    });
+
+    describe("Deprecated callback APIs", () => {
+        it("SceneLoader.ImportMesh invokes the success callback", async () => {
+            const { name, extension } = nextPluginIdentity("legacyimport");
+            const mesh = new Mesh("legacy", scene);
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult({ meshes: [mesh] })),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const meshes = await new Promise<ReadonlyArray<Mesh>>((resolve, reject) => {
+                SceneLoader.ImportMesh(
+                    "",
+                    "",
+                    "data:dummy",
+                    scene,
+                    (loadedMeshes) => resolve(loadedMeshes as Mesh[]),
+                    null,
+                    (_s, message) => reject(new Error(message)),
+                    extension
+                );
+            });
+
+            expect(meshes).toEqual([mesh]);
+        });
+
+        it("SceneLoader.ImportMesh invokes the error callback on failure", async () => {
+            const { name, extension } = nextPluginIdentity("legacyimporterror");
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.reject(new Error("legacy boom")),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const message = await new Promise<string>((resolve, reject) => {
+                SceneLoader.ImportMesh(
+                    "",
+                    "",
+                    "data:dummy",
+                    scene,
+                    () => reject(new Error("expected failure")),
+                    null,
+                    (_s, errorMessage) => resolve(errorMessage),
+                    extension
+                );
+            });
+
+            expect(message).toMatch(/legacy boom/);
+        });
+
+        it("SceneLoader.Append invokes the success callback", async () => {
+            const { name, extension } = nextPluginIdentity("legacyappend");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const appendedScene = await new Promise<Scene>((resolve, reject) => {
+                SceneLoader.Append(
+                    "",
+                    "data:dummy",
+                    scene,
+                    (s) => resolve(s),
+                    null,
+                    (_s, message) => reject(new Error(message)),
+                    extension
+                );
+            });
+
+            expect(appendedScene).toBe(scene);
+        });
+
+        it("SceneLoader.Load invokes the success callback", async () => {
+            const { name, extension } = nextPluginIdentity("legacyload");
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: (s) => new AssetContainer(s),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loadedScene = await new Promise<Scene>((resolve, reject) => {
+                SceneLoader.Load(
+                    "",
+                    "data:dummy",
+                    engine,
+                    (s) => resolve(s),
+                    null,
+                    (_s, message) => reject(new Error(message)),
+                    extension
+                );
+            });
+
+            expect(loadedScene).toBeInstanceOf(Scene);
+            loadedScene.dispose();
+        });
+
+        it("SceneLoader.LoadAssetContainer invokes the success callback", async () => {
+            const { name, extension } = nextPluginIdentity("legacycontainer");
+            const container = new AssetContainer(scene);
+            const plugin: ISceneLoaderPlugin = {
+                name,
+                extensions: extension,
+                importMesh: () => true,
+                load: () => true,
+                loadAssetContainer: () => container,
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loaded = await new Promise<AssetContainer>((resolve, reject) => {
+                SceneLoader.LoadAssetContainer(
+                    "",
+                    "data:dummy",
+                    scene,
+                    (assets) => resolve(assets),
+                    null,
+                    (_s, message) => reject(new Error(message)),
+                    extension
+                );
+            });
+
+            expect(loaded).toBe(container);
+        });
+
+        it("SceneLoader.ImportMeshAsync resolves with the imported results", async () => {
+            const { name, extension } = nextPluginIdentity("legacyimportasync");
+            const mesh = new Mesh("legacyAsync", scene);
+            const plugin: ISceneLoaderPluginAsync = {
+                name,
+                extensions: extension,
+                importMeshAsync: () => Promise.resolve(createEmptyAsyncResult({ meshes: [mesh] })),
+                loadAsync: () => Promise.resolve(),
+                loadAssetContainerAsync: (s) => Promise.resolve(new AssetContainer(s)),
+            };
+            RegisterSceneLoaderPlugin(plugin);
+
+            const loaded = await SceneLoader.ImportMeshAsync("", "", "data:dummy", scene, null, extension);
+
+            expect(loaded.meshes).toEqual([mesh]);
+        });
+    });
+});

--- a/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
+++ b/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
@@ -250,9 +250,12 @@ test.describe("Babylon Scene Loader", function () {
                 });
 
                 // promises.push(
-                BABYLON.SceneLoader.AppendAsync("https://playground.babylonjs.com/scenes/BoomBox/", "BoomBox.gltf", window.scene).then(() => {
-                    ready = true;
-                });
+                BABYLON.SceneLoader.AppendAsync("https://playground.babylonjs.com/scenes/BoomBox/", "BoomBox.gltf", window.scene)
+                    .then(() => {
+                        ready = true;
+                    })
+                    // Disposing the loader mid-load rejects the load promise; swallow it so it does not surface as an unhandled rejection.
+                    .catch(() => {});
                 // );
 
                 return Promise.all(promises);


### PR DESCRIPTION
## Summary

This PR reworks `SceneLoader` so that all internal orchestration is **Promise / `async`/`await`-first**. Callback chaining, explicit `Promise.then`/`Promise.catch`, and the old mixed control flow have been removed from the internals. The public callback-style APIs (the deprecated `SceneLoader.ImportMesh`, `Load`, `Append`, `LoadAssetContainer`, `ImportAnimations` statics and their `*Async` variants) are now thin wrappers around a small set of core `async` functions.

Along the way, the refactor fixes a class of long-standing bugs where a load operation could **never settle** (the returned Promise never resolved or rejected, and success/error callbacks were never invoked) or where **pending plugin data leaked**. A comprehensive unit test suite was added to lock in the corrected behavior.

## Motivation

`sceneLoader.ts` had accumulated a mix of three different async styles: raw callbacks, hand-written `Promise` executors with `.then`/`.catch`, and `async`/`await`. This made the control flow hard to follow and, more importantly, hid several edge cases where errors thrown synchronously vs. asynchronously were handled inconsistently — sometimes leaving a load hanging forever.

## Changes

### Core refactor (`packages/dev/core/src/Loading/sceneLoader.ts`)

- **Single async core per operation.** Each public operation now funnels through one core `async` function:
  - `importMeshCoreAsync`
  - `loadSceneCoreAsync`
  - `appendSceneCoreAsync`
  - `loadAssetContainerCoreAsync`
  - `importAnimationsCoreAsync`
  These contain the real logic; every public/legacy entry point (modern `*Async` functions and the deprecated `SceneLoader` statics, including the callback overloads) simply `await`s the appropriate core function and adapts the result/errors to its signature.

- **`loadDataAsync` returns the loaded payload.** Plugin instantiation, `directLoad`, and file loading are bridged into a single Promise that resolves with `{ plugin, data }` and rejects on any failure, instead of driving everything through `onSuccess`/`onError` callbacks. `try/finally` guarantees pending data cleanup.

- **Unified plugin handling via an async adapter.** Added a `SceneLoaderPlugin` union type, an `isSyncPlugin` type guard, and a `toAsyncPlugin` adapter that wraps a synchronous `ISceneLoaderPlugin` as an `ISceneLoaderPluginAsync`. Call sites no longer branch on `(plugin as ISceneLoaderPlugin).importMesh` / `.load` with casts and non-null assertions; they work against a single async-shaped interface.

- **Centralized error handling.** Added `createLoadError`, `toLoadError`, and `getErrorMessage` helpers so synchronous throws and asynchronous rejections are funneled into a consistent `RuntimeError` with `ErrorCodes.SceneLoaderError`, without double-wrapping already-tagged scene-loader errors.

- **Robust progress callbacks.** Added `wrapProgress`, which isolates user `onProgress` callbacks so that a throw inside `onProgress` is logged (`Logger.Warn`) and does **not** abort the load.

- **Preserved eager `OnPluginActivatedObservable` timing.** Plugin factories are only `await`ed when `createPlugin` actually returns a `Promise` (`const p = createPlugin(...); plugin = p instanceof Promise ? await p : p;`). This avoids deferring synchronous plugin activation to a microtask, keeping `OnPluginActivatedObservable` firing synchronously for backward compatibility.

### Bug fixes (behavioral)

The refactor closes several "never settles" / leak paths that previously could hang a load or silently swallow errors:

- **Silent `false` return:** a synchronous plugin's `importMesh`/`load` returning falsy *without* calling `onError` now rejects (and clears pending data) instead of hanging forever.
- **Invalid file info:** `GetFileInfo` returning `null` now rejects the operation instead of leaving the Promise unsettled.
- **Null scene/engine paths:** these now reject instead of silently never settling.
- **Plugin disposed mid-load:** now rejects with a clear "plugin was disposed" error rather than hanging.
- **Unknown `animationGroupLoadingMode`:** now rejects instead of never settling.
- **Synchronous `directLoad` throw:** now cleans up pending data and rejects, matching the async `directLoad` rejection path.
- **Swallowed `LoadSceneAsync` rejection** (e.g. disabled/unavailable plugin) is now surfaced.
- **Offline provider bypass (PR #18584 class):** in-memory sources (`File` / raw data / `data:`) bypass the offline provider; URL-backed loads still go through it.
- **Consistent error logging:** callback statics now log via `Logger.Error` when no `onError` handler is supplied, including paths that were previously swallowed silently.

### Tests

- **New unit suite:** `packages/dev/core/test/unit/Loading/sceneLoader.test.ts` (58 tests). It uses a fully controllable dummy loader plugin to exercise:
  - sync vs. async plugins, plugin factories, `directLoad`, `loadFile`, binary/`ArrayBufferView` input, options, and observables;
  - synchronous throws **and** asynchronous rejections from plugin entry points;
  - every "never settles" / leak path listed above (added first as failing regression tests, then made green by the refactor);
  - PR #18584 scenarios (offline provider bypass for in-memory vs. URL sources);
  - the deprecated `SceneLoader` static callback APIs (success and error callbacks).

- **Integration test:** `packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts` — the "Load BoomBox with dispose" test now `.catch(() => {})`s the `AppendAsync` promise, since disposing the loader mid-load now (correctly) rejects the load promise; this prevents an unhandled rejection. Full SceneLoader integration file passes (requires the Babylon CDN dev server).

## Backward compatibility

- Public API signatures are unchanged. Deprecated callback statics keep behaving as wrappers over the new async cores.
- `OnPluginActivatedObservable` still fires synchronously for synchronous plugin factories.
- The only intentional behavioral differences are the bug fixes above: operations that used to hang now reject, and a few previously-silent error paths now log or reject. These are corrections to clearly buggy behavior.

## Validation

- Unit: `sceneLoader.test.ts` — 58/58 passing.
- Integration: `babylon.sceneLoader.test.ts` — passing with the dev server running.
