### PR TITLE
fix(SPLAT): Fix GSplat PLY misclassified as point cloud when both RGB and f_dc colors present

### DIFF
--- a/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
+++ b/packages/dev/loaders/src/SPLAT/splatFileLoader.ts
@@ -704,7 +704,7 @@ export class SPLATFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlu
                     propertyColorCount++;
                 }
             }
-            const hasMandatoryProperties = propertyCount == splatProperties.length && propertyColorCount == 3;
+            const hasMandatoryProperties = propertyCount == splatProperties.length && propertyColorCount >= 3;
             const currentMode = faceCount ? Mode.Mesh : hasMandatoryProperties ? Mode.Splat : Mode.PointCloud;
             // parsed ready ready to be used as a splat
             return await new Promise((resolve) => {


### PR DESCRIPTION
A valid Gaussian Splat PLY containing **both** `red/green/blue` (uchar) and `f_dc_0/1/2` (float) color properties was loaded as a point cloud instead of a splat, so it rendered as plain points with no splatting.

### Cause
In `splatFileLoader.ts`, the splat-detection check used a strict equality on the color-property count:

```js
const hasMandatoryProperties = propertyCount == splatProperties.length && propertyColorCount == 3;
```

When a file carries both color encodings, `propertyColorCount` is 6, so `== 3` fails and the file falls through to `Mode.PointCloud`. (Some exporters write both a precomputed RGB and the SH DC color.)

### Fix
Changed the color check to `>= 3`:

```js
const hasMandatoryProperties = propertyCount == splatProperties.length && propertyColorCount >= 3;
```

Since the gate is `&&`-ed with `propertyCount == 11` (all mandatory splat geometry properties), the relaxed color count only ever applies to files that are already full splats, with point-cloud detection is unaffected. 