### PR TITLE
fix overrides on morphs

### DIFF
--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -492,11 +492,10 @@ export class RuntimeAnimation {
             // influence into (for example) RELATIVE mode and make it accumulate offset * repeatCount every loop.
             // When the override is the inherited scene one, use the animation's own loop mode instead.
             // An override set explicitly on the morph target is still respected.
-            if (
-                this._target.animationPropertiesOverride === this._scene.animationPropertiesOverride &&
-                this._target.getClassName &&
-                this._target.getClassName() === "MorphTarget"
-            ) {
+            const isMorphTarget = this._target.getClassName?.() === "MorphTarget";
+            // MorphTarget.animationPropertiesOverride getter inherits from the scene when no per-target override is set.
+            // Only bypass the override when it is truly inherited (ie. the target has no local override).
+            if (isMorphTarget && (this._target as any)._animationPropertiesOverride == null) {
                 return this._animation.loopMode;
             }
 

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -492,10 +492,13 @@ export class RuntimeAnimation {
             // influence into (for example) RELATIVE mode and make it accumulate offset * repeatCount every loop.
             // When the override is the inherited scene one, use the animation's own loop mode instead.
             // An override set explicitly on the morph target is still respected.
-            const isMorphTarget = this._target.getClassName?.() === "MorphTarget";
-            // MorphTarget.animationPropertiesOverride getter inherits from the scene when no per-target override is set.
-            // Only bypass the override when it is truly inherited (ie. the target has no local override).
-            if (isMorphTarget && (this._target as any)._animationPropertiesOverride == null) {
+            const isMorphTarget = this._target.getClassName?.() === "MorphTarget";
+
+            // MorphTarget.animationPropertiesOverride getter inherits from the scene when no per-target override is set.
+
+            // Only bypass the override when it is truly inherited (ie. the target has no local override).
+
+            if (isMorphTarget && (this._target as any)._animationPropertiesOverride == null) {
                 return this._animation.loopMode;
             }
 

--- a/packages/dev/core/src/Animations/runtimeAnimation.ts
+++ b/packages/dev/core/src/Animations/runtimeAnimation.ts
@@ -487,6 +487,19 @@ export class RuntimeAnimation {
      */
     private _getCorrectLoopMode(): number | undefined {
         if (this._target && this._target.animationPropertiesOverride) {
+            // A morph target with no per-target override inherits the scene-level animationPropertiesOverride.
+            // That loop mode is meant for transform/bone animations: honoring it here would force the morph
+            // influence into (for example) RELATIVE mode and make it accumulate offset * repeatCount every loop.
+            // When the override is the inherited scene one, use the animation's own loop mode instead.
+            // An override set explicitly on the morph target is still respected.
+            if (
+                this._target.animationPropertiesOverride === this._scene.animationPropertiesOverride &&
+                this._target.getClassName &&
+                this._target.getClassName() === "MorphTarget"
+            ) {
+                return this._animation.loopMode;
+            }
+
             return this._target.animationPropertiesOverride.loopMode as number;
         }
 

--- a/packages/dev/core/test/unit/Animations/babylon.runtimeAnimation.test.ts
+++ b/packages/dev/core/test/unit/Animations/babylon.runtimeAnimation.test.ts
@@ -3,7 +3,10 @@ import { Engine } from "core/Engines/engine";
 import { Scene } from "core/scene";
 import { Animation } from "core/Animations/animation";
 import { AnimationGroup } from "core/Animations/animationGroup";
+import { AnimationPropertiesOverride } from "core/Animations/animationPropertiesOverride";
 import { FreeCamera } from "core/Cameras/freeCamera";
+import { TransformNode } from "core/Meshes/transformNode";
+import { MorphTarget } from "core/Morph/morphTarget";
 import { Vector3 } from "core/Maths/math.vector";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
@@ -178,6 +181,97 @@ describe("Babylon RuntimeAnimation", function () {
             // Start C while both A and B are running — should still inherit the original (0)
             groupC.start(false, 1.0, 0, 60);
             expect((groupC.animatables[0].getAnimations()[0] as any)._originalValue[0]).toBe(0);
+        });
+    });
+
+    describe("loop mode inheritance for morph targets", () => {
+        // Builds an influence animation whose own loop mode is CYCLE and whose last keyframe does not return
+        // to the first value, so the RELATIVE offset (last - first) is non-zero and would accumulate if applied.
+        const createMorphInfluenceAnimation = () => {
+            const anim = new Animation("morphAnim", "influence", 30, Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE);
+            anim.setKeys([
+                { frame: 0, value: 0 },
+                { frame: 15, value: 0.3 },
+                { frame: 30, value: 0.05 },
+            ]);
+            return anim;
+        };
+
+        const getRuntimeLoopMode = (group: AnimationGroup) => (group.animatables[0].getAnimations()[0] as any)._animationState.loopMode as number;
+
+        it("does not inherit a scene-level RELATIVE loop mode for morph target influence", () => {
+            const scene = new Scene(engine);
+            scene.useConstantAnimationDeltaTime = true;
+            new FreeCamera("camera", Vector3.Zero(), scene);
+
+            // Scene-level override (typically set for transform/bone blending) using RELATIVE loop mode.
+            scene.animationPropertiesOverride = new AnimationPropertiesOverride();
+            scene.animationPropertiesOverride.loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE;
+
+            const morphTarget = new MorphTarget("BrowsUp", 0, scene);
+            const group = new AnimationGroup("TestMorphAnim", scene);
+            group.addTargetedAnimation(createMorphInfluenceAnimation(), morphTarget);
+            group.start(true, 1.0, 0, 30);
+
+            // The inherited scene loop mode must not leak into the morph influence animation.
+            expect(getRuntimeLoopMode(group)).toBe(Animation.ANIMATIONLOOPMODE_CYCLE);
+
+            // Run several loops: the influence must keep cycling instead of drifting upward.
+            let maxInfluence = 0;
+            for (let i = 0; i < 400; i++) {
+                scene.render();
+                maxInfluence = Math.max(maxInfluence, morphTarget.influence);
+            }
+
+            // The maximum keyframe value is 0.3; allow a small epsilon for interpolation/blending.
+            expect(maxInfluence).toBeLessThan(0.4);
+        });
+
+        it("respects a RELATIVE override set explicitly on the morph target", () => {
+            const scene = new Scene(engine);
+            scene.useConstantAnimationDeltaTime = true;
+            new FreeCamera("camera", Vector3.Zero(), scene);
+
+            const morphTarget = new MorphTarget("BrowsUp", 0, scene);
+            morphTarget.animationPropertiesOverride = new AnimationPropertiesOverride();
+            morphTarget.animationPropertiesOverride.loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE;
+
+            const group = new AnimationGroup("TestMorphAnim", scene);
+            group.addTargetedAnimation(createMorphInfluenceAnimation(), morphTarget);
+            group.start(true, 1.0, 0, 30);
+
+            // An override set on the morph target itself must still be honored.
+            expect(getRuntimeLoopMode(group)).toBe(Animation.ANIMATIONLOOPMODE_RELATIVE);
+
+            let maxInfluence = 0;
+            for (let i = 0; i < 400; i++) {
+                scene.render();
+                maxInfluence = Math.max(maxInfluence, morphTarget.influence);
+            }
+
+            // With RELATIVE accumulation the influence drifts well past the keyframe maximum.
+            expect(maxInfluence).toBeGreaterThan(0.4);
+        });
+
+        it("still inherits a scene-level RELATIVE loop mode for non-morph targets", () => {
+            const scene = new Scene(engine);
+            new FreeCamera("camera", Vector3.Zero(), scene);
+
+            scene.animationPropertiesOverride = new AnimationPropertiesOverride();
+            scene.animationPropertiesOverride.loopMode = Animation.ANIMATIONLOOPMODE_RELATIVE;
+
+            const node = new TransformNode("node", scene);
+            const anim = new Animation("posAnim", "position.x", 30, Animation.ANIMATIONTYPE_FLOAT, Animation.ANIMATIONLOOPMODE_CYCLE);
+            anim.setKeys([
+                { frame: 0, value: 0 },
+                { frame: 30, value: 1 },
+            ]);
+            const group = new AnimationGroup("TestNodeAnim", scene);
+            group.addTargetedAnimation(anim, node);
+            group.start(true, 1.0, 0, 30);
+
+            // Transform nodes keep inheriting the scene loop mode (behavior is unchanged by the morph-target fix).
+            expect(getRuntimeLoopMode(group)).toBe(Animation.ANIMATIONLOOPMODE_RELATIVE);
         });
     });
 });


### PR DESCRIPTION
A morph target with no per-target override inherits the scene-level animationPropertiesOverride.
That loop mode is meant for transform/bone animations: honoring it here would force the morph
influence into (for example) RELATIVE mode and make it accumulate offset * repeatCount every loop.
When the override is the inherited scene one, use the animation's own loop mode instead.
An override set explicitly on the morph target is still respected.

Repro: https://playground.babylonjs.com/#F92VVI