### PR TITLE
Add canvasTabIndex engine option

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -182,8 +182,9 @@ export interface AbstractEngineOptions {
 
     /**
      * Defines the tab index to set on the rendering canvas (default: 1).
-     * 1 is the minimum value required to be able to capture keyboard events on the canvas.
-     * Set this to a custom value to control the canvas position in the document's tab order.
+     * Any value >= 0 makes the canvas focusable so it can capture keyboard events and places it in the
+     * document's sequential tab order (0 follows DOM order, a positive value forces an explicit order).
+     * Use -1 to keep the canvas focusable programmatically (via focus()) while excluding it from the tab order.
      */
     canvasTabIndex?: number;
 }
@@ -489,7 +490,7 @@ export abstract class AbstractEngine {
      */
     public postProcesses: PostProcess[] = [];
 
-    /** Gets or sets the tab index to set to the rendering canvas. 1 is the minimum value to set to be able to capture keyboard events */
+    /** Gets or sets the tab index to set to the rendering canvas. Any value >= 0 makes the canvas focusable to capture keyboard events and adds it to the tab order; use -1 to keep it focusable programmatically but out of the tab order */
     public canvasTabIndex = 1;
 
     /** @internal */

--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -179,6 +179,13 @@ export interface AbstractEngineOptions {
      * Otherwise, the default is to use a cheaper approximation.
      */
     useExactSrgbConversions?: boolean;
+
+    /**
+     * Defines the tab index to set on the rendering canvas (default: 1).
+     * 1 is the minimum value required to be able to capture keyboard events on the canvas.
+     * Set this to a custom value to control the canvas position in the document's tab order.
+     */
+    canvasTabIndex?: number;
 }
 
 /**
@@ -2133,6 +2140,7 @@ export abstract class AbstractEngine {
         this._doNotHandleContextLost = !!options.doNotHandleContextLost;
         this._isStencilEnable = options.stencil ? true : false;
         this.useExactSrgbConversions = options.useExactSrgbConversions ?? false;
+        this.canvasTabIndex = options.canvasTabIndex ?? this.canvasTabIndex;
 
         const devicePixelRatio = IsWindowObjectExist() ? window.devicePixelRatio || 1.0 : 1.0;
 


### PR DESCRIPTION
## Problem

`AbstractEngine` exposes a public `canvasTabIndex` property that defaults to `1` and is applied to the rendering canvas/input element when input is attached. However, there was no way to configure it at engine creation — the only way to change it was to mutate `engine.canvasTabIndex` after construction but before the scene attaches input, which is awkward and easy to miss.

## Change

Added an optional `canvasTabIndex?: number` to `AbstractEngineOptions` (inherited by `EngineOptions` / WebGPU options). It is applied in the `AbstractEngine` constructor:

```ts
this.canvasTabIndex = options.canvasTabIndex ?? this.canvasTabIndex;
```

Usage:

```ts
const engine = new Engine(canvas, true, { canvasTabIndex: 0 });
// or: new WebGPUEngine(canvas, { canvasTabIndex: 0 });
```

## Backward compatibility

Fully backward compatible — the default remains `1` when the option is not provided, and the existing public `canvasTabIndex` property is unchanged.