### PR TITLE
Playground: support importing external resources by absolute URL

### DIFF
--- a/packages/tools/playground/src/tools/monaco/run/runner.ts
+++ b/packages/tools/playground/src/tools/monaco/run/runner.ts
@@ -317,11 +317,18 @@ export async function CreateV2Runner(manifest: V2Manifest, opts: V2RunnerOptions
             } // skip non-static or unsupported cases
 
             const isRel = spec.startsWith("./") || spec.startsWith("../") || spec.startsWith("/");
+            // Absolute URL specifiers (e.g. import { x } from "https://cdn.example.com/mod.js"),
+            // protocol-relative URLs, and data:/blob: URLs are already resolvable by the browser /
+            // es-module-shims and must be passed through untouched. Without this, they would fall
+            // into the bare-import branch below and get wrapped with the CDN base (esm.sh/https://…).
+            const isAbsoluteUrl = /^(?:https?:)?\/\//i.test(spec) || spec.startsWith("data:") || spec.startsWith("blob:");
             let replacement = spec;
             const normalized = normalizeForCdn(spec);
 
             const localHit = resolveLocal(spec) ?? resolveLocal(normalized);
-            if (localHit) {
+            if (isAbsoluteUrl) {
+                replacement = spec;
+            } else if (localHit) {
                 replacement = localHit;
             } else if (/@local(?:\/|$)/.test(spec)) {
                 throw new Error(`Unresolved local import: ${spec}. Link the package and export types/entry in the editor.`);

--- a/packages/tools/playground/src/tools/monaco/run/runner.ts
+++ b/packages/tools/playground/src/tools/monaco/run/runner.ts
@@ -321,7 +321,8 @@ export async function CreateV2Runner(manifest: V2Manifest, opts: V2RunnerOptions
             // protocol-relative URLs, and data:/blob: URLs are already resolvable by the browser /
             // es-module-shims and must be passed through untouched. Without this, they would fall
             // into the bare-import branch below and get wrapped with the CDN base (esm.sh/https://…).
-            const isAbsoluteUrl = /^(?:https?:)?\/\//i.test(spec) || spec.startsWith("data:") || spec.startsWith("blob:");
+            // URL schemes are case-insensitive, so match case-insensitively.
+            const isAbsoluteUrl = /^(?:https?:)?\/\//i.test(spec) || /^(?:data|blob):/i.test(spec);
             let replacement = spec;
             const normalized = normalizeForCdn(spec);
 

--- a/packages/tools/playground/src/tools/monaco/ts/tsPipeline.ts
+++ b/packages/tools/playground/src/tools/monaco/ts/tsPipeline.ts
@@ -94,13 +94,17 @@ declare module "*.fx"   { const content: string; export default content; }`;
         // Allow importing external resources directly by absolute URL (e.g.
         // `import { foo } from "https://cdn.example.com/mod.js"`). These specifiers are
         // resolved at runtime by es-module-shims / the browser, so we declare them as
-        // `any`-typed ambient modules to stop the TS worker from reporting "Cannot find
-        // module" (2307) and aborting the run.
+        // shorthand ambient modules to stop the TS worker from reporting "Cannot find
+        // module" (2307) and aborting the run. Shorthand ambient modules (no body) make
+        // every import shape — default, named and namespace — resolve to `any`, which a
+        // `export =`/`export default` body would not (named imports would still raise
+        // 2305/2614). The `//*` entry covers protocol-relative specifiers.
         const urlImportDts = `
-declare module "https://*" { const mod: any; export = mod; }
-declare module "http://*"  { const mod: any; export = mod; }
-declare module "data:*"    { const mod: any; export = mod; }
-declare module "blob:*"    { const mod: any; export = mod; }`;
+declare module "https://*";
+declare module "http://*";
+declare module "//*";
+declare module "data:*";
+declare module "blob:*";`;
         const urlTsDisposable = typescript.typescriptDefaults.addExtraLib(urlImportDts, "file:///external/urlImports.d.ts");
         const urlJsDisposable = typescript.javascriptDefaults.addExtraLib(urlImportDts, "file:///external/urlImports.d.ts");
         this._extraLibDisposables.push(urlTsDisposable, urlJsDisposable);

--- a/packages/tools/playground/src/tools/monaco/ts/tsPipeline.ts
+++ b/packages/tools/playground/src/tools/monaco/ts/tsPipeline.ts
@@ -91,6 +91,20 @@ declare module "*.fx"   { const content: string; export default content; }`;
         const shaderJsDisposable = typescript.javascriptDefaults.addExtraLib(shaderDts, "file:///external/shaders.d.ts");
         this._extraLibDisposables.push(shaderTsDisposable, shaderJsDisposable);
 
+        // Allow importing external resources directly by absolute URL (e.g.
+        // `import { foo } from "https://cdn.example.com/mod.js"`). These specifiers are
+        // resolved at runtime by es-module-shims / the browser, so we declare them as
+        // `any`-typed ambient modules to stop the TS worker from reporting "Cannot find
+        // module" (2307) and aborting the run.
+        const urlImportDts = `
+declare module "https://*" { const mod: any; export = mod; }
+declare module "http://*"  { const mod: any; export = mod; }
+declare module "data:*"    { const mod: any; export = mod; }
+declare module "blob:*"    { const mod: any; export = mod; }`;
+        const urlTsDisposable = typescript.typescriptDefaults.addExtraLib(urlImportDts, "file:///external/urlImports.d.ts");
+        const urlJsDisposable = typescript.javascriptDefaults.addExtraLib(urlImportDts, "file:///external/urlImports.d.ts");
+        this._extraLibDisposables.push(urlTsDisposable, urlJsDisposable);
+
         // Global shim for legacy PG with less strict checking
         this._addGlobalAnyStub();
     }


### PR DESCRIPTION
## Problem

The Playground (V2 runner) could not `import` from an external file by absolute URL, which made async loading of external ESM resources impossible. Two things broke it:

1. **Runtime rewrite** — an absolute-URL specifier such as `import { x } from "https://cdn.example.com/mod.js"` fell into the bare-import branch and was wrapped with the CDN base, producing a broken URL like `https://esm.sh/https://cdn.example.com/mod.js`.
2. **TS diagnostics** — the Monaco TS worker reported `2307 Cannot find module 'https://…'` for URL imports and aborted the run before it could execute.

## Change

- `runner.ts`: detect absolute-URL specifiers (`http(s)://`, protocol-relative `//`, `data:`, `blob:`) and pass them through untouched so es-module-shims / the browser resolve them natively.
- `tsPipeline.ts`: register ambient `any`-typed module declarations for `https://*`, `http://*`, `data:*`, and `blob:*` so the TS worker no longer flags URL imports and aborts the run.

## Result

External ESM resources can now be loaded from the Playground, e.g.:

```ts
const { SomeHelper } = await import("https://cdn.example.com/my-lib.js");
// or top-level:
import { SomeHelper } from "https://cdn.example.com/my-lib.js";
```

Bare imports (resolved via CDN/import map) and relative/local imports are unaffected — the passthrough only applies to absolute URLs that the browser can already resolve.