### PR TITLE
fix(AudioV2): apply play options when resuming a paused sound

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -174,15 +174,16 @@ export abstract class AbstractSound extends AbstractSoundSource {
 
     /**
      * Resumes the sound.
+     * @param options The options to use when resuming the sound. Only options explicitly set here override the paused instance's current options; unset options keep their paused values so playback continues from where it was paused.
      */
-    public resume(): void {
+    public resume(options?: Partial<IAbstractSoundPlayOptions>): void {
         if (this._state !== SoundState.Paused) {
             return;
         }
 
         const it = this._instances.values();
         for (let next = it.next(); !next.done; next = it.next()) {
-            next.value.resume();
+            next.value.resume(options);
         }
 
         this._state = SoundState.Started;

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundInstance.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundInstance.ts
@@ -50,7 +50,7 @@ export abstract class _AbstractSoundInstance extends AbstractAudioNode {
 
     public abstract play(options: Partial<IAbstractSoundPlayOptions>): void;
     public abstract pause(): void;
-    public abstract resume(): void;
+    public abstract resume(options?: Partial<IAbstractSoundPlayOptions>): void;
     public abstract stop(): void;
 
     protected _setState(value: SoundState) {

--- a/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
@@ -221,6 +221,15 @@ export abstract class StaticSound extends AbstractSound {
     }
 
     /**
+     * Resumes the sound.
+     * - Only options explicitly set here override the paused instance's current options; unset options keep their paused values so playback continues from where it was paused.
+     * @param options The options to use when resuming the sound.
+     */
+    public override resume(options?: Partial<IStaticSoundPlayOptions>): void {
+        super.resume(options);
+    }
+
+    /**
      * Stops the sound.
      * - Triggers `onEndedObservable` if the sound is playing.
      * @param options - The options to use when stopping the sound.

--- a/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/staticSound.ts
@@ -200,7 +200,7 @@ export abstract class StaticSound extends AbstractSound {
      */
     public play(options: Partial<IStaticSoundPlayOptions> = {}): void {
         if (this.state === SoundState.Paused) {
-            this.resume();
+            this.resume(options);
             return;
         }
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/streamingSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/streamingSound.ts
@@ -97,7 +97,7 @@ export abstract class StreamingSound extends AbstractSound {
      */
     public play(options: Partial<IStreamingSoundPlayOptions> = {}): void {
         if (this.state === SoundState.Paused) {
-            this.resume();
+            this.resume(options);
             return;
         }
 

--- a/packages/dev/core/src/AudioV2/abstractAudio/streamingSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/streamingSound.ts
@@ -129,6 +129,15 @@ export abstract class StreamingSound extends AbstractSound {
     }
 
     /**
+     * Resumes the sound.
+     * - Only options explicitly set here override the paused instance's current options; unset options keep their paused values so playback continues from where it was paused.
+     * @param options The options to use when resuming the sound.
+     */
+    public override resume(options?: Partial<IStreamingSoundPlayOptions>): void {
+        super.resume(options);
+    }
+
+    /**
      * Stops the sound.
      */
     public stop(): void {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -415,7 +415,10 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
 
         this._enginePlayTime = this.engine.currentTime + (options.waitTime ?? 0);
 
-        this._volumeNode.gain.value = options.volume ?? 1;
+        // Only override the volume when explicitly provided so resuming a paused instance keeps its current volume.
+        if (options.volume !== undefined) {
+            this._volumeNode.gain.value = options.volume;
+        }
 
         this._initSourceNode();
 

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -449,9 +449,9 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
     }
 
     /** @internal */
-    public resume(): void {
+    public resume(options: Partial<IStaticSoundPlayOptions> = {}): void {
         if (this._state === SoundState.Paused) {
-            this.play();
+            this.play(options);
         }
     }
 

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -308,11 +308,11 @@ class _WebAudioStreamingSoundInstance extends _StreamingSoundInstance implements
     }
 
     /** @internal */
-    public resume(): void {
+    public resume(options: Partial<IStreamingSoundPlayOptions> = {}): void {
         if (this._state === SoundState.Paused) {
-            this.play();
+            this.play(options);
         } else if (this._currentTimeChangedWhilePaused) {
-            this.play();
+            this.play(options);
         }
     }
 

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -290,7 +290,10 @@ class _WebAudioStreamingSoundInstance extends _StreamingSoundInstance implements
             this._mediaElement.currentTime = startOffset;
         }
 
-        this._volumeNode.gain.value = options.volume ?? 1;
+        // Only override the volume when explicitly provided so resuming a paused instance keeps its current volume.
+        if (options.volume !== undefined) {
+            this._volumeNode.gain.value = options.volume;
+        }
 
         this._play();
     }

--- a/packages/tools/tests/test/audioV2/shared/abstractSound.playback.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSound.playback.ts
@@ -127,6 +127,32 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
             expect(volumes[Channel.R]).toBeCloseTo(0.5, VolumePrecision);
         });
 
+        test("Play sound, pause it, and resume it with `volume` parameter set to 0.5", async ({ page }) => {
+            await page.evaluate(
+                async ({ soundType }) => {
+                    await AudioV2Test.CreateAudioEngineAsync(soundType);
+                    const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulseTrainSoundFile);
+
+                    sound.play();
+                    await AudioV2Test.WaitAsync(0.5, () => {
+                        sound.pause();
+                    });
+                    await AudioV2Test.WaitAsync(0.5, () => {
+                        sound.resume({ volume: 0.5 });
+                    });
+                    await AudioV2Test.WaitAsync(1, () => {
+                        sound.stop();
+                    });
+                },
+                { soundType }
+            );
+
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 1.5);
+
+            expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
+            expect(volumes[Channel.R]).toBeCloseTo(0.5, VolumePrecision);
+        });
+
         test("Play sound with `startOffset` option set to 1", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
                 await AudioV2Test.CreateAudioEngineAsync(soundType);

--- a/packages/tools/tests/test/audioV2/shared/abstractSound.playback.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSound.playback.ts
@@ -153,6 +153,32 @@ export const AddSharedAbstractSoundPlaybackTests = (soundType: SoundType) => {
             expect(volumes[Channel.R]).toBeCloseTo(0.5, VolumePrecision);
         });
 
+        test("Play sound, pause it, and resume it by calling `play` with `volume` parameter set to 0.5", async ({ page }) => {
+            await page.evaluate(
+                async ({ soundType }) => {
+                    await AudioV2Test.CreateAudioEngineAsync(soundType);
+                    const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulseTrainSoundFile);
+
+                    sound.play();
+                    await AudioV2Test.WaitAsync(0.5, () => {
+                        sound.pause();
+                    });
+                    await AudioV2Test.WaitAsync(0.5, () => {
+                        sound.play({ volume: 0.5 });
+                    });
+                    await AudioV2Test.WaitAsync(1, () => {
+                        sound.stop();
+                    });
+                },
+                { soundType }
+            );
+
+            const volumes = await EvaluateVolumesAtTimeAsync(page, 1.5);
+
+            expect(volumes[Channel.L]).toBeCloseTo(0.5, VolumePrecision);
+            expect(volumes[Channel.R]).toBeCloseTo(0.5, VolumePrecision);
+        });
+
         test("Play sound with `startOffset` option set to 1", async ({ page }) => {
             const pulses = await EvaluatePulseCountTestAsync(page, soundType, async ({ soundType }) => {
                 await AudioV2Test.CreateAudioEngineAsync(soundType);


### PR DESCRIPTION
## Problem

Reported on the forum: [AudioV2: Play over paused with new options?](https://forum.babylonjs.com/t/audiov2-play-over-paused-with-new-options/63649)

When a sound is in `SoundState.Paused`, calling `play(options)` or `resume()` with new options ignored them entirely:

```js
sound.resume({ waitTime: 1, volume: 0.3 }); // options ignored
sound.play({ waitTime: 1, volume: 0.3 });   // options ignored on a paused sound
```

## Root cause

The options were dropped along the resume path:

1. `StaticSound.play()` / `StreamingSound.play()` short-circuited on `Paused` and called `resume()` **without forwarding `options`**.
2. `AbstractSound.resume()` took **no parameters**, so options could not be threaded through.
3. The instance-level `resume()` called `play()` with no arguments.

The instance-level `play(options)` already applies provided options correctly (and accounts for the pause position) — the options simply never reached it.

## Fix

Thread the play options through the resume path, forwarding **only** what the caller explicitly set so unset options keep their paused values (playback continues from where it was paused):

- `AbstractSound.resume(options?)` and the abstract `_AbstractSoundInstance.resume(options?)` now accept options.
- `StaticSound.play()` / `StreamingSound.play()` forward `options` to `resume(options)`.
- The WebAudio static/streaming instance `resume(options)` passes them into `play(options)`.

This is backward-compatible (new optional parameter).

### Note
`resume({ startOffset })` on a static sound is added to the pause offset (existing instance behavior), not treated as an absolute seek. Absolute seek-on-resume would be a separate, larger change. For the reported use case (volume / waitTime / duration / loop) the behavior is now correct.

## Tests

Added a shared playback test: play a sound, pause it, then `resume({ volume: 0.5 })` and assert the measured output volume is 0.5. Runs for both `StaticSound` and `StreamingSound`.
