### PR TITLE
Add FBX support to the Sandbox

### DIFF
--- a/packages/tools/sandbox/public/manifest.webmanifest
+++ b/packages/tools/sandbox/public/manifest.webmanifest
@@ -60,7 +60,7 @@
                 "model/obj": [".obj"],
                 "model/stl": [".stl"],
                 "application/x-ply": [".ply"],
-                "application/octet-stream": [".splat", ".spz", ".babylon", ".bvh", ".sog"]
+                "application/octet-stream": [".splat", ".spz", ".babylon", ".bvh", ".sog", ".fbx"]
             },
             "icons": [
                 {

--- a/packages/tools/sandbox/src/components/footer.tsx
+++ b/packages/tools/sandbox/src/components/footer.tsx
@@ -139,7 +139,7 @@ export class Footer extends React.Component<IFooterProps, IFooterState> {
                             this.props.globalState.currentScene?.getEngine().clearInternalTexturesCache();
                             this.props.globalState.filesInput.loadFiles(evt);
                         }}
-                        label="Open your scene from your hard drive (.babylon, .gltf, .glb, .obj)"
+                        label="Open your scene from your hard drive (.babylon, .gltf, .glb, .fbx, .obj)"
                     />
                     <DropUpButton
                         globalState={this.props.globalState}

--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -197,9 +197,10 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
 
             camera = this._scene.activeCamera! as ArcRotateCamera;
 
-            if (this._currentPluginName === "gltf" || this._currentPluginName === "obj") {
+            if (this._currentPluginName === "gltf" || this._currentPluginName === "obj" || this._currentPluginName === "fbx") {
                 // glTF assets use a +Z forward convention while the default camera faces +Z. Rotate the camera to look at the front of the asset.
                 // We do this same for obj as it matches other viewers, but obj does not specify a forward convention.
+                // The FBX loader applies the same right-handed-to-left-handed flip as glTF, so its assets share the +Z forward convention.
                 camera.alpha += Math.PI;
             }
 
@@ -303,6 +304,12 @@ export class RenderingZone extends React.Component<IRenderingZoneProps> {
         }
 
         this.props.globalState.onSceneLoaded.notifyObservers({ scene: this._scene, filename: filename });
+
+        // The FBX loader creates animation groups but does not auto-play them the way the glTF loader does.
+        // Treat FBX assets like glTF in the Sandbox by playing the first animation group (looped) on load.
+        if (this._currentPluginName === "fbx" && this._scene.animationGroups.length > 0) {
+            this._scene.animationGroups[0].start(true);
+        }
 
         const camera = this.prepareCamera();
         this.prepareLighting();

--- a/packages/tools/sandbox/src/main.ts
+++ b/packages/tools/sandbox/src/main.ts
@@ -11,6 +11,8 @@
 // Register GLTF/GLB loader (2.0 sub-loader assigns GLTFFileLoader._CreateGLTF2Loader).
 // The sandbox loads .glb/.gltf files directly via SceneLoader.
 import "loaders/glTF/2.0/glTFLoader";
+// Register the FBX loader so .fbx files can be loaded via SceneLoader (drag-and-drop and the file picker).
+import "loaders/FBX/fbxFileLoader";
 import { Sandbox } from "./sandbox";
 
 const HostElement = document.getElementById("host-element") as HTMLElement;

--- a/packages/tools/sandbox/src/sandbox.tsx
+++ b/packages/tools/sandbox/src/sandbox.tsx
@@ -403,7 +403,7 @@ export class Sandbox extends React.Component<
      * @returns A formatted string of supported extensions like "gltf, glb, obj or babylon"
      */
     private _getSupportedExtensions(): string {
-        const fallbackExtensions = "babylon, gltf, glb, obj, ply, sog, splat, spz or stl";
+        const fallbackExtensions = "babylon, gltf, glb, fbx, obj, ply, sog, splat, spz or stl";
 
         try {
             const plugins = BABYLON.GetRegisteredSceneLoaderPluginMetadata();

--- a/packages/tools/sandbox/test/interaction.sandbox.test.ts
+++ b/packages/tools/sandbox/test/interaction.sandbox.test.ts
@@ -53,7 +53,7 @@ test("Sandbox exposes the render canvas and main controls without page errors", 
 
     await expect(page.locator("#renderCanvas")).toBeVisible();
     await expect(page.locator("#droptext")).toBeVisible();
-    await expect(page.getByTitle("Open your scene from your hard drive (.babylon, .gltf, .glb, .obj)")).toBeVisible();
+    await expect(page.getByTitle("Open your scene from your hard drive (.babylon, .gltf, .glb, .fbx, .obj)")).toBeVisible();
     expect(pageErrors).toHaveLength(0);
 });
 


### PR DESCRIPTION
## What

Adds FBX (`.fbx`) as a first-class supported format in the Babylon.js Sandbox, bringing it to parity with the existing glTF drag-and-drop / file-picker workflow.

## Changes

- **Register the FBX loader** (`loaders/FBX/fbxFileLoader`) in `main.ts` so `.fbx` files load via drag-and-drop and the file picker.
- **Surface the format in the UI:**
  - Open-file button label (`footer.tsx`)
  - Supported-formats fallback / drop text (`sandbox.tsx`)
  - Installable-app (PWA) file handlers (`manifest.webmanifest`)
- **Viewer parity with glTF** (`renderingZone.tsx`):
  - Apply the same 180° camera framing rotation — the FBX loader uses the same right-handed → left-handed flip as glTF, so its assets share the +Z forward convention and frame correctly on load.
  - Auto-play the first animation group (looped) on load — the FBX loader creates animation groups but, unlike the glTF loader, does not auto-play them.

## Testing

- Updated the Sandbox interaction test to assert the new supported-formats label.
- Manually validated against Babylon's FBX test assets and real-world Sketchfab content: correct orientation, animation playback, and texture assignment.

## Notes

- Sandbox-only change — no core or loader modifications.
