### PR TITLE
fix(playground): declare uuid as a direct dependency to fix broken build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6000,13 +6000,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/uuid": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-            "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/ws": {
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -21482,12 +21475,12 @@
                 "@tools/snippet-loader": "1.0.0",
                 "@types/react": "^18.0.0",
                 "@types/react-dom": "^18.0.0",
-                "@types/uuid": "^10.0.0",
                 "@typescript/ata": "^0.9.8",
                 "es-module-lexer": "^1.7.0",
                 "monaco-editor": "^0.55.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "uuid": "^11.0.0",
                 "vite-plugin-svgr": "^5.2.0"
             }
         },
@@ -21497,6 +21490,20 @@
             "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "dev": true,
             "license": "MIT"
+        },
+        "packages/tools/playground/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
         },
         "packages/tools/reflector": {
             "name": "@tools/reflector",

--- a/packages/tools/playground/package.json
+++ b/packages/tools/playground/package.json
@@ -20,12 +20,12 @@
         "@tools/snippet-loader": "1.0.0",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
-        "@types/uuid": "^10.0.0",
         "@typescript/ata": "^0.9.8",
         "es-module-lexer": "^1.7.0",
         "monaco-editor": "^0.55.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "uuid": "^11.0.0",
         "vite-plugin-svgr": "^5.2.0"
     },
     "sideEffects": true


### PR DESCRIPTION
## Problem

The Playground production build (`npm run build -w @tools/playground`) currently fails:

```
[vite]: Rollup failed to resolve import "uuid" from
".../packages/tools/playground/src/tools/monaco/monacoManager.ts".
```

`monacoManager.ts` imports the **runtime** `uuid` package:

```ts
import { v5 as uuidv5 } from "uuid";
```

It is used in `_createConfigHash()` to produce a deterministic v5 hash of a runner configuration (manifest + options) for runner caching.

## Root cause — a phantom (undeclared) dependency

The playground only ever declared `@types/uuid` (the TypeScript types), **never the `uuid` runtime package itself**. So the import was a phantom dependency.

It nevertheless built for a while purely by accident:

- npm **hoisted a transitive `uuid@8.3.2`** to the top-level `node_modules/uuid`.
- That copy was pulled in by `istanbul-lib-processinfo@3.0.0` (a code-coverage tooling dependency).
- Because it lived at the top level, Vite/Rollup happened to resolve the playground's bare `"uuid"` import against it — even though the playground never listed `uuid`.

## What changed (why it broke now)

The import was added in #17216 (*"Playground Editor V2: Multi-file, ES modules, NPM Support"*, merged 2025-10-20) but **never had a declared dependency** — so the production build has technically been fragile since then.

It actually broke on **2026-06-22** with commit `aa91e3eaa0` — *"chore(deps): npm audit fix — 20260622" (#18600)*. That audit fix bumped `istanbul-lib-processinfo` **3.0.0 → 3.0.1**, and the newer version dropped its `uuid@^8.3.2` dependency (it switched to the built-in `crypto.randomUUID`). The relevant lockfile diff:

```diff
- istanbul-lib-processinfo-3.0.0.tgz
+ istanbul-lib-processinfo-3.0.1.tgz
-     "uuid": "^8.3.2"          # dependency removed
- "node_modules/uuid": { ... } # hoisted top-level uuid deleted
```

With no other package pulling `uuid` to the top level, the hoisted `node_modules/uuid` disappeared and the playground's phantom import had nothing left to resolve against → build failure.

## Fix

Declare `uuid` directly in the playground's `package.json` so the build no longer relies on transitive hoisting from an unrelated coverage tool.

- Added `uuid` as a direct dependency.
- Used **`uuid@11`** instead of v10: the lockfile flags `uuid@10 and below` as deprecated and recommends `uuid@latest` for ESM codebases (the playground is ESM via Vite). This avoids immediately re-tripping the next `npm audit fix`.
- Removed the now-redundant `@types/uuid` — `uuid@11` ships its own type definitions.

The public API used (`v5`) is unchanged between v8/v10/v11, so no source changes were needed.

## Validation

- `npm run build -w @tools/playground` — ✅ succeeds (`✓ built in ~14s`)
- `npm run typecheck -w @tools/playground` — ✅ passes
- Confirmed via repo-wide grep that the playground is the only consumer of `uuid`/`@types/uuid`.
