### PR TITLE
Flow Graph Editor: playground snippet auto-load, no auto-run on load, and stopped-state variable types

### DIFF
--- a/packages/dev/core/src/FlowGraph/flowGraph.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraph.ts
@@ -255,6 +255,15 @@ export class FlowGraph {
         // Rebuild with the new scene
         (this as { _scene: Scene })._scene = scene;
         this._scene.constantlyUpdateMeshUnderPointer = true; // ensure pointer info is always up to date for event blocks that need it
+        // Re-resolve node references (e.g. meshes targeted by Get/Set property blocks) against the
+        // new scene. This is required when the graph was parsed before its scene was populated (for
+        // example an editor that loads a graph from a snippet first and the referenced scene second):
+        // the references would otherwise stay bound to nodes from the old/disposed scene.
+        for (const block of this._allBlocks) {
+            for (const input of block.dataInputs) {
+                input._reresolveDefaultValueForScene(scene);
+            }
+        }
         this._sceneEventCoordinator = new FlowGraphSceneEventCoordinator(this._scene);
         // Pre-attach the event observer so that events from the new
         // coordinator are routed to the graph immediately.  The handler

--- a/packages/dev/core/src/FlowGraph/flowGraphDataConnection.pure.ts
+++ b/packages/dev/core/src/FlowGraph/flowGraphDataConnection.pure.ts
@@ -6,8 +6,9 @@ import { FlowGraphConnection, FlowGraphConnectionType } from "./flowGraphConnect
 import { type FlowGraphContext } from "./flowGraphContext";
 import { type RichType } from "./flowGraphRichTypes.pure";
 import { Observable } from "core/Misc/observable.pure";
-import { defaultValueSerializationFunction } from "./serialization";
+import { defaultValueSerializationFunction, GetSceneNodeFromSerializedReference } from "./serialization";
 import { RegisterClass } from "../Misc/typeStore";
+import { type Scene } from "core/scene";
 /**
  * Represents a connection point for data.
  * An unconnected input point can have a default value.
@@ -116,6 +117,44 @@ export class FlowGraphDataConnection<T> extends FlowGraphConnection<FlowGraphBlo
      */
     public resetToDefaultValue(context: FlowGraphContext): void {
         context._setConnectionValue(this, this._defaultValue);
+    }
+
+    /**
+     * Re-resolves this input's default value against a (new) scene when the value is a node reference.
+     * This handles two cases that occur when a graph is moved to a different scene (see
+     * {@link FlowGraph.setScene}):
+     * - the value is still an unresolved serialized reference (`{ id, name, className, uniqueId }`)
+     *   because the node did not yet exist in the scene at parse time, or
+     * - the value is a node that belongs to a different (e.g. disposed) scene.
+     * Values that are not node references (numbers, vectors, matrices, etc.) are left untouched, and
+     * the default value is only replaced when a matching node is found in the new scene.
+     * @param scene the scene to resolve the reference against
+     * @internal
+     */
+    public _reresolveDefaultValueForScene(scene: Scene): void {
+        const value = this._defaultValue as any;
+        if (!value || typeof value !== "object") {
+            return;
+        }
+
+        let reference: { id?: string; name?: string; className?: string; uniqueId?: number } | undefined;
+        if (typeof value.getClassName === "function" && typeof value.getScene === "function") {
+            // A scene node — only rebind when it belongs to a different scene.
+            if (value.getScene() === scene) {
+                return;
+            }
+            reference = { id: value.id, name: value.name, className: value.getClassName(), uniqueId: value.uniqueId };
+        } else if (typeof value.className === "string" && (value.id || value.name) && value.value === undefined) {
+            // An unresolved serialized node reference left by the parser.
+            reference = value;
+        } else {
+            return;
+        }
+
+        const node = GetSceneNodeFromSerializedReference(reference, scene);
+        if (node) {
+            this._defaultValue = node as unknown as T;
+        }
     }
 
     /**

--- a/packages/dev/core/src/FlowGraph/serialization.ts
+++ b/packages/dev/core/src/FlowGraph/serialization.ts
@@ -28,7 +28,17 @@ function IsAnimationGroupClassName(className: string) {
     return className === "AnimationGroup";
 }
 
-function GetSceneNodeFromSerializedReference(serializedReference: any, scene: Scene): Node | undefined {
+/**
+ * Resolves a serialized node reference (`{ id, name, className, uniqueId }`) to an actual scene node.
+ * Matching prefers `id` (falling back to `name`), then narrows by class name, then by `uniqueId`.
+ * Because `uniqueId` is reassigned every time a scene is built, it is only used as a tie-breaker so
+ * that references still resolve after a scene is reloaded (e.g. an editor preview).
+ * @param serializedReference the serialized reference to resolve
+ * @param scene the scene to resolve the reference against
+ * @returns the matching node, or undefined when none is found
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function GetSceneNodeFromSerializedReference(serializedReference: any, scene: Scene): Node | undefined {
     if (!serializedReference || (!serializedReference.id && !serializedReference.name)) {
         return undefined;
     }

--- a/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
+++ b/packages/dev/core/test/unit/FlowGraph/flowGraphSerialization.test.ts
@@ -394,6 +394,46 @@ describe("Flow Graph Serialization", () => {
         expect(camera.alpha).toBe(1);
     });
 
+    it("setScene re-resolves node references against the new scene", () => {
+        // Mimics an editor that loads a graph before its referenced scene exists: the parser leaves
+        // node-targeting inputs holding the raw serialized reference ({ id, name, className, uniqueId })
+        // instead of a live node. Moving the graph to the populated scene via setScene must rebind those
+        // references to the matching nodes in the new scene (uniqueIds differ across scene builds).
+        const coordinator = new FlowGraphCoordinator({ scene });
+        const graph = coordinator.createGraph();
+
+        // Case 1: an unresolved serialized reference left by the parser (node absent at parse time).
+        const unresolvedBlock = new FlowGraphSetPropertyBlock<Vector3, FlowGraphAssetType.Mesh>({ propertyName: "position" });
+        graph.addBlock(unresolvedBlock);
+        (unresolvedBlock.object as any)._defaultValue = { id: "hero", name: "hero", className: "Mesh", uniqueId: 20 };
+
+        // Case 2: a reference to a node that belongs to a different (e.g. disposed) scene.
+        const oldScene = new Scene(engine);
+        const oldGoomba = new Mesh("goomba", oldScene);
+        const staleBlock = new FlowGraphSetPropertyBlock<Vector3, FlowGraphAssetType.Mesh>({ propertyName: "position", target: oldGoomba });
+        graph.addBlock(staleBlock);
+
+        // Case 3: a non-node value must be left untouched.
+        const numberBlock = new FlowGraphSetPropertyBlock<number, FlowGraphAssetType.Mesh>({ propertyName: "visibility" });
+        graph.addBlock(numberBlock);
+        (numberBlock.object as any)._defaultValue = 42;
+
+        // The populated preview scene holds fresh instances with different uniqueIds.
+        const previewScene = new Scene(engine);
+        const liveHero = new Mesh("hero", previewScene);
+        const liveGoomba = new Mesh("goomba", previewScene);
+
+        graph.setScene(previewScene);
+
+        const context = graph.createContext();
+        expect(unresolvedBlock.object.getValue(context)).toBe(liveHero);
+        expect(staleBlock.object.getValue(context)).toBe(liveGoomba);
+        expect(numberBlock.object.getValue(context)).toBe(42);
+
+        oldScene.dispose();
+        previewScene.dispose();
+    });
+
     it("Event block fires both out and done signals after round-trip", async () => {
         const mockContext: any = {};
         const pathConverter = new FlowGraphPathConverter(mockContext);

--- a/packages/tools/devHost/src/flowgraph/babylonBrosFlowGraph.json
+++ b/packages/tools/devHost/src/flowgraph/babylonBrosFlowGraph.json
@@ -1,0 +1,15128 @@
+{
+    "_flowGraphs": [
+        {
+            "name": "Babylon Bros — Interactions",
+            "uniqueId": "5e5c9ede-95bf-4fa7-b1a9-704e24127da9",
+            "allBlocks": [
+                {
+                    "uniqueId": "5d0f559e-c286-49a7-bfc3-ad0dbea3e05b",
+                    "config": {
+                        "name": "spike_1_core hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "06155683-49ed-40c2-9885-16cef376d913",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6ebeff04-5500-4593-ad6e-6097ce9154fe"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "177291bd-2bf9-4a66-a409-8fc12c6951a3",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "af1314e0-d439-44f8-a0e2-1063d63f4263",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "8135297c-0d9d-4149-8924-ac3df2bd6c1a",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "1a9d2227-db2f-457c-8840-dbf7f06d3bca",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "97a2ff9a-938e-408d-805b-9eb19f173ab5",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "452c22c0-dcb2-40b6-98a1-daa9cc08855f",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "955e8fcf-1ae3-4d20-8834-42ac63bfb6a1",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "16d11121-5394-4ade-a8e4-3613a059edb6",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["50a58e1d-0db2-41e5-8ea7-9edd61e69c6c"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "d05f0366-5319-4035-a1ba-d0aef67f2d9d",
+                    "config": {
+                        "name": "spike_1_core active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "1d750f20-9fb8-4ca8-96c8-2d08ac6bc8d0",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3ddfa700-ff48-4fd1-893e-789a68a1e1e8"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "50a58e1d-0db2-41e5-8ea7-9edd61e69c6c",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["16d11121-5394-4ade-a8e4-3613a059edb6"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "6ad81489-0e24-4b98-8821-3d2c18ddc5eb",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "1344d75c-b280-49b8-9182-7a7d8a7d1bdd",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cb73ec51-5122-44fc-bb95-439f7ba4cf50"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4271d568-3d8a-4705-8d7d-8768e07c1f6b",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "7091ca22-8e08-4812-b2b6-4ef8ce9bd9b3",
+                    "config": {
+                        "name": "spike_1_core inactive",
+                        "variable": "spike_1_core_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "62729c26-171f-46a4-9e79-ad0ca3395821",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "cb73ec51-5122-44fc-bb95-439f7ba4cf50",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["1344d75c-b280-49b8-9182-7a7d8a7d1bdd"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "14112d28-8adc-4e9f-874c-6d9f80f68fdb",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "e6e7cdd0-e954-4b19-8739-a4faf80406e7",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cc1784ba-e9fa-46c1-91d8-6c4e946c4633"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "8d62acda-fbae-494d-9172-bc3f6b30a518",
+                    "config": {
+                        "name": "Emit hurt",
+                        "eventId": "hurt",
+                        "eventData": {}
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSendCustomEventBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "cc1784ba-e9fa-46c1-91d8-6c4e946c4633",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": [
+                                "d80ac180-8f94-4a76-af01-eb8bdc69401c",
+                                "7a163a71-b07f-41c4-ae32-095853541077",
+                                "5ed96517-1163-4e65-b1e6-1b4a42fcb71d",
+                                "e6e7cdd0-e954-4b19-8739-a4faf80406e7"
+                            ],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "980d9a14-2be6-4a33-8efb-961776448510",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5edd9164-6d67-4a78-864d-3cd31877cf7b",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "64af9473-db73-48e4-905a-bad795751457",
+                    "config": {
+                        "name": "spike_1_core active",
+                        "variable": "spike_1_core_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "3ddfa700-ff48-4fd1-893e-789a68a1e1e8",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1d750f20-9fb8-4ca8-96c8-2d08ac6bc8d0"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "4659b47d-4cc4-4705-8260-446769efb2d8",
+                    "config": {
+                        "name": "spike_1_core body",
+                        "object": {
+                            "id": "spike_1_core",
+                            "name": "spike_1_core",
+                            "className": "Mesh",
+                            "uniqueId": 34
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "621d6075-46c2-4d78-8750-ef0ee1646c66",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "spike_1_core",
+                                "name": "spike_1_core",
+                                "className": "Mesh",
+                                "uniqueId": 34
+                            }
+                        },
+                        {
+                            "uniqueId": "a78dca4e-4f07-4dfc-9538-d6c622c4bf20",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "ab208aeb-823b-4e1f-b107-3c5fe56a0d50",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "6ebeff04-5500-4593-ad6e-6097ce9154fe",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["06155683-49ed-40c2-9885-16cef376d913"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b8264d88-a2cd-438a-abf1-64b57eaf087f",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "0af6d92a-b036-4fa9-9686-29428cb249e7",
+                    "config": {
+                        "name": "flyer_1_body hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "bc0a0009-010e-4cb5-b9a1-9d86aae86037",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5a7d6850-e855-467b-ba34-93783a9abbb0"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "8f2a9e25-40f1-4aa1-afcf-b270ef855344",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "0d8112d0-4d98-42b4-b30e-8f0d3956ea85",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "7ad30947-f6a6-49f9-a3f1-28a2cc415b11",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "19754dfc-bdfc-4b6b-9d3f-73284f7c784d",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "02ae0cd0-c6e3-4c8c-b2c5-cef5a3ce4852",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "9f6b894b-ccd7-4dbb-8bc4-d1cbe38b52ed",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0172a476-9916-47a5-85ca-ce2b0681b4c4",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b90b8889-4aa6-461a-a29e-73ee6739a396",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d7d6353d-114a-403d-9f75-02366bd00bf4"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "9744c594-45a8-408a-bef9-b3bc5b19569c",
+                    "config": {
+                        "name": "flyer_1_body active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "ee613962-6496-4c3c-92f8-bd4390ef024a",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["33a84310-38a4-48c9-8bd9-dd87399bf6f0"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "d7d6353d-114a-403d-9f75-02366bd00bf4",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b90b8889-4aa6-461a-a29e-73ee6739a396"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "c0e2e0a6-1040-4c48-87a7-e028e92776cf",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "19a31a30-be69-423e-b77a-40df06e25081",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d2d6b6d8-f5f7-48d7-b859-eaac2a5b3c55"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "75b2e06c-51ea-4c90-a2cd-d807f59e8ad0",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "976b7d2d-748d-4489-adec-52573119598f",
+                    "config": {
+                        "name": "flyer_1_body inactive",
+                        "variable": "flyer_1_body_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "6f21e6d8-f08e-4964-bcc2-f645bb081021",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "d2d6b6d8-f5f7-48d7-b859-eaac2a5b3c55",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19a31a30-be69-423e-b77a-40df06e25081"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "1292cf4d-b7ee-42e5-b1da-377c62032226",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5ed96517-1163-4e65-b1e6-1b4a42fcb71d",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cc1784ba-e9fa-46c1-91d8-6c4e946c4633"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "791073a5-4957-410f-8dcc-b9192f3690fa",
+                    "config": {
+                        "name": "flyer_1_body active",
+                        "variable": "flyer_1_body_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "33a84310-38a4-48c9-8bd9-dd87399bf6f0",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ee613962-6496-4c3c-92f8-bd4390ef024a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "2c0f8063-9754-4410-8912-838d16563155",
+                    "config": {
+                        "name": "flyer_1_body body",
+                        "object": {
+                            "id": "flyer_1_body",
+                            "name": "flyer_1_body",
+                            "className": "Mesh",
+                            "uniqueId": 33
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "94beb9d3-3799-4c1c-b61b-c6f73854adba",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "flyer_1_body",
+                                "name": "flyer_1_body",
+                                "className": "Mesh",
+                                "uniqueId": 33
+                            }
+                        },
+                        {
+                            "uniqueId": "2e02f010-5131-4c30-a698-b364cac32cce",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "1ab3cb7f-a23a-4cf4-aca5-e81afc52d459",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5a7d6850-e855-467b-ba34-93783a9abbb0",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["bc0a0009-010e-4cb5-b9a1-9d86aae86037"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "652e2608-7554-4bf5-a7c4-bd38849804cd",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "c7a98aba-8e40-4c7c-ba06-6af2dd5baf41",
+                    "config": {
+                        "name": "goomba_2_body hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5e59e8d4-8dc1-43f5-a2f8-98239b0f953c",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["80477f69-e900-4387-bde6-46006ba3a194"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "401814ca-fdd8-4139-8553-c698d5755154",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "5448ea77-a1fc-4253-ba2c-99739bd25b57",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "5eb04194-bf95-4937-8d83-f4681b0aabea",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "c1ab0dd2-418b-4f15-ad81-7e6fff445cb6",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "157fc4ca-18bf-48e4-94c4-7ee4a21ad7f9",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "25d8713d-7ed9-4fde-a6a5-05915983125a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4bb1567e-5a01-4e50-9994-9e704117b5c6",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7bdc5086-846b-4c63-b5a3-3da44c722869",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4b14d425-aeff-4ae6-8fdc-3dcb01c96b74"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "299177fb-7581-4c23-8960-9e0df9356cf7",
+                    "config": {
+                        "name": "goomba_2_body active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d119988f-1485-446a-805b-5f86c31ffb6f",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5b8a6739-753e-49cf-8427-2e7dfe0c865b"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "4b14d425-aeff-4ae6-8fdc-3dcb01c96b74",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["7bdc5086-846b-4c63-b5a3-3da44c722869"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5c12dd1d-6988-4199-94bc-b6b268dd014a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "be28b1d4-7450-4930-ba42-71f63d21becb",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["3f1f037e-17a3-4457-99d2-1e3921385279"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0c98c4d9-1d6f-4df5-927e-b9664a9066ba",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "2c4eee80-cc65-4f5e-924d-e5fd6748b8f8",
+                    "config": {
+                        "name": "goomba_2_body inactive",
+                        "variable": "goomba_2_body_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "fdb32fc9-1dd0-4574-a231-ec90c6786dfc",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "3f1f037e-17a3-4457-99d2-1e3921385279",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["be28b1d4-7450-4930-ba42-71f63d21becb"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "8ba6793e-651b-41ed-8b83-d010add72097",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7a163a71-b07f-41c4-ae32-095853541077",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cc1784ba-e9fa-46c1-91d8-6c4e946c4633"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "42454ea4-945c-4ba1-8925-3c8de1d3baf0",
+                    "config": {
+                        "name": "goomba_2_body active",
+                        "variable": "goomba_2_body_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5b8a6739-753e-49cf-8427-2e7dfe0c865b",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d119988f-1485-446a-805b-5f86c31ffb6f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "02f520b5-7d61-4b7a-ab01-897ba5fe7467",
+                    "config": {
+                        "name": "goomba_2_body body",
+                        "object": {
+                            "id": "goomba_2_body",
+                            "name": "goomba_2_body",
+                            "className": "Mesh",
+                            "uniqueId": 32
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "1a3cbed5-4c6b-4368-ac88-e21623e0e6e2",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "goomba_2_body",
+                                "name": "goomba_2_body",
+                                "className": "Mesh",
+                                "uniqueId": 32
+                            }
+                        },
+                        {
+                            "uniqueId": "ac30633d-d3aa-4f3b-a06c-c1de8dd63e17",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "2fa4a8a5-34dc-478e-b616-7ed5e6a7848f",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "80477f69-e900-4387-bde6-46006ba3a194",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5e59e8d4-8dc1-43f5-a2f8-98239b0f953c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "c7812892-3e1a-4300-849a-3d9dabdd7506",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "1a051d9a-35e3-4d97-972a-b7e8c16758b5",
+                    "config": {
+                        "name": "goomba_1_body hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e1521940-bffa-4bd8-9ed7-2e5d85d44970",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["53c79201-c4b5-4681-9676-fe19c137de05"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "4ee6caa3-e891-4651-8259-b3d5f9e6e3a9",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "c432f3fb-9c7c-440b-b890-122266d71a61",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "fa17271d-e61a-4302-8b05-dfc0747130f3",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "5fac0a30-3b44-4a45-ac23-d279d69a288b",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "81d82bf0-03ec-4b46-973d-dd55f8ecc680",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "de854e27-1bd4-4cd7-b558-8e3f2a5dedff",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a148b339-8230-42ad-a84a-f60191baa1ae",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d6286935-8319-4963-8cbf-be5e414fa9a2",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b4b2282c-bb37-42e6-b92e-c77b61e5318d"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "43240976-2b18-4495-bbc6-7ccd80fdc1e6",
+                    "config": {
+                        "name": "goomba_1_body active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "6bedfb98-1cd0-401e-bdb4-ace7f7031644",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d8dbc6c8-9309-400e-b43d-456b8942edd4"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "b4b2282c-bb37-42e6-b92e-c77b61e5318d",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d6286935-8319-4963-8cbf-be5e414fa9a2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "7227e92b-61a7-4c4e-b152-f4dc60a6b84d",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "317c659f-d682-43a9-bacb-e9dc1b372436",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["9fa28b82-58cb-41b8-a5cd-288f1c71e4da"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f1dff69e-9334-4acd-8973-8ad76dbf8891",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "8191efe7-4e70-45b3-9e2a-52c4d928d428",
+                    "config": {
+                        "name": "goomba_1_body inactive",
+                        "variable": "goomba_1_body_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0c7097b1-746e-48c4-b10f-ec909952cb97",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "9fa28b82-58cb-41b8-a5cd-288f1c71e4da",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["317c659f-d682-43a9-bacb-e9dc1b372436"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "c7fb4f80-2e01-4e95-b2a3-a96f769c0be2",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d80ac180-8f94-4a76-af01-eb8bdc69401c",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cc1784ba-e9fa-46c1-91d8-6c4e946c4633"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "a7220d97-b8d8-43b7-b88f-408aebd3988a",
+                    "config": {
+                        "name": "goomba_1_body active",
+                        "variable": "goomba_1_body_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "d8dbc6c8-9309-400e-b43d-456b8942edd4",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["6bedfb98-1cd0-401e-bdb4-ace7f7031644"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "35d128ad-d299-4515-807b-f2a3d0799cab",
+                    "config": {
+                        "name": "goomba_1_body body",
+                        "object": {
+                            "id": "goomba_1_body",
+                            "name": "goomba_1_body",
+                            "className": "Mesh",
+                            "uniqueId": 31
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "630c8dd3-458a-4def-abaf-cb84cec67c04",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "goomba_1_body",
+                                "name": "goomba_1_body",
+                                "className": "Mesh",
+                                "uniqueId": 31
+                            }
+                        },
+                        {
+                            "uniqueId": "c5136f5f-def3-4704-aa2c-833e24905ddb",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "ed2423be-18ba-4a42-b787-a06336566ae7",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "53c79201-c4b5-4681-9676-fe19c137de05",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["e1521940-bffa-4bd8-9ed7-2e5d85d44970"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "402697a3-9707-4664-8fe9-2c44991eb66c",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "d28bd424-b0b1-47c8-a586-804ca4f33692",
+                    "config": {
+                        "name": "spring_2 hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "20b64bf2-f570-4ba7-a124-7db3a1fb8e92",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6cdfbe24-2777-4ecb-9fb2-95feaeb78715"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "de98440e-8e49-4ec5-83c3-9a2d28b2cbf1",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "98d26dcf-cbc9-4599-9e8b-313dee63d143",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "678caf2f-b43a-4a9a-950f-b9c2009afc1e",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "92b74d59-20b1-4a63-b79e-2c5b2aaef2d5",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ba53ea6c-2a97-4d37-b504-22233ada21b4",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "632d1709-d9be-4983-bb3b-cd28df858c76",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "74b46f0f-15f0-4e55-b134-3506ee867121",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "156aac0a-40a6-4c8e-baeb-547b5a7cf5c6",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8f34ea4c-5732-4097-8f14-3037d8550193"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "c5c1bcb2-e0c3-43f1-84e7-78e1c12a5a3f",
+                    "config": {
+                        "name": "spring_2 can bounce?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0aebd555-ef9d-489c-a33b-bb3252c82bb7",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["572c12a0-117f-4e05-972c-47a70b69b6e1"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "8f34ea4c-5732-4097-8f14-3037d8550193",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["156aac0a-40a6-4c8e-baeb-547b5a7cf5c6"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "9af9d456-28f4-49ef-a072-1152c422cd54",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "af68d6e2-77da-4376-b8c7-7c58def2d0c0",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["dcf5a088-0114-420e-b310-3e1cf2edea95"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7a1be1e7-0dfb-40d9-9282-5af64e1ab0bb",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "7b1fa7e8-ea52-4f11-a387-52fac37b5fd6",
+                    "config": {
+                        "name": "spring_2 launch"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "32baa924-c23a-48fb-a94a-ee510cba1198",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "6ac0e04d-c5a4-4b0f-82d1-5652d97c2e4c",
+                            "name": "velocity",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["88339d85-3bc7-483c-8521-3abc7bfeb304"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetLinearVelocityBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "dcf5a088-0114-420e-b310-3e1cf2edea95",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["af68d6e2-77da-4376-b8c7-7c58def2d0c0"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "0af23cae-46d1-4dcd-aa18-3fa4eacfb30b",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d8f6b14d-18a5-4738-8402-f35cdc161afb",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fea65b9b-d611-4928-b6fc-749e7990a08b"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "322e9780-bd73-427e-b26c-f155876a8d27",
+                    "config": {
+                        "name": "spring_2 compress",
+                        "animationGroup": {
+                            "name": "spring_2_compress",
+                            "className": "AnimationGroup",
+                            "uniqueId": 19
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "32b92509-f330-4efa-ab31-0cb95d354f50",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "7ad1ad23-1ec8-4846-bfad-14de2e93c9bd",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "ad662537-8338-4827-88a6-9520ccee291f",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "f1cecd67-0aba-42fb-bf26-a300e99e72db",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "45f96910-8998-43dc-a27b-89abfdfb12a1",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "spring_2_compress",
+                                "className": "AnimationGroup",
+                                "uniqueId": 19
+                            }
+                        },
+                        {
+                            "uniqueId": "9c2a2835-6849-4ca1-8f9d-2dfea83b9a6e",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b64d37e0-1c2b-4920-a39c-f7d6764ee69f",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "380a7b74-d020-48ce-af65-8fe952d119f8",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "31fb4b05-c9cb-448d-acbe-917213133a82",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "775ec2bb-5c6e-4d69-8bf3-c5e959b02d0f",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "fea65b9b-d611-4928-b6fc-749e7990a08b",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d8f6b14d-18a5-4738-8402-f35cdc161afb"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "d4c7b4c2-59b9-459a-9562-f0eb4d26b5a6",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "520fa811-770e-4b6b-940a-b25e7b636fde",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1f9de541-6199-4a12-b9e2-480d7b766fd1"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c50b52de-3d4f-4c2f-b7f8-c29ddc39eef3",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "bce9ddcc-8f41-4250-8141-b34409c3c9e6",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "da1a614f-856b-47c7-bb8e-3992da6f6624",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "baae17cd-ec0c-4c60-a545-3387179f1e80",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "f2ec2edd-682e-47c4-bbe9-28654b6bef67",
+                    "config": {
+                        "name": "spring_2 boing"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "dc993b34-900b-4ea7-8f38-095bd5a5855c",
+                            "name": "sound",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["cecccb5d-d4d2-450d-ac14-60cf97d2cf01"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "688da201-1ec4-48bd-96b5-426590fcb8eb",
+                            "name": "volume",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        },
+                        {
+                            "uniqueId": "6009e5a5-e5e0-42d0-aeb3-2a5f6c826523",
+                            "name": "startOffset",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "3c5813fe-132a-4303-95e9-fc5795e9c874",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphPlaySoundBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "1f9de541-6199-4a12-b9e2-480d7b766fd1",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["520fa811-770e-4b6b-940a-b25e7b636fde"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "8e5a3011-d5f8-4c06-b5f8-2e0f3f357863",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "3fbba6ab-f558-4b55-838b-a0b4a735b71d",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "d5a4fec6-0ff0-484d-833a-abe281aa0167",
+                    "config": {
+                        "name": "spring_2 sound",
+                        "variable": "jumpSound"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "cecccb5d-d4d2-450d-ac14-60cf97d2cf01",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["dc993b34-900b-4ea7-8f38-095bd5a5855c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "a3804924-d6ff-49f9-ba81-c26ca054674e",
+                    "config": {
+                        "name": "spring_2 launch vel"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "729238ad-f9f6-40b1-aba6-4883da752a3e",
+                            "name": "input_0",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["dcbca6e0-cc7e-4c8a-bed4-c169de343a98"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "c57c7440-7f65-444f-999f-29752046e1cb",
+                            "name": "input_1",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 16
+                        },
+                        {
+                            "uniqueId": "bb754835-a167-4a02-a730-c7c0ede3c079",
+                            "name": "input_2",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["0c6be714-d7bc-4739-9b3f-ec87e34992b1"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "88339d85-3bc7-483c-8521-3abc7bfeb304",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["6ac0e04d-c5a4-4b0f-82d1-5652d97c2e4c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "e4a15b45-3e9e-4c3d-9ae7-4639b2a76553",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphCombineVector3Block"
+                },
+                {
+                    "uniqueId": "ad36b778-8c2a-4661-a91e-a559ff900c26",
+                    "config": {
+                        "name": "spring_2 extract vel"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "516f1a78-8f95-40c8-814a-a2d3d902cdba",
+                            "name": "input",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d0f2c5e1-bd84-41b1-8797-1108628f995e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "dcbca6e0-cc7e-4c8a-bed4-c169de343a98",
+                            "name": "output_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["729238ad-f9f6-40b1-aba6-4883da752a3e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "8078f193-8fa3-47b4-bfc3-ce11a135c5d5",
+                            "name": "output_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a81041cd-d98c-41a1-92e6-cc130b53b4ac"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "0c6be714-d7bc-4739-9b3f-ec87e34992b1",
+                            "name": "output_2",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["bb754835-a167-4a02-a730-c7c0ede3c079"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphExtractVector3Block"
+                },
+                {
+                    "uniqueId": "d3eed65f-2d2b-4904-b600-2b72bb302c20",
+                    "config": {
+                        "name": "spring_2 hero vel"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "15884083-d668-482a-bd74-470b55a157b3",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "d0f2c5e1-bd84-41b1-8797-1108628f995e",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["516f1a78-8f95-40c8-814a-a2d3d902cdba"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "6a199a35-1644-40bf-baf1-16530e75e53c",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetLinearVelocityBlock"
+                },
+                {
+                    "uniqueId": "590313dd-4a24-4637-a254-5d27220f9497",
+                    "config": {
+                        "name": "Hero body",
+                        "object": {
+                            "id": "hero",
+                            "name": "hero",
+                            "className": "Mesh",
+                            "uniqueId": 20
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "aa8614c4-08d1-4a93-9416-930888179b38",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "hero",
+                                "name": "hero",
+                                "className": "Mesh",
+                                "uniqueId": 20
+                            }
+                        },
+                        {
+                            "uniqueId": "823372b2-5ec5-4592-becd-48a9a9459b10",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "b246dd80-8a01-44c9-ad7e-d3a3c25fa387",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "19d7faae-2a15-4c4e-a873-f287eeed8488",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": [
+                                "a299e8c8-4f97-47c4-b06f-d26057d7345d",
+                                "4aa3a8d9-ee51-4c59-81eb-d1b7df347796",
+                                "36873e66-5b0f-4f7d-9db9-07dd10557177",
+                                "23f8f118-3bb7-4b4e-b83b-f0aa6a2fce85",
+                                "d4198a4a-0174-4630-b495-371fbe303980",
+                                "a3eb49ad-afce-4583-b411-b01aa2488b6a",
+                                "15884083-d668-482a-bd74-470b55a157b3",
+                                "32baa924-c23a-48fb-a94a-ee510cba1198"
+                            ],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "95e9622a-f1a3-4425-9bd4-1c17e2ec61dd",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "7f8a4554-4602-4f3f-a11b-63baab8dccce",
+                    "config": {
+                        "name": "spring_2 descending?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a81041cd-d98c-41a1-92e6-cc130b53b4ac",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8078f193-8fa3-47b4-bfc3-ce11a135c5d5"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "4944223c-9781-4af7-a052-cb2116c5a8ee",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "572c12a0-117f-4e05-972c-47a70b69b6e1",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0aebd555-ef9d-489c-a33b-bb3252c82bb7"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "5717eb1e-bd7e-44e9-9950-8fc527660ef9",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "4813377a-8871-4d90-ba37-9dbae36cf4b7",
+                    "config": {
+                        "name": "spring_2 body",
+                        "object": {
+                            "id": "spring_2",
+                            "name": "spring_2",
+                            "className": "Mesh",
+                            "uniqueId": 36
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "ab1b3a40-88e6-480e-a0ce-9769085d81f0",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "spring_2",
+                                "name": "spring_2",
+                                "className": "Mesh",
+                                "uniqueId": 36
+                            }
+                        },
+                        {
+                            "uniqueId": "aaec5875-8c49-405e-bbf4-96472d8ae04c",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "64680301-e9d0-4e0e-8462-50d0ac9ba859",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "6cdfbe24-2777-4ecb-9fb2-95feaeb78715",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["20b64bf2-f570-4ba7-a124-7db3a1fb8e92"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "bec2eeeb-699d-4689-983a-3b4d786433c8",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "926b3f6c-6bb3-46bb-b675-0ce35187e518",
+                    "config": {
+                        "name": "spring_1 hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "f9e4fd5e-90c9-4b07-97e9-3f03ff64a90a",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["bff1af3e-f88b-4f16-bf09-ce191e63385f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5ec43ff3-ded3-4ab5-ad92-5c339b8fd254",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "4f3fd596-e812-4667-8ec5-28a6b41a26af",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "bc90e4aa-4ff4-4d3f-a6dd-a83c7ce625f9",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "21b74fb6-315e-4873-b24f-2ffc72fa31b8",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ce3b0ccb-7084-44df-9056-ebe7f1bb8f0e",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "0ac814d0-a95d-4ee3-b4d7-352735124554",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "fa18f593-e07c-4e91-ad48-a0010df40755",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9c604c01-64f9-43ee-86a7-9bee910981ee",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["c2b1dc3f-1a16-4910-b7a5-655e08c64ed7"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "c5770cdd-a0f9-4d98-847d-9344129f6ff9",
+                    "config": {
+                        "name": "spring_1 can bounce?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "3103fbbe-c8a0-4dd4-8c9e-9fc8d16e8b8c",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["18ffc364-5c45-4a43-bee7-65425bfc04b2"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "c2b1dc3f-1a16-4910-b7a5-655e08c64ed7",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["9c604c01-64f9-43ee-86a7-9bee910981ee"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "2bb347e7-d807-49d6-8551-01aeae5ba6aa",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ad3645d0-a035-4f60-a71e-068de949b594",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fb2b77c2-bf6b-45ee-a64d-1e8f3098d28c"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f16a2619-1ee9-4c09-a026-f3f9d83af66a",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "700cebb3-a0a0-4bfc-a73b-827efc84fae3",
+                    "config": {
+                        "name": "spring_1 launch"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a3eb49ad-afce-4583-b411-b01aa2488b6a",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "55919e09-6600-4473-b57a-4b444b3ced5c",
+                            "name": "velocity",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a898fca1-708c-4436-9078-40cd8eb871b7"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetLinearVelocityBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "fb2b77c2-bf6b-45ee-a64d-1e8f3098d28c",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ad3645d0-a035-4f60-a71e-068de949b594"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "0147fb53-497f-40fc-a791-7c932886ea2a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8221be65-da9b-431a-9192-9e8c9ec74fb9",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["97c893f4-b57e-4b52-ab54-05911ca6ffc6"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "98aa7640-950a-4c9d-b908-4091a54b9bf0",
+                    "config": {
+                        "name": "spring_1 compress",
+                        "animationGroup": {
+                            "name": "spring_1_compress",
+                            "className": "AnimationGroup",
+                            "uniqueId": 18
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "3a41e784-9a3f-4d48-85e8-e89775f0d1b3",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "fcdc4070-dd0d-4d06-8f49-73d50570c788",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "2ffa43b1-21dc-4cd9-8fdf-7b7895e30913",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "abc84c14-0eee-4563-87b0-9f6ea3165fa2",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "79bf3d8a-5101-40dd-9813-ab9ff5f279c1",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "spring_1_compress",
+                                "className": "AnimationGroup",
+                                "uniqueId": 18
+                            }
+                        },
+                        {
+                            "uniqueId": "23bfcfcd-4e4a-4890-990b-d3956ea9add0",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b256f7b0-5a46-4e07-a491-343993dd71ca",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "01e1f792-a560-4efb-bad9-216d52106ea5",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "8d84d6b6-25c4-42ba-8096-ef068847badb",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "2e76a7b0-bdc2-4849-aca3-aa8a663a333c",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "97c893f4-b57e-4b52-ab54-05911ca6ffc6",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8221be65-da9b-431a-9192-9e8c9ec74fb9"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "2551336c-45fa-41c6-8beb-4a0f7ef69a0e",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8c59c561-e05c-4794-9e00-a0dabb8d0f1d",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["e78aa1c4-359d-4b9b-accf-454be54389b6"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "aed8cbb8-8045-44ae-b284-6439280d05f9",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "31b40ce7-dc88-49e6-831f-e7ea0d6faf27",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a9b44e34-c049-4a0f-98e6-99035ae7cd37",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "818043c7-6dc3-41ad-a7fb-c45716382a40",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "6192d9ef-284d-453e-a7d8-3b40771174d8",
+                    "config": {
+                        "name": "spring_1 boing"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "50971910-63a7-4c13-acdd-d1535884570c",
+                            "name": "sound",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5da83015-d0a2-4bbe-8182-49a9399d88d9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "1f5ceabc-53b0-4e18-ab26-893242a28f7d",
+                            "name": "volume",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        },
+                        {
+                            "uniqueId": "f6f56467-df2f-4230-948f-0b0f23756603",
+                            "name": "startOffset",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "a3613f60-d56a-412b-b75a-d14a0d5b6839",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphPlaySoundBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "e78aa1c4-359d-4b9b-accf-454be54389b6",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8c59c561-e05c-4794-9e00-a0dabb8d0f1d"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "8845758b-56c1-450e-a082-2ec29b213fef",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "375a8e3b-30dc-45f9-83dc-73344a451006",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "1eb88937-1a6c-4910-bd08-0e428f31fa33",
+                    "config": {
+                        "name": "spring_1 sound",
+                        "variable": "jumpSound"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5da83015-d0a2-4bbe-8182-49a9399d88d9",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["50971910-63a7-4c13-acdd-d1535884570c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "3717f128-64b0-4289-b44e-122e87491369",
+                    "config": {
+                        "name": "spring_1 launch vel"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "491ca8a8-2464-46a2-8ca6-b986b5059a57",
+                            "name": "input_0",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["c35881f4-d618-407e-a3c7-1511772886d5"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "9507effc-e3ce-4ae7-a79d-293d30ab333e",
+                            "name": "input_1",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 16
+                        },
+                        {
+                            "uniqueId": "90396a63-8185-495e-a097-5cb256d8529f",
+                            "name": "input_2",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["04172637-e472-40d1-bd23-26eb375d9c13"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a898fca1-708c-4436-9078-40cd8eb871b7",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["55919e09-6600-4473-b57a-4b444b3ced5c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "70f6ef44-4414-4d6e-bbc6-7b4fd730c91f",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphCombineVector3Block"
+                },
+                {
+                    "uniqueId": "55de5fb5-b2f4-478e-afaf-b479ea226d4c",
+                    "config": {
+                        "name": "spring_1 extract vel"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5adcf8c0-297e-4960-a1e1-76e3df6df2df",
+                            "name": "input",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["1507aee9-3f34-4fab-a2fb-8e29d9cffdd2"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "c35881f4-d618-407e-a3c7-1511772886d5",
+                            "name": "output_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["491ca8a8-2464-46a2-8ca6-b986b5059a57"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "965b9eec-c150-4886-bf98-09a61a4cdade",
+                            "name": "output_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a8104fd8-3ba1-471e-bb53-99f8b830cb34"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "04172637-e472-40d1-bd23-26eb375d9c13",
+                            "name": "output_2",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["90396a63-8185-495e-a097-5cb256d8529f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphExtractVector3Block"
+                },
+                {
+                    "uniqueId": "fe50238f-8725-4630-a472-61e813aae334",
+                    "config": {
+                        "name": "spring_1 hero vel"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d4198a4a-0174-4630-b495-371fbe303980",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "1507aee9-3f34-4fab-a2fb-8e29d9cffdd2",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5adcf8c0-297e-4960-a1e1-76e3df6df2df"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "8ee304f9-f863-459a-ac0e-4289cf94636a",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetLinearVelocityBlock"
+                },
+                {
+                    "uniqueId": "81d0e8d5-7352-45f0-9693-60a9cbc24534",
+                    "config": {
+                        "name": "spring_1 descending?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a8104fd8-3ba1-471e-bb53-99f8b830cb34",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["965b9eec-c150-4886-bf98-09a61a4cdade"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "78518c57-620b-427b-afec-966cbfb14e7c",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "18ffc364-5c45-4a43-bee7-65425bfc04b2",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["3103fbbe-c8a0-4dd4-8c9e-9fc8d16e8b8c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "18a9713c-2fa6-411c-b351-2b97a28e5c5f",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "370729e9-f286-4d7f-be92-01887a7ae53d",
+                    "config": {
+                        "name": "spring_1 body",
+                        "object": {
+                            "id": "spring_1",
+                            "name": "spring_1",
+                            "className": "Mesh",
+                            "uniqueId": 35
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4bed99f6-1ce0-4c0b-b15b-688196e0a5bd",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "spring_1",
+                                "name": "spring_1",
+                                "className": "Mesh",
+                                "uniqueId": 35
+                            }
+                        },
+                        {
+                            "uniqueId": "1c4dca80-bd7e-4dc0-a591-60a12d9d7f25",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "8b23d001-2936-491a-9a25-02b4129fca55",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "bff1af3e-f88b-4f16-bf09-ce191e63385f",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["f9e4fd5e-90c9-4b07-97e9-3f03ff64a90a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "54e72f80-19a8-4413-87d6-4ecdc8117a8e",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "7f92875c-dadd-49fe-a66d-331416383a69",
+                    "config": {
+                        "name": "block_3 hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "3d617b68-e5d7-4ffa-8055-c4f2193e7ed2",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ac580a4b-52d8-4dae-889f-1749fa37a096"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "aec75766-cbc9-413e-8d21-ea09e4159e07",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "026f1d38-90dc-4395-9b66-067fd8d9aaab",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "ad39e6be-2521-4627-896f-a052cf9cdc67",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "c405a7f4-ad1f-4005-bd6b-4c18da45b594",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ff7deb6d-b4b0-4033-9134-002b8351d7dc",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "a9e71e85-272e-4777-841c-db483e38dd1c",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4afcecee-97d4-4cb1-89bd-67104bc5deef",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "26e88247-95fd-4cea-813c-5b79ead4fff2",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["810cdea6-2e49-443f-ab22-b0930379ef59"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "7438c356-2afb-4ecd-934f-861ea12dcc66",
+                    "config": {
+                        "name": "block_3 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b2cf607a-749f-443c-b0eb-aad462cb8ec2",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["07057257-7d98-44e2-9f36-c6fdc2dee8b0"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "810cdea6-2e49-443f-ab22-b0930379ef59",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["26e88247-95fd-4cea-813c-5b79ead4fff2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "3c1dd850-f081-4545-be55-8462067285e6",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "3ec20322-a631-4e41-aca2-657af0aa845c",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["631c3b14-b51d-4359-b959-b8df57685420"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4761ea2d-a425-4afb-9471-9441a2a3b2c4",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "fdbd2501-c96b-4389-83f8-82991b213dda",
+                    "config": {
+                        "name": "block_3 inactive",
+                        "variable": "block_3_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "cfeced9b-b3d1-46e6-9c58-a684f5ae5e65",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "631c3b14-b51d-4359-b959-b8df57685420",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3ec20322-a631-4e41-aca2-657af0aa845c"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "aed58ddc-4254-4e87-bb5a-6e30ecb72f40",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c3cfe8a4-190e-4974-b4b9-0aab27fff697",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["770600f0-4ef3-47d0-b2f3-598dbfdaf52a"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "2a2c8f3d-ec5d-4a1e-beda-85d14b44dc87",
+                    "config": {
+                        "name": "block_3 bump",
+                        "animationGroup": {
+                            "name": "block_3_bump",
+                            "className": "AnimationGroup",
+                            "uniqueId": 17
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4a518613-6559-481c-9320-d9e6dae76b81",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "dc02aa92-cc71-40c0-8e4f-e7b423458bc9",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "fc7cf726-32ba-49fd-addd-37b7108c7ce4",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "cafba489-41c8-4ba3-83ab-91383f0cd221",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "cd3d58a0-f3e6-4189-b16e-ffcafe493084",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "block_3_bump",
+                                "className": "AnimationGroup",
+                                "uniqueId": 17
+                            }
+                        },
+                        {
+                            "uniqueId": "b5666cba-a4dc-43ac-93ab-2014182568d8",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "06282bc4-f8b6-47c4-8788-e84aee447327",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "2cc552f1-6195-4d64-904a-9cd42adca332",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "2cc7f44f-756b-4183-a3b2-bac48252b297",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "82ea1e0e-4f9c-4cec-9ff9-ed51a70ac768",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "770600f0-4ef3-47d0-b2f3-598dbfdaf52a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["c3cfe8a4-190e-4974-b4b9-0aab27fff697"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "b9f060bd-3299-44f1-98f2-21e04e7570cf",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8041b4a0-d9db-4208-895c-7e74fbf3336c",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "20f1acb4-baff-452e-b822-d22eaffa9060",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5cf8e3d5-adc7-416f-bb02-7bf50558cab7",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "1d200511-bdc6-4b55-9729-5a3f283124a1",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7c8ba679-94fa-4227-9cd0-d3a5f1377b68",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "44650b13-c2a5-4e22-b418-25a5c22bf464",
+                    "config": {
+                        "name": "Emit collect",
+                        "eventId": "collect",
+                        "eventData": {}
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSendCustomEventBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "1a568a57-b414-4283-9308-8a51c06c97d0",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": [
+                                "5a3ecc1c-f727-4457-97e0-bc760be6c8a1",
+                                "a39eb941-2915-498e-888e-0831d63a9f39",
+                                "c7c2a175-0c04-4d8b-a6e6-333d11e7aae6",
+                                "21166f7c-0fa3-4c12-901b-0af8be168ba9",
+                                "627d215f-5994-414c-b5d0-2ec6460230a5",
+                                "38ecb424-c67f-4f70-88a9-27bd935552d3",
+                                "236b9374-ff7b-4c6c-9306-abe3bed7a34b",
+                                "63a8daa2-89fe-44ab-bd41-c74137fe63c2",
+                                "b827e024-b824-4538-b869-a08966db448a",
+                                "8041b4a0-d9db-4208-895c-7e74fbf3336c"
+                            ],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "c9ad0026-4b87-49ab-a4bc-315174668df9",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "25043dbf-b0b5-422c-8625-94afa4a7f848",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "03c48902-029c-43c6-bd6f-0a35b881614e",
+                    "config": {
+                        "name": "block_3 active",
+                        "variable": "block_3_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "07057257-7d98-44e2-9f36-c6fdc2dee8b0",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b2cf607a-749f-443c-b0eb-aad462cb8ec2"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "36a69362-b6eb-41aa-879d-b635167e3e8b",
+                    "config": {
+                        "name": "block_3 body",
+                        "object": {
+                            "id": "block_3",
+                            "name": "block_3",
+                            "className": "Mesh",
+                            "uniqueId": 30
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "ecbfa2d1-9ff5-40bf-b87c-a347a65cbc49",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "block_3",
+                                "name": "block_3",
+                                "className": "Mesh",
+                                "uniqueId": 30
+                            }
+                        },
+                        {
+                            "uniqueId": "ac4cce12-599f-4cbe-bf33-fb52047426a0",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "1dfa772e-1dbd-429b-abfc-c694e46f241c",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ac580a4b-52d8-4dae-889f-1749fa37a096",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["3d617b68-e5d7-4ffa-8055-c4f2193e7ed2"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "ae73ecf2-bb1c-486b-ac25-0aa1f5f5d2bd",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "f2a9b83c-2502-4f98-94a9-063b1ad58142",
+                    "config": {
+                        "name": "block_2 hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "dcd6dd84-2ad6-4482-8843-b4eea9827c19",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f37b2acb-7a41-479d-ac14-972b335f492e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "482d23e7-f1bc-4928-b8dd-4794117e837b",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "38ae791f-7986-443c-94c7-31870aa8c0ec",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "281b85cd-6539-4877-8c2e-f286165f16a4",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "c205bc83-120f-4614-bfef-ff50f8e12d28",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "209f31d0-e313-4fb0-ba27-715b684a834e",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "138dd340-7acc-481d-a432-86a5ced0bd14",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d2c84c23-b9b1-4470-9239-3a4d3b91d436",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ef68ec67-79a8-4f27-89d6-ab8b07a92351",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["3f086e1e-fe3d-4868-bab0-1068456c6252"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "bdac99ac-96d9-425c-9554-1e8cfcda41b6",
+                    "config": {
+                        "name": "block_2 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "8b741e44-67c3-464c-9104-9c94f41b4110",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b06103da-82fd-4537-934f-a92e9a4fd5eb"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "3f086e1e-fe3d-4868-bab0-1068456c6252",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ef68ec67-79a8-4f27-89d6-ab8b07a92351"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "e122d4da-62c7-4393-9633-e0400cd4027f",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9ca2ee1d-52bc-4f07-827e-691b3f87a569",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["f155da96-63de-41b3-b3ff-4e4132459bb9"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "82fdb131-861d-4b33-acd1-c2563b210a94",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "898bf8a8-d7ab-4e7b-920d-d229b6a509c0",
+                    "config": {
+                        "name": "block_2 inactive",
+                        "variable": "block_2_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "1700f10d-0b4b-4d1c-8ddd-de8c7be786d7",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "f155da96-63de-41b3-b3ff-4e4132459bb9",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["9ca2ee1d-52bc-4f07-827e-691b3f87a569"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "67d5e11b-fc90-4d2d-8a20-76a8b138ddba",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7e779db1-8577-4a3a-87fd-1beb2bba8d12",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5ee421f7-dff6-461c-9d99-e3452f44132f"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "35832254-a626-45ce-aaba-95fe1dc5207f",
+                    "config": {
+                        "name": "block_2 bump",
+                        "animationGroup": {
+                            "name": "block_2_bump",
+                            "className": "AnimationGroup",
+                            "uniqueId": 16
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "cf701563-854a-4cfd-82d3-840720f2a001",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "05467419-6454-42c1-b612-6d967dd16e72",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "7f9a92fe-07ae-4c23-b4f3-8350a3e42b04",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "bf9c083c-d229-4988-a7cc-cab046260170",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "165ef5da-a25b-43a6-93b0-cb88c6334db0",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "block_2_bump",
+                                "className": "AnimationGroup",
+                                "uniqueId": 16
+                            }
+                        },
+                        {
+                            "uniqueId": "c8d3f6de-8050-434a-ad58-8c973b1c23b2",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "9bf6bda1-6196-4e02-9d89-3fed8e34e935",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ed0ced94-2146-4451-a2b6-40b17028a184",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "5b9e7967-88b7-4009-ae5a-5a8160ca036d",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "e6627e35-a3e8-41d4-a7bc-b6f58b907a6e",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "5ee421f7-dff6-461c-9d99-e3452f44132f",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["7e779db1-8577-4a3a-87fd-1beb2bba8d12"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "cdc28d92-5722-4c29-a09e-e7c085842c88",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b827e024-b824-4538-b869-a08966db448a",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "23ebda78-3b40-41d3-8d92-780448f4d0ae",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4274e922-e5a8-4ad7-98c0-4ebce8de4587",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5ba00fb0-9656-4022-a9ab-f64f78d36bc0",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d4eb7e90-a482-43ee-91c6-710e662e67f9",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "2c0bcbc8-e7bb-415f-b680-8849b874de4d",
+                    "config": {
+                        "name": "block_2 active",
+                        "variable": "block_2_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "b06103da-82fd-4537-934f-a92e9a4fd5eb",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8b741e44-67c3-464c-9104-9c94f41b4110"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "334b10a7-e6d5-44bd-8e02-150b59c0ea2a",
+                    "config": {
+                        "name": "block_2 body",
+                        "object": {
+                            "id": "block_2",
+                            "name": "block_2",
+                            "className": "Mesh",
+                            "uniqueId": 29
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e40ee76f-512c-44c3-b6b4-747c49664d53",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "block_2",
+                                "name": "block_2",
+                                "className": "Mesh",
+                                "uniqueId": 29
+                            }
+                        },
+                        {
+                            "uniqueId": "fb5cb12e-3221-4769-b064-967a9bf1aed9",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "fad200b2-0350-4315-ad6b-32b3f46a98e7",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "f37b2acb-7a41-479d-ac14-972b335f492e",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["dcd6dd84-2ad6-4482-8843-b4eea9827c19"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "e1ddb3a2-b102-4eca-b8a0-0f54fe0d1a93",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "af5027c8-46b1-4f40-9154-1400354e051c",
+                    "config": {
+                        "name": "block_1 hit"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "fa63edc3-aaaf-430d-a7cb-f9d11ace1c6f",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["68bfeb24-7dec-40ba-8f6f-8601a7201602"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "788c438d-6aff-499e-b835-7dff34ed6dae",
+                            "name": "otherBody",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "91dbf653-467d-4b09-a26d-98053b4f604e",
+                            "name": "point",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "3e005861-2af9-4874-88a8-ac958705dd57",
+                            "name": "normal",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "2c652d72-fe82-4523-b9e0-a7dc210b52ff",
+                            "name": "impulse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "9a63fbb6-56fc-406f-b222-d0a696e064c8",
+                            "name": "distance",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphPhysicsCollisionEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "033986b5-837c-4e50-bc8f-3015386dfb73",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d24e8350-e8df-4fea-bf49-a8d314aabfd0",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ce8fe691-4c33-4080-826a-1ec1a45d2967",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a32bb0a1-1b7d-4c60-920f-ffe8d4b75d29"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "964277cc-a68d-4e40-ab11-2f6e47b3e136",
+                    "config": {
+                        "name": "block_1 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4322628d-b1b5-4901-a174-64f9133365f9",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b10d9cef-d8bd-4089-b8d1-6f846befdbde"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "a32bb0a1-1b7d-4c60-920f-ffe8d4b75d29",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ce8fe691-4c33-4080-826a-1ec1a45d2967"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "66da1209-1839-4ea3-9203-5cefaf9400d5",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "92c6e1d8-84a5-4bbb-98ec-a70870ce5a6f",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["dba1fea4-887d-49c2-9527-1b76cec06e57"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9b0cbcf9-ec33-4366-8a8d-5223e01f53df",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4a8af5cb-402c-4c54-8867-513359ae8bd2",
+                    "config": {
+                        "name": "block_1 inactive",
+                        "variable": "block_1_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "976aaaeb-1565-4df2-9a7c-5a6fca7d98fe",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "dba1fea4-887d-49c2-9527-1b76cec06e57",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["92c6e1d8-84a5-4bbb-98ec-a70870ce5a6f"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "f5d70982-b378-42a2-86e7-e03a33c2cf43",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "00e2197f-0cb5-4f9e-a830-7c918b8a2914",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["e43dc4f1-2fc7-444d-84ca-b82e52fecaab"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "cf27959b-bab4-491e-9e19-eb237f4272f9",
+                    "config": {
+                        "name": "block_1 bump",
+                        "animationGroup": {
+                            "name": "block_1_bump",
+                            "className": "AnimationGroup",
+                            "uniqueId": 15
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a8ce69ec-c579-4fc9-b583-8fc49050673c",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "dd321d13-2a73-4b9d-8d5c-4813525a79c8",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "ec679bb8-042a-4d3c-a7a0-e039222f89de",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "934762fc-d2b1-49e1-8a7a-ccf5ce6482df",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "de76fbba-ffa0-45d4-91c0-a7792384db42",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "block_1_bump",
+                                "className": "AnimationGroup",
+                                "uniqueId": 15
+                            }
+                        },
+                        {
+                            "uniqueId": "a73afded-71bd-49a8-980f-67fae26b1587",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "c70adbc9-8ce1-469f-ac3f-c6b65ee6c2ac",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "e2ca5dfd-11cf-49ec-a95b-916ef6ff1739",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ea0a2f98-095f-40ba-974a-ab38481c6b6c",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "6f89e0b9-93e2-49c8-9f1e-742d05448e79",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "e43dc4f1-2fc7-444d-84ca-b82e52fecaab",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["00e2197f-0cb5-4f9e-a830-7c918b8a2914"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "74212fa1-44d1-4a20-b196-f1512a50e1ab",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "63a8daa2-89fe-44ab-bd41-c74137fe63c2",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b3132276-0a83-4e7e-aa93-415fa3e17a8f",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c1aec36b-b74d-4a24-b0b5-cb53c4c55d1b",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b80652de-fafc-474a-a09d-82f451279fdd",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a428baa0-85c5-4ce6-843b-19b7b67d4cf9",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "b1ec7eca-4e34-4821-87b5-00ed6bc2e8ac",
+                    "config": {
+                        "name": "block_1 active",
+                        "variable": "block_1_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "b10d9cef-d8bd-4089-b8d1-6f846befdbde",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4322628d-b1b5-4901-a174-64f9133365f9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "2dd065c6-cb15-4a8c-a009-4e44b4cc2b00",
+                    "config": {
+                        "name": "block_1 body",
+                        "object": {
+                            "id": "block_1",
+                            "name": "block_1",
+                            "className": "Mesh",
+                            "uniqueId": 28
+                        },
+                        "propertyName": "physicsBody"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "365ecc79-db4a-46de-b925-92ceb68d2108",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "block_1",
+                                "name": "block_1",
+                                "className": "Mesh",
+                                "uniqueId": 28
+                            }
+                        },
+                        {
+                            "uniqueId": "35076ad8-843f-4eb8-8b6b-6301119d519e",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "physicsBody"
+                        },
+                        {
+                            "uniqueId": "f126f1bf-b022-4b44-92e3-9600ee8bf0ad",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "68bfeb24-7dec-40ba-8f6f-8601a7201602",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fa63edc3-aaaf-430d-a7cb-f9d11ace1c6f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "4cf2d38d-b4dc-44d0-a363-3f6397910385",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "8bd6dbce-b927-432c-ab5e-d67670663c2d",
+                    "config": {
+                        "name": "On Win",
+                        "eventId": "win",
+                        "eventData": {}
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphReceiveCustomEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "78fd3266-736a-40ec-a397-5bb6ab1c83a3",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "974852d2-92d8-4630-8381-f5e4f1465eba",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d14e7505-d0d6-4939-b4ec-a5a2d9deda72",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["57168472-cf7b-4cbf-8841-8ab54047078f"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "1f4898a8-aa4b-4afa-9fb4-ab2b39d826aa",
+                    "config": {
+                        "name": "Set gameDone",
+                        "variable": "gameDone"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b90fb045-b5be-4a5a-b81c-2e6c2a7e37e6",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "57168472-cf7b-4cbf-8841-8ab54047078f",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d14e7505-d0d6-4939-b4ec-a5a2d9deda72"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ffce3c10-4a6b-4ea2-bf60-00dfd4c8a559",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "fddfea8b-c18a-4095-9ff3-257819e65073",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["57eb1bf5-850e-4ebc-98c3-0301b7fd94e9"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "abcb3478-d007-42c9-bbef-14999b3d0a89",
+                    "config": {
+                        "name": "Log win",
+                        "messageTemplate": "Level complete! You win!"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "91d3abe6-d624-48fe-9b9d-fe900aad1c6b",
+                            "name": "message",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "ff3e71aa-3037-447f-9c6b-3ca9924b7e96",
+                            "name": "logType",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "log"
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphConsoleLogBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "57eb1bf5-850e-4ebc-98c3-0301b7fd94e9",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["fddfea8b-c18a-4095-9ff3-257819e65073"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "24636600-34db-42d9-9d58-b7ffc4971b49",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "34e49b03-193e-4caa-8332-890e27bf7db2",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8b5e32ce-0232-42ae-bda8-bf23e9c573d6"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ee4a1e54-0264-440e-b779-649258b73d45",
+                    "config": {
+                        "name": "Play win music"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4440f529-598d-416e-aca6-b8396586e42f",
+                            "name": "sound",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d5579c03-2257-403e-8057-480f04e5790a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "6e079e3a-5de5-4007-802a-a4fa359362d3",
+                            "name": "volume",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        },
+                        {
+                            "uniqueId": "9e8fdaf6-5425-414a-9a52-2fcd8f25bd07",
+                            "name": "startOffset",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "0d7994c6-d61c-4b8c-91be-73ed678e6a14",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphPlaySoundBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "8b5e32ce-0232-42ae-bda8-bf23e9c573d6",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["34e49b03-193e-4caa-8332-890e27bf7db2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "af8c59c4-f0cd-4005-8b0b-f59c3fd858ad",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2144ee70-e36d-4505-ab51-86088161d0df",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ae143865-8f87-4d57-89cb-838e62ca2f8d",
+                    "config": {
+                        "name": "Get win sound",
+                        "variable": "winSound"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "d5579c03-2257-403e-8057-480f04e5790a",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4440f529-598d-416e-aca6-b8396586e42f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "698c1b3b-fa04-4099-bc8e-e94640c7a514",
+                    "config": {
+                        "name": "On Hurt",
+                        "eventId": "hurt",
+                        "eventData": {}
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphReceiveCustomEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "f5789aed-a5a3-4b57-af8f-c53886825544",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ba2c19fc-01b3-456e-bd6a-a081d62e6656",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "e86bfcc4-e4b8-48aa-a84f-9d2aa50e0613",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["41906441-cd6f-4d85-b7e4-533379a10f96"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "63c07903-9751-43e0-8534-db1d476b865c",
+                    "config": {
+                        "name": "Set score (hurt)",
+                        "variable": "score"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0c9e9340-4c34-42d6-a84e-10a9b1e99630",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["267ed210-6ece-4a10-83f2-cdfb863924e2"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "41906441-cd6f-4d85-b7e4-533379a10f96",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["e86bfcc4-e4b8-48aa-a84f-9d2aa50e0613"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "720e5cc5-1ac8-44ee-82b2-61ebe978101d",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b66ee510-2f5a-4f1f-98e2-b5027d3dc402",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ddc07cef-2855-4429-aa04-6a6fac5d8f0f"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "6ed644df-5f47-452e-93ea-be5b2332b03c",
+                    "config": {
+                        "name": "Log hurt",
+                        "messageTemplate": "Ouch! Score: {score}"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d141ff00-f096-4fe9-bd26-be77113a18e0",
+                            "name": "message",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "fcc300dc-80aa-44fa-b81e-ff8d19743f9c",
+                            "name": "logType",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "log"
+                        },
+                        {
+                            "uniqueId": "316db1da-43a9-47e9-8e27-558d8c004307",
+                            "name": "score",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["267ed210-6ece-4a10-83f2-cdfb863924e2"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphConsoleLogBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ddc07cef-2855-4429-aa04-6a6fac5d8f0f",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b66ee510-2f5a-4f1f-98e2-b5027d3dc402"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "4c4df060-8d26-4680-be74-de4677928b43",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5d5dec43-4e75-4eac-bf53-9dc6d7b8ca36",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a0fa96fc-5dce-4d88-a145-de616ce1c62a"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "00fefbab-f531-4e5e-8486-776dca8f70f2",
+                    "config": {
+                        "name": "Play hurt sound"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5ec87430-b265-45e2-85c4-00edbde1f601",
+                            "name": "sound",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5be225c2-a503-488b-8614-ab4c92dfce8c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "d7892927-47a9-4d61-939f-b23fa438a8a5",
+                            "name": "volume",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        },
+                        {
+                            "uniqueId": "019efbe3-8e0a-4556-bfae-7ee2e530c031",
+                            "name": "startOffset",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "4484aa90-ab32-40fd-93c6-2a6f79ef70f5",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphPlaySoundBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "a0fa96fc-5dce-4d88-a145-de616ce1c62a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5d5dec43-4e75-4eac-bf53-9dc6d7b8ca36"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ee129479-55a2-4f3c-aebb-56eacbceb6a1",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "00d4198a-f4e0-427d-ac62-071461761a81",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "99ae7b57-7c37-4b2c-be9c-29e2c8b96e4f",
+                    "config": {
+                        "name": "Get hurt sound",
+                        "variable": "hurtSound"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5be225c2-a503-488b-8614-ab4c92dfce8c",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5ec87430-b265-45e2-85c4-00edbde1f601"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "77d3639d-6077-4288-b6de-7ad2e4db47a8",
+                    "config": {
+                        "name": "score - 1"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b410da7b-c9d9-45dd-ab77-8be1f8a52d42",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["745a10f3-4d20-4839-8386-7b457fe27643"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "f4c6b815-2a0f-49c1-bffe-c9a680af9cd1",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "267ed210-6ece-4a10-83f2-cdfb863924e2",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0c9e9340-4c34-42d6-a84e-10a9b1e99630", "316db1da-43a9-47e9-8e27-558d8c004307"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "f6099611-01b6-4d73-8ee3-1e681b3c6c7f",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "4d040663-3a19-4fb0-bf34-9f9c4db74722",
+                    "config": {
+                        "name": "Get score (hurt)",
+                        "variable": "score",
+                        "initialValue": 0
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "745a10f3-4d20-4839-8386-7b457fe27643",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b410da7b-c9d9-45dd-ab77-8be1f8a52d42"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "529ce2e0-0621-4a89-a100-172bfa909c78",
+                    "config": {
+                        "name": "On Collect",
+                        "eventId": "collect",
+                        "eventData": {}
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphReceiveCustomEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "de1d0772-7424-473c-90c0-ebead55d7244",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5233b4e5-2a02-494c-adff-e433301ef4e5",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b88849db-d9ac-49ad-aed3-6847e9990130",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ee376b6a-d6cd-4f78-b6fe-403af09fbd4a"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "843038e2-6e3e-41a7-b11b-b1caa4badad1",
+                    "config": {
+                        "name": "Set score",
+                        "variable": "score"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "cc0413a9-c0b4-4802-9e06-9fa24b979168",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["eed54feb-a551-443a-ab0e-0a6db1938c3a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ee376b6a-d6cd-4f78-b6fe-403af09fbd4a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b88849db-d9ac-49ad-aed3-6847e9990130"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5297f7a1-8272-4f39-b5b6-a91bfef5062d",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4af43d9a-0e1d-4e0e-8eb0-3e4c1a9dcb67",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5b7744cc-b46a-449c-a28b-22b954d4d0fb"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "26aee585-facf-4403-9e7d-2288197aa6cf",
+                    "config": {
+                        "name": "Log score",
+                        "messageTemplate": "Score: {score}"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "73b0f1ed-6b17-47cd-9348-4c494ef4cd1b",
+                            "name": "message",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "e8cb7542-35a7-4146-8d44-af9d2b83c7ac",
+                            "name": "logType",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "log"
+                        },
+                        {
+                            "uniqueId": "d2365e75-f1ad-4e68-b8c8-48024c0258d4",
+                            "name": "score",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["eed54feb-a551-443a-ab0e-0a6db1938c3a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphConsoleLogBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "5b7744cc-b46a-449c-a28b-22b954d4d0fb",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["4af43d9a-0e1d-4e0e-8eb0-3e4c1a9dcb67"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "02c0255e-0ba2-4b60-a26a-64f5085fbcf5",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "db53253a-c2e0-46d5-a48b-fbc467e6e937",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d5578f95-4320-4ed2-a8de-20177c5b53b5"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "7813b00b-3c0f-4eb4-ae43-96cd159db9e2",
+                    "config": {
+                        "name": "Play coin sound"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b5912b1d-ece2-4eb5-8902-1ba78c8bd497",
+                            "name": "sound",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["1b3898be-5b19-4077-a8be-f3d97e460574"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "46d0a735-4405-42a7-925b-3cf35a628b2e",
+                            "name": "volume",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        },
+                        {
+                            "uniqueId": "df67ff61-60e3-497b-9934-543a7285b9e7",
+                            "name": "startOffset",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0.19
+                        },
+                        {
+                            "uniqueId": "8e5057df-bc02-4a8a-81b5-69a723a2709f",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphPlaySoundBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "d5578f95-4320-4ed2-a8de-20177c5b53b5",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["db53253a-c2e0-46d5-a48b-fbc467e6e937"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "3af3744c-b401-4bf4-9f5d-da185fde61bc",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9ba92fde-e961-41dd-8c86-941394fe2f08",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "36bc0fcc-edcb-43f1-bf62-32ac4e5bd567",
+                    "config": {
+                        "name": "Get coin sound",
+                        "variable": "coinSound"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "1b3898be-5b19-4077-a8be-f3d97e460574",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b5912b1d-ece2-4eb5-8902-1ba78c8bd497"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "9474ef70-e08f-4d67-9f71-675cdad49183",
+                    "config": {
+                        "name": "score + 1"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "bf01ea87-f905-4bc9-925b-6923569362e8",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3daa8018-a934-4030-8286-c08dcba4a0f7"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "8c1466ac-83b6-470f-89cc-4345f641e5b8",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "eed54feb-a551-443a-ab0e-0a6db1938c3a",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cc0413a9-c0b4-4802-9e06-9fa24b979168", "d2365e75-f1ad-4e68-b8c8-48024c0258d4"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "8603469d-2629-43f1-ac91-a1eef9dcb1df",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphAddBlock"
+                },
+                {
+                    "uniqueId": "165c6ec9-e4a6-42e2-96d6-aeddfb60ec7b",
+                    "config": {
+                        "name": "Get score",
+                        "variable": "score",
+                        "initialValue": 0
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "3daa8018-a934-4030-8286-c08dcba4a0f7",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["bf01ea87-f905-4bc9-925b-6923569362e8"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "3e4f18ca-db8a-46ab-8c8d-ad229d212ab9",
+                    "config": {
+                        "name": "Left up"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "8e223737-3c04-46b1-b044-2c8ad7a02fc7",
+                            "name": "key",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "ArrowLeft"
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "07785075-822f-42a5-be46-4232382d20c0",
+                            "name": "keyCode",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "53a7b3c8-2a39-4235-8f85-509abc696a42",
+                            "name": "keyValue",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "8cbf9534-36e2-49e5-86a7-e45469a7d100",
+                            "name": "shiftKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "53b2ba18-6ce3-4a3d-bf47-910bf17e099f",
+                            "name": "ctrlKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "db4e52c1-451b-4039-bc22-e8f5180d4870",
+                            "name": "altKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "4807ffa6-2d08-403b-b9b1-d96ccb23e195",
+                            "name": "metaKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "3ee59bfb-eff9-4fc9-a527-1cc56265b78f",
+                            "name": "commandOrCtrl",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphKeyUpEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "0d91be49-6cec-413f-8f99-cad21bd3bd05",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "fc813f9c-7a97-4e10-97c8-bf5cea8563d7",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "20595183-b144-47f8-879f-5ac7c7cea26c",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ae5a2953-a8e7-400c-aeae-2d4a5ea12b41"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "8b43cbb2-1b06-4e0b-85e7-4186e961eeae",
+                    "config": {
+                        "name": "Left → heroVX=0",
+                        "variable": "heroVX"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e6a9ba78-e9e4-4312-b321-7965fa2f6fc1",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ae5a2953-a8e7-400c-aeae-2d4a5ea12b41",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["20595183-b144-47f8-879f-5ac7c7cea26c"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "050b5be0-c7c9-4602-b70e-d5e3d4ebebc3",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ac2f800b-e6f1-468e-90d4-aba94397c0c8",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "c8f65952-c2d7-4f9a-9c03-71d35a7267b6",
+                    "config": {
+                        "name": "Right up"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "f6fe1cc7-b5d5-4ff8-a2ee-2765fbd70eff",
+                            "name": "key",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "ArrowRight"
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "73d0a8e5-4935-4e0c-b7fe-4276fbd940c3",
+                            "name": "keyCode",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "b0a7f0f7-8107-402d-b0d9-c48628bf3211",
+                            "name": "keyValue",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "c91490c1-e841-49ed-9e5e-cd3fbd37c8b3",
+                            "name": "shiftKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "00edd414-f76e-47eb-83a6-ad8b8b06b71b",
+                            "name": "ctrlKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "e73ec913-5953-4ede-b1b8-b0caf9e2c64f",
+                            "name": "altKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "1db9600d-e18a-4f01-8e81-f7cf9e2d897d",
+                            "name": "metaKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "ae5196d9-92ba-4a2a-bfba-11f77f4ce936",
+                            "name": "commandOrCtrl",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphKeyUpEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "7d346210-5f26-46cb-bfb2-3d0a4d1b9014",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c0c5d5e0-77c6-477d-83d0-1e05a3cfdc93",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6ec5a722-119b-4dc4-a9ef-f9d96fabdc94",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["bc839802-316a-4737-9b95-9306e59616a4"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "2f2d3708-3c4e-4cd8-bacb-2c9c6868bf82",
+                    "config": {
+                        "name": "Right → heroVX=0",
+                        "variable": "heroVX"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "c4196d92-d871-47e7-bfab-99242274a0bf",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "bc839802-316a-4737-9b95-9306e59616a4",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6ec5a722-119b-4dc4-a9ef-f9d96fabdc94"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "6137fb61-3147-4559-be57-d75ccd2030a1",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f7846718-8011-4605-a704-9ea4e032d227",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "6096470d-03d0-47fe-af4f-52c61bdacd90",
+                    "config": {
+                        "name": "On Space",
+                        "ignoreRepeat": true
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a65285c8-9e6b-4b0b-bc91-bc50a89c3aeb",
+                            "name": "key",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "Space"
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a7e627fc-687d-4f53-921e-6bd17b51d44c",
+                            "name": "keyCode",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "a2204473-347f-4692-b70b-883e02568152",
+                            "name": "keyValue",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "a5e0ec1e-df68-4ce3-b1d0-1710f9d5ad45",
+                            "name": "shiftKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "d6f30dca-8d97-473b-9a8f-cb362c0e6844",
+                            "name": "ctrlKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "fb231791-b777-44fc-9273-446d5b5a0d9a",
+                            "name": "altKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "bd90ed69-795d-4145-af8c-a063b8fe300b",
+                            "name": "metaKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "5895b5f4-e7a6-4964-b56c-7be8884941dd",
+                            "name": "commandOrCtrl",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "0adccaae-3891-40c1-af26-4f9074e9cab7",
+                            "name": "isRepeat",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphKeyDownEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "75ed458e-29ec-4aa9-900b-5b5bf808160a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "874d3d01-f9a1-4bd6-b04a-78de331358a8",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "3ac3985c-dabc-41e0-a310-f7d266ae5208",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["c4509d81-66f2-4c39-93c7-17ef68b2b57b"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "6503f04c-b74d-4b01-bb13-dd5998c5a5e2",
+                    "config": {
+                        "name": "Can jump?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "9c1784e7-4c6a-4c11-9db4-1af32b11000e",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["34897a08-8eb9-4640-9e93-68c1e54786ea"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "c4509d81-66f2-4c39-93c7-17ef68b2b57b",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3ac3985c-dabc-41e0-a310-f7d266ae5208"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "7794aaa0-88a6-46ff-8e9d-5aa7a6942afa",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f6cbaf8a-38be-4836-8825-cd739d19d982",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["951ed1fc-8a84-4073-a69b-5f6df69ccae0"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2e54fc93-13d7-4633-832a-065717f3755c",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "936da38f-1bea-4d19-bd94-0ce3aaa1011f",
+                    "config": {
+                        "name": "Jump impulse"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4aa3a8d9-ee51-4c59-81eb-d1b7df347796",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "040e4397-e150-4141-8076-cdb801c6bb63",
+                            "name": "impulse",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 11, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "69a664b0-8a0b-4f13-bedc-87a7501e57b3",
+                            "name": "location",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f5bf0b4f-9a7d-4478-912a-aa4db65ce4fd"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphApplyImpulseBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "951ed1fc-8a84-4073-a69b-5f6df69ccae0",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f6cbaf8a-38be-4836-8825-cd739d19d982"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "49155a9a-1c3b-4a66-ac1c-cb58b01285ba",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a50b2c5e-98ca-4190-8a0c-a1213f7c7b03",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8d82841e-6208-4303-b45c-6ac83a2e63d6"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "566d2d9c-2912-4e9c-a326-b4c265f47fb2",
+                    "config": {
+                        "name": "Play jump sound"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "776de47b-e0fa-49fa-b57b-ef420af35ee7",
+                            "name": "sound",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["239bf2cd-09fb-4f7d-a115-41daff561d07"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "e7591dc4-417d-4844-bc2d-c801658ac6c8",
+                            "name": "volume",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        },
+                        {
+                            "uniqueId": "7dce57ad-7761-4185-8d2a-6063415358a5",
+                            "name": "startOffset",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "f6171f5e-06e1-49a2-aa92-c356f9db0bbd",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphPlaySoundBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "8d82841e-6208-4303-b45c-6ac83a2e63d6",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a50b2c5e-98ca-4190-8a0c-a1213f7c7b03"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "b1b2cff0-3b7e-42e3-964f-4f545e8286ef",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "99ce141d-2c36-4cab-83e0-b301e3921faf",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "5b47c2b0-4fe7-43ab-b43f-53bbd6cb7f24",
+                    "config": {
+                        "name": "Get jump sound",
+                        "variable": "jumpSound"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "239bf2cd-09fb-4f7d-a115-41daff561d07",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["776de47b-e0fa-49fa-b57b-ef420af35ee7"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "bb0ce866-69aa-4bed-85bf-10b21ea3eb7d",
+                    "config": {
+                        "name": "Hero position (jump)",
+                        "object": {
+                            "id": "hero",
+                            "name": "hero",
+                            "className": "Mesh",
+                            "uniqueId": 20
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "dd943aea-14ae-4923-a4b6-69a15984dd68",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "hero",
+                                "name": "hero",
+                                "className": "Mesh",
+                                "uniqueId": 20
+                            }
+                        },
+                        {
+                            "uniqueId": "3fe8b4c5-7da1-4e79-8f01-675a7a0346c4",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "3e241174-5b2e-4843-b070-098661b25916",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "f5bf0b4f-9a7d-4478-912a-aa4db65ce4fd",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["69a664b0-8a0b-4f13-bedc-87a7501e57b3"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "e317ecac-29db-4480-a6ee-f73ff710f44e",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "4e470d1a-5959-4510-836c-04e306d25027",
+                    "config": {
+                        "name": "Grounded?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "76ac29f4-cf07-4250-bab6-1e236d2e9268",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a13c396b-f727-4ea0-bf81-89187f4b9fdb"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "f94be06b-0831-462d-bcfe-9d34fd9321bd",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.5
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "34897a08-8eb9-4640-9e93-68c1e54786ea",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["9c1784e7-4c6a-4c11-9db4-1af32b11000e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "39fe022d-3331-42e5-ab81-69c008ec4ef0",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "af9d4439-7dde-477c-bf70-9a0bc0599332",
+                    "config": {
+                        "name": "|vy| (jump)"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "99fc2551-86cb-496d-af75-1d518cf3ee1e",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6cfec4fc-1e95-4ff2-accd-b707edffb9c9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a13c396b-f727-4ea0-bf81-89187f4b9fdb",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["76ac29f4-cf07-4250-bab6-1e236d2e9268"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "07b0489a-5b4d-4dfa-92fb-53d4ca99967e",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphAbsBlock"
+                },
+                {
+                    "uniqueId": "6475096b-92e8-4cf5-b171-851af4821c6a",
+                    "config": {
+                        "name": "Extract vy (jump)"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "74a5fd1e-6359-481b-aab2-d5f2f16b9ad4",
+                            "name": "input",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d7a13dbf-2cb6-47ab-bdf5-2780ff81dd95"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "cd338255-906d-4320-a08b-9124b63b5102",
+                            "name": "output_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "6cfec4fc-1e95-4ff2-accd-b707edffb9c9",
+                            "name": "output_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["99fc2551-86cb-496d-af75-1d518cf3ee1e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "8df88fa4-a772-45ee-8919-976bd3e4b10b",
+                            "name": "output_2",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphExtractVector3Block"
+                },
+                {
+                    "uniqueId": "23e2a21e-9d0c-484d-92df-35a658329973",
+                    "config": {
+                        "name": "Hero velocity (jump)"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a299e8c8-4f97-47c4-b06f-d26057d7345d",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "d7a13dbf-2cb6-47ab-bdf5-2780ff81dd95",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["74a5fd1e-6359-481b-aab2-d5f2f16b9ad4"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "620c96eb-c8eb-4a5e-a772-31c7ad53ddbb",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetLinearVelocityBlock"
+                },
+                {
+                    "uniqueId": "d025dafd-584a-4648-ae43-4c3f255fa620",
+                    "config": {
+                        "name": "Left down",
+                        "ignoreRepeat": true
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e25b2294-b591-49b5-a193-b723c299bc0e",
+                            "name": "key",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "ArrowLeft"
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "05c395d3-232d-4d93-92a0-fbf92ebf2e83",
+                            "name": "keyCode",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "6160ab2b-cbe4-4eb0-b8ad-d0ef617bafdd",
+                            "name": "keyValue",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "babb0e25-46b6-42c7-8b12-a7f7348b6118",
+                            "name": "shiftKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "c1f1eb94-bb41-45f0-bf7e-986863f13682",
+                            "name": "ctrlKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "f9314732-9114-434d-91e9-f5333f50e83d",
+                            "name": "altKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "ab7cc674-e1f5-4055-9870-fec69ee0c10a",
+                            "name": "metaKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "bd659541-7db6-4026-9ca5-bf1e3b385e1e",
+                            "name": "commandOrCtrl",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "b3148f5b-6445-42f3-960b-ce7b80da6bcf",
+                            "name": "isRepeat",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphKeyDownEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "a0494088-bd92-4a90-b6d7-f66ff65ff332",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8dcef0d0-7abc-4b2a-a9ea-a5a15568c92a",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "64a87d34-bcde-413b-91f7-80ce723a08ae",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ee89fff4-bd7a-45eb-a74b-504722eaa6a3"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "1670f265-893f-497e-aded-6c0efaec46de",
+                    "config": {
+                        "name": "Left → heroVX=-1",
+                        "variable": "heroVX"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "44d2e143-b57c-4678-ac09-ec2098bad818",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": -1
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ee89fff4-bd7a-45eb-a74b-504722eaa6a3",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["64a87d34-bcde-413b-91f7-80ce723a08ae"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "248be503-e656-447a-83af-70445d7d198a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7dada2fc-0a35-4a94-a276-459faed6990e",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "b2b3df41-94d9-43b9-bb19-2692382a176f",
+                    "config": {
+                        "name": "Right down",
+                        "ignoreRepeat": true
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "9d1ec40b-35de-4cd5-91dc-f64d02547019",
+                            "name": "key",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "ArrowRight"
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "c392e14e-5be9-40ca-9794-dd3139a303f6",
+                            "name": "keyCode",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "3b52330b-16c5-4c67-8e89-0ab5647bbb3d",
+                            "name": "keyValue",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": ""
+                        },
+                        {
+                            "uniqueId": "1179d167-9967-46e7-a280-192931987d60",
+                            "name": "shiftKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "34be8b16-bfc9-4517-a168-56e1884ac225",
+                            "name": "ctrlKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "9d4bef1c-5f31-4010-b85e-ca24026c1d46",
+                            "name": "altKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "b9975ac3-7860-43a7-bc36-9510798a2f32",
+                            "name": "metaKey",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "71cd7eb2-e50d-44c2-a25a-3e92a49f174d",
+                            "name": "commandOrCtrl",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "15df0af9-1113-4da9-ae75-4e8067af4702",
+                            "name": "isRepeat",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphKeyDownEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "c156060e-9523-4e4b-909d-47bc82311c48",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9cda421b-c1a5-4f85-a0ca-134bdf8d5f2c",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "636c837f-dedf-414e-820b-a731a2a84b44",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ee1f627e-d02c-4aa7-a924-a896463c98ed"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "374ba1fb-f767-488c-b853-b25bc84ce58c",
+                    "config": {
+                        "name": "Right → heroVX=1",
+                        "variable": "heroVX"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b148c0e5-488a-4a27-b97e-f1edc1ea9098",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ee1f627e-d02c-4aa7-a924-a896463c98ed",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["636c837f-dedf-414e-820b-a731a2a84b44"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "c8d28ba8-c683-4c3e-b3db-364a80617fd7",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "deb8dc52-699a-4a90-84c4-b5a71ca65909",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "7d6590ef-428c-4d22-9baf-12238bfe0923",
+                    "config": {},
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "4e1c9755-b6d8-4261-a515-fbde2d4eb91d",
+                            "name": "timeSinceStart",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "128b2479-0308-442f-84a7-304ff5b05b56",
+                            "name": "deltaTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphSceneTickEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ed4288ec-e16b-4ae9-b2e5-86ce26843ae5",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9d75bd9a-9fa7-4ac0-a7c2-a71e06bc5cc7",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d773adee-2b8c-4f80-9ff7-8d3649be088a",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["35f0a5fe-df14-412d-b5bc-e7fec11fc316"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ce0ca745-5656-447a-b94b-f1ee71c24e1c",
+                    "config": {
+                        "name": "Coin tick fan-out",
+                        "outputSignalCount": 7
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSequenceBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "35f0a5fe-df14-412d-b5bc-e7fec11fc316",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d773adee-2b8c-4f80-9ff7-8d3649be088a"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "476f1956-cc0b-4a39-b34f-e0a6e5e2e4f0",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a3062ced-1264-42d5-aa5c-d04e3a025a13",
+                            "name": "out_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["68025f35-0a38-4082-8607-e57c5c84ca3c"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ba749e47-d5d9-4738-8e22-dc1c9e4f822c",
+                            "name": "out_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0d4ab9fe-8967-43a7-8171-23b194342d5a"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "abcc19bf-2872-4946-9bc7-bd8c5ad741bb",
+                            "name": "out_2",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ee031d3b-8cd8-4d86-909e-e884472bf4cd"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b81231f7-8408-4ef0-a1a6-8b1b86f055ae",
+                            "name": "out_3",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4483f436-9575-4dfc-b661-e0f8e7ca44eb"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7e637813-286f-47a1-a1c5-28d5ea320d8e",
+                            "name": "out_4",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fcdc4a16-8e5f-400a-9a04-442eed55807d"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "12cdbc70-4bad-4880-aa78-dbfa7a12ced1",
+                            "name": "out_5",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["c5b3fc11-cef1-478a-a558-38a70d856147"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2f8087fc-e81a-4f3d-93dc-9c9b745ecf1b",
+                            "name": "out_6",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["7ab48a1d-a102-4582-aa2c-1fbef58f6e2b"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "e8821844-a362-44ac-bc9d-87cce3601653",
+                    "config": {
+                        "name": "coin_7 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "cac05aca-2edc-4f3b-90d8-22a0bab9f1bf",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a335f6fd-79c0-44f8-933f-b8ad67ed7651"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "7ab48a1d-a102-4582-aa2c-1fbef58f6e2b",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["2f8087fc-e81a-4f3d-93dc-9c9b745ecf1b"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ccf286a5-3d99-402f-8342-7bdac03f3311",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "695c53c7-213d-4034-b008-5ae1f2148d87",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5f20f46d-9cce-420a-899b-78679ec22b8a"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "076b6bd1-540f-4e95-89e6-660e34d99d30",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "555d00fe-2449-4ee8-a3f1-6bcb16bc359d",
+                    "config": {
+                        "name": "coin_7 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "49834427-473b-4f37-b4cb-52d1521e348b",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f3117aaa-50d5-439b-80d7-4bd23da4139c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "5f20f46d-9cce-420a-899b-78679ec22b8a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["695c53c7-213d-4034-b008-5ae1f2148d87"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "336e849a-67ce-49a1-adfe-163b65b9e9be",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6078428a-57bf-439e-96ef-c97e3f851ed6",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["caad3e57-7caf-45b3-9d82-218a9608fa47"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d35722ba-1a1f-44ae-8e46-ee4859115bfc",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ae59d585-ae12-480e-a4b8-4d144076ee61",
+                    "config": {
+                        "name": "coin_7 inactive",
+                        "variable": "coin_7_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "62b5eb5e-5b00-4d50-8725-8fc3bd3489fd",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "caad3e57-7caf-45b3-9d82-218a9608fa47",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6078428a-57bf-439e-96ef-c97e3f851ed6"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ec64514c-c72f-481b-b0f0-c7d895890767",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "e2803cb4-37ee-4f56-90d6-3fdbc487ae4b",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5ca18944-99fb-4b10-9b83-063f22568b8a"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "e9a84360-1675-44ab-82fd-19a832359ff9",
+                    "config": {
+                        "name": "coin_7 hide",
+                        "target": {
+                            "id": "coin_7",
+                            "name": "coin_7",
+                            "className": "Mesh",
+                            "uniqueId": 27
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e202e255-8817-46f2-a01b-0d3a19973226",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_7",
+                                "name": "coin_7",
+                                "className": "Mesh",
+                                "uniqueId": 27
+                            }
+                        },
+                        {
+                            "uniqueId": "451eb5cb-bafe-4292-84c7-79dd6e542bf0",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "369a661c-71c4-4adf-880e-2dd656d210b4",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "ea3e3c16-6695-40ea-b952-d98331196127",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "5ca18944-99fb-4b10-9b83-063f22568b8a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["e2803cb4-37ee-4f56-90d6-3fdbc487ae4b"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "334e5f2d-de6e-49bb-8e7e-b3caf7be6180",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "236b9374-ff7b-4c6c-9306-abe3bed7a34b",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "bc40750e-cba1-4124-8ed2-ac051cbac84f",
+                    "config": {
+                        "name": "coin_7 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "665b0ac6-e37c-44ae-b46b-de7bed383a80",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["4cd57c9e-bcd7-4a61-87ab-179704979460"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "79cc74c7-ddc1-4b67-97f4-ca4e7d74614f",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "f3117aaa-50d5-439b-80d7-4bd23da4139c",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["49834427-473b-4f37-b4cb-52d1521e348b"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "e789e126-87ca-4375-aec8-645dcc7245f3",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "9f708fda-6728-4362-bd6a-7c219fefb97e",
+                    "config": {
+                        "name": "coin_7 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d7793724-b041-4854-9601-72c59a549132",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3cb12ee9-a308-4628-8898-ef37f5775712"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "4cd57c9e-bcd7-4a61-87ab-179704979460",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["665b0ac6-e37c-44ae-b46b-de7bed383a80"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "c1502e97-e804-4a93-b88a-80b1737207a9",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "8a551527-279b-440d-a009-284d7ece8065",
+                    "config": {
+                        "name": "coin_7 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d9d05cde-767a-4b22-8662-02fe771fc0c8",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "0a70919f-b327-41ef-8bea-fb7749722eef",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5e4defe3-bbb7-4c61-b3f3-9f4bbf43c7f3"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "3cb12ee9-a308-4628-8898-ef37f5775712",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d7793724-b041-4854-9601-72c59a549132"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "a55259bb-77e2-40f9-a4b3-0874e9151d3e",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "1a8e22d6-c0a9-41c2-a4b9-a0cd5f4b4a36",
+                    "config": {
+                        "name": "coin_7 position",
+                        "object": {
+                            "id": "coin_7",
+                            "name": "coin_7",
+                            "className": "Mesh",
+                            "uniqueId": 27
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "7e0ef7fd-6228-4190-a407-6823b1074d38",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_7",
+                                "name": "coin_7",
+                                "className": "Mesh",
+                                "uniqueId": 27
+                            }
+                        },
+                        {
+                            "uniqueId": "c9c8a056-98cf-4adc-8125-d0d2f3005ca0",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "2c9893ba-a19a-48cc-849c-c7eaf43bab5f",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5e4defe3-bbb7-4c61-b3f3-9f4bbf43c7f3",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0a70919f-b327-41ef-8bea-fb7749722eef"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "9533551e-8bcc-4fcc-a8c2-fba08af435d4",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "f3534d6a-a874-47eb-be79-7de6ef141679",
+                    "config": {
+                        "name": "Hero position (coins)",
+                        "object": {
+                            "id": "hero",
+                            "name": "hero",
+                            "className": "Mesh",
+                            "uniqueId": 20
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "1f91d304-062f-454f-9905-5c13113b43cf",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "hero",
+                                "name": "hero",
+                                "className": "Mesh",
+                                "uniqueId": 20
+                            }
+                        },
+                        {
+                            "uniqueId": "730d25da-4336-47c1-b35d-239e381c7eb9",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "541a18ea-6375-4fa1-8ecf-722631a2e936",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "24961ac1-8064-4d3b-ae6b-4462696e1120",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": [
+                                "3af76152-3250-4a91-8979-2e4adbe87d91",
+                                "f8928bb1-69a8-48e1-88f8-5e544a8aa2a7",
+                                "0db4ec5b-d3c5-4bd4-b075-0f0ec70ca52f",
+                                "db0b124b-5121-4fb2-b408-348528323eeb",
+                                "6f6c4e03-e98a-4314-84a8-1a0ac4566fef",
+                                "2a866fd9-f2ba-4171-a6e1-d6b9d02617b4",
+                                "d9d05cde-767a-4b22-8662-02fe771fc0c8"
+                            ],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "54aaa115-0d55-478c-810e-afb8220890e3",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "20751d00-17cd-4437-9e0e-e3ffa01cd932",
+                    "config": {
+                        "name": "coin_7 active",
+                        "variable": "coin_7_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a335f6fd-79c0-44f8-933f-b8ad67ed7651",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["cac05aca-2edc-4f3b-90d8-22a0bab9f1bf"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "8aed0b9a-355a-4cb3-99f5-4fa1a62f4a89",
+                    "config": {
+                        "name": "coin_6 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "786d93b5-815a-478b-9a80-82a660ed4780",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["cebf4115-59ea-42d2-ae4b-4a3c7dc26fda"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "c5b3fc11-cef1-478a-a558-38a70d856147",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["12cdbc70-4bad-4880-aa78-dbfa7a12ced1"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "89fd67ba-024f-4666-a241-419a700a3edb",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ac2f8900-0780-49c2-a0e1-db1bf68f506f",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["77d65485-9ea8-459c-8372-5a558f538973"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6eb6f8cb-285b-447e-a5de-01cc2726b7fa",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ed3b468c-5275-4009-8e65-0f28c0942e4f",
+                    "config": {
+                        "name": "coin_6 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "42903225-2a6f-4cc6-80c2-70269601c964",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["48f0ebc6-4756-4fb9-993d-426af9d573ea"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "77d65485-9ea8-459c-8372-5a558f538973",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ac2f8900-0780-49c2-a0e1-db1bf68f506f"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "598656ee-1918-4898-acd3-29267b78a078",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "001d406a-4c72-490e-881d-f32bdf491e37",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0a833f4e-eb48-4f4e-9b0a-2ea1a80bde11"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "1de38e1e-10f1-4ec8-993e-51c454bb33f1",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "70ad7bde-c7c8-4ff7-a515-c3dc38a160da",
+                    "config": {
+                        "name": "coin_6 inactive",
+                        "variable": "coin_6_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a06b60cd-40c4-4ce9-8646-f2d8b95e4ca0",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "0a833f4e-eb48-4f4e-9b0a-2ea1a80bde11",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["001d406a-4c72-490e-881d-f32bdf491e37"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "29930fd7-8576-4f43-9ae4-08e610a026ed",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "05434f40-5a41-45dc-be3d-d81f6db69153",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b3360559-7721-4c27-8ad0-56723c80824c"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "c6265ad5-2cc9-4e4e-baaa-1fe40d7b8e7b",
+                    "config": {
+                        "name": "coin_6 hide",
+                        "target": {
+                            "id": "coin_6",
+                            "name": "coin_6",
+                            "className": "Mesh",
+                            "uniqueId": 26
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "7c66c992-3842-4c37-beb7-7002761e6525",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_6",
+                                "name": "coin_6",
+                                "className": "Mesh",
+                                "uniqueId": 26
+                            }
+                        },
+                        {
+                            "uniqueId": "0dd2ef65-a19a-4a62-88b4-7e8e503d269f",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "4c1067a7-e561-47e3-8d5b-5fc2c6ca013e",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "5cac8f3c-5947-4272-8032-4cde7f10372b",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "b3360559-7721-4c27-8ad0-56723c80824c",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["05434f40-5a41-45dc-be3d-d81f6db69153"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ce9961dc-0402-489d-896a-5150963d8973",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "38ecb424-c67f-4f70-88a9-27bd935552d3",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4784477f-8620-4c31-a6ad-0e9c1da0140e",
+                    "config": {
+                        "name": "coin_6 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "8be456f3-5785-46c8-8c08-7aafcd9be94f",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a7aab6bb-e969-4e77-bcd4-3bdc970e9f1d"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "c287c5a9-867c-45dd-a3b7-ec6d1af7bb32",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "48f0ebc6-4756-4fb9-993d-426af9d573ea",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["42903225-2a6f-4cc6-80c2-70269601c964"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "1f20ea53-0f3a-4b48-8f1f-515ea03caf92",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "4d3de935-73e5-4e89-af2c-ca7e2a573592",
+                    "config": {
+                        "name": "coin_6 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "464b2592-f2ce-4fec-bb20-ae2d4d72659b",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["737fdb19-ac5f-41ad-adfc-0d3c3b3ec8f3"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a7aab6bb-e969-4e77-bcd4-3bdc970e9f1d",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8be456f3-5785-46c8-8c08-7aafcd9be94f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "12a85555-ee3b-442b-b46a-991d39059cae",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "6468112d-d69e-44b0-b2c4-9d526117f4f8",
+                    "config": {
+                        "name": "coin_6 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "2a866fd9-f2ba-4171-a6e1-d6b9d02617b4",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "c5cf8b6b-21b3-4a33-b70e-42734f8b2a64",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["9f9cf87c-c449-4077-9889-ff541e6b2670"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "737fdb19-ac5f-41ad-adfc-0d3c3b3ec8f3",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["464b2592-f2ce-4fec-bb20-ae2d4d72659b"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "018b1ae6-e4e1-4eba-ba9e-28ab3ae73bf4",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "86f1fe6b-a70d-447e-b39b-72241192273f",
+                    "config": {
+                        "name": "coin_6 position",
+                        "object": {
+                            "id": "coin_6",
+                            "name": "coin_6",
+                            "className": "Mesh",
+                            "uniqueId": 26
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a2a760f8-413a-4c4b-82aa-d0a3e97d0eac",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_6",
+                                "name": "coin_6",
+                                "className": "Mesh",
+                                "uniqueId": 26
+                            }
+                        },
+                        {
+                            "uniqueId": "577fa973-bddf-4ddd-b7d3-29f3384dd1a1",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "9b9e8842-fcd0-44fa-81cf-ae865d3b4c68",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "9f9cf87c-c449-4077-9889-ff541e6b2670",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["c5cf8b6b-21b3-4a33-b70e-42734f8b2a64"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "1232bdc0-e8ea-4eec-a93d-e449397e44df",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "51e3e130-0e24-49bd-b34b-b85988cea0bb",
+                    "config": {
+                        "name": "coin_6 active",
+                        "variable": "coin_6_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "cebf4115-59ea-42d2-ae4b-4a3c7dc26fda",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["786d93b5-815a-478b-9a80-82a660ed4780"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "997b3699-ce9a-44c6-960a-44935d4fc2a9",
+                    "config": {
+                        "name": "coin_5 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b31e3d70-399c-471b-9b23-2f91d3b456ef",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a8f02c11-6887-4ab2-bb1a-da878e38b9e6"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "fcdc4a16-8e5f-400a-9a04-442eed55807d",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["7e637813-286f-47a1-a1c5-28d5ea320d8e"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "3ac65ebd-19b9-405d-bad0-6af11b320fe2",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ce58c8d0-bd79-44fe-9fbd-9b9c69be707a",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5d4adb73-f8b9-4898-8e16-1deae8d7785c"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b4a429f9-726a-4593-85d9-58d218371968",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "21193c9c-e391-41db-8c1e-100be255f0eb",
+                    "config": {
+                        "name": "coin_5 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "ce6cc7ca-3a7d-4bf6-ad99-1e0787780966",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ca70706a-1c69-4048-810b-852f6484a3ac"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "5d4adb73-f8b9-4898-8e16-1deae8d7785c",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ce58c8d0-bd79-44fe-9fbd-9b9c69be707a"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "35d0fa3e-7b10-4d3e-987a-576c566c3d22",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2d5a8048-1091-420a-81b6-e1b9eca6fda7",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["aab6ba71-6ac8-46ac-b2c2-5ad6115c1c3d"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4d1a73ce-f170-4063-a08f-987b85ce79a3",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ea6d4ee4-66bf-419e-85ff-2426e1bbaa29",
+                    "config": {
+                        "name": "coin_5 inactive",
+                        "variable": "coin_5_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5d625acd-9925-46e9-8074-fa5fd3a11adb",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "aab6ba71-6ac8-46ac-b2c2-5ad6115c1c3d",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["2d5a8048-1091-420a-81b6-e1b9eca6fda7"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "6084eb6e-516a-4b00-ab4b-3892058bd859",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ba47b288-5469-4e09-886f-fb3b25c279b3",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["c457b89a-1212-4064-af52-e3231effb9eb"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "e081996c-ec09-4773-aa7a-183b5ca95489",
+                    "config": {
+                        "name": "coin_5 hide",
+                        "target": {
+                            "id": "coin_5",
+                            "name": "coin_5",
+                            "className": "Mesh",
+                            "uniqueId": 25
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "10297b87-bb67-49af-9e98-ceac51f668a6",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_5",
+                                "name": "coin_5",
+                                "className": "Mesh",
+                                "uniqueId": 25
+                            }
+                        },
+                        {
+                            "uniqueId": "9cd05ddc-0df8-46ae-92cb-265b145562e4",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "8f3d42fd-e69b-499e-a359-622a1b25ecac",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "f2aafa66-8c08-4c62-8c2a-40b25348e4f1",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "c457b89a-1212-4064-af52-e3231effb9eb",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ba47b288-5469-4e09-886f-fb3b25c279b3"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "4562d1a7-caf9-403d-917d-cff0030e11c1",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "627d215f-5994-414c-b5d0-2ec6460230a5",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "747446a9-b2d3-4d1e-aa0d-08131fe3df3e",
+                    "config": {
+                        "name": "coin_5 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "c6f6ec3b-cb12-4227-98d2-3b6688090b41",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["cd5833aa-02b4-4483-9cc1-9b251dc9a505"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "58f25a24-afbf-4036-a129-2d123e267e2d",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ca70706a-1c69-4048-810b-852f6484a3ac",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ce6cc7ca-3a7d-4bf6-ad99-1e0787780966"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "5301343e-c4b6-4f8f-ae7d-822d2dfd9de7",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "6b5a2b77-eece-490d-8ef9-58910ef5ecd4",
+                    "config": {
+                        "name": "coin_5 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "17af426e-0e38-4821-a04c-443e4a69e225",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["83581293-f679-4166-a079-10821040984e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "cd5833aa-02b4-4483-9cc1-9b251dc9a505",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["c6f6ec3b-cb12-4227-98d2-3b6688090b41"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "1b4a4c06-7b42-478e-868d-497beeee9f39",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "ee6b389f-86bf-4444-9765-17be95efdd7e",
+                    "config": {
+                        "name": "coin_5 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "6f6c4e03-e98a-4314-84a8-1a0ac4566fef",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "f066f066-77f2-4c78-a72f-4ce770c9fe05",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["00d5363e-aefe-4e42-8e82-6bfd585438a6"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "83581293-f679-4166-a079-10821040984e",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["17af426e-0e38-4821-a04c-443e4a69e225"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "d0538176-b7d8-42bd-a670-58913575c230",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "daf127c2-edf3-488e-8689-69d6038654f9",
+                    "config": {
+                        "name": "coin_5 position",
+                        "object": {
+                            "id": "coin_5",
+                            "name": "coin_5",
+                            "className": "Mesh",
+                            "uniqueId": 25
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5195e965-31c9-429f-8415-afc783283ace",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_5",
+                                "name": "coin_5",
+                                "className": "Mesh",
+                                "uniqueId": 25
+                            }
+                        },
+                        {
+                            "uniqueId": "414ddfe1-2f6c-45d5-a46c-d05be1ff58f8",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "d908d26f-fe48-4d71-9a23-a9a27570f64e",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "00d5363e-aefe-4e42-8e82-6bfd585438a6",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["f066f066-77f2-4c78-a72f-4ce770c9fe05"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "733d2794-aefb-472c-8936-324c2f409c87",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "5020e097-3e14-4735-a7f8-b148efbced75",
+                    "config": {
+                        "name": "coin_5 active",
+                        "variable": "coin_5_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a8f02c11-6887-4ab2-bb1a-da878e38b9e6",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b31e3d70-399c-471b-9b23-2f91d3b456ef"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "d4a8aac6-a00b-4cad-bc82-1819edadbc5e",
+                    "config": {
+                        "name": "coin_4 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "197021dd-91b8-45c8-bc7b-22c2f63bce13",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["9c955e39-17d3-4b20-9d51-10a99eb3eafd"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "4483f436-9575-4dfc-b661-e0f8e7ca44eb",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b81231f7-8408-4ef0-a1a6-8b1b86f055ae"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "25893062-4a3f-4827-b54f-97fb7c0040a3",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "251f8954-ee06-4dde-a2a4-1636e41fb66c",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["e8383494-bda6-4a94-9178-54cdbe6e7233"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9d6ceed7-e131-40db-b538-e002afcdc6fb",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "37099ce8-063f-4bfc-8406-bfc1706a993b",
+                    "config": {
+                        "name": "coin_4 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "3aea874d-11c3-4cc6-804e-ebf9c0483c21",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["39e6d2b3-4618-4839-a429-791fee4ec20a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "e8383494-bda6-4a94-9178-54cdbe6e7233",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["251f8954-ee06-4dde-a2a4-1636e41fb66c"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "a71250d8-18ad-4746-a21e-033b4c9a6bcc",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "3eaa5e09-d9a5-4d4e-8ccd-1e014f36a5fc",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["7b6a3438-696a-4089-b655-9a3abbd38346"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c8f2e0e9-3ac7-4777-b619-1da19549cab2",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "30b33fbd-14c6-4abb-b6fd-529e56c33ba3",
+                    "config": {
+                        "name": "coin_4 inactive",
+                        "variable": "coin_4_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "833729cb-d7d0-4e38-a033-22eb6287eac5",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "7b6a3438-696a-4089-b655-9a3abbd38346",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3eaa5e09-d9a5-4d4e-8ccd-1e014f36a5fc"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "3b962021-3764-491a-a2a3-b541abf01c7d",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6db94319-6588-4e82-80bc-478e4110f1f5",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["6faedca9-28e2-4932-9a41-c6076970c20b"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "6830386b-8fa7-47b7-827c-de4999f12ee7",
+                    "config": {
+                        "name": "coin_4 hide",
+                        "target": {
+                            "id": "coin_4",
+                            "name": "coin_4",
+                            "className": "Mesh",
+                            "uniqueId": 24
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "c7e03501-fed3-438c-96a4-55e11b3b1ccc",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_4",
+                                "name": "coin_4",
+                                "className": "Mesh",
+                                "uniqueId": 24
+                            }
+                        },
+                        {
+                            "uniqueId": "344a244f-3b5e-4519-ae17-6e20e1978a3c",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "85766451-4587-4059-a4f6-a56ae8c135f9",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "9d8ada4c-0fec-4951-8e3e-12e509654b84",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "6faedca9-28e2-4932-9a41-c6076970c20b",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6db94319-6588-4e82-80bc-478e4110f1f5"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "19108dde-2a8a-48be-a62b-3664bb797624",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "21166f7c-0fa3-4c12-901b-0af8be168ba9",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4642a21c-3adb-4fb5-904b-75ab8f072fb5",
+                    "config": {
+                        "name": "coin_4 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "edbfba82-221e-4cb3-b55f-9251bb77450a",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["34f3aa9d-b287-43af-ad9f-5e53148431f9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "3b0afc76-0d72-478f-8916-d02f7e6dc5c5",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "39e6d2b3-4618-4839-a429-791fee4ec20a",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["3aea874d-11c3-4cc6-804e-ebf9c0483c21"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "05c30da0-266a-46d8-b500-b945e1509468",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "afc1fdc6-19a2-4042-89ff-a10918ec7599",
+                    "config": {
+                        "name": "coin_4 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4e485a1f-b015-4f16-873c-87dac758b4e9",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["657e08bc-e9ef-4cbe-894c-d277a2aa84cb"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "34f3aa9d-b287-43af-ad9f-5e53148431f9",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["edbfba82-221e-4cb3-b55f-9251bb77450a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "a59de679-b3e9-4210-83e6-c8868543bd52",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "15b917f3-03ed-4d1e-a70c-eb3b886c3c65",
+                    "config": {
+                        "name": "coin_4 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "db0b124b-5121-4fb2-b408-348528323eeb",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "020565a0-3453-4067-bc9f-8a7e17a4dd84",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["90122887-7a80-4eaf-b892-e1f4054679d1"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "657e08bc-e9ef-4cbe-894c-d277a2aa84cb",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4e485a1f-b015-4f16-873c-87dac758b4e9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "cc4c1efb-cae0-4444-8c62-b4f7a1206551",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "5e476e5d-2535-4599-87b7-2cfc65361b28",
+                    "config": {
+                        "name": "coin_4 position",
+                        "object": {
+                            "id": "coin_4",
+                            "name": "coin_4",
+                            "className": "Mesh",
+                            "uniqueId": 24
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "53c799d6-cfb7-4b41-b798-fc4ff5dd2f77",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_4",
+                                "name": "coin_4",
+                                "className": "Mesh",
+                                "uniqueId": 24
+                            }
+                        },
+                        {
+                            "uniqueId": "4f95707b-3a68-4a30-94ae-a2456827b4a9",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "c71c7531-6f6e-4e5e-b579-cc7871573a3f",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "90122887-7a80-4eaf-b892-e1f4054679d1",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["020565a0-3453-4067-bc9f-8a7e17a4dd84"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "9623b623-c686-451b-9fd9-9ef754966ad5",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "93918e26-043a-4cc5-9c28-ba3612acac05",
+                    "config": {
+                        "name": "coin_4 active",
+                        "variable": "coin_4_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "9c955e39-17d3-4b20-9d51-10a99eb3eafd",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["197021dd-91b8-45c8-bc7b-22c2f63bce13"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "dabb08b7-e5b6-43c7-bd28-c709d5298b44",
+                    "config": {
+                        "name": "coin_3 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "9de5767d-9eab-4828-8265-d7b90a7a37a9",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["35f9a53b-8b14-40c6-a593-e9ef0f251382"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ee031d3b-8cd8-4d86-909e-e884472bf4cd",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["abcc19bf-2872-4946-9bc7-bd8c5ad741bb"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "05ece7c1-4582-41c2-80e7-6300e9e5f814",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ab262d07-0d7b-499f-9ae2-15c84389df8b",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fcd1a0a6-7323-4fa6-8f08-c0d221fcf7ae"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a5e84f79-0cbd-4c8d-b0cd-e1162201adb3",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "c108bbb8-bbf2-434e-b26f-e2e213d31064",
+                    "config": {
+                        "name": "coin_3 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e13305ef-acb7-40d6-b0bd-b03236f0c922",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["7f9cacbf-fa8f-4579-8605-77b414586f23"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "fcd1a0a6-7323-4fa6-8f08-c0d221fcf7ae",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ab262d07-0d7b-499f-9ae2-15c84389df8b"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "04f93b59-f05a-4cc7-967c-3335ef1dae13",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5fdf99ee-9014-4a1d-af62-384c53220332",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0eb7c358-4fac-427e-a25f-e4729f745b46"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8cfe3347-e763-4778-a159-f5f9e298114e",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "c9187e3a-1697-4cb2-bfea-575fa956ddcf",
+                    "config": {
+                        "name": "coin_3 inactive",
+                        "variable": "coin_3_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "2ca96a03-b38c-4339-b04b-07f0481cfb7e",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "0eb7c358-4fac-427e-a25f-e4729f745b46",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5fdf99ee-9014-4a1d-af62-384c53220332"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "842967d3-21df-44b3-a00d-5f46ed6791fc",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d87fd156-f459-4562-ba2d-27b262f81a78",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["7a6b0ee6-019b-43d8-b761-37a81c48d5e6"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "d48fc087-423d-49ff-92f7-eccb6aeee0dd",
+                    "config": {
+                        "name": "coin_3 hide",
+                        "target": {
+                            "id": "coin_3",
+                            "name": "coin_3",
+                            "className": "Mesh",
+                            "uniqueId": 23
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "87f60481-b128-45c4-b110-a44f40967ea5",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_3",
+                                "name": "coin_3",
+                                "className": "Mesh",
+                                "uniqueId": 23
+                            }
+                        },
+                        {
+                            "uniqueId": "e62bd7c9-ab37-4acb-9a90-a80c9ecd627b",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "b8ed8746-24fb-4717-b96f-801f485d2baf",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "c635326e-da77-492d-8e2e-7551b54f1669",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "7a6b0ee6-019b-43d8-b761-37a81c48d5e6",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["d87fd156-f459-4562-ba2d-27b262f81a78"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "c8f8161e-bc39-408f-b0c1-1e178c44d18f",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c7c2a175-0c04-4d8b-a6e6-333d11e7aae6",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ecdd20cf-825a-4465-976e-e24c30bce561",
+                    "config": {
+                        "name": "coin_3 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "6648aa8a-a07c-4424-b8f8-f2c296c82985",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ffe31bb2-8549-46a2-8048-b5005cdd7ae5"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "d7aae55e-835f-4394-a708-f56bedff4d84",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "7f9cacbf-fa8f-4579-8605-77b414586f23",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["e13305ef-acb7-40d6-b0bd-b03236f0c922"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "e5e45c70-0f1a-44c3-9280-9879b259823c",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "7411c95b-897c-461a-8170-3a443ba49ad9",
+                    "config": {
+                        "name": "coin_3 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "1f21ec27-e16a-44b3-a086-684e510a6695",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8a0c5fad-9337-4512-9bf0-d042b8bd8d60"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ffe31bb2-8549-46a2-8048-b5005cdd7ae5",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["6648aa8a-a07c-4424-b8f8-f2c296c82985"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "46361b13-5dee-4e62-b286-99499ba887db",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "2d0cfbdb-f592-44a6-b3d3-7c0e76ea94c3",
+                    "config": {
+                        "name": "coin_3 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0db4ec5b-d3c5-4bd4-b075-0f0ec70ca52f",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "38baaa4e-e37d-4603-80cf-be9b2b9d7f06",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["bb01d08e-381b-4b67-9f61-4494973102bf"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "8a0c5fad-9337-4512-9bf0-d042b8bd8d60",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1f21ec27-e16a-44b3-a086-684e510a6695"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "4a2b12cc-8f23-4e64-a8f2-ed86c6d761ff",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "1c9462f7-5722-437b-bb05-e3f45556a0eb",
+                    "config": {
+                        "name": "coin_3 position",
+                        "object": {
+                            "id": "coin_3",
+                            "name": "coin_3",
+                            "className": "Mesh",
+                            "uniqueId": 23
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "70724668-fd0b-4bd2-b776-3cd9b7fbef6a",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_3",
+                                "name": "coin_3",
+                                "className": "Mesh",
+                                "uniqueId": 23
+                            }
+                        },
+                        {
+                            "uniqueId": "6c5f4751-49bc-40a8-8f78-bd0ec18f7260",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "203b0fe4-5a04-44d6-8272-631826bb7a2a",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "bb01d08e-381b-4b67-9f61-4494973102bf",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["38baaa4e-e37d-4603-80cf-be9b2b9d7f06"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "adadbd08-420b-4856-9623-5d11f4b6d230",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "0cf4786e-ed02-45e5-93a9-c6ea7bc01bd5",
+                    "config": {
+                        "name": "coin_3 active",
+                        "variable": "coin_3_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "35f9a53b-8b14-40c6-a593-e9ef0f251382",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["9de5767d-9eab-4828-8265-d7b90a7a37a9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "01ba02d1-1676-4a12-b533-c1d956a2ceea",
+                    "config": {
+                        "name": "coin_2 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5c502cde-5074-436b-90aa-2ba6b441c6c3",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ecdd17eb-dc61-4729-ab5b-4fbc2d649edf"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "0d4ab9fe-8967-43a7-8171-23b194342d5a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ba749e47-d5d9-4738-8e22-dc1c9e4f822c"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "6720458b-fdbf-4ee1-8943-b4729d0459fd",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6a27c9a7-f3b9-48b7-8e3b-2ca6a902a7f2",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["070d9fb0-5cbb-4462-bb5f-34ebe5d0ee23"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5fdbd2ee-e1d7-4dfd-8595-fea27f1ffaef",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "d8109695-c8f8-40ec-bb5c-7bbe02b98088",
+                    "config": {
+                        "name": "coin_2 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a8c601b9-cbd8-48d6-8b17-fc77b62a2d67",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["41eab31a-9720-456b-b8cc-1215cfd05529"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "070d9fb0-5cbb-4462-bb5f-34ebe5d0ee23",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6a27c9a7-f3b9-48b7-8e3b-2ca6a902a7f2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "45ba8e7e-4050-4c12-8ec1-3b6f423b2a03",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "476cec53-dc4e-4f9d-8941-a2bf7efd553e",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["40ee8963-2c5e-4ec0-87a8-fc498bbaee53"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7bd769b3-da28-452e-8ab6-b26774ec84a8",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "8548235c-232a-4552-af4d-e9c700360c1d",
+                    "config": {
+                        "name": "coin_2 inactive",
+                        "variable": "coin_2_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "5af9cc26-72cb-4d88-b083-764ac3b7242b",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "40ee8963-2c5e-4ec0-87a8-fc498bbaee53",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["476cec53-dc4e-4f9d-8941-a2bf7efd553e"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5da8ef3b-bbaf-4afb-ad6b-3c29b621513a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a7f75a45-f1ea-4888-861b-04369c2988ac",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d8c0aea7-c462-4a91-a2a2-9dc87e29964e"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "cbebf577-b813-4011-b91a-c6da68367425",
+                    "config": {
+                        "name": "coin_2 hide",
+                        "target": {
+                            "id": "coin_2",
+                            "name": "coin_2",
+                            "className": "Mesh",
+                            "uniqueId": 22
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "41a16466-3a6f-464f-8b17-84975384cc06",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_2",
+                                "name": "coin_2",
+                                "className": "Mesh",
+                                "uniqueId": 22
+                            }
+                        },
+                        {
+                            "uniqueId": "7b7a7a18-4bcb-4a48-b695-21e67649d27c",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "b12510fa-7927-4fac-824a-2dbb443f976b",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "20116fae-1d39-4e80-9dca-05ab346593a7",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "d8c0aea7-c462-4a91-a2a2-9dc87e29964e",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a7f75a45-f1ea-4888-861b-04369c2988ac"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "568d9d92-c4fd-44cb-afa0-a453e159bbaf",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a39eb941-2915-498e-888e-0831d63a9f39",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4201dd3f-ee77-4733-980b-a731f4b06f2f",
+                    "config": {
+                        "name": "coin_2 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "aa031d01-ef25-4dcf-b77d-d5bac184d21a",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["4fd18483-4b0a-4b37-a743-7fa63dde36ce"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "481e0864-8f11-41e0-a641-d977b828ae65",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "41eab31a-9720-456b-b8cc-1215cfd05529",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a8c601b9-cbd8-48d6-8b17-fc77b62a2d67"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "3da1a692-4d86-4024-8cda-23e9f618cb40",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "91b35834-825f-46ec-a58c-449926d42711",
+                    "config": {
+                        "name": "coin_2 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d160f569-6bc5-4bb0-b9cb-60115f30456c",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["e85d84d8-ad18-4b34-8840-e63e40f40a5b"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "4fd18483-4b0a-4b37-a743-7fa63dde36ce",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["aa031d01-ef25-4dcf-b77d-d5bac184d21a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "151dbe9b-5e25-4ca5-8cea-ad00c0966bf6",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "b71923d7-b65e-4211-9cc1-5971ee5d9dc4",
+                    "config": {
+                        "name": "coin_2 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "f8928bb1-69a8-48e1-88f8-5e544a8aa2a7",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "3133b2e9-f1c5-4d32-ae18-d8c15aa947bd",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["deb36ae0-37cb-4037-b4d5-b6b9aeacd978"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "e85d84d8-ad18-4b34-8840-e63e40f40a5b",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d160f569-6bc5-4bb0-b9cb-60115f30456c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "4e3edc69-748e-4c23-b4b8-7cd31465dcc5",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "b279bad6-bc14-4465-9bbd-459a5cc3e5de",
+                    "config": {
+                        "name": "coin_2 position",
+                        "object": {
+                            "id": "coin_2",
+                            "name": "coin_2",
+                            "className": "Mesh",
+                            "uniqueId": 22
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "dd10b621-0bea-4145-9453-a9ee4fe5416e",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_2",
+                                "name": "coin_2",
+                                "className": "Mesh",
+                                "uniqueId": 22
+                            }
+                        },
+                        {
+                            "uniqueId": "8c189e2b-02ac-4fe1-93b9-80261aaddbee",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "b2e3d241-ab03-429b-ac73-1545750ae0d8",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "deb36ae0-37cb-4037-b4d5-b6b9aeacd978",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["3133b2e9-f1c5-4d32-ae18-d8c15aa947bd"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "84b606c1-b4f8-4111-bcac-dee1e4e53961",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "e7e4e626-c7d4-415f-9388-3ff89e4b1375",
+                    "config": {
+                        "name": "coin_2 active",
+                        "variable": "coin_2_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ecdd17eb-dc61-4729-ab5b-4fbc2d649edf",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["5c502cde-5074-436b-90aa-2ba6b441c6c3"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "df05e506-a12d-4646-ab85-616caf2070de",
+                    "config": {
+                        "name": "coin_1 active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "6517dfd0-26a7-46db-8f42-4837fe5f4990",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f3bf3b6a-3188-4098-b173-4239104a71fd"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "68025f35-0a38-4082-8607-e57c5c84ca3c",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a3062ced-1264-42d5-aa5c-d04e3a025a13"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ca6aff61-4d4c-4934-99c6-137a82c54c78",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8da84185-f03f-42da-b448-c1a78d42d65d",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8d1c1803-9d4f-4b4d-b86b-56525536f4c2"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c8dfa342-8941-4999-9708-7c9c30ea43c4",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "a8da0505-a3c5-4187-900e-c4cfe4b65eda",
+                    "config": {
+                        "name": "coin_1 reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "9885f1a2-2c3e-4a43-818b-bfc17314c4c9",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f96b07fa-547d-4508-9bc6-099706baedf6"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "8d1c1803-9d4f-4b4d-b86b-56525536f4c2",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8da84185-f03f-42da-b448-c1a78d42d65d"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "2d47a3be-cb2b-420c-86c8-615019632a4f",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "e698f37e-5104-439f-a95f-372f24375946",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["51d0ee66-f263-4ce3-9d48-1ff8989ece3a"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7cc80348-c7e9-4890-a48a-51e227786db0",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "41874375-d422-45e1-baaf-a953dd819c27",
+                    "config": {
+                        "name": "coin_1 inactive",
+                        "variable": "coin_1_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "68e04afe-418c-4610-a520-a1ce5cd6dfd4",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "51d0ee66-f263-4ce3-9d48-1ff8989ece3a",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["e698f37e-5104-439f-a95f-372f24375946"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5c70a52b-75f8-45c1-89d9-d9f21dea769d",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "338abaeb-b5ec-46fb-92d1-9eab7f1fa6cf",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1aa869c1-4ee8-47af-b300-92e2a191522f"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "32377c2c-86c5-4a18-afdc-40dc7b7d9530",
+                    "config": {
+                        "name": "coin_1 hide",
+                        "target": {
+                            "id": "coin_1",
+                            "name": "coin_1",
+                            "className": "Mesh",
+                            "uniqueId": 21
+                        },
+                        "propertyName": "isVisible"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "be5cef80-097d-447c-b4ba-34dd829283fd",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_1",
+                                "name": "coin_1",
+                                "className": "Mesh",
+                                "uniqueId": 21
+                            }
+                        },
+                        {
+                            "uniqueId": "991c232e-71fa-430f-a270-ad0800ebe82d",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "f386a96e-2234-450e-9f2b-68bd0fe0c241",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "isVisible"
+                        },
+                        {
+                            "uniqueId": "39b7c129-b159-41cb-8276-f6f18a3f0f67",
+                            "name": "customSetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetPropertyBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "1aa869c1-4ee8-47af-b300-92e2a191522f",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["338abaeb-b5ec-46fb-92d1-9eab7f1fa6cf"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "9806bbad-25d6-4574-a64a-902a83caf5b1",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5a3ecc1c-f727-4457-97e0-bc760be6c8a1",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1a568a57-b414-4283-9308-8a51c06c97d0"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "3a4708ff-2b47-45f2-b922-94df9e475f4f",
+                    "config": {
+                        "name": "coin_1 near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e8627538-c728-414a-8386-b5b987879d3f",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["673133fd-b6eb-4573-b719-34064b09316c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "6f27a6a2-e6d6-4cff-b850-372d5c3407be",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "f96b07fa-547d-4508-9bc6-099706baedf6",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["9885f1a2-2c3e-4a43-818b-bfc17314c4c9"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "81152905-d349-41e9-bdfc-e68cfc698003",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "d7073d4e-39f9-4f30-adba-3703fad2faf3",
+                    "config": {
+                        "name": "coin_1 distance"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "edb926e9-c946-4733-b162-c81aa4cd37a7",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["b6d716d5-d9fd-4ade-9fd0-3a213a79f50a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "673133fd-b6eb-4573-b719-34064b09316c",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["e8627538-c728-414a-8386-b5b987879d3f"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "61f2d656-d289-453d-8d41-7c0ae6a961d1",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLengthBlock"
+                },
+                {
+                    "uniqueId": "0b6aa30a-690d-4cb7-a727-6a9eab6f6001",
+                    "config": {
+                        "name": "coin_1 delta"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "3af76152-3250-4a91-8979-2e4adbe87d91",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["24961ac1-8064-4d3b-ae6b-4462696e1120"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "17825af1-deba-4fbf-9eb8-13c558036265",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["73974881-ca66-4ff4-b257-f2745272e092"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "b6d716d5-d9fd-4ade-9fd0-3a213a79f50a",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["edb926e9-c946-4733-b162-c81aa4cd37a7"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "acd97061-3b60-4d48-b750-5b14a86870f6",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "2b7978ee-2bd0-47c6-9308-9bcbbb0267c5",
+                    "config": {
+                        "name": "coin_1 position",
+                        "object": {
+                            "id": "coin_1",
+                            "name": "coin_1",
+                            "className": "Mesh",
+                            "uniqueId": 21
+                        },
+                        "propertyName": "position"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "73d3c713-a217-4d51-aa1f-d4ba2187ee9a",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "coin_1",
+                                "name": "coin_1",
+                                "className": "Mesh",
+                                "uniqueId": 21
+                            }
+                        },
+                        {
+                            "uniqueId": "a54a9b97-fe5c-4ee5-9f94-06618dfb1117",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position"
+                        },
+                        {
+                            "uniqueId": "5a241524-fff3-4b86-9a3b-f4bcb2c8439c",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "73974881-ca66-4ff4-b257-f2745272e092",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["17825af1-deba-4fbf-9eb8-13c558036265"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "9275da8d-7d9b-46e5-b133-53e208ee55a8",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "a7e36997-2abf-4780-aed4-ade7796358ee",
+                    "config": {
+                        "name": "coin_1 active",
+                        "variable": "coin_1_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "f3bf3b6a-3188-4098-b173-4239104a71fd",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["6517dfd0-26a7-46db-8f42-4837fe5f4990"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "14bb3dab-a5a3-4d1b-a367-646fcee9b593",
+                    "config": {},
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "c5b06cd3-18ab-4832-bd71-ebd476cecd8f",
+                            "name": "timeSinceStart",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "9fb469c2-6cee-44c8-ad23-978203cc64c5",
+                            "name": "deltaTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphSceneTickEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "1962473c-4795-41c6-91b5-8edb58acf1b0",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ae2bb964-cc5a-4911-a946-fd2921118312",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2e8c4f47-af0c-433d-82c0-a948cd5c04f9",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fef82d58-bed0-4ee0-b92c-07bf4fa49f69"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "63ec3b94-ea25-4259-b780-5c9d2833fdea",
+                    "config": {
+                        "name": "Tick fan-out",
+                        "outputSignalCount": 2
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSequenceBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "fef82d58-bed0-4ee0-b92c-07bf4fa49f69",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["2e8c4f47-af0c-433d-82c0-a948cd5c04f9"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "70a815b6-30e3-4674-907b-79380f099942",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8963aa86-db8e-4699-9b04-f339fbeff24f",
+                            "name": "out_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["227ab82a-9257-4986-8d19-81437939de0b"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8a32bfba-4806-4c48-bcc8-8aab841ba66e",
+                            "name": "out_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["41b2ed5e-f9c1-485d-8a71-87c790d5e146"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "7e271fa7-11f8-4572-8ae4-20cc8742bf13",
+                    "config": {
+                        "name": "Goal active?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0ec66836-ca8d-4c3b-bf76-36eaee8ff4cf",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["1c081f14-c28f-4505-bc69-06273c523da4"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "41b2ed5e-f9c1-485d-8a71-87c790d5e146",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8a32bfba-4806-4c48-bcc8-8aab841ba66e"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "cb993c28-c9d6-47c5-ae85-10d78158b373",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4c956bc6-549d-46b4-871f-f98b26bfc9c7",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a81491a9-b805-411b-b9a7-d375816c6921"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a365f918-1367-4f96-b5f9-c9f60c023f30",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "3b787cb7-8b2b-415d-a6a5-871e1f13697a",
+                    "config": {
+                        "name": "Goal reached?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "94e7fdaa-58fd-49bd-a793-65b051b2d4f1",
+                            "name": "condition",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["252cc8be-0918-48d2-8297-83e9ae88f0aa"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphBranchBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "a81491a9-b805-411b-b9a7-d375816c6921",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["4c956bc6-549d-46b4-871f-f98b26bfc9c7"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "67bba5cb-f658-43b2-a9aa-0d30f60a49c4",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4f7012f8-3017-4671-8fe8-e4859a31a9c2",
+                            "name": "onTrue",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["035a8f28-69c1-4cd3-ac4e-220c87ea4e29"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "aecb3581-e7e4-4934-b611-8a69fa81ad4b",
+                            "name": "onFalse",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "0908d758-9cf5-4791-b2c5-125fb3fe5999",
+                    "config": {
+                        "name": "Goal inactive",
+                        "variable": "goal_active"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "60ee549b-6b59-4612-b044-35ed147a30ae",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "035a8f28-69c1-4cd3-ac4e-220c87ea4e29",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["4f7012f8-3017-4671-8fe8-e4859a31a9c2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "cd803f60-faf7-4848-b91a-27023ecbdec6",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "378225b8-5360-470d-bde2-2821cc94e7a2",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["2703fa07-0e66-4b67-898b-75aaf8459714"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "5b054b1c-46c8-4c5d-af8b-0cf69456104a",
+                    "config": {
+                        "name": "Raise flag",
+                        "animationGroup": {
+                            "name": "goal_flag_raise",
+                            "className": "AnimationGroup",
+                            "uniqueId": 14
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0088a6f1-9030-43ca-abfa-59dfe8bd246e",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ec3d8082-2633-4b57-a461-68c0beaafbe1",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "f0e65c3f-99a2-4ac0-9544-dd8f873d17ad",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "b452373d-7352-473b-8585-0968b7678a38",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "8676fa91-125a-44dd-a0e4-4bc3953c3e34",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "goal_flag_raise",
+                                "className": "AnimationGroup",
+                                "uniqueId": 14
+                            }
+                        },
+                        {
+                            "uniqueId": "4a94d3ee-e0b5-4d97-a25d-67f437d26ceb",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b770c9b8-eea0-4256-8605-4ab6d40a9fa4",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "9e2c4b3a-4539-4a0f-b306-ff5fcb843410",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "96c38375-7ff5-4314-8fb5-472415c574e5",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "4c5942fb-56b3-4d12-abc9-f917cd92b1c3",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "2703fa07-0e66-4b67-898b-75aaf8459714",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["378225b8-5360-470d-bde2-2821cc94e7a2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "f6b6974c-4a59-4495-ae48-3e843fc6f000",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "05adddde-c67b-40fe-962d-eef269b5dac0",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d26369f5-b18a-4853-99c0-c3467a9f111b"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "26f01f3e-0c1a-479b-87b9-6ebcdc1131cc",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0cd7f219-93a5-46a5-885b-fa7212a62ef3",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "570bcefd-7a5e-4390-9445-adc5c2c84642",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ef3bd494-4aad-4083-94fc-d48ec0f12db3",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "29879122-8540-4277-a1c0-0b6b1b180405",
+                    "config": {
+                        "name": "Emit win",
+                        "eventId": "win",
+                        "eventData": {}
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSendCustomEventBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "d26369f5-b18a-4853-99c0-c3467a9f111b",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["05adddde-c67b-40fe-962d-eef269b5dac0"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "6b3841b4-2486-441e-ac75-73adf6e65a83",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9d3a47b1-4172-4090-afd7-089e6d206e75",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "d3bedd7d-5642-4c2d-8506-8e26c9d5a19d",
+                    "config": {
+                        "name": "Goal near?"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "4e688974-bf85-435e-8bf8-544d97af0c3b",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["5524a1cf-7885-4ba6-a2d2-fc9cc0734ce7"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "07a54f66-fc1a-4d1f-9361-154b99029a2f",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 1.6
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "252cc8be-0918-48d2-8297-83e9ae88f0aa",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["94e7fdaa-58fd-49bd-a793-65b051b2d4f1"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        },
+                        {
+                            "uniqueId": "82b32181-af17-4b2e-bdc5-1132a6afa71f",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphLessThanBlock"
+                },
+                {
+                    "uniqueId": "17474b8a-6bdb-47c0-bd58-63c800b44552",
+                    "config": {
+                        "name": "Goal |dx|"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "fe69fa29-6625-4bca-8dd6-ac39513d0211",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["ee66932a-5901-4366-acb9-59bab109cd8d"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5524a1cf-7885-4ba6-a2d2-fc9cc0734ce7",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4e688974-bf85-435e-8bf8-544d97af0c3b"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "94bb8aeb-1490-410b-8d31-e7253d322e54",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphAbsBlock"
+                },
+                {
+                    "uniqueId": "4c2ed059-3ac9-40c0-9356-21abb1f39d4a",
+                    "config": {
+                        "name": "Goal dx"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "8d7c42ef-36e4-435f-a3ff-9b82f9eb0e4d",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["c9c8495c-6a67-47d1-8b64-6bc75e389c4c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "987a5a76-d771-4f91-9493-73c010a15c7a",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["57bf4a6a-82a1-4623-91ac-1a4bf1c181a6"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ee66932a-5901-4366-acb9-59bab109cd8d",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["fe69fa29-6625-4bca-8dd6-ac39513d0211"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b7656638-07e0-4886-ba2b-d4affe01f22c",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphSubtractBlock"
+                },
+                {
+                    "uniqueId": "5c12f816-8228-43b8-8827-d0e35e5060ad",
+                    "config": {
+                        "name": "Goal X",
+                        "object": {
+                            "id": "goal_flag",
+                            "name": "goal_flag",
+                            "className": "TransformNode",
+                            "uniqueId": 37
+                        },
+                        "propertyName": "position.x"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "311e09a3-485e-4699-ba53-d75820469d42",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "goal_flag",
+                                "name": "goal_flag",
+                                "className": "TransformNode",
+                                "uniqueId": 37
+                            }
+                        },
+                        {
+                            "uniqueId": "7d72bd5a-b748-46ec-8047-52e8e547485d",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position.x"
+                        },
+                        {
+                            "uniqueId": "d7143514-e9f6-44ca-bdde-8c210b069dcf",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "57bf4a6a-82a1-4623-91ac-1a4bf1c181a6",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["987a5a76-d771-4f91-9493-73c010a15c7a"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "754ade26-c7b5-448e-8fec-cc71ead2146b",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "dddf4081-1eb3-4b94-8f5a-10521eb83f5d",
+                    "config": {
+                        "name": "Hero X",
+                        "object": {
+                            "id": "hero",
+                            "name": "hero",
+                            "className": "Mesh",
+                            "uniqueId": 20
+                        },
+                        "propertyName": "position.x"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "bfa1faca-197d-4f9e-be5d-f2103a98cb01",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "id": "hero",
+                                "name": "hero",
+                                "className": "Mesh",
+                                "uniqueId": 20
+                            }
+                        },
+                        {
+                            "uniqueId": "557705f4-d345-4074-9df8-57df34d21c94",
+                            "name": "propertyName",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "position.x"
+                        },
+                        {
+                            "uniqueId": "3154c386-f64f-4a97-ac70-eaaa0a5140c8",
+                            "name": "customGetFunction",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "c9c8495c-6a67-47d1-8b64-6bc75e389c4c",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["8d7c42ef-36e4-435f-a3ff-9b82f9eb0e4d"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "13262a2b-5a99-430b-9aa1-05f41c909c86",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetPropertyBlock"
+                },
+                {
+                    "uniqueId": "a12929fc-1b75-423a-b22d-3ed3b33d6370",
+                    "config": {
+                        "name": "Goal active",
+                        "variable": "goal_active",
+                        "initialValue": true
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "1c081f14-c28f-4505-bc69-06273c523da4",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["0ec66836-ca8d-4c3b-bf76-36eaee8ff4cf"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "3dab658e-477a-4090-86e3-c63aca1d57ea",
+                    "config": {
+                        "name": "Set hero velocity"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "23f8f118-3bb7-4b4e-b83b-f0aa6a2fce85",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "1c1d3f68-3170-435d-a765-4ac831d6aca1",
+                            "name": "velocity",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["fd41715e-b44c-41fd-ac6b-150be3b5695e"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetLinearVelocityBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "227ab82a-9257-4986-8d19-81437939de0b",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["8963aa86-db8e-4699-9b04-f339fbeff24f"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "f9ce0393-4082-4da4-8a5f-a8e15b5a2d82",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9607ee0f-0c9a-47f2-b43c-581c3adba5f8",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "89f87149-f207-4d3c-a195-c30888c68078",
+                    "config": {
+                        "name": "Compose velocity"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a17beb2e-856b-4f2c-b667-a3c1c07a79a6",
+                            "name": "input_0",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["9054e7e8-2a95-45b1-af10-cbee9feb7742"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ee37dbce-c7c3-4df8-b46e-9d2a10efda6c",
+                            "name": "input_1",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["004be1c1-4c3f-4ef7-aff6-38f4e0cd3820"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "57b45c77-e1b6-434b-8da4-994d214e834c",
+                            "name": "input_2",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "fd41715e-b44c-41fd-ac6b-150be3b5695e",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["1c1d3f68-3170-435d-a765-4ac831d6aca1"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "df612375-875b-4b7c-a3a8-399c1fd69dac",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphCombineVector3Block"
+                },
+                {
+                    "uniqueId": "4e125359-a981-45e7-bf4e-bbac7e0b0181",
+                    "config": {
+                        "name": "Extract velocity"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "84be205a-0910-44de-8a9a-dc2ab07093e6",
+                            "name": "input",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["3c1563ae-39c1-4f79-96e0-5287d7759cc1"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "3e9445ef-bb75-4fb0-abd7-6b2d906c2437",
+                            "name": "output_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "004be1c1-4c3f-4ef7-aff6-38f4e0cd3820",
+                            "name": "output_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ee37dbce-c7c3-4df8-b46e-9d2a10efda6c"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "c0c16c72-e5fe-492c-944a-a02b1abdda37",
+                            "name": "output_2",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphExtractVector3Block"
+                },
+                {
+                    "uniqueId": "7d249f0a-5438-4578-b7b0-fbcfecead0fa",
+                    "config": {
+                        "name": "Hero velocity"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "36873e66-5b0f-4f7d-9db9-07dd10557177",
+                            "name": "body",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["19d7faae-2a15-4c4e-a873-f287eeed8488"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "3c1563ae-39c1-4f79-96e0-5287d7759cc1",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["84be205a-0910-44de-8a9a-dc2ab07093e6"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "Vector3",
+                                "defaultValue": {
+                                    "_isDirty": true,
+                                    "_x": 0,
+                                    "_y": 0,
+                                    "_z": 0
+                                }
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "value": [0, 0, 0],
+                                "className": "Vector3"
+                            }
+                        },
+                        {
+                            "uniqueId": "b33a2f3d-d9d4-49d8-a1e6-83a208addc11",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphGetLinearVelocityBlock"
+                },
+                {
+                    "uniqueId": "7af0a780-d1e0-4db7-9dc7-31ae819c1ee6",
+                    "config": {
+                        "name": "heroVX * speed"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b10f985b-344a-4c6f-a84d-b42826927651",
+                            "name": "a",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["2fac7a04-6a0e-45d0-b776-07131b85c1ce"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "332d1b06-7c4e-4e69-a42d-866913a5b2ba",
+                            "name": "b",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 7
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "9054e7e8-2a95-45b1-af10-cbee9feb7742",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["a17beb2e-856b-4f2c-b667-a3c1c07a79a6"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "344860f5-a8f8-4f0e-a4bd-5e1e0fb2ac0e",
+                            "name": "isValid",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": false
+                        }
+                    ],
+                    "className": "FlowGraphMultiplyBlock"
+                },
+                {
+                    "uniqueId": "ad8a6d52-1098-44c1-8dad-c9c5d52cf41b",
+                    "config": {
+                        "name": "Get heroVX",
+                        "variable": "heroVX",
+                        "initialValue": 0
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "2fac7a04-6a0e-45d0-b776-07131b85c1ce",
+                            "name": "value",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["b10f985b-344a-4c6f-a84d-b42826927651"],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "className": "FlowGraphGetVariableBlock"
+                },
+                {
+                    "uniqueId": "9286df7b-3aa5-4003-884c-259cad3f6afe",
+                    "config": {
+                        "name": "On Scene Ready"
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSceneReadyEventBlock",
+                    "signalInputs": [],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5c2197af-b217-4070-adfa-9647a95b301d",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "e3364af7-11b8-4371-9ec8-3029435a5ca0",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "79e236ae-30ed-4610-a932-d92aa9349204",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["63704c6d-6fb5-4061-abe4-8726bcc42444"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "ce899283-e58e-4f65-b0f6-0e2e28d3304d",
+                    "config": {
+                        "name": "Reset score",
+                        "variable": "score"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "78406303-7c83-4046-833b-2b8d7842efd5",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "63704c6d-6fb5-4061-abe4-8726bcc42444",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["79e236ae-30ed-4610-a932-d92aa9349204"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "08fc6adb-5c81-4310-94a9-373daf3a579c",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "274c86b9-8687-46a4-b46f-b4af75f9a52d",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["68b2f977-27bf-4bc8-a347-f6bf3b9b190d"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "d53b7baa-aafa-4954-bead-46ec9ed88832",
+                    "config": {
+                        "name": "Reset heroVX",
+                        "variable": "heroVX"
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "b418f6fa-f524-4776-8577-5a9681149d76",
+                            "name": "value",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSetVariableBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "68b2f977-27bf-4bc8-a347-f6bf3b9b190d",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["274c86b9-8687-46a4-b46f-b4af75f9a52d"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "2902679e-131c-4828-adc1-bf76cb967750",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "aaaa72b4-84e9-40ca-873d-54dc93841e85",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["15a6718a-5c2d-4d4f-bb29-a61304251575"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4752b5f5-d0d3-46f8-8e7a-ab0aa4f8808b",
+                    "config": {
+                        "name": "Log start",
+                        "messageTemplate": "Babylon Bros — GO! Arrow keys to run, Space to jump onto the platforms."
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "dc5d1e9f-411e-4d98-9686-e2712c7f853d",
+                            "name": "message",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "a099339a-be82-446d-8df2-7933e1187250",
+                            "name": "logType",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "string",
+                                "defaultValue": ""
+                            },
+                            "optional": false,
+                            "defaultValue": "log"
+                        }
+                    ],
+                    "dataOutputs": [],
+                    "className": "FlowGraphConsoleLogBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "15a6718a-5c2d-4d4f-bb29-a61304251575",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["aaaa72b4-84e9-40ca-873d-54dc93841e85"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "e894f475-2d5a-4865-81ec-6fc11bf119cb",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "28ed7c46-6c78-4069-b484-c5e335a9bbef",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["244973b7-2752-49cb-a013-38057ff257ae"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "e35dcfb7-1504-49ae-bc90-fa3bf5dae629",
+                    "config": {
+                        "name": "Start loops",
+                        "outputSignalCount": 12
+                    },
+                    "dataInputs": [],
+                    "dataOutputs": [],
+                    "className": "FlowGraphSequenceBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "244973b7-2752-49cb-a013-38057ff257ae",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["28ed7c46-6c78-4069-b484-c5e335a9bbef"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "63c6eee8-807b-48d3-b0b3-01ba11e33de9",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6bcec05e-a035-4cec-9bd5-e1ca0e2050e3",
+                            "name": "out_0",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["d04ede69-cadb-4d1e-95cb-57bf822f982c"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "fe3cb65a-dc59-4193-b42f-8359051b0323",
+                            "name": "out_1",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["241f257b-0524-45a7-9730-ae3710145955"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "6e9633a9-50a8-4469-b19c-f5b45fc8ae71",
+                            "name": "out_2",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["04b7fd33-5716-452c-93c6-401ee99af5fc"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "622794a1-b658-4384-aa38-8567c210d1d6",
+                            "name": "out_3",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["32c2aa70-b307-4fea-9790-279daf5d8125"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "58300a19-7932-4ad7-ac88-54c3d509cee2",
+                            "name": "out_4",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["195b1826-5bc3-46bb-a5db-73b20b157842"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "75b91900-47cc-450d-a3b7-712e60d35c1e",
+                            "name": "out_5",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["39d79613-ab55-4033-83cd-30562bbb5fbd"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a8b8cbac-432c-43de-be4c-e5cfdd492cfd",
+                            "name": "out_6",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["6ec096b6-c43b-48e8-a22f-2193ad230082"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0fcde097-716b-4df9-9fba-7e3a8a6ea83d",
+                            "name": "out_7",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4729928c-80e9-4344-a73b-ad783a4e788e"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c8b11e21-e885-4067-8b11-8640f99bfb36",
+                            "name": "out_8",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["4456b71b-4bed-44ef-869c-d202705699ae"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "321abe18-da89-406f-8e83-88369676e57a",
+                            "name": "out_9",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["ec5aa1ac-c4d5-4c33-8cad-e70192bdfbe5"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f64c913b-78a9-4cf2-a562-34495d3029f9",
+                            "name": "out_10",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["379390ef-d42e-4425-bc9c-fbfd1084e3ac"],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0c75153b-cd61-4094-aaa4-65f40dee45b4",
+                            "name": "out_11",
+                            "_connectionType": 1,
+                            "connectedPointIds": ["587f681b-132a-4fb4-aa72-943bee3a3d6e"],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "883bfd4b-fd4c-4030-bd30-0c43ce27592f",
+                    "config": {
+                        "name": "Loop coin_7_spin",
+                        "animationGroup": {
+                            "name": "coin_7_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 13
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "8b17070a-33a4-4d0c-a30f-2e5c8352ae92",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "92ae5de2-c2ca-4ffa-826c-8eb72d157ddb",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "75f565b5-9be0-47f2-994a-7728958be44c",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "3c0f103b-6222-4e78-8588-1828bbb33157",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "8112d012-f2d4-48c6-b7ae-3c390daadbc5",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_7_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 13
+                            }
+                        },
+                        {
+                            "uniqueId": "ba5a88c9-3ff1-4a41-baa5-2dbb2a77a265",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "e6b5908c-403c-4235-811f-aa7ab96ff632",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "eb812ce1-df2f-40af-a379-688da27ca178",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "b44352b2-807b-499f-9eda-957f8c441d45",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "c1a9b6b3-6b07-4d3d-85aa-60560e9032f5",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "587f681b-132a-4fb4-aa72-943bee3a3d6e",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["0c75153b-cd61-4094-aaa4-65f40dee45b4"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5d613675-2de4-426c-8c5f-2e0b4488b87a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5f5f3f52-a00d-467a-a539-6c98590bf138",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "184b029e-5a65-4a9a-8c63-d32527be1f48",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "983441d0-b892-49b4-b1e7-23e4aaf93ef0",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5cf19806-5947-4d54-8bcd-113696a1830c",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "e2e301f1-7907-4061-9b22-65e347d41e89",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "5a5ace38-f6e2-4add-80fc-5f6831756d1c",
+                    "config": {
+                        "name": "Loop coin_6_spin",
+                        "animationGroup": {
+                            "name": "coin_6_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 12
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a97b94d4-8531-499c-b459-cd1010c5aa21",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "5435173b-0d3c-4c94-89f3-93bee48967b2",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "f15752fb-35ec-4d82-8817-9c71a58d20f8",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "13928c1e-c5b8-43f4-b403-4ab22f8cedc2",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "bb0ab57e-3841-4b13-bc3b-d9c1c675d5d6",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_6_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 12
+                            }
+                        },
+                        {
+                            "uniqueId": "07659d6d-045e-42a6-babb-81d3335ec96e",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "570c946d-db7a-4375-906d-76583c6b8d91",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "ba957fb0-0d9a-4e13-b990-b1e20c4a6f67",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "eb7afa1e-b136-48cf-a4d5-44604a29cff7",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "27cccef0-aba7-49f2-94c0-f2b24c07a607",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "379390ef-d42e-4425-bc9c-fbfd1084e3ac",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["f64c913b-78a9-4cf2-a562-34495d3029f9"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "3d77faac-35d4-4980-9daa-3333ccba2ef2",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "829a7ca8-a77b-425c-878e-7874c92e32aa",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d865c4a2-9c50-4000-8134-0986eb86e900",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8b3ee448-7e5b-4c20-b4ab-37ba082262cf",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ae1f6247-5a79-490f-8687-ad0e3ac381ec",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0660d87c-f27d-4d3a-8a7e-b95717be9230",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "77c08c2d-8a83-434e-aa98-0cb15dac0da7",
+                    "config": {
+                        "name": "Loop coin_5_spin",
+                        "animationGroup": {
+                            "name": "coin_5_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 11
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "66a5c9cf-5c2e-4058-9b2a-9a9ebd3a79c9",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "55515a28-8944-45f2-bc7a-18c39c1559d0",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "3eea4bc7-f262-400e-8b16-785dd41c13c3",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "feedc72c-de07-4c4a-b97a-1915a1ad0287",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "0db53a60-b2b0-4e35-aa18-800338bb57df",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_5_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 11
+                            }
+                        },
+                        {
+                            "uniqueId": "e707f842-bff9-4d7d-b0d3-a906fcff770b",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "747aeef3-6188-4998-868e-b327fb88147d",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "a04edec0-4748-4502-99ac-d58164bfd53a",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ca7af09a-b838-4a11-8653-1df66b84c7e1",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "9908f5d4-7f10-49f8-8325-c4ab9b5b1ef5",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "ec5aa1ac-c4d5-4c33-8cad-e70192bdfbe5",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["321abe18-da89-406f-8e83-88369676e57a"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "f96c48fe-2dc0-4c8e-b290-d9d429015b29",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7d715ce5-b27f-4085-999c-7420a26b6144",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "5bda68dd-db6c-4b62-82f2-fc3bee1e978c",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ea069e64-4efa-441d-8fe0-d989875f9ab0",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "1065a5c5-d2c3-4bfa-9d59-5649d7ca1a1b",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b6aee1a9-5658-47c8-a556-c353a49d5fe3",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4da4944d-0a2e-416f-884a-43073d2149f9",
+                    "config": {
+                        "name": "Loop coin_4_spin",
+                        "animationGroup": {
+                            "name": "coin_4_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 10
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "d848ee3e-06d8-4fc8-b9ff-66a8f5d848d0",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "90e77799-8e2c-4e38-bcdd-6ca402590cd4",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "ff60ee4a-708f-4eb2-ad88-acd1e1175e24",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "a3cb2e21-0767-4544-9cd7-cbf3b8317746",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "880bf949-fee5-41d7-b498-d9b6dab3d508",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_4_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 10
+                            }
+                        },
+                        {
+                            "uniqueId": "7bf92ad2-10df-43a9-9ab8-69a094ce92dd",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "eb8279f9-2f58-4e68-9de7-c6d31e32df40",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "5f4acf57-d9a3-4258-9205-f5b5b028ae17",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "368ae087-f248-442f-b7b9-7e7689c7726e",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "123ef498-a8d6-4706-915e-f6ca53e5d1aa",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "4456b71b-4bed-44ef-869c-d202705699ae",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["c8b11e21-e885-4067-8b11-8640f99bfb36"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "7f4c3a26-6d0e-477a-a557-107a237b962a",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "29e0a4b6-6947-4902-aa32-1b7755ca0d60",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9a499a4b-140b-4846-800f-130dd9c0a7f1",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "3c363e42-676b-4576-aac4-6f76f2543b24",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "165fc079-e44e-49f6-9f4d-dc540d12369a",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "455a5983-6c35-45cb-84c8-4d1f84cce82c",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "3d9972a4-2bf9-4c2a-a467-16b007ef50e7",
+                    "config": {
+                        "name": "Loop coin_3_spin",
+                        "animationGroup": {
+                            "name": "coin_3_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 9
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "6b347b58-5495-4cc4-bb73-7cf77948633d",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "e1e2a321-2254-499a-80f9-3562f82ae21f",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "336ee518-2dbf-40c5-bd11-f47a58a56406",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "c691bd02-5bbe-4e60-b29b-0eccf2277cd0",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "2462ee9a-93a9-49bf-8eeb-f31f2f4b6550",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_3_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 9
+                            }
+                        },
+                        {
+                            "uniqueId": "d9337ed7-daaa-47ef-a020-4543695dafaa",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b63411c0-e906-4fa8-a0ae-aa09241c5ab1",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "2caa50b9-0857-4184-9bca-d6996ea9d389",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "9d3377dd-8dcb-43de-a5c6-5946f63e8a88",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "4c41ee7f-2d6a-4017-85db-5f38615f023e",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "4729928c-80e9-4344-a73b-ad783a4e788e",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["0fcde097-716b-4df9-9fba-7e3a8a6ea83d"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "78634f43-d25c-4f1d-9393-345fd1f54b3e",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "47bdcdec-a480-4107-a571-0891b265dc32",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "d8e60012-d293-4520-bb3c-e41cf0723638",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8c5caea4-11e0-4f74-a40c-cadcd3b2cc85",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0132b4c3-797a-4119-8447-8eabca1b9225",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b03e12e6-68b4-44b7-80f2-9cffd7870ff7",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "4345a19a-69da-4979-a36e-79c59b7be152",
+                    "config": {
+                        "name": "Loop coin_2_spin",
+                        "animationGroup": {
+                            "name": "coin_2_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 8
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "fe4f5c9e-376c-43c3-9ad5-34654de6f228",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "1343eee5-e9ae-41b7-b7bb-292fe6db81e2",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "14a8d46d-9c7f-42e3-ac11-48256fee2f84",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "168f1109-6eb5-4537-bf1e-26a4d0aecce0",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "e6f5cd07-9c56-4091-a2a4-d661519d4b65",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_2_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 8
+                            }
+                        },
+                        {
+                            "uniqueId": "056dfc02-4f5c-4ef0-b9c4-366797c4defd",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "5a32eb43-e1b0-44b3-aa48-b56c42112a00",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "9738a71f-1731-4ac5-90e5-e7f6628fcb8a",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "6af17e3a-5bc6-4da8-a95b-128d9fca0d8f",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "899efcde-2681-41b8-83ac-1f49ed9314cd",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "6ec096b6-c43b-48e8-a22f-2193ad230082",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["a8b8cbac-432c-43de-be4c-e5cfdd492cfd"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ed472a22-1884-468e-a87b-496aa44838de",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "34337140-e7b9-4229-a186-b6d25f0fe5f0",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "bfd1e74d-a7b9-483e-bb48-a2d335ed9993",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f76e859d-0d23-4a16-b511-c77b2b8139c1",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "888dd915-d94c-419a-a467-54d9f351e503",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f9ac0308-767a-4ac7-8af6-efdec66f903f",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "3627e97e-7e30-42be-bddf-7545e4cbec05",
+                    "config": {
+                        "name": "Loop coin_1_spin",
+                        "animationGroup": {
+                            "name": "coin_1_spin",
+                            "className": "AnimationGroup",
+                            "uniqueId": 7
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "a6ad2773-96f7-4910-9442-c99ac38cfdde",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "8311adda-9e35-4e0d-b9a7-8a4705b58716",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "bb6564b5-ebe1-490f-b085-fef9a7cba656",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "2e6ae71e-7e4b-4a17-ac29-72016e91ad34",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "d32f1f7c-65c0-43ef-8b66-971c2e9d6a43",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "coin_1_spin",
+                                "className": "AnimationGroup",
+                                "uniqueId": 7
+                            }
+                        },
+                        {
+                            "uniqueId": "3ad35f09-9aed-42b2-bd3f-fb0e77f9eb8a",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "8ac2614d-0ad1-4ee0-b84c-64eec9f5940a",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "639dd041-3d9c-44e5-b3a9-8bdf6d292ed4",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "2b45c617-dd3c-439c-84a5-4abd5d1b7bc3",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "1f9cc322-99b7-4995-9691-fa3d0cfd75b0",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "39d79613-ab55-4033-83cd-30562bbb5fbd",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["75b91900-47cc-450d-a3b7-712e60d35c1e"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "9851b7a1-1a28-4606-a22b-3cc107787838",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ca26ff49-69e9-472c-bc56-62ab2dce717d",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9782a055-a616-49fd-9fde-6daadf61907a",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "409d65e6-02db-4435-af08-b8797347c597",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "518e95d0-f778-44ca-ae3c-2faa3314bbc8",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "01ba057e-650d-4fe4-8349-29ff81a36da6",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "cadd0849-e401-4283-a205-86d0890ba245",
+                    "config": {
+                        "name": "Loop platform_moving_loop",
+                        "animationGroup": {
+                            "name": "platform_moving_loop",
+                            "className": "AnimationGroup",
+                            "uniqueId": 6
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "711dee35-ebf4-4778-8b26-53cb279e1916",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "85254a2c-c94c-43df-bb5b-1384fd0a049c",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "04d40bde-a9cd-4c49-871a-4ee3694ed355",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "cf48b98b-55ab-4820-aed2-b1819492b811",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "991553e9-b3fd-4594-acd1-dd8d79a542e7",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "platform_moving_loop",
+                                "className": "AnimationGroup",
+                                "uniqueId": 6
+                            }
+                        },
+                        {
+                            "uniqueId": "a02cf761-93d0-4172-a458-e62081239ce3",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "9a188b7c-fa1b-482e-93e6-3ac7a8419b17",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "578d8646-fc76-40d4-92fe-357028f5ff30",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "7556813e-d713-4e35-8eda-e4403532e8e9",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "401bba45-90bf-448b-8138-3fa9b2a45bcc",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "195b1826-5bc3-46bb-a5db-73b20b157842",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["58300a19-7932-4ad7-ac88-54c3d509cee2"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "5a22c508-88a1-4e3e-9cc3-ddf7d9942d17",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "c91688fb-b207-4804-96f0-c84abb9f0779",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a32f727e-1cb2-4aea-9159-a427e32c7b82",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "3ccb5557-c4cd-4486-94d6-d9392442c9e2",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "8a44f583-4d25-49ec-a1d7-024349903315",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a0673a34-8307-4ddd-9ba1-19def0c9f6d4",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "f0e08f59-1048-4eee-9a43-d9aa223993bb",
+                    "config": {
+                        "name": "Loop spike_1_pulse",
+                        "animationGroup": {
+                            "name": "spike_1_pulse",
+                            "className": "AnimationGroup",
+                            "uniqueId": 5
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "813aeeaf-f637-45c1-aabe-e7c0769d3133",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "37667c94-521b-44c9-9d1d-dc618747d025",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "56f8971c-2ba3-4da6-b14c-f6b95e7d304b",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "b5546807-5d43-4324-9482-35a771326239",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "b6644600-2c02-471b-9af3-aa6dd4ed9175",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "spike_1_pulse",
+                                "className": "AnimationGroup",
+                                "uniqueId": 5
+                            }
+                        },
+                        {
+                            "uniqueId": "04df72be-674b-4066-a9cf-c483080ccb21",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "b6004bd0-5b7f-4310-a5a4-0e8108a2ce5b",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "aefc7fe6-9329-40ef-b088-bcda538f879c",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "63e2311d-da94-4c43-b337-4177935ae8ea",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "eec1d915-c859-4b11-9c75-2de07c3148a4",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "32c2aa70-b307-4fea-9790-279daf5d8125",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["622794a1-b658-4384-aa38-8567c210d1d6"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "f3e94b69-ad24-434f-91ce-f9a060ada123",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "581e7698-53ee-4ee3-af39-1a5e5999157a",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "ed67d404-8ffc-4196-aeb9-581fc24ff627",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "fb85b6e2-8af5-4094-9e94-9bde77110990",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2a5434eb-4818-4ebd-a013-6d9ef82db3eb",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "24a0c423-228b-4370-acfc-07224d512285",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "829f3e58-21ae-4ed8-aef6-07ed6cc7a787",
+                    "config": {
+                        "name": "Loop flyer_1_hover",
+                        "animationGroup": {
+                            "name": "flyer_1_hover",
+                            "className": "AnimationGroup",
+                            "uniqueId": 4
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "e60c653c-07b9-4bbb-b594-e22f07289670",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "5d4bc365-cbc4-44bf-a75d-1e149fe55121",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "eca7af3a-09e2-422d-8c8b-2a1e32ef9c65",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "c425b894-5b8b-4da3-bbb0-2bcd0069cb73",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ff7a6f14-5730-492e-9cf5-4ed388a751bb",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "flyer_1_hover",
+                                "className": "AnimationGroup",
+                                "uniqueId": 4
+                            }
+                        },
+                        {
+                            "uniqueId": "44240a8a-33ef-4a4e-98d8-6d8f96c81b40",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "7a44c18b-f123-4d84-bb2e-38657e13fc2d",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "d7872a19-aef2-4304-ad67-8fe865b56fa1",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "72f9a894-69e4-4875-b8fd-c748a89143f3",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "26a28e0c-ae43-48f3-b717-2e8affb3d6a7",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "04b7fd33-5716-452c-93c6-401ee99af5fc",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6e9633a9-50a8-4469-b19c-f5b45fc8ae71"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "34bde638-5c4d-4387-a34a-ad527cb934fd",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "4e63f20e-3b23-4256-af31-94e2963e9564",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "89e873de-176f-40ed-9996-dc3d168d20a2",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "412b17f1-e9a0-4cfd-a220-0b5003e798bd",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "0bc87a1b-917e-4e2e-9f9b-cadeeb322ed7",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "2d3590e9-285e-4d61-8fb3-0441e0c93ef1",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "b5b5eec7-d593-4b5a-b63a-d4ae547630f5",
+                    "config": {
+                        "name": "Loop goomba_2_walk",
+                        "animationGroup": {
+                            "name": "goomba_2_walk",
+                            "className": "AnimationGroup",
+                            "uniqueId": 3
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "06581454-b90b-4954-8858-8177ed8d9850",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "580a7add-7e82-438f-87ac-bf9ddff576e4",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "921b6f06-dde2-42cd-ac62-925342c873d4",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "185f9198-32cc-4fc0-8dc2-e45fbd593de3",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "113fc56a-ad90-43c9-9c67-38e510dac794",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "goomba_2_walk",
+                                "className": "AnimationGroup",
+                                "uniqueId": 3
+                            }
+                        },
+                        {
+                            "uniqueId": "835c47eb-ac1a-48b0-bc7a-6d7bc5e80a9b",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "2d92e91f-3dcb-4109-96eb-104fff7bdfcc",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "7da59f17-2e4c-4b0f-b76f-3be336897e06",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "ed4e5f97-7914-4300-a863-2cff1a61e5a2",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "23c2aeae-0901-4ebe-9ad8-da0b1ab65f83",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "241f257b-0524-45a7-9730-ae3710145955",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["fe3cb65a-dc59-4193-b42f-8359051b0323"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "ea4f7b99-bca9-47c7-91e9-ceeb8b6e6b81",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b3462b34-d308-47a7-ada4-3647134fe705",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "055a2933-0e41-4f19-b14d-91772dab4b5f",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "887e283a-d94a-44b3-92d0-e14f8801d69d",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "9b1d2d89-3598-41b9-8dcf-c7b3e15dbe3d",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "a88a31ad-f77f-4504-b7e2-af26139b8016",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                },
+                {
+                    "uniqueId": "f91e9ffb-5fb3-456e-91f2-55a613a09530",
+                    "config": {
+                        "name": "Loop goomba_1_walk",
+                        "animationGroup": {
+                            "name": "goomba_1_walk",
+                            "className": "AnimationGroup",
+                            "uniqueId": 2
+                        }
+                    },
+                    "dataInputs": [
+                        {
+                            "uniqueId": "0cd7dac8-0029-4ef9-bfd5-8338b2beacf8",
+                            "name": "speed",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "a2faefad-6309-40ad-82cf-7a2cb976ef7c",
+                            "name": "loop",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "boolean",
+                                "defaultValue": false
+                            },
+                            "optional": false,
+                            "defaultValue": true
+                        },
+                        {
+                            "uniqueId": "dcea549d-b95c-41ae-926e-c2ebd3bc9a45",
+                            "name": "from",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "86d42786-b69f-4bec-85be-61dee2297e07",
+                            "name": "to",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "3913c6bb-4665-4b1b-aa8a-ddacdd522820",
+                            "name": "animationGroup",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false,
+                            "defaultValue": {
+                                "name": "goomba_1_walk",
+                                "className": "AnimationGroup",
+                                "uniqueId": 2
+                            }
+                        },
+                        {
+                            "uniqueId": "c2c1b326-07da-4c4e-80a8-333a6aa5f7da",
+                            "name": "animation",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        },
+                        {
+                            "uniqueId": "aacf1cc6-25bc-49ec-946c-956b63311052",
+                            "name": "object",
+                            "_connectionType": 0,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "dataOutputs": [
+                        {
+                            "uniqueId": "030157ca-258d-43ec-8e88-838b80eced5b",
+                            "name": "currentFrame",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "bd0c4204-3a46-4539-a467-cb9330759819",
+                            "name": "currentTime",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "number",
+                                "defaultValue": 0
+                            },
+                            "optional": false,
+                            "defaultValue": 0
+                        },
+                        {
+                            "uniqueId": "99738a4c-0236-417f-bde0-1bafee1b6241",
+                            "name": "currentAnimationGroup",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FlowGraphDataConnection",
+                            "richType": {
+                                "typeName": "any"
+                            },
+                            "optional": false
+                        }
+                    ],
+                    "className": "FlowGraphPlayAnimationBlock",
+                    "signalInputs": [
+                        {
+                            "uniqueId": "d04ede69-cadb-4d1e-95cb-57bf822f982c",
+                            "name": "in",
+                            "_connectionType": 0,
+                            "connectedPointIds": ["6bcec05e-a035-4cec-9bd5-e1ca0e2050e3"],
+                            "className": "FGConnection"
+                        }
+                    ],
+                    "signalOutputs": [
+                        {
+                            "uniqueId": "31d76166-6976-4801-a780-32fce9cec78b",
+                            "name": "error",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f3bc6fab-c195-4d98-ad8e-f714c1b19988",
+                            "name": "out",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "7a3943c3-46e6-4068-89d4-f5c1b55370ee",
+                            "name": "done",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "acd63a1a-2d48-410d-9072-0978df9a59a6",
+                            "name": "animationLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "b81b1d30-d818-4a9a-9225-6d5343fc5e3d",
+                            "name": "animationEndEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        },
+                        {
+                            "uniqueId": "f8212703-6737-430f-aa6a-6a151f265e22",
+                            "name": "animationGroupLoopEvent",
+                            "_connectionType": 1,
+                            "connectedPointIds": [],
+                            "className": "FGConnection"
+                        }
+                    ]
+                }
+            ],
+            "executionContexts": []
+        }
+    ],
+    "activeGraphIndex": 0,
+    "sceneSnippetId": ""
+}

--- a/packages/tools/devHost/src/flowgraph/createScene.ts
+++ b/packages/tools/devHost/src/flowgraph/createScene.ts
@@ -1,0 +1,765 @@
+import { type Engine } from "core/Engines/engine";
+import { Scene } from "core/scene";
+import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
+import { HemisphericLight } from "core/Lights/hemisphericLight";
+import { DirectionalLight } from "core/Lights/directionalLight";
+import { ShadowGenerator } from "core/Lights/Shadows/shadowGenerator";
+import "core/Lights/Shadows/shadowGeneratorSceneComponent";
+import { GlowLayer } from "core/Layers/glowLayer";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { MeshBuilder } from "core/Meshes/meshBuilder";
+import { TransformNode } from "core/Meshes/transformNode";
+import { type Mesh } from "core/Meshes/mesh";
+import { type AbstractMesh } from "core/Meshes/abstractMesh";
+import { Vector3 } from "core/Maths/math.vector";
+import { Color3, Color4 } from "core/Maths/math.color";
+import { Animation } from "core/Animations/animation";
+import { AnimationGroup } from "core/Animations/animationGroup";
+import { SineEase, CircleEase, EasingFunction, BackEase } from "core/Animations/easing";
+import { CreateAudioEngineAsync } from "core/AudioV2/webAudio/webAudioEngine";
+import { CreateSoundAsync } from "core/AudioV2/abstractAudio/audioEngineV2";
+import { type StaticSound } from "core/AudioV2/abstractAudio/staticSound";
+// Importing from the FlowGraph index also registers every block class used below.
+import { ParseCoordinatorAsync } from "core/FlowGraph";
+
+// Physics v2 (Havok) — gives the hero gravity, lets it stand/jump on platforms
+// and physically collide with the coins.
+import { HavokPlugin } from "core/Physics/v2/Plugins/havokPlugin";
+import { PhysicsAggregate } from "core/Physics/v2/physicsAggregate";
+import { PhysicsShapeType, PhysicsMotionType } from "core/Physics/v2/IPhysicsEnginePlugin";
+import "core/Physics/joinedPhysicsEngineComponent";
+
+import "core/Culling/ray";
+
+// The serialized "Babylon Bros." interaction graph that drives all gameplay.
+// It is also published on the snippet server (#EH7L45) and can be opened in the
+// Flow Graph Editor for editing.
+import BabylonBrosFlowGraph from "./babylonBrosFlowGraph.json";
+
+/**
+ * ---------------------------------------------------------------------------
+ * "Babylon Bros." — a sophisticated, STATIC Mario-style world.
+ * ---------------------------------------------------------------------------
+ * This scene is intentionally inert: nothing moves, plays, or reacts on its
+ * own. Every interactive behavior (jumping, enemy patrols, coin spins, block
+ * bumps, spring bounces, sounds, win condition...) is pre-built and left
+ * paused so that a Flow Graph can drive it step by step.
+ *
+ * Conventions that make the scene Flow-Graph-friendly:
+ *  - Every interactive object has a stable, unique, human-readable name.
+ *  - Every behavior is an AnimationGroup (Flow Graph "Play Animation" target),
+ *    created and normalized but NEVER started here.
+ *  - Every sound is loaded via Audio v2 and parked (never played here).
+ *  - A discovery registry is attached to `scene.metadata.world` so tooling can
+ *    enumerate the actors, animation groups and sounds quickly.
+ * ---------------------------------------------------------------------------
+ */
+
+// CDN sound files verified to exist on the Babylon public assets host.
+const SoundBaseUrl = "https://playground.babylonjs.com/sounds/";
+const SoundUrls = {
+    jump: SoundBaseUrl + "bounce.wav",
+    stomp: SoundBaseUrl + "gunshot.wav",
+    // Short 2 ms "click" (a single pulse at ~0.2 s in an otherwise silent 1 s
+    // buffer) — used as the quick coin-pickup blip. The Flow Graph PlaySound
+    // block skips the silent lead-in with a startOffset so it fires instantly.
+    coin: "https://assets.babylonjs.com/sound/testing/audioV2/pulsed-1.mp3",
+    spring: SoundBaseUrl + "bounce.wav",
+    // Triumphant violin flourish played as the "end of level" music when the
+    // hero reaches the flag.
+    win: SoundBaseUrl + "violons11.wav",
+};
+
+const Fps = 30;
+
+type World = {
+    hero: TransformNode;
+    enemies: TransformNode[];
+    platforms: AbstractMesh[];
+    movingPlatform: AbstractMesh;
+    springs: AbstractMesh[];
+    coins: AbstractMesh[];
+    blocks: AbstractMesh[];
+    goal: TransformNode;
+    animationGroups: Record<string, AnimationGroup>;
+    sounds: Record<string, StaticSound>;
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention, no-restricted-syntax
+export const createScene = async function (engine: Engine, canvas: HTMLCanvasElement): Promise<Scene> {
+    const scene = new Scene(engine);
+    scene.clearColor = new Color4(0.46, 0.74, 0.96, 1.0); // bright platformer sky
+    scene.ambientColor = new Color3(0.3, 0.3, 0.35);
+
+    // --- Physics (Havok) -----------------------------------------------------
+    // Enable before any body is created. The Havok WASM is served by the
+    // devHost Vite config (serveHavokWasmPlugin) at "/HavokPhysics.wasm".
+    let physicsEnabled = false;
+    try {
+        const { default: havokFactory } = await import("@babylonjs/havok");
+        const havok = await havokFactory();
+        scene.enablePhysics(new Vector3(0, -16, 0), new HavokPlugin(true, havok));
+        physicsEnabled = true;
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn("[BabylonBros] Havok physics unavailable; the hero will not be physics-driven:", e);
+    }
+
+    // --- Camera: a comfortable 3/4 side-scroller view of the whole level. ---
+    const camera = new ArcRotateCamera("mainCamera", -Math.PI / 2.4, Math.PI / 2.7, 38, new Vector3(12, 4, 0), scene);
+    camera.lowerRadiusLimit = 10;
+    camera.upperRadiusLimit = 80;
+    camera.upperBetaLimit = Math.PI / 2.05;
+    camera.wheelDeltaPercentage = 0.02;
+    camera.attachControl(canvas, true);
+    // Detach the keyboard from the camera so the arrow keys drive the hero (via
+    // the Flow Graph) instead of panning/rotating the view.
+    camera.inputs.removeByType("ArcRotateCameraKeyboardMoveInput");
+
+    // --- Lighting + shadows. ---
+    const hemi = new HemisphericLight("ambientLight", new Vector3(0.2, 1, 0.1), scene);
+    hemi.intensity = 0.75;
+    hemi.groundColor = new Color3(0.35, 0.3, 0.4);
+
+    const sun = new DirectionalLight("sunLight", new Vector3(-0.6, -1, 0.4), scene);
+    sun.position = new Vector3(20, 30, -20);
+    sun.intensity = 1.1;
+    // Tight depth bounds keep the shadow map's precision focused on the level
+    // instead of being stretched across a huge auto-computed frustum.
+    sun.shadowMinZ = 1;
+    sun.shadowMaxZ = 140;
+
+    const shadows = new ShadowGenerator(2048, sun);
+    // Blurred exponential shadow maps were smearing the whole level into a soft
+    // grey wash. Percentage-closer filtering with a small bias gives crisp,
+    // correctly-placed contact shadows instead.
+    shadows.usePercentageCloserFiltering = true;
+    shadows.filteringQuality = ShadowGenerator.QUALITY_HIGH;
+    shadows.bias = 0.012;
+    shadows.normalBias = 0.02;
+
+    // Make coins / blocks / goal glow.
+    const glow = new GlowLayer("glow", scene);
+    glow.intensity = 0.6;
+
+    // --- Shared material palette. ---
+    const mat = (name: string, hex: string, opts?: { emissive?: string; specular?: string }) => {
+        const m = new StandardMaterial(name, scene);
+        m.diffuseColor = Color3.FromHexString(hex);
+        m.specularColor = opts?.specular ? Color3.FromHexString(opts.specular) : new Color3(0.1, 0.1, 0.1);
+        if (opts?.emissive) {
+            m.emissiveColor = Color3.FromHexString(opts.emissive);
+        }
+        return m;
+    };
+
+    const materials = {
+        ground: mat("mat_ground", "#5fae3a"),
+        dirt: mat("mat_dirt", "#7a4a23"),
+        brick: mat("mat_brick", "#b5651d"),
+        block: mat("mat_block", "#f2c14e", { emissive: "#5a3d00" }),
+        blockUsed: mat("mat_blockUsed", "#8a6d3b"),
+        heroBody: mat("mat_heroBody", "#d6322b"),
+        heroOveralls: mat("mat_heroOveralls", "#2b53d6"),
+        heroSkin: mat("mat_heroSkin", "#f1c27d"),
+        goomba: mat("mat_goomba", "#7a4a23"),
+        goombaFoot: mat("mat_goombaFoot", "#3a2412"),
+        flyer: mat("mat_flyer", "#9b59b6"),
+        flyerWing: mat("mat_flyerWing", "#ecf0f1"),
+        spike: mat("mat_spike", "#c0392b"),
+        spikeTip: mat("mat_spikeTip", "#ecf0f1"),
+        coin: mat("mat_coin", "#ffd700", { emissive: "#b8860b" }),
+        spring: mat("mat_spring", "#bdc3c7", { specular: "#ffffff" }),
+        platform: mat("mat_platform", "#8e7cc3"),
+        flagPole: mat("mat_flagPole", "#dddddd"),
+        flag: mat("mat_flag", "#2ecc71", { emissive: "#0d5c2c" }),
+    };
+
+    // --- Easing helpers. ---
+    const ease = (fn: EasingFunction, mode: number = EasingFunction.EASINGMODE_EASEINOUT) => {
+        fn.setEasingMode(mode);
+        return fn;
+    };
+
+    // Build a paused AnimationGroup from a single keyframed animation.
+    const buildGroup = (
+        groupName: string,
+        target: TransformNode | AbstractMesh,
+        property: string,
+        keys: { frame: number; value: number | Vector3 }[],
+        loop: boolean,
+        easing?: EasingFunction
+    ): AnimationGroup => {
+        const sample = keys[0].value;
+        const dataType = sample instanceof Vector3 ? Animation.ANIMATIONTYPE_VECTOR3 : Animation.ANIMATIONTYPE_FLOAT;
+        const anim = new Animation(groupName + "_anim", property, Fps, dataType, Animation.ANIMATIONLOOPMODE_CYCLE);
+        anim.setKeys(keys);
+        if (easing) {
+            anim.setEasingFunction(easing);
+        }
+        const group = new AnimationGroup(groupName, scene);
+        group.addTargetedAnimation(anim, target);
+        const lastFrame = keys[keys.length - 1].frame;
+        group.normalize(0, lastFrame);
+        group.loopAnimation = loop;
+        // Park it: explicitly NOT played. The group stays at rest for a clean static look.
+        return group;
+    };
+
+    const animationGroups: Record<string, AnimationGroup> = {};
+    const register = (g: AnimationGroup) => {
+        animationGroups[g.name] = g;
+        return g;
+    };
+
+    // =======================================================================
+    // GROUND & TERRAIN
+    // =======================================================================
+    const ground = MeshBuilder.CreateBox("ground", { width: 56, height: 2, depth: 8 }, scene);
+    ground.position.set(16, -1, 0);
+    ground.material = materials.ground;
+    ground.receiveShadows = true;
+
+    // A pit gap is implied by raised terrain blocks; add a couple of dirt steps.
+    const step1 = MeshBuilder.CreateBox("terrain_step_1", { width: 6, height: 4, depth: 8 }, scene);
+    step1.position.set(-2, 1, 0);
+    step1.material = materials.dirt;
+    step1.receiveShadows = true;
+
+    const step2 = MeshBuilder.CreateBox("terrain_step_2", { width: 6, height: 8, depth: 8 }, scene);
+    step2.position.set(34, 3, 0);
+    step2.material = materials.dirt;
+    step2.receiveShadows = true;
+
+    const terrain: AbstractMesh[] = [ground, step1, step2];
+
+    // =======================================================================
+    // HERO  ("Babylon Bro")
+    // =======================================================================
+    // The hero root is an invisible box that doubles as the physics collider.
+    // Visual parts are parented to it and centered on its origin.
+    const hero = MeshBuilder.CreateBox("hero", { width: 1.0, height: 2.2, depth: 0.7 }, scene);
+    hero.isVisible = false;
+    hero.position.set(-8, 1.3, 0);
+
+    const heroBody = MeshBuilder.CreateBox("hero_body", { width: 1, height: 1.1, depth: 0.7 }, scene);
+    heroBody.material = materials.heroOveralls;
+    heroBody.parent = hero;
+    heroBody.position.y = -0.55;
+
+    const heroTorso = MeshBuilder.CreateBox("hero_torso", { width: 1.02, height: 0.5, depth: 0.72 }, scene);
+    heroTorso.material = materials.heroBody;
+    heroTorso.parent = hero;
+    heroTorso.position.y = -0.05;
+
+    const heroHead = MeshBuilder.CreateSphere("hero_head", { diameter: 0.7, segments: 16 }, scene);
+    heroHead.material = materials.heroSkin;
+    heroHead.parent = hero;
+    heroHead.position.y = 0.5;
+
+    const heroCap = MeshBuilder.CreateCylinder("hero_cap", { diameterTop: 0.78, diameterBottom: 0.82, height: 0.22, tessellation: 16 }, scene);
+    heroCap.material = materials.heroBody;
+    heroCap.parent = hero;
+    heroCap.position.y = 0.85;
+
+    for (const part of [heroBody, heroTorso, heroHead, heroCap]) {
+        shadows.addShadowCaster(part);
+    }
+
+    // The hero's vertical motion (jumping, falling, idle bob) is now driven by
+    // the physics engine, so no position.y animation groups are registered here.
+
+    // =======================================================================
+    // ENEMIES  (3 types)
+    // =======================================================================
+    const enemies: TransformNode[] = [];
+
+    // --- Type 1: Goomba (ground patroller). ---
+    const makeGoomba = (id: string, x: number): TransformNode => {
+        const root = new TransformNode(id, scene);
+        root.position.set(x, 0.6, 0);
+
+        const body = MeshBuilder.CreateSphere(id + "_body", { diameterX: 1.3, diameterY: 1.0, diameterZ: 1.1, segments: 16 }, scene);
+        body.material = materials.goomba;
+        body.parent = root;
+
+        const footL = MeshBuilder.CreateBox(id + "_footL", { width: 0.4, height: 0.25, depth: 0.5 }, scene);
+        footL.material = materials.goombaFoot;
+        footL.parent = root;
+        footL.position.set(-0.35, -0.55, 0);
+
+        const footR = footL.clone(id + "_footR", root)!;
+        footR.position.x = 0.35;
+
+        shadows.addShadowCaster(body);
+        register(
+            buildGroup(
+                id + "_walk",
+                root,
+                "position.x",
+                [
+                    { frame: 0, value: x },
+                    { frame: Fps * 2, value: x - 4 },
+                    { frame: Fps * 4, value: x },
+                ],
+                true,
+                ease(new SineEase())
+            )
+        );
+        enemies.push(root);
+        return root;
+    };
+    makeGoomba("goomba_1", 6);
+    makeGoomba("goomba_2", 22);
+
+    // --- Type 2: Flyer (hovering enemy). ---
+    const makeFlyer = (id: string, position: Vector3): TransformNode => {
+        const root = new TransformNode(id, scene);
+        root.position.copyFrom(position);
+
+        const body = MeshBuilder.CreateSphere(id + "_body", { diameter: 1.0, segments: 16 }, scene);
+        body.material = materials.flyer;
+        body.parent = root;
+
+        const wingL = MeshBuilder.CreateBox(id + "_wingL", { width: 0.7, height: 0.08, depth: 0.5 }, scene);
+        wingL.material = materials.flyerWing;
+        wingL.parent = root;
+        wingL.position.set(-0.7, 0.1, 0);
+        wingL.rotation.z = 0.4;
+
+        const wingR = wingL.clone(id + "_wingR", root)!;
+        wingR.position.x = 0.7;
+        wingR.rotation.z = -0.4;
+
+        shadows.addShadowCaster(body);
+        register(
+            buildGroup(
+                id + "_hover",
+                root,
+                "position.y",
+                [
+                    { frame: 0, value: position.y },
+                    { frame: Fps * 1.5, value: position.y + 1.4 },
+                    { frame: Fps * 3, value: position.y },
+                ],
+                true,
+                ease(new SineEase())
+            )
+        );
+        enemies.push(root);
+        return root;
+    };
+    makeFlyer("flyer_1", new Vector3(16, 6, 0));
+
+    // --- Type 3: Spiky (stationary hazard that pulses). ---
+    const makeSpike = (id: string, position: Vector3): TransformNode => {
+        const root = new TransformNode(id, scene);
+        root.position.copyFrom(position);
+
+        const core = MeshBuilder.CreateSphere(id + "_core", { diameter: 0.9, segments: 12 }, scene);
+        core.material = materials.spike;
+        core.parent = root;
+
+        const dirs = [
+            new Vector3(0, 1, 0),
+            new Vector3(0, -1, 0),
+            new Vector3(1, 0, 0),
+            new Vector3(-1, 0, 0),
+            new Vector3(0, 0, 1),
+            new Vector3(0, 0, -1),
+        ];
+        dirs.forEach((d, i) => {
+            const spike = MeshBuilder.CreateCylinder(id + "_spike_" + i, { diameterTop: 0, diameterBottom: 0.28, height: 0.6, tessellation: 8 }, scene);
+            spike.material = materials.spikeTip;
+            spike.parent = root;
+            spike.position = d.scale(0.6);
+            // Point the cone outward along d.
+            if (d.y === 0) {
+                spike.rotation.z = d.x !== 0 ? (d.x > 0 ? -Math.PI / 2 : Math.PI / 2) : 0;
+                spike.rotation.x = d.z !== 0 ? (d.z > 0 ? Math.PI / 2 : -Math.PI / 2) : 0;
+            } else if (d.y < 0) {
+                spike.rotation.x = Math.PI;
+            }
+            shadows.addShadowCaster(spike);
+        });
+
+        shadows.addShadowCaster(core);
+        register(
+            buildGroup(
+                id + "_pulse",
+                root,
+                "scaling",
+                [
+                    { frame: 0, value: new Vector3(1, 1, 1) },
+                    { frame: Fps * 0.5, value: new Vector3(1.25, 1.25, 1.25) },
+                    { frame: Fps, value: new Vector3(1, 1, 1) },
+                ],
+                true,
+                ease(new SineEase())
+            )
+        );
+        enemies.push(root);
+        return root;
+    };
+    makeSpike("spike_1", new Vector3(28, 1.4, 0));
+
+    // =======================================================================
+    // PLATFORMS  (static + one moving)
+    // =======================================================================
+    const platforms: AbstractMesh[] = [];
+    const makePlatform = (id: string, position: Vector3, size = { w: 3, h: 0.6, d: 4 }): Mesh => {
+        const p = MeshBuilder.CreateBox(id, { width: size.w, height: size.h, depth: size.d }, scene);
+        p.position.copyFrom(position);
+        p.material = materials.platform;
+        p.receiveShadows = true;
+        shadows.addShadowCaster(p);
+        platforms.push(p);
+        return p;
+    };
+    makePlatform("platform_static_1", new Vector3(2, 3.2, 0));
+    makePlatform("platform_static_2", new Vector3(11, 5.0, 0));
+    makePlatform("platform_static_3", new Vector3(18, 3.6, 0));
+    makePlatform("platform_static_4", new Vector3(26, 6.2, 0));
+
+    // Moving platform (paused loop between two points).
+    const movingPlatform = makePlatform("platform_moving", new Vector3(7, 4.2, 0), { w: 3.2, h: 0.5, d: 4 });
+    // A vertical "elevator". The per-frame hero velocity override owns the
+    // horizontal axis, so a sideways platform would slide out from under a
+    // standing hero (leaving them briefly floating). Moving on Y instead means
+    // the elevator physically lifts/lowers the hero, which the velocity override
+    // preserves, so it behaves as expected.
+    register(
+        buildGroup(
+            "platform_moving_loop",
+            movingPlatform,
+            "position.y",
+            [
+                { frame: 0, value: 4.2 },
+                { frame: Fps * 2.5, value: 7.2 },
+                { frame: Fps * 5, value: 4.2 },
+            ],
+            true,
+            ease(new SineEase())
+        )
+    );
+
+    // =======================================================================
+    // SPRINGS  (bounce pads)
+    // =======================================================================
+    const springs: AbstractMesh[] = [];
+    const makeSpring = (id: string, x: number): Mesh => {
+        const base = MeshBuilder.CreateCylinder(id, { diameterTop: 1.0, diameterBottom: 1.2, height: 0.8, tessellation: 16 }, scene);
+        base.position.set(x, 0.4, 0);
+        base.material = materials.spring;
+        base.setPivotPoint(new Vector3(0, -0.4, 0)); // compress from the bottom
+        base.receiveShadows = true;
+        shadows.addShadowCaster(base);
+        springs.push(base);
+        register(
+            buildGroup(
+                id + "_compress",
+                base,
+                "scaling",
+                [
+                    { frame: 0, value: new Vector3(1, 1, 1) },
+                    { frame: Fps * 0.15, value: new Vector3(1.1, 0.4, 1.1) },
+                    { frame: Fps * 0.5, value: new Vector3(1, 1, 1) },
+                ],
+                false,
+                ease(new BackEase(), EasingFunction.EASINGMODE_EASEOUT)
+            )
+        );
+        return base;
+    };
+    makeSpring("spring_1", 14);
+    makeSpring("spring_2", 31);
+
+    // =======================================================================
+    // COINS  (collectibles)
+    // =======================================================================
+    const coins: AbstractMesh[] = [];
+    // Coins sit roughly at hero chest height over a reachable surface so that
+    // running or jumping into them triggers a physics collision.
+    const coinSpots = [
+        new Vector3(-6, 1.0, 0), // ground, before the first dirt step
+        new Vector3(-2, 4.0, 0), // on top of terrain_step_1
+        new Vector3(2, 4.5, 0), // on platform_static_1
+        new Vector3(11, 6.3, 0), // on platform_static_2
+        new Vector3(18, 4.9, 0), // on platform_static_3
+        new Vector3(22, 1.0, 0), // back down on the ground
+        new Vector3(26, 7.5, 0), // on platform_static_4
+    ];
+    coinSpots.forEach((pos, i) => {
+        const id = "coin_" + (i + 1);
+        const coin = MeshBuilder.CreateCylinder(id, { diameter: 0.9, height: 0.14, tessellation: 24 }, scene);
+        coin.rotation.x = Math.PI / 2; // face the camera like a disc
+        coin.position.copyFrom(pos);
+        coin.material = materials.coin;
+        shadows.addShadowCaster(coin);
+        coins.push(coin);
+        register(
+            buildGroup(
+                id + "_spin",
+                coin,
+                "rotation.y",
+                [
+                    { frame: 0, value: 0 },
+                    { frame: Fps * 2, value: Math.PI * 2 },
+                ],
+                true
+            )
+        );
+    });
+
+    // =======================================================================
+    // QUESTION BLOCKS  (interactive bump blocks)
+    // =======================================================================
+    const blocks: AbstractMesh[] = [];
+    // A classic "question block" row floating over the open running stretch past
+    // platform_static_3: high enough for the hero to run underneath, low enough
+    // to bonk from a ground jump, and clear of the platform-to-platform jump
+    // arcs so they no longer block traversal between platforms.
+    const blockSpots = [new Vector3(20, 5.0, 0), new Vector3(22, 5.0, 0), new Vector3(24, 5.0, 0)];
+    blockSpots.forEach((pos, i) => {
+        const id = "block_" + (i + 1);
+        const block = MeshBuilder.CreateBox(id, { size: 1 }, scene);
+        block.position.copyFrom(pos);
+        block.material = materials.block;
+        shadows.addShadowCaster(block);
+        blocks.push(block);
+        register(
+            buildGroup(
+                id + "_bump",
+                block,
+                "position.y",
+                [
+                    { frame: 0, value: pos.y },
+                    { frame: Fps * 0.2, value: pos.y + 0.6 },
+                    { frame: Fps * 0.5, value: pos.y },
+                ],
+                false,
+                ease(new BackEase(), EasingFunction.EASINGMODE_EASEOUT)
+            )
+        );
+    });
+
+    // =======================================================================
+    // GOAL  (flag at the end of the level)
+    // =======================================================================
+    const goal = new TransformNode("goal_flag", scene);
+    goal.position.set(40, 7, 0);
+
+    const pole = MeshBuilder.CreateCylinder("goal_pole", { diameter: 0.18, height: 8, tessellation: 12 }, scene);
+    pole.material = materials.flagPole;
+    pole.parent = goal;
+    pole.position.y = 0;
+
+    const flag = MeshBuilder.CreateBox("goal_flag_cloth", { width: 1.6, height: 1.0, depth: 0.05 }, scene);
+    flag.material = materials.flag;
+    flag.parent = goal;
+    flag.position.set(0.8, 2.2, 0); // parked low; "raise" lifts it to the top
+    shadows.addShadowCaster(pole);
+    shadows.addShadowCaster(flag);
+
+    register(
+        buildGroup(
+            "goal_flag_raise",
+            flag,
+            "position.y",
+            [
+                { frame: 0, value: 2.2 },
+                { frame: Fps * 1.2, value: 3.6 },
+            ],
+            false,
+            ease(new CircleEase(), EasingFunction.EASINGMODE_EASEOUT)
+        )
+    );
+
+    // =======================================================================
+    // AUDIO v2  (loaded & parked — never played here)
+    // =======================================================================
+    const sounds: Record<string, StaticSound> = {};
+    try {
+        const audioEngine = await CreateAudioEngineAsync({ volume: 0.6 });
+        // All sounds load as static sounds (short SFX + the win flourish).
+        const sfxNames = ["jump", "stomp", "coin", "spring", "win"] as const;
+        await Promise.all(
+            sfxNames.map(async (key) => {
+                try {
+                    sounds[key] = await CreateSoundAsync("sfx_" + key, SoundUrls[key], { autoplay: false }, audioEngine);
+                } catch (e) {
+                    // eslint-disable-next-line no-console
+                    console.warn(`[BabylonBros] Could not load sound '${key}':`, e);
+                }
+            })
+        );
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn("[BabylonBros] Audio v2 engine unavailable; continuing without sound:", e);
+    }
+
+    // =======================================================================
+    // DISCOVERY REGISTRY
+    // =======================================================================
+    const world: World = {
+        hero,
+        enemies,
+        platforms: [...platforms],
+        movingPlatform,
+        springs,
+        coins,
+        blocks,
+        goal,
+        animationGroups,
+        sounds,
+    };
+    scene.metadata = { ...(scene.metadata ?? {}), world, terrain };
+
+    // eslint-disable-next-line no-console
+    console.log(
+        `[BabylonBros] Static world ready: ${enemies.length} enemies, ${platforms.length} platforms, ${coins.length} coins, ${blocks.length} blocks, ` +
+            `${Object.keys(animationGroups).length} paused animation groups, ${Object.keys(sounds).length} parked sounds.`
+    );
+
+    // =======================================================================
+    // PHYSICS BODIES
+    // The hero is a dynamic capsule-ish box; the ground, dirt steps and
+    // platforms are static; the moving platform is an ANIMATED vertical elevator
+    // so it lifts the hero; coins are non-physical (collected by proximity).
+    // =======================================================================
+    if (physicsEnabled) {
+        // Static world geometry.
+        for (const mesh of [...terrain, ...platforms]) {
+            new PhysicsAggregate(mesh, PhysicsShapeType.BOX, { mass: 0, friction: 0.6, restitution: 0 }, scene);
+        }
+
+        // Moving platform: keep it kinematic/ANIMATED so its animation drives it
+        // through physics and it carries dynamic bodies resting on top.
+        const movingAggregate = new PhysicsAggregate(movingPlatform, PhysicsShapeType.BOX, { mass: 0, friction: 0.8, restitution: 0 }, scene);
+        movingAggregate.body.setMotionType(PhysicsMotionType.ANIMATED);
+        movingAggregate.body.disablePreStep = false;
+
+        // Springs: solid STATIC bounce-pad colliders. The Flow Graph applies a
+        // strong upward impulse to the hero on contact, so they launch the hero
+        // back up to the platforms after a fall down to the ground.
+        for (const spring of springs) {
+            new PhysicsAggregate(spring, PhysicsShapeType.BOX, { mass: 0, friction: 0.6, restitution: 0 }, scene);
+        }
+
+        // Coins are intentionally NON-physical. A solid coin collider can be
+        // stood on, and a static-vs-dynamic contact only sometimes re-fires, so
+        // the Flow Graph collects coins with a per-frame proximity test instead.
+        // This lets the hero pass cleanly through them like real pickups.
+
+        // Enemies: give each a solid collider so the hero physically bumps into
+        // them. The collider is the enemy's body/core child mesh (the roots are
+        // bare TransformNodes with no geometry). Goombas patrol and the flyer
+        // hovers, so their bodies are ANIMATED (disablePreStep off) to let their
+        // patrol animation drive the physics body; the spike only pulses in
+        // place, so it stays STATIC. A BOX shape avoids the non-uniform-scale
+        // warning the sphere bodies would otherwise emit.
+        for (const enemy of enemies) {
+            const isSpike = enemy.name.startsWith("spike");
+            const collider = scene.getMeshByName(enemy.name + (isSpike ? "_core" : "_body"));
+            if (!collider) {
+                continue;
+            }
+            // A SPHERE collider sized to the visible body keeps the hit area a
+            // tight round shape. A BOX circumscribes the sphere, so its corners
+            // would "hit" the hero well before the visible body is touched.
+            const colliderRadius = enemy.name.startsWith("goomba") ? 0.6 : 0.5;
+            const enemyAggregate = new PhysicsAggregate(collider, PhysicsShapeType.SPHERE, { mass: 0, radius: colliderRadius, friction: 0.4, restitution: 0 }, scene);
+            if (isSpike) {
+                enemyAggregate.body.setMotionType(PhysicsMotionType.STATIC);
+            } else {
+                enemyAggregate.body.setMotionType(PhysicsMotionType.ANIMATED);
+                enemyAggregate.body.disablePreStep = false;
+            }
+        }
+
+        // Question blocks floating at the top of the level: solid STATIC boxes so
+        // the hero can bump into them and land on top.
+        for (const block of blocks) {
+            new PhysicsAggregate(block, PhysicsShapeType.BOX, { mass: 0, friction: 0.6, restitution: 0 }, scene);
+        }
+
+        // Hero: dynamic, upright. Zeroing the inertia locks rotation so the box
+        // never topples while running and jumping. The mass must be passed
+        // explicitly here, otherwise Havok recomputes it from the box volume
+        // (~1540) and the jump impulse becomes imperceptible.
+        const heroAggregate = new PhysicsAggregate(hero, PhysicsShapeType.BOX, { mass: 1, friction: 0.4, restitution: 0 }, scene);
+        heroAggregate.body.setMassProperties({ mass: 1, inertia: Vector3.Zero() });
+        heroAggregate.body.setAngularDamping(100);
+    }
+
+    // =======================================================================
+    // FLOW GRAPH — load & start the serialized interaction graph locally so we
+    // can verify it drives the static world (enemy patrols, coin spins, jumps,
+    // pickups, win condition...). References resolve against the scene by name.
+    // =======================================================================
+    try {
+        const coordinator = await ParseCoordinatorAsync(BabylonBrosFlowGraph, { scene });
+        coordinator.start();
+        // Audio V2 sounds are not a serializable Flow Graph asset type, so each
+        // PlaySound block reads its sound from a named graph variable. Bind the
+        // parked sounds into every execution context here (after start, so the
+        // contexts exist) — the play logic itself lives entirely in the Flow Graph.
+        const soundBindings: Record<string, StaticSound | undefined> = {
+            coinSound: sounds.coin,
+            jumpSound: sounds.jump,
+            hurtSound: sounds.stomp,
+            winSound: sounds.win,
+        };
+        for (const flowGraph of coordinator.flowGraphs) {
+            for (let i = 0; i < flowGraph.contextCount; i++) {
+                const ctx = flowGraph.getContext(i);
+                for (const key of Object.keys(soundBindings)) {
+                    const snd = soundBindings[key];
+                    if (snd) {
+                        ctx.setVariable(key, snd);
+                    }
+                }
+            }
+        }
+
+        // --- Score HUD (polled, NOT driven by the Flow Graph) ----------------
+        // The Flow Graph owns the "score" and "gameDone" variables; this HTML
+        // overlay merely reads them every frame and renders them. No game logic
+        // lives here — it is a pure view that polls the graph context.
+        const hudContext = coordinator.flowGraphs[0]?.contextCount ? coordinator.flowGraphs[0].getContext(0) : undefined;
+        const hudId = "babylonBrosHud";
+        document.getElementById(hudId)?.remove();
+        const hud = document.createElement("div");
+        hud.id = hudId;
+        hud.style.cssText =
+            "position:fixed;top:14px;left:16px;z-index:20;pointer-events:none;" +
+            "font-family:'Segoe UI',system-ui,sans-serif;font-weight:700;color:#ffffff;" +
+            "text-shadow:0 2px 4px rgba(0,0,0,0.65);";
+        hud.innerHTML =
+            '<div style="font-size:26px;letter-spacing:1px">SCORE&nbsp;<span id="bbScore">0</span></div>' +
+            '<div id="bbState" style="font-size:32px;color:#ffe14d;margin-top:6px"></div>';
+        document.body.appendChild(hud);
+        const scoreEl = hud.querySelector("#bbScore") as HTMLSpanElement;
+        const stateEl = hud.querySelector("#bbState") as HTMLDivElement;
+        scene.onDisposeObservable.addOnce(() => hud.remove());
+        scene.onBeforeRenderObservable.add(() => {
+            if (!hudContext) {
+                return;
+            }
+            const score = hudContext.hasVariable("score") ? hudContext.getVariable("score") : 0;
+            scoreEl.textContent = String(score ?? 0);
+            const done = hudContext.hasVariable("gameDone") ? hudContext.getVariable("gameDone") : false;
+            stateEl.textContent = done ? "GAME DONE!" : "";
+        });
+
+        // eslint-disable-next-line no-console
+        console.log(
+            `[BabylonBros] Flow graph started: ${coordinator.flowGraphs.length} graph(s) driving the scene. Use ←/→ to run, Space to jump onto the platforms; bump into the coins to collect them and reach the flag to win.`
+        );
+    } catch (e) {
+        // eslint-disable-next-line no-console
+        console.warn("[BabylonBros] Could not start the Babylon Bros flow graph:", e);
+    }
+
+    return scene;
+};

--- a/packages/tools/devHost/src/flowgraph/main.ts
+++ b/packages/tools/devHost/src/flowgraph/main.ts
@@ -1,0 +1,31 @@
+import { type Scene } from "core/scene";
+import { Engine } from "core/Engines/engine";
+
+import { createScene } from "./createScene";
+
+/**
+ * Entry point for the "flowgraph" devhost experience: a physics-driven,
+ * Flow-Graph-powered "Babylon Bros." platformer showcase.
+ * @param _searchParams URL QSPs where the keys have been lowercased.
+ */
+export async function Main(_searchParams: URLSearchParams): Promise<void> {
+    // Setup the engine canvas
+    const mainDiv = document.getElementById("main-div") as HTMLDivElement;
+    const canvas = document.createElement("canvas");
+    canvas.id = "babylon-canvas";
+    mainDiv.appendChild(canvas);
+
+    // Setup the engine and create the scene
+    const engine = new Engine(canvas, true);
+    const scene: Scene = await createScene(engine, canvas);
+
+    // Register a render loop to repeatedly render the scene
+    engine.runRenderLoop(function () {
+        scene.render();
+    });
+
+    // Watch for browser/canvas resize events
+    window.addEventListener("resize", function () {
+        engine.resize();
+    });
+}

--- a/packages/tools/devHost/src/index.ts
+++ b/packages/tools/devHost/src/index.ts
@@ -19,6 +19,10 @@ switch (ExpQsp) {
         ImportPromise = import("./bodyTracking/main");
         break;
     }
+    case "flowgraph": {
+        ImportPromise = import("./flowgraph/main");
+        break;
+    }
     case "testscene":
     default: {
         ImportPromise = import("./testScene/main");

--- a/packages/tools/devHost/tsconfig.json
+++ b/packages/tools/devHost/tsconfig.json
@@ -4,6 +4,7 @@
     "compilerOptions": {
         "allowJs": true,
         "esModuleInterop": true,
-        "noImplicitAny": false
+        "noImplicitAny": false,
+        "resolveJsonModule": true
     }
 }

--- a/packages/tools/devHost/vite.config.ts
+++ b/packages/tools/devHost/vite.config.ts
@@ -1,7 +1,38 @@
 import path from "path";
+import { readFile } from "fs";
+import { fileURLToPath } from "url";
 import { defineConfig, normalizePath, type Plugin, type UserConfig } from "vite";
 // @ts-ignore -- untyped JS helper
 import { commonDevViteConfiguration } from "../../public/viteToolsHelper.mjs";
+
+// Serve the Havok physics WASM (used by the flowgraph showcase) from node_modules
+// during dev. The Havok ESM loader requests "/HavokPhysics.wasm" at runtime.
+const HavokWasmFilePath = fileURLToPath(new URL("../../../node_modules/@babylonjs/havok/lib/esm/HavokPhysics.wasm", import.meta.url));
+
+function serveHavokWasmPlugin(): Plugin {
+    return {
+        name: "serve-havok-wasm",
+        configureServer(server) {
+            server.middlewares.use((request, response, next) => {
+                const requestPath = request.url?.split("?", 1)[0];
+                if (!requestPath?.endsWith("/HavokPhysics.wasm")) {
+                    next();
+                    return;
+                }
+                readFile(HavokWasmFilePath, (error, wasm) => {
+                    if (error) {
+                        next(error);
+                        return;
+                    }
+                    response.statusCode = 200;
+                    response.setHeader("Content-Type", "application/wasm");
+                    response.setHeader("Cache-Control", "no-cache");
+                    response.end(wasm);
+                });
+            });
+        },
+    };
+}
 
 const OptionalPeerDependencies = ["draco3dgltf", "ammo.js", "cannon", "oimo", "recast", "havok", "basis_transcoder"];
 const OptionalPeerDependencyPattern = OptionalPeerDependencies.map((p) => p.replace(".", "\\.")).join("|");
@@ -179,6 +210,6 @@ export default defineConfig((_env) => {
 
     return {
         ...base,
-        plugins: [...(base.plugins ?? []), lottieClassicWorkerPlugin(aliases), stubOptionalPeerDepsPlugin()],
+        plugins: [...(base.plugins ?? []), lottieClassicWorkerPlugin(aliases), stubOptionalPeerDepsPlugin(), serveHavokWasmPlugin()],
     };
 });

--- a/packages/tools/devHost/vite.config.ts
+++ b/packages/tools/devHost/vite.config.ts
@@ -21,6 +21,14 @@ function serveHavokWasmPlugin(): Plugin {
                 }
                 readFile(HavokWasmFilePath, (error, wasm) => {
                     if (error) {
+                        // Havok is an optional dependency. When the wasm file isn't installed,
+                        // respond with a clean 404 instead of forwarding the error to Vite, which
+                        // would surface a noisy 500 + error overlay across the whole devHost.
+                        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                            response.statusCode = 404;
+                            response.end();
+                            return;
+                        }
                         next(error);
                         return;
                     }

--- a/packages/tools/flowGraphEditor/src/components/graphControls/graphControlsComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/graphControls/graphControlsComponent.tsx
@@ -11,6 +11,7 @@ import {
     EditRegular,
     FastForwardRegular,
     FlashRegular,
+    FlowchartRegular,
     NextRegular,
     PauseRegular,
     PlayRegular,
@@ -415,6 +416,9 @@ export const GraphControlsComponent: FunctionComponent<IGraphControlsProps> = (p
                         forceUpdate({});
                     }}
                 />
+            </Tooltip>
+            <Tooltip content="Sort graph (arrange by execution flow)" relationship="label">
+                <Button size="small" appearance="subtle" icon={<FlowchartRegular />} onClick={() => globalState.onSortGraphRequiredObservable.notifyObservers()} />
             </Tooltip>
             <Divider vertical className={classes.separator} />
             <Tooltip content="Start" relationship="label">

--- a/packages/tools/flowGraphEditor/src/components/help/helpContent.ts
+++ b/packages/tools/flowGraphEditor/src/components/help/helpContent.ts
@@ -61,7 +61,8 @@ export const HelpTopics: IHelpTopic[] = [
 <li>Enter a Playground snippet ID (e.g. <code>ABC123</code>), a versioned ID (<code>ABC123#5</code>), or a full Playground URL.</li>
 <li>Press <b>Enter</b> to load and run the scene.</li>
 </ol>
-<p>The loaded scene's objects (meshes, lights, cameras, etc.) become available as references in flow graph block configuration fields.</p>`,
+<p>The loaded scene's objects (meshes, lights, cameras, etc.) become available as references in flow graph block configuration fields.</p>
+<p>If the playground builds its flow graph from a snippet (e.g. <code>ParseFlowGraphCoordinatorFromSnippetAsync</code>), that flow graph is automatically opened in the editor for editing. Saving it to the snippet server then publishes a new version of that same snippet.</p>`,
             },
             {
                 heading: "Saving and Loading Graphs",

--- a/packages/tools/flowGraphEditor/src/components/preview/scenePreviewComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/preview/scenePreviewComponent.tsx
@@ -9,6 +9,7 @@ import { type FlowGraph } from "core/FlowGraph/flowGraph";
 import { SceneContext } from "../../sceneContext";
 import { SerializationTools } from "../../serializationTools";
 import { LogEntry } from "../log/logComponent";
+import { ShowToast } from "../toast/toastComponent";
 import { LoadSnippet, type IPlaygroundSnippetResult } from "@tools/snippet-loader";
 import { Body1, Button, Input, Tooltip, makeStyles, tokens } from "@fluentui/react-components";
 import { CheckmarkRegular } from "@fluentui/react-icons";
@@ -644,6 +645,30 @@ class ScenePreviewInner extends React.Component<IScenePreviewComponentInnerProps
     }
 
     /**
+     * Scan a loaded playground's source for a flow graph snippet reference such
+     * as `ParseFlowGraphCoordinatorFromSnippetAsync("#ABC123#0", ...)`. When a
+     * playground builds its flow graph from a snippet, that snippet can be
+     * opened directly in the editor for editing.
+     * @param pgResult - the loaded playground snippet
+     * @returns the referenced flow graph snippet id, or null when none is found
+     */
+    private _detectFlowGraphSnippetId(pgResult: IPlaygroundSnippetResult): Nullable<string> {
+        // Matches Parse.../Get...FlowGraph...FromSnippetAsync("<id>") with any quote style.
+        const snippetCallRegex = /FlowGraph[A-Za-z]*FromSnippetAsync\s*\(\s*(["'`])([^"'`]+)\1/;
+        const sources = [pgResult.code, ...Object.values(pgResult.files ?? {})];
+        for (const source of sources) {
+            if (!source) {
+                continue;
+            }
+            const match = snippetCallRegex.exec(source);
+            if (match && match[2]) {
+                return match[2].trim();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Load a playground snippet, execute it, and populate the scene context.
      */
     async loadSnippetAsync() {
@@ -718,6 +743,11 @@ class ScenePreviewInner extends React.Component<IScenePreviewComponentInnerProps
 
             const langTag = pgResult.language === "TS" ? " [TypeScript]" : "";
             this.props.globalState.onLogRequiredObservable.notifyObservers(new LogEntry(`Loaded snippet${langTag} with ${sceneContext.entries.length} scene objects`, false));
+
+            // If the playground builds its flow graph from a snippet, open that
+            // snippet in the editor so it becomes editable. Saving afterwards
+            // publishes a new version of that same flow graph snippet.
+            await this._tryLoadReferencedFlowGraphAsync(pgResult);
         } catch (err: any) {
             this.setState({
                 isLoading: false,
@@ -728,6 +758,39 @@ class ScenePreviewInner extends React.Component<IScenePreviewComponentInnerProps
 
             // Notify listeners that the reload failed so waiting promises (e.g. _onResetAsync) don't hang
             this.props.globalState.onSceneContextChanged.notifyObservers(null);
+        }
+    }
+
+    /**
+     * Detect a flow graph snippet referenced by the just-loaded playground and,
+     * when present, load it into the editor for editing. The loaded snippet id
+     * is remembered so the next save publishes a new version of it.
+     * @param pgResult - the loaded playground snippet
+     */
+    private async _tryLoadReferencedFlowGraphAsync(pgResult: IPlaygroundSnippetResult): Promise<void> {
+        const flowGraphSnippetId = this._detectFlowGraphSnippetId(pgResult);
+        if (!flowGraphSnippetId) {
+            return;
+        }
+
+        try {
+            const loadedId = await SerializationTools.LoadFromSnippetServerAsync(flowGraphSnippetId, this.props.globalState);
+            if (loadedId) {
+                this.props.globalState.stateManager.onSelectionChangedObservable.notifyObservers(null);
+                this.props.globalState.onClearUndoStack.notifyObservers();
+                this.props.globalState.onLogRequiredObservable.notifyObservers(
+                    new LogEntry(`Loaded flow graph snippet ${loadedId} referenced by the playground — edit and save to publish a new version`, false)
+                );
+                ShowToast(this.props.globalState, `Flow graph ${loadedId} loaded for editing`, "success");
+            } else {
+                this.props.globalState.onLogRequiredObservable.notifyObservers(
+                    new LogEntry(`The playground references flow graph snippet ${flowGraphSnippetId}, but it could not be loaded`, true)
+                );
+            }
+        } catch (err: any) {
+            this.props.globalState.onLogRequiredObservable.notifyObservers(
+                new LogEntry(`Could not load the flow graph snippet ${flowGraphSnippetId} referenced by the playground: ${err?.message ?? err}`, true)
+            );
         }
     }
 

--- a/packages/tools/flowGraphEditor/src/components/preview/scenePreviewComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/preview/scenePreviewComponent.tsx
@@ -748,6 +748,14 @@ class ScenePreviewInner extends React.Component<IScenePreviewComponentInnerProps
             // snippet in the editor so it becomes editable. Saving afterwards
             // publishes a new version of that same flow graph snippet.
             await this._tryLoadReferencedFlowGraphAsync(pgResult);
+
+            // The playground's own code typically builds and starts a
+            // FlowGraphCoordinator on the preview scene, so the graph would be
+            // running the moment the scene loads. Stop those coordinators so the
+            // preview waits for the user to press Start in the editor instead of
+            // running immediately. The editor's editable copy lives on its own
+            // scene (globalState.scene), not this preview scene, so it is unaffected.
+            await this._stopSceneFlowGraphCoordinatorsAsync(scene);
         } catch (err: any) {
             this.setState({
                 isLoading: false,
@@ -791,6 +799,27 @@ class ScenePreviewInner extends React.Component<IScenePreviewComponentInnerProps
             this.props.globalState.onLogRequiredObservable.notifyObservers(
                 new LogEntry(`Could not load the flow graph snippet ${flowGraphSnippetId} referenced by the playground: ${err?.message ?? err}`, true)
             );
+        }
+    }
+
+    /**
+     * Dispose every {@link FlowGraphCoordinator} the playground created on the preview
+     * scene. Playgrounds usually call `coordinator.start()` (directly or via
+     * `ParseFlowGraphCoordinatorFromSnippetAsync` + `start`), which would leave the graph
+     * running as soon as the scene loads. Disposing the coordinators leaves the scene
+     * static until the user presses Start in the editor, which runs the editor's own
+     * (separate) copy of the graph against this preview scene.
+     * @param scene - the preview scene whose coordinators should be stopped
+     */
+    private async _stopSceneFlowGraphCoordinatorsAsync(scene: Scene): Promise<void> {
+        const { FlowGraphCoordinator } = await import("core/FlowGraph/flowGraphCoordinator");
+        const coordinators = FlowGraphCoordinator.SceneCoordinators.get(scene);
+        if (!coordinators || coordinators.length === 0) {
+            return;
+        }
+        // dispose() mutates the registry array in place, so iterate over a copy.
+        for (const coordinator of [...coordinators]) {
+            coordinator.dispose();
         }
     }
 

--- a/packages/tools/flowGraphEditor/src/components/variables/variablesPanelComponent.tsx
+++ b/packages/tools/flowGraphEditor/src/components/variables/variablesPanelComponent.tsx
@@ -18,6 +18,7 @@ import {
     BuildFromComponents,
     GetDefaultValueForType,
     InferVariableType,
+    InferVariableTypesFromBlocks,
     type IVariableEntry,
     type VariableTypeName,
 } from "../../variableUtils";
@@ -386,20 +387,31 @@ class VariablesPanelInner extends React.Component<IVariablesPanelInnerProps, IVa
 
         const variables = GatherVariables(fg);
 
+        // Statically infer types from the SetVariable blocks that write each variable. This works
+        // even when the graph is stopped (no runtime context), so variables show meaningful types
+        // instead of defaulting to "any".
+        const staticTypes = InferVariableTypesFromBlocks(fg);
+
         // Read type annotations from the selected context (or first available)
         const ctx = fg.getContext(this.props.globalState.selectedContextIndex) ?? fg.getContext(0);
         const variableTypes = new Map<string, VariableTypeName>();
-        if (ctx) {
-            for (const v of variables) {
-                const declared = ctx.getVariableType(v.name) as VariableTypeName | undefined;
-                if (declared) {
-                    variableTypes.set(v.name, declared);
-                } else {
-                    // Infer from current value
-                    const val = ctx.userVariables[v.name];
-                    variableTypes.set(v.name, InferVariableType(val));
+        for (const v of variables) {
+            // 1. An explicit type declared on the context always wins.
+            const declared = ctx?.getVariableType(v.name) as VariableTypeName | undefined;
+            if (declared) {
+                variableTypes.set(v.name, declared);
+                continue;
+            }
+            // 2. Infer from the live runtime value, when running.
+            if (ctx) {
+                const runtimeType = InferVariableType(ctx.userVariables[v.name]);
+                if (runtimeType !== "any") {
+                    variableTypes.set(v.name, runtimeType);
+                    continue;
                 }
             }
+            // 3. Fall back to the type statically inferred from the SetVariable blocks.
+            variableTypes.set(v.name, staticTypes.get(v.name) ?? "any");
         }
         this.setState({ variables, variableTypes });
     }

--- a/packages/tools/flowGraphEditor/src/globalState.ts
+++ b/packages/tools/flowGraphEditor/src/globalState.ts
@@ -47,6 +47,8 @@ export class GlobalState {
     onZoomToFitRequiredObservable = new Observable<void>();
     /** Observable triggered when reorganization is required */
     onReOrganizedRequiredObservable = new Observable<void>();
+    /** Observable triggered when a flow-aware graph sort is required */
+    onSortGraphRequiredObservable = new Observable<void>();
     /** Observable triggered when log entry is required */
     onLogRequiredObservable = new Observable<LogEntry>();
     /** Observable triggered when loading state changes */

--- a/packages/tools/flowGraphEditor/src/graphEditor.tsx
+++ b/packages/tools/flowGraphEditor/src/graphEditor.tsx
@@ -20,6 +20,8 @@ import { HistoryStack } from "shared-ui-components/historyStack";
 import { FlowGraphEventBlock } from "core/FlowGraph/flowGraphEventBlock";
 import { type IFlowGraphValidationResult, FlowGraphValidationSeverity } from "core/FlowGraph/flowGraphValidator";
 import { AnalyzeSmartGroup, ApplySmartGroupExposure } from "./graphSystem/smartGroup";
+import { ComputeFlowGraphLayout, type IFlowLayoutNode } from "./graphSystem/flowGraphLayout";
+import { type ConnectionPointPortData } from "./graphSystem/connectionPointPortData";
 import { HelpDialogComponent } from "./components/help/helpDialogComponent";
 import { type HelpTopicId } from "./components/help/helpContent";
 import { GraphTabBarComponent } from "./components/graphTabBar/graphTabBarComponent";
@@ -661,6 +663,10 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             this.reOrganize();
         });
 
+        this.props.globalState.onSortGraphRequiredObservable.add(() => {
+            this.sortGraph();
+        });
+
         this.props.globalState.onGetNodeFromBlock = (block) => {
             let node = this._blockToNodeMap.get(block);
             if (!node) {
@@ -841,16 +847,17 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         if (editorData) {
             this.reOrganize(editorData);
         } else {
-            // No saved positions — defer auto-layout until after the browser
-            // has painted so that node DOM elements have real dimensions.
-            // setTimeout(0) defers to the next macro-task, after the browser
-            // has completed layout and paint. rAF alone is not sufficient
-            // because it fires *before* layout in some browsers.
+            // No saved positions — the graph was never laid out, so apply the flow-aware
+            // "Sort graph" automatically. Deferred to the next macro-task so node DOM
+            // elements have real dimensions: setTimeout(0) runs after the browser has
+            // completed layout and paint (rAF alone is not sufficient because it fires
+            // *before* layout in some browsers).
             setTimeout(() => {
                 if (buildVersion !== this._buildVersion || flowGraph !== this.props.globalState.flowGraph) {
                     return;
                 }
-                this.reOrganize(null);
+                this.sortGraph();
+                this.zoomToFit();
             }, 0);
         }
 
@@ -936,6 +943,82 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         this._graphCanvas.x = 0;
         this._graphCanvas.y = 0;
         this._graphCanvas.zoom = 1;
+    }
+
+    /**
+     * Flow-aware "Sort graph" layout.
+     *
+     * Arranges the blocks following execution semantics: event blocks are anchored in the
+     * left-most column stacked vertically, execution (signal) flow runs left-to-right, and
+     * when flow diverges the branches are stacked with each branch's sub-tree forming a
+     * contiguous vertical band. Data wires are used only as a secondary placement hint and
+     * loop back-edges are dropped so the loop body still flows rightward. Unlike the generic
+     * dagre "Reorganize", this understands the difference between signal and data ports.
+     */
+    sortGraph() {
+        const canvas = this._graphCanvas;
+        if (canvas.nodes.length === 0) {
+            return;
+        }
+
+        this.showWaitScreen();
+        canvas._isLoading = true;
+
+        // Build the layout input from the live visual nodes.
+        const nodeToId = new Map<GraphNode, number>();
+        for (const node of canvas.nodes) {
+            nodeToId.set(node, node.id);
+        }
+
+        const layoutNodes: IFlowLayoutNode[] = canvas.nodes.map((node) => {
+            const signalOut: number[] = [];
+            const dataOut: number[] = [];
+            for (const output of node.content.outputs) {
+                if (!output.hasEndpoints) {
+                    continue;
+                }
+                const kind = (output as ConnectionPointPortData).connectionKind;
+                for (const endpoint of output.endpoints ?? []) {
+                    const targetNode = canvas.nodes.find((n) => n.content.data === endpoint.ownerData);
+                    if (!targetNode) {
+                        continue;
+                    }
+                    const targetId = targetNode.id;
+                    if (kind === "signal") {
+                        signalOut.push(targetId);
+                    } else {
+                        dataOut.push(targetId);
+                    }
+                }
+            }
+            return {
+                id: node.id,
+                width: node.width,
+                height: node.height,
+                isEvent: node.content.data instanceof FlowGraphEventBlock,
+                signalOut,
+                dataOut,
+            };
+        });
+
+        const positions = ComputeFlowGraphLayout(layoutNodes);
+        for (const node of canvas.nodes) {
+            const position = positions.get(node.id);
+            if (position) {
+                node.x = position.x;
+                node.y = position.y;
+                node.cleanAccumulation();
+            }
+        }
+
+        canvas.x = 0;
+        canvas.y = 0;
+        canvas.zoom = 1;
+        canvas._isLoading = false;
+        for (const node of canvas.nodes) {
+            node._refreshLinks();
+        }
+        this.hideWaitScreen();
     }
 
     /** @internal */
@@ -1151,6 +1234,10 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             items.push({
                 label: "Reorganize",
                 action: () => globalState.onReOrganizedRequiredObservable.notifyObservers(),
+            });
+            items.push({
+                label: "Sort graph",
+                action: () => globalState.onSortGraphRequiredObservable.notifyObservers(),
             });
         }
 

--- a/packages/tools/flowGraphEditor/src/graphEditor.tsx
+++ b/packages/tools/flowGraphEditor/src/graphEditor.tsx
@@ -964,10 +964,11 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
         this.showWaitScreen();
         canvas._isLoading = true;
 
-        // Build the layout input from the live visual nodes.
-        const nodeToId = new Map<GraphNode, number>();
+        // Precompute a single block-instance -> node-id lookup so resolving each endpoint's
+        // owner is O(1) instead of an O(N) scan of canvas.nodes per endpoint.
+        const dataToNodeId = new Map<unknown, number>();
         for (const node of canvas.nodes) {
-            nodeToId.set(node, node.id);
+            dataToNodeId.set(node.content.data, node.id);
         }
 
         const layoutNodes: IFlowLayoutNode[] = canvas.nodes.map((node) => {
@@ -979,11 +980,10 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
                 }
                 const kind = (output as ConnectionPointPortData).connectionKind;
                 for (const endpoint of output.endpoints ?? []) {
-                    const targetNode = canvas.nodes.find((n) => n.content.data === endpoint.ownerData);
-                    if (!targetNode) {
+                    const targetId = dataToNodeId.get(endpoint.ownerData);
+                    if (targetId === undefined) {
                         continue;
                     }
-                    const targetId = targetNode.id;
                     if (kind === "signal") {
                         signalOut.push(targetId);
                     } else {

--- a/packages/tools/flowGraphEditor/src/graphSystem/flowGraphLayout.ts
+++ b/packages/tools/flowGraphEditor/src/graphSystem/flowGraphLayout.ts
@@ -1,0 +1,434 @@
+/**
+ * Flow-aware automatic layout for the Flow Graph Editor.
+ *
+ * Unlike the generic dagre layout shared by the node editors (which treats every wire
+ * equally), this layout understands flow-graph execution semantics:
+ *  - Event / entry blocks anchor the start (left edge) of each independent flow.
+ *  - Execution (signal) flow runs left-to-right; each downstream block sits in a later
+ *    column than the block that triggers it.
+ *  - When flow diverges, the branches are stacked vertically and the whole sub-tree of
+ *    each branch occupies a contiguous vertical band below the previous branch.
+ *  - Data-only provider blocks (constants, getters, ...) are parked one column to the left
+ *    of the block they feed, as a secondary hint.
+ *  - Unrelated flows (separate event chains) are laid out independently and then tiled into
+ *    a roughly square grid, so a graph with many event chains never collapses into one tall
+ *    column of blocks.
+ *
+ * The algorithm is deterministic, DOM-free and runs in O(V + E), so it can be unit-tested
+ * in isolation and applied to very large generated graphs without the cost of dagre.
+ */
+
+/** A single node to be laid out. Connections reference other nodes by id. */
+export interface IFlowLayoutNode {
+    /** Unique numeric id of the node. */
+    id: number;
+    /** Rendered width of the node, in pixels. */
+    width: number;
+    /** Rendered height of the node, in pixels. */
+    height: number;
+    /** Whether the node is an event / entry block (anchored in the left-most column). */
+    isEvent: boolean;
+    /** Ids of nodes reached through execution (signal) output connections. */
+    signalOut: number[];
+    /** Ids of nodes reached through data output connections (used as a secondary hint). */
+    dataOut: number[];
+}
+
+/** Options controlling spacing of the computed layout. */
+export interface IFlowLayoutOptions {
+    /** Horizontal gap between columns, in pixels. */
+    horizontalGap?: number;
+    /** Vertical gap between stacked nodes, in pixels. */
+    verticalGap?: number;
+    /** X coordinate of the left-most column. */
+    startX?: number;
+    /** Y coordinate of the top of every column. */
+    startY?: number;
+}
+
+/** Computed top-left pixel position of a node. */
+export interface IFlowLayoutPosition {
+    /** X coordinate (left edge). */
+    x: number;
+    /** Y coordinate (top edge). */
+    y: number;
+}
+
+const DefaultOptions: Required<IFlowLayoutOptions> = {
+    horizontalGap: 80,
+    verticalGap: 40,
+    startX: 0,
+    startY: 0,
+};
+
+/**
+ * Maximum number of blocks stacked in a single column before the column is wrapped into a
+ * compact block of sub-columns. Prevents a wide fan-out from becoming one very tall column.
+ */
+const MaxNodesPerColumn = 8;
+
+/** Internal: a laid-out independent flow, positioned relative to its own (0, 0) origin. */
+interface IComponentLayout {
+    /** Positions of the component's nodes, relative to the component origin. */
+    positions: Map<number, IFlowLayoutPosition>;
+    /** Total width of the component's bounding box, in pixels. */
+    width: number;
+    /** Total height of the component's bounding box, in pixels. */
+    height: number;
+    /** Smallest node id contained in the component (used for deterministic tiling order). */
+    minId: number;
+}
+
+/**
+ * Computes a flow-aware layout for the supplied nodes.
+ *
+ * The graph is split into one flow per event / entry block (each event owns the blocks it
+ * triggers), every flow is laid out left-to-right on its own, and the flows are then tiled
+ * into a roughly square grid. This keeps execution flowing left-to-right while preventing a
+ * single tall column of blocks when a graph contains many event chains.
+ * @param nodes - The nodes to lay out.
+ * @param options - Optional spacing overrides.
+ * @returns A map from node id to its computed top-left pixel position.
+ */
+export function ComputeFlowGraphLayout(nodes: IFlowLayoutNode[], options?: IFlowLayoutOptions): Map<number, IFlowLayoutPosition> {
+    const opts = { ...DefaultOptions, ...options };
+    const positions = new Map<number, IFlowLayoutPosition>();
+    if (nodes.length === 0) {
+        return positions;
+    }
+
+    const byId = new Map<number, IFlowLayoutNode>();
+    for (const node of nodes) {
+        byId.set(node.id, node);
+    }
+
+    // Partition the graph into one flow per event / entry root: each root claims the blocks
+    // reachable from it through execution (signal) wires. Shared downstream blocks are owned
+    // by the first root that reaches them, data-only providers attach to a block they feed,
+    // and anything left over forms its own flow. Keeping each flow anchored to a single event
+    // lets many event chains tile into a grid instead of piling into one tall column.
+    const hasSignalInGlobal = new Set<number>();
+    for (const node of nodes) {
+        for (const target of node.signalOut) {
+            if (byId.has(target)) {
+                hasSignalInGlobal.add(target);
+            }
+        }
+    }
+
+    const owner = new Map<number, number>();
+    const claim = (rootId: number) => {
+        if (owner.has(rootId)) {
+            return;
+        }
+        const stack = [rootId];
+        owner.set(rootId, rootId);
+        while (stack.length > 0) {
+            const current = stack.pop()!;
+            for (const next of byId.get(current)!.signalOut) {
+                if (byId.has(next) && !owner.has(next)) {
+                    owner.set(next, rootId);
+                    stack.push(next);
+                }
+            }
+        }
+    };
+
+    // Roots in priority order: events, then signal-island entries (outgoing signal but no
+    // incoming), then any remaining signal node (to break pure cycles deterministically).
+    for (const node of nodes) {
+        if (node.isEvent) {
+            claim(node.id);
+        }
+    }
+    for (const node of nodes) {
+        if (!owner.has(node.id) && node.signalOut.length > 0 && !hasSignalInGlobal.has(node.id)) {
+            claim(node.id);
+        }
+    }
+    for (const node of nodes) {
+        if (!owner.has(node.id) && node.signalOut.length > 0) {
+            claim(node.id);
+        }
+    }
+
+    // Attach data-only providers / isolated blocks to a flow they feed; iterate for chains.
+    let attachChanged = true;
+    while (attachChanged) {
+        attachChanged = false;
+        for (const node of nodes) {
+            if (owner.has(node.id)) {
+                continue;
+            }
+            let target: number | undefined;
+            for (const id of [...node.signalOut, ...node.dataOut]) {
+                if (owner.has(id)) {
+                    target = owner.get(id);
+                    break;
+                }
+            }
+            if (target !== undefined) {
+                owner.set(node.id, target);
+                attachChanged = true;
+            }
+        }
+    }
+    // Anything still unowned (fully isolated) forms its own single-node flow.
+    for (const node of nodes) {
+        if (!owner.has(node.id)) {
+            owner.set(node.id, node.id);
+        }
+    }
+
+    const groupsById = new Map<number, IFlowLayoutNode[]>();
+    for (const node of nodes) {
+        const root = owner.get(node.id)!;
+        let group = groupsById.get(root);
+        if (!group) {
+            group = [];
+            groupsById.set(root, group);
+        }
+        group.push(node);
+    }
+
+    const laidOut = [...groupsById.values()].map((group) => LayoutComponent(group, opts));
+    // Deterministic tiling order: by the smallest id each flow contains.
+    laidOut.sort((a, b) => a.minId - b.minId);
+
+    // Tile the independent flows into a roughly square grid (ceil(sqrt(n)) flows per row) so
+    // the result never collapses into a single very tall column.
+    const flowsPerRow = Math.max(1, Math.ceil(Math.sqrt(laidOut.length)));
+    const componentGapX = opts.horizontalGap * 2;
+    const componentGapY = opts.verticalGap * 2;
+    let rowX = opts.startX;
+    let rowY = opts.startY;
+    let rowHeight = 0;
+    for (let i = 0; i < laidOut.length; i++) {
+        if (i > 0 && i % flowsPerRow === 0) {
+            rowX = opts.startX;
+            rowY += rowHeight + componentGapY;
+            rowHeight = 0;
+        }
+        const component = laidOut[i];
+        for (const [id, position] of component.positions) {
+            positions.set(id, { x: position.x + rowX, y: position.y + rowY });
+        }
+        rowX += component.width + componentGapX;
+        rowHeight = Math.max(rowHeight, component.height);
+    }
+
+    return positions;
+}
+
+/**
+ * Lays out a single independent flow relative to its own (0, 0) origin.
+ * @param nodes - The nodes belonging to one connected flow.
+ * @param opts - Resolved spacing options.
+ * @returns The component's node positions and bounding-box size.
+ */
+function LayoutComponent(nodes: IFlowLayoutNode[], opts: Required<IFlowLayoutOptions>): IComponentLayout {
+    const positions = new Map<number, IFlowLayoutPosition>();
+    const byId = new Map<number, IFlowLayoutNode>();
+    let minId = Number.POSITIVE_INFINITY;
+    for (const node of nodes) {
+        byId.set(node.id, node);
+        minId = Math.min(minId, node.id);
+    }
+
+    // Forward signal edges kept for layering. Back-edges (e.g. loop bodies) are dropped
+    // during the DFS so the loop body still flows rightward instead of running away.
+    const forwardSucc = new Map<number, number[]>();
+    for (const node of nodes) {
+        forwardSucc.set(node.id, []);
+    }
+
+    const hasSignalIn = new Set<number>();
+    for (const node of nodes) {
+        for (const target of node.signalOut) {
+            if (byId.has(target)) {
+                hasSignalIn.add(target);
+            }
+        }
+    }
+
+    const visited = new Set<number>();
+    const onStack = new Set<number>();
+    const orderIndex = new Map<number, number>();
+    let orderCounter = 0;
+
+    // Iterative DFS that records a pre-order index (used to keep branch sub-trees grouped)
+    // and classifies signal edges into forward (kept) vs back (dropped) edges.
+    const dfs = (rootId: number) => {
+        if (visited.has(rootId)) {
+            return;
+        }
+        const stack: { id: number; i: number }[] = [{ id: rootId, i: 0 }];
+        visited.add(rootId);
+        onStack.add(rootId);
+        orderIndex.set(rootId, orderCounter++);
+        while (stack.length > 0) {
+            const frame = stack[stack.length - 1];
+            const node = byId.get(frame.id)!;
+            if (frame.i < node.signalOut.length) {
+                const childId = node.signalOut[frame.i++];
+                if (!byId.has(childId) || onStack.has(childId)) {
+                    // Missing target or a back-edge to an ancestor: skip.
+                    continue;
+                }
+                forwardSucc.get(frame.id)!.push(childId);
+                if (!visited.has(childId)) {
+                    visited.add(childId);
+                    onStack.add(childId);
+                    orderIndex.set(childId, orderCounter++);
+                    stack.push({ id: childId, i: 0 });
+                }
+            } else {
+                onStack.delete(frame.id);
+                stack.pop();
+            }
+        }
+    };
+
+    // Roots, in priority order: events first, then signal-island entries (a block with
+    // outgoing signal flow but no incoming signal), then any remaining signal node (to
+    // break pure cycles). Keeping the supplied order makes the result deterministic.
+    for (const node of nodes) {
+        if (node.isEvent) {
+            dfs(node.id);
+        }
+    }
+    for (const node of nodes) {
+        if (!visited.has(node.id) && node.signalOut.length > 0 && !hasSignalIn.has(node.id)) {
+            dfs(node.id);
+        }
+    }
+    for (const node of nodes) {
+        if (!visited.has(node.id) && node.signalOut.length > 0) {
+            dfs(node.id);
+        }
+    }
+
+    // Longest-path column assignment over the forward (acyclic) signal graph.
+    const column = new Map<number, number>();
+    const indegree = new Map<number, number>();
+    for (const id of visited) {
+        indegree.set(id, 0);
+    }
+    for (const [, succs] of forwardSucc) {
+        for (const v of succs) {
+            indegree.set(v, (indegree.get(v) ?? 0) + 1);
+        }
+    }
+    const queue: number[] = [];
+    for (const id of visited) {
+        if ((indegree.get(id) ?? 0) === 0) {
+            column.set(id, 0);
+            queue.push(id);
+        }
+    }
+    let head = 0;
+    while (head < queue.length) {
+        const u = queue[head++];
+        const cu = column.get(u) ?? 0;
+        for (const v of forwardSucc.get(u) ?? []) {
+            const cv = Math.max(column.get(v) ?? 0, cu + 1);
+            column.set(v, cv);
+            const remaining = (indegree.get(v) ?? 0) - 1;
+            indegree.set(v, remaining);
+            if (remaining === 0) {
+                queue.push(v);
+            }
+        }
+    }
+
+    // Sort key drives vertical order inside a column. Visited nodes use their DFS pre-order
+    // so that branch sub-trees stay grouped and diverging branches stack top-to-bottom.
+    const sortKey = new Map<number, number>();
+    for (const [id, idx] of orderIndex) {
+        sortKey.set(id, idx);
+    }
+
+    // Place data-only / isolated nodes that never participate in signal flow. A provider is
+    // parked one column to the left of the earliest block it feeds, just above that block.
+    // Iterate to resolve short provider chains; anything left over is parked in column 0.
+    let changed = true;
+    let guard = 0;
+    while (changed && guard <= nodes.length) {
+        changed = false;
+        guard++;
+        for (const node of nodes) {
+            if (column.has(node.id)) {
+                continue;
+            }
+            const consumers = [...node.signalOut, ...node.dataOut].filter((id) => byId.has(id) && column.has(id));
+            if (consumers.length === 0) {
+                continue;
+            }
+            let minColumn = Number.POSITIVE_INFINITY;
+            let minKey = Number.POSITIVE_INFINITY;
+            for (const id of consumers) {
+                minColumn = Math.min(minColumn, column.get(id)!);
+                minKey = Math.min(minKey, sortKey.get(id) ?? 0);
+            }
+            column.set(node.id, Math.max(0, minColumn - 1));
+            sortKey.set(node.id, minKey - 0.5);
+            changed = true;
+        }
+    }
+    for (const node of nodes) {
+        if (!column.has(node.id)) {
+            column.set(node.id, 0);
+            sortKey.set(node.id, orderCounter++);
+        }
+    }
+
+    // Group nodes by column, compute per-column widths, then stack nodes vertically inside
+    // each column in sort-key order. Stacking with real heights guarantees no overlap.
+    const columns = new Map<number, IFlowLayoutNode[]>();
+    for (const node of nodes) {
+        const c = column.get(node.id)!;
+        let bucket = columns.get(c);
+        if (!bucket) {
+            bucket = [];
+            columns.set(c, bucket);
+        }
+        bucket.push(node);
+    }
+
+    const sortedColumns = [...columns.keys()].sort((a, b) => a - b);
+    let cursorX = 0;
+    let width = 0;
+    let height = 0;
+    for (const c of sortedColumns) {
+        const bucket = columns.get(c)!;
+        // Events always lead their column so they read as the start of every flow; the rest
+        // keep their DFS / consumer-relative order.
+        bucket.sort((a, b) => {
+            if (a.isEvent !== b.isEvent) {
+                return a.isEvent ? -1 : 1;
+            }
+            return sortKey.get(a.id)! - sortKey.get(b.id)! || a.id - b.id;
+        });
+        // A wide fan-out would otherwise become one very tall column; wrap large columns into
+        // a compact block of sub-columns (kept roughly square) instead.
+        const count = bucket.length;
+        const rowsPerColumn = count > MaxNodesPerColumn ? Math.ceil(Math.sqrt(count)) : count;
+        let subCursorX = cursorX;
+        for (let start = 0; start < count; start += rowsPerColumn) {
+            let subWidth = 0;
+            let subCursorY = 0;
+            for (let r = 0; r < rowsPerColumn && start + r < count; r++) {
+                const node = bucket[start + r];
+                positions.set(node.id, { x: subCursorX, y: subCursorY });
+                subCursorY += node.height + opts.verticalGap;
+                subWidth = Math.max(subWidth, node.width);
+                height = Math.max(height, subCursorY - opts.verticalGap);
+            }
+            subCursorX += subWidth + opts.horizontalGap;
+        }
+        cursorX = subCursorX;
+        width = cursorX - opts.horizontalGap;
+    }
+
+    return { positions, width, height, minId };
+}

--- a/packages/tools/flowGraphEditor/src/serializationTools.ts
+++ b/packages/tools/flowGraphEditor/src/serializationTools.ts
@@ -9,6 +9,7 @@ import { type Scene } from "core/scene";
 import { Logger } from "core/Misc/logger";
 import { Constants } from "core/Engines/constants";
 import { type ISerializedFlowGraph } from "core/FlowGraph/typeDefinitions";
+import { FetchSnippet, type ISnippetServerResponse } from "@tools/snippet-loader";
 
 /**
  * Provides serialization and deserialization utilities for the flow graph editor.
@@ -216,15 +217,19 @@ export class SerializationTools {
      */
     public static async LoadFromSnippetServerAsync(id: string, globalState: GlobalState): Promise<Nullable<string>> {
         const cleanId = id.replace(/^#/, "");
-        const url = Constants.SnippetUrl + "/" + cleanId.replace(/#/g, "/");
 
-        const response = await fetch(url);
-        if (!response.ok) {
+        let snippet: ISnippetServerResponse;
+        try {
+            // Reuse the shared snippet-loader for the fetch + id/url normalization
+            // instead of hand-rolling the request here.
+            snippet = await FetchSnippet(cleanId, Constants.SnippetUrl);
+        } catch {
+            // FetchSnippet throws on a non-OK response; preserve the historical
+            // null ("could not be loaded") contract expected by the caller.
             return null;
         }
 
-        const snippet = await response.json();
-        const jsonPayload = JSON.parse(snippet.jsonPayload);
+        const jsonPayload = JSON.parse(snippet.jsonPayload ?? "{}");
         // The Flow Graph Editor saves `flowGraph` as a stringified graph, but
         // older/other producers may store it as a plain object — handle both.
         const serializationObject = typeof jsonPayload.flowGraph === "string" ? JSON.parse(jsonPayload.flowGraph) : jsonPayload.flowGraph;

--- a/packages/tools/flowGraphEditor/src/serializationTools.ts
+++ b/packages/tools/flowGraphEditor/src/serializationTools.ts
@@ -7,6 +7,7 @@ import { FlowGraphCoordinator } from "core/FlowGraph/flowGraphCoordinator";
 import { ParseFlowGraphAsync } from "core/FlowGraph/flowGraphParser";
 import { type Scene } from "core/scene";
 import { Logger } from "core/Misc/logger";
+import { Constants } from "core/Engines/constants";
 import { type ISerializedFlowGraph } from "core/FlowGraph/typeDefinitions";
 
 /**
@@ -201,6 +202,36 @@ export class SerializationTools {
         } finally {
             globalState.onIsLoadingChanged.notifyObservers(false);
         }
+    }
+
+    /**
+     * Fetches a flow graph snippet from the Babylon snippet server and loads it
+     * into the editor. Supports plain ids ("ABC123"), versioned ids
+     * ("ABC123#4") and ids with a leading '#'. After a successful load the
+     * snippet id is stored on `globalState.flowGraphSnippetId`, so the next save
+     * publishes a new version of that same snippet.
+     * @param id - the flow graph snippet id to load
+     * @param globalState - the editor's global state
+     * @returns the normalized snippet id that was loaded, or `null` if the load failed
+     */
+    public static async LoadFromSnippetServerAsync(id: string, globalState: GlobalState): Promise<Nullable<string>> {
+        const cleanId = id.replace(/^#/, "");
+        const url = Constants.SnippetUrl + "/" + cleanId.replace(/#/g, "/");
+
+        const response = await fetch(url);
+        if (!response.ok) {
+            return null;
+        }
+
+        const snippet = await response.json();
+        const jsonPayload = JSON.parse(snippet.jsonPayload);
+        // The Flow Graph Editor saves `flowGraph` as a stringified graph, but
+        // older/other producers may store it as a plain object — handle both.
+        const serializationObject = typeof jsonPayload.flowGraph === "string" ? JSON.parse(jsonPayload.flowGraph) : jsonPayload.flowGraph;
+
+        await SerializationTools.DeserializeAsync(serializationObject, globalState);
+        globalState.flowGraphSnippetId = cleanId;
+        return cleanId;
     }
 
     /**

--- a/packages/tools/flowGraphEditor/src/variableUtils.ts
+++ b/packages/tools/flowGraphEditor/src/variableUtils.ts
@@ -352,6 +352,87 @@ export function GatherVariables(fg: FlowGraph): IVariableEntry[] {
 }
 
 /**
+ * Map a flow-graph rich-type name (the {@link FlowGraphTypes} string stored on a
+ * connection's `richType.typeName`) to an editor {@link VariableTypeName}.
+ * Returns "any" for rich types the editor does not model (Quaternion, Matrix, etc.).
+ * @param typeName - the rich-type name to map
+ * @returns the matching editor variable type name, or "any"
+ */
+function MapRichTypeNameToVariableType(typeName: string | undefined): VariableTypeName {
+    switch (typeName) {
+        case "string":
+        case "number":
+        case "boolean":
+        case "FlowGraphInteger":
+        case "Vector2":
+        case "Vector3":
+        case "Vector4":
+        case "Color3":
+        case "Color4":
+            return typeName;
+        default:
+            return "any";
+    }
+}
+
+/**
+ * Statically infer variable types from the SetVariable blocks that write them, without
+ * running the graph. For each variable a SetVariable block sets, the type is deduced from
+ * (in order of preference): the connected source output's rich type, the value input's own
+ * rich type, the value input's literal default value, then the last value the input saw.
+ * This lets the variables panel display meaningful types even while the graph is stopped,
+ * where no runtime context values exist to infer from.
+ * @param fg - The flow graph to scan.
+ * @returns A map of variable name to inferred type. Variables whose type cannot be deduced are omitted.
+ */
+export function InferVariableTypesFromBlocks(fg: FlowGraph): Map<string, VariableTypeName> {
+    const types = new Map<string, VariableTypeName>();
+
+    const inferFromInput = (variableName: string, input?: FlowGraphBlock["dataInputs"][number]): void => {
+        if (!input || types.has(variableName)) {
+            return;
+        }
+        let inferred: VariableTypeName = "any";
+        // 1. The connected source output's rich type (SetVariable inputs are RichTypeAny, so the
+        // useful type information lives on whatever output is wired into them).
+        if (input.isConnected() && input._connectedPoint.length > 0) {
+            inferred = MapRichTypeNameToVariableType(input._connectedPoint[0].richType?.typeName);
+        }
+        // 2. The input's own rich type (in case a future block declares a typed value input).
+        if (inferred === "any") {
+            inferred = MapRichTypeNameToVariableType(input.richType?.typeName);
+        }
+        // 3. The literal default value typed directly into the input.
+        if (inferred === "any") {
+            inferred = InferVariableType((input as unknown as { _defaultValue?: unknown })._defaultValue);
+        }
+        // 4. The last value the input resolved to during a prior run (debug snapshot).
+        if (inferred === "any") {
+            inferred = InferVariableType(input._getLastValue());
+        }
+        if (inferred !== "any") {
+            types.set(variableName, inferred);
+        }
+    };
+
+    for (const block of fg.getAllBlocks()) {
+        if (block.getClassName() !== FlowGraphBlockNames.SetVariable) {
+            continue;
+        }
+        const config = block.config as any;
+        if (config?.variables) {
+            for (const v of config.variables) {
+                inferFromInput(v, block.getDataInput(v));
+            }
+        } else if (config?.variable) {
+            inferFromInput(config.variable, block.getDataInput("value"));
+        }
+    }
+
+    return types;
+}
+
+/**
  * Gather all variable names from a flow graph, excluding variables owned
  * by a specific block (to avoid self-reference in pickers).
  * @param fg - The flow graph to scan.

--- a/packages/tools/flowGraphEditor/test/unit/flowGraphLayout.test.ts
+++ b/packages/tools/flowGraphEditor/test/unit/flowGraphLayout.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { ComputeFlowGraphLayout, type IFlowLayoutNode } from "flow-graph-editor/graphSystem/flowGraphLayout";
+
+/**
+ * Helper to build a layout node with sane defaults so each test only declares what it cares about.
+ */
+function MakeNode(id: number, overrides: Partial<IFlowLayoutNode> = {}): IFlowLayoutNode {
+    return {
+        id,
+        width: 100,
+        height: 50,
+        isEvent: false,
+        signalOut: [],
+        dataOut: [],
+        ...overrides,
+    };
+}
+
+const Options = { horizontalGap: 80, verticalGap: 40, startX: 0, startY: 0 };
+
+describe("ComputeFlowGraphLayout", () => {
+    it("returns an empty map for no nodes", () => {
+        expect(ComputeFlowGraphLayout([]).size).toBe(0);
+    });
+
+    it("places an event before the block it triggers (left-to-right)", () => {
+        const nodes = [MakeNode(1, { isEvent: true, signalOut: [2] }), MakeNode(2)];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        const event = positions.get(1)!;
+        const target = positions.get(2)!;
+        expect(event.x).toBeLessThan(target.x);
+        // Both start at the same top because each occupies its own column.
+        expect(event.y).toBe(0);
+        expect(target.y).toBe(0);
+    });
+
+    it("tiles independent flows side by side instead of one tall column", () => {
+        // Two unrelated event chains: 1 -> 10 and 2 -> 20.
+        const nodes = [MakeNode(1, { isEvent: true, signalOut: [10] }), MakeNode(2, { isEvent: true, signalOut: [20] }), MakeNode(10), MakeNode(20)];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        const e1 = positions.get(1)!;
+        const e2 = positions.get(2)!;
+        // The two flows are tiled into a grid (here, side by side on the same row) rather than
+        // stacked into a single column.
+        expect(e1.y).toBe(e2.y);
+        expect(e1.x).toBeLessThan(e2.x);
+        // Each event still starts (is left of) the block it triggers.
+        expect(e1.x).toBeLessThan(positions.get(10)!.x);
+        expect(e2.x).toBeLessThan(positions.get(20)!.x);
+    });
+
+    it("stacks diverging branches vertically and pushes downstream blocks rightward", () => {
+        // event -> branch -> { a, b }
+        const nodes = [MakeNode(1, { isEvent: true, signalOut: [2] }), MakeNode(2, { signalOut: [3, 4] }), MakeNode(3), MakeNode(4)];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        const branch = positions.get(2)!;
+        const a = positions.get(3)!;
+        const b = positions.get(4)!;
+        // a and b share a column to the right of the branch.
+        expect(a.x).toBe(b.x);
+        expect(a.x).toBeGreaterThan(branch.x);
+        // First branch above the second.
+        expect(a.y).toBeLessThan(b.y);
+    });
+
+    it("places a join node to the right of both incoming branches", () => {
+        // event -> branch -> { a, b } -> join
+        const nodes = [
+            MakeNode(1, { isEvent: true, signalOut: [2] }),
+            MakeNode(2, { signalOut: [3, 4] }),
+            MakeNode(3, { signalOut: [5] }),
+            MakeNode(4, { signalOut: [5] }),
+            MakeNode(5),
+        ];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        const join = positions.get(5)!;
+        expect(join.x).toBeGreaterThan(positions.get(3)!.x);
+        expect(join.x).toBeGreaterThan(positions.get(4)!.x);
+    });
+
+    it("does not run away on a loop back-edge", () => {
+        // event -> body -> back to body (self/loop). The body must still get a finite column.
+        const nodes = [MakeNode(1, { isEvent: true, signalOut: [2] }), MakeNode(2, { signalOut: [3] }), MakeNode(3, { signalOut: [2] })];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        // Three distinct columns at most; back-edge from 3 -> 2 is dropped.
+        const xs = [positions.get(1)!.x, positions.get(2)!.x, positions.get(3)!.x];
+        expect(xs[0]).toBeLessThan(xs[1]);
+        expect(xs[1]).toBeLessThan(xs[2]);
+    });
+
+    it("parks a pure data provider one column left of the block it feeds", () => {
+        // event -> consumer ; const(10) feeds consumer via a data wire only.
+        const nodes = [MakeNode(1, { isEvent: true, signalOut: [2] }), MakeNode(2), MakeNode(10, { dataOut: [2] })];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        const provider = positions.get(10)!;
+        const consumer = positions.get(2)!;
+        expect(provider.x).toBeLessThan(consumer.x);
+    });
+
+    it("never overlaps two nodes within the same column", () => {
+        const nodes = [MakeNode(1, { isEvent: true, signalOut: [2, 3, 4] }), MakeNode(2), MakeNode(3), MakeNode(4)];
+        const positions = ComputeFlowGraphLayout(nodes, Options);
+        const ys = [positions.get(2)!.y, positions.get(3)!.y, positions.get(4)!.y].sort((a, b) => a - b);
+        // Each node is 50 tall with a 40 gap, so consecutive tops differ by at least 90.
+        expect(ys[1] - ys[0]).toBeGreaterThanOrEqual(90);
+        expect(ys[2] - ys[1]).toBeGreaterThanOrEqual(90);
+    });
+});

--- a/packages/tools/flowGraphEditor/test/unit/variableUtils.test.ts
+++ b/packages/tools/flowGraphEditor/test/unit/variableUtils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { type Engine, NullEngine } from "core/Engines";
 import { type FlowGraph, type FlowGraphContext, FlowGraphCoordinator, FlowGraphGetVariableBlock } from "core/FlowGraph";
 import { FlowGraphSetVariableBlock } from "core/FlowGraph/Blocks/Execution/flowGraphSetVariableBlock";
+import { FlowGraphConstantBlock } from "core/FlowGraph/Blocks/Data/flowGraphConstantBlock";
 import { Scene } from "core/scene";
 import { Vector2, Vector3 } from "core/Maths/math.vector";
 import { Color3, Color4 } from "core/Maths/math.color";
@@ -21,6 +22,7 @@ import {
     BuildFromComponents,
     GetDefaultValueForType,
     InferVariableType,
+    InferVariableTypesFromBlocks,
     type VariableTypeName,
 } from "flow-graph-editor/variableUtils";
 import { CONSTRUCTOR_CONFIG } from "flow-graph-editor/graphSystem/properties/constructorConfigRegistry";
@@ -764,6 +766,75 @@ describe("Flow Graph Variable Utils", () => {
         it("returns any for objects with unrecognized className", () => {
             const obj = { getClassName: () => "SomeUnknownType" };
             expect(InferVariableType(obj)).toBe("any");
+        });
+    });
+
+    // --------------------------------------------------------
+    // inferVariableTypesFromBlocks
+    // --------------------------------------------------------
+    describe("inferVariableTypesFromBlocks", () => {
+        it("returns an empty map when there are no SetVariable blocks", () => {
+            flowGraph.addBlock(new FlowGraphGetVariableBlock({ variable: "x" }));
+            expect(InferVariableTypesFromBlocks(flowGraph).size).toBe(0);
+        });
+
+        it("infers a type from the value input's literal default", () => {
+            const set = new FlowGraphSetVariableBlock({ variable: "score" });
+            flowGraph.addBlock(set);
+            (set.getDataInput("value") as unknown as { _defaultValue: unknown })._defaultValue = 42;
+
+            const types = InferVariableTypesFromBlocks(flowGraph);
+            expect(types.get("score")).toBe("number");
+        });
+
+        it("infers a boolean type from a literal default", () => {
+            const set = new FlowGraphSetVariableBlock({ variable: "active" });
+            flowGraph.addBlock(set);
+            (set.getDataInput("value") as unknown as { _defaultValue: unknown })._defaultValue = false;
+
+            const types = InferVariableTypesFromBlocks(flowGraph);
+            expect(types.get("active")).toBe("boolean");
+        });
+
+        it("infers a type from the connected source output's rich type", () => {
+            const constant = new FlowGraphConstantBlock<number>({ value: 7 });
+            const set = new FlowGraphSetVariableBlock({ variable: "lives" });
+            flowGraph.addBlock(constant);
+            flowGraph.addBlock(set);
+            constant.output.connectTo(set.getDataInput("value")!);
+
+            const types = InferVariableTypesFromBlocks(flowGraph);
+            expect(types.get("lives")).toBe("number");
+        });
+
+        it("infers types for each variable of a multi-variable SetVariable block", () => {
+            const set = new FlowGraphSetVariableBlock({ variables: ["a", "b"] });
+            flowGraph.addBlock(set);
+            (set.getDataInput("a") as unknown as { _defaultValue: unknown })._defaultValue = "hello";
+            (set.getDataInput("b") as unknown as { _defaultValue: unknown })._defaultValue = true;
+
+            const types = InferVariableTypesFromBlocks(flowGraph);
+            expect(types.get("a")).toBe("string");
+            expect(types.get("b")).toBe("boolean");
+        });
+
+        it("omits variables whose type cannot be deduced", () => {
+            const set = new FlowGraphSetVariableBlock({ variable: "mystery" });
+            flowGraph.addBlock(set);
+
+            const types = InferVariableTypesFromBlocks(flowGraph);
+            expect(types.has("mystery")).toBe(false);
+        });
+
+        it("infers a Vector3 from the connected source output", () => {
+            const constant = new FlowGraphConstantBlock<Vector3>({ value: new Vector3(1, 2, 3) });
+            const set = new FlowGraphSetVariableBlock({ variable: "position" });
+            flowGraph.addBlock(constant);
+            flowGraph.addBlock(set);
+            constant.output.connectTo(set.getDataInput("value")!);
+
+            const types = InferVariableTypesFromBlocks(flowGraph);
+            expect(types.get("position")).toBe("Vector3");
         });
     });
 });


### PR DESCRIPTION
# Flow Graph Editor: playground snippet auto-load, no auto-run, and stopped-state variable types

This PR improves the Flow Graph Editor's playground/preview and variables experience. It contains three commits that build on each other.

## What was done

### 1. Auto-load a referenced flow graph snippet from a playground (`e910551`)
When a playground references a flow graph snippet (e.g. via `…FromSnippetAsync("…")`), the editor now detects that snippet ID in the playground source and loads it as the editable graph, so saving publishes a new version of that same snippet. Also adds a `flowgraph` dev host experiment for local testing.

### 2. Flow-aware Sort layout with auto-sort on load (`d344de0`)
Adds a flow-aware graph auto-layout ("Sort") that orders nodes along the execution flow, and runs it automatically when a graph is loaded so imported graphs come up readable instead of overlapping.

### 3. Fixes (`21837e3`) — the focus of this round

**a. Playground graphs no longer auto-run on load.**
A playground's own code typically builds and starts a `FlowGraphCoordinator` on the preview scene, so the graph ran the instant the scene loaded. The preview now disposes any coordinators the playground created on the preview scene, so it stays static until the user presses **Start**. The editor's editable copy lives on a separate scene (`globalState.scene`) and is unaffected.

**b. Node references re-resolve when a graph's scene changes (`FlowGraph.setScene`).**
The editor can parse a graph before its referenced scene exists, leaving node-targeting inputs holding the raw serialized reference (`{ id, name, className, uniqueId }`) or a node from a now-disposed scene. `setScene` now rebinds those inputs against the new scene — matching by `id`/`name`, narrowed by class name, with `uniqueId` only as a tie-breaker (uniqueIds are reassigned every scene build). Non-node values (numbers, vectors, matrices, …) are left untouched. `GetSceneNodeFromSerializedReference` is exported for this.

**c. Variable types show even when the graph is stopped.**
Types were previously inferred only from live runtime values, so a stopped graph displayed every variable as "Any". The variables panel now statically infers types from the `SetVariable` blocks that write each variable, in order of preference: the connected source output's rich type → the input's own rich type → the literal default value → the last seen value. Runtime/declared types still win when available.

## How it was tested

**Automated**
- New core unit test in `flowGraphSerialization.test.ts`: `setScene` re-resolves an unresolved serialized reference, rebinds a node from a disposed scene to the matching node in the new scene, and leaves a non-node value untouched.
- New editor unit tests in `variableUtils.test.ts` covering `InferVariableTypesFromBlocks`: empty graph, literal number/boolean defaults, connected source rich type (number and Vector3), multi-variable SetVariable, and omission of undeducible variables.
- Full affected suites pass (142 tests across the two files). `prettier --check` clean and `eslint` clean on all changed source files.

**Manual (live in the editor against real snippets)**
- Loaded playground `#P41T6E#1`: after load, the preview scene has **0** running coordinators (`previewSceneCoordinatorCount: 0`) and the editor's graph is in **Stopped** state — it now waits for **Start** instead of running immediately. The editor's own coordinator (separate scene) remains intact.
- Variables panel: with the graph **stopped**, variables written by `SetVariable` blocks now display concrete types (Number / Boolean / Vector3) instead of "Any"; read-only (GetVariable-only) variables correctly remain "Any".

## Notes
- No public API behavior changes beyond exporting `GetSceneNodeFromSerializedReference` (previously file-private).
- No new dependencies.
