### PR TITLE
ci(pr): accelerate Monorepo CI with caching and parallelism

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -460,8 +460,6 @@ jobs:
                 version: "22.x"
 
           - template: templates/cache-steps.yml
-            parameters:
-                nx: true
 
           - script: npm install
             displayName: "npm install"

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -1042,6 +1042,8 @@ jobs:
           displayName: "Memory leak tests (ci suite)"
           npmScript: "test:memory-leaks"
           suiteLabel: "ci suite"
+          # First-class PR-facing suite: always posts a single results comment.
+          alwaysComment: true
 
     - template: templates/memory-leak-job.yml
       parameters:
@@ -1049,6 +1051,9 @@ jobs:
           displayName: "Memory leak tests (packages suite)"
           npmScript: "test:memory-leaks:packages"
           suiteLabel: "packages suite"
+          # Secondary suite: only comments when it actually detects a leak, so
+          # the common (clean) case keeps the PR to a single memory-leak comment.
+          alwaysComment: false
 
     # ============================================================================
     # VIEWER TESTS

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -67,6 +67,14 @@ variables:
       value: "chrome@143:OSX Sonoma"
     - name: system.debug
       value: false
+    # Stable, cacheable locations (see templates/cache-steps.yml). Kept outside
+    # the repo working dir so Cache@2 can restore/save them across runs & reruns.
+    - name: npm_config_cache
+      value: $(Pipeline.Workspace)/.npm
+    - name: NX_CACHE_DIRECTORY
+      value: $(Pipeline.Workspace)/.nxcache
+    - name: PLAYWRIGHT_BROWSERS_PATH
+      value: $(Pipeline.Workspace)/.playwright
 
 pool:
     vmImage: ubuntu-latest
@@ -169,6 +177,10 @@ jobs:
                     *This build will release a new package on npm*
 
                     If that was unintentional please make sure to revert those changes or close this PR.
+
+          - template: templates/cache-steps.yml
+            parameters:
+                nx: true
 
           - script: npm install
             displayName: "npm install"
@@ -279,12 +291,15 @@ jobs:
                     https://sfe.babylonjs.com/?snapshot=$(BuildName)
 
     # ============================================================================
-    # ES6
-    # Builds ES6 modules and generates file size reports
+    # ES6 (libs + visualization)
+    # Builds only the ES6 lib packages (core/gui/loaders/…) that the ES6
+    # visualization tests consume, then runs those tests. The editor/tool
+    # builds, tree-shaking check, and file-size report run in parallel in the
+    # sibling ES6Tools job, keeping them off the visualization critical path.
     # No dependencies - runs immediately
     # ============================================================================
     - job: ES6
-      displayName: "ES6"
+      displayName: "ES6 (libs + visualization)"
       steps:
           - template: templates/checkout-with-tag-override.yml
 
@@ -295,32 +310,26 @@ jobs:
             inputs:
                 version: "22.x"
 
+          - template: templates/cache-steps.yml
+            parameters:
+                nx: true
+
           - script: npm install
             displayName: "npm install"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
 
-          - task: Npm@1
-            displayName: "npm build es6"
-            inputs:
-                command: custom
-                customCommand: "run build:es6"
-
+          # Only the lib packages (core/gui/loaders/…) are needed for the
+          # visualization tests below. The editor/tool builds and the
+          # tree-shaking check run in parallel in the ES6Tools job.
           - bash: |
-                npx nx run-many --target=prepublishOnly --all
-            displayName: "Make sure es6 packages are ready"
-            continueOnError: true
+                npm run build:assets:smart-filters && npm run build:es6:libs
+            displayName: "npm build es6 libs"
 
           - template: templates/check-snapshot-exists.yml
             parameters:
                 snapshotPath: "$(BuildName)/testResults/es6visplaywright"
-
-          - task: Npm@1
-            displayName: "Test ES6 packages"
-            inputs:
-                command: custom
-                customCommand: "run test:es6-packages -w @tools/tests"
 
           - bash: .azure-pipelines/browserstack-wait.sh npx playwright test --config ./playwright.browserstack.config.ts
             displayName: "ES6 visualization tests (BrowserStack)"
@@ -359,6 +368,54 @@ jobs:
             inputs:
                 testResultsFormat: JUnit
                 testResultsFiles: "./junit.xml"
+
+    # ============================================================================
+    # ES6 TOOLS, TREE-SHAKING, AND FILE SIZES
+    # Runs the full ES6 build (editor/tool packages + check:treeshaking-all),
+    # validates publishability, and generates/uploads the file-size report.
+    # Split out of the ES6 job so this work runs in parallel with the ES6
+    # visualization tests instead of gating them. Blocking: tree-shaking and
+    # build failures fail the pipeline here just as they did in the ES6 job.
+    # No dependencies - runs immediately
+    # ============================================================================
+    - job: ES6Tools
+      displayName: "ES6 tools, tree-shaking, and file sizes"
+      steps:
+          - template: templates/checkout-with-tag-override.yml
+
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                version: "22.x"
+
+          - template: templates/cache-steps.yml
+            parameters:
+                nx: true
+
+          - script: npm install
+            displayName: "npm install"
+            env:
+                PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+                PUPPETEER_SKIP_DOWNLOAD: "true"
+
+          - task: Npm@1
+            displayName: "npm build es6"
+            inputs:
+                command: custom
+                customCommand: "run build:es6"
+
+          - bash: |
+                npx nx run-many --target=prepublishOnly --all
+            displayName: "Make sure es6 packages are ready"
+            continueOnError: true
+
+          - task: Npm@1
+            displayName: "Test ES6 packages"
+            inputs:
+                command: custom
+                customCommand: "run test:es6-packages -w @tools/tests"
 
           - task: Npm@1
             displayName: "npm build modules size"
@@ -402,6 +459,10 @@ jobs:
             inputs:
                 version: "22.x"
 
+          - template: templates/cache-steps.yml
+            parameters:
+                nx: true
+
           - script: npm install
             displayName: "npm install"
             env:
@@ -439,6 +500,8 @@ jobs:
             inputs:
                 version: "22.x"
 
+          - template: templates/cache-steps.yml
+
           - script: npm install
             displayName: "npm install"
             retryCountOnTaskFailure: 1
@@ -466,12 +529,17 @@ jobs:
 
     # ============================================================================
     # UNIT TESTS
-    # Depends on: Build, FormatLint
+    # Depends on: FormatLint (fail-fast gate only).
+    # Intentionally does NOT depend on Build: the unit suite runs in-process
+    # (vitest) and needs no Build snapshot. The one CDN-dependent assertion
+    # (moduleFileSize.test.ts -> fileSizes.json) already self-skips when the
+    # file is absent, so dropping the Build dependency changes no test outcome
+    # while moving this job out of the post-Build "wave 2" (keeps peak agents
+    # per PR at <= 8).
     # ============================================================================
     - job: UnitTests
       displayName: "Unit tests"
       dependsOn:
-          - Build
           - FormatLint
       steps:
           - template: templates/checkout-with-tag-override.yml
@@ -482,6 +550,8 @@ jobs:
             retryCountOnTaskFailure: 1
             inputs:
                 version: "22.x"
+
+          - template: templates/cache-steps.yml
 
           - task: Npm@1
             displayName: "npm install"
@@ -550,6 +620,10 @@ jobs:
           - template: templates/check-snapshot-exists.yml
             parameters:
                 snapshotPath: "$(BuildName)/testResults/interactionplaywright"
+
+          - template: templates/cache-steps.yml
+            parameters:
+                playwright: true
 
           - script: |
                 npm install
@@ -624,6 +698,8 @@ jobs:
           - template: templates/check-snapshot-exists.yml
             parameters:
                 snapshotPath: "$(BuildName)/testResults/webgl2playwright"
+
+          - template: templates/cache-steps.yml
 
           - script: |
                 npm install
@@ -707,6 +783,8 @@ jobs:
           - template: templates/check-snapshot-exists.yml
             parameters:
                 snapshotPath: "$(BuildName)/testResults/webgpuplaywright"
+
+          - template: templates/cache-steps.yml
 
           - script: |
                 npm install
@@ -890,6 +968,8 @@ jobs:
             inputs:
                 version: "22.x"
 
+          - template: templates/cache-steps.yml
+
           - script: npm install
             displayName: "npm install"
             retryCountOnTaskFailure: 1
@@ -951,71 +1031,26 @@ jobs:
     # ============================================================================
     # MEMORY LEAK TESTS
     # Depends on: Build, FormatLint
-    # Runs memlab (Puppeteer/Chromium) on the CI agent — heap snapshots require
-    # local Chrome DevTools Protocol access, so BrowserStack is not viable here.
-    # Non-blocking: failures do not fail the overall pipeline.
+    # Split into two parallel jobs (ci + packages suites) — see
+    # templates/memory-leak-job.yml. Each runs memlab locally (BrowserStack is
+    # not viable for heap snapshots) and is non-blocking. Running them in
+    # parallel instead of sequentially shortens the post-Build critical-path
+    # tail. UnitTests was moved out of "wave 2", so adding one job here keeps
+    # the peak parallel jobs per PR at <= 8.
     # ============================================================================
-    - job: MemoryLeakTests
-      displayName: "Memory leak tests"
-      dependsOn:
-          - Build
-          - FormatLint
-      continueOnError: true
-      timeoutInMinutes: 45
-      steps:
-          - checkout: self
-            clean: true
-            fetchTags: false
+    - template: templates/memory-leak-job.yml
+      parameters:
+          jobName: MemoryLeakTestsCI
+          displayName: "Memory leak tests (ci suite)"
+          npmScript: "test:memory-leaks"
+          suiteLabel: "ci suite"
 
-          - task: UseNode@1
-            displayName: "Use Node 22.x"
-            continueOnError: true
-            retryCountOnTaskFailure: 1
-            inputs:
-                version: "22.x"
-
-          - script: npm install
-            displayName: "npm install"
-            retryCountOnTaskFailure: 1
-
-          - script: npm run test:memory-leaks -- --no-fail-fast
-            displayName: "Run memory leak tests (ci suite)"
-            continueOnError: true
-            env:
-                CDN_BASE_URL: "$(SNAPSHOT_CDN_URL)/$(BuildName)"
-                MEMLEAK_COMMENT_FILE: "$(Build.ArtifactStagingDirectory)/memleak-comment.md"
-
-          - script: npm run test:memory-leaks:packages -- --no-fail-fast
-            displayName: "Run memory leak tests (packages suite)"
-            continueOnError: true
-            env:
-                CDN_BASE_URL: "$(SNAPSHOT_CDN_URL)/$(BuildName)"
-                MEMLEAK_COMMENT_FILE: "$(Build.ArtifactStagingDirectory)/memleak-comment.md"
-
-          - bash: |
-                if [ -f "$(Build.ArtifactStagingDirectory)/memleak-comment.md" ]; then
-                    COMMENT=$(cat "$(Build.ArtifactStagingDirectory)/memleak-comment.md")
-                    COMMENT="${COMMENT//'%'/'%25'}"
-                    COMMENT="${COMMENT//$'\n'/'%0A'}"
-                    COMMENT="${COMMENT//$'\r'/'%0D'}"
-                    echo "##vso[task.setvariable variable=MEMLEAK_COMMENT]$COMMENT"
-                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]true"
-                else
-                    echo "No memory leak comment file found"
-                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
-                fi
-            displayName: "Read memory leak comment"
-            condition: succeededOrFailed()
-
-          - task: GitHubComment@0
-            displayName: "Post memory leak results"
-            condition: and(succeededOrFailed(), eq(variables['HAS_MEMLEAK_COMMENT'], 'true'))
-            continueOnError: true
-            inputs:
-                gitHubConnection: "$(GITHUB_SERVICE_CONNECTION)"
-                repositoryName: "$(Build.Repository.Name)"
-                comment: |
-                    $(MEMLEAK_COMMENT)
+    - template: templates/memory-leak-job.yml
+      parameters:
+          jobName: MemoryLeakTestsPackages
+          displayName: "Memory leak tests (packages suite)"
+          npmScript: "test:memory-leaks:packages"
+          suiteLabel: "packages suite"
 
     # ============================================================================
     # VIEWER TESTS
@@ -1032,6 +1067,10 @@ jobs:
             retryCountOnTaskFailure: 1
             inputs:
                 version: "22.x"
+
+          - template: templates/cache-steps.yml
+            parameters:
+                playwright: true
 
           - task: Npm@1
             displayName: "npm install"
@@ -1060,7 +1099,7 @@ jobs:
 
     # ============================================================================
     # DEPLOY
-    # Depends on: Build, UnitTests, VisualizationWebGL2, ES6,
+    # Depends on: Build, UnitTests, VisualizationWebGL2, ES6, ES6Tools,
     #             VisualizationWebGPU, InteractionTests
     # Only runs on master/preview branch for Manual/ResourceTrigger/Schedule/
     # BuildCompletion builds
@@ -1072,6 +1111,7 @@ jobs:
           - UnitTests
           - VisualizationWebGL2
           - ES6
+          - ES6Tools
           - VisualizationWebGPU
           - InteractionTests
       condition: >-

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -1051,8 +1051,9 @@ jobs:
           displayName: "Memory leak tests (packages suite)"
           npmScript: "test:memory-leaks:packages"
           suiteLabel: "packages suite"
-          # Secondary suite: only comments when it actually detects a leak, so
-          # the common (clean) case keeps the PR to a single memory-leak comment.
+          # Secondary suite: stays silent only on a clean pass, and still
+          # comments on any leak or runner error, so the common (clean) case
+          # keeps the PR to a single memory-leak comment without hiding failures.
           alwaysComment: false
 
     # ============================================================================

--- a/.azure-pipelines/templates/cache-steps.yml
+++ b/.azure-pipelines/templates/cache-steps.yml
@@ -54,3 +54,11 @@ steps:
                 restoreKeys: |
                     playwright | "$(Agent.OS)"
                 path: $(PLAYWRIGHT_BROWSERS_PATH)
+
+    # Guarantee the cache paths exist so the automatic post-job save never
+    # fails on a missing directory (e.g. a job whose tool wrote nothing, or a
+    # tool that hasn't created its dir yet). Caching an empty dir is harmless,
+    # and paths without a Cache task above are simply left unused.
+    - bash: |
+          mkdir -p "$(npm_config_cache)" "$(NX_CACHE_DIRECTORY)" "$(PLAYWRIGHT_BROWSERS_PATH)"
+      displayName: "Ensure cache directories exist"

--- a/.azure-pipelines/templates/cache-steps.yml
+++ b/.azure-pipelines/templates/cache-steps.yml
@@ -1,0 +1,56 @@
+# =============================================================================
+# Template: Pipeline caches (npm / Nx / Playwright)
+#
+# Emits Cache@2 restore+save steps. Insert this immediately BEFORE the job's
+# `npm install` step so the npm download cache is restored first, and (when
+# enabled) the Nx computation cache is available for the later build target.
+#
+# Requires these pipeline-level variables to be defined (see ci-monorepo.yml):
+#   - npm_config_cache          e.g. $(Pipeline.Workspace)/.npm
+#   - NX_CACHE_DIRECTORY        e.g. $(Pipeline.Workspace)/.nxcache
+#   - PLAYWRIGHT_BROWSERS_PATH  e.g. $(Pipeline.Workspace)/.playwright
+#
+# Cache keys:
+#   - npm:        keyed on package-lock.json (hits until dependencies change).
+#   - nx:         keyed per-job on the commit, with restoreKeys falling back to
+#                 the most recent prior cache. Nx validates each task by its own
+#                 input hash, so unchanged packages are restored as cache hits —
+#                 this is what makes re-pushes (e.g. fixing one comment) fast.
+#   - playwright: keyed on package-lock.json (browser version is pinned there).
+# =============================================================================
+
+parameters:
+    - name: nx
+      type: boolean
+      default: false
+    - name: playwright
+      type: boolean
+      default: false
+
+steps:
+    - task: Cache@2
+      displayName: "Cache npm packages"
+      inputs:
+          key: 'npm | "$(Agent.OS)" | package-lock.json'
+          restoreKeys: |
+              npm | "$(Agent.OS)"
+          path: $(npm_config_cache)
+
+    - ${{ if eq(parameters.nx, true) }}:
+          - task: Cache@2
+            displayName: "Cache Nx computation"
+            inputs:
+                key: 'nx | "$(Agent.OS)" | "$(System.JobName)" | $(Build.SourceVersion)'
+                restoreKeys: |
+                    nx | "$(Agent.OS)" | "$(System.JobName)"
+                    nx | "$(Agent.OS)"
+                path: $(NX_CACHE_DIRECTORY)
+
+    - ${{ if eq(parameters.playwright, true) }}:
+          - task: Cache@2
+            displayName: "Cache Playwright browsers"
+            inputs:
+                key: 'playwright | "$(Agent.OS)" | package-lock.json'
+                restoreKeys: |
+                    playwright | "$(Agent.OS)"
+                path: $(PLAYWRIGHT_BROWSERS_PATH)

--- a/.azure-pipelines/templates/memory-leak-job.yml
+++ b/.azure-pipelines/templates/memory-leak-job.yml
@@ -5,7 +5,10 @@
 # local Chrome DevTools Protocol access, so BrowserStack is not viable).
 # The two suites (ci + packages) used to run sequentially in one job; they are
 # now instantiated as two parallel jobs via this template to trim the
-# post-Build critical-path tail. Each job posts its own GitHub comment.
+# post-Build critical-path tail. To avoid doubling PR comments, each job's
+# GitHub comment is gated by the `alwaysComment` parameter: the first-class
+# `ci` suite always comments, while secondary suites only comment when they
+# actually detect a leak (see ci-monorepo.yml).
 #
 # Non-blocking: failures do not fail the overall pipeline.
 # =============================================================================
@@ -19,6 +22,13 @@ parameters:
       type: string
     - name: suiteLabel
       type: string
+    # When false, this suite only posts its GitHub comment if it actually
+    # detected a leak. Used to keep the steady-state PR noise at a single
+    # comment (the first-class "ci" suite) while still surfacing a packages
+    # suite regression the moment one appears.
+    - name: alwaysComment
+      type: boolean
+      default: true
 
 jobs:
     - job: ${{ parameters.jobName }}
@@ -54,16 +64,21 @@ jobs:
                 MEMLEAK_COMMENT_FILE: "$(Build.ArtifactStagingDirectory)/memleak-comment.md"
 
           - bash: |
-                if [ -f "$(Build.ArtifactStagingDirectory)/memleak-comment.md" ]; then
-                    COMMENT=$(cat "$(Build.ArtifactStagingDirectory)/memleak-comment.md")
+                FILE="$(Build.ArtifactStagingDirectory)/memleak-comment.md"
+                ALWAYS=$(echo "${{ parameters.alwaysComment }}" | tr '[:upper:]' '[:lower:]')
+                if [ ! -f "$FILE" ]; then
+                    echo "No memory leak comment file found"
+                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
+                elif [ "$ALWAYS" != "true" ] && ! grep -q "Leaked Scenarios" "$FILE"; then
+                    echo "Suite is clean and alwaysComment=false; skipping PR comment to reduce noise"
+                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
+                else
+                    COMMENT=$(cat "$FILE")
                     COMMENT="${COMMENT//'%'/'%25'}"
                     COMMENT="${COMMENT//$'\n'/'%0A'}"
                     COMMENT="${COMMENT//$'\r'/'%0D'}"
                     echo "##vso[task.setvariable variable=MEMLEAK_COMMENT]$COMMENT"
                     echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]true"
-                else
-                    echo "No memory leak comment file found"
-                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
                 fi
             displayName: "Read memory leak comment"
             condition: succeededOrFailed()

--- a/.azure-pipelines/templates/memory-leak-job.yml
+++ b/.azure-pipelines/templates/memory-leak-job.yml
@@ -7,8 +7,9 @@
 # now instantiated as two parallel jobs via this template to trim the
 # post-Build critical-path tail. To avoid doubling PR comments, each job's
 # GitHub comment is gated by the `alwaysComment` parameter: the first-class
-# `ci` suite always comments, while secondary suites only comment when they
-# actually detect a leak (see ci-monorepo.yml).
+# `ci` suite always comments, while secondary suites only stay silent on a
+# clean pass and still comment on any leak or runner error (see
+# ci-monorepo.yml).
 #
 # Non-blocking: failures do not fail the overall pipeline.
 # =============================================================================
@@ -69,7 +70,11 @@ jobs:
                 if [ ! -f "$FILE" ]; then
                     echo "No memory leak comment file found"
                     echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
-                elif [ "$ALWAYS" != "true" ] && ! grep -q "Leaked Scenarios" "$FILE"; then
+                elif [ "$ALWAYS" != "true" ] && grep -q "no leaks detected" "$FILE"; then
+                    # The runner only emits the "no leaks detected" all-clear when
+                    # it ran scenarios, found no leaks, and hit no error. Any other
+                    # state (leaks, or a runner error/empty results) lacks that line
+                    # and still comments, so secondary-suite failures stay visible.
                     echo "Suite is clean and alwaysComment=false; skipping PR comment to reduce noise"
                     echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
                 else

--- a/.azure-pipelines/templates/memory-leak-job.yml
+++ b/.azure-pipelines/templates/memory-leak-job.yml
@@ -1,0 +1,79 @@
+# =============================================================================
+# Template: a single Memory leak test suite job
+#
+# memlab runs Puppeteer/Chromium locally on the agent (heap snapshots need
+# local Chrome DevTools Protocol access, so BrowserStack is not viable).
+# The two suites (ci + packages) used to run sequentially in one job; they are
+# now instantiated as two parallel jobs via this template to trim the
+# post-Build critical-path tail. Each job posts its own GitHub comment.
+#
+# Non-blocking: failures do not fail the overall pipeline.
+# =============================================================================
+
+parameters:
+    - name: jobName
+      type: string
+    - name: displayName
+      type: string
+    - name: npmScript
+      type: string
+    - name: suiteLabel
+      type: string
+
+jobs:
+    - job: ${{ parameters.jobName }}
+      displayName: ${{ parameters.displayName }}
+      dependsOn:
+          - Build
+          - FormatLint
+      continueOnError: true
+      timeoutInMinutes: 45
+      steps:
+          - checkout: self
+            clean: true
+            fetchTags: false
+
+          - task: UseNode@1
+            displayName: "Use Node 22.x"
+            continueOnError: true
+            retryCountOnTaskFailure: 1
+            inputs:
+                version: "22.x"
+
+          - template: cache-steps.yml
+
+          - script: npm install
+            displayName: "npm install"
+            retryCountOnTaskFailure: 1
+
+          - script: npm run ${{ parameters.npmScript }} -- --no-fail-fast
+            displayName: "Run memory leak tests (${{ parameters.suiteLabel }})"
+            continueOnError: true
+            env:
+                CDN_BASE_URL: "$(SNAPSHOT_CDN_URL)/$(BuildName)"
+                MEMLEAK_COMMENT_FILE: "$(Build.ArtifactStagingDirectory)/memleak-comment.md"
+
+          - bash: |
+                if [ -f "$(Build.ArtifactStagingDirectory)/memleak-comment.md" ]; then
+                    COMMENT=$(cat "$(Build.ArtifactStagingDirectory)/memleak-comment.md")
+                    COMMENT="${COMMENT//'%'/'%25'}"
+                    COMMENT="${COMMENT//$'\n'/'%0A'}"
+                    COMMENT="${COMMENT//$'\r'/'%0D'}"
+                    echo "##vso[task.setvariable variable=MEMLEAK_COMMENT]$COMMENT"
+                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]true"
+                else
+                    echo "No memory leak comment file found"
+                    echo "##vso[task.setvariable variable=HAS_MEMLEAK_COMMENT]false"
+                fi
+            displayName: "Read memory leak comment"
+            condition: succeededOrFailed()
+
+          - task: GitHubComment@0
+            displayName: "Post memory leak results"
+            condition: and(succeededOrFailed(), eq(variables['HAS_MEMLEAK_COMMENT'], 'true'))
+            continueOnError: true
+            inputs:
+                gitHubConnection: "$(GITHUB_SERVICE_CONNECTION)"
+                repositoryName: "$(Build.Repository.Name)"
+                comment: |
+                    $(MEMLEAK_COMMENT)


### PR DESCRIPTION
## Goal

Speed up PR CI (Monorepo CI pipeline) **without dropping any tests**. Constraints respected:
- **Peak ≤ 8 parallel jobs per PR** (org has 15 shared agents).
- **No Nx Cloud cost** — only the free `Cache@2` local cache + free Pipeline Artifacts.

This is a CI-only change; no product code is touched. Opening as **draft to validate on real CI** before merge.

## What changed

### Caching (free `Cache@2`, biggest win on re-pushes)
- New `templates/cache-steps.yml` emits npm / Nx / Playwright pipeline caches, plus pipeline vars for stable cacheable locations under `$(Pipeline.Workspace)`.
- Wired into Build, ES6, ES6Tools, FormatLint, TypeDoc, UnitTests, Interaction, VisWebGL2, VisWebGPU, Performance, Viewer.
- Nx cache is keyed per-job on the commit with `restoreKeys` fallback to the most recent prior cache; Nx's own input hashing keeps it correct. This is what makes "fix one comment + repush" fast.

### Parallelism / restructuring (behavior-preserving)
- **ES6 job split.** `ES6` now builds only the lib packages the ES6 visualization tests consume (`build:es6:libs`) and runs `es6vis`. A new parallel **`ES6Tools`** job runs the full `build:es6` (editor packages + `check:treeshaking-all`, still **blocking**), the `es6-packages` smoke test (which hard-requires the editor builds), and the file-size report. `Deploy` now also depends on `ES6Tools` (it consumes `fileSizes.json`). This pulls ~7–9 min of editor/tree-shaking work off the es6vis critical path.
- **UnitTests moved out of post-Build "wave 2".** It runs in-process (vitest) and needs no Build snapshot; the one CDN-dependent assertion (`moduleFileSize.test.ts`) already self-skips when `fileSizes.json` is absent. It keeps only a `FormatLint` fail-fast gate. Frees an agent slot.
- **MemoryLeakTests split** into two parallel suite jobs (ci + packages) via `templates/memory-leak-job.yml`, trimming the post-Build critical-path tail.

## Behavior preserved (everything still runs and fails as before)
- Tree-shaking violations → fail `build:es6` in `ES6Tools` (blocking) → fail pipeline.
- `es6-packages` smoke → blocking in `ES6Tools`, with editor builds present.
- `es6vis` → blocking in `ES6`.
- `prepublishOnly` → still `continueOnError`.
- File-size report → still generated and uploaded.
- Memory-leak suites → still non-blocking.

## Expected impact
- ES6 critical pole ≈ **36 min → ~27 min**.
- Faster re-pushes via npm/Nx caches.
- **Peak parallel jobs stays ≤ 8.**

## Why no Pipeline Artifacts for the ES6 handoff
The es6 build output is hundreds of MB of many small files written in-place into `packages/public/@babylonjs/*` — a poor artifact fit (per-file overhead, would need tar), and Nx rebuilds deps anyway. Parallelizing the work es6vis doesn't need beats an artifact handoff here.

## Note for reviewers
Splitting MemoryLeakTests produces **two** PR comments (one per suite) instead of one.

🤖 Validating on CI before marking ready.