### PR TITLE
fix(sandbox): import LoadingScreen side-effect in renderingZone

### DIFF
--- a/packages/tools/sandbox/src/components/renderingZone.tsx
+++ b/packages/tools/sandbox/src/components/renderingZone.tsx
@@ -17,6 +17,7 @@ import { Animation } from "core/Animations/animation";
 import { CreatePlane } from "core/Meshes/Builders/planeBuilder";
 
 import "core/Helpers/sceneHelpers";
+import "core/Loading/loadingScreen";
 
 import "../scss/renderingZone.scss";
 import { PBRBaseMaterial } from "core/Materials/PBR/pbrBaseMaterial";


### PR DESCRIPTION
## Problem

Running the Sandbox throws an unhandled promise rejection on startup:

```
LoadingScreen needs to be imported before as it contains a side-effect required by your code.
    at initEngine (renderingZone.tsx)
    at componentDidMount (renderingZone.tsx)
```

## Cause

`initEngine()` sets `this._engine.loadingUIBackgroundColor = "#2A2342"`, which accesses the engine's loading screen. After the tree-shaking refactor, the `LoadingScreen` implementation (which registers `AbstractEngine.DefaultLoadingScreenFactory`) is only installed via the side-effect of importing `core/Loading/loadingScreen`. Without that import, the loading-screen getter throws.

## Fix

Add the `import "core/Loading/loadingScreen";` side-effect import alongside the other side-effect imports in `renderingZone.tsx`.