### PR TITLE
Geospatial camera: configurable double-tap fly-to, primary-pointer guard, and normalized keyboard pan

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/BaseCameraPointersInput.ts
@@ -135,7 +135,7 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
                     }
                 }
             } else if (p.type === PointerEventTypes.POINTERDOUBLETAP) {
-                this.onDoubleTap(evt.pointerType);
+                this.onDoubleTap(evt.pointerType, evt);
             } else if (p.type === PointerEventTypes.POINTERUP && (this._currentMousePointerIdDown === evt.pointerId || isTouch)) {
                 try {
                     srcElement?.releasePointerCapture(evt.pointerId);
@@ -304,9 +304,10 @@ export abstract class BaseCameraPointersInput implements ICameraInput<Camera> {
      * Called on pointer POINTERDOUBLETAP event.
      * Override this method to provide functionality on POINTERDOUBLETAP event.
      * @param type type of event
+     * @param evt the pointer event that triggered the double tap (carries button / buttons state)
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    public onDoubleTap(type: string) {}
+    public onDoubleTap(type: string, evt?: IPointerEvent) {}
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     /**

--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
@@ -276,7 +276,9 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
                         }
                     } else if (resolved.interaction === "pan") {
                         // Accumulate a unit direction per pan key; the combined vector is normalized after the loop.
-                        panSensitivity = sens;
+                        // Aggregate sensitivity with max so the pan speed is independent of key insertion order
+                        // when keys resolve to different per-key sensitivities.
+                        panSensitivity = Math.max(panSensitivity, sens);
                         if (this.keysLeft.indexOf(keyCode) !== -1) {
                             panDirection.x += 1;
                         } else if (this.keysRight.indexOf(keyCode) !== -1) {

--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
@@ -8,6 +8,7 @@ import { type KeyboardInfo, KeyboardEventTypes } from "../../Events/keyboardEven
 import { Tools } from "../../Misc/tools.pure";
 import { type AbstractEngine } from "../../Engines/abstractEngine";
 import { type KeyboardConditions } from "../inputMapper";
+import { Vector2 } from "../../Maths/math.vector.pure";
 
 /**
  * Manage the keyboard inputs to control the movement of a geospatial camera.
@@ -129,6 +130,9 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
     /** Cached conditions object to avoid per-frame allocations in checkInputs */
     private _keyboardConditions: KeyboardConditions = { modifiers: this._keyboardModifiers };
 
+    /** Reused accumulator for the per-frame keyboard pan direction, to avoid per-frame allocations */
+    private _panDirection = new Vector2();
+
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
@@ -238,12 +242,11 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
             this._keyboardModifiers.alt = this._altPressed;
             this._keyboardModifiers.shift = this._shiftPressed;
 
-            // Pan keys are accumulated into a single direction vector and applied once below.
-            // This way holding two directions at once (e.g. up + left) produces a normalized
-            // diagonal at the same speed as a single direction, instead of a ~1.41x speed boost
-            // (sqrt(1^2 + 1^2)) that comes from applying each pan key independently.
-            let panOffsetX = 0;
-            let panOffsetY = 0;
+            // Pan keys are accumulated into a single direction vector and applied once below, so that
+            // holding two directions at once (e.g. up + left) pans along a normalized diagonal at the
+            // same speed as a single direction, instead of the ~1.41x boost (sqrt(2)) that results from
+            // applying each pan key independently.
+            const panDirection = this._panDirection.set(0, 0);
             let panSensitivity = 0;
 
             for (let index = 0; index < this._keys.length; index++) {
@@ -275,25 +278,22 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
                         // Accumulate a unit direction per pan key; the combined vector is normalized after the loop.
                         panSensitivity = sens;
                         if (this.keysLeft.indexOf(keyCode) !== -1) {
-                            panOffsetX += 1;
+                            panDirection.x += 1;
                         } else if (this.keysRight.indexOf(keyCode) !== -1) {
-                            panOffsetX -= 1;
+                            panDirection.x -= 1;
                         } else if (this.keysUp.indexOf(keyCode) !== -1) {
-                            panOffsetY += 1;
+                            panDirection.y += 1;
                         } else if (this.keysDown.indexOf(keyCode) !== -1) {
-                            panOffsetY -= 1;
+                            panDirection.y -= 1;
                         }
                     }
                 }
             }
 
             // Apply a single, normalized pan once all pan keys for this frame have been accumulated.
-            if (panOffsetX !== 0 || panOffsetY !== 0) {
-                // Normalize the direction so diagonal pans aren't faster than axis-aligned ones.
-                // The guard above guarantees the length is non-zero, so there is no divide-by-zero.
-                const length = Math.sqrt(panOffsetX * panOffsetX + panOffsetY * panOffsetY);
-                const normalizedX = (panOffsetX / length) * panSensitivity;
-                const normalizedY = (panOffsetY / length) * panSensitivity;
+            if (panDirection.x !== 0 || panDirection.y !== 0) {
+                // Normalize so a diagonal isn't faster than an axis-aligned pan (normalize() is a no-op on a zero-length vector).
+                panDirection.normalize().scaleInPlace(panSensitivity);
 
                 // Call into movement class handleDrag so that behavior matches that of pointer input, simulating drag from center of screen.
                 // getRenderWidth/Height return render buffer pixels (scaled by hardwareScalingLevel relative to CSS pixels),
@@ -302,7 +302,7 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
                 const centerX = (this._engine.getRenderWidth() / 2) * hardwareScaling;
                 const centerY = (this._engine.getRenderHeight() / 2) * hardwareScaling;
                 input.handlers.pan.start(centerX, centerY);
-                input.handlers.pan.update(centerX + normalizedX, centerY + normalizedY);
+                input.handlers.pan.update(centerX + panDirection.x, centerY + panDirection.y);
                 input.handlers.pan.stop();
             }
         }

--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraKeyboardInput.ts
@@ -238,6 +238,14 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
             this._keyboardModifiers.alt = this._altPressed;
             this._keyboardModifiers.shift = this._shiftPressed;
 
+            // Pan keys are accumulated into a single direction vector and applied once below.
+            // This way holding two directions at once (e.g. up + left) produces a normalized
+            // diagonal at the same speed as a single direction, instead of a ~1.41x speed boost
+            // (sqrt(1^2 + 1^2)) that comes from applying each pan key independently.
+            let panOffsetX = 0;
+            let panOffsetY = 0;
+            let panSensitivity = 0;
+
             for (let index = 0; index < this._keys.length; index++) {
                 const keyCode = this._keys[index];
 
@@ -264,25 +272,38 @@ export class GeospatialCameraKeyboardInput implements ICameraInput<GeospatialCam
                             input.handlers.rotate(0, sens);
                         }
                     } else if (resolved.interaction === "pan") {
-                        // Call into movement class handleDrag so that behavior matches that of pointer input, simulating drag from center of screen.
-                        // getRenderWidth/Height return render buffer pixels (scaled by hardwareScalingLevel relative to CSS pixels),
-                        // but the picking logic (scene.pick via CreatePickingRayToRef) expects CSS pixels (it divides by hardwareScalingLevel internally).
-                        const hardwareScaling = this._engine.getHardwareScalingLevel();
-                        const centerX = (this._engine.getRenderWidth() / 2) * hardwareScaling;
-                        const centerY = (this._engine.getRenderHeight() / 2) * hardwareScaling;
-                        input.handlers.pan.start(centerX, centerY);
+                        // Accumulate a unit direction per pan key; the combined vector is normalized after the loop.
+                        panSensitivity = sens;
                         if (this.keysLeft.indexOf(keyCode) !== -1) {
-                            input.handlers.pan.update(centerX + sens, centerY);
+                            panOffsetX += 1;
                         } else if (this.keysRight.indexOf(keyCode) !== -1) {
-                            input.handlers.pan.update(centerX - sens, centerY);
+                            panOffsetX -= 1;
                         } else if (this.keysUp.indexOf(keyCode) !== -1) {
-                            input.handlers.pan.update(centerX, centerY + sens);
+                            panOffsetY += 1;
                         } else if (this.keysDown.indexOf(keyCode) !== -1) {
-                            input.handlers.pan.update(centerX, centerY - sens);
+                            panOffsetY -= 1;
                         }
-                        input.handlers.pan.stop();
                     }
                 }
+            }
+
+            // Apply a single, normalized pan once all pan keys for this frame have been accumulated.
+            if (panOffsetX !== 0 || panOffsetY !== 0) {
+                // Normalize the direction so diagonal pans aren't faster than axis-aligned ones.
+                // The guard above guarantees the length is non-zero, so there is no divide-by-zero.
+                const length = Math.sqrt(panOffsetX * panOffsetX + panOffsetY * panOffsetY);
+                const normalizedX = (panOffsetX / length) * panSensitivity;
+                const normalizedY = (panOffsetY / length) * panSensitivity;
+
+                // Call into movement class handleDrag so that behavior matches that of pointer input, simulating drag from center of screen.
+                // getRenderWidth/Height return render buffer pixels (scaled by hardwareScalingLevel relative to CSS pixels),
+                // but the picking logic (scene.pick via CreatePickingRayToRef) expects CSS pixels (it divides by hardwareScalingLevel internally).
+                const hardwareScaling = this._engine.getHardwareScalingLevel();
+                const centerX = (this._engine.getRenderWidth() / 2) * hardwareScaling;
+                const centerY = (this._engine.getRenderHeight() / 2) * hardwareScaling;
+                input.handlers.pan.start(centerX, centerY);
+                input.handlers.pan.update(centerX + normalizedX, centerY + normalizedY);
+                input.handlers.pan.stop();
             }
         }
     }

--- a/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/geospatialCameraPointersInput.ts
@@ -1,4 +1,5 @@
 import { type GeospatialCamera } from "../../Cameras/geospatialCamera";
+import { type EasingFunction } from "../../Animations/easing";
 import { type IPointerEvent } from "../../Events/deviceInputEvents";
 import { type PointerTouch } from "../../Events/pointerEvents";
 import { type Nullable } from "../../types";
@@ -72,6 +73,17 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
      * in pinch mode.
      */
     public pinchToPanMax: number = 20;
+
+    /**
+     * Duration (in milliseconds) of the fly-to animation triggered by a double tap.
+     */
+    public doubleTapAnimationDurationMs: number = 1000;
+
+    /**
+     * Optional easing function applied to the double-tap fly-to animation.
+     * An EasingFunction instance can be created once and reused across double taps.
+     */
+    public doubleTapEasingFunction: Nullable<EasingFunction> = null;
 
     public override getClassName(): string {
         return "GeospatialCameraPointersInput";
@@ -177,10 +189,17 @@ export class GeospatialCameraPointersInput extends OrbitCameraPointersInput {
         }
     }
 
-    public override onDoubleTap(type: string): void {
+    public override onDoubleTap(type: string, evt?: IPointerEvent): void {
+        // Only respond to a double tap from the primary pointer (left mouse button / primary touch).
+        // Ignore non-primary buttons (e.g. double right-click) and mixed combinations (e.g. left then right).
+        // Also ignore the double tap if any other button is still pressed (e.g. right-click held for
+        // rotation while double-tapping left), since `evt.buttons` is a bitmask of currently-pressed buttons.
+        if (evt && (evt.button !== 0 || evt.buttons !== 0)) {
+            return;
+        }
         const pickResult = this.camera._scene.pick(this.camera._scene.pointerX, this.camera._scene.pointerY, this.camera.movement.pickPredicate);
         if (pickResult.pickedPoint) {
-            void this.camera.flyToPointAsync(pickResult.pickedPoint);
+            void this.camera.flyToPointAsync(pickResult.pickedPoint, undefined, this.doubleTapAnimationDurationMs, this.doubleTapEasingFunction ?? undefined);
         }
     }
 

--- a/packages/dev/core/test/unit/Cameras/geospatialCameraInputs.test.ts
+++ b/packages/dev/core/test/unit/Cameras/geospatialCameraInputs.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GeospatialCamera } from "core/Cameras/geospatialCamera";
+import { GeospatialCameraPointersInput } from "core/Cameras/Inputs/geospatialCameraPointersInput";
+import { GeospatialCameraKeyboardInput } from "core/Cameras/Inputs/geospatialCameraKeyboardInput";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { Vector3 } from "core/Maths/math.vector";
+import { SineEase } from "core/Animations/easing";
+import { type IPointerEvent } from "core/Events/deviceInputEvents";
+import { type Nullable } from "core/types";
+
+describe("GeospatialCamera inputs", () => {
+    let engine: Nullable<NullEngine> = null;
+    let scene: Nullable<Scene> = null;
+    let camera: GeospatialCamera;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        camera = new GeospatialCamera("test", scene!, { planetRadius: 1 });
+    });
+
+    afterEach(() => {
+        scene?.dispose();
+        engine?.dispose();
+    });
+
+    // ============================================
+    // Double tap (pointers input)
+    // ============================================
+    describe("double tap", () => {
+        const makeEvt = (button: number, buttons: number): IPointerEvent => ({ button, buttons, pointerType: "mouse" }) as IPointerEvent;
+
+        let input: GeospatialCameraPointersInput;
+        let flySpy: ReturnType<typeof vi.spyOn>;
+
+        beforeEach(() => {
+            input = new GeospatialCameraPointersInput();
+            input.camera = camera;
+            vi.spyOn(camera._scene, "pick").mockReturnValue({ pickedPoint: new Vector3(1, 0, 0) } as any);
+            flySpy = vi.spyOn(camera, "flyToPointAsync").mockResolvedValue(undefined as any);
+        });
+
+        it("should fly to point on a primary-button double tap", () => {
+            input.onDoubleTap("mouse", makeEvt(0, 0));
+            expect(flySpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("should ignore a non-primary (right) button double tap", () => {
+            input.onDoubleTap("mouse", makeEvt(2, 0));
+            expect(flySpy).not.toHaveBeenCalled();
+        });
+
+        it("should ignore a double tap while another button is held", () => {
+            // Primary button released but right button (bit 2) still pressed.
+            input.onDoubleTap("mouse", makeEvt(0, 2));
+            expect(flySpy).not.toHaveBeenCalled();
+        });
+
+        it("should still fly when no event is provided (back-compat)", () => {
+            input.onDoubleTap("mouse");
+            expect(flySpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("should forward configured duration and easing function", () => {
+            const easing = new SineEase();
+            input.doubleTapAnimationDurationMs = 500;
+            input.doubleTapEasingFunction = easing;
+            input.onDoubleTap("mouse", makeEvt(0, 0));
+            expect(flySpy).toHaveBeenCalledWith(expect.anything(), undefined, 500, easing);
+        });
+    });
+
+    // ============================================
+    // Keyboard pan normalization
+    // ============================================
+    describe("keyboard pan normalization", () => {
+        let keyboard: GeospatialCameraKeyboardInput;
+        let startSpy: ReturnType<typeof vi.spyOn>;
+        let updateSpy: ReturnType<typeof vi.spyOn>;
+
+        const panHandler = () => camera.movement.input.handlers.pan;
+
+        beforeEach(() => {
+            keyboard = new GeospatialCameraKeyboardInput();
+            keyboard.camera = camera;
+            // Wire up the internals normally set by attachControl so checkInputs runs.
+            (keyboard as any)._engine = engine;
+            (keyboard as any)._scene = scene;
+            (keyboard as any)._onKeyboardObserver = {};
+
+            startSpy = vi.spyOn(panHandler(), "start").mockImplementation(() => {});
+            updateSpy = vi.spyOn(panHandler(), "update").mockImplementation(() => {});
+            vi.spyOn(panHandler(), "stop").mockImplementation(() => {});
+        });
+
+        // Returns the magnitude of the pan offset (update position relative to start position).
+        const runAndMeasure = (keys: number[]): number => {
+            startSpy.mockClear();
+            updateSpy.mockClear();
+            (keyboard as any)._keys = keys;
+            keyboard.checkInputs();
+            // A single, combined pan must be issued regardless of how many direction keys are held.
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            const [startX, startY] = startSpy.mock.calls[0] as number[];
+            const [updateX, updateY] = updateSpy.mock.calls[0] as number[];
+            const dx = updateX - startX;
+            const dy = updateY - startY;
+            return Math.sqrt(dx * dx + dy * dy);
+        };
+
+        it("should produce equal pan speed for a single direction and a diagonal (no sqrt(2) boost)", () => {
+            const single = runAndMeasure([38]); // up
+            const diagonal = runAndMeasure([38, 37]); // up + left
+            expect(diagonal).toBeCloseTo(single, 5);
+        });
+
+        it("should not pan when no direction keys are held", () => {
+            (keyboard as any)._keys = [];
+            keyboard.checkInputs();
+            expect(updateSpy).not.toHaveBeenCalled();
+        });
+
+        it("should not pan (and not divide by zero) when opposite direction keys cancel out", () => {
+            // up + down nets to a zero direction vector; the guard must skip normalization to avoid 0/0.
+            (keyboard as any)._keys = [38, 40]; // up + down
+            keyboard.checkInputs();
+            expect(updateSpy).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
## What

Addresses several reported improvements and one bug on the `GeospatialCamera` input handling.

### Double tap (`GeospatialCameraPointersInput`)
- **Configurable fly-to animation duration** via new `doubleTapAnimationDurationMs` (default `1000`).
- **Reusable easing function** via new `doubleTapEasingFunction` (default `null`); an `EasingFunction` instance can be created once and reused across double taps.
- **Primary-pointer only**: a double tap now only triggers the fly-to when it comes from the primary pointer with no other button held (`evt.button === 0 && evt.buttons === 0`). This fixes double right-click triggering a fly-to, and ignores a double tap while another button is held (e.g. right-button held for rotation).

To make the button state available, `BaseCameraPointersInput.onDoubleTap` now receives the originating pointer event as an optional second argument (`onDoubleTap(type, evt?)`). This is an additive, backward-compatible signature change — the existing `ArcRotateCameraPointersInput` override is unaffected.

### Keyboard (`GeospatialCameraKeyboardInput`)
- **Normalized diagonal pan**: holding two pan directions at once (e.g. up + left) previously produced a ~1.41× (`sqrt(2)`) speed boost because each key was applied independently. Pan keys are now accumulated into a single reused `Vector2` direction, normalized, and applied once per frame. `Vector2.normalize()` is a no-op on a zero-length vector, so opposite keys cancelling out (and any divide-by-zero) is handled inherently.

## Tests

New unit tests in `packages/dev/core/test/unit/Cameras/geospatialCameraInputs.test.ts`:
- primary-button double tap flies; non-primary (right) button ignored; double tap while another button held ignored; back-compat (no event) still flies; configured duration + easing forwarded.
- keyboard: diagonal pan equals single-axis speed (no `sqrt(2)` boost); no keys → no pan; opposite keys cancel → no pan / no divide-by-zero.

## Notes

- No new public knob was added for the fly-to distance scale; the existing `flyToPointAsync` default is preserved by passing `undefined`.
