### PR TITLE
fix: four pure-import / tree-shaking regressions (clearQuad 404, clustered lighting, snapshot helper, glTF worker materials)

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuClearQuad.pure.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuClearQuad.pure.ts
@@ -50,7 +50,24 @@ export class WebGPUClearQuad {
         this._cacheRenderPipeline.setDepthTestEnabled(false);
         this._cacheRenderPipeline.setStencilReadMask(0xff);
 
-        this._effect = engine.createEffect("clearQuad", [], ["color", "depthValue"], undefined, undefined, undefined, undefined, undefined, undefined, ShaderLanguage.WGSL);
+        this._effect = engine.createEffect(
+            "clearQuad",
+            [],
+            ["color", "depthValue"],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            ShaderLanguage.WGSL,
+            // On the pure import path the wrapper modules that eagerly register the clearQuad shaders are not in the
+            // module graph, so load the generated shader modules here to guarantee they are present in the ShaderStore
+            // before the effect compiles (otherwise the engine falls back to fetching clearQuad.*.fx and 404s).
+            async () => {
+                await Promise.all([import("../../ShadersWGSL/clearQuad.vertex"), import("../../ShadersWGSL/clearQuad.fragment")]);
+            }
+        );
     }
 
     public clear(

--- a/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.pure.ts
+++ b/packages/dev/core/src/Lights/Clustered/clusteredLightContainer.pure.ts
@@ -28,6 +28,10 @@ import { type RenderTargetWrapper } from "../../Engines/renderTargetWrapper";
 import { RegisterClass } from "core/Misc/typeStore";
 import { Node } from "core/node";
 import { RegisterClusteredLightingSceneComponent } from "./clusteredLightingSceneComponent.pure";
+import { RegisterEnginesExtensionsEngineRawTexture } from "core/Engines/Extensions/engine.rawTexture.pure";
+import { RegisterEnginesExtensionsEngineRenderTarget } from "core/Engines/Extensions/engine.renderTarget.pure";
+import { RegisterEnginesExtensionsEngineRenderTargetTexture } from "core/Engines/Extensions/engine.renderTargetTexture.pure";
+import { RegisterThinInstanceMesh } from "core/Meshes/thinInstanceMesh.pure";
 
 const DefaultDepthSlices = 16;
 const MobileClusteredLightBatchSize = 8;
@@ -236,6 +240,16 @@ export class ClusteredLightContainer extends Light {
         super(name, scene);
         const engine = this.getEngine();
         this._batchSize = ClusteredLightContainer._GetEngineBatchSize(engine);
+
+        // Clustered lighting relies on engine and mesh side effects that are not part of the
+        // pure import baseline. Register them here (idempotently) so the feature works on the
+        // tree-shakeable path without requiring callers to import these extensions manually.
+        // Without this, createRawTexture/createRenderTargetTexture throw and the thin-instance
+        // setters silently no-op, leaving the scene unlit with no error.
+        RegisterEnginesExtensionsEngineRawTexture();
+        RegisterEnginesExtensionsEngineRenderTarget();
+        RegisterEnginesExtensionsEngineRenderTargetTexture();
+        RegisterThinInstanceMesh();
 
         const proxyShader = { vertex: "lightProxy", fragment: "lightProxy" };
         const defines = [`CLUSTLIGHT_BATCH ${this._batchSize}`];

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -1,27 +1,23 @@
-import {
-    type AbstractEngine,
-    type AbstractMesh,
-    type EffectLayer,
-    type Mesh,
-    type Nullable,
-    type Observer,
-    type Scene,
-    type WebGPUDrawContext,
-    type WebGPUShaderProcessor,
-    type WebGPUPipelineContext,
-    type GaussianSplattingMesh,
-    type DrawWrapper,
-    type Camera,
-    type SpriteManager,
-    type IParticleSystem,
-    type ParticleSystem,
-    type Matrix,
-} from "core/index";
+import { type AbstractEngine } from "core/Engines/abstractEngine.pure";
+import { type AbstractMesh } from "core/Meshes/abstractMesh.pure";
+import { type EffectLayer } from "core/Layers/effectLayer";
+import { type Mesh } from "core/Meshes/mesh.pure";
+import { type Nullable } from "core/types";
+import { type Observer } from "core/Misc/observable.pure";
+import { type Scene, ScenePerformancePriority } from "core/scene.pure";
+import { type WebGPUDrawContext } from "core/Engines/WebGPU/webgpuDrawContext";
+import { type WebGPUShaderProcessor } from "core/Engines/WebGPU/webgpuShaderProcessor";
+import { type WebGPUPipelineContext } from "core/Engines/WebGPU/webgpuPipelineContext";
+import { type GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
+import { type DrawWrapper } from "core/Materials/drawWrapper";
+import { type Camera } from "core/Cameras/camera.pure";
+import { type SpriteManager } from "core/Sprites/spriteManager";
+import { type IParticleSystem } from "core/Particles/IParticleSystem";
+import { type ParticleSystem } from "core/Particles/particleSystem.pure";
 
 import { Constants } from "core/Engines/constants";
 import { BindMorphTargetParameters } from "core/Materials/materialHelper.functions";
-import { ScenePerformancePriority } from "core/scene.pure";
-import { TmpVectors } from "core/Maths/math.vector.pure";
+import { TmpVectors, type Matrix } from "core/Maths/math.vector.pure";
 import { Logger } from "core/Misc/logger";
 import { FrameGraphBaseLayerTask } from "../FrameGraph/Tasks/Layers/baseLayerTask";
 import { FrameGraphUtils } from "../FrameGraph/frameGraphUtils";

--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.pure.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.pure.ts
@@ -477,8 +477,18 @@ export class GLTFLoader implements IGLTFLoader {
 
                     if (needsOpenPBR && !this._pbrMaterialImpls.has("openpbr")) {
                         implPromises.push(
-                            Promise.all([import("core/Materials/PBR/openpbrMaterial"), import("./openpbrMaterialLoadingAdapter")]).then(
-                                ([{ OpenPBRMaterial: openPBRMaterialClass }, { OpenPBRMaterialLoadingAdapter: openPBRAdapterClass }]) => {
+                            // Import the .pure module (which directly declares the class and its registration
+                            // function) rather than the side-effect wrapper. The wrapper re-exports the class via
+                            // `export *`, and some bundlers fail to surface star-re-exported bindings on a dynamic
+                            // import namespace across a chunk boundary (e.g. a Web Worker chunk), which would leave
+                            // materialClass undefined and throw a cryptic "materialClass is not a constructor" later.
+                            // A direct named export is reliable everywhere; we trigger registration explicitly.
+                            Promise.all([import("core/Materials/PBR/openpbrMaterial.pure"), import("./openpbrMaterialLoadingAdapter")]).then(
+                                ([
+                                    { OpenPBRMaterial: openPBRMaterialClass, RegisterOpenpbrMaterial: registerOpenPBRMaterial },
+                                    { OpenPBRMaterialLoadingAdapter: openPBRAdapterClass },
+                                ]) => {
+                                    registerOpenPBRMaterial();
                                     this._pbrMaterialImpls.set("openpbr", {
                                         materialClass: openPBRMaterialClass,
                                         adapterClass: openPBRAdapterClass,
@@ -490,8 +500,11 @@ export class GLTFLoader implements IGLTFLoader {
 
                     if (needsPBR && !this._pbrMaterialImpls.has("pbr")) {
                         implPromises.push(
-                            Promise.all([import("core/Materials/PBR/pbrMaterial"), import("./pbrMaterialLoadingAdapter")]).then(
-                                ([{ PBRMaterial: pbrMaterialClass }, { PBRMaterialLoadingAdapter: pbrAdapterClass }]) => {
+                            // See the openpbr note above: import the .pure module for a reliable class binding and
+                            // register the class explicitly instead of relying on the wrapper's `export *` re-export.
+                            Promise.all([import("core/Materials/PBR/pbrMaterial.pure"), import("./pbrMaterialLoadingAdapter")]).then(
+                                ([{ PBRMaterial: pbrMaterialClass, RegisterPbrMaterial: registerPBRMaterial }, { PBRMaterialLoadingAdapter: pbrAdapterClass }]) => {
+                                    registerPBRMaterial();
                                     this._pbrMaterialImpls.set("pbr", {
                                         materialClass: pbrMaterialClass,
                                         adapterClass: pbrAdapterClass,


### PR DESCRIPTION
## Summary

Fixes four pure-import / tree-shaking regressions reported by a forum user when consuming `@babylonjs/core` and `@babylonjs/loaders` via pure (side-effect-free) imports, including a Web Worker + dev-build setup.

| # | Issue | Status |
|---|-------|--------|
| 1 | `clearQuad.vertex.fx` / `clearQuad.fragment.fx` 404 (WebGPU) | ✅ Reproduced & fixed |
| 2 | Clustered Lighting renders scenes dark with no console errors | ✅ Reproduced & fixed |
| 3 | `SnapshotRenderingHelper` becomes `undefined` in dev builds | ✅ Fixed (hardening) |
| 4 | `n.materialClass is not a constructor` from glTF loader inside a Web Worker | ✅ Root-caused & fixed |

## Details

### 1. clearQuad shader 404 (WebGPU) — `webgpuClearQuad.pure.ts`
The `clearQuad` effect was created without registering its shaders on the pure path, so the WebGPU clear quad tried to fetch `clearQuad.vertex.fx` / `clearQuad.fragment.fx` over HTTP and 404'd. Added `extraInitializationsAsync` to the `createEffect("clearQuad")` call so the shaders are pulled in on the pure import path.

### 2. Clustered Lighting silently dark — `clusteredLightContainer.pure.ts`
`ClusteredLightContainer` creates `RawTexture` / `RenderTargetTexture` and uses thin instances, but those engine/mesh extensions aren't registered on the pure path. `createRawTexture` *throws* in some scenes, while the thin-instance setter is a silent no-op stub in others — which is exactly why some scenes errored and others just went dark with no console error. The constructor now idempotently registers the four required engine/mesh extensions, mirroring existing scene-component self-registration.

### 3. `SnapshotRenderingHelper` undefined — `snapshotRenderingHelper.ts`
The module imported all of its types from the full `core/index` barrel. Under any toolchain that does not elide the type-only import, that creates a `core/index ↔ Misc ↔ snapshotRenderingHelper` cycle that can leave the export `undefined`. Replaced the barrel import with direct per-module type imports (the documented pure-path convention). Type-only change — no runtime effect on builds that already elide it.

### 4. glTF `materialClass is not a constructor` in a Web Worker — `glTFLoader.pure.ts`
Root cause: the loader dynamically imported the PBR / OpenPBR material **wrapper** modules and destructured the class from their `export *` re-export. Some bundlers don't surface star-re-exported bindings on a dynamic-import namespace across a chunk boundary — and a Web Worker is exactly such a boundary — so the destructured class comes back `undefined`, the impl is stored with `materialClass: undefined`, and `new impl.materialClass()` later throws. The loader now imports the `.pure` modules (which *directly declare* the class plus its registration function) and calls registration explicitly. Direct named exports are reliable across all bundlers; behavior and registration are unchanged.

## Testing
- **#1 and #2 reproduced locally** (esbuild + Playwright, headless WebGL2) and verified fixed — clustered pure import now renders byte-identical to the full import.
- **#3 and #4** are evidence-based hardening. #4's code-level root cause is unambiguous, but I could not reproduce #3/#4 in isolation across node+esbuild, webpack-prod, Vite-prod, and Vite-dev worker harnesses — they depend on the user's full bundler/worker chunk graph. They should be confirmed in the reporting user's environment.
- ESLint, Prettier, `tsc -b`, tree-shaking verification (core + loaders), and side-effects sync all pass.
- Loaders unit tests: 27 files / 329 tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>