### PR TITLE
Fix unregistered image processing parser breaking material clone in tree-shaken builds

### DIFF
--- a/packages/dev/core/src/Materials/Background/backgroundMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Background/backgroundMaterial.pure.ts
@@ -15,7 +15,7 @@ import { type IEffectCreationOptions } from "../../Materials/effect.pure";
 import { MaterialDefines } from "../../Materials/materialDefines";
 import { PushMaterial } from "../../Materials/pushMaterial";
 import { ImageProcessingDefinesMixin } from "../../Materials/imageProcessingConfiguration.defines";
-import { ImageProcessingConfiguration } from "../../Materials/imageProcessingConfiguration.pure";
+import { ImageProcessingConfiguration, RegisterImageProcessingConfiguration } from "../../Materials/imageProcessingConfiguration.pure";
 import { type BaseTexture } from "../../Materials/Textures/baseTexture.pure";
 import { type RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture.pure";
 import { type IShadowLight } from "../../Lights/shadowLight";
@@ -1167,6 +1167,9 @@ export function RegisterBackgroundMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // BackgroundMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     RegisterClass("BABYLON.BackgroundMaterial", BackgroundMaterial);
 }

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -66,6 +66,7 @@ import { type NodeMaterialTeleportInBlock } from "./Blocks/Teleport/teleportInBl
 import { Logger } from "core/Misc/logger";
 import { PrepareDefinesForCamera, PrepareDefinesForPrePass, AreLightsTexturesReady } from "../materialHelper.functions";
 import { ImageProcessingDefinesMixin } from "../imageProcessingConfiguration.defines";
+import { RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
 import { ShaderLanguage } from "../shaderLanguage";
 import { AbstractEngine } from "../../Engines/abstractEngine.pure";
 import { type LoopBlock } from "./Blocks/loopBlock.pure";
@@ -2811,6 +2812,9 @@ export function RegisterNodeMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // NodeMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     NodeMaterial._BlockIsTextureBlock = NodeMaterialBlockIsTextureBlock;
     NodeMaterial.Parse = NodeMaterialParse;

--- a/packages/dev/core/src/Materials/PBR/openpbrMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/PBR/openpbrMaterial.pure.ts
@@ -6,7 +6,7 @@ import { GetEnvironmentFuzzBRDFTexture, GetOpenPBREnvironmentBRDFTexture } from 
 import { type Nullable } from "../../types";
 import { type Scene } from "../../scene.pure";
 import { Color3, Color4 } from "../../Maths/math.color.pure";
-import { ImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
+import { ImageProcessingConfiguration, RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
 import { type BaseTexture } from "../../Materials/Textures/baseTexture.pure";
 import { type ThinTexture } from "../../Materials/Textures/thinTexture";
 import { Texture } from "../Textures/texture.pure";
@@ -3429,6 +3429,9 @@ export function RegisterOpenpbrMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // OpenPBRMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     RegisterClass("BABYLON.OpenPBRMaterial", OpenPBRMaterial);
 }

--- a/packages/dev/core/src/Materials/PBR/pbrMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMaterial.pure.ts
@@ -7,6 +7,7 @@ import { type Scene } from "../../scene.pure";
 import { Color3 } from "../../Maths/math.color.pure";
 import { type BaseTexture } from "../../Materials/Textures/baseTexture.pure";
 import { PBRBaseMaterial } from "./pbrBaseMaterial.pure";
+import { RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
 import { Material } from "../material.pure";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
 import { RegisterClass } from "../../Misc/typeStore";
@@ -759,6 +760,9 @@ export function RegisterPbrMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // PBRMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     RegisterClass("BABYLON.PBRMaterial", PBRMaterial);
 }

--- a/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrMetallicRoughnessMaterial.pure.ts
@@ -6,6 +6,7 @@ import { type Scene } from "../../scene.pure";
 import { type Color3 } from "../../Maths/math.color.pure";
 import { type BaseTexture } from "../../Materials/Textures/baseTexture.pure";
 import { PBRBaseSimpleMaterial } from "./pbrBaseSimpleMaterial";
+import { RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
 import { type Nullable } from "../../types";
 import { RegisterClass } from "../../Misc/typeStore";
 
@@ -171,6 +172,9 @@ export function RegisterPbrMetallicRoughnessMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // PBRMetallicRoughnessMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     RegisterClass("BABYLON.PBRMetallicRoughnessMaterial", PBRMetallicRoughnessMaterial);
 }

--- a/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/PBR/pbrSpecularGlossinessMaterial.pure.ts
@@ -5,6 +5,7 @@ import { type Scene } from "../../scene.pure";
 import { type Color3 } from "../../Maths/math.color.pure";
 import { type BaseTexture } from "../../Materials/Textures/baseTexture.pure";
 import { PBRBaseSimpleMaterial } from "./pbrBaseSimpleMaterial";
+import { RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
 import { type Nullable } from "../../types";
 import { SerializationHelper } from "../../Misc/decorators.serialization";
 import { RegisterClass } from "../../Misc/typeStore";
@@ -168,6 +169,9 @@ export function RegisterPbrSpecularGlossinessMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // PBRSpecularGlossinessMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     RegisterClass("BABYLON.PBRSpecularGlossinessMaterial", PBRSpecularGlossinessMaterial);
 }

--- a/packages/dev/core/src/Materials/standardMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/standardMaterial.pure.ts
@@ -13,7 +13,7 @@ import { type AbstractMesh } from "../Meshes/abstractMesh.pure";
 import { type Mesh } from "../Meshes/mesh.pure";
 import { PrePassConfiguration } from "./prePassConfiguration";
 import { ImageProcessingDefinesMixin } from "./imageProcessingConfiguration.defines";
-import { ImageProcessingConfiguration } from "./imageProcessingConfiguration.pure";
+import { ImageProcessingConfiguration, RegisterImageProcessingConfiguration } from "./imageProcessingConfiguration.pure";
 import { type FresnelParameters } from "./fresnelParameters.pure";
 import { Material } from "../Materials/material.pure";
 import { type ICustomShaderNameResolveOptions } from "../Materials/material";
@@ -2003,6 +2003,9 @@ export function RegisterStandardMaterial(): void {
         return;
     }
     _Registered = true;
+
+    // StandardMaterial serializes its image processing configuration, so the parser must be registered for clone/parse to work.
+    RegisterImageProcessingConfiguration();
 
     RegisterClass("BABYLON.StandardMaterial", StandardMaterial);
 

--- a/packages/dev/core/test/unit/Materials/babylon.imageProcessingSideEffect.test.ts
+++ b/packages/dev/core/test/unit/Materials/babylon.imageProcessingSideEffect.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression coverage for the tree-shaken build issue where
+ * `SerializationHelper._ImageProcessingConfigurationParser` stayed unregistered,
+ * causing `clone()`/`Parse()` to throw for any material that serializes an
+ * image processing configuration.
+ *
+ * Each material that mixes in image processing must register the parser from its
+ * own `Register*()` function so that importing only that material (without the
+ * `imageProcessingConfiguration` side-effect wrapper) still produces a working
+ * `clone()`.
+ */
+describe("Image processing serialization side effect", () => {
+    // Reset the module registry before each case so every material is validated
+    // against a freshly imported, unregistered SerializationHelper.
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    it.each([
+        ["StandardMaterial", "core/Materials/standardMaterial.pure", "RegisterStandardMaterial"],
+        ["BackgroundMaterial", "core/Materials/Background/backgroundMaterial.pure", "RegisterBackgroundMaterial"],
+        ["NodeMaterial", "core/Materials/Node/nodeMaterial.pure", "RegisterNodeMaterial"],
+        ["OpenPBRMaterial", "core/Materials/PBR/openpbrMaterial.pure", "RegisterOpenpbrMaterial"],
+        ["PBRMaterial", "core/Materials/PBR/pbrMaterial.pure", "RegisterPbrMaterial"],
+        ["PBRMetallicRoughnessMaterial", "core/Materials/PBR/pbrMetallicRoughnessMaterial.pure", "RegisterPbrMetallicRoughnessMaterial"],
+        ["PBRSpecularGlossinessMaterial", "core/Materials/PBR/pbrSpecularGlossinessMaterial.pure", "RegisterPbrSpecularGlossinessMaterial"],
+    ])(
+        "registers the image processing parser when %s is registered",
+        async (_materialName, pureModulePath, registerName) => {
+            const { SerializationHelper } = await import("core/Misc/decorators.serialization");
+            const unregisteredParser = SerializationHelper._ImageProcessingConfigurationParser;
+
+            // The unregistered parser is a throwing stub.
+            expect(() => unregisteredParser({})).toThrow();
+
+            // Importing the pure module must not have any side effects.
+            const materialModule = (await import(/* @vite-ignore */ pureModulePath)) as Record<string, () => void>;
+            expect(SerializationHelper._ImageProcessingConfigurationParser).toBe(unregisteredParser);
+
+            // Running the material's registration must wire up the parser.
+            materialModule[registerName]();
+            expect(SerializationHelper._ImageProcessingConfigurationParser).not.toBe(unregisteredParser);
+            expect(() => SerializationHelper._ImageProcessingConfigurationParser({})).not.toThrow();
+        },
+        30000
+    );
+});


### PR DESCRIPTION
## Problem

In tree-shaken builds, `SerializationHelper._ImageProcessingConfigurationParser` stays an unregistered throwing stub unless the `imageProcessingConfiguration` side-effect wrapper happens to be imported transitively. As a result, `clone()` / `Parse()` throws for any material that serializes an image processing configuration, because cloning serializes `_imageProcessingConfiguration` (serialization type 9) and invokes that unset parser.

This affects every material that mixes in `ImageProcessingMixin`:
- `StandardMaterial`
- `BackgroundMaterial`
- `NodeMaterial`
- `PBRMaterial`
- `PBRMetallicRoughnessMaterial`
- `PBRSpecularGlossinessMaterial`
- `OpenPBRMaterial`

## Fix

Rather than relying on a manual side-effect import at the call site, each affected material now calls `RegisterImageProcessingConfiguration()` from its own `Register*()` function in its `.pure.ts` — the place the tree-shaking architecture designates for side effects. Importing a material's side-effect wrapper (or calling its register function directly) now self-registers the parser, while the pure import path remains side-effect-free.

## Tests

Adds `babylon.imageProcessingSideEffect.test.ts`, which for each of the 7 materials asserts:
1. The parser is a throwing stub on a fresh module import.
2. Importing the material's `.pure` module produces no side effect.
3. Running the material's `Register*()` wires up a working parser.

This test fails on `master` before the fix.

## Validation

- `tsc` build: clean
- ESLint (incl. pure-import rules): 0 errors
- Prettier: formatted
- `check:manifest-drift` and `check:side-effects-sync`: up-to-date (no top-level side-effect change)
- Existing material unit tests: pass

## Note

`StandardMaterial` also serializes `FresnelParameters` (`_FresnelParametersParser`), which has the same latent stub problem in tree-shaken builds. This PR is intentionally scoped to the reported image-processing issue; happy to extend the same pattern to fresnel parameters in a follow-up if desired.