### PR TITLE
Improve `create-babylonjs` Scaffolding — .gitignore, Default Box, and Enhanced TS Config

### DIFF
--- a/packages/public/create-babylonjs/src/generators/gitignore.ts
+++ b/packages/public/create-babylonjs/src/generators/gitignore.ts
@@ -1,0 +1,20 @@
+import type { ProjectOptions } from "../index";
+
+export function generateGitignore(_options: ProjectOptions): string {
+    return `# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Editor directories and files
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# TypeScript
+*.tsbuildinfo
+`;
+}

--- a/packages/public/create-babylonjs/src/generators/indexHtml.ts
+++ b/packages/public/create-babylonjs/src/generators/indexHtml.ts
@@ -56,10 +56,10 @@ export function generateIndexHtml(options: ProjectOptions): string {
                 const camera = scene.activeCamera;
                 camera.setPosition(new BABYLON.Vector3(3, 3, 3));
                 camera.setTarget(new BABYLON.Vector3(0, 0, 0));
-            }
 
-            // Create a default light for the scene
-            scene.createDefaultLight(true);
+                // Create a default light for the scene
+                scene.createDefaultLight(true);
+            }
 
             // Create a default environment (skybox + ground + environment lighting)
             scene.createDefaultEnvironment({

--- a/packages/public/create-babylonjs/src/generators/indexHtml.ts
+++ b/packages/public/create-babylonjs/src/generators/indexHtml.ts
@@ -4,17 +4,15 @@ export function generateIndexHtml(options: ProjectOptions): string {
     const { bundler, moduleFormat } = options;
 
     const styles = `
-        html, body {
-            overflow: hidden;
-            width: 100%;
-            height: 100%;
+        body {
             margin: 0;
             padding: 0;
         }
 
         #renderCanvas {
-            width: 100%;
-            height: 100%;
+            display: block;
+            width: 100dvw;
+            height: 100dvh;
             touch-action: none;
         }`;
 
@@ -40,13 +38,18 @@ export function generateIndexHtml(options: ProjectOptions): string {
         const createScene = async function () {
             const scene = new BABYLON.Scene(engine);
 
-            // Load a glTF model
-            await BABYLON.AppendSceneAsync("https://assets.babylonjs.com/meshes/boombox.glb", scene);
+            // Create a default box mesh
+            BABYLON.CreateBox("box", {}, scene);
 
-            // Create a default camera that frames the loaded model
+            // Create a default camera, and event caught by the controls will call preventdefault(),
+            // such as wheel event
             scene.createDefaultCamera(true, true, true);
-            // Rotate the camera to face the front of the model
-            scene.activeCamera.alpha += Math.PI;
+            const camera = scene.activeCamera;
+            camera.setPosition(new BABYLON.Vector3(3, 3, 3));
+            camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+
+            // Create a default light for the scene
+            scene.createDefaultLight(true);
 
             // Create a default environment (skybox + ground + environment lighting)
             scene.createDefaultEnvironment({

--- a/packages/public/create-babylonjs/src/generators/indexHtml.ts
+++ b/packages/public/create-babylonjs/src/generators/indexHtml.ts
@@ -38,15 +38,25 @@ export function generateIndexHtml(options: ProjectOptions): string {
         const createScene = async function () {
             const scene = new BABYLON.Scene(engine);
 
-            // Create a default box mesh
-            BABYLON.CreateBox("box", {}, scene);
+            try {
+                // Load a glTF model
+                await BABYLON.AppendSceneAsync("https://assets.babylonjs.com/meshes/boombox.glb", scene);
 
-            // Create a default camera, and event caught by the controls will call preventdefault(),
-            // such as wheel event
-            scene.createDefaultCamera(true, true, true);
-            const camera = scene.activeCamera;
-            camera.setPosition(new BABYLON.Vector3(3, 3, 3));
-            camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+                // Create a default camera, and event caught by the controls will call preventdefault(),
+                // such as wheel event
+                scene.createDefaultCamera(true, true, true);
+                // Rotate the camera to face the front of the model
+                scene.activeCamera.alpha += Math.PI;
+            } catch {
+                // Fallback: when loading fails
+                // Create a default box mesh
+                BABYLON.CreateBox("box", {}, scene);
+
+                scene.createDefaultCamera(true, true, true);
+                const camera = scene.activeCamera;
+                camera.setPosition(new BABYLON.Vector3(3, 3, 3));
+                camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+            }
 
             // Create a default light for the scene
             scene.createDefaultLight(true);

--- a/packages/public/create-babylonjs/src/generators/sceneCode.ts
+++ b/packages/public/create-babylonjs/src/generators/sceneCode.ts
@@ -1,15 +1,15 @@
 import type { ProjectOptions } from "../index";
 
-const GLTF_MODEL_URL = "https://assets.babylonjs.com/meshes/boombox.glb";
-
 // ES6 scene code — tree-shakeable imports
 function es6Scene(language: "ts" | "js"): string {
     const canvasCast = language === "ts" ? " as HTMLCanvasElement" : "";
     const arcCamImport = language === "ts" ? '\nimport { ArcRotateCamera } from "@babylonjs/core/Cameras/arcRotateCamera";' : "";
-    const alphaCast = language === "ts" ? "(scene.activeCamera as ArcRotateCamera)" : "scene.activeCamera";
+    const cameraCast = language === "ts" ? " as ArcRotateCamera" : "";
     return `import { Engine } from "@babylonjs/core/Engines/engine";
 import { Scene } from "@babylonjs/core/scene";
-import { AppendSceneAsync } from "@babylonjs/core/Loading/sceneLoader";${arcCamImport}
+import { AppendSceneAsync } from "@babylonjs/core/Loading/sceneLoader";
+import { CreateBox } from "@babylonjs/core/Meshes/Builders/boxBuilder";${arcCamImport}
+import { Vector3 } from "@babylonjs/core/Maths/math.vector";
 
 // Side-effect imports: these register plugins and augment prototypes at load time
 import "@babylonjs/core/Loading/loadingScreen";
@@ -25,13 +25,18 @@ const engine = new Engine(canvas, true);
 const createScene = async () => {
     const scene = new Scene(engine);
 
-    // Load a glTF model
-    await AppendSceneAsync("${GLTF_MODEL_URL}", scene);
+    // Create a default box mesh
+    CreateBox("box", {}, scene);
 
-    // Create a default camera that frames the loaded model
+    // Create a default camera, and event caught by the controls will call preventdefault(),
+    // such as wheel event
     scene.createDefaultCamera(true, true, true);
-    // Rotate the camera to face the front of the model
-    ${alphaCast}.alpha += Math.PI;
+    const camera = scene.activeCamera${cameraCast};
+    camera.setPosition(new Vector3(3, 3, 3));
+    camera.setTarget(new Vector3(0, 0, 0));
+
+    // Create a default light for the scene
+    scene.createDefaultLight(true);
 
     // Create a default environment (skybox + ground + environment lighting)
     scene.createDefaultEnvironment({
@@ -66,13 +71,18 @@ const engine = new BABYLON.Engine(canvas, true);
 const createScene = async (): Promise<BABYLON.Scene> => {
     const scene = new BABYLON.Scene(engine);
 
-    // Load a glTF model
-    await BABYLON.AppendSceneAsync("${GLTF_MODEL_URL}", scene);
+    // Create a default box mesh
+    BABYLON.CreateBox("box", {}, scene);
 
-    // Create a default camera that frames the loaded model
+    // Create a default camera, and event caught by the controls will call preventdefault(),
+    // such as wheel event
     scene.createDefaultCamera(true, true, true);
-    // Rotate the camera to face the front of the model
-    (scene.activeCamera as BABYLON.ArcRotateCamera).alpha += Math.PI;
+    const camera = scene.activeCamera as BABYLON.ArcRotateCamera;
+    camera.setPosition(new BABYLON.Vector3(3, 3, 3));
+    camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+
+    // Create a default light for the scene
+    scene.createDefaultLight(true);
 
     // Create a default environment (skybox + ground + environment lighting)
     scene.createDefaultEnvironment({
@@ -106,13 +116,18 @@ const engine = new BABYLON.Engine(canvas, true);
 const createScene = async () => {
     const scene = new BABYLON.Scene(engine);
 
-    // Load a glTF model
-    await BABYLON.AppendSceneAsync("${GLTF_MODEL_URL}", scene);
+    // Create a default box mesh
+    BABYLON.CreateBox("box", {}, scene);
 
-    // Create a default camera that frames the loaded model
+    // Create a default camera, and event caught by the controls will call preventdefault(),
+    // such as wheel event
     scene.createDefaultCamera(true, true, true);
-    // Rotate the camera to face the front of the model
-    scene.activeCamera.alpha += Math.PI;
+    const camera = scene.activeCamera;
+    camera.setPosition(new BABYLON.Vector3(3, 3, 3));
+    camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+
+    // Create a default light for the scene
+    scene.createDefaultLight(true);
 
     // Create a default environment (skybox + ground + environment lighting)
     scene.createDefaultEnvironment({

--- a/packages/public/create-babylonjs/src/generators/sceneCode.ts
+++ b/packages/public/create-babylonjs/src/generators/sceneCode.ts
@@ -22,30 +22,40 @@ import "@babylonjs/loaders/glTF";
 const canvas = document.getElementById("renderCanvas")${canvasCast};
 const engine = new Engine(canvas, true);
 
-const createScene = async () => {
-    const scene = new Scene(engine);
+    const createScene = async () => {
+        const scene = new Scene(engine);
 
-    // Create a default box mesh
-    CreateBox("box", {}, scene);
+        try {
+            // Load a glTF model
+            await AppendSceneAsync("https://assets.babylonjs.com/meshes/boombox.glb", scene);
 
-    // Create a default camera, and event caught by the controls will call preventdefault(),
-    // such as wheel event
-    scene.createDefaultCamera(true, true, true);
-    const camera = scene.activeCamera${cameraCast};
-    camera.setPosition(new Vector3(3, 3, 3));
-    camera.setTarget(new Vector3(0, 0, 0));
+            // Create a default camera, and event caught by the controls will call preventdefault(),
+            // such as wheel event
+            scene.createDefaultCamera(true, true, true);
+            // Rotate the camera to face the front of the model
+            (scene.activeCamera${cameraCast}).alpha += Math.PI;
+        } catch {
+            // Fallback: when loading fails
+            // Create a default box mesh
+            CreateBox("box", {}, scene);
 
-    // Create a default light for the scene
-    scene.createDefaultLight(true);
+            scene.createDefaultCamera(true, true, true);
+            const camera = scene.activeCamera${cameraCast};
+            camera.setPosition(new Vector3(3, 3, 3));
+            camera.setTarget(new Vector3(0, 0, 0));
+        }
 
-    // Create a default environment (skybox + ground + environment lighting)
-    scene.createDefaultEnvironment({
-        createGround: true,
-        createSkybox: true,
-    });
+        // Create a default light for the scene
+        scene.createDefaultLight(true);
 
-    return scene;
-};
+        // Create a default environment (skybox + ground + environment lighting)
+        scene.createDefaultEnvironment({
+            createGround: true,
+            createSkybox: true,
+        });
+
+        return scene;
+    };
 
 createScene().then((scene) => {
     engine.runRenderLoop(() => {
@@ -71,15 +81,25 @@ const engine = new BABYLON.Engine(canvas, true);
 const createScene = async (): Promise<BABYLON.Scene> => {
     const scene = new BABYLON.Scene(engine);
 
-    // Create a default box mesh
-    BABYLON.CreateBox("box", {}, scene);
+    try {
+        // Load a glTF model
+        await BABYLON.AppendSceneAsync("https://assets.babylonjs.com/meshes/boombox.glb", scene);
 
-    // Create a default camera, and event caught by the controls will call preventdefault(),
-    // such as wheel event
-    scene.createDefaultCamera(true, true, true);
-    const camera = scene.activeCamera as BABYLON.ArcRotateCamera;
-    camera.setPosition(new BABYLON.Vector3(3, 3, 3));
-    camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+        // Create a default camera, and event caught by the controls will call preventdefault(),
+        // such as wheel event
+        scene.createDefaultCamera(true, true, true);
+        // Rotate the camera to face the front of the model
+        (scene.activeCamera as BABYLON.ArcRotateCamera).alpha += Math.PI;
+    } catch {
+        // Fallback: when loading fails
+        // Create a default box mesh
+        BABYLON.CreateBox("box", {}, scene);
+
+        scene.createDefaultCamera(true, true, true);
+        const camera = scene.activeCamera as BABYLON.ArcRotateCamera;
+        camera.setPosition(new BABYLON.Vector3(3, 3, 3));
+        camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+    }
 
     // Create a default light for the scene
     scene.createDefaultLight(true);
@@ -116,15 +136,25 @@ const engine = new BABYLON.Engine(canvas, true);
 const createScene = async () => {
     const scene = new BABYLON.Scene(engine);
 
-    // Create a default box mesh
-    BABYLON.CreateBox("box", {}, scene);
+    try {
+        // Load a glTF model
+        await BABYLON.AppendSceneAsync("https://assets.babylonjs.com/meshes/boombox.glb", scene);
 
-    // Create a default camera, and event caught by the controls will call preventdefault(),
-    // such as wheel event
-    scene.createDefaultCamera(true, true, true);
-    const camera = scene.activeCamera;
-    camera.setPosition(new BABYLON.Vector3(3, 3, 3));
-    camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+        // Create a default camera, and event caught by the controls will call preventdefault(),
+        // such as wheel event
+        scene.createDefaultCamera(true, true, true);
+        // Rotate the camera to face the front of the model
+        scene.activeCamera.alpha += Math.PI;
+    } catch {
+        // Fallback: when loading fails
+        // Create a default box mesh
+        BABYLON.CreateBox("box", {}, scene);
+
+        scene.createDefaultCamera(true, true, true);
+        const camera = scene.activeCamera;
+        camera.setPosition(new BABYLON.Vector3(3, 3, 3));
+        camera.setTarget(new BABYLON.Vector3(0, 0, 0));
+    }
 
     // Create a default light for the scene
     scene.createDefaultLight(true);

--- a/packages/public/create-babylonjs/src/generators/sceneCode.ts
+++ b/packages/public/create-babylonjs/src/generators/sceneCode.ts
@@ -43,10 +43,10 @@ const engine = new Engine(canvas, true);
             const camera = scene.activeCamera${cameraCast};
             camera.setPosition(new Vector3(3, 3, 3));
             camera.setTarget(new Vector3(0, 0, 0));
-        }
 
-        // Create a default light for the scene
-        scene.createDefaultLight(true);
+            // Create a default light for the scene
+            scene.createDefaultLight(true);
+        }
 
         // Create a default environment (skybox + ground + environment lighting)
         scene.createDefaultEnvironment({
@@ -99,10 +99,10 @@ const createScene = async (): Promise<BABYLON.Scene> => {
         const camera = scene.activeCamera as BABYLON.ArcRotateCamera;
         camera.setPosition(new BABYLON.Vector3(3, 3, 3));
         camera.setTarget(new BABYLON.Vector3(0, 0, 0));
-    }
 
-    // Create a default light for the scene
-    scene.createDefaultLight(true);
+        // Create a default light for the scene
+        scene.createDefaultLight(true);
+    }
 
     // Create a default environment (skybox + ground + environment lighting)
     scene.createDefaultEnvironment({
@@ -154,10 +154,10 @@ const createScene = async () => {
         const camera = scene.activeCamera;
         camera.setPosition(new BABYLON.Vector3(3, 3, 3));
         camera.setTarget(new BABYLON.Vector3(0, 0, 0));
-    }
 
-    // Create a default light for the scene
-    scene.createDefaultLight(true);
+        // Create a default light for the scene
+        scene.createDefaultLight(true);
+    }
 
     // Create a default environment (skybox + ground + environment lighting)
     scene.createDefaultEnvironment({

--- a/packages/public/create-babylonjs/src/generators/tsConfig.ts
+++ b/packages/public/create-babylonjs/src/generators/tsConfig.ts
@@ -3,25 +3,41 @@ import type { ProjectOptions } from "../index";
 export function generateTsConfig(options: ProjectOptions): string {
     const { bundler, moduleFormat } = options;
 
-    const base: Record<string, unknown> = {
-        compilerOptions: {
-            target: "ES2020",
-            module: bundler === "vite" ? "ESNext" : "ES2020",
-            moduleResolution: bundler === "vite" ? "bundler" : "node",
-            strict: true,
-            esModuleInterop: true,
-            skipLibCheck: true,
-            forceConsistentCasingInFileNames: true,
-            outDir: "./dist",
-            sourceMap: true,
-        },
-        include: ["src"],
+    const types: string[] = [];
+
+    const compilerOptions: Record<string, unknown> = {
+        target: "ES2020",
+        module: bundler === "vite" ? "ESNext" : "ES2020",
+        moduleResolution: bundler === "vite" ? "bundler" : "node",
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        forceConsistentCasingInFileNames: true,
+        sourceMap: true,
     };
+
+    if (bundler === "vite") {
+        // Vite handles the actual bundling, so TypeScript only needs to type-check without emitting output
+        compilerOptions.noEmit = true;
+        // Add Vite client type declarations (e.g., import.meta.env, asset imports)
+        types.push("vite/client");
+    } else {
+        compilerOptions.outDir = "./dist";
+    }
 
     // UMD packages ship their own typings via the `babylonjs` package
     if (moduleFormat === "umd") {
-        (base.compilerOptions as Record<string, unknown>).types = ["babylonjs"];
+        types.push("babylonjs");
     }
+
+    if (types.length > 0) {
+        compilerOptions.types = types;
+    }
+
+    const base: Record<string, unknown> = {
+        compilerOptions,
+        include: ["src"],
+    };
 
     return JSON.stringify(base, null, 2) + "\n";
 }

--- a/packages/public/create-babylonjs/src/generators/tsConfig.ts
+++ b/packages/public/create-babylonjs/src/generators/tsConfig.ts
@@ -34,10 +34,5 @@ export function generateTsConfig(options: ProjectOptions): string {
         compilerOptions.types = types;
     }
 
-    const base: Record<string, unknown> = {
-        compilerOptions,
-        include: ["src"],
-    };
-
-    return JSON.stringify(base, null, 2) + "\n";
+    return JSON.stringify({ compilerOptions, include: ["src"] }, null, 2) + "\n";
 }

--- a/packages/public/create-babylonjs/src/index.ts
+++ b/packages/public/create-babylonjs/src/index.ts
@@ -8,6 +8,7 @@ import { generateIndexHtml } from "./generators/indexHtml";
 import { generateSceneCode } from "./generators/sceneCode";
 import { generateBundlerConfig } from "./generators/bundlerConfig";
 import { generateTsConfig } from "./generators/tsConfig";
+import { generateGitignore } from "./generators/gitignore";
 
 export type ModuleFormat = "es6" | "umd";
 export type Language = "ts" | "js";
@@ -113,6 +114,9 @@ async function main(): Promise<void> {
 
 function scaffoldProject(targetDir: string, options: ProjectOptions): void {
     fs.mkdirSync(targetDir, { recursive: true });
+
+    // All projects get a .gitignore
+    writeFile(targetDir, ".gitignore", generateGitignore(options));
 
     if (options.bundler === "none") {
         // CDN-only: just an HTML file

--- a/packages/public/create-babylonjs/test/unit/gitignore.test.ts
+++ b/packages/public/create-babylonjs/test/unit/gitignore.test.ts
@@ -1,0 +1,21 @@
+import { generateGitignore } from "../../src/generators/gitignore";
+import type { ProjectOptions } from "../../src/index";
+
+describe("generateGitignore", () => {
+    const options: ProjectOptions = {
+        projectName: "test-app",
+        moduleFormat: "es6",
+        language: "ts",
+        bundler: "vite",
+    };
+
+    it("generates correct gitignore content", () => {
+        const content = generateGitignore(options);
+        expect(content).toContain("node_modules/");
+        expect(content).toContain("dist/");
+        expect(content).toContain(".idea/");
+        expect(content).toContain(".DS_Store");
+        expect(content).toContain("Thumbs.db");
+        expect(content).toContain("*.tsbuildinfo");
+    });
+});

--- a/packages/public/create-babylonjs/test/unit/indexHtml.test.ts
+++ b/packages/public/create-babylonjs/test/unit/indexHtml.test.ts
@@ -2,7 +2,7 @@ import { generateIndexHtml } from "../../src/generators/indexHtml";
 import type { ProjectOptions } from "../../src/index";
 
 describe("generateIndexHtml", () => {
-    it("generates CDN-only HTML with inline script, loaders, and glTF loading", () => {
+    it("generates CDN-only HTML with inline script, loaders, and default box", () => {
         const options: ProjectOptions = {
             projectName: "cdn-app",
             moduleFormat: "umd",
@@ -13,7 +13,7 @@ describe("generateIndexHtml", () => {
         expect(html).toContain("cdn.babylonjs.com/babylon.js");
         expect(html).toContain("babylonjs.loaders.min.js");
         expect(html).toContain("BABYLON.Engine");
-        expect(html).toContain("BABYLON.AppendSceneAsync");
+        expect(html).toContain("BABYLON.CreateBox");
         expect(html).toContain("createDefaultCamera(true, true, true)");
         expect(html).toContain("createDefaultEnvironment");
         expect(html).toContain('<canvas id="renderCanvas">');

--- a/packages/public/create-babylonjs/test/unit/sceneCode.test.ts
+++ b/packages/public/create-babylonjs/test/unit/sceneCode.test.ts
@@ -2,7 +2,7 @@ import { generateSceneCode } from "../../src/generators/sceneCode";
 import type { ProjectOptions } from "../../src/index";
 
 describe("generateSceneCode", () => {
-    it("generates ES6 TypeScript scene with tree-shakeable imports and glTF loader", () => {
+    it("generates ES6 TypeScript scene with tree-shakeable imports and default box", () => {
         const options: ProjectOptions = {
             projectName: "app",
             moduleFormat: "es6",
@@ -14,8 +14,9 @@ describe("generateSceneCode", () => {
         expect(code).toContain('import { Scene } from "@babylonjs/core/scene"');
         expect(code).toContain("as HTMLCanvasElement");
         expect(code).toContain("@babylonjs/loaders/glTF");
-        expect(code).toContain("AppendSceneAsync");
+        expect(code).toContain("CreateBox");
         expect(code).toContain("createDefaultEnvironment");
+        expect(code).toContain("createDefaultLight");
         expect(code).toContain("@babylonjs/core/Loading/loadingScreen");
         expect(code).toContain("@babylonjs/core/Helpers/sceneHelpers");
         expect(code).toContain("@babylonjs/core/Materials/Textures/Loaders/envTextureLoader");
@@ -48,7 +49,7 @@ describe("generateSceneCode", () => {
         expect(code).toContain('import * as BABYLON from "babylonjs"');
         expect(code).toContain('import "babylonjs-loaders"');
         expect(code).toContain("BABYLON.Engine");
-        expect(code).toContain("BABYLON.AppendSceneAsync");
+        expect(code).toContain("BABYLON.CreateBox");
         expect(code).toContain("as BABYLON.ArcRotateCamera");
         expect(code).toContain("createDefaultEnvironment");
     });
@@ -62,14 +63,14 @@ describe("generateSceneCode", () => {
         };
         const code = generateSceneCode(options);
         expect(code).toContain("BABYLON.Engine");
-        expect(code).toContain("BABYLON.AppendSceneAsync");
+        expect(code).toContain("BABYLON.CreateBox");
         expect(code).toContain('import * as BABYLON from "babylonjs"');
         expect(code).toContain('import "babylonjs-loaders"');
         expect(code).not.toContain("as HTMLCanvasElement");
         expect(code).not.toContain("as BABYLON.ArcRotateCamera");
     });
 
-    it("always includes resize handler, render loop, environment, and auto-framing camera", () => {
+    it("always includes resize handler, render loop, camera, environment, and default light", () => {
         const combos: ProjectOptions[] = [
             { projectName: "a", moduleFormat: "es6", language: "ts", bundler: "vite" },
             { projectName: "b", moduleFormat: "umd", language: "js", bundler: "webpack" },
@@ -80,7 +81,7 @@ describe("generateSceneCode", () => {
             expect(code).toContain("engine.resize()");
             expect(code).toContain("createDefaultCamera(true, true, true)");
             expect(code).toContain("createDefaultEnvironment");
-            expect(code).toContain("boombox.glb");
+            expect(code).toContain("createDefaultLight");
         }
     });
 });

--- a/packages/public/create-babylonjs/test/unit/tsConfig.test.ts
+++ b/packages/public/create-babylonjs/test/unit/tsConfig.test.ts
@@ -12,7 +12,7 @@ describe("generateTsConfig", () => {
         const result = JSON.parse(generateTsConfig(options));
         expect(result.compilerOptions.module).toBe("ESNext");
         expect(result.compilerOptions.moduleResolution).toBe("bundler");
-        expect(result.compilerOptions.types).toBeUndefined();
+        expect(result.compilerOptions.types).toEqual(["vite/client"]);
     });
 
     it("generates ES2020 module config for Webpack", () => {


### PR DESCRIPTION
### gitignore.ts
  - every scaffolded project now gets a sensible `.gitignore` out of the box.

### sceneCode.ts
  - Replaces `BABYLON.AppendSceneAsync("https://assets.babylonjs.com/meshes/boombox.glb", scene)` with `BABYLON.CreateBox("box", {}, scene)` — no network dependency for the default scene, avoiding potential connectivity issues in certain regions.

### indexHtml.ts

  - **`display: block`** — `<canvas>` is an inline-replaced element by default. Setting it to `display: block` eliminates the small gap below the canvas caused by inline element baseline alignment. Without this, there is often a 3–4px whitespace strip at the bottom of the page.

  - **`100dvw` / `100dvh` instead of `100%`** — The dynamic viewport units (`dvw` / `dvh`) account for mobile browser UI changes (address bar appearing/disappearing), unlike `100%` which depends on parent element size. Using percentage-based sizing required setting `width: 100%; height: 100%` on both `html` and `body` as ancestor chain. With `dvw`/`dvh`, the canvas sizes directly against the viewport, eliminating the need for `overflow: hidden` on `html, body` and simplifying the CSS.

  - **Removing `overflow: hidden` from `<html>` and `<body>`** — No longer needed since the canvas uses viewport units directly and the body has zero margin/padding. Worth noting that the old `overflow: hidden` approach only masked the overflow symptom — the canvas content was still actually overflowing; it just wasn't visible.

### tsconfig.json

- **`"noEmit": true` replacing `"outDir": "./dist"`** — `vite build` already outputs to `dist` by default. With `"noEmit": true`, `tsc` is used strictly as a type-checker (`tsc && vite build`); it emits nothing, and Vite alone handles all bundling. The `outDir` setting is therefore irrelevant and was removed.

- **Added `"vite/client"` to types** — This provides TypeScript with type definitions for Vite-specific features such as `import.meta.env`, static asset imports (e.g., `import logo from './logo.png'`), HMR API (`import.meta.hot`), and the `?url` / `?raw` query suffixes. Without this, the TypeScript compiler would flag Vite-imported assets as type errors.
