### PR TITLE
fix(sandbox): load glTF extensions, animation side-effects, and inspector in dev

### DIFF
--- a/packages/tools/sandbox/src/main.ts
+++ b/packages/tools/sandbox/src/main.ts
@@ -8,18 +8,25 @@
  * the Show args and dispatches a "babylonSandboxReady" event that we pick up
  * here to start the sandbox with the correct version info.
  */
-// Register GLTF/GLB loader (2.0 sub-loader assigns GLTFFileLoader._CreateGLTF2Loader).
-// The sandbox loads .glb/.gltf files directly via SceneLoader.
-import "loaders/glTF/2.0/glTFLoader";
+// Register the GLTF/GLB loader plus all glTF 2.0 extensions (draco, mesh quantization, KHR materials, etc.).
+// The sandbox loads .glb/.gltf files directly via SceneLoader and must support arbitrary extensions.
+import "loaders/glTF/2.0";
 // Register the FBX loader so .fbx files can be loaded via SceneLoader (drag-and-drop and the file picker).
 import "loaders/FBX/fbxFileLoader";
+// Register Scene animation extensions (e.g. getAllAnimatablesByTarget) used by the Inspector's animation panel.
+import "core/Animations/animatable";
 import { Sandbox } from "./sandbox";
 
 const HostElement = document.getElementById("host-element") as HTMLElement;
 
 if (import.meta.env.DEV) {
-    // Dev mode — show immediately with minimal version info
-    Sandbox.Show(HostElement, { version: "dev", bundles: [] });
+    // Dev mode — register the Inspector v2 debug layer (production gets it from the CDN bundle),
+    // then show immediately. The inspector index attaches Scene.debugLayer as a side effect.
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    (async () => {
+        await import("inspector/index");
+        Sandbox.Show(HostElement, { version: "dev", bundles: [] });
+    })();
 } else {
     // Production — CDN bootstrap calls BABYLON.Sandbox.Show which stores args
     const win = window as unknown as Record<string, unknown>;

--- a/packages/tools/sandbox/vite.config.ts
+++ b/packages/tools/sandbox/vite.config.ts
@@ -13,6 +13,14 @@ const base = commonDevViteConfiguration({
         serializers: path.resolve("../../dev/serializers/dist"),
         materials: path.resolve("../../dev/materials/dist"),
         addons: path.resolve("../../dev/addons/dist"),
+        inspector: path.resolve("../../dev/inspector-v2/dist"),
+        // Inspector v2 lazily imports the node/GUI editors when those panels are opened.
+        // Alias them so Vite can resolve the dynamic imports in dev (loaded on demand only).
+        "gui-editor": path.resolve("../../tools/guiEditor/dist"),
+        "node-editor": path.resolve("../../tools/nodeEditor/dist"),
+        "node-geometry-editor": path.resolve("../../tools/nodeGeometryEditor/dist"),
+        "node-particle-editor": path.resolve("../../tools/nodeParticleEditor/dist"),
+        "node-render-graph-editor": path.resolve("../../tools/nodeRenderGraphEditor/dist"),
     },
     productionExternals: {
         babylonjs: "BABYLON",


### PR DESCRIPTION
## Problem

Reported on the forum: [Sandbox dev server no longer works after Vite tree-shaking changes](https://forum.babylonjs.com/t/sandbox-dev-server-no-longer-works-from-documented-command-after-vite-tree-shaking-changes/63693). On a fresh checkout, the sandbox dev server (`npm run serve -w @tools/sandbox`) had several runtime failures:

- Dragging a **DRACO** (and mesh-quantization) GLB failed to load.
- Opening the **Inspector** threw `Cannot read properties of undefined (reading 'show')`.
- After that was worked around, the Inspector still crashed (`getAllAnimatablesByTarget` undefined) on a non-draco model.

## Root cause

The sandbox dev server aliases Babylon packages to their tree-shaken `dist` builds, so only explicitly-imported side effects are present. Three were missing:

1. Only `loaders/glTF/2.0/glTFLoader` was imported → no glTF extensions registered (draco, mesh quantization, KHR materials, …).
2. The Inspector v2 debug-layer side effect was never loaded → `scene.debugLayer.show()` blew up.
3. `core/Animations/animatable` was tree-shaken out → `getAllAnimatablesByTarget` missing, crashing the Inspector properties panel.

## Fix (`packages/tools/sandbox`)

- **main.ts**: import the full `loaders/glTF/2.0` extension barrel, import `core/Animations/animatable`, and in dev load `inspector/index` (attaches `Scene.debugLayer` for v2; production keeps getting it from the CDN bundle).
- **vite.config.ts**: alias `inspector` to `inspector-v2/dist` plus the lazily-loaded `gui-editor`/`node-*-editor` packages so Vite can resolve those dynamic imports.

## Verification

Reproduced all three errors with Playwright, then confirmed after the fix: draco GLB renders, Inspector opens with a clean properties panel, no console errors. Dev-only imports are gated by `import.meta.env.DEV`, so the production `vite build` still passes and stays small (~188 kB). tsc/eslint/prettier clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>