### PR TITLE
Fix WGSL exact sRGB conversions failing on WebGPU

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/helperFunctions.fx
@@ -87,14 +87,14 @@ fn toLinearSpaceExact(color: vec3f) -> vec3f
 {
     let nearZeroSection: vec3f = 0.0773993808 * color;
     let remainingSection: vec3f = pow(0.947867299 * (color + vec3f(0.055)), vec3f(2.4));
-    return mix(remainingSection, nearZeroSection, lessThanEqual(color, vec3f(0.04045)));
+    return select(remainingSection, nearZeroSection, color <= vec3f(0.04045));
 }
 
 fn toGammaSpaceExact(color: vec3f) -> vec3f
 {
     let nearZeroSection: vec3f = 12.92 * color;
     let remainingSection: vec3f = 1.055 * pow(color, vec3f(0.41666)) - vec3f(0.055);
-    return mix(remainingSection, nearZeroSection, lessThanEqual(color, vec3f(0.0031308)));
+    return select(remainingSection, nearZeroSection, color <= vec3f(0.0031308));
 }
 #endif
 


### PR DESCRIPTION
## Problem

When `engine.useExactSrgbConversions = true` is set on WebGPU, shaders fail to compile and nothing renders (blank canvas). Reproduced via https://playground.babylonjs.com/#XDNVAY#41:

```
Error while parsing WGSL: unresolved call target 'lessThanEqual'
return mix(remainingSection, nearZeroSection, lessThanEqual(color, vec3f(0.04045)));
```

## Cause

The vec3 exact sRGB↔linear conversion helpers in `helperFunctions.fx` (WGSL) used GLSL's `lessThanEqual()`, which does not exist in WGSL. The scalar variants already correctly used `select()`.

## Fix

Replaced `mix(..., lessThanEqual(...))` with `select(..., color <= ...)`. Arg order is preserved since `mix(a,b,cond)` and `select(a,b,cond)` both return `b` where the condition is true, and `vec3f <= vec3f` yields the `vec3<bool>` that `select` accepts per-component.

Only the WebGPU exact-sRGB path was affected; default conversions and WebGL2 were unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>