### PR TITLE
fix(core): restore CubeTexture static crash in EnvironmentHelper (pure barrel)

### DIFF
--- a/packages/dev/core/src/Helpers/environmentHelper.ts
+++ b/packages/dev/core/src/Helpers/environmentHelper.ts
@@ -9,7 +9,7 @@ import { Mesh } from "../Meshes/mesh.pure";
 import { BaseTexture } from "../Materials/Textures/baseTexture.pure";
 import { Texture } from "../Materials/Textures/texture.pure";
 import { MirrorTexture } from "../Materials/Textures/mirrorTexture.pure";
-import { CubeTexture } from "../Materials/Textures/cubeTexture.pure";
+import { CubeTexture, CubeTextureCreateFromPrefilteredData } from "../Materials/Textures/cubeTexture.pure";
 import { BackgroundMaterial } from "../Materials/Background/backgroundMaterial.pure";
 import { Constants } from "../Engines/constants";
 
@@ -460,7 +460,7 @@ export class EnvironmentHelper {
             return;
         }
 
-        const environmentTexture = CubeTexture.CreateFromPrefilteredData(this._options.environmentTexture, this._scene);
+        const environmentTexture = CubeTextureCreateFromPrefilteredData(this._options.environmentTexture, this._scene);
         this._scene.environmentTexture = environmentTexture;
     }
 

--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.pure.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.pure.ts
@@ -7,7 +7,7 @@ import { Geometry } from "../../Meshes/geometry";
 import { TransformNode } from "../../Meshes/transformNode.pure";
 import { Material } from "../../Materials/material.pure";
 import { MultiMaterial } from "../../Materials/multiMaterial.pure";
-import { CubeTexture } from "../../Materials/Textures/cubeTexture.pure";
+import { CubeTexture, CubeTextureCreateFromPrefilteredData, CubeTextureParse } from "../../Materials/Textures/cubeTexture.pure";
 import { HDRCubeTexture } from "../../Materials/Textures/hdrCubeTexture.pure";
 import { AnimationGroupParse } from "../../Animations/animationGroup.pure";
 import { Light } from "../../Lights/light";
@@ -219,7 +219,7 @@ export const LoadAssetContainer = (
                 scene.environmentTexture = hdrTexture;
             } else {
                 if (typeof parsedData.environmentTexture === "object") {
-                    const environmentTexture = CubeTexture.Parse(parsedData.environmentTexture, scene, rootUrl);
+                    const environmentTexture = CubeTextureParse(parsedData.environmentTexture, scene, rootUrl);
                     scene.environmentTexture = environmentTexture;
                 } else if ((parsedData.environmentTexture as string).endsWith(".env")) {
                     const compressedTexture = new CubeTexture(
@@ -232,7 +232,7 @@ export const LoadAssetContainer = (
                     }
                     scene.environmentTexture = compressedTexture;
                 } else {
-                    const cubeTexture = CubeTexture.CreateFromPrefilteredData(
+                    const cubeTexture = CubeTextureCreateFromPrefilteredData(
                         (parsedData.environmentTexture.match(/https?:\/\//g) ? "" : rootUrl) + parsedData.environmentTexture,
                         scene,
                         parsedData.environmentTextureForcedExtension

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.pure.ts
@@ -14,7 +14,7 @@ import { InputBlock } from "../Input/inputBlock.pure";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { Constants } from "../../../../Engines/constants";
 
-import { CubeTexture } from "../../../Textures/cubeTexture.pure";
+import { CubeTexture, CubeTextureParse } from "../../../Textures/cubeTexture.pure";
 import { Texture } from "../../../Textures/texture.pure";
 import { EngineStore } from "../../../../Engines/engineStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
@@ -627,7 +627,7 @@ export abstract class ReflectionTextureBaseBlock extends NodeMaterialBlock {
         if (serializationObject.texture && !NodeMaterial.IgnoreTexturesAtLoadTime) {
             rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? "" : rootUrl;
             if (serializationObject.texture.isCube) {
-                this.texture = CubeTexture.Parse(serializationObject.texture, scene, rootUrl);
+                this.texture = CubeTextureParse(serializationObject.texture, scene, rootUrl);
             } else {
                 this.texture = Texture.Parse(serializationObject.texture, scene, rootUrl);
             }

--- a/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.pure.ts
@@ -14,7 +14,7 @@ import { InputBlock } from "../Input/inputBlock.pure";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { Constants } from "../../../../Engines/constants";
 
-import { CubeTexture, CubeTextureParse } from "../../../Textures/cubeTexture.pure";
+import { CubeTextureParse, type CubeTexture } from "../../../Textures/cubeTexture.pure";
 import { Texture } from "../../../Textures/texture.pure";
 import { EngineStore } from "../../../../Engines/engineStore";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.pure.ts
@@ -14,7 +14,7 @@ import { type Effect } from "../../../effect.pure";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import { type Scene } from "../../../../scene.pure";
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
-import { CubeTexture } from "../../../Textures/cubeTexture.pure";
+import { CubeTexture, CubeTextureParse } from "../../../Textures/cubeTexture.pure";
 import { Texture } from "../../../Textures/texture.pure";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
@@ -425,7 +425,7 @@ export class RefractionBlock extends NodeMaterialBlock {
         if (serializationObject.texture) {
             rootUrl = serializationObject.texture.url.indexOf("data:") === 0 ? "" : rootUrl;
             if (serializationObject.texture.isCube) {
-                this.texture = CubeTexture.Parse(serializationObject.texture, scene, rootUrl);
+                this.texture = CubeTextureParse(serializationObject.texture, scene, rootUrl);
             } else {
                 this.texture = Texture.Parse(serializationObject.texture, scene, rootUrl);
             }

--- a/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/PBR/refractionBlock.pure.ts
@@ -14,7 +14,7 @@ import { type Effect } from "../../../effect.pure";
 import { editableInPropertyPage, PropertyTypeForEdition } from "../../../../Decorators/nodeDecorator";
 import { type Scene } from "../../../../scene.pure";
 import { NodeMaterialBlock } from "../../nodeMaterialBlock";
-import { CubeTexture, CubeTextureParse } from "../../../Textures/cubeTexture.pure";
+import { CubeTextureParse, type CubeTexture } from "../../../Textures/cubeTexture.pure";
 import { Texture } from "../../../Textures/texture.pure";
 import { NodeMaterialSystemValues } from "../../Enums/nodeMaterialSystemValues";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";


### PR DESCRIPTION
## Problem

Since v9.12, `Scene.createDefaultEnvironment` crashes with:

```
TypeError: CubeTexture.CreateFromPrefilteredData is not a function
  at _EnvironmentHelper._setupEnvironmentTexture
```

`CubeTexture.CreateFromPrefilteredData`, `CreateFromImages` and `Parse` are static methods attached only inside `RegisterCubeTexture()` — the side effect run by the `cubeTexture.ts` wrapper. After the pure-barrel work, several modules import `CubeTexture` from `cubeTexture.pure` (side-effect-free) and called those statics directly, so they were `undefined` at runtime.

## Fix

Use the exported pure functions instead of the dynamically-attached statics:

- `Helpers/environmentHelper.ts` → `CubeTextureCreateFromPrefilteredData`
- `Loading/Plugins/babylonFileLoader.pure.ts` → `CubeTextureParse`, `CubeTextureCreateFromPrefilteredData`
- `Materials/Node/Blocks/PBR/refractionBlock.pure.ts` → `CubeTextureParse`
- `Materials/Node/Blocks/Dual/reflectionTextureBaseBlock.pure.ts` → `CubeTextureParse`

The `CubeTexture` class import is kept where the constructor / type is still used. This also fixes the same latent crash for `.babylon` environment loading and NME refraction/reflection deserialization on the pure path.