### PR TITLE
TC39 prep: Symbol.metadata-based serialization decorator store (no behavior change)

### DIFF
--- a/packages/dev/core/src/Misc/decorators.functions.ts
+++ b/packages/dev/core/src/Misc/decorators.functions.ts
@@ -1,16 +1,68 @@
-const MergedStore = {};
+/**
+ * Internal helpers for reading and writing decorator metadata used by serialization.
+ *
+ * The serialization store is attached to each class constructor via `Symbol.metadata`. The polyfill
+ * required for `Symbol.metadata` lives in `symbolMetadataPolyfill.ts` and is applied at package
+ * entry points.
+ */
 
-const DecoratorInitialStore = {};
+/** @internal */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export const __bjsSerializableKey = "__bjs_serializable__";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const _mergedStoreCache = new WeakMap<object, any>();
+
+function GetMetadataSymbol(): symbol {
+    let metadataSymbol = (Symbol as any).metadata as symbol | undefined;
+    if (!metadataSymbol) {
+        // Defensive idempotent fallback for runtimes (or import orders) where the entry-point polyfill
+        // has not yet run. Matches symbolMetadataPolyfill.ts.
+        metadataSymbol = Symbol("Symbol.metadata");
+        Object.defineProperty(Symbol, "metadata", {
+            configurable: true,
+            writable: true,
+            value: metadataSymbol,
+        });
+    }
+    return metadataSymbol;
+}
+
+// Returns the constructor for the provided decorator/serialization target.
+// Experimental decorators pass a prototype; serialization passes an instance or a constructor.
+function GetConstructor(target: any): any {
+    return typeof target === "function" ? target : target?.constructor;
+}
+
+// Returns (creating if necessary) the metadata object owned by the given constructor.
+// The metadata's prototype mirrors the class hierarchy so merged lookups can walk it.
+function GetOwnMetadata(ctor: any): any {
+    if (!ctor) {
+        return undefined;
+    }
+    if (!Object.prototype.hasOwnProperty.call(ctor, GetMetadataSymbol())) {
+        const parent = Object.getPrototypeOf(ctor);
+        const parentMetadata = parent ? parent[GetMetadataSymbol()] : null;
+        Object.defineProperty(ctor, GetMetadataSymbol(), {
+            value: Object.create(parentMetadata ?? null),
+            configurable: true,
+            writable: true,
+            enumerable: false,
+        });
+    }
+    return ctor[GetMetadataSymbol()];
+}
 
 /** @internal */
 export function GetDirectStore(target: any): any {
-    const classKey = target.getClassName();
-
-    if (!(<any>DecoratorInitialStore)[classKey]) {
-        (<any>DecoratorInitialStore)[classKey] = {};
+    const metadata = GetOwnMetadata(GetConstructor(target));
+    if (!metadata) {
+        return {};
     }
-
-    return (<any>DecoratorInitialStore)[classKey];
+    if (!Object.prototype.hasOwnProperty.call(metadata, __bjsSerializableKey)) {
+        metadata[__bjsSerializableKey] = {};
+    }
+    return metadata[__bjsSerializableKey];
 }
 
 /**
@@ -18,47 +70,35 @@ export function GetDirectStore(target: any): any {
  * @param target host object
  */
 export function GetMergedStore(target: any): any {
-    const classKey = target.getClassName();
-
-    if ((<any>MergedStore)[classKey]) {
-        return (<any>MergedStore)[classKey];
+    const ctor = GetConstructor(target);
+    const metadata = ctor ? ctor[GetMetadataSymbol()] : undefined;
+    if (!metadata) {
+        return {};
     }
 
-    (<any>MergedStore)[classKey] = {};
-
-    const store = (<any>MergedStore)[classKey];
-    let currentTarget = target;
-    let currentKey = classKey;
-    while (currentKey) {
-        const initialStore = (<any>DecoratorInitialStore)[currentKey];
-        for (const property in initialStore) {
-            store[property] = initialStore[property];
-        }
-
-        let parent: any;
-        let done = false;
-
-        do {
-            parent = Object.getPrototypeOf(currentTarget);
-            if (!parent.getClassName) {
-                done = true;
-                break;
-            }
-
-            if (parent.getClassName() !== currentKey) {
-                break;
-            }
-
-            currentTarget = parent;
-        } while (parent);
-
-        if (done) {
-            break;
-        }
-
-        currentKey = parent.getClassName();
-        currentTarget = parent;
+    const cached = _mergedStoreCache.get(metadata);
+    if (cached) {
+        return cached;
     }
 
+    const store: any = {};
+    // Walk the metadata prototype chain (most derived first); parents overwrite children to match the
+    // original class-name-keyed merge order.
+    const chain: any[] = [];
+    let current: any = metadata;
+    while (current) {
+        chain.push(current);
+        current = Object.getPrototypeOf(current);
+    }
+    for (const meta of chain) {
+        if (Object.prototype.hasOwnProperty.call(meta, __bjsSerializableKey)) {
+            const initialStore = meta[__bjsSerializableKey];
+            for (const property in initialStore) {
+                store[property] = initialStore[property];
+            }
+        }
+    }
+
+    _mergedStoreCache.set(metadata, store);
     return store;
 }

--- a/packages/dev/core/src/Misc/decorators.functions.ts
+++ b/packages/dev/core/src/Misc/decorators.functions.ts
@@ -6,9 +6,8 @@
  * entry points.
  */
 
-/** @internal */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const __bjsSerializableKey = "__bjs_serializable__";
+const __bjsSerializableKey = "__bjs_serializable__";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _mergedStoreCache = new WeakMap<object, any>();

--- a/packages/dev/core/src/Misc/decorators.functions.ts
+++ b/packages/dev/core/src/Misc/decorators.functions.ts
@@ -12,6 +12,14 @@ const __bjsSerializableKey = "__bjs_serializable__";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const _mergedStoreCache = new WeakMap<object, any>();
 
+// Universal `Object.hasOwn` equivalent. We intentionally avoid the native `Object.hasOwn` (ES2022)
+// because TypeScript does not down-level runtime APIs and some Babylon Native engines (e.g. ChakraCore)
+// do not provide it. `Object.prototype.hasOwnProperty` exists on every engine, and routing through it
+// here also stays safe for the null-prototype metadata objects created below.
+function HasOwn(target: object, key: PropertyKey): boolean {
+    return Object.prototype.hasOwnProperty.call(target, key);
+}
+
 function GetMetadataSymbol(): symbol {
     let metadataSymbol = (Symbol as any).metadata as symbol | undefined;
     if (!metadataSymbol) {
@@ -39,7 +47,7 @@ function GetOwnMetadata(ctor: any): any {
     if (!ctor) {
         return undefined;
     }
-    if (!Object.prototype.hasOwnProperty.call(ctor, GetMetadataSymbol())) {
+    if (!HasOwn(ctor, GetMetadataSymbol())) {
         const parent = Object.getPrototypeOf(ctor);
         const parentMetadata = parent ? parent[GetMetadataSymbol()] : null;
         Object.defineProperty(ctor, GetMetadataSymbol(), {
@@ -58,7 +66,7 @@ export function GetDirectStore(target: any): any {
     if (!metadata) {
         return {};
     }
-    if (!Object.prototype.hasOwnProperty.call(metadata, __bjsSerializableKey)) {
+    if (!HasOwn(metadata, __bjsSerializableKey)) {
         metadata[__bjsSerializableKey] = {};
     }
     return metadata[__bjsSerializableKey];
@@ -90,7 +98,7 @@ export function GetMergedStore(target: any): any {
         current = Object.getPrototypeOf(current);
     }
     for (const meta of chain) {
-        if (Object.prototype.hasOwnProperty.call(meta, __bjsSerializableKey)) {
+        if (HasOwn(meta, __bjsSerializableKey)) {
             const initialStore = meta[__bjsSerializableKey];
             for (const property in initialStore) {
                 store[property] = initialStore[property];

--- a/packages/dev/core/src/Misc/symbolMetadataPolyfill.ts
+++ b/packages/dev/core/src/Misc/symbolMetadataPolyfill.ts
@@ -1,0 +1,21 @@
+/**
+ * Ensures the global `Symbol.metadata` well-known symbol exists.
+ *
+ * The serialization decorator store keys its metadata off `Symbol.metadata`. On a runtime that
+ * supports `Symbol` but does not yet expose `Symbol.metadata` natively, the symbol must be created
+ * so decorated classes can attach their serialization metadata to their constructor.
+ *
+ * This module installs the symbol as a one-time, idempotent side effect. Import it for its side
+ * effect at package entry points before any decorated class is evaluated.
+ */
+function ApplySymbolMetadataPolyfill(): void {
+    if (typeof Symbol !== "undefined" && !(Symbol as any).metadata) {
+        Object.defineProperty(Symbol, "metadata", {
+            configurable: true,
+            writable: true,
+            value: Symbol("Symbol.metadata"),
+        });
+    }
+}
+
+ApplySymbolMetadataPolyfill();

--- a/packages/dev/core/src/index.ts
+++ b/packages/dev/core/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
+import "./Misc/symbolMetadataPolyfill";
 export * from "./Actions/index";
 export * from "./Animations/index";
 export * from "./assetContainer";

--- a/packages/public/@babylonjs/core/package.json
+++ b/packages/public/@babylonjs/core/package.json
@@ -562,6 +562,7 @@
         "Misc/observable.extensions.js",
         "Misc/observableCoroutine.js",
         "Misc/screenshotTools.js",
+        "Misc/symbolMetadataPolyfill.js",
         "Misc/tools.js",
         "Offline/database.js",
         "Particles/Node/Blocks/Conditions/particleConditionBlock.js",

--- a/scripts/treeshaking/side-effects-manifest/core/Misc.json
+++ b/scripts/treeshaking/side-effects-manifest/core/Misc.json
@@ -14,6 +14,7 @@
         "Misc/observableCoroutine.ts": ["top-level-call"],
         "Misc/observableCoroutine.types.ts": ["declare-module"],
         "Misc/screenshotTools.ts": ["top-level-call"],
+        "Misc/symbolMetadataPolyfill.ts": ["top-level-call"],
         "Misc/tools.ts": ["top-level-call"]
     }
 }


### PR DESCRIPTION
## Summary

PR1 of the multi-PR effort to migrate Babylon.js to TC39 Stage 3 decorators. **Infrastructure only — no runtime behavior change.**

This PR swaps the serialization decorator metadata **store** from class-name-keyed global maps to per-constructor `Symbol.metadata`, while **keeping `experimentalDecorators: true`** in tsconfig. Serialization output and all unit tests are unchanged.

## What changed

- **`packages/dev/core/src/Misc/decorators.functions.ts`** — `GetDirectStore`/`GetMergedStore` now read/write the store on each class constructor's own `Symbol.metadata` instead of the `DecoratorInitialStore`/`MergedStore` class-name-keyed maps.
  - Experimental decorators call with `(prototype, propertyKey)`, so the store is attached to `prototype.constructor[Symbol.metadata]`.
  - Each constructor gets its **own** metadata object whose prototype mirrors the class hierarchy (`Object.create(parentMetadata)`), so `GetMergedStore` can walk the metadata prototype chain.
  - Merge order is preserved (most-derived first, parents overwrite) to match the original class-name-keyed merge.
  - Merged store is memoized via a `WeakMap` keyed on the metadata object.
  - **Public signatures of `GetDirectStore`/`GetMergedStore` are unchanged**, so all serialization consumers compile untouched.
- **`packages/dev/core/src/Misc/symbolMetadataPolyfill.ts`** (new) — idempotently defines `Symbol.metadata` as a one-time side effect. `decorators.functions.ts` also self-heals defensively for import orders/runtimes where the entry-point polyfill hasn't run yet.
- **`packages/dev/core/src/index.ts`** — imports the polyfill for side effect as the first statement, before any decorated class is evaluated.
- Tree-shaking manifest + `@babylonjs/core` `sideEffects` regenerated to record the polyfill's top-level side effect.

## Out of scope (later PRs)
No call-site changes, no `accessor` keyword, no `experimentalDecorators` flip, no UMD target changes.

## Validation
- `npm run format:check` ✅
- `npm run lint:check` (eslint + typecheck + `check:treeshaking` all-packages + `check:side-effects-sync`) ✅ — all 16 checks pass
- `npm run test:unit` ✅ — 4062 passed, 1 expected fail, 60 skipped. Serialization tests (core + gui) pass. (The 10 `EnvironmentTeardownError` rejections are pre-existing lazy-shader teardown flakiness, unrelated to this change.)

🤖 Generated with Copilot CLI