### PR TITLE
Fix the issue where the texture uploading for gltf files via inspector-v2 does not work properly.

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/materials/pbrBaseMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/pbrBaseMaterialProperties.tsx
@@ -160,6 +160,15 @@ export const PBRBaseMaterialChannelsProperties: FunctionComponent<{ material: PB
     const scene = material.getScene();
 
     const selectEntity = (entity: object) => (selectionService.selectedEntity = entity);
+    const useGltfMetallicRoughnessChannels = (texture: typeof material._metallicTexture) => {
+        if (texture) {
+            material._useRoughnessFromMetallicTextureAlpha = false;
+            material._useRoughnessFromMetallicTextureGreen = true;
+            material._useMetallnessFromMetallicTextureBlue = true;
+        }
+
+        return texture;
+    };
 
     return (
         <>
@@ -202,6 +211,7 @@ export const PBRBaseMaterialChannelsProperties: FunctionComponent<{ material: PB
                 onLink={selectEntity}
                 defaultValue={null}
                 material={material}
+                convertFrom={useGltfMetallicRoughnessChannels}
             />
             <BoundProperty
                 component={MaterialTextureDebugPropertyLine}


### PR DESCRIPTION
The reason is that the PBR material does not utilize the Blue and Green channels.