### PR TITLE
Normalize diagonal keyboard movement for Free, Fly, and ArcRotate cameras

### DIFF
--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
@@ -8,6 +8,7 @@ import { type KeyboardInfo, KeyboardEventTypes } from "../../Events/keyboardEven
 import { Tools } from "../../Misc/tools.pure";
 import { type AbstractEngine } from "../../Engines/abstractEngine";
 import { type KeyboardConditions } from "../inputMapper";
+import { Vector2 } from "../../Maths/math.vector.pure";
 
 /**
  * Manage the keyboard inputs to control the movement of an arc rotate camera.
@@ -139,6 +140,10 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
     /** Cached conditions object to avoid per-frame allocations in checkInputs */
     private _keyboardConditions: KeyboardConditions = { modifiers: this._keyboardModifiers };
 
+    /** Reused accumulators for the per-frame keyboard rotate/pan directions, to avoid per-frame allocations */
+    private _rotateDirection = new Vector2();
+    private _panDirection = new Vector2();
+
     /**
      * Attach the input controls to a specific dom element to get the input from.
      * @param noPreventDefault Defines whether event caught by the controls should call preventdefault() (https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault)
@@ -245,6 +250,15 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
             this._keyboardModifiers.ctrl = this._ctrlPressed;
             this._keyboardModifiers.alt = this._altPressed;
 
+            // Rotate and pan directions are accumulated across keys and applied once below (normalized), so
+            // holding two directions at once (e.g. up + left) moves along a normalized diagonal at the same
+            // speed as a single direction, instead of the ~1.41x boost (sqrt(2)) that results from applying
+            // each key independently. Zoom is one-dimensional and is applied per key.
+            const rotateDirection = this._rotateDirection.set(0, 0);
+            const panDirection = this._panDirection.set(0, 0);
+            let rotateSensitivity = 0;
+            let panSensitivity = 0;
+
             for (let index = 0; index < this._keys.length; index++) {
                 const keyCode = this._keys[index];
 
@@ -261,15 +275,16 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
                         // legacy sensibility/angularSpeed properties over time). When `sensitivity` is
                         // undefined, fall back to the legacy properties for backward compatibility.
                         if (resolved.interaction === "pan") {
-                            const panSens = resolved.sensitivity ?? 1 / this.panningSensibility;
+                            // Accumulate a unit direction per pan key; the combined vector is normalized after the loop.
+                            panSensitivity = resolved.sensitivity ?? 1 / this.panningSensibility;
                             if (this.keysLeft.indexOf(keyCode) !== -1) {
-                                input.handlers.pan(-panSens, 0);
+                                panDirection.x -= 1;
                             } else if (this.keysRight.indexOf(keyCode) !== -1) {
-                                input.handlers.pan(panSens, 0);
+                                panDirection.x += 1;
                             } else if (this.keysUp.indexOf(keyCode) !== -1) {
-                                input.handlers.pan(0, panSens);
+                                panDirection.y += 1;
                             } else if (this.keysDown.indexOf(keyCode) !== -1) {
-                                input.handlers.pan(0, -panSens);
+                                panDirection.y -= 1;
                             }
                         } else if (resolved.interaction === "zoom") {
                             const zoomSens = resolved.sensitivity ?? 1 / this.zoomingSensibility;
@@ -279,15 +294,16 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
                                 input.handlers.zoom(-zoomSens);
                             }
                         } else if (resolved.interaction === "rotate") {
-                            const rotateSens = resolved.sensitivity ?? this.angularSpeed;
+                            // Accumulate a unit direction per rotate key; the combined vector is normalized after the loop.
+                            rotateSensitivity = resolved.sensitivity ?? this.angularSpeed;
                             if (this.keysLeft.indexOf(keyCode) !== -1) {
-                                input.handlers.rotate(-rotateSens, 0);
+                                rotateDirection.x -= 1;
                             } else if (this.keysRight.indexOf(keyCode) !== -1) {
-                                input.handlers.rotate(rotateSens, 0);
+                                rotateDirection.x += 1;
                             } else if (this.keysUp.indexOf(keyCode) !== -1) {
-                                input.handlers.rotate(0, -rotateSens);
+                                rotateDirection.y -= 1;
                             } else if (this.keysDown.indexOf(keyCode) !== -1) {
-                                input.handlers.rotate(0, rotateSens);
+                                rotateDirection.y += 1;
                             }
                         }
                     }
@@ -298,6 +314,16 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
                         camera.restoreState();
                     }
                 }
+            }
+
+            // Apply the accumulated rotate/pan once, normalized so a diagonal isn't faster than an axis-aligned move.
+            if (rotateDirection.x !== 0 || rotateDirection.y !== 0) {
+                rotateDirection.normalize().scaleInPlace(rotateSensitivity);
+                input.handlers.rotate(rotateDirection.x, rotateDirection.y);
+            }
+            if (panDirection.x !== 0 || panDirection.y !== 0) {
+                panDirection.normalize().scaleInPlace(panSensitivity);
+                input.handlers.pan(panDirection.x, panDirection.y);
             }
         }
     }

--- a/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/arcRotateCameraKeyboardMoveInput.ts
@@ -276,7 +276,9 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
                         // undefined, fall back to the legacy properties for backward compatibility.
                         if (resolved.interaction === "pan") {
                             // Accumulate a unit direction per pan key; the combined vector is normalized after the loop.
-                            panSensitivity = resolved.sensitivity ?? 1 / this.panningSensibility;
+                            // Aggregate sensitivity with max so the pan speed is independent of key insertion order
+                            // when keys resolve to different per-key sensitivities.
+                            panSensitivity = Math.max(panSensitivity, resolved.sensitivity ?? 1 / this.panningSensibility);
                             if (this.keysLeft.indexOf(keyCode) !== -1) {
                                 panDirection.x -= 1;
                             } else if (this.keysRight.indexOf(keyCode) !== -1) {
@@ -295,7 +297,9 @@ export class ArcRotateCameraKeyboardMoveInput implements ICameraInput<ArcRotateC
                             }
                         } else if (resolved.interaction === "rotate") {
                             // Accumulate a unit direction per rotate key; the combined vector is normalized after the loop.
-                            rotateSensitivity = resolved.sensitivity ?? this.angularSpeed;
+                            // Aggregate sensitivity with max so the rotate speed is independent of key insertion order
+                            // when keys resolve to different per-key sensitivities.
+                            rotateSensitivity = Math.max(rotateSensitivity, resolved.sensitivity ?? this.angularSpeed);
                             if (this.keysLeft.indexOf(keyCode) !== -1) {
                                 rotateDirection.x -= 1;
                             } else if (this.keysRight.indexOf(keyCode) !== -1) {

--- a/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/flyCameraKeyboardInput.ts
@@ -177,31 +177,44 @@ export class FlyCameraKeyboardInput implements ICameraInput<FlyCamera> {
                 return;
             }
             const translateGain = translateEntry.sensitivity ?? 1;
+
+            // Movement keys are accumulated into a single local direction and applied once below, so that
+            // holding two directions at once (e.g. forward + left) moves along a normalized diagonal at the
+            // same speed as a single direction, instead of the ~1.41x boost (sqrt(2)) that results from
+            // applying each movement key independently.
+            const localDirection = camera._localDirection.copyFromFloats(0, 0, 0);
+
             // Keyboard
             for (let index = 0; index < this._keys.length; index++) {
                 const keyCode = this._keys[index];
-                const speed = camera._computeLocalCameraSpeed() * translateGain;
 
                 if (this.keysForward.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, speed);
+                    localDirection.z += 1;
                 } else if (this.keysBackward.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, -speed);
+                    localDirection.z -= 1;
                 } else if (this.keysUp.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, speed, 0);
+                    localDirection.y += 1;
                 } else if (this.keysDown.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, -speed, 0);
+                    localDirection.y -= 1;
                 } else if (this.keysRight.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(speed, 0, 0);
+                    localDirection.x += 1;
                 } else if (this.keysLeft.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(-speed, 0, 0);
+                    localDirection.x -= 1;
                 }
+            }
+
+            // Apply a single, normalized movement once all keys for this frame have been accumulated.
+            if (localDirection.x !== 0 || localDirection.y !== 0 || localDirection.z !== 0) {
+                const speed = camera._computeLocalCameraSpeed() * translateGain;
+                // Normalize so a diagonal isn't faster than an axis-aligned move, then scale to the per-frame speed.
+                localDirection.normalize().scaleInPlace(speed);
 
                 if (camera.getScene().useRightHandedSystem) {
-                    camera._localDirection.z *= -1;
+                    localDirection.z *= -1;
                 }
 
                 camera.getViewMatrix().invertToRef(camera._cameraTransformMatrix);
-                Vector3.TransformNormalToRef(camera._localDirection, camera._cameraTransformMatrix, camera._transformedDirection);
+                Vector3.TransformNormalToRef(localDirection, camera._cameraTransformMatrix, camera._transformedDirection);
                 camera.cameraDirection.addInPlace(camera._transformedDirection);
             }
         }

--- a/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
+++ b/packages/dev/core/src/Cameras/Inputs/freeCameraKeyboardMoveInput.ts
@@ -190,57 +190,62 @@ export class FreeCameraKeyboardMoveInput implements ICameraInput<FreeCamera> {
             const translateEntry = input.getEntry("keyboard", "translate");
             const rotateEntry = input.getEntry("keyboard", "rotate");
             const rotateGain = rotateEntry?.sensitivity ?? 1;
+
+            // Movement keys are accumulated into a single local direction and applied once below, so that
+            // holding two directions at once (e.g. forward + left) moves along a normalized diagonal at the
+            // same speed as a single direction, instead of the ~1.41x boost (sqrt(2)) that results from
+            // applying each movement key independently. Rotation keys act on separate angular axes and are
+            // applied directly as before.
+            const localDirection = camera._localDirection.copyFromFloats(0, 0, 0);
+
             // Keyboard
             for (let index = 0; index < this._keys.length; index++) {
                 const keyCode = this._keys[index];
-                const speed = camera._computeLocalCameraSpeed() * (translateEntry?.sensitivity ?? 1);
 
                 if (this.keysLeft.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(-speed, 0, 0);
+                    localDirection.x -= 1;
                 } else if (this.keysUp.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, speed);
+                    localDirection.z += 1;
                 } else if (this.keysRight.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(speed, 0, 0);
+                    localDirection.x += 1;
                 } else if (this.keysDown.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, -speed);
+                    localDirection.z -= 1;
                 } else if (this.keysUpward.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, speed, 0);
+                    localDirection.y += 1;
                 } else if (this.keysDownward.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, -speed, 0);
+                    localDirection.y -= 1;
                 } else if (this.keysRotateLeft.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, 0);
                     if (rotateEntry) {
                         camera.cameraRotation.y -= this._getLocalRotation() * rotateGain;
                     }
                 } else if (this.keysRotateRight.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, 0);
                     if (rotateEntry) {
                         camera.cameraRotation.y += this._getLocalRotation() * rotateGain;
                     }
                 } else if (this.keysRotateUp.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, 0);
                     if (rotateEntry) {
                         camera.cameraRotation.x -= this._getLocalRotation() * rotateGain;
                     }
                 } else if (this.keysRotateDown.indexOf(keyCode) !== -1) {
-                    camera._localDirection.copyFromFloats(0, 0, 0);
                     if (rotateEntry) {
                         camera.cameraRotation.x += this._getLocalRotation() * rotateGain;
                     }
                 }
+            }
 
-                // Suppress accumulated translation when the keyboard→translate mapping is removed.
-                // Rotation keys already zeroed `_localDirection`, so this is a no-op for them.
-                if (!translateEntry) {
-                    camera._localDirection.copyFromFloats(0, 0, 0);
-                }
+            // Apply a single, normalized movement once all keys for this frame have been accumulated.
+            // Translation is suppressed when the keyboard→translate mapping is removed.
+            if (translateEntry && (localDirection.x !== 0 || localDirection.y !== 0 || localDirection.z !== 0)) {
+                const speed = camera._computeLocalCameraSpeed() * (translateEntry.sensitivity ?? 1);
+                // Normalize so a diagonal isn't faster than an axis-aligned move, then scale to the per-frame speed.
+                localDirection.normalize().scaleInPlace(speed);
 
                 if (camera.getScene().useRightHandedSystem) {
-                    camera._localDirection.z *= -1;
+                    localDirection.z *= -1;
                 }
 
                 camera.getViewMatrix().invertToRef(camera._cameraTransformMatrix);
-                Vector3.TransformNormalToRef(camera._localDirection, camera._cameraTransformMatrix, camera._transformedDirection);
+                Vector3.TransformNormalToRef(localDirection, camera._cameraTransformMatrix, camera._transformedDirection);
                 camera.cameraDirection.addInPlace(camera._transformedDirection);
             }
         }

--- a/packages/dev/core/test/unit/Cameras/arcRotateCameraMovement.test.ts
+++ b/packages/dev/core/test/unit/Cameras/arcRotateCameraMovement.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ArcRotateCamera } from "core/Cameras/arcRotateCamera";
+import { KeyboardEventTypes } from "core/Events/keyboardEvents";
 import { Vector3 } from "core/Maths/math.vector";
 import { NullEngine } from "core/Engines/nullEngine";
 import { Scene } from "core/scene";
@@ -25,6 +26,59 @@ describe("ArcRotateCameraMovement", () => {
     afterEach(() => {
         scene?.dispose();
         engine?.dispose();
+    });
+
+    const pressKey = (keyCode: number, modifiers: { ctrl?: boolean; alt?: boolean } = {}) => {
+        scene!.onKeyboardObservable.notifyObservers({
+            type: KeyboardEventTypes.KEYDOWN,
+            event: { keyCode, metaKey: false, ctrlKey: !!modifiers.ctrl, altKey: !!modifiers.alt, preventDefault: () => {} },
+        } as any);
+    };
+
+    describe("diagonal keyboard movement normalization", () => {
+        it("rotation: a two-axis diagonal rotates at the same speed as a single axis (no sqrt(2) boost)", () => {
+            camera.attachControl();
+            const keyboard = camera.inputs.attached["keyboard"] as any;
+
+            pressKey(37); // left
+            keyboard.checkInputs();
+            const single = camera.movement.rotationAccumulatedPixels;
+            const singleMag = Math.hypot(single.x, single.y);
+
+            camera.movement.rotationAccumulatedPixels.set(0, 0, 0);
+            keyboard._keys.length = 0;
+
+            pressKey(37); // left
+            pressKey(38); // up
+            keyboard.checkInputs();
+            const diagonal = camera.movement.rotationAccumulatedPixels;
+            const diagonalMag = Math.hypot(diagonal.x, diagonal.y);
+
+            expect(singleMag).toBeGreaterThan(0);
+            expect(diagonalMag).toBeCloseTo(singleMag, 5);
+        });
+
+        it("pan: a two-axis diagonal pans at the same speed as a single axis (no sqrt(2) boost)", () => {
+            camera.attachControl();
+            const keyboard = camera.inputs.attached["keyboard"] as any;
+
+            pressKey(37, { ctrl: true }); // ctrl+left -> pan
+            keyboard.checkInputs();
+            const single = camera.movement.panAccumulatedPixels;
+            const singleMag = Math.hypot(single.x, single.y);
+
+            camera.movement.panAccumulatedPixels.set(0, 0, 0);
+            keyboard._keys.length = 0;
+
+            pressKey(37, { ctrl: true }); // ctrl+left -> pan
+            pressKey(38, { ctrl: true }); // ctrl+up -> pan
+            keyboard.checkInputs();
+            const diagonal = camera.movement.panAccumulatedPixels;
+            const diagonalMag = Math.hypot(diagonal.x, diagonal.y);
+
+            expect(singleMag).toBeGreaterThan(0);
+            expect(diagonalMag).toBeCloseTo(singleMag, 5);
+        });
     });
 
     describe("always-on movement", () => {

--- a/packages/dev/core/test/unit/Cameras/freeCameraInputMapping.test.ts
+++ b/packages/dev/core/test/unit/Cameras/freeCameraInputMapping.test.ts
@@ -132,6 +132,46 @@ describe("FreeCamera/FlyCamera input map wiring", () => {
         });
     });
 
+    describe("diagonal movement normalization", () => {
+        it("FreeCamera: a two-axis diagonal moves at the same speed as a single axis (no sqrt(2) boost)", () => {
+            const single = new FreeCamera("single", new Vector3(0, 0, 0), scene!);
+            single.attachControl();
+            pressKey(38); // forward
+            single._checkInputs();
+            const singleDist = single.position.length();
+            single.detachControl();
+
+            const diagonal = new FreeCamera("diagonal", new Vector3(0, 0, 0), scene!);
+            diagonal.attachControl();
+            pressKey(38); // forward
+            pressKey(37); // left strafe
+            diagonal._checkInputs();
+            const diagonalDist = diagonal.position.length();
+
+            expect(singleDist).toBeGreaterThan(0);
+            expect(diagonalDist).toBeCloseTo(singleDist, 5);
+        });
+
+        it("FlyCamera: a two-axis diagonal moves at the same speed as a single axis (no sqrt(2) boost)", () => {
+            const single = new FlyCamera("single", new Vector3(0, 0, 0), scene!);
+            single.attachControl();
+            pressKey(87); // forward
+            single._checkInputs();
+            const singleDist = single.position.length();
+            single.detachControl();
+
+            const diagonal = new FlyCamera("diagonal", new Vector3(0, 0, 0), scene!);
+            diagonal.attachControl();
+            pressKey(87); // forward
+            pressKey(65); // left strafe
+            diagonal._checkInputs();
+            const diagonalDist = diagonal.position.length();
+
+            expect(singleDist).toBeGreaterThan(0);
+            expect(diagonalDist).toBeCloseTo(singleDist, 5);
+        });
+    });
+
     describe("FreeCameraTouchInput", () => {
         const dragOneFinger = (input: FreeCameraTouchInput, dx: number, dy: number) => {
             const down = new PointerInfo(


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Holding two perpendicular movement keys applied each key's full impulse independently, making diagonal keyboard movement ~1.41x (√2) faster than a single axis. This PR accumulates the per-frame direction across pressed keys and normalizes it before applying, matching the existing `GeospatialCamera` keyboard fix.

**Cameras fixed:**
- `FreeCamera` — translation (WASD/arrows)
- `FlyCamera` — translation
- `ArcRotateCamera` — rotate and pan

`FreeCamera` rotation keys and `ArcRotateCamera` zoom remain per-key (1D axes, unaffected).

**Motivation:** Reported on the forum — [Moving camera diagonally (keyboard) is ~40% faster](https://forum.babylonjs.com/t/moving-camera-diagonally-keyboard-its-40-faster/63704/2).

**Tests:** Added unit tests asserting diagonal movement distance ≈ single-axis distance for all affected cameras.
