### PR TITLE
chore: npm audit fix lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5330,9 +5330,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5613,9 +5613,9 @@
             }
         },
         "node_modules/@nx/nx-darwin-arm64": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.5.tgz",
-            "integrity": "sha512-eoPtwx0qZqvRUD+VVOHm150AlSYwYoPxkDHBBGqKCn5nzPspb0lLWw8q83crM/L1M928YgK0WmGf3C++7eqsTA==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.6.tgz",
+            "integrity": "sha512-FBKG9Tqrl8H0A4oIekVTJNNq+tRMrkyF0fLBV4Cpi9Hm1ejA8dl5gpEG/o5V7MwiClVddDwtXp1ymdCa2qSoyg==",
             "cpu": [
                 "arm64"
             ],
@@ -5627,9 +5627,9 @@
             ]
         },
         "node_modules/@nx/nx-darwin-x64": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.5.tgz",
-            "integrity": "sha512-VLOn/ZoEn3HfjSj+yIHLCM56/el79r+9I28CkZNHaSXJQWZ3edSkcgcfYjVxCurpN2VEwDQHLBeFCH8M+lQ7wQ==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.6.tgz",
+            "integrity": "sha512-IpXL2NYYBDj9k+7u6jEdKpWOqPGZNBpGcW+LyY3l5qoyaa0lq3gzZrDNae9XP2dmGwnUn1kD9OTgq9kmkcK3Bg==",
             "cpu": [
                 "x64"
             ],
@@ -5641,9 +5641,9 @@
             ]
         },
         "node_modules/@nx/nx-freebsd-x64": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.5.tgz",
-            "integrity": "sha512-LEVer/E2xfGvK9Go+imMQoEninOoq/38Z2bhV1SD3AThXrp1xaLFVkW5jQ6juebeVkAeztEoMLFlr576egS0vw==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.6.tgz",
+            "integrity": "sha512-1QVXcfu0FiVyfd6GLBKIWNuGtPh/Pbjhwyhucc/kI2EgV1f+Sl6kePDp2pI8PQ00HKVLy/NqAwgcx05YyGtYYg==",
             "cpu": [
                 "x64"
             ],
@@ -5655,9 +5655,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-arm-gnueabihf": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.5.tgz",
-            "integrity": "sha512-NP27EFGpmFJM6RL1Ey/AFJ7gA2xuqtIHaw6jjSNGvfrnZRUNaway30GrVaGGeODf0DsvAty/unqoBMPy6kDHbw==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.6.tgz",
+            "integrity": "sha512-YD6vjl39oxtR8kxxq9Ow/bFahb61M1soVMPz7dEhV3weM3/h3yRLdcscibvayIJ5nBFLxlYpXHG/n9qWxon8tw==",
             "cpu": [
                 "arm"
             ],
@@ -5669,9 +5669,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-arm64-gnu": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.5.tgz",
-            "integrity": "sha512-QLnkJl3HkHsPfpLiNiAiMfpfAeFpic0U1diAxF8RqChOkCpQ7ulvyBVgE1UrQxvhd+gFQ3ed5RNDxtCRw8nTiw==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.6.tgz",
+            "integrity": "sha512-kMIpH8KvNUsbekkbcWGI+h3FnVOr+jL6cHv7r8Mvh1SusQzgxYcxE8iy0mPXcdbkfF5eaU9RcLB+uIKTyt8OmQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5683,9 +5683,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-arm64-musl": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.5.tgz",
-            "integrity": "sha512-cEP6KmwBgnb38+jTTaibWCjwXcHmigqhTfy0tN1be7WZr6bHxbqNLsXqKRN70PSNA3HouZcxw1cdRL8tqbPBBA==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.6.tgz",
+            "integrity": "sha512-FsRoirT/wx7vdGl7fvkssyBvzu/JoZYYosBPDycaPg5LxSb2lPrvzcCcqG3c++jtSOn/IbbjGBA1bi8ApQ/Ulw==",
             "cpu": [
                 "arm64"
             ],
@@ -5697,9 +5697,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-x64-gnu": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.5.tgz",
-            "integrity": "sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.6.tgz",
+            "integrity": "sha512-SA1nPymYHgi2NP2ra9r1hrSc+6jTR5xPTzjUhzNFXAColvgUO/aP0Gn+dXhwOtzzau8fKVc3K1qaHi+kIHT54g==",
             "cpu": [
                 "x64"
             ],
@@ -5711,9 +5711,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-x64-musl": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.5.tgz",
-            "integrity": "sha512-H0M7csOZIgPT822LqjxSXzf4MXRND15vIkAQe3F3Jlr3Si8LC3tzbL52aVcRfgb8MF/xOB5U47mSwxWt1M2bPQ==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.6.tgz",
+            "integrity": "sha512-Aeol4pSRuMuAEC16Se+WS+Xar8W6pymCDmRaIWNLhbDG/+JQqvvuW1izrMLD9DY1Vpn+acN3bHLvdHhTux/DZw==",
             "cpu": [
                 "x64"
             ],
@@ -5725,9 +5725,9 @@
             ]
         },
         "node_modules/@nx/nx-win32-arm64-msvc": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.5.tgz",
-            "integrity": "sha512-JTcZch9YAnDL1gbhqePz3DZ4x7iYemLn1yJzrjbbXAmXju2eiiJiZvJJHbV06+SP9HKXDT8RjTKuAWTdVxnHug==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.6.tgz",
+            "integrity": "sha512-iNdxFfvkePnAYRhKyEEVfskiiL2QdiALeeZG+STh+rfD15cUO2YiQU+iQzgpzqmi9J2QjhGykIdFA6E/8v09lg==",
             "cpu": [
                 "arm64"
             ],
@@ -5739,9 +5739,9 @@
             ]
         },
         "node_modules/@nx/nx-win32-x64-msvc": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.5.tgz",
-            "integrity": "sha512-ngcMyHdBJ9FSz2nHdbZ7gtJlFq0O2b05sPAsVMkZ18CKzdaA1qrBDJfsMO49hPCny505eiT766+CkKdaCDl5kA==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.6.tgz",
+            "integrity": "sha512-thikDrOhCbUdzx5fQcpM34qZ7LV5RiszoNVG4m4TS3wAvx2bl+/qnVL6F6PwMlS6B/RVv6TqPhTuGHT7sjEGTA==",
             "cpu": [
                 "x64"
             ],
@@ -12075,17 +12075,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -12550,9 +12550,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -14934,9 +14934,9 @@
             }
         },
         "node_modules/nx": {
-            "version": "22.7.5",
-            "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.5.tgz",
-            "integrity": "sha512-zoxsJabb33jl1QYnalDn0bicryrEBgSzdKp90d7VGGv/jDgzKrcLg/hw2ZxeYiOjWPIT/o8QNT9G9vTs4dv3AQ==",
+            "version": "22.7.6",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.6.tgz",
+            "integrity": "sha512-cT2iX6NAtuNT/yaMTtwpIuNQBrW2Zhg4X8zdTEo/h27bz/JYnFm7B9MAKbAXNWK6k0Yxz+jv7zJoMBHutd1Dww==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -14988,7 +14988,7 @@
                 "figures": "3.2.0",
                 "flat": "5.0.2",
                 "follow-redirects": "1.16.0",
-                "form-data": "4.0.5",
+                "form-data": "4.0.6",
                 "fs-constants": "1.0.0",
                 "function-bind": "1.1.2",
                 "get-caller-file": "2.0.5",
@@ -14998,7 +14998,7 @@
                 "has-flag": "4.0.0",
                 "has-symbols": "1.1.0",
                 "has-tostringtag": "1.0.2",
-                "hasown": "2.0.2",
+                "hasown": "2.0.4",
                 "ieee754": "1.2.1",
                 "ignore": "7.0.5",
                 "inherits": "2.0.4",
@@ -15039,7 +15039,7 @@
                 "strip-bom": "3.0.0",
                 "supports-color": "7.2.0",
                 "tar-stream": "2.2.0",
-                "tmp": "0.2.6",
+                "tmp": "0.2.7",
                 "tree-kill": "1.2.2",
                 "tsconfig-paths": "4.2.0",
                 "tslib": "2.8.1",
@@ -15057,16 +15057,16 @@
                 "nx-cloud": "dist/bin/nx-cloud.js"
             },
             "optionalDependencies": {
-                "@nx/nx-darwin-arm64": "22.7.5",
-                "@nx/nx-darwin-x64": "22.7.5",
-                "@nx/nx-freebsd-x64": "22.7.5",
-                "@nx/nx-linux-arm-gnueabihf": "22.7.5",
-                "@nx/nx-linux-arm64-gnu": "22.7.5",
-                "@nx/nx-linux-arm64-musl": "22.7.5",
-                "@nx/nx-linux-x64-gnu": "22.7.5",
-                "@nx/nx-linux-x64-musl": "22.7.5",
-                "@nx/nx-win32-arm64-msvc": "22.7.5",
-                "@nx/nx-win32-x64-msvc": "22.7.5"
+                "@nx/nx-darwin-arm64": "22.7.6",
+                "@nx/nx-darwin-x64": "22.7.6",
+                "@nx/nx-freebsd-x64": "22.7.6",
+                "@nx/nx-linux-arm-gnueabihf": "22.7.6",
+                "@nx/nx-linux-arm64-gnu": "22.7.6",
+                "@nx/nx-linux-arm64-musl": "22.7.6",
+                "@nx/nx-linux-x64-gnu": "22.7.6",
+                "@nx/nx-linux-x64-musl": "22.7.6",
+                "@nx/nx-win32-arm64-msvc": "22.7.6",
+                "@nx/nx-win32-x64-msvc": "22.7.6"
             },
             "peerDependencies": {
                 "@swc-node/register": "^1.11.1",
@@ -19397,9 +19397,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
## Summary

Applies `npm audit fix` — lockfile-only changes bumping transitive dependencies to patched versions.

## Changes

`package-lock.json` only (60 insertions / 60 deletions), patch-level bumps:

- `js-yaml` 3.14.2 → 3.15.0
- `nx` / `@nx/*` platform binaries 22.7.5 → 22.7.6
- `form-data` 4.0.5 → 4.0.6
- `hasown` 2.0.2 → 2.0.4
- `tmp` 0.2.6 → 0.2.7

No `package.json` manifest changes. No source changes.