### PR TITLE
[XR] WebGPU-XR phase 0 (PR 1/3): type WebXR engine references as AbstractEngine

### DIFF
--- a/packages/dev/core/src/Engines/abstractEngine.pure.ts
+++ b/packages/dev/core/src/Engines/abstractEngine.pure.ts
@@ -873,6 +873,17 @@ export abstract class AbstractEngine {
      */
     public customAnimationFrameRequester: Nullable<ICustomAnimationFrameRequester> = null;
 
+    protected _framebufferDimensionsObject: Nullable<{ framebufferWidth: number; framebufferHeight: number }>;
+
+    /**
+     * sets the object from which width and height will be taken from when getting render width and height
+     * Will fallback to the gl object
+     * @param dimensions the framebuffer width and height that will be used.
+     */
+    public set framebufferDimensionsObject(dimensions: Nullable<{ framebufferWidth: number; framebufferHeight: number }>) {
+        this._framebufferDimensionsObject = dimensions;
+    }
+
     /**
      * Gets the list of current active render loop functions
      * @returns a read only array with the current render loop functions

--- a/packages/dev/core/src/Engines/thinEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinEngine.pure.ts
@@ -244,17 +244,6 @@ export class ThinEngine extends AbstractEngine {
         return false;
     }
 
-    protected _framebufferDimensionsObject: Nullable<{ framebufferWidth: number; framebufferHeight: number }>;
-
-    /**
-     * sets the object from which width and height will be taken from when getting render width and height
-     * Will fallback to the gl object
-     * @param dimensions the framebuffer width and height that will be used.
-     */
-    public set framebufferDimensionsObject(dimensions: Nullable<{ framebufferWidth: number; framebufferHeight: number }>) {
-        this._framebufferDimensionsObject = dimensions;
-    }
-
     /**
      * Creates a new snapshot at the next frame using the current snapshotRenderingMode
      */

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -9,7 +9,6 @@ import { WebXRFeatureName, WebXRFeaturesManager } from "./webXRFeaturesManager";
 import { Logger } from "../Misc/logger";
 import { UniversalCamera } from "../Cameras/universalCamera.pure";
 import { Quaternion, Vector3 } from "../Maths/math.vector.pure";
-import { type ThinEngine } from "../Engines/thinEngine";
 import { AbstractEngine } from "core/Engines/abstractEngine";
 
 /**
@@ -310,7 +309,7 @@ export class WebXRExperienceHelper implements IDisposable {
                     this._spectatorAfterRenderObserver = this._scene.onAfterRenderCameraObservable.add((camera) => {
                         if (camera === this.camera) {
                             // reset the dimensions object for correct resizing
-                            (this._scene.getEngine() as ThinEngine).framebufferDimensionsObject = null;
+                            this._scene.getEngine().framebufferDimensionsObject = null;
                         }
                     });
                 } else if (this.state === WebXRState.EXITING_XR) {

--- a/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
@@ -1,4 +1,5 @@
-import { type Engine } from "../Engines/engine";
+import { type AbstractEngine } from "../Engines/abstractEngine";
+import { type ThinEngine } from "../Engines/thinEngine";
 import { WebGLHardwareTexture } from "../Engines/WebGL/webGLHardwareTexture";
 import { type WebGLRenderTargetWrapper } from "../Engines/WebGL/webGLRenderTargetWrapper";
 import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
@@ -47,20 +48,21 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
     protected _renderTargetTextures = new Array<RenderTargetTexture>();
     protected _framebufferDimensions: Nullable<{ framebufferWidth: number; framebufferHeight: number }>;
 
-    private _engine: Engine;
+    private _engine: AbstractEngine;
 
     constructor(
         private readonly _scene: Scene,
         public readonly layerWrapper: WebXRLayerWrapper
     ) {
-        this._engine = _scene.getEngine() as Engine;
+        this._engine = _scene.getEngine();
     }
 
     private _createInternalTexture(textureSize: { width: number; height: number }, texture: WebGLTexture): InternalTexture {
         const internalTexture = new InternalTexture(this._engine, InternalTextureSource.Unknown, true);
         internalTexture.width = textureSize.width;
         internalTexture.height = textureSize.height;
-        internalTexture._hardwareTexture = new WebGLHardwareTexture(texture, this._engine._gl);
+        // WebGL-specific hardware texture creation; relocated to the WebGL-specific provider in a later phase.
+        internalTexture._hardwareTexture = new WebGLHardwareTexture(texture, (this._engine as ThinEngine)._gl);
         internalTexture.isReady = true;
         return internalTexture;
     }

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -5,7 +5,6 @@ import { type IDisposable, type Scene } from "../scene";
 import { type RenderTargetTexture } from "../Materials/Textures/renderTargetTexture";
 import { type WebXRRenderTarget } from "./webXRTypes";
 import { WebXRManagedOutputCanvas, WebXRManagedOutputCanvasOptions } from "./webXRManagedOutputCanvas";
-import { type Engine } from "../Engines/engine";
 import { type IWebXRRenderTargetTextureProvider, type WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetTextureProvider";
 import { type Viewport } from "../Maths/math.viewport";
 import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
@@ -18,7 +17,7 @@ import { type AbstractEngine } from "../Engines/abstractEngine";
  * @see https://doc.babylonjs.com/features/featuresDeepDive/webXR/webXRSessionManagers
  */
 export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextureProvider {
-    private _engine: Nullable<Engine>;
+    private _engine: Nullable<AbstractEngine>;
     private _referenceSpace: XRReferenceSpace;
     private _baseLayerWrapper: Nullable<WebXRLayerWrapper>;
     private _baseLayerRTTProvider: Nullable<WebXRLayerRenderTargetTextureProvider>;
@@ -120,7 +119,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
         /** The scene which the session should be created for */
         public scene: Scene
     ) {
-        this._engine = scene.getEngine() as Engine;
+        this._engine = scene.getEngine();
         this._onEngineDisposedObserver = this._engine.onDisposeObservable.addOnce(() => {
             this._engine = null;
         });


### PR DESCRIPTION
## WebGPU support for WebXR — Phase 0, PR 1 of 3

Part of #18637 (epic #18635).

This is the first of three **behavior-preserving, WebGL-only** refactor PRs that introduce API-agnostic seams into Babylon WebXR so a future WebGPU-backed XR session (layers-only, `XRGPUBinding`, `engine.wrapWebGPUTexture`) can plug in later. **No functional change for existing WebGL2 XR, and no WebGPU/XRGPUBinding code in this phase.**

### What this PR does (engine typing)
- Promotes `framebufferDimensionsObject` (the public setter + protected backing field) from `ThinEngine` up to `AbstractEngine`. This is additive and backward-compatible: `ThinEngine`/`Engine` keep consuming/overriding it, WebGPU inherits harmless default storage. It lets the XR render loop drive any engine backend by type.
- Retypes `WebXRSessionManager._engine` and `WebXRLayerRenderTargetTextureProvider._engine` from `Engine` to `AbstractEngine`, and removes the `scene.getEngine() as Engine` casts.
- The remaining WebGL `_gl` access in the RT provider is temporarily narrowed via `ThinEngine` (clearly commented) and will be **relocated to a WebGL-specific provider subclass in PR 2**.

### Why
Today WebXR hard-casts the engine to the WebGL `Engine` type in the shared/abstract seams. Removing that coupling is a prerequisite for the RT-provider split (PR 2) and the type/binding generalization (PR 3).

### Scope / follow-ups
- **PR 2** — RT-provider split: keep an API-agnostic base with a `_createRenderTargetTextureInternal` hook and move all WebGL specifics into a WebGL-specific provider that both the WebGL-layer and Native providers extend.
- **PR 3** — generalize `WebXRRenderTarget` / `WebXRLayerWrapper` / `WebXRLayerType`, abstract managed-output-canvas context creation behind the engine, and introduce a `WebXRGraphicsBinding` abstraction (`XRWebGLBinding` vs future `XRGPUBinding`). Per-feature deep ports remain Phase 4.

### Validation
- `tsc -b tsconfig.devpackages.json` ✅
- `prettier --check` (changed files) ✅
- `eslint --quiet` (changed files) ✅
- Unit tests: `vitest run --project=unit` for `XR/` + `Engines/` (309 passed, 1 expected-fail) ✅
- `check:treeshaking` (all 4 packages) ✅ and `check:side-effects-sync` ✅

Public API surface is unchanged (additive base-class member only).