### PR TITLE
WebGPU-XR Phase 0 (PR 2/3): split WebGL specifics out of the XR RT-provider base

### DIFF
--- a/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
@@ -3,7 +3,8 @@ import { type RenderTargetTexture } from "core/Materials/Textures/renderTargetTe
 import { type Viewport } from "core/Maths/math.viewport";
 import { Observable } from "core/Misc/observable";
 import { type WebXRLayerType, WebXRLayerWrapper } from "core/XR/webXRLayerWrapper";
-import { WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
+import { type WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
+import { WebXRWebGLRenderTargetTextureProvider } from "core/XR/webXRWebGLRenderTargetTextureProvider";
 import { type WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { type Nullable } from "core/types";
 
@@ -29,7 +30,7 @@ export class WebXRCompositionLayerWrapper extends WebXRLayerWrapper {
  * Provides render target textures and other important rendering information for a given XRCompositionLayer.
  * @internal
  */
-export class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+export class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRWebGLRenderTargetTextureProvider {
     protected _lastSubImages = new Map<XREye, XRWebGLSubImage>();
     private _compositionLayer: XRCompositionLayer;
     /**

--- a/packages/dev/core/src/XR/native/nativeXRRenderTarget.ts
+++ b/packages/dev/core/src/XR/native/nativeXRRenderTarget.ts
@@ -2,7 +2,8 @@ import { type RenderTargetTexture } from "../../Materials/Textures/renderTargetT
 import { type Viewport } from "../../Maths/math.viewport";
 import { type Nullable } from "../../types";
 import { WebXRLayerWrapper } from "../webXRLayerWrapper";
-import { WebXRLayerRenderTargetTextureProvider } from "../webXRRenderTargetTextureProvider";
+import { type WebXRLayerRenderTargetTextureProvider } from "../webXRRenderTargetTextureProvider";
+import { WebXRWebGLRenderTargetTextureProvider } from "../webXRWebGLRenderTargetTextureProvider";
 import { type WebXRSessionManager } from "../webXRSessionManager";
 import { type WebXRRenderTarget } from "../webXRTypes";
 
@@ -26,7 +27,7 @@ export class NativeXRLayerWrapper extends WebXRLayerWrapper {
  * Provides render target textures for layers created by Babylon Native.
  * @internal
  */
-export class NativeXRLayerRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+export class NativeXRLayerRenderTargetTextureProvider extends WebXRWebGLRenderTargetTextureProvider {
     private _nativeRTTProvider: WebXRLayerRenderTargetTextureProvider;
     private _nativeLayer: XRWebGLLayer;
 

--- a/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
@@ -1,8 +1,5 @@
 import { type AbstractEngine } from "../Engines/abstractEngine";
-import { type ThinEngine } from "../Engines/thinEngine";
-import { WebGLHardwareTexture } from "../Engines/WebGL/webGLHardwareTexture";
-import { type WebGLRenderTargetWrapper } from "../Engines/WebGL/webGLRenderTargetWrapper";
-import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
+import { type InternalTexture } from "../Materials/Textures/internalTexture";
 import { MultiviewRenderTarget } from "../Materials/Textures/MultiviewRenderTarget";
 import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture.pure";
 import { type Viewport } from "../Maths/math.viewport";
@@ -48,7 +45,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
     protected _renderTargetTextures = new Array<RenderTargetTexture>();
     protected _framebufferDimensions: Nullable<{ framebufferWidth: number; framebufferHeight: number }>;
 
-    private _engine: AbstractEngine;
+    protected _engine: AbstractEngine;
 
     constructor(
         private readonly _scene: Scene,
@@ -57,56 +54,49 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
         this._engine = _scene.getEngine();
     }
 
-    private _createInternalTexture(textureSize: { width: number; height: number }, texture: WebGLTexture): InternalTexture {
-        const internalTexture = new InternalTexture(this._engine, InternalTextureSource.Unknown, true);
-        internalTexture.width = textureSize.width;
-        internalTexture.height = textureSize.height;
-        // WebGL-specific hardware texture creation; relocated to the WebGL-specific provider in a later phase.
-        internalTexture._hardwareTexture = new WebGLHardwareTexture(texture, (this._engine as ThinEngine)._gl);
-        internalTexture.isReady = true;
-        return internalTexture;
+    /**
+     * Creates the render target texture "shell" (with the correct multiview type and MSAA sample count)
+     * without attaching any graphics-API-specific resource. Subclasses attach their own textures.
+     * @param width the width of the render target
+     * @param height the height of the render target
+     * @param multiview whether the render target should be a multiview render target
+     * @returns the created (but not yet registered) render target texture
+     */
+    protected _createRenderTargetTextureShell(width: number, height: number, multiview: boolean): RenderTargetTexture {
+        const textureSize = { width, height };
+        const renderTargetTexture = multiview ? new MultiviewRenderTarget(this._scene, textureSize) : new RenderTargetTexture("XR renderTargetTexture", textureSize, this._scene);
+        renderTargetTexture.renderTarget!._samples = renderTargetTexture.samples;
+        return renderTargetTexture;
     }
 
-    protected _createRenderTargetTexture(
+    /**
+     * Builds a render target texture from already-wrapped internal textures, without referencing any
+     * graphics-API-specific type. A GPU-based backend (e.g. WebGPU / XRGPUBinding) wraps its native
+     * textures with the engine and calls this hook; the WebGL backend has its own typed entry point.
+     * @param width the width of the render target
+     * @param height the height of the render target
+     * @param colorTexture the internal texture to use as the color attachment, if any
+     * @param depthStencilTexture the internal texture to use as the depth/stencil attachment, if any
+     * @param multiview whether the render target should be a multiview render target
+     * @returns the created render target texture
+     */
+    protected _createRenderTargetTextureInternal(
         width: number,
         height: number,
-        framebuffer: Nullable<WebGLFramebuffer>,
-        colorTexture?: WebGLTexture,
-        depthStencilTexture?: WebGLTexture,
-        multiview?: boolean
+        colorTexture: Nullable<InternalTexture>,
+        depthStencilTexture: Nullable<InternalTexture>,
+        multiview: boolean
     ): RenderTargetTexture {
-        if (!this._engine) {
-            throw new Error("Engine is disposed");
-        }
+        const renderTargetTexture = this._createRenderTargetTextureShell(width, height, multiview);
+        const renderTargetWrapper = renderTargetTexture.renderTarget!;
 
-        const textureSize = { width, height };
-
-        // Create render target texture from the internal texture
-        const renderTargetTexture = multiview ? new MultiviewRenderTarget(this._scene, textureSize) : new RenderTargetTexture("XR renderTargetTexture", textureSize, this._scene);
-        const renderTargetWrapper = renderTargetTexture.renderTarget as WebGLRenderTargetWrapper;
-        renderTargetWrapper._samples = renderTargetTexture.samples;
-        // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers
-        if (framebuffer || !colorTexture) {
-            renderTargetWrapper._framebuffer = framebuffer;
-        }
-
-        // Create internal texture
         if (colorTexture) {
-            if (multiview) {
-                renderTargetWrapper._colorTextureArray = colorTexture;
-            } else {
-                const internalTexture = this._createInternalTexture(textureSize, colorTexture);
-                renderTargetWrapper.setTexture(internalTexture, 0);
-                renderTargetTexture._texture = internalTexture;
-            }
+            renderTargetWrapper.setTexture(colorTexture, 0);
+            renderTargetTexture._texture = colorTexture;
         }
 
         if (depthStencilTexture) {
-            if (multiview) {
-                renderTargetWrapper._depthStencilTextureArray = depthStencilTexture;
-            } else {
-                renderTargetWrapper._depthStencilTexture = this._createInternalTexture(textureSize, depthStencilTexture);
-            }
+            renderTargetWrapper._depthStencilTexture = depthStencilTexture;
         }
 
         renderTargetTexture.disableRescaling();

--- a/packages/dev/core/src/XR/webXRWebGLLayer.ts
+++ b/packages/dev/core/src/XR/webXRWebGLLayer.ts
@@ -3,7 +3,7 @@ import { type Viewport } from "../Maths/math.viewport";
 import { type Scene } from "../scene";
 import { type Nullable } from "../types";
 import { WebXRLayerWrapper } from "./webXRLayerWrapper";
-import { WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetTextureProvider";
+import { WebXRWebGLRenderTargetTextureProvider } from "./webXRWebGLRenderTargetTextureProvider";
 
 /**
  * Wraps xr webgl layers.
@@ -29,7 +29,7 @@ export class WebXRWebGLLayerWrapper extends WebXRLayerWrapper {
  * Provides render target textures and other important rendering information for a given XRWebGLLayer.
  * @internal
  */
-export class WebXRWebGLLayerRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+export class WebXRWebGLLayerRenderTargetTextureProvider extends WebXRWebGLRenderTargetTextureProvider {
     // The dimensions will always be defined in this class.
     protected override _framebufferDimensions: { framebufferWidth: number; framebufferHeight: number };
     private _rtt: Nullable<RenderTargetTexture>;

--- a/packages/dev/core/src/XR/webXRWebGLRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRWebGLRenderTargetTextureProvider.ts
@@ -1,0 +1,71 @@
+import { type ThinEngine } from "../Engines/thinEngine";
+import { WebGLHardwareTexture } from "../Engines/WebGL/webGLHardwareTexture";
+import { type WebGLRenderTargetWrapper } from "../Engines/WebGL/webGLRenderTargetWrapper";
+import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
+import { type RenderTargetTexture } from "../Materials/Textures/renderTargetTexture.pure";
+import { type Nullable } from "../types";
+import { WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetTextureProvider";
+
+/**
+ * Provides render target textures for WebGL-backed XR layers. Owns all WebGL-specific
+ * framebuffer/texture wiring so the base provider can stay graphics-API-agnostic.
+ * @internal
+ */
+export abstract class WebXRWebGLRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+    private _createInternalTexture(textureSize: { width: number; height: number }, texture: WebGLTexture): InternalTexture {
+        const internalTexture = new InternalTexture(this._engine, InternalTextureSource.Unknown, true);
+        internalTexture.width = textureSize.width;
+        internalTexture.height = textureSize.height;
+        internalTexture._hardwareTexture = new WebGLHardwareTexture(texture, (this._engine as ThinEngine)._gl);
+        internalTexture.isReady = true;
+        return internalTexture;
+    }
+
+    protected _createRenderTargetTexture(
+        width: number,
+        height: number,
+        framebuffer: Nullable<WebGLFramebuffer>,
+        colorTexture?: WebGLTexture,
+        depthStencilTexture?: WebGLTexture,
+        multiview?: boolean
+    ): RenderTargetTexture {
+        if (!this._engine) {
+            throw new Error("Engine is disposed");
+        }
+
+        const textureSize = { width, height };
+
+        const renderTargetTexture = this._createRenderTargetTextureShell(width, height, !!multiview);
+        const renderTargetWrapper = renderTargetTexture.renderTarget as WebGLRenderTargetWrapper;
+        // Set the framebuffer, make sure it works in all scenarios - emulator, no layers and layers.
+        // This must happen before binding any texture, since setTexture binds it to the framebuffer.
+        if (framebuffer || !colorTexture) {
+            renderTargetWrapper._framebuffer = framebuffer;
+        }
+
+        // Create internal texture
+        if (colorTexture) {
+            if (multiview) {
+                renderTargetWrapper._colorTextureArray = colorTexture;
+            } else {
+                const internalTexture = this._createInternalTexture(textureSize, colorTexture);
+                renderTargetWrapper.setTexture(internalTexture, 0);
+                renderTargetTexture._texture = internalTexture;
+            }
+        }
+
+        if (depthStencilTexture) {
+            if (multiview) {
+                renderTargetWrapper._depthStencilTextureArray = depthStencilTexture;
+            } else {
+                renderTargetWrapper._depthStencilTexture = this._createInternalTexture(textureSize, depthStencilTexture);
+            }
+        }
+
+        renderTargetTexture.disableRescaling();
+
+        this._renderTargetTextures.push(renderTargetTexture);
+
+        return renderTargetTexture;
+    }
+}


### PR DESCRIPTION
## Phase 0 — PR #2 of 3: RT-provider split (WebGL-only, behavior-preserving)

Part of the **WebGPU support for WebXR** epic. Tracking issue: #18637 (epic #18635).

**Stacked on #18643 (PR #1).** Review/merge #18643 first — this PR targets that branch.

### What this does
Splits the WebGL specifics out of the XR render-target-texture provider so a future WebGPU/`XRGPUBinding` backend can produce a `RenderTargetTexture` from an already-wrapped `InternalTexture` without any WebGL types.

- `WebXRLayerRenderTargetTextureProvider` (base) is now **graphics-API-agnostic** — no WebGL imports. It exposes two protected hooks:
  - `_createRenderTargetTextureShell(width, height, multiview)` — builds the `RenderTargetTexture`/`MultiviewRenderTarget` with the correct sample count.
  - `_createRenderTargetTextureInternal(...)` — assembles a `RenderTargetTexture` from already-wrapped `InternalTexture`s, with no graphics-API types. **This is the seam a future GPU backend uses** (`wrapWebGPUTexture` → `_createRenderTargetTextureInternal`). Intentionally unused in Phase 0.
- New **WebGL-specific abstract** provider `WebXRWebGLRenderTargetTextureProvider` owns the WebGL-typed `_createRenderTargetTexture` and `_createInternalTexture` (`WebGLHardwareTexture` via `engine._gl`). The **exact original creation order is preserved** (framebuffer assigned before `setTexture`, since `setTexture` binds to the framebuffer).
- All WebGL-backed subclasses repointed to the new base: `WebXRWebGLLayerRenderTargetTextureProvider`, `NativeXRLayerRenderTargetTextureProvider`, `WebXRCompositionLayerRenderTargetTextureProvider` (and the projection-layer provider that extends it).

### Behavior change
None. Strict no-op for WebGL2 XR. No WebGPU/`XRGPUBinding` code. No public API removed or renamed.

### Validation
- `tsc -b` typecheck ✅
- prettier ✅ / eslint ✅
- XR unit tests: 244 pass ✅
- tree-shaking (16 checks) ✅ / side-effects-sync ✅
