### PR TITLE
fix(flowGraphEditor): keep connections attached to nodes while dragging

### DIFF
--- a/packages/tools/flowGraphEditor/src/graphEditor.tsx
+++ b/packages/tools/flowGraphEditor/src/graphEditor.tsx
@@ -852,6 +852,13 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
             // elements have real dimensions: setTimeout(0) runs after the browser has
             // completed layout and paint (rAF alone is not sufficient because it fires
             // *before* layout in some browsers).
+            //
+            // The bulk node creation in loadGraph() is already done, so clear the loading
+            // flag synchronously here. Otherwise it would stay set until the deferred
+            // sortGraph() runs, and if that is skipped (newer build, changed flow graph,
+            // or empty graph) the flag would be stranded as true — which freezes link and
+            // frame updates while dragging nodes (_refreshLinks/_refreshFrames early-out).
+            this._graphCanvas._isLoading = false;
             setTimeout(() => {
                 if (buildVersion !== this._buildVersion || flowGraph !== this.props.globalState.flowGraph) {
                     return;
@@ -958,6 +965,9 @@ export class GraphEditor extends React.Component<IGraphEditorProps, IGraphEditor
     sortGraph() {
         const canvas = this._graphCanvas;
         if (canvas.nodes.length === 0) {
+            // Nothing to lay out, but make sure the loading flag is never left set by a
+            // caller (e.g. build()) so node drags keep refreshing links and frames.
+            canvas._isLoading = false;
             return;
         }
 

--- a/packages/tools/flowGraphEditor/test/playwright/fge.utils.ts
+++ b/packages/tools/flowGraphEditor/test/playwright/fge.utils.ts
@@ -94,6 +94,19 @@ export class FlowGraphEditorPage {
     }
 
     /**
+     * Get the geometry ("d" attribute) of every visible SVG link path (excluding selection overlays).
+     * Useful for asserting that connections follow their nodes when the nodes are moved.
+     */
+    async getLinkPaths(): Promise<string[]> {
+        return await this.page.evaluate(() => {
+            const svg = document.getElementById("graph-svg-container");
+            if (!svg) throw new Error("graph-svg-container not found");
+            const paths = svg.querySelectorAll("path:not([class*='selection'])");
+            return Array.from(paths).map((p) => p.getAttribute("d") ?? "");
+        });
+    }
+
+    /**
      * Add a new graph tab and wait for the canvas to rebuild.
      */
     async addGraphTab(): Promise<void> {

--- a/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
+++ b/packages/tools/flowGraphEditor/test/playwright/flowGraphEditor.test.ts
@@ -534,6 +534,29 @@ test.describe("Flow Graph Editor — Node Operations", () => {
         expect(after.y).toBeGreaterThan(before.y);
     });
 
+    test("connections follow their nodes when a node is dragged", async ({ page }) => {
+        const fge = new FlowGraphEditorPage(page);
+        await fge.goto();
+        await fge.assertEditorReady();
+
+        // Reproduces the stranded-loading-flag bug: on a fresh (empty) editor the initial
+        // build defers to sortGraph(), which used to early-return on 0 nodes without clearing
+        // the canvas _isLoading flag. That left link refreshes disabled, so dragging a node
+        // moved the box but froze its connections in place.
+        await fge.addBlockFromPalette("SceneReadyEvent");
+        await fge.addBlockFromPalette("ConsoleLog");
+        await fge.connectPorts("FlowGraphSceneReadyEventBlock", "out", "FlowGraphConsoleLogBlock", "in");
+
+        expect(await fge.getLinkCount()).toBeGreaterThanOrEqual(1);
+
+        const before = await fge.getLinkPaths();
+        await fge.dragNode("FlowGraphConsoleLogBlock", 160, 120);
+        const after = await fge.getLinkPaths();
+
+        // The link geometry must change to follow the moved node.
+        expect(after).not.toEqual(before);
+    });
+
     test("user can delete a node", async ({ page }) => {
         const fge = new FlowGraphEditorPage(page);
         await fge.goto();


### PR DESCRIPTION
## Problem

In the Flow Graph Editor, dragging a box moved the node but its connections stayed frozen in place instead of stretching along with it.

## Root cause

Link redraws (`GraphNode._refreshLinks`) early-out whenever `GraphCanvasComponent._isLoading` is `true`.

The editor calls `build()` on mount. With an empty graph (no saved `_editorData`), `build()` defers layout to a `setTimeout` → `sortGraph()`, which **early-returned on zero nodes without clearing `_isLoading`**. So the flag was stranded `true` from the very first mount, and every subsequent node drag skipped the link (and frame) update — the box moved, the wires didn't.

This is specific to the Flow Graph Editor; NME/NGE/etc. always clear the flag via `reOrganize`, so they aren't affected.

## Fix

- Clear `_isLoading = false` synchronously in `build()`'s no-editorData branch (bulk node creation in `loadGraph()` is already done by then), so the flag is never held across the deferred `sortGraph()` — which can be skipped by a newer build, a changed flow graph, or an empty graph.
- Defensively clear `_isLoading` in `sortGraph()`'s zero-node early return.

## Testing

- Added a Playwright regression test that adds two blocks, connects them, drags one, and asserts the SVG link geometry follows the moved node (plus a `getLinkPaths()` helper in `fge.utils.ts`).
- Verified the test **fails without the fix** (link `d` attribute identical before/after drag) and **passes with it**.
- `prettier`, `tsc -b`, and `eslint` pass on the changed source; all 124 flowGraphEditor unit tests pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>