### PR TITLE
feat(XR): WebGPU-compatible XR session + XRGPUBinding plumbing (Phase 1, #18638)

### DIFF
--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -154,6 +154,16 @@ export interface WebGPUEngineOptions extends AbstractEngineOptions, GPURequestAd
     forceFallbackAdapter?: boolean;
 
     /**
+     * When set to true, requests a GPU adapter that is compatible with the user agent's XR device,
+     * as required to create a WebGPU-compatible WebXR session (see the WebXR/WebGPU binding spec).
+     * This mirrors the WebGL `xrCompatible` context attribute and must be set when the engine is
+     * created (adapter-request time): WebGPU has no post-hoc "make XR compatible" step, so it cannot
+     * be toggled on later. Leave unset/false for the default non-XR path.
+     * Default: false
+     */
+    xrCompatible?: boolean;
+
+    /**
      * Defines the device descriptor used to create a device once we have retrieved an appropriate adapter
      */
     deviceDescriptor?: GPUDeviceDescriptor;

--- a/packages/dev/core/src/LibDeclarations/webxr.webgpu.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.webgpu.d.ts
@@ -1,0 +1,94 @@
+/* eslint-disable babylonjs/available */
+/* eslint-disable @typescript-eslint/naming-convention */
+// Ambient declarations for the WebXR/WebGPU binding module.
+// The community-maintained webxr.d.ts does not yet include XRGPUBinding and its associated
+// types, so they are declared here as a companion (mirroring webxr.nativeextensions.d.ts).
+//
+// Shapes are grounded in the immersive-web/WebXR-WebGPU-Binding explainer + proposed IDL:
+// https://github.com/immersive-web/WebXR-WebGPU-Binding/blob/main/explainer.md
+//
+// The base XR layer/sub-image types (XRSubImage, XRProjectionLayer, XRQuadLayer, XRCylinderLayer,
+// XREquirectLayer, XRCubeLayer, XRCompositionLayer, XRLayerLayout, XRFrame, XRView, XREye,
+// XRSpace, XRRigidTransform) come from webxr.d.ts. The WebGPU adapter opt-in
+// (GPURequestAdapterOptions.xrCompatible) is declared in webgpu.d.ts and intentionally not
+// duplicated here.
+
+// XRGPUSubImage : XRSubImage
+interface XRGPUSubImage extends XRSubImage {
+    readonly colorTexture: GPUTexture;
+    readonly depthStencilTexture?: GPUTexture;
+    readonly motionVectorTexture?: GPUTexture;
+    getViewDescriptor(): GPUTextureViewDescriptor;
+}
+
+declare abstract class XRGPUSubImage implements XRGPUSubImage {}
+
+// dictionary XRGPUProjectionLayerInit
+interface XRGPUProjectionLayerInit {
+    colorFormat: GPUTextureFormat;
+    depthStencilFormat?: GPUTextureFormat;
+    // GPUTextureUsage.RENDER_ATTACHMENT (0x10) per spec default.
+    textureUsage?: GPUTextureUsageFlags;
+    scaleFactor?: number;
+}
+
+// dictionary XRGPULayerInit
+interface XRGPULayerInit {
+    colorFormat: GPUTextureFormat;
+    depthStencilFormat?: GPUTextureFormat;
+    // GPUTextureUsage.RENDER_ATTACHMENT (0x10) per spec default.
+    textureUsage?: GPUTextureUsageFlags;
+    space: XRSpace;
+    mipLevels?: number;
+    viewPixelWidth: number;
+    viewPixelHeight: number;
+    layout?: XRLayerLayout;
+    isStatic?: boolean;
+}
+
+// dictionary XRGPUQuadLayerInit : XRGPULayerInit
+interface XRGPUQuadLayerInit extends XRGPULayerInit {
+    transform?: XRRigidTransform;
+    width?: number;
+    height?: number;
+}
+
+// dictionary XRGPUCylinderLayerInit : XRGPULayerInit
+interface XRGPUCylinderLayerInit extends XRGPULayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralAngle?: number;
+    aspectRatio?: number;
+}
+
+// dictionary XRGPUEquirectLayerInit : XRGPULayerInit
+interface XRGPUEquirectLayerInit extends XRGPULayerInit {
+    transform?: XRRigidTransform;
+    radius?: number;
+    centralHorizontalAngle?: number;
+    upperVerticalAngle?: number;
+    lowerVerticalAngle?: number;
+}
+
+// dictionary XRGPUCubeLayerInit : XRGPULayerInit
+interface XRGPUCubeLayerInit extends XRGPULayerInit {
+    orientation?: DOMPointReadOnly;
+}
+
+// [Exposed=Window] interface XRGPUBinding
+declare class XRGPUBinding {
+    constructor(session: XRSession, device: GPUDevice);
+
+    readonly nativeProjectionScaleFactor: number;
+
+    createProjectionLayer(init?: XRGPUProjectionLayerInit): XRProjectionLayer;
+    createQuadLayer(init?: XRGPUQuadLayerInit): XRQuadLayer;
+    createCylinderLayer(init?: XRGPUCylinderLayerInit): XRCylinderLayer;
+    createEquirectLayer(init?: XRGPUEquirectLayerInit): XREquirectLayer;
+    createCubeLayer(init?: XRGPUCubeLayerInit): XRCubeLayer;
+
+    getSubImage(layer: XRCompositionLayer, frame: XRFrame, eye?: XREye): XRGPUSubImage;
+    getViewSubImage(layer: XRProjectionLayer, view: XRView): XRGPUSubImage;
+
+    getPreferredColorFormat(): GPUTextureFormat;
+}

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -160,7 +160,10 @@ export class WebXRExperienceHelper implements IDisposable {
             };
 
             // The layers feature will have already initialized the xr session's layers on session init.
-            if (!this.featuresManager.getEnabledFeature(WebXRFeatureName.LAYERS)) {
+            // A WebGPU-compatible XR session is layers-only (per the WebXR/WebGPU binding spec): the
+            // baseLayer/XRWebGLLayer path cannot be used. The WebGPU XRProjectionLayer is wired up in a
+            // later phase, so a WebGPU XR session currently enters with no layer and renders nothing yet.
+            if (!this._scene.getEngine().isWebGPU && !this.featuresManager.getEnabledFeature(WebXRFeatureName.LAYERS)) {
                 const baseLayer = await renderTarget.initializeXRLayerAsync(this.sessionManager.session);
                 xrRenderState.baseLayer = baseLayer;
             }

--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -163,6 +163,12 @@ export class WebXRExperienceHelper implements IDisposable {
             // A WebGPU-compatible XR session is layers-only (per the WebXR/WebGPU binding spec): the
             // baseLayer/XRWebGLLayer path cannot be used. The WebGPU XRProjectionLayer is wired up in a
             // later phase, so a WebGPU XR session currently enters with no layer and renders nothing yet.
+            // Because no layer is attached, the session receives no requestAnimationFrame callbacks, so
+            // onXRFrameObservable never fires and WebXRState stays at ENTERING_XR (it does NOT reach
+            // IN_XR, which is gated on the first frame below) until the later-phase projection layer
+            // produces that first frame. This is the expected Phase 1 end-state, not a regression, and
+            // has been confirmed on Quest hardware as well as at the raw-browser level (a no-layer WebXR
+            // session gets zero rAF callbacks). The session still ends cleanly via its native "end" path.
             if (!this._scene.getEngine().isWebGPU && !this.featuresManager.getEnabledFeature(WebXRFeatureName.LAYERS)) {
                 const baseLayer = await renderTarget.initializeXRLayerAsync(this.sessionManager.session);
                 xrRenderState.baseLayer = baseLayer;

--- a/packages/dev/core/src/XR/webXRGraphicsBinding.ts
+++ b/packages/dev/core/src/XR/webXRGraphicsBinding.ts
@@ -1,5 +1,6 @@
 import { type AbstractEngine } from "../Engines/abstractEngine";
 import { type ThinEngine } from "../Engines/thinEngine";
+import { type WebGPUEngine } from "../Engines/webgpuEngine";
 
 /**
  * The kind of underlying native binding an {@link IWebXRGraphicsBinding} wraps.
@@ -10,6 +11,11 @@ export const enum WebXRGraphicsBindingType {
      * Backed by an XRWebGLBinding (WebGL / WebGL2).
      */
     WebGL,
+
+    /**
+     * Backed by an XRGPUBinding (WebGPU).
+     */
+    WebGPU,
 }
 
 /**
@@ -64,5 +70,50 @@ export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding {
             throw new Error("WebXRWebGLGraphicsBinding requires a WebGL-capable engine.");
         }
         return new WebXRWebGLGraphicsBinding(session, gl);
+    }
+}
+
+/**
+ * WebGPU implementation of {@link IWebXRGraphicsBinding}, wrapping an `XRGPUBinding`.
+ *
+ * This is introduced as part of the WebGPU-for-WebXR plumbing and is not consumed yet:
+ * the per-frame layer/sub-image operations are wired up by later phases. The `XRGPUBinding`
+ * requires a WebGPU-compatible XR session (created with the `webgpu` feature descriptor) and a
+ * `GPUDevice` obtained from an `xrCompatible` adapter, otherwise its constructor throws.
+ * @internal
+ */
+export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding {
+    /**
+     * The kind of native binding that is wrapped.
+     */
+    public readonly bindingType = WebXRGraphicsBindingType.WebGPU;
+
+    /**
+     * The wrapped native `XRGPUBinding`.
+     */
+    public readonly binding: XRGPUBinding;
+
+    /**
+     * Creates a new WebGPU graphics binding.
+     * @param session the XR session the binding is created for
+     * @param device the WebGPU device to bind to
+     */
+    constructor(session: XRSession, device: GPUDevice) {
+        this.binding = new XRGPUBinding(session, device);
+    }
+
+    /**
+     * Creates a new WebGPU graphics binding from an engine, extracting its `GPUDevice`.
+     * The WebGPU-specific device access is localized here so callers can stay graphics-API-agnostic.
+     * @param session the XR session the binding is created for
+     * @param engine the engine whose WebGPU device should be bound
+     * @returns the created WebGPU graphics binding
+     */
+    public static CreateFromEngine(session: XRSession, engine: AbstractEngine): WebXRWebGPUGraphicsBinding {
+        const device = (engine as WebGPUEngine)._device;
+        if (!device) {
+            throw new Error("WebXRWebGPUGraphicsBinding requires a WebGPU-capable engine.");
+        }
+        return new WebXRWebGPUGraphicsBinding(session, device);
     }
 }

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -282,6 +282,19 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
      * @returns a promise which will resolve once the session has been initialized
      */
     public async initializeSessionAsync(xrSessionMode: XRSessionMode = "immersive-vr", xrSessionInit: XRSessionInit = {}): Promise<XRSession> {
+        // A WebGPU engine requires a WebGPU-compatible XR session (per the WebXR/WebGPU binding spec).
+        // The "webgpu" feature descriptor is requested as a *required* feature: a WebGPU engine cannot
+        // fall back to a WebGL-compatible session, so if the UA/device cannot provide one we let
+        // requestSession reject and surface that error to the caller rather than silently handing back
+        // an incompatible session. WebGL engines leave xrSessionInit untouched.
+        if (this._engine?.isWebGPU) {
+            const requiredFeatures = xrSessionInit.requiredFeatures ? [...xrSessionInit.requiredFeatures] : [];
+            if (!requiredFeatures.includes("webgpu")) {
+                requiredFeatures.push("webgpu");
+            }
+            xrSessionInit = { ...xrSessionInit, requiredFeatures };
+        }
+
         const session = await this._xrNavigator.xr.requestSession(xrSessionMode, xrSessionInit);
 
         this.session = session;

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -10,7 +10,7 @@ import { type Viewport } from "../Maths/math.viewport";
 import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
 import { NativeXRLayerWrapper, NativeXRRenderTarget } from "./native/nativeXRRenderTarget";
 import { WebXRWebGLLayerWrapper } from "./webXRWebGLLayer";
-import { type IWebXRGraphicsBinding, WebXRWebGLGraphicsBinding } from "./webXRGraphicsBinding";
+import { type IWebXRGraphicsBinding, WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "./webXRGraphicsBinding";
 import { type AbstractEngine } from "../Engines/abstractEngine";
 
 /**
@@ -239,7 +239,9 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
             throw new Error("Cannot create the XR graphics binding before the XR session is initialized.");
         }
         if (!this._graphicsBinding) {
-            this._graphicsBinding = WebXRWebGLGraphicsBinding.CreateFromEngine(this.session, this._engine);
+            this._graphicsBinding = this._engine.isWebGPU
+                ? WebXRWebGPUGraphicsBinding.CreateFromEngine(this.session, this._engine)
+                : WebXRWebGLGraphicsBinding.CreateFromEngine(this.session, this._engine);
         }
         return this._graphicsBinding;
     }

--- a/packages/dev/core/test/unit/XR/webXRExperienceHelper.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRExperienceHelper.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines";
+import { Scene } from "core/scene";
+import { UniversalCamera } from "core/Cameras/universalCamera";
+import { Vector3 } from "core/Maths/math.vector";
+import { WebXRExperienceHelper } from "core/XR/webXRExperienceHelper";
+import { WebXRState } from "core/XR/webXRTypes";
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+
+describe("WebXRExperienceHelper", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let helper: WebXRExperienceHelper;
+    const originalXr = (navigator as any).xr;
+
+    beforeEach(async () => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        // A non-VR active camera is restored on exit; give the scene one.
+        scene.activeCamera = new UniversalCamera("nonVR", Vector3.Zero(), scene);
+        // initializeAsync only needs navigator.xr to exist.
+        (navigator as any).xr = {};
+        helper = await WebXRExperienceHelper.CreateAsync(scene);
+    });
+
+    afterEach(() => {
+        helper.dispose();
+        scene.dispose();
+        engine.dispose();
+        (navigator as any).xr = originalXr;
+    });
+
+    // Reproduces the hardware-observed WebGPU Phase 1 flow: the WebGPU XR session enters but,
+    // with no layer attached (the XRProjectionLayer is a later phase), no XR frame ever arrives,
+    // so onXRFrameObservable never fires and the state stays at ENTERING_XR (never IN_XR).
+    describe("WebGPU Phase 1 enter/exit (no-frame stall)", () => {
+        beforeEach(() => {
+            (engine as any)._isWebGPU = true;
+            // Stub the heavy session-manager collaborators so enterXRAsync's real state machine
+            // runs without live WebXR globals. runXRRenderLoop is a no-op, so no frame is produced.
+            vi.spyOn(helper.sessionManager, "initializeSessionAsync").mockImplementation(async () => {
+                (helper.sessionManager as any).session = {};
+                helper.sessionManager.inXRSession = true;
+                return (helper.sessionManager as any).session;
+            });
+            vi.spyOn(helper.sessionManager, "setReferenceSpaceTypeAsync").mockResolvedValue({} as XRReferenceSpace);
+            vi.spyOn(helper.sessionManager, "updateRenderState").mockImplementation(() => {});
+            vi.spyOn(helper.sessionManager, "runXRRenderLoop").mockImplementation(() => {});
+            // Camera transform is irrelevant to the state machine under test.
+            vi.spyOn(helper as any, "_nonXRToXRCamera").mockImplementation(() => {});
+        });
+
+        it("stays at ENTERING_XR when no frame arrives", async () => {
+            await helper.enterXRAsync("immersive-vr", "local-floor", {} as any);
+            expect(helper.state).toBe(WebXRState.ENTERING_XR);
+        });
+
+        it("exitXRAsync from ENTERING_XR is a clean no-op (no hang, no leak)", async () => {
+            await helper.enterXRAsync("immersive-vr", "local-floor", {} as any);
+            const smExit = vi.spyOn(helper.sessionManager, "exitXRAsync");
+
+            await expect(helper.exitXRAsync()).resolves.toBeUndefined();
+
+            // Guarded by state !== IN_XR: it must not touch the session manager and must not change state.
+            expect(smExit).not.toHaveBeenCalled();
+            expect(helper.state).toBe(WebXRState.ENTERING_XR);
+        });
+
+        it("returns to NOT_IN_XR when the session ends from ENTERING_XR", async () => {
+            await helper.enterXRAsync("immersive-vr", "local-floor", {} as any);
+            expect(helper.state).toBe(WebXRState.ENTERING_XR);
+
+            // Simulate the native "end" (what the session manager's end listener notifies).
+            expect(() => helper.sessionManager.onXRSessionEnded.notifyObservers(null)).not.toThrow();
+
+            expect(helper.state).toBe(WebXRState.NOT_IN_XR);
+        });
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
@@ -307,4 +307,50 @@ describe("WebXRSessionManager", () => {
             });
         });
     });
+
+    describe("initializeSessionAsync webgpu feature descriptor", () => {
+        const fakeSession = { addEventListener: vi.fn() } as unknown as XRSession;
+        let requestSession: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            requestSession = vi.fn().mockResolvedValue(fakeSession);
+            (sessionManager as any)._xrNavigator = { xr: { requestSession } };
+        });
+
+        it("adds the 'webgpu' required feature for a WebGPU engine", async () => {
+            (engine as any)._isWebGPU = true;
+
+            await sessionManager.initializeSessionAsync("immersive-vr", {});
+
+            expect(requestSession).toHaveBeenCalledWith("immersive-vr", expect.objectContaining({ requiredFeatures: ["webgpu"] }));
+        });
+
+        it("leaves the session init untouched for a non-WebGPU engine", async () => {
+            const init: XRSessionInit = { requiredFeatures: ["local-floor"] };
+
+            await sessionManager.initializeSessionAsync("immersive-vr", init);
+
+            // WebGL path must be byte-for-byte identical: same object, no 'webgpu' injected.
+            expect(requestSession.mock.calls[0][1]).toBe(init);
+            expect(init.requiredFeatures).toEqual(["local-floor"]);
+        });
+
+        it("preserves existing required features and avoids duplicates for a WebGPU engine", async () => {
+            (engine as any)._isWebGPU = true;
+
+            await sessionManager.initializeSessionAsync("immersive-vr", { requiredFeatures: ["local-floor", "webgpu"] });
+
+            expect(requestSession.mock.calls[0][1].requiredFeatures).toEqual(["local-floor", "webgpu"]);
+        });
+    });
+
+    describe("updateRenderState", () => {
+        it("does not throw when neither baseLayer nor layers is provided (WebGPU Phase 1 state)", () => {
+            const updateRenderState = vi.fn();
+            (sessionManager as any).session = { updateRenderState };
+
+            expect(() => sessionManager.updateRenderState({ depthFar: 100, depthNear: 0.1 })).not.toThrow();
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
@@ -353,4 +353,44 @@ describe("WebXRSessionManager", () => {
             expect(updateRenderState).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("native session end cleanup", () => {
+        let endHandler: (() => void) | undefined;
+        let requestSession: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            endHandler = undefined;
+            const fakeSession = {
+                addEventListener: (type: string, cb: () => void) => {
+                    if (type === "end") {
+                        endHandler = cb;
+                    }
+                },
+            } as unknown as XRSession;
+            requestSession = vi.fn().mockResolvedValue(fakeSession);
+            (sessionManager as any)._xrNavigator = { xr: { requestSession } };
+        });
+
+        // A WebGPU Phase 1 session stalls with no layer/no frame; ending it (e.g. the headset
+        // system menu) must still clean up regardless of whether a frame ever arrived.
+        it("cleans up when the session ends before any frame arrives (WebGPU no-frame path)", async () => {
+            (engine as any)._isWebGPU = true;
+            const endedObserver = vi.fn();
+            sessionManager.onXRSessionEnded.add(endedObserver);
+
+            await sessionManager.initializeSessionAsync("immersive-vr", {});
+            expect(sessionManager.inXRSession).toBe(true);
+
+            // Seed a graphics binding so we can assert it is released on end.
+            (sessionManager as any)._graphicsBinding = {};
+            expect(endHandler).toBeDefined();
+
+            // Simulate the native "end" event (no XR frame was ever produced).
+            expect(() => endHandler!()).not.toThrow();
+
+            expect(sessionManager.inXRSession).toBe(false);
+            expect(endedObserver).toHaveBeenCalledTimes(1);
+            expect((sessionManager as any)._graphicsBinding).toBeNull();
+        });
+    });
 });

--- a/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
@@ -5,6 +5,7 @@
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "core/XR/webXRGraphicsBinding";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 
 describe("WebXRSessionManager", () => {
@@ -260,6 +261,50 @@ describe("WebXRSessionManager", () => {
             sessionManager.dispose();
 
             expect(() => sessionManager._getGraphicsBinding()).toThrow(/has been disposed/);
+        });
+
+        describe("binding selection", () => {
+            const fakeSession = {} as XRSession;
+            let originalWebGLBinding: unknown;
+            let originalGPUBinding: unknown;
+
+            beforeEach(() => {
+                originalWebGLBinding = (globalThis as any).XRWebGLBinding;
+                originalGPUBinding = (globalThis as any).XRGPUBinding;
+                // jsdom has neither binding constructor; stub them so CreateFromEngine can run.
+                (globalThis as any).XRWebGLBinding = vi.fn();
+                (globalThis as any).XRGPUBinding = vi.fn();
+                (sessionManager as any).session = fakeSession;
+            });
+
+            afterEach(() => {
+                (globalThis as any).XRWebGLBinding = originalWebGLBinding;
+                (globalThis as any).XRGPUBinding = originalGPUBinding;
+            });
+
+            it("returns a WebGL binding for a non-WebGPU engine", () => {
+                (engine as any)._gl = {};
+                expect(engine.isWebGPU).toBe(false);
+
+                expect(sessionManager._getGraphicsBinding()).toBeInstanceOf(WebXRWebGLGraphicsBinding);
+            });
+
+            it("returns a WebGPU binding for a WebGPU engine", () => {
+                (engine as any)._isWebGPU = true;
+                (engine as any)._device = {};
+                expect(engine.isWebGPU).toBe(true);
+
+                expect(sessionManager._getGraphicsBinding()).toBeInstanceOf(WebXRWebGPUGraphicsBinding);
+            });
+
+            it("caches the binding across calls", () => {
+                (engine as any)._gl = {};
+
+                const first = sessionManager._getGraphicsBinding();
+                const second = sessionManager._getGraphicsBinding();
+
+                expect(second).toBe(first);
+            });
         });
     });
 });


### PR DESCRIPTION
## Phase 1 (#18638) — WebGPU-compatible XR session + XRGPUBinding plumbing

Closes #18638 (Phase 1 of the WebGPU-for-WebXR epic #18635 — the epic stays open for Phases 2–5).

Part of the WebGPU-for-WebXR effort (epic #18635). **Plumbing only — no per-frame WebGPU XR rendering (Phase 2), no camera/NDC (Phase 3), no feature rewiring (Phase 4).** WebGL2 XR behavior is byte-for-byte identical; every WebGPU path is gated behind `AbstractEngine.isWebGPU` and is unreachable for WebGL engines.

> Consolidated from an initial 3-PR stack into this single PR (kept as focused commits for readability). Supersedes #18651 and #18652. Rebased onto master after Phase 0 (#18645) merged.

### What's in here

**1. TS typings + adapter opt-in**
- New companion `packages/dev/core/src/LibDeclarations/webxr.webgpu.d.ts` (mirrors the existing `webxr.nativeextensions.d.ts` split so the large community-maintained `webxr.d.ts` stays untouched). Declares `XRGPUBinding`, `XRGPUSubImage`, and the `XRGPU*LayerInit` dictionaries. Base XR layer/sub-image types come from `webxr.d.ts`; `GPURequestAdapterOptions.xrCompatible` stays in `webgpu.d.ts` (not duplicated).
- Documented `xrCompatible` on `WebGPUEngineOptions`. It is inherited from `GPURequestAdapterOptions` and already flows end-to-end (`initAsync` passes `_options` straight to `navigator.gpu.requestAdapter()`), so this is JSDoc/discoverability only — it notes the flag must be set at adapter-request/engine-construction time (WebGPU has no post-hoc "make XR compatible" step).

**2. `@internal` WebGPU graphics binding + wiring**
- `WebXRWebGPUGraphicsBinding` implementing the Phase-0 `IWebXRGraphicsBinding` seam, wrapping `new XRGPUBinding(session, device)`, plus a `WebXRGraphicsBindingType.WebGPU` enum member. Minimal/introduced-but-unused — per-frame layer/sub-image ops are deferred to later phases.
- `WebXRSessionManager._getGraphicsBinding()` branches on `AbstractEngine.isWebGPU`: WebGPU engine → `XRGPUBinding`-backed binding; everything else → the existing `XRWebGLBinding`-backed one. The `GPUDevice` is read from `WebGPUEngine._device` via a **type-only** import + cast (mirrors Phase 0's `(engine as ThinEngine)._gl`), so there is no runtime coupling/side effect. Kept `@internal` and out of `index.ts`/`pure.ts`.

**3. WebGPU-compatible session gating**
- `initializeSessionAsync` requests the `'webgpu'` feature descriptor as a **required** feature when the engine is WebGPU (a WebGPU engine cannot fall back to a WebGL XR session; the native `requestSession` rejection is left to propagate to the caller, not swallowed). The WebGL branch leaves the `XRSessionInit` object untouched (same reference passed through — asserted in a test).
- `webXRExperienceHelper.enterXRAsync` skips the `baseLayer`/`XRWebGLLayer` path for WebGPU, since a WebGPU-compatible session is **layers-only**.

**4. Doc-only clarification** of the ENTERING_XR end-state (see below) — comment-only, no logic change.

### ✅ Hardware-validated Phase 1 end-state (not a regression)
Validated on Meta Quest Browser with the experimental `XRGPUBinding` flag, against this PR's snapshot build. The precise Phase 1 end-state is:

> The native WebGPU XR session **enters** — an `xrCompatible` WebGPU engine is created, the `'webgpu'` feature is accepted and appears in `session.enabledFeatures`, `baseLayer` is correctly skipped, and `enterXRAsync` resolves without throwing. **But** because Phase 1 attaches **no layer** (the `XRProjectionLayer` is Phase 2), the session receives **no `requestAnimationFrame` callbacks**, so `onXRFrameObservable` never fires and Babylon's `WebXRState` **stays at `ENTERING_XR` and never reaches `IN_XR`** (which is gated on the first frame). This is the correct Phase 1 result, **not a regression**.

This "no layer → no frame" behavior was confirmed both through Babylon and at the **raw-browser level**: a bare `navigator.xr` `immersive-vr` session requested with `requiredFeatures: ['webgpu']` is granted `'webgpu'`, yet a `requestAnimationFrame` with no layer set yields **zero callbacks**. So the stall is inherent to the layers-only WebGPU-XR design and the WebXR spec, not a bug in this plumbing. Reaching `IN_XR` / actually rendering is **Phase 2** (projection-layer RTT provider via `wrapWebGPUTexture`).

**Exit is clean from `ENTERING_XR`:** ending the session via its native `end` path (e.g. the headset system menu) fires `onXRSessionEnded` regardless of `WebXRState`, restoring the framebuffer/render loop/camera and returning `WebXRState` to `NOT_IN_XR` with no hang or leak (the `@internal` binding is nulled on end). Note: the programmatic `exitXRAsync()` is a no-op from `ENTERING_XR` (its pre-existing `state !== IN_XR` guard, unchanged by this PR) — a no-op, not a hang; the session remains exitable via the native path.

A unit test confirms `updateRenderState` with neither `baseLayer` nor `layers` does not throw. /cc @RaananW.

### Spec grounding
Declarations/behavior are taken from the immersive-web/WebXR-WebGPU-Binding explainer + proposed IDL: https://github.com/immersive-web/WebXR-WebGPU-Binding/blob/main/explainer.md — including the `'webgpu'` feature descriptor, the layers-only rule (no `baseLayer`), and the `XRGPUBinding(session, device)` shape requiring an `xrCompatible` adapter.

### Constraints honored
- WebGL2 XR byte-for-byte identical; all WebGPU logic gated behind `isWebGPU`.
- No `.pure.ts` split, no top-level side effects (confirmed: no side-effect-manifest churn on any commit).
- **Zero net public-API additions** — the binding is `@internal` and out of the barrels; `xrCompatible` is an inherited, now-documented option.

### Testing
- `tsc -b tsconfig.devPackages.json` exit 0.
- `npm run format:check` ✅ ; `npm run lint:check` ✅ (eslint + all 16 tree-shaking checks + side-effects-sync across core/gui/loaders/serializers).
- XR unit gate `vitest run --project=unit -t "XR"`: **260 passed**. `webXRSessionManager.test.ts` cases cover binding selection (WebGL vs WebGPU), binding caching, the uninitialized-session guard, `'webgpu'` injected only for WebGPU engines (existing required features preserved, no duplicates), WebGL init passed through unchanged (same object ref), `updateRenderState` with no layer not throwing, and the native session-`end` handler cleaning up (nulls the graphics binding, clears `inXRSession`, notifies `onXRSessionEnded`) even when no frame ever arrived. New `webXRExperienceHelper.test.ts` covers the no-frame WebGPU lifecycle: state stays at `ENTERING_XR` with no frame, `exitXRAsync()` from `ENTERING_XR` is a clean no-op (does not touch the session manager, state unchanged), and a native session end from `ENTERING_XR` returns state to `NOT_IN_XR` with no hang or leak.
- **Hardware-validated** on Meta Quest Browser (XRGPUBinding flag) against the PR snapshot — see the end-state section above.
- Note: the unrelated `smartFilterBlocks` vitest suite fails to import in this environment (missing generated `.block.js` artifacts) — pre-existing, not touched by this PR.

