### PR TITLE
feat(XR): WebGPU XR phase 1 — internal WebGPU graphics binding + wiring (PR2/3, #18638)

### DIFF
--- a/packages/dev/core/src/XR/webXRGraphicsBinding.ts
+++ b/packages/dev/core/src/XR/webXRGraphicsBinding.ts
@@ -1,5 +1,6 @@
 import { type AbstractEngine } from "../Engines/abstractEngine";
 import { type ThinEngine } from "../Engines/thinEngine";
+import { type WebGPUEngine } from "../Engines/webgpuEngine";
 
 /**
  * The kind of underlying native binding an {@link IWebXRGraphicsBinding} wraps.
@@ -10,6 +11,11 @@ export const enum WebXRGraphicsBindingType {
      * Backed by an XRWebGLBinding (WebGL / WebGL2).
      */
     WebGL,
+
+    /**
+     * Backed by an XRGPUBinding (WebGPU).
+     */
+    WebGPU,
 }
 
 /**
@@ -64,5 +70,50 @@ export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding {
             throw new Error("WebXRWebGLGraphicsBinding requires a WebGL-capable engine.");
         }
         return new WebXRWebGLGraphicsBinding(session, gl);
+    }
+}
+
+/**
+ * WebGPU implementation of {@link IWebXRGraphicsBinding}, wrapping an `XRGPUBinding`.
+ *
+ * This is introduced as part of the WebGPU-for-WebXR plumbing and is not consumed yet:
+ * the per-frame layer/sub-image operations are wired up by later phases. The `XRGPUBinding`
+ * requires a WebGPU-compatible XR session (created with the `webgpu` feature descriptor) and a
+ * `GPUDevice` obtained from an `xrCompatible` adapter, otherwise its constructor throws.
+ * @internal
+ */
+export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding {
+    /**
+     * The kind of native binding that is wrapped.
+     */
+    public readonly bindingType = WebXRGraphicsBindingType.WebGPU;
+
+    /**
+     * The wrapped native `XRGPUBinding`.
+     */
+    public readonly binding: XRGPUBinding;
+
+    /**
+     * Creates a new WebGPU graphics binding.
+     * @param session the XR session the binding is created for
+     * @param device the WebGPU device to bind to
+     */
+    constructor(session: XRSession, device: GPUDevice) {
+        this.binding = new XRGPUBinding(session, device);
+    }
+
+    /**
+     * Creates a new WebGPU graphics binding from an engine, extracting its `GPUDevice`.
+     * The WebGPU-specific device access is localized here so callers can stay graphics-API-agnostic.
+     * @param session the XR session the binding is created for
+     * @param engine the engine whose WebGPU device should be bound
+     * @returns the created WebGPU graphics binding
+     */
+    public static CreateFromEngine(session: XRSession, engine: AbstractEngine): WebXRWebGPUGraphicsBinding {
+        const device = (engine as WebGPUEngine)._device;
+        if (!device) {
+            throw new Error("WebXRWebGPUGraphicsBinding requires a WebGPU-capable engine.");
+        }
+        return new WebXRWebGPUGraphicsBinding(session, device);
     }
 }

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -10,7 +10,7 @@ import { type Viewport } from "../Maths/math.viewport";
 import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
 import { NativeXRLayerWrapper, NativeXRRenderTarget } from "./native/nativeXRRenderTarget";
 import { WebXRWebGLLayerWrapper } from "./webXRWebGLLayer";
-import { type IWebXRGraphicsBinding, WebXRWebGLGraphicsBinding } from "./webXRGraphicsBinding";
+import { type IWebXRGraphicsBinding, WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "./webXRGraphicsBinding";
 import { type AbstractEngine } from "../Engines/abstractEngine";
 
 /**
@@ -239,7 +239,9 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
             throw new Error("Cannot create the XR graphics binding before the XR session is initialized.");
         }
         if (!this._graphicsBinding) {
-            this._graphicsBinding = WebXRWebGLGraphicsBinding.CreateFromEngine(this.session, this._engine);
+            this._graphicsBinding = this._engine.isWebGPU
+                ? WebXRWebGPUGraphicsBinding.CreateFromEngine(this.session, this._engine)
+                : WebXRWebGLGraphicsBinding.CreateFromEngine(this.session, this._engine);
         }
         return this._graphicsBinding;
     }

--- a/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
@@ -5,6 +5,7 @@
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "core/XR/webXRGraphicsBinding";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 
 describe("WebXRSessionManager", () => {
@@ -246,6 +247,56 @@ describe("WebXRSessionManager", () => {
             scene.dispose();
 
             expect(disposeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("_getGraphicsBinding", () => {
+        const fakeSession = {} as XRSession;
+        let originalWebGLBinding: unknown;
+        let originalGPUBinding: unknown;
+
+        beforeEach(() => {
+            originalWebGLBinding = (globalThis as any).XRWebGLBinding;
+            originalGPUBinding = (globalThis as any).XRGPUBinding;
+            // jsdom has neither binding constructor; stub them so CreateFromEngine can run.
+            (globalThis as any).XRWebGLBinding = vi.fn();
+            (globalThis as any).XRGPUBinding = vi.fn();
+            (sessionManager as any).session = fakeSession;
+        });
+
+        afterEach(() => {
+            (globalThis as any).XRWebGLBinding = originalWebGLBinding;
+            (globalThis as any).XRGPUBinding = originalGPUBinding;
+        });
+
+        it("returns a WebGL binding for a non-WebGPU engine", () => {
+            (engine as any)._gl = {};
+            expect(engine.isWebGPU).toBe(false);
+
+            expect(sessionManager._getGraphicsBinding()).toBeInstanceOf(WebXRWebGLGraphicsBinding);
+        });
+
+        it("returns a WebGPU binding for a WebGPU engine", () => {
+            (engine as any)._isWebGPU = true;
+            (engine as any)._device = {};
+            expect(engine.isWebGPU).toBe(true);
+
+            expect(sessionManager._getGraphicsBinding()).toBeInstanceOf(WebXRWebGPUGraphicsBinding);
+        });
+
+        it("caches the binding across calls", () => {
+            (engine as any)._gl = {};
+
+            const first = sessionManager._getGraphicsBinding();
+            const second = sessionManager._getGraphicsBinding();
+
+            expect(second).toBe(first);
+        });
+
+        it("throws when the session is not initialized", () => {
+            (sessionManager as any).session = undefined;
+
+            expect(() => sessionManager._getGraphicsBinding()).toThrow();
         });
     });
 });


### PR DESCRIPTION
## Phase 1 (#18638) — PR 2 of 3: internal WebGPU graphics binding + wiring

Part of the WebGPU-for-WebXR effort (epic #18635). **Plumbing only; introduced-but-unused.** Stacked on PR1 (base = `raananw-webgpu-xr-phase1-binding-plumbing`); depends on the `XRGPUBinding` ambient typings from PR1. Retargets up the stack toward master once #18645 and PR1 land.

### What this does
1. **`WebXRWebGPUGraphicsBinding`** — `@internal` WebGPU implementation of the Phase-0 `IWebXRGraphicsBinding` seam, wrapping `new XRGPUBinding(session, device)`. Added next to the existing `WebXRWebGLGraphicsBinding` in `webXRGraphicsBinding.ts`. Minimal by design — the per-frame layer/sub-image ops (`createProjectionLayer`, `getViewSubImage`, …) are deferred to Phase 2/4.
2. **`WebXRGraphicsBindingType.WebGPU`** enum member.
3. **Binding selection** — `WebXRSessionManager._getGraphicsBinding()` now branches on `AbstractEngine.isWebGPU`: a WebGPU engine gets the `XRGPUBinding`-backed binding, everything else keeps the `XRWebGLBinding`-backed one. Still lazily created and cached.

### Design notes
- The `GPUDevice` is read from `WebGPUEngine._device` via a **type-only** import + cast in `CreateFromEngine`, mirroring Phase 0's `(engine as ThinEngine)._gl` access. Type-only ⇒ no runtime module coupling, no side effects.
- Detection uses the existing public `AbstractEngine.isWebGPU` getter — no hard import coupling between the XR and WebGPU-engine modules.
- Kept `@internal` and out of `index.ts`/`pure.ts` (mirrors the Phase-0 seam), so there are **zero net public-API additions**.

### Constraints honored
- WebGL2 XR behavior byte-for-byte identical (WebGL branch untouched; WebGPU branch unreachable for WebGL engines).
- No `.pure.ts` split, no top-level side effects (confirmed: no side-effect-manifest churn on commit).

### Testing
- `tsc -b tsconfig.devPackages.json` exit 0; prettier + eslint clean on the changed `src` files.
- XR unit gate `vitest run --project=unit -t "XR"`: **249 passed** (baseline ~244 + 4 new). New tests in `webXRSessionManager.test.ts` cover: WebGL binding for a non-WebGPU engine, WebGPU binding for a WebGPU engine (via `_isWebGPU`/`_device` stubs), caching across calls, and the uninitialized-session guard.
- Full WebGPU-XR runtime validation still needs a Quest browser with the XRGPUBinding flag (hardware check by @RaananW).
- Note: the unrelated `smartFilterBlocks` suite fails to import in this environment (missing generated `.block.js` artifacts) — pre-existing, not touched by this PR.

Follow-up: PR3 gates the WebGPU-compatible session (`'webgpu'` feature descriptor + baseLayer skip).
