### PR TITLE
feat(XR): WebGPU XR phase 1 — WebGPU-compatible session gating (PR3/3, #18638)

### DIFF
--- a/packages/dev/core/src/XR/webXRExperienceHelper.ts
+++ b/packages/dev/core/src/XR/webXRExperienceHelper.ts
@@ -160,7 +160,10 @@ export class WebXRExperienceHelper implements IDisposable {
             };
 
             // The layers feature will have already initialized the xr session's layers on session init.
-            if (!this.featuresManager.getEnabledFeature(WebXRFeatureName.LAYERS)) {
+            // A WebGPU-compatible XR session is layers-only (per the WebXR/WebGPU binding spec): the
+            // baseLayer/XRWebGLLayer path cannot be used. The WebGPU XRProjectionLayer is wired up in a
+            // later phase, so a WebGPU XR session currently enters with no layer and renders nothing yet.
+            if (!this._scene.getEngine().isWebGPU && !this.featuresManager.getEnabledFeature(WebXRFeatureName.LAYERS)) {
                 const baseLayer = await renderTarget.initializeXRLayerAsync(this.sessionManager.session);
                 xrRenderState.baseLayer = baseLayer;
             }

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -282,6 +282,19 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
      * @returns a promise which will resolve once the session has been initialized
      */
     public async initializeSessionAsync(xrSessionMode: XRSessionMode = "immersive-vr", xrSessionInit: XRSessionInit = {}): Promise<XRSession> {
+        // A WebGPU engine requires a WebGPU-compatible XR session (per the WebXR/WebGPU binding spec).
+        // The "webgpu" feature descriptor is requested as a *required* feature: a WebGPU engine cannot
+        // fall back to a WebGL-compatible session, so if the UA/device cannot provide one we let
+        // requestSession reject and surface that error to the caller rather than silently handing back
+        // an incompatible session. WebGL engines leave xrSessionInit untouched.
+        if (this._engine?.isWebGPU) {
+            const requiredFeatures = xrSessionInit.requiredFeatures ? [...xrSessionInit.requiredFeatures] : [];
+            if (!requiredFeatures.includes("webgpu")) {
+                requiredFeatures.push("webgpu");
+            }
+            xrSessionInit = { ...xrSessionInit, requiredFeatures };
+        }
+
         const session = await this._xrNavigator.xr.requestSession(xrSessionMode, xrSessionInit);
 
         this.session = session;

--- a/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
@@ -299,4 +299,50 @@ describe("WebXRSessionManager", () => {
             expect(() => sessionManager._getGraphicsBinding()).toThrow();
         });
     });
+
+    describe("initializeSessionAsync webgpu feature descriptor", () => {
+        const fakeSession = { addEventListener: vi.fn() } as unknown as XRSession;
+        let requestSession: ReturnType<typeof vi.fn>;
+
+        beforeEach(() => {
+            requestSession = vi.fn().mockResolvedValue(fakeSession);
+            (sessionManager as any)._xrNavigator = { xr: { requestSession } };
+        });
+
+        it("adds the 'webgpu' required feature for a WebGPU engine", async () => {
+            (engine as any)._isWebGPU = true;
+
+            await sessionManager.initializeSessionAsync("immersive-vr", {});
+
+            expect(requestSession).toHaveBeenCalledWith("immersive-vr", expect.objectContaining({ requiredFeatures: ["webgpu"] }));
+        });
+
+        it("leaves the session init untouched for a non-WebGPU engine", async () => {
+            const init: XRSessionInit = { requiredFeatures: ["local-floor"] };
+
+            await sessionManager.initializeSessionAsync("immersive-vr", init);
+
+            // WebGL path must be byte-for-byte identical: same object, no 'webgpu' injected.
+            expect(requestSession.mock.calls[0][1]).toBe(init);
+            expect(init.requiredFeatures).toEqual(["local-floor"]);
+        });
+
+        it("preserves existing required features and avoids duplicates for a WebGPU engine", async () => {
+            (engine as any)._isWebGPU = true;
+
+            await sessionManager.initializeSessionAsync("immersive-vr", { requiredFeatures: ["local-floor", "webgpu"] });
+
+            expect(requestSession.mock.calls[0][1].requiredFeatures).toEqual(["local-floor", "webgpu"]);
+        });
+    });
+
+    describe("updateRenderState", () => {
+        it("does not throw when neither baseLayer nor layers is provided (WebGPU Phase 1 state)", () => {
+            const updateRenderState = vi.fn();
+            (sessionManager as any).session = { updateRenderState };
+
+            expect(() => sessionManager.updateRenderState({ depthFar: 100, depthNear: 0.1 })).not.toThrow();
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+        });
+    });
 });


### PR DESCRIPTION
## Phase 1 (#18638) — PR 3 of 3: WebGPU-compatible XR session gating

Part of the WebGPU-for-WebXR effort (epic #18635). **Plumbing only.** Stacked on PR2 (base = `raananw-webgpu-xr-phase1-graphics-binding`). Retargets up the stack toward master once the earlier PRs and #18645 land.

### What this does
When the engine is a WebGPU engine (`AbstractEngine.isWebGPU`):
1. **`initializeSessionAsync`** requests the `'webgpu'` feature descriptor as a **required** feature. Per the WebXR/WebGPU binding spec a WebGPU engine cannot fall back to a WebGL-compatible XR session, so `'webgpu'` must be required. The native `requestSession` rejection (e.g. on a UA/device without WebGPU-XR support) is **left to propagate** to the caller — it is not caught or swallowed. A friendly pre-flight capability message is out of scope (Phase 5).
2. **`webXRExperienceHelper.enterXRAsync`** skips the `baseLayer`/`XRWebGLLayer` path, because a WebGPU-compatible session is **layers-only** (`baseLayer` cannot be set in `updateRenderState`).

### ⚠️ Expected Phase 1 end-state (not a bug)
The WebGPU `XRProjectionLayer` (via `updateRenderState({ layers: [...] })`) is wired up in **Phase 2**. So in Phase 1 a WebGPU XR session **enters with no layer and renders nothing yet** — a blank headset is the correct Phase 1 result. A unit test confirms `updateRenderState` with neither `baseLayer` nor `layers` does not throw. /cc @RaananW so a blank headset isn't mistaken for a regression during hardware testing.

### Constraints honored
- **WebGL2 XR byte-for-byte identical:** the WebGL branch leaves the `XRSessionInit` object untouched (same reference passed to `requestSession`) and keeps the existing `baseLayer` path. All WebGPU logic is gated behind `isWebGPU`, unreachable for WebGL engines.
- No `.pure.ts` split, no top-level side effects, no public-API additions (confirmed: no side-effect-manifest churn on commit).

### Testing
- `tsc -b tsconfig.devPackages.json` exit 0.
- `npm run format:check` ✅ ; `npm run lint:check` ✅ (eslint + all 16 tree-shaking checks + side-effects-sync across core/gui/loaders/serializers).
- XR unit gate `vitest run --project=unit -t "XR"`: **253 passed** (baseline ~244 + the new PR2/PR3 tests). New tests: `'webgpu'` injected only for WebGPU engines, existing required features preserved without duplicates, WebGL init passed through unchanged (same object), and `updateRenderState` with no layer doesn't throw.
- Full WebGPU-XR runtime validation needs a Quest browser with the XRGPUBinding flag (hardware check by @RaananW).
- Note: the unrelated `smartFilterBlocks` suite fails to import in this environment (missing generated `.block.js` artifacts) — pre-existing, not touched by this PR.
