### PR TITLE
Fix lighting volume WGSL depth texture binding

### DIFF
--- a/packages/dev/core/src/ShadersWGSL/lightingVolume.compute.fx
+++ b/packages/dev/core/src/ShadersWGSL/lightingVolume.compute.fx
@@ -8,7 +8,7 @@ struct Params {
     orthoMax: vec3f,
 };
 
-@group(0) @binding(0) var shadowMap : texture_2d<f32>;
+@group(0) @binding(0) var shadowMap : texture_depth_2d;
 @group(0) @binding(1) var<uniform> params : Params;
 @group(0) @binding(2) var<storage,read_write> positions : array<f32>;
 
@@ -27,7 +27,7 @@ fn updateFarPlaneVertices(@builtin(global_invocation_id) global_id : vec3u) {
     let stepY = floor(params.step * f32(coord.y));
     let depthCoord = vec2u(u32(floor(f32(coord.x) * params.step)), u32(stepY));
 
-    var depth = textureLoad(shadowMap, depthCoord, 0).r;
+    var depth = textureLoad(shadowMap, depthCoord, 0);
 #ifdef MOVE_FAR_DEPTH_TO_NEAR
     if (depth == 1.0) {
         depth = 0.0;


### PR DESCRIPTION
Replaces #18564 after it was closed while I was on summer holidays.

Rebased on latest `master`; the change is still limited to treating the lighting volume shadow map as a WGSL depth texture and reading it with `textureLoad`.

Local validation:
- `npx nx build babylonjs --outputStyle=static`
- `npx nx build babylonjs-gui --outputStyle=static`
- `npm run check:treeshaking`