### PR TITLE
ci: use Browserstack-Opensource variable group

### DIFF
--- a/.azure-pipelines/VARIABLE-GROUPS.md
+++ b/.azure-pipelines/VARIABLE-GROUPS.md
@@ -61,7 +61,7 @@ Azure Front Door profile names used alongside the endpoints above.
 | `CDN_PROFILE_PLAYGROUND` | Profile for the playground endpoint                     |
 | `CDN_PROFILE_TOOLS`      | Profile for all editor tool and documentation endpoints |
 
-## Variable Group: `BabylonJS-BrowserStack`
+## Variable Group: `Browserstack-Opensource`
 
 BrowserStack credentials shared by pipelines that run browser tests.
 

--- a/.azure-pipelines/ci-browser-testing.yml
+++ b/.azure-pipelines/ci-browser-testing.yml
@@ -11,7 +11,7 @@
 # Schedule: 1:00 AM PST daily (09:00 UTC), plus 3:00 AM PST Saturday (11:00 UTC)
 #
 # Variable groups:
-#   - BabylonJS-BrowserStack (BROWSERSTACK_ACCESS_KEY, BROWSERSTACK_USERNAME)
+#   - Browserstack-Opensource (BROWSERSTACK_ACCESS_KEY, BROWSERSTACK_USERNAME)
 # =============================================================================
 
 trigger: none
@@ -35,7 +35,7 @@ schedules:
       always: true
 
 variables:
-    - group: BabylonJS-BrowserStack
+    - group: Browserstack-Opensource
     - group: BabylonJS-Deployment
     - name: system.debug
       value: false

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -5,7 +5,7 @@
 # IMPORTANT SETUP NOTES:
 # 1. Link variable groups (see VARIABLE-GROUPS.md):
 #    - BabylonJS-CI-Infrastructure
-#    - BabylonJS-BrowserStack (BROWSERSTACK_ACCESS_KEY, BROWSERSTACK_USERNAME)
+#    - Browserstack-Opensource (BROWSERSTACK_ACCESS_KEY, BROWSERSTACK_USERNAME)
 #    - BabylonJS-Deployment (DEPLOY_TOKEN, DEPLOYMENT_SERVER)
 #
 # 2. Fork build settings (allow secrets, require comments for non-team members)
@@ -59,7 +59,7 @@ resources:
 
 variables:
     - group: BabylonJS-CI-Infrastructure
-    - group: BabylonJS-BrowserStack
+    - group: Browserstack-Opensource
     - group: BabylonJS-Deployment
     - name: BuildName
       value: $(Build.SourceBranch)


### PR DESCRIPTION
## Summary

Switches the Azure Pipelines that run BrowserStack browser tests to the `Browserstack-Opensource` variable group (previously `BabylonJS-BrowserStack`).

The new group already exists in CI and exposes the same variable names — `BROWSERSTACK_ACCESS_KEY` and `BROWSERSTACK_USERNAME` — so only the group reference changes; no env remapping is required.

## Changes

- `.azure-pipelines/ci-monorepo.yml`: group reference + header comment
- `.azure-pipelines/ci-browser-testing.yml`: group reference + header comment
- `.azure-pipelines/VARIABLE-GROUPS.md`: renamed the documented group section

No workflow logic or env variable names changed.