### PR TITLE
TC39 cleanup: treat decorators as Stage 3 in UMD transpile fallbacks

### DIFF
--- a/packages/public/rollupUMDHelper.mjs
+++ b/packages/public/rollupUMDHelper.mjs
@@ -471,7 +471,10 @@ function transpileExternalTsPlugin() {
                     jsx: isTsx ? ts.JsxEmit.ReactJSX : ts.JsxEmit.Preserve,
                     esModuleInterop: true,
                     allowSyntheticDefaultImports: true,
-                    experimentalDecorators: true,
+                    // The codebase uses TC39 Stage 3 decorators (experimentalDecorators is off),
+                    // so leave experimentalDecorators unset here and keep assignment (not define)
+                    // class-field semantics so decorated fields match the rest of the build.
+                    useDefineForClassFields: false,
                     sourceMap: true,
                     inlineSources: true,
                 },
@@ -505,7 +508,9 @@ function esbuildTranspilePlugin(opts = {}) {
                 format: "esm",
                 tsconfigRaw: {
                     compilerOptions: {
-                        experimentalDecorators: true,
+                        // TC39 Stage 3 decorators (experimentalDecorators is off across the codebase);
+                        // esbuild lowers them natively. useDefineForClassFields:false keeps assignment
+                        // (not define) class-field semantics so decorated fields behave as in the main build.
                         useDefineForClassFields: false,
                     },
                 },


### PR DESCRIPTION
## Summary

Follow-up cleanup to the TC39 Stage 3 decorators migration (#18647). That PR removed `experimentalDecorators` from the tsconfigs, but two UMD-build transpile **fallbacks** in `packages/public/rollupUMDHelper.mjs` still hardcoded `experimentalDecorators: true`, leaving them inconsistent with the migrated codebase.

## What changed

`packages/public/rollupUMDHelper.mjs` — dropped `experimentalDecorators: true` from both transpile fallbacks so `@decorator` is treated as **TC39 Stage 3** (tsc/esbuild lower it natively), matching the rest of the build:

- **`transpileExternalTsPlugin`** (tsc `transpileModule`) — the production fallback that transpiles aliased `.ts` sources from other monorepo packages (outside the current package's `rootDir`), which now use TC39 decorators + the `accessor` keyword. Also set `useDefineForClassFields: false` here (esbuild path already had it) so a `declare` field assigned by a base constructor is not clobbered.
- **`esbuildTranspilePlugin`** (esbuild) — the dev-mode fast transpile path.

These mirror the same fix already applied during the migration to `vitest.config.mts` and the viewer's `vite.config.mjs`.

## Why

With `experimentalDecorators: true`, these fallbacks would interpret Stage 3 decorators under legacy semantics. This is the last residual `experimentalDecorators: true` in the build tooling after #18647 (the playground Monaco/snippet-loader flags were already flipped in that PR).

## Validation

Ran a representative TC39 `@serialize() accessor` class (extending a base whose constructor assigns a `declare` field) through both transforms with the exact new compiler options:

- **tsc fallback**: 0 error diagnostics; emits `__esDecorate`/`__runInitializers` (TC39), no legacy `__decorate`; `accessor` lowered to get/set; runtime preserves the base-constructor-assigned field.
- **esbuild path**: emits `Symbol.metadata` TC39 lowering (`__decoratorStart`/`__decoratorMetadata`); runtime correct.
- Both runtime smokes pass and preserve the `declare` field (`useDefineForClassFields: false`).
- `prettier --check` clean; `node --check` clean.

CI (Build / ES6 tools UMD jobs) is the integration gate for the actual bundles.
