### PR TITLE
fix(inspector): declare missing Fluent UI peer dependencies

### DIFF
--- a/packages/dev/sharedUiComponents/package.json
+++ b/packages/dev/sharedUiComponents/package.json
@@ -27,6 +27,8 @@
         "@fluentui-contrib/react-resize-handle": "^0.8.4",
         "@fluentui/react-components": "^9.70.0",
         "@fluentui/react-icons": "^2.0.310",
+        "@fluentui/react-motion-components-preview": "^0.15.2",
+        "@fluentui/react-utilities": "^9.26.2",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "react": "^18.2.0",
@@ -43,6 +45,8 @@
         "@fluentui-contrib/react-resize-handle": "^0.8.4",
         "@fluentui/react-components": "^9.70.0",
         "@fluentui/react-icons": "^2.0.310",
+        "@fluentui/react-motion-components-preview": "^0.15.2",
+        "@fluentui/react-utilities": "^9.26.2",
         "react-dnd": "15.0.1",
         "react-dnd-touch-backend": "15.0.1",
         "sass": "^1.62.1"

--- a/packages/public/@babylonjs/inspector-v2/package.json
+++ b/packages/public/@babylonjs/inspector-v2/package.json
@@ -43,6 +43,8 @@
         "@fluentui-contrib/react-virtualizer": "^1.0.0",
         "@fluentui/react-components": "^9.70.0",
         "@fluentui/react-icons": "^2.0.310",
+        "@fluentui/react-motion-components-preview": "^0.15.2",
+        "@fluentui/react-utilities": "^9.26.2",
         "react": ">=16.14.0 <20.0.0",
         "react-dom": ">=16.14.0 <20.0.0",
         "usehooks-ts": "^3.1.1"


### PR DESCRIPTION
## Problem

Reported on the forum: [Broken inspector dependencies](https://forum.babylonjs.com/t/broken-inspector-dependencies/63476). Consumers of the published `@babylonjs/inspector` (v2) hit build errors like:

```
ERROR: Could not resolve "@fluentui/react-motion-components-preview"
```

even after installing every peer dependency the package declares.

## Root cause

The inspector-v2 rollup config externalizes **all** `@fluentui/*` and `@fluentui-contrib/*` imports:

```js
if (/^@fluentui(-contrib)?\//.test(id)) return true;
```

so every one of them stays as a bare import in the shipped bundle and must be declared as a peer dependency. Two externalized packages are imported by the bundle (via `shared-ui-components`' `extensionsListService.tsx`, `shellService.tsx`, and `collapse.tsx` — the `extensionsListService-*.js` file in the forum error) but were **not** declared:

- `@fluentui/react-motion-components-preview`
- `@fluentui/react-utilities`

They only resolve inside our monorepo because they're transitive deps of `@fluentui/react-accordion` (part of `@fluentui/react-components`). That makes them phantom dependencies — strict resolvers (esbuild, pnpm, yarn) fail to resolve them for consumers.

## Fix

Declare both packages as peer dependencies in:
- `packages/public/@babylonjs/inspector-v2/package.json`
- `packages/dev/sharedUiComponents/package.json` (where the imports originate)

Versions match the current lockfile (`^0.15.2` / `^9.26.2`).

## Notes

- No source/behavior changes — packaging metadata only.
- The separate `@fortawesome/*` resolution error in the same thread comes from bundled `@babylonjs/gui-editor` and is an "install the peer" situation, not addressed here.