### PR TITLE
chore: drop legacy-peer-deps in favor of scoped @eslint/compat override

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 node-options=--max-old-space-size=8192
-legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,20 +112,6 @@
                 "lru-cache": "^11.2.6"
             }
         },
-        "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mdn-data": "2.27.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-            }
-        },
         "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
             "version": "11.4.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
@@ -135,13 +121,6 @@
             "engines": {
                 "node": "20 || >=22"
             }
-        },
-        "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
-            "version": "2.27.1",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-            "dev": true,
-            "license": "CC0-1.0"
         },
         "node_modules/@asamuzakjp/nwsapi": {
             "version": "2.3.9",
@@ -1688,7 +1667,6 @@
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
             "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -2039,7 +2017,6 @@
             "version": "3.6.1",
             "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
             "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -2219,7 +2196,6 @@
             "version": "0.9.2",
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
             "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@es-joy/jsdoccomment": {
@@ -2695,7 +2671,6 @@
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
@@ -2714,51 +2689,15 @@
             "version": "4.12.2",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@eslint/compat": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.1.tgz",
-            "integrity": "sha512-cfO82V9zxxGBxcQDr1lfaYB7wykTa0b00mGa36FrJl7iTFd0Z2cHfEYuxcBRP/iNijCsWsEkA+jzT8hGYmv33w==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@eslint/core": "^0.17.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "peerDependencies": {
-                "eslint": "^8.40 || 9"
-            },
-            "peerDependenciesMeta": {
-                "eslint": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@eslint/compat/node_modules/@eslint/core": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/json-schema": "^7.0.15"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/config-array": {
             "version": "0.23.3",
             "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
             "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/object-schema": "^3.0.3",
@@ -2773,7 +2712,6 @@
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
             "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.1.1"
@@ -2783,10 +2721,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-            "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
-            "dev": true,
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
@@ -2966,7 +2903,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
             "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -2976,7 +2912,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
             "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^1.1.1",
@@ -3008,7 +2943,6 @@
             "version": "1.7.5",
             "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
             "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/utils": "^0.2.11"
@@ -3018,7 +2952,6 @@
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
             "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0"
@@ -3028,7 +2961,6 @@
             "version": "1.7.6",
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
             "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/core": "^1.7.5",
@@ -3039,14 +2971,12 @@
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
             "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@fluentui-contrib/react-resize-handle": {
             "version": "0.8.4",
             "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-resize-handle/-/react-resize-handle-0.8.4.tgz",
             "integrity": "sha512-g3cJ3q+nn32BB5b5mEtuSh6sGNYOGcKvRxQljvfg+UAhStceCPZYRM8gF+HswPPhQ0LUR6h780WMe072ndR6Lw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-utilities": "^9.16.0",
@@ -3064,7 +2994,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-1.0.0.tgz",
             "integrity": "sha512-z1KE+OyCTICkOeyCmFI0nlNRTPAhCv2ZhCIDjebnlkNQMIcMtTrI/ogy4Fu8UgbFP+WReE50JeduLtM+Sst+1A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.0.29",
@@ -3084,7 +3013,6 @@
             "version": "9.0.8",
             "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
             "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.1"
@@ -3094,7 +3022,6 @@
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
             "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.1"
@@ -3104,7 +3031,6 @@
             "version": "9.9.2",
             "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.9.2.tgz",
             "integrity": "sha512-Mmi5nVKfQrBiBiD1JPVtCmIMrR1CpCy8hsWZLwv/pHt+uHHyW9HyrPXwiOitj3ookA5ec1kXyl34BN8RUi7DGQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-aria": "^9.17.10",
@@ -3131,7 +3057,6 @@
             "version": "9.0.0-beta.136",
             "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.136.tgz",
             "integrity": "sha512-tXxU+fTjWtpv4V6qn21Vuhy1FS6VveRYy747241R1Ta4lqvxHfZ+Z8fowRZaXNdcso0ZM+QUzpcaz8kAELUm2g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-avatar": "^9.10.3",
@@ -3155,7 +3080,6 @@
             "version": "9.17.10",
             "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.10.tgz",
             "integrity": "sha512-KqS2XcdN84XsgVG4fAESyOBfixN7zbObWfQVLNZ2gZrp2b1hPGVYfQ6J4WOO0vXMKYp0rre/QMOgDm6/srL0XQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3176,7 +3100,6 @@
             "version": "9.10.3",
             "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.10.3.tgz",
             "integrity": "sha512-f8oW58Z+9nehDk/7PInN1paw1jptN2+TiBKcRagU6evHlmnfsV9+GKnS/vInEG3QPQAVPSdYVub03EkF/w90SA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-badge": "^9.5.0",
@@ -3203,7 +3126,6 @@
             "version": "9.5.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.5.0.tgz",
             "integrity": "sha512-38vaGn7DjS2BqIzjon2U6Xmh+39e2khBwOfsmYx36Z3jqGHbuPwAjQ/kiquTIvtlRRSufwmNtj6C8/J1gN8jmw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
@@ -3225,7 +3147,6 @@
             "version": "9.4.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.4.0.tgz",
             "integrity": "sha512-QpCjYlM3JTMnNwh/sDehDbuAVjTcgSfjkPdSmFaPk2lPHpER32CBcJVhheP9en2U5NbW1e+Gtvq8y06RN8FCWw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-aria": "^9.17.10",
@@ -3251,7 +3172,6 @@
             "version": "9.9.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.9.0.tgz",
             "integrity": "sha512-aH3aSjKyxIiNb9jJOUaaIq47w7jP5ESFSRzvMjcWOETvlWo4QgNqEOOsYqpcltM1OrQZ0sTy/isxppRcyMDlcQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3276,7 +3196,6 @@
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.6.0.tgz",
             "integrity": "sha512-vgBvhtSzQDa01aOP9zdhJXFLsZAiDVslRfX3HmlIo1pAMt8w+PBq+ypDp1wxM7HPFpj9+RYcERRKtf4MSNP9Nw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3300,7 +3219,6 @@
             "version": "9.9.5",
             "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.5.tgz",
             "integrity": "sha512-YitJHBj+9bbJMB6E6mdqV0tLSFMkxXUdqa0xMY6QKjGXoFkG8GYLI8FZwIfpbqmQfZ2oP7cdUvibGQ4Qyh3LHQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-aria": "^9.17.10",
@@ -3330,7 +3248,6 @@
             "version": "9.5.17",
             "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.5.17.tgz",
             "integrity": "sha512-40uRrCnWBMiWyVF2ZN9Ep2nnl/onYrSaa8fNnLBn6Tunhuk9flCxWZygkO5h9Da2QP6DasyGG8WZld1nrR9GUg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -3355,7 +3272,6 @@
             "version": "9.2.15",
             "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.15.tgz",
             "integrity": "sha512-RMmawl7g4gUYLuTQG2QwCcR9fGC+vDD+snsBlXtObpj/cKpeDmYif46g88pYv86jeIXY1zsjINmLpELmz+uFmw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ctrl/tinycolor": "^3.3.4",
@@ -3379,7 +3295,6 @@
             "version": "9.16.18",
             "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.16.18.tgz",
             "integrity": "sha512-nmyleswOSS9O/3gn8AWQ9Uuyis0WTHO1zZnDVapFUdgd2+hAcUSjJXPQv6NGftuUB5bgS2qAx9prRJg17ZrZvA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3408,7 +3323,6 @@
             "version": "9.73.5",
             "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.73.5.tgz",
             "integrity": "sha512-vq7xsdImOXaSAT6jBqPWRPiDDZFs44Lc8IshxO/IjzbstqLNz6T6I65BBueyhX7lHFQnCq6JpAah+HXVRqpkpQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-accordion": "^9.9.2",
@@ -3485,7 +3399,6 @@
             "version": "9.2.15",
             "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.15.tgz",
             "integrity": "sha512-QymBntFLJNZ9VfTOaBn2ApUSSSC5UuDW8ZcgPJPA+06XEFH+U9Zny2d9QAg1xYNYwIGWahWGQ+7ATOuLxtB8Jw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-utilities": "^9.26.2",
@@ -3503,7 +3416,6 @@
             "version": "9.17.2",
             "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.17.2.tgz",
             "integrity": "sha512-mZdKylSvh2fRf0e3wMX3ZNccb9DahsOE7A5Y9LG97ghYvndMBVG2YwScIzUFVvLS206ari6HMOl0lC5JRB1bKA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3532,7 +3444,6 @@
             "version": "9.7.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.7.0.tgz",
             "integrity": "sha512-U8Nhrghjeh+XCGM4B7aHYosd6fXaxHC3MpZi7DB0xQ20ljn5cSTpBt4Yvl+tB9ld2+/eM8wekx1GVKyI4yWa3g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -3553,7 +3464,6 @@
             "version": "9.11.5",
             "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.11.5.tgz",
             "integrity": "sha512-eoZY+jKZwbJo1PUsb7Ico7u/8aObHL4BhPP6hd+HHNzB7seTpN7rLd0DpASLZsxJUy5yvch4QF2TrjOu6V8kRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-dialog": "^9.17.2",
@@ -3579,7 +3489,6 @@
             "version": "9.4.16",
             "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.4.16.tgz",
             "integrity": "sha512-2mfuYGldeqr9Llt8QSfwdj1hQofScvNQ/1Rns9TE4QUP6cdqs3cPX2+FZNJzpgO9vq5bk0hJpKqo7lvXZdyEzw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-context-selector": "^9.2.15",
@@ -3603,7 +3512,6 @@
             "version": "2.0.322",
             "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.322.tgz",
             "integrity": "sha512-JOzF9+KgjMhSUz3KQdWj5YqqqpdzGQC9w2KvWKkWU1cqsDgOobMu/AUhvduYvWN1bP7uVVsKi2ncOyxCa8W9aQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@griffel/react": "^1.6.1",
@@ -3617,7 +3525,6 @@
             "version": "9.4.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.4.0.tgz",
             "integrity": "sha512-BpcBlmkukm7YYf6PTCbAIMkeCXc8+7aq2eMADsxF5gFD8j3d5lBY3cKByOWRM1NvXcMXmqXr/hQP+ovqNAHzEA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -3638,7 +3545,6 @@
             "version": "9.0.0-beta.112",
             "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.112.tgz",
             "integrity": "sha512-Fhqoc6b1MQtHW+Mm5sBhfa5ZrRdOV4azuUa5WyBvwD4Ozq/z2pBOC/wi/A/WCjKMnGoMlQ2CggoLaMhQmenzAQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.237",
@@ -3662,7 +3568,6 @@
             "version": "9.4.17",
             "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.17.tgz",
             "integrity": "sha512-zLw52jn2wAuEKWFzaNj3aKhuB4BAEI8LqblryCg0LKPKHcv/z9d9RllCqcVz+ngdK1tQGtCIPH/wxNlZXx/I3Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
@@ -3687,7 +3592,6 @@
             "version": "9.8.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.8.0.tgz",
             "integrity": "sha512-y/CUMEo2pgFLHUDnKTfXV1hwZ5j0GUD5exTyBKoeNgfAwY1UelWIvKc7fgelhV5GYEQJL7ycm8eNq71CqLA74A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -3709,7 +3613,6 @@
             "version": "9.4.1",
             "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.1.tgz",
             "integrity": "sha512-ZodSm7jRa4kaLKDi+emfHFMP/IDnYwFQQAI2BdtKbVrvfwvzPRprGcnTgivnqKBT1ROvKOCY2ddz7+yZzesnNw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-utilities": "^9.26.2",
@@ -3724,7 +3627,6 @@
             "version": "9.3.15",
             "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.3.15.tgz",
             "integrity": "sha512-ycmaQwC4tavA8WeDfgcay1Ywu/4goHq1NOeVxkyzWTPGA7rs+tdCgdZBQZLAsBK2XFaZiHs7l+KG9r1oIRKolA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -3745,7 +3647,6 @@
             "version": "9.8.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.8.0.tgz",
             "integrity": "sha512-TH5LS4iuQ4jYzlR84A4n7lQTKaJuiuuGFHMIxoEqtKeMoL9F5AiabuBs6m7Q7clSdTrrcRMNzXLuEFarQrzGTQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3768,7 +3669,6 @@
             "version": "9.6.12",
             "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.12.tgz",
             "integrity": "sha512-vFeqP4r3rjqtd/p9p7woma/j2U3UlcirfqGje26ppBMzDs/0MWQiUmjTkQTMLnPeh72knnqwsF43dRSKSdTSng==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3793,7 +3693,6 @@
             "version": "9.23.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.23.0.tgz",
             "integrity": "sha512-KM08C5GQ+wcsZ6dcmjrMonsW1RRcuhygR7GBT6rnWxxx6qzKv6RCumckzL5NfSgvyJw4wWKs857k5sUczs+7VQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3823,7 +3722,6 @@
             "version": "9.6.22",
             "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.22.tgz",
             "integrity": "sha512-9FvKlJwBvfcvwjOf/hsiXUjcIFOvPmJ0woFH4y6rwXGCY/TL3dztcLHbPZ6oVPN4GK+5VwRt1eRRVifrpQRGZw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-button": "^9.9.0",
@@ -3849,7 +3747,6 @@
             "version": "9.13.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.13.0.tgz",
             "integrity": "sha512-YdOpW6e7qfvzoWKcqh8hReCqwYEoiEmNBcCprGaupKjWOi9jBbF/JESM1AHI9nOjPd8aY90WUG2+ahvrqfL9LA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-shared-contexts": "^9.26.2",
@@ -3867,7 +3764,6 @@
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.2.tgz",
             "integrity": "sha512-KqHRV8lLmVwOWiHBdpUFA+TwMbuYu9cyzNvmhbMFLVKzZyr3MPgN+97Tf+6QYPf22o99SMT0BPySDv/HiNYanA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-motion": "*",
@@ -3885,7 +3781,6 @@
             "version": "9.3.21",
             "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.21.tgz",
             "integrity": "sha512-HsynotAKugl+mESwrON1rrahODNvbU8lsKNzwge/OQuf9yE0TdkpgpZPgYNzLgIabj1B4mtP3rUvHTRNy78GOQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-aria": "^9.17.10",
@@ -3916,7 +3811,6 @@
             "version": "9.7.1",
             "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.1.tgz",
             "integrity": "sha512-Ml1GlcLrAUv31d9WN15WGOZv32gzDtZD5Mp1MOQ3ichDfTtxrswIch7MDzZ8hLMGf/7Y2IzBpV8iFR1XdSrGBA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/priority-overflow": "^9.3.0",
@@ -3937,7 +3831,6 @@
             "version": "9.7.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.7.0.tgz",
             "integrity": "sha512-RBxY9nKL1TwuDzK8mAe29A7RigUbqiAUrJ0R14fom5cDWo+e4qLwTxgUy/8MVe6+joWLjfLeuVWbgvIEYNoEbg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-avatar": "^9.10.3",
@@ -3960,7 +3853,6 @@
             "version": "9.14.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.14.0.tgz",
             "integrity": "sha512-XrZlSfSYhA12j5bna4Sq8N/If2vul7gl8woVrN8U3iQUjdaHB6OAMZ/WMNUdMm35Z+4e4rHClAZxU2dUsbHrmw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -3989,7 +3881,6 @@
             "version": "9.8.11",
             "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.11.tgz",
             "integrity": "sha512-2eg4MdW7e2UGRYWPg05GCytAjWYNd55YOP9+iUDINoQwwto9oeFTtZRyn08HYw37cSNqoH24qGz/VBctzTkqDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-shared-contexts": "^9.26.2",
@@ -4009,7 +3900,6 @@
             "version": "9.22.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.0.tgz",
             "integrity": "sha512-i3DLC4jd4MoYSZMYLKQNUTpkjKAJ0snIcihvkrjt2jpvv34CifKJhqVtjFQ470pRW4XNx/pBBX07vdXpA3poxA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/devtools": "^0.2.3",
@@ -4032,7 +3922,6 @@
             "version": "9.4.16",
             "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.4.16.tgz",
             "integrity": "sha512-IWVuD1hQoyIBK+RIGOCTc3HUPkdtOQghJPZ5uGwRrUlxGgpUV1h7rdAApiuQTWitrFfN6bP4PrsJmHT2DM2OFw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4054,7 +3943,6 @@
             "version": "9.22.15",
             "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.15.tgz",
             "integrity": "sha512-a+ImgL9DOlylDM4UYPnxQTA3yXxbVj+O0iNEyTZ6fMzdMsHzpALU4GAq6tOyW4L7RaQtRBmNpVfwTCEKpqaTJQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
@@ -4078,7 +3966,6 @@
             "version": "9.5.16",
             "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.5.16.tgz",
             "integrity": "sha512-xHRqm+MTkIf6JLEz/dMLlHSL9X+ysXAkig+VOV5QTPZwDIr3SqfJVvBmLNUVmtzf+cmWsRKrrIbVGpFGo/CvxA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4102,7 +3989,6 @@
             "version": "9.4.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.4.0.tgz",
             "integrity": "sha512-qVesFNgQ7uuX8z9d8xqxIXn5ax06xffgBr/eAuZfqVYZG5aRrPHHRoiWf0HDrYD4Lb/HRBLPtbNihNxhXj/LEA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
@@ -4125,7 +4011,6 @@
             "version": "9.4.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.4.0.tgz",
             "integrity": "sha512-/uBJv2IK7gN7Mt+diByV+0COvKnkluvJ2gCnYQfeOpGjPS97IIeGUIa2xpfSq+eB7Ri++1OWlK61jRjlItDmsw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-icons": "^2.0.245",
@@ -4148,7 +4033,6 @@
             "version": "9.4.16",
             "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.4.16.tgz",
             "integrity": "sha512-YsHMZsiKxH8suBtNTBXhtsvjM0u9UUXH641cEumgtjUz7SzeKNc/cWToLVyNz7GIoANL49rvubkByTeAQVCo2g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4171,7 +4055,6 @@
             "version": "9.26.2",
             "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
             "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-theme": "^9.2.1",
@@ -4186,7 +4069,6 @@
             "version": "9.7.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.7.0.tgz",
             "integrity": "sha512-dSmB0jiz/swu/zquCbHx4nS0HKLJ09N6m9+3HNXY/t24JtK4gFNcl0jQssjIsgupeA8xWsjP7+b+VxUeWq1h9Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4208,7 +4090,6 @@
             "version": "9.6.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.6.0.tgz",
             "integrity": "sha512-AlSU3GVVgcuiHL0b5xcSy8KDPZbN7yuFZMjKRe1yInK9mGfc6LuUB73EQoSIdJxRw74lMAC+am/+xCtjONlc9w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4231,7 +4112,6 @@
             "version": "9.5.16",
             "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.5.16.tgz",
             "integrity": "sha512-V4U9PSJM26BXrFqJ9K/VYYQeusBf8ldx5KOlZZ7hRamPsKTS5hyytWrF39lTLqCRlGckXPCLNzJpb1DLB+ID1g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4255,7 +4135,6 @@
             "version": "9.8.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.8.0.tgz",
             "integrity": "sha512-E1jMQueIvEEHdON6itZb3KxP67ACv+IKU/APNvQPftZVEpAZWn265T1EIe3OXAnAFHbXI3MjFcVxV9tu8+6yeg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -4277,7 +4156,6 @@
             "version": "9.5.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.5.0.tgz",
             "integrity": "sha512-sl7MifqQGR4QGDhhgBIYc25YgPuFQW7+BOfNRMO5DYPq33lX5xHNcczhXywcBESAVHrjM0MC1lsE7glv6gU8RA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-context-selector": "^9.2.15",
@@ -4302,7 +4180,6 @@
             "version": "9.7.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.7.0.tgz",
             "integrity": "sha512-fSgbLWmB+O7BREZsT9QvXsqRB39+DXMNkJwsVyRnzZ9XboUHTeN7fVGEuvWQdj8HTjtYE2YYfGUXFo3fST88xA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4327,7 +4204,6 @@
             "version": "9.19.12",
             "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.12.tgz",
             "integrity": "sha512-4SgGOAAL9P1gi9A6286SHGde6JJnT1uiT/st7wHJOMhbo8QE6+Cfn5MgH9LnvMbW+RxZ8m0NV8sMPi9QorAMZg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4356,7 +4232,6 @@
             "version": "9.11.2",
             "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.11.2.tgz",
             "integrity": "sha512-zmWzySlPM9EwHJNW0/JhyxBCqBvmfZIj1OZLdRDpbPDsKjhO0aGZV6WjLHFYJmq58kbN0wHKUbxc7LfafHHUwA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-context-selector": "^9.2.15",
@@ -4379,7 +4254,6 @@
             "version": "9.26.13",
             "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.13.tgz",
             "integrity": "sha512-uOuJj7jn1ME52Vc685/Ielf6srK/sfFQA5zBIbXIvy2Eisfp7R1RmJe2sXWoszz/Fu/XDkPwdM/GLv23N3vrvQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-shared-contexts": "^9.26.2",
@@ -4401,7 +4275,6 @@
             "version": "9.8.3",
             "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.3.tgz",
             "integrity": "sha512-dM+Cl+Y1FDYBbpa5MNWzxGLCrcAlz0B2n90Fjt2LKeA4S5+zWH3/vzH3U9M0YxJCKe7S/5XlAtgO6VwDYu3CRw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4432,7 +4305,6 @@
             "version": "9.7.18",
             "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.7.18.tgz",
             "integrity": "sha512-8SIdeU3jjkvbIlwno/VuAk5zoMuk1qBfLgSIrFXG/PJWI7hjWL5S6gT/5AqAZYQMzftHZkm6hRnLJhWpgHqllA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4458,7 +4330,6 @@
             "version": "9.6.19",
             "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.19.tgz",
             "integrity": "sha512-rSidcDbgnJaZPA7RW6uJqQqEga/2ON5PuuLauZFLGxZyuAAZv+8dwUBsxHYwneVpbFIITF3GX4f1sdH5Ei+lqQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-aria": "^9.17.10",
@@ -4486,7 +4357,6 @@
             "version": "9.6.15",
             "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.15.tgz",
             "integrity": "sha512-YB1azhq8MGfnYTGlEAX1mzcFZ6CvqkkaxaCogU4TM9BtPgQ1YUAxE01RMenl8VVi8W9hNbJKkuc8R8GzYwzT4Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -4507,7 +4377,6 @@
             "version": "9.7.0",
             "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.7.0.tgz",
             "integrity": "sha512-AaBcoTHQv1dZ36w0Uoy8bnnkO0Ag7T0+6ZbjkiSGu50245WvK+MJawuCW91UuZvEUR7MPaAK/TDXWlHYWlMqRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-field": "^9.4.16",
@@ -4529,7 +4398,6 @@
             "version": "9.2.1",
             "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
             "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/tokens": "1.0.0-alpha.23",
@@ -4540,7 +4408,6 @@
             "version": "9.7.15",
             "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.15.tgz",
             "integrity": "sha512-iuk4rf/WumpGrNIpRVLNamlPBY0rT9BhI4qTnVmzXqz5pY+8GmAq/TKUPER9/withtQW8V9srj91FWblxzpHRg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4568,7 +4435,6 @@
             "version": "9.7.5",
             "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.7.5.tgz",
             "integrity": "sha512-mafkxOQAdmUyDqaWC0FLMxYOCx2dEYafDK+3V3IQALuCuZ90nrW3lH9Uh6/GdkcXQ21ykiOmkGoxtQ3xNt6YeQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-button": "^9.9.0",
@@ -4594,7 +4460,6 @@
             "version": "9.9.3",
             "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.9.3.tgz",
             "integrity": "sha512-a351JFoaBAOn0SnQ76tzuNv2ieHzAS+VO8Ncy4m9/emrIs5lvBBfKX8fvA4/efVxY+683XEQdoL1LuApuJuTWw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4619,7 +4484,6 @@
             "version": "9.15.14",
             "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.15.14.tgz",
             "integrity": "sha512-gjLlvjFD64SREUeKaSocueUnntSofplU4EMZToaYqGixlzAouHzTFEZeiohuuYjVWhOn/WBBZsOEdr7bPva+kQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4651,7 +4515,6 @@
             "version": "9.26.2",
             "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.2.tgz",
             "integrity": "sha512-Yp2GGNoWifj8Z/VVir4HyRumRsqXnLJd4IP/Y70vEm9ruAvyqUvfn+1lQUuA+k/Reqw8GI+Ix7FTo3rogixZBg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
@@ -4667,7 +4530,6 @@
             "version": "9.0.0-alpha.111",
             "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.111.tgz",
             "integrity": "sha512-yku++0779Ve1RNz6y/HWjlXKd2x1wCSbWMydT2IdCICBVwolXjPYMpkqqZUSjbJ0N9gl6BfsCBpU9Dfe2bR8Zg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.4.1",
@@ -4687,7 +4549,6 @@
             "version": "1.0.0-alpha.23",
             "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
             "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.1"
@@ -4742,7 +4603,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
             "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -4777,7 +4637,6 @@
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.20.1.tgz",
             "integrity": "sha512-ld1mX04zpmeHn8agx4slSEh8kJ+8or3Y0x9gsJNKSKn6GdCkZBSiGUh+oBXCBn8RKzz8l60TA9IhVSStnyKekA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@emotion/hash": "^0.9.0",
@@ -4792,7 +4651,6 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.6.1.tgz",
             "integrity": "sha512-mNM4/+dIXzqeHboWpVZ1/jiwTAYNc5/8y/V/HasnQ2QXnV6gSUYpeUk/0n6IFU3NJmVJly9JrLSfNo0hM/IFeA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@griffel/core": "^1.20.1",
@@ -4806,7 +4664,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.4.0.tgz",
             "integrity": "sha512-vNDfOGV7RN/XkA7vxgf7Z5HgW8eiBm5cHT9wQPhsKB4pxWom5u6eQ9CkYE5mCCTSPl9H6Nd1NBai04d4P6BD7Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.1.3"
@@ -4828,7 +4685,6 @@
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
@@ -4838,7 +4694,6 @@
             "version": "0.16.7",
             "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
             "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
@@ -4852,7 +4707,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.22"
@@ -4866,7 +4720,6 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18"
@@ -5738,6 +5591,7 @@
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
@@ -5780,6 +5634,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5801,6 +5656,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5822,6 +5678,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5843,6 +5700,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5864,6 +5722,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5885,6 +5744,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5906,6 +5766,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5927,6 +5788,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5948,6 +5810,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5969,6 +5832,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -5990,6 +5854,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -6011,6 +5876,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
@@ -6032,26 +5898,13 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 10.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/@pkgr/core": {
@@ -6087,21 +5940,18 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
             "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@react-dnd/invariant": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
             "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@react-dnd/shallowequal": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
             "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@recast-navigation/core": {
@@ -6665,19 +6515,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.60.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
@@ -6690,7 +6527,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.60.0",
@@ -6704,7 +6542,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.60.0",
@@ -6718,7 +6557,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.60.0",
@@ -6732,7 +6572,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.60.0",
@@ -6746,7 +6587,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.60.0",
@@ -6760,7 +6602,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.60.0",
@@ -6774,7 +6617,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.60.0",
@@ -6788,7 +6632,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.60.0",
@@ -6802,7 +6647,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.60.0",
@@ -6816,7 +6662,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
             "version": "4.60.0",
@@ -6830,7 +6677,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
             "version": "4.60.0",
@@ -6844,7 +6692,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.60.0",
@@ -6858,7 +6707,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
             "version": "4.60.0",
@@ -6872,7 +6722,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.60.0",
@@ -6886,7 +6737,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.60.0",
@@ -6900,7 +6752,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.60.0",
@@ -6914,7 +6767,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.60.0",
@@ -6928,7 +6782,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.60.0",
@@ -6942,7 +6797,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
             "version": "4.60.0",
@@ -6956,7 +6812,8 @@
             "optional": true,
             "os": [
                 "openbsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
             "version": "4.60.0",
@@ -6970,7 +6827,8 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.60.0",
@@ -6984,7 +6842,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.60.0",
@@ -6998,7 +6857,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
             "version": "4.60.0",
@@ -7012,7 +6872,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.60.0",
@@ -7026,7 +6887,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
@@ -7141,7 +7003,6 @@
             "version": "0.5.20",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.20.tgz",
             "integrity": "sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.8.0"
@@ -7341,7 +7202,6 @@
             "version": "0.7.54",
             "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
             "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/deep-eql": {
@@ -7400,14 +7260,12 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/filesystem": {
@@ -7448,7 +7306,6 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json5": {
@@ -7483,14 +7340,12 @@
             "version": "15.7.15",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
             "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.3.28",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -7501,7 +7356,6 @@
             "version": "18.3.7",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^18.0.0"
@@ -8235,7 +8089,6 @@
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -8261,7 +8114,6 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -8440,6 +8292,19 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/anymatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/append-transform": {
@@ -8913,7 +8778,6 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -9135,7 +8999,6 @@
             "version": "5.0.6",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
             "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -9934,14 +9797,14 @@
             }
         },
         "node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "mdn-data": "2.0.30",
-                "source-map-js": "^1.0.1"
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -10117,20 +9980,6 @@
                 "node": ">=20"
             }
         },
-        "node_modules/cssstyle/node_modules/css-tree": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mdn-data": "2.27.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-            }
-        },
         "node_modules/cssstyle/node_modules/lru-cache": {
             "version": "11.4.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
@@ -10141,25 +9990,16 @@
                 "node": "20 || >=22"
             }
         },
-        "node_modules/cssstyle/node_modules/mdn-data": {
-            "version": "2.27.1",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-            "dev": true,
-            "license": "CC0-1.0"
-        },
         "node_modules/csstype": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/dagre": {
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
             "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graphlib": "^2.1.8",
@@ -10295,7 +10135,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/deepmerge": {
@@ -10468,7 +10307,6 @@
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-15.0.1.tgz",
             "integrity": "sha512-pqVsLKNYdIYwOesmeAC9wcfDmyAHsiZwLoIYs+bDXaUjnuGZc3h/QWFenPSPFgp2ichG50P9sIFy4yuBZd49JQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@react-dnd/asap": "^4.0.0",
@@ -10651,14 +10489,12 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/embla-carousel-autoplay": {
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
             "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "embla-carousel": "8.6.0"
@@ -10668,7 +10504,6 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
             "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "embla-carousel": "8.6.0"
@@ -11021,7 +10856,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -11055,7 +10889,6 @@
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
             "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
@@ -11292,6 +11125,27 @@
             },
             "peerDependencies": {
                 "eslint": "^8 || ^9"
+            }
+        },
+        "node_modules/eslint-plugin-github/node_modules/@eslint/compat": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+            "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^1.2.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "peerDependencies": {
+                "eslint": "^8.40 || 9 || 10"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-plugin-github/node_modules/@eslint/js": {
@@ -11573,7 +11427,6 @@
             "version": "9.1.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
             "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
@@ -11592,7 +11445,6 @@
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -11605,7 +11457,6 @@
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -11622,7 +11473,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -11635,7 +11485,6 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
@@ -11648,7 +11497,6 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
@@ -11658,14 +11506,12 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/espree": {
             "version": "11.2.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
             "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.16.0",
@@ -11683,7 +11529,6 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -11696,7 +11541,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -11722,7 +11566,6 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -11735,7 +11578,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
@@ -11984,14 +11826,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
@@ -12091,7 +11931,6 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flat-cache": "^4.0.0"
@@ -12182,7 +12021,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "locate-path": "^6.0.0",
@@ -12209,7 +12047,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -12223,7 +12060,6 @@
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/fn.name": {
@@ -12676,7 +12512,6 @@
             "version": "2.1.8",
             "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
             "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lodash": "^4.17.15"
@@ -12790,7 +12625,6 @@
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "react-is": "^16.7.0"
@@ -12800,7 +12634,6 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/hono": {
@@ -13035,7 +12868,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.19"
@@ -13255,7 +13087,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -13308,7 +13139,6 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -13929,7 +13759,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
@@ -13954,7 +13783,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json5": {
@@ -14006,14 +13834,12 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
             "integrity": "sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
@@ -14059,7 +13885,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
@@ -14404,19 +14229,6 @@
                 "node": ">=20"
             }
         },
-        "node_modules/lint-staged/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/listr2": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
@@ -14576,7 +14388,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-locate": "^5.0.0"
@@ -14592,7 +14403,6 @@
             "version": "4.18.1",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.camelcase": {
@@ -14606,7 +14416,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.flattendeep": {
@@ -15057,9 +14866,9 @@
             }
         },
         "node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -15120,6 +14929,19 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/mime-db": {
@@ -15220,7 +15042,6 @@
             "version": "10.2.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
             "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "brace-expansion": "^5.0.5"
@@ -15304,7 +15125,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/negotiator": {
@@ -15349,7 +15169,8 @@
             "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
             "dev": true,
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/node-gyp-build": {
             "version": "4.8.4",
@@ -16146,7 +15967,6 @@
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "deep-is": "^0.1.3",
@@ -16244,7 +16064,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
@@ -16260,7 +16079,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
@@ -16540,7 +16358,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -16628,13 +16445,13 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -17387,27 +17204,6 @@
                 "node": ">=16"
             }
         },
-        "node_modules/postcss-svgo/node_modules/css-tree": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mdn-data": "2.27.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-            }
-        },
-        "node_modules/postcss-svgo/node_modules/mdn-data": {
-            "version": "2.27.1",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-            "dev": true,
-            "license": "CC0-1.0"
-        },
         "node_modules/postcss-svgo/node_modules/svgo": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
@@ -17474,7 +17270,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8.0"
@@ -17637,7 +17432,6 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -17740,7 +17534,6 @@
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.0.1.tgz",
             "integrity": "sha512-qUqVY+KlG4ZX3eSFTcOHU2HcVa6B9x6bKmyDfji8AkOl15/3gkbEyIARCyJVByFjTjwUPF1VnRiEcvVHYw8APA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
@@ -17771,7 +17564,6 @@
             "version": "15.0.1",
             "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-15.0.1.tgz",
             "integrity": "sha512-DoigPaIAs70DRy4qd+i1U5+wLyyhtiuydqHuhXTObxjQzimG70UN7L3Qzx/3SXYQroOIj9fEOXvb9yzMsD2TMA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
@@ -17819,11 +17611,23 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/readdirp/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/redux": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
@@ -18289,19 +18093,6 @@
                 }
             }
         },
-        "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
             "version": "0.7.6",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -18349,7 +18140,6 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
             "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.1.2"
@@ -19549,7 +19339,6 @@
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
             "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/supports-color": {
@@ -19634,6 +19423,27 @@
                 "node": ">= 10"
             }
         },
+        "node_modules/svgo/node_modules/css-tree": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.30",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/svgo/node_modules/mdn-data": {
+            "version": "2.0.30",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+            "dev": true,
+            "license": "CC0-1.0"
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -19661,7 +19471,6 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.7.0.tgz",
             "integrity": "sha512-AKYquti8AdWzuqJdQo4LUMQDZrHoYQy6V+8yUq2PmgLZV10EaB+8BD0nWOfC/3TBp4mPNg4fbHkz6SFtkr0PpA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "keyborg": "2.6.0",
@@ -19678,7 +19487,6 @@
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -19861,19 +19669,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
-        "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/tinyrainbow": {
@@ -20104,7 +19899,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
@@ -20297,7 +20091,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
             "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -20460,7 +20254,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -20470,10 +20263,25 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
             "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/usehooks-ts": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+            "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "lodash.debounce": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=16.15.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
             }
         },
         "node_modules/utf-8-validate": {
@@ -20870,19 +20678,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/vitest": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
@@ -20971,19 +20766,6 @@
                 "vite": {
                     "optional": false
                 }
-            }
-        },
-        "node_modules/vitest/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/w3c-xmlserializer": {
@@ -21334,7 +21116,6 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -21538,7 +21319,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -161,6 +161,10 @@
         "eslint-plugin-tsdoc": {
             "@typescript-eslint/utils": "^8.58.2"
         },
+        "@eslint/compat": {
+            ".": "^2.0.0",
+            "eslint": "$eslint"
+        },
         "dompurify": "3.4.0"
     }
 }


### PR DESCRIPTION
## What & why

Replaces the blanket `legacy-peer-deps=true` flag in the root `.npmrc` with a single **scoped** npm `override`, so peer-dependency checking stays enabled repo-wide instead of being globally suppressed.

The blanket flag was added during the TypeScript 6 upgrade (#18202), but that reason no longer applies. The only peer conflict it was actually masking is ESLint: `eslint-plugin-github@6` pulls in `@eslint/compat@1.x`, whose `peerOptional eslint@"^8.40 || 9"` doesn't cover this repo's `eslint@10`. `@eslint/compat@2.x` officially supports eslint 10 (`^8.40 || 9 || 10`).

### Primary change
- Remove `legacy-peer-deps=true` from `.npmrc` (keep the `node-options` line).
- Add a scoped override to root `package.json`:
  ```json
  "@eslint/compat": { ".": "^2.0.0", "eslint": "$eslint" }
  ```
  This bumps `@eslint/compat` to **2.1.0** (eslint-10 compatible) and satisfies its peer — resolving the eslint@10 vs `@eslint/compat@1.x` conflict.

### Lockfile scope disclosure

Dropping the blanket flag necessarily re-enables strict peer resolution repo-wide, so `package-lock.json` changes beyond just the eslint subtree. This is expected and inherent to disabling the flag globally (it can't be scoped per-package). The actual resolved-version changes are:

- `@eslint/compat` 1.4.1 → **2.1.0** (the intended fix)
- `@eslint/core` consolidated to 1.2.1 (transitive dep of `@eslint/compat`)
- **`usehooks-ts` → 3.1.1 newly installed**: this is a declared `peerDependency` of `@babylonjs/inspector-v2` that `legacy-peer-deps` was silently skipping. Note it is currently **declared-but-unused** — it was scaffolded in #17086 and externalized in that package's rollup config, but is not imported anywhere in source. It's pulled in here only because the flag can't be scoped per-package. A reviewer may want to separately decide whether to prune that stale peer declaration; the clean `^3.1.1` match means it's harmless regardless.
- `picomatch` nested patch bump 4.0.4 → 4.0.5 (benign dedup)

### Verification
- `npm install --package-lock-only`, `npm ci`, and `npm run lint:check` all pass with **zero `ERESOLVE` warnings**.
- Only three files change: `.npmrc`, `package.json`, `package-lock.json`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>