### PR TITLE
feat(inspector): expose PBR metallic texture channel mapping (glTF ORM)

### DIFF
--- a/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/animation/animationsProperties.tsx
@@ -16,6 +16,11 @@ import { type Nullable } from "core/types";
 import { type IAnimatable } from "core/Animations/animatable.interface";
 import { type Scene } from "core/scene";
 import { AnimationPropertiesOverride } from "core/Animations/animationPropertiesOverride";
+
+// Registers the Scene animation prototype methods (getAllAnimatablesByTarget, beginAnimation, stopAnimation) used by this component.
+// Without this side-effect import they remain missing-side-effect stubs (returning undefined) and getAllAnimatablesByTarget().length throws on first render.
+import "core/Animations/animatable";
+
 import { useProperty } from "../../../hooks/compoundPropertyHooks";
 import { BoundProperty } from "../boundProperty";
 import { CurveEditorButton } from "../../curveEditor/curveEditorButton";

--- a/packages/dev/inspector-v2/src/components/properties/materials/pbrBaseMaterialProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/materials/pbrBaseMaterialProperties.tsx
@@ -336,6 +336,8 @@ export const PBRBaseMaterialMetallicWorkflowProperties: FunctionComponent<{ mate
 
     const selectEntity = (entity: object) => (selectionService.selectedEntity = entity);
 
+    const metallicTexture = useProperty(material, "_metallicTexture");
+
     return (
         <>
             <BoundProperty component={SyncedSliderPropertyLine} label="Metallic" target={material} propertyKey="_metallic" min={0} max={1} step={0.01} nullable defaultValue={0} />
@@ -401,6 +403,38 @@ export const PBRBaseMaterialMetallicWorkflowProperties: FunctionComponent<{ mate
                 onLink={selectEntity}
                 defaultValue={null}
             />
+            <Collapse visible={!!metallicTexture}>
+                <>
+                    <BoundProperty
+                        component={SwitchPropertyLine}
+                        label="Use AO from Red Channel"
+                        description="Interpret the metallic texture's red channel as ambient occlusion (glTF ORM packing)."
+                        target={material}
+                        propertyKey="_useAmbientOcclusionFromMetallicTextureRed"
+                    />
+                    <BoundProperty
+                        component={SwitchPropertyLine}
+                        label="Use Roughness from Green Channel"
+                        description="Interpret the metallic texture's green channel as roughness (glTF ORM packing). Requires 'Use Roughness from Alpha Channel' to be disabled."
+                        target={material}
+                        propertyKey="_useRoughnessFromMetallicTextureGreen"
+                    />
+                    <BoundProperty
+                        component={SwitchPropertyLine}
+                        label="Use Metallic from Blue Channel"
+                        description="Interpret the metallic texture's blue channel as metalness (glTF ORM packing)."
+                        target={material}
+                        propertyKey="_useMetallnessFromMetallicTextureBlue"
+                    />
+                    <BoundProperty
+                        component={SwitchPropertyLine}
+                        label="Use Roughness from Alpha Channel"
+                        description="Interpret the metallic texture's alpha channel as roughness (Babylon legacy default). Takes precedence over the green channel."
+                        target={material}
+                        propertyKey="_useRoughnessFromMetallicTextureAlpha"
+                    />
+                </>
+            </Collapse>
         </>
     );
 };


### PR DESCRIPTION
## Motivation

Forum discussion: [Should Babylon.js Inspector provide a glTF ORM preset for PBRMaterial?](https://forum.babylonjs.com/t/should-babylon-js-inspector-provide-a-gltf-orm-preset-for-pbrmaterial/63739)

A newly created `PBRMaterial` does **not** interpret a `metallicTexture` using the standard glTF ORM (Occlusion-Roughness-Metallic) channel layout by default:

```
useRoughnessFromMetallicTextureAlpha = true;
useRoughnessFromMetallicTextureGreen = false;
useMetallnessFromMetallicTextureBlue = false;
useAmbientOcclusionFromMetallicTextureRed = false;
```

So assigning a standard glTF ORM texture (R=AO, G=Roughness, B=Metallic) to a hand-created `PBRMaterial` in the Sandbox/Inspector renders incorrectly, even though the same texture works when loaded via the glTF loader (which configures these flags automatically). These channel-mapping flags could previously only be set from code.

## Changes

### 1. Expose PBR metallic texture channel mapping in the Inspector (feature)

Implements **Option 2** from the forum thread — exposing the channel-mapping options directly. When a metallic texture is assigned, the PBRMaterial properties pane now shows switches for:

- **Use AO from Red Channel** (`useAmbientOcclusionFromMetallicTextureRed`)
- **Use Roughness from Green Channel** (`useRoughnessFromMetallicTextureGreen`)
- **Use Metallic from Blue Channel** (`useMetallnessFromMetallicTextureBlue`)
- **Use Roughness from Alpha Channel** (`useRoughnessFromMetallicTextureAlpha`)

Each switch has a description clarifying the glTF ORM vs. Babylon legacy behavior. This preserves backward compatibility (defaults unchanged) while making it easy to configure a standard glTF ORM texture directly in the Inspector. The switches are wrapped in a `Collapse` so they only appear when a metallic texture is present.

<img width="337" height="437" alt="image" src="https://github.com/user-attachments/assets/26cf6df2-ec06-4c7b-ab8b-914e1f2d377e" />

### 2. Fix missing animatable side-effect import in `AnimationsProperties` (bug discovered while testing)

While validating the change in the inspector-v2 test app, the app threw a runtime error on **first** load:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
  at AnimationsProperties
```

**Root cause:** `AnimationsProperties` calls the prototype-augmented `Scene` methods `getAllAnimatablesByTarget`, `beginAnimation`, and `stopAnimation`, but never imported the module that registers them. When the host boots from `core/pure` (as the inspector-v2 test app does), those methods remain `_MissingSideEffect` stubs that return `undefined`, so `scene.getAllAnimatablesByTarget(entity).length` threw and the properties pane was torn down by its error boundary. It only reproduced on first load because an async glTF load happened to register the side effect as a byproduct afterward — a race, not a real fix.

The fix adds the documented side-effect import (`import "core/Animations/animatable";`) to the consuming component, matching the existing inspector-v2 convention (e.g. `abstractMeshProperties.tsx` importing `core/Rendering/edgesRenderer`). This registers the methods synchronously at module load, and as a bonus makes the animation controls functional rather than silent no-ops.

## Testing

- Verified in the inspector-v2 test app (`http://localhost:9001/`):
  - Before: first load threw the `AnimationsProperties` `TypeError` and tripped the error boundary.
  - After: fresh first-load (hard reload, cache ignored) has a clean console — no runtime errors.
- Verified the new PBR metallic-texture channel switches appear in the properties pane when a metallic texture is assigned and correctly drive the underlying flags.
