### PR TITLE
fix: restore side-effect registrations dropped by the 9.15 pure/non-pure split

### DIFF
--- a/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
+++ b/packages/dev/core/src/Lights/Shadows/shadowGenerator.ts
@@ -13,7 +13,7 @@ import { Light } from "../../Lights/light";
 import { type MaterialDefines } from "../../Materials/materialDefines";
 import { type Effect, type IEffectCreationOptions } from "../../Materials/effect";
 import { Texture } from "../../Materials/Textures/texture.pure";
-import { RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture.pure";
+import { RegisterRenderTargetTexture, RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture.pure";
 
 import { PostProcess } from "../../PostProcesses/postProcess.pure";
 import { BlurPostProcess } from "../../PostProcesses/blurPostProcess.pure";
@@ -1003,6 +1003,12 @@ export class ShadowGenerator implements IShadowGenerator {
 
         RegisterShadowGeneratorSceneComponent(ShadowGenerator);
         ShadowGenerator._SceneComponentInitialization(this._scene);
+
+        // PCF and PCSS filtering bind a comparison sampler through Effect.setDepthStencilTexture,
+        // which is only installed by the render target texture registration. This module imports
+        // renderTargetTexture.pure (side-effect free), so pull the registration in here to guarantee
+        // the sampler is available (otherwise WebGPU bind-group assembly fails for filtered shadows).
+        RegisterRenderTargetTexture();
 
         // Texture type fallback from float to int if not supported.
         const caps = this._scene.getEngine().getCaps();

--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.pure.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.pure.ts
@@ -1,7 +1,7 @@
 /** This file must only contain pure code and pure imports */
 
 import { Logger } from "../../Misc/logger";
-import { Camera } from "../../Cameras/camera.pure";
+import { Camera, RegisterCamera } from "../../Cameras/camera.pure";
 import { Mesh } from "../../Meshes/mesh.pure";
 import { Geometry } from "../../Meshes/geometry";
 import { TransformNode } from "../../Meshes/transformNode.pure";
@@ -803,6 +803,13 @@ export function RegisterBabylonFileLoader(): void {
     }
     _Registered = true;
 
+    // The loader parses cameras through the Camera.Parse static, which is only
+    // installed by the render-time camera registration. Because this module imports
+    // camera.pure (side-effect free), pull the registration in here so a tree-shaken
+    // build that only imports the .babylon loader can still parse cameras. Without
+    // this, Camera.Parse throws mid-load and the scene ends up with no active camera.
+    RegisterCamera();
+
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const ParseMaterialByPredicate = (predicate: (parsedMaterial: any) => boolean, parsedData: any, scene: Scene, rootUrl: string) => {
         if (!parsedData.materials) {
@@ -1335,6 +1342,13 @@ export function RegisterBabylonFileLoader(): void {
 
                 if (parsedData.activeCameraID !== undefined && parsedData.activeCameraID !== null) {
                     scene.setActiveCameraById(parsedData.activeCameraID);
+                }
+
+                // If no active camera has been resolved (e.g. the serialized activeCameraID
+                // does not match any loaded camera) but the scene does contain cameras,
+                // fall back to the first one so the scene can still be rendered.
+                if (!scene.activeCamera && scene.cameras.length > 0) {
+                    scene.activeCamera = scene.cameras[0];
                 }
 
                 // Finish

--- a/packages/dev/core/test/unit/Lights/Shadows/babylon.shadowGeneratorSideEffect.test.ts
+++ b/packages/dev/core/test/unit/Lights/Shadows/babylon.shadowGeneratorSideEffect.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Pre-load shader modules that ShadowGenerator dynamically imports during construction.
+// Without these, the fire-and-forget import() in _initShaderSourceAsync may still be
+// resolving when the test environment tears down, causing EnvironmentTeardownError.
+import "core/Shaders/shadowMap.fragment";
+import "core/Shaders/shadowMap.vertex";
+import "core/Shaders/depthBoxBlur.fragment";
+import "core/Shaders/ShadersInclude/shadowMapFragmentSoftTransparentShadow";
+
+/**
+ * Regression coverage for the 9.15 tree-shaking split where PCF/PCSS shadows threw
+ * `Sampler "shadowTexture0Sampler" not found in the material context` on WebGPU.
+ *
+ * `ShadowGenerator.bindShadowLight` calls `effect.setDepthStencilTexture(...)` for
+ * PCF and PCSS filtering, but that method is only installed by the render target
+ * texture registration. Because the shadow modules import `renderTargetTexture.pure`
+ * (no side effects), the method stayed unregistered and the comparison sampler was
+ * never bound. Constructing a ShadowGenerator (or CascadedShadowGenerator) must
+ * therefore trigger the render target texture registration at runtime.
+ */
+describe("ShadowGenerator setDepthStencilTexture side effect", () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    afterEach(() => {
+        vi.resetModules();
+    });
+
+    it("does not install setDepthStencilTexture merely by importing the shadow module", async () => {
+        const { Effect } = await import("core/Materials/effect");
+        expect(Effect.prototype.setDepthStencilTexture).toBeUndefined();
+
+        // Importing the module (which pulls in renderTargetTexture.pure) must not have side effects.
+        await import("core/Lights/Shadows/shadowGenerator");
+        expect(Effect.prototype.setDepthStencilTexture).toBeUndefined();
+    });
+
+    it("installs setDepthStencilTexture when a ShadowGenerator is constructed", async () => {
+        const { Effect } = await import("core/Materials/effect");
+        const { NullEngine } = await import("core/Engines/nullEngine");
+        const { Scene } = await import("core/scene");
+        const { DirectionalLight } = await import("core/Lights/directionalLight");
+        const { Vector3 } = await import("core/Maths/math.vector");
+        const { ShadowGenerator } = await import("core/Lights/Shadows/shadowGenerator");
+
+        expect(Effect.prototype.setDepthStencilTexture).toBeUndefined();
+
+        const engine = new NullEngine({ renderHeight: 256, renderWidth: 256, textureSize: 256, deterministicLockstep: false, lockstepMaxSteps: 1 });
+        try {
+            const scene = new Scene(engine);
+            const light = new DirectionalLight("dir", new Vector3(0, -1, 0), scene);
+            const generator = new ShadowGenerator(1024, light);
+            generator.usePercentageCloserFiltering = true;
+
+            expect(typeof Effect.prototype.setDepthStencilTexture).toBe("function");
+        } finally {
+            engine.dispose();
+        }
+    });
+});

--- a/packages/dev/core/test/unit/Loading/babylonFileLoader.activeCamera.test.ts
+++ b/packages/dev/core/test/unit/Loading/babylonFileLoader.activeCamera.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { LoadAssetContainer } from "core/Loading/Plugins/babylonFileLoader";
+
+// Import the camera classes a tree-shaken app would use (registering their
+// constructors) but deliberately NOT "core/Cameras/camera", whose wrapper is what
+// installs Camera.Parse. The loader registration must supply Camera.Parse itself.
+import "core/Cameras/universalCamera";
+import "core/Cameras/freeCamera";
+
+/**
+ * Regression coverage for the 9.15 tree-shaking split where appending a .babylon
+ * scene left `scene.activeCamera` null (so the scene never rendered and consumer
+ * code doing `scene.activeCamera.attachControl(...)` null-dereferenced).
+ *
+ * The .babylon loader parses cameras through the `Camera.Parse` static, which is
+ * only installed by the camera registration (non-pure `camera` wrapper). Because
+ * the loader imports `camera.pure` (side-effect free), a tree-shaken build that
+ * imports only the loader would throw "Camera.Parse is not a function" mid-load.
+ * Since cameras are parsed after meshes/materials/lights, geometry loaded but no
+ * camera was created. The loader registration must pull in the camera registration.
+ */
+
+function makeBabylonScene(camera: Record<string, unknown>, activeCameraID?: string | null): string {
+    const parsed: Record<string, unknown> = {
+        producer: { name: "Babylon.js", version: "1.0", exporter_version: "1.0" },
+        cameras: [camera],
+        meshes: [],
+        lights: [],
+        materials: [],
+    };
+    if (activeCameraID !== null) {
+        parsed.activeCameraID = activeCameraID ?? "camId";
+    }
+    return JSON.stringify(parsed);
+}
+
+describe("Babylon file loader active camera", () => {
+    // Importing only the .babylon loader (as a tree-shaken consumer might) must be
+    // enough to parse cameras; the loader owns the Camera.Parse dependency.
+    it("parses cameras without importing the camera side-effect wrapper", () => {
+        const engine = new NullEngine();
+        const scene = new Scene(engine);
+
+        const container = LoadAssetContainer(scene, makeBabylonScene({ name: "cam", id: "camId", uniqueId: 1, type: "FreeCamera", position: [0, 0, -10] }), "", (message) => {
+            throw new Error(message);
+        });
+
+        expect(container.cameras.length).toBe(1);
+        engine.dispose();
+    });
+
+    // A camera with no explicit type must still parse (falls back to a default
+    // camera) and the scene must end up with a valid active camera.
+    it("resolves an active camera for a type-less camera", () => {
+        const engine = new NullEngine();
+        const scene = new Scene(engine);
+
+        LoadAssetContainer(scene, makeBabylonScene({ name: "cam", id: "camId", uniqueId: 1, position: [0, 0, -10] }), "", undefined, true);
+
+        expect(scene.cameras.length).toBe(1);
+        expect(scene.activeCamera).not.toBeNull();
+        engine.dispose();
+    });
+});


### PR DESCRIPTION
## Context

Three issues were reported in the 9.15.0 release, primarily affecting WebGPU rendering. Two are concrete regressions caused by the 9.15 pure/non-pure tree-shaking split, where a feature imports the `.pure` variant of a dependency but relies on that dependency's side-effect registration at runtime — which is never triggered in a tree-shaken build. The third is a characterization request.

Each issue was reproduced and root-caused against the current source before changing anything.

---

## Issue 1 — WebGPU PCF/PCSS shadows throw `Sampler "shadowTexture0Sampler" not found in the material context` ✅ Fixed

**Root cause:** `ShadowGenerator.bindShadowLight` calls `effect.setDepthStencilTexture(...)` for PCF/PCSS filtering. That method is installed **only** by `RegisterRenderTargetTexture()` in the non-pure `renderTargetTexture.ts`. The shadow module imports `renderTargetTexture.pure` (side-effect free), so the method stayed unregistered → the comparison sampler was never bound → WebGPU bind-group assembly failed at render time.

**Fix:** Call `RegisterRenderTargetTexture()` during `ShadowGenerator` construction (in `_createInstance`), directly alongside the existing `RegisterShadowGeneratorSceneComponent(...)` precedent in the same method. Registering from the constructor covers **every** construction path — `ShadowGenerator`, `CascadedShadowGenerator` (via `super()`), FrameGraph tasks/blocks, and `Parse` — with no module split, no side-effect-import closure violations, and no manifest/barrel churn. The call is idempotent.

## Issue 2 — `.babylon` loader leaves `scene.activeCamera` null after append ✅ Fixed

**Root cause:** `babylonFileLoader.pure` imports `camera.pure` and calls `Camera.Parse(...)`, which is installed only by `RegisterCamera()` in the non-pure `camera.ts`. In a tree-shaken build `Camera.Parse` was `undefined` and threw mid-load. Because cameras are parsed after meshes/materials/lights, geometry loaded fine but no camera was created, and `setActiveCameraById` then left `activeCamera` null — so the scene never rendered and consumer code doing `scene.activeCamera.attachControl(...)` null-dereferenced.

**Fix:** Call `RegisterCamera()` from `RegisterBabylonFileLoader()` so a tree-shaken build that only imports the `.babylon` loader can still parse cameras. Also added a defensive fallback that sets `scene.activeCamera = scene.cameras[0]` when the serialized `activeCameraID` fails to resolve but cameras exist.

## Issue 3 — WebGPU render-output differences ✅ Characterized (no code fix warranted)

- **PBR clearcoat — intended behavior change.** The clearcoat shader math is unchanged since before 9.5.0. The only PBR shading changes in the 9.5→9.15 window are intentional: the refraction-intensity correctness fix (#18513, corrects irradiance being multiplied by `(1 - refractionOpacity)²` instead of `(1 - refractionOpacity)`) and an opt-in texture-repetition-breaking feature (#18448). A modest clearcoat difference is expected, not a regression.
- **DepthRenderer (WebGPU) — not a verifiable pure-split regression.** The natural "missing `createRenderTargetTexture` registration" hypothesis does **not** hold: both WebGL (`engine.ts`) and WebGPU (`webgpuEngine.ts`) register their own render-target extensions on engine import, and WebGPU installs its override on `ThinWebGPUEngine.prototype` (shadowing the base), so `createRenderTargetTexture` is always present when an engine exists. The only depthRenderer change since May is the split itself, and none of its dropped side-effect imports are used by the depth-map render or postprocess-sampling path (any real scene already imports them). Rather than ship a speculative no-op fix, this sub-case is documented as needing a WebGPU runtime repro to confirm; no code change is included.

---

## Tests

- `babylon.shadowGeneratorSideEffect.test.ts` — asserts `Effect.prototype.setDepthStencilTexture` is undefined before construction and installed after a `ShadowGenerator` is built. Verified to fail without the fix and pass with it.
- `babylonFileLoader.activeCamera.test.ts` — appends a `.babylon` scene with a type-less camera without importing the camera side-effect wrapper and asserts `activeCamera` is resolved. Verified to fail without the fix and pass with it.

## Validation

- `npm run check:treeshaking` — 16/16 checks pass; precommit regenerated manifests/barrels with zero drift (constructor-based fix needs no infrastructure changes).
- `npm run check:side-effects-sync` — pass.
- Prettier + ESLint (0 errors) on all changed files.
- 81 Lights + Loading unit tests pass, plus the two new regression tests.

Both fixes keep `Register*()` side effects out of module top-level scope (they run only during construction/registration), respecting the `.pure` vs non-pure split convention.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>