### PR TITLE
Fix ParticleSystem.clone() / GPUParticleSystem.clone() changing the particle texture

### DIFF
--- a/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
@@ -2500,10 +2500,20 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         const serialization = this.serialize(cloneTexture);
+        if (cloneTexture === false) {
+            // When the texture is not serialized it is stored by name only. Prevent Parse from
+            // reloading it from that name (which can resolve to a different image and resets texture
+            // settings like level) and copy the source texture faithfully below instead.
+            serialization.textureName = undefined;
+        }
         const result = GPUParticleSystem.Parse(serialization, this._scene || this._engine, this._rootUrl);
         result.name = name;
         result.customShader = program;
         result._customWrappers = custom;
+
+        if (cloneTexture === false && this.particleTexture) {
+            result.particleTexture = this.particleTexture.clone();
+        }
 
         if (newEmitter === undefined) {
             newEmitter = this.emitter;

--- a/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
@@ -2500,10 +2500,12 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         const serialization = this.serialize(cloneTexture);
-        if (cloneTexture === false) {
-            // When the texture is not serialized it is stored by name only. Prevent Parse from
-            // reloading it from that name (which can resolve to a different image and resets texture
-            // settings like level) and copy the source texture faithfully below instead.
+        // When the texture is not serialized it is stored by name only, and Parse would reload it from
+        // that name (which can resolve to a different image and reset texture settings like level).
+        // Prefer a faithful copy of the source texture, and only skip the name-based reload when that
+        // copy is available (clone() can legally return null for textures that do not implement it).
+        const clonedTexture = cloneTexture === false && this.particleTexture ? this.particleTexture.clone() : null;
+        if (clonedTexture) {
             serialization.textureName = undefined;
         }
         const result = GPUParticleSystem.Parse(serialization, this._scene || this._engine, this._rootUrl);
@@ -2511,8 +2513,8 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         result.customShader = program;
         result._customWrappers = custom;
 
-        if (cloneTexture === false && this.particleTexture) {
-            result.particleTexture = this.particleTexture.clone();
+        if (clonedTexture) {
+            result.particleTexture = clonedTexture;
         }
 
         if (newEmitter === undefined) {

--- a/packages/dev/core/src/Particles/particleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/particleSystem.pure.ts
@@ -1107,10 +1107,20 @@ export class ParticleSystem extends ThinParticleSystem {
         }
 
         const serialization = this.serialize(cloneTexture);
+        if (cloneTexture === false) {
+            // When the texture is not serialized it is stored by name only. Prevent Parse from
+            // reloading it from that name (which can resolve to a different image and resets texture
+            // settings like level) and copy the source texture faithfully below instead.
+            serialization.textureName = undefined;
+        }
         const result = ParticleSystem.Parse(serialization, this._scene || this._engine, this._rootUrl);
         result.name = name;
         result.customShader = program;
         result._customWrappers = custom;
+
+        if (cloneTexture === false && this.particleTexture) {
+            result.particleTexture = this.particleTexture.clone();
+        }
 
         if (newEmitter === undefined) {
             newEmitter = this.emitter;

--- a/packages/dev/core/src/Particles/particleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/particleSystem.pure.ts
@@ -1107,10 +1107,12 @@ export class ParticleSystem extends ThinParticleSystem {
         }
 
         const serialization = this.serialize(cloneTexture);
-        if (cloneTexture === false) {
-            // When the texture is not serialized it is stored by name only. Prevent Parse from
-            // reloading it from that name (which can resolve to a different image and resets texture
-            // settings like level) and copy the source texture faithfully below instead.
+        // When the texture is not serialized it is stored by name only, and Parse would reload it from
+        // that name (which can resolve to a different image and reset texture settings like level).
+        // Prefer a faithful copy of the source texture, and only skip the name-based reload when that
+        // copy is available (clone() can legally return null for textures that do not implement it).
+        const clonedTexture = cloneTexture === false && this.particleTexture ? this.particleTexture.clone() : null;
+        if (clonedTexture) {
             serialization.textureName = undefined;
         }
         const result = ParticleSystem.Parse(serialization, this._scene || this._engine, this._rootUrl);
@@ -1118,8 +1120,8 @@ export class ParticleSystem extends ThinParticleSystem {
         result.customShader = program;
         result._customWrappers = custom;
 
-        if (cloneTexture === false && this.particleTexture) {
-            result.particleTexture = this.particleTexture.clone();
+        if (clonedTexture) {
+            result.particleTexture = clonedTexture;
         }
 
         if (newEmitter === undefined) {

--- a/packages/dev/core/test/unit/Particles/particleSystemClone.test.ts
+++ b/packages/dev/core/test/unit/Particles/particleSystemClone.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Vector3 } from "core/Maths/math.vector";
+import { ParticleSystem } from "core/Particles/particleSystem";
+import { Texture } from "core/Materials/Textures/texture";
+import { Scene } from "core/scene";
+
+// Preload the particle shaders so the async import triggered by the ParticleSystem constructor
+// resolves from cache and does not race the test environment teardown.
+import "core/Shaders/particles.vertex";
+import "core/Shaders/particles.fragment";
+
+describe("ParticleSystem.clone", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("preserves the source particle texture and its settings when cloneTexture is false", () => {
+        const system = new ParticleSystem("source", 100, scene);
+        system.emitter = new Vector3(0, 0, 0);
+        // Avoid auto-starting the clone so the test does not trigger async shader compilation.
+        system.preventAutoStart = true;
+
+        // A texture whose display name differs from its actual source, with non-default settings.
+        // Reloading the texture by name (the old clone behavior) would load a different image and
+        // reset these settings to their defaults.
+        const texture = new Texture("https://example.com/actual-source.png", scene);
+        texture.name = "https://example.com/display-name.png";
+        texture.level = 2;
+        texture.coordinatesIndex = 1;
+        system.particleTexture = texture;
+
+        const clone = system.clone("clone", undefined);
+
+        expect(clone.particleTexture).toBeTruthy();
+        // The clone must be an independent copy, not the same instance.
+        expect(clone.particleTexture).not.toBe(texture);
+        // Texture settings must survive the clone (previously reset by the name-based reload).
+        expect(clone.particleTexture!.level).toBe(2);
+        expect((clone.particleTexture as Texture).coordinatesIndex).toBe(1);
+
+        // Disposing the source (as in the forum repro) must not break the clone's texture.
+        system.dispose();
+        expect(clone.particleTexture).toBeTruthy();
+        expect(clone.particleTexture!.level).toBe(2);
+
+        clone.dispose();
+    });
+});

--- a/packages/dev/core/test/unit/Particles/particleSystemClone.test.ts
+++ b/packages/dev/core/test/unit/Particles/particleSystemClone.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NullEngine } from "core/Engines/nullEngine";
 import { Vector3 } from "core/Maths/math.vector";
 import { ParticleSystem } from "core/Particles/particleSystem";
@@ -58,6 +58,25 @@ describe("ParticleSystem.clone", () => {
         system.dispose();
         expect(clone.particleTexture).toBeTruthy();
         expect(clone.particleTexture!.level).toBe(2);
+
+        clone.dispose();
+    });
+
+    it("falls back to reloading the texture by name when the source texture cannot be cloned", () => {
+        const system = new ParticleSystem("source", 100, scene);
+        system.emitter = new Vector3(0, 0, 0);
+        system.preventAutoStart = true;
+
+        const texture = new Texture("https://example.com/flare.png", scene);
+        // BaseTexture.clone() can legally return null; the clone must not silently drop the texture.
+        vi.spyOn(texture, "clone").mockReturnValue(null as unknown as Texture);
+        system.particleTexture = texture;
+
+        const clone = system.clone("clone", undefined);
+
+        // Since the texture could not be cloned, it is reloaded from its name instead of being lost.
+        expect(clone.particleTexture).toBeTruthy();
+        expect(clone.particleTexture!.name).toBe("https://example.com/flare.png");
 
         clone.dispose();
     });


### PR DESCRIPTION
## Fix `ParticleSystem.clone()` / `GPUParticleSystem.clone()` changing the particle texture

### Problem

Cloning a particle system with the default `cloneTexture = false` could change the particle's texture — a different image and/or lost texture settings (e.g. `level`) — which shows up visually as "the colors break."

Reported on the forum: [Particle system clone method breaks colors (and maybe smth else?)](https://forum.babylonjs.com/t/particle-system-clone-method-breaks-colors-and-maybe-smth-else/63758)

### Root cause

`clone()` reproduces the system via a `serialize(false)` → `Parse()` round-trip. With `cloneTexture = false`, the texture is serialized **by name only**, so `Parse` rebuilds it with `new Texture(rootUrl + textureName)`. That reload:

1. **Resets texture settings to defaults** — `level`, `coordinatesMode`, scaling, wrap modes, etc. (only `invertY` was carried over).
2. **Can load a different image** — the name is just a label and may not match the pixels the source texture actually holds. In the reported snippet the texture is an embedded (`data:`) image whose `name` points at `.../Flare.png`, so the reload fetched the *current* Flare.png (256×256) instead of the embedded original (243×251).

### Backward compatibility

- `serialize()` output is unchanged (the `textureName` clear only affects the throwaway object inside `clone()`).
- The `cloneTexture = true` path is unchanged.
- The public default (`cloneTexture = false`) is unchanged; only its texture handling is corrected.

### Tests

- New `packages/dev/core/test/unit/Particles/particleSystemClone.test.ts` verifies the cloned texture is an independent copy that preserves `level`/`coordinatesIndex` and survives disposing the source.
- All existing particle unit tests pass.

### Screenshot

<img width="1062" height="329" alt="image" src="https://github.com/user-attachments/assets/3e028296-b88c-4451-ba4f-938d8b469f97" />
