### PR TITLE
Preserve particle texture settings when serializing by reference

### DIFF
--- a/packages/dev/core/src/Particles/particleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/particleSystem.pure.ts
@@ -31,6 +31,32 @@ import { _IsSideEffectImplemented } from "../Misc/devTools";
 import { type FlowMap } from "./flowMap";
 import { type NodeParticleSystemSet } from "./Node/nodeParticleSystemSet";
 
+// Names of the particle texture display settings persisted alongside `textureName` when the texture
+// pixels are serialized by reference (serializeTexture === false), so a serialize/parse round-trip
+// keeps the same appearance. `samplingMode` is handled separately (passed to the Texture constructor).
+const ParticleTextureSettingKeys = [
+    "level",
+    "hasAlpha",
+    "getAlphaFromRGB",
+    "gammaSpace",
+    "coordinatesIndex",
+    "coordinatesMode",
+    "wrapU",
+    "wrapV",
+    "wrapR",
+    "anisotropicFilteringLevel",
+    "uOffset",
+    "vOffset",
+    "uScale",
+    "vScale",
+    "uAng",
+    "vAng",
+    "wAng",
+    "uRotationCenter",
+    "vRotationCenter",
+    "wRotationCenter",
+] as const;
+
 /**
  * This represents a particle system in Babylon.
  * Particles are often small sprites used to simulate hard-to-reproduce phenomena like fire, smoke, water, or abstract visual effects like magic glitter and faery dust.
@@ -349,13 +375,24 @@ export class ParticleSystem extends ThinParticleSystem {
             if (parsedParticleSystem.texture) {
                 particleSystem.particleTexture = internalClass.Parse(parsedParticleSystem.texture, scene, rootUrl) as BaseTexture;
             } else if (parsedParticleSystem.textureName) {
+                const textureSettings = parsedParticleSystem.textureSettings;
                 particleSystem.particleTexture = new internalClass(
                     rootUrl + parsedParticleSystem.textureName,
                     scene,
                     false,
-                    parsedParticleSystem.invertY !== undefined ? parsedParticleSystem.invertY : true
+                    parsedParticleSystem.invertY !== undefined ? parsedParticleSystem.invertY : true,
+                    textureSettings ? textureSettings.samplingMode : undefined
                 );
                 particleSystem.particleTexture!.name = parsedParticleSystem.textureName;
+
+                if (textureSettings) {
+                    const texture = particleSystem.particleTexture as any;
+                    for (const key of ParticleTextureSettingKeys) {
+                        if (textureSettings[key] !== undefined) {
+                            texture[key] = textureSettings[key];
+                        }
+                    }
+                }
             }
         }
 
@@ -797,8 +834,18 @@ export class ParticleSystem extends ThinParticleSystem {
             if (serializeTexture) {
                 serializationObject.texture = particleSystem.particleTexture.serialize();
             } else {
+                const particleTexture = particleSystem.particleTexture as any;
                 serializationObject.textureName = particleSystem.particleTexture.name;
-                serializationObject.invertY = !!(particleSystem.particleTexture as any)._invertY;
+                serializationObject.invertY = !!particleTexture._invertY;
+                // The texture pixels are referenced by name only, but its display settings would
+                // otherwise be lost on reload. Persist them so a serialize/parse round-trip keeps the
+                // same appearance.
+                const textureSettings: any = {};
+                for (const key of ParticleTextureSettingKeys) {
+                    textureSettings[key] = particleTexture[key];
+                }
+                textureSettings.samplingMode = particleTexture.samplingMode;
+                serializationObject.textureSettings = textureSettings;
             }
         }
 

--- a/packages/dev/core/test/unit/Particles/particleSystemSerializeTexture.test.ts
+++ b/packages/dev/core/test/unit/Particles/particleSystemSerializeTexture.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Vector3 } from "core/Maths/math.vector";
+import { ParticleSystem } from "core/Particles/particleSystem";
+import { Texture } from "core/Materials/Textures/texture";
+import { Scene } from "core/scene";
+
+// Preload the particle shaders so the async import triggered by the ParticleSystem constructor
+// resolves from cache and does not race the test environment teardown.
+import "core/Shaders/particles.vertex";
+import "core/Shaders/particles.fragment";
+
+describe("ParticleSystem serialize/parse (texture settings)", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("preserves particle texture settings across a serialize(false) / Parse round-trip", () => {
+        const system = new ParticleSystem("source", 100, scene);
+        system.emitter = new Vector3(0, 0, 0);
+        system.preventAutoStart = true;
+
+        const texture = new Texture("https://example.com/flare.png", scene, false, true, Texture.NEAREST_SAMPLINGMODE);
+        texture.level = 2;
+        texture.uScale = 3;
+        texture.vScale = 4;
+        texture.uOffset = 0.25;
+        texture.vOffset = 0.5;
+        texture.coordinatesIndex = 1;
+        texture.wrapU = Texture.CLAMP_ADDRESSMODE;
+        texture.hasAlpha = true;
+        system.particleTexture = texture;
+
+        // Serialize without embedding the texture: it is referenced by name only.
+        const serialized = system.serialize(false);
+        expect(serialized.textureName).toBe("https://example.com/flare.png");
+        expect(serialized.texture).toBeUndefined();
+
+        const parsed = ParticleSystem.Parse(serialized, scene, "", true /* doNotStart */);
+        const parsedTexture = parsed.particleTexture as Texture;
+
+        expect(parsedTexture).toBeTruthy();
+        // Settings must survive the round-trip (previously reset to defaults on reload).
+        expect(parsedTexture.level).toBe(2);
+        expect(parsedTexture.uScale).toBe(3);
+        expect(parsedTexture.vScale).toBe(4);
+        expect(parsedTexture.uOffset).toBe(0.25);
+        expect(parsedTexture.vOffset).toBe(0.5);
+        expect(parsedTexture.coordinatesIndex).toBe(1);
+        expect(parsedTexture.wrapU).toBe(Texture.CLAMP_ADDRESSMODE);
+        expect(parsedTexture.hasAlpha).toBe(true);
+        expect(parsedTexture.samplingMode).toBe(Texture.NEAREST_SAMPLINGMODE);
+
+        system.dispose();
+        parsed.dispose();
+    });
+});

--- a/packages/dev/core/test/unit/Particles/particleSystemSerializeTexture.test.ts
+++ b/packages/dev/core/test/unit/Particles/particleSystemSerializeTexture.test.ts
@@ -46,8 +46,9 @@ describe("ParticleSystem serialize/parse (texture settings)", () => {
         texture.hasAlpha = true;
         system.particleTexture = texture;
 
-        // Serialize without embedding the texture: it is referenced by name only.
-        const serialized = system.serialize(false);
+        // Round-trip through JSON to match a real .babylon save/load, where undefined fields are
+        // dropped and values are coerced through JSON.stringify / JSON.parse.
+        const serialized = JSON.parse(JSON.stringify(system.serialize(false)));
         expect(serialized.textureName).toBe("https://example.com/flare.png");
         expect(serialized.texture).toBeUndefined();
 


### PR DESCRIPTION
### Problem

When a particle system is serialized with `serializeTexture = false` (the texture is referenced by name, not embedded), a `serialize` → `Parse` round-trip reset the texture's display settings — `level`, `coordinatesMode`, `uScale`/`vScale`, offsets, wrap modes, `samplingMode`, etc. — back to their defaults, because only `textureName` + `invertY` were stored.

This is a follow-up to the particle **clone** fix (which handled the in-memory case). It addresses the `.babylon`/snippet save→load path.

### Fix

`ParticleSystem._Serialize` (shared by CPU and GPU) now writes the texture's display settings into a `textureSettings` object in the `serializeTexture === false` branch, and `_Parse` re-applies them when reconstructing the texture from `textureName` (`samplingMode` is passed to the `Texture` constructor since it needs its setter).

### Backward compatibility

- **Additive.** Older files without `textureSettings` still load exactly as before (defaults).
- New files load fine on older engines (the extra field is ignored).
- The `serializeTexture = true` (embedded) path is unchanged.

> Note: the texture *pixels* are still referenced by URL in this mode — an asset that changed at its URL is out of scope here (that's what `serializeTexture = true` is for). This only makes the *settings* round-trip faithfully.

### Tests

New `packages/dev/core/test/unit/Particles/particleSystemSerializeTexture.test.ts` asserts a `serialize(false)` → `Parse` round-trip preserves `level`, tiling/offset, wrap mode, `coordinatesIndex`, `hasAlpha`, and `samplingMode`. All existing particle unit tests pass.