### PR TITLE
fix(mcp): fix registry/catalog drift and add drift guards to all graph MCP servers

### DIFF
--- a/.github/instructions/mcp-server-coverage.instructions.md
+++ b/.github/instructions/mcp-server-coverage.instructions.md
@@ -17,3 +17,11 @@ When adding, removing, or renaming a graph block or GUI control, update the matc
 Keep the MCP metadata aligned with the runtime block/control class name, serialized class name, public inputs, public outputs, configurable properties, and default serialized properties. If a block/control is intentionally omitted because it is abstract, a base class, editor-internal, or non-creatable, leave the omission clear in nearby registry comments or tests.
 
 After changing coverage, run the affected MCP server tests or build and also rebuild `@babylonjs/mcp-servers` so the public package stays current.
+
+Every graph/GUI MCP server has a `registryDrift.test.ts` guard that checks its registry/catalog against the real Babylon definitions and fails on drift. If you add or change a block's ports (or a control's properties), update the registry so these guards stay green:
+
+- Node Material, Node Geometry, Node Particle: construct the real block via `GetClass` and compare input/output port names.
+- Node Render Graph: construct the real block under a `NullEngine`/`FrameGraph` harness and compare input/output port names.
+- Flow Graph: resolve each block via the async block factory, construct it, and compare signal/data input/output names.
+- Smart Filters: parse annotated-GLSL blocks with `ImportCustomBlockDefinition`, construct hand-written TS blocks via their factory, and compare connection point names.
+- GUI: construct the real control and verify every catalog property name exists as a real member.

--- a/packages/tools/flow-graph-mcp-server/examples/AnimateOnReady.flowgraph.json
+++ b/packages/tools/flow-graph-mcp-server/examples/AnimateOnReady.flowgraph.json
@@ -8,31 +8,24 @@
           "uniqueId": "fg-00000002",
           "dataInputs": [],
           "dataOutputs": [],
-          "signalInputs": [
-            {
-              "uniqueId": "fg-00000003",
-              "name": "in",
-              "_connectionType": 0,
-              "connectedPointIds": []
-            }
-          ],
+          "signalInputs": [],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000004",
+              "uniqueId": "fg-00000003",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000005",
+              "uniqueId": "fg-00000004",
               "name": "done",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000008"
+                "fg-00000007"
               ]
             },
             {
-              "uniqueId": "fg-00000006",
+              "uniqueId": "fg-00000005",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -47,10 +40,10 @@
           "config": {
             "targetMesh": "hero"
           },
-          "uniqueId": "fg-00000007",
+          "uniqueId": "fg-00000006",
           "dataInputs": [
             {
-              "uniqueId": "fg-0000000f",
+              "uniqueId": "fg-0000000e",
               "name": "speed",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -62,7 +55,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000010",
+              "uniqueId": "fg-0000000f",
               "name": "loop",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -74,7 +67,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000011",
+              "uniqueId": "fg-00000010",
               "name": "from",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -86,7 +79,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000012",
+              "uniqueId": "fg-00000011",
               "name": "to",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -98,7 +91,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000013",
+              "uniqueId": "fg-00000012",
               "name": "animationGroup",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -109,7 +102,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000014",
+              "uniqueId": "fg-00000013",
               "name": "animation",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -120,7 +113,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-00000015",
+              "uniqueId": "fg-00000014",
               "name": "object",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -133,7 +126,7 @@
           ],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000016",
+              "uniqueId": "fg-00000015",
               "name": "currentFrame",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -144,7 +137,7 @@
               }
             },
             {
-              "uniqueId": "fg-00000017",
+              "uniqueId": "fg-00000016",
               "name": "currentTime",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -155,7 +148,7 @@
               }
             },
             {
-              "uniqueId": "fg-00000018",
+              "uniqueId": "fg-00000017",
               "name": "currentAnimationGroup",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -167,7 +160,7 @@
           ],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000008",
+              "uniqueId": "fg-00000007",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -175,37 +168,37 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000009",
+              "uniqueId": "fg-00000008",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000000a",
+              "uniqueId": "fg-00000009",
               "name": "done",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000000b",
+              "uniqueId": "fg-0000000a",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000000c",
+              "uniqueId": "fg-0000000b",
               "name": "animationLoopEvent",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000000d",
+              "uniqueId": "fg-0000000c",
               "name": "animationEndEvent",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000000e",
+              "uniqueId": "fg-0000000d",
               "name": "animationGroupLoopEvent",
               "_connectionType": 1,
               "connectedPointIds": []

--- a/packages/tools/flow-graph-mcp-server/examples/ClickLogger.flowgraph.json
+++ b/packages/tools/flow-graph-mcp-server/examples/ClickLogger.flowgraph.json
@@ -10,7 +10,7 @@
           "uniqueId": "fg-00000002",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000007",
+              "uniqueId": "fg-00000006",
               "name": "asset",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -21,7 +21,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-00000008",
+              "uniqueId": "fg-00000007",
               "name": "pointerType",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -34,7 +34,7 @@
           ],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000009",
+              "uniqueId": "fg-00000008",
               "name": "pickedPoint",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -52,7 +52,7 @@
               }
             },
             {
-              "uniqueId": "fg-0000000a",
+              "uniqueId": "fg-00000009",
               "name": "pickOrigin",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -70,7 +70,7 @@
               }
             },
             {
-              "uniqueId": "fg-0000000b",
+              "uniqueId": "fg-0000000a",
               "name": "pointerId",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -81,7 +81,7 @@
               }
             },
             {
-              "uniqueId": "fg-0000000c",
+              "uniqueId": "fg-0000000b",
               "name": "pickedMesh",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -91,31 +91,24 @@
               }
             }
           ],
-          "signalInputs": [
-            {
-              "uniqueId": "fg-00000003",
-              "name": "in",
-              "_connectionType": 0,
-              "connectedPointIds": []
-            }
-          ],
+          "signalInputs": [],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000004",
+              "uniqueId": "fg-00000003",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000005",
+              "uniqueId": "fg-00000004",
               "name": "done",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-0000000e"
+                "fg-0000000d"
               ]
             },
             {
-              "uniqueId": "fg-00000006",
+              "uniqueId": "fg-00000005",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -130,10 +123,10 @@
           "config": {
             "message": "Clicked!"
           },
-          "uniqueId": "fg-0000000d",
+          "uniqueId": "fg-0000000c",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000011",
+              "uniqueId": "fg-00000010",
               "name": "message",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -145,7 +138,7 @@
               "defaultValue": "Clicked!"
             },
             {
-              "uniqueId": "fg-00000012",
+              "uniqueId": "fg-00000011",
               "name": "logType",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -159,7 +152,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-0000000e",
+              "uniqueId": "fg-0000000d",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -167,13 +160,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-0000000f",
+              "uniqueId": "fg-0000000e",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000010",
+              "uniqueId": "fg-0000000f",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []

--- a/packages/tools/flow-graph-mcp-server/examples/SequentialSetup.flowgraph.json
+++ b/packages/tools/flow-graph-mcp-server/examples/SequentialSetup.flowgraph.json
@@ -8,31 +8,24 @@
           "uniqueId": "fg-00000002",
           "dataInputs": [],
           "dataOutputs": [],
-          "signalInputs": [
-            {
-              "uniqueId": "fg-00000003",
-              "name": "in",
-              "_connectionType": 0,
-              "connectedPointIds": []
-            }
-          ],
+          "signalInputs": [],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000004",
+              "uniqueId": "fg-00000003",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000005",
+              "uniqueId": "fg-00000004",
               "name": "done",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000008"
+                "fg-00000007"
               ]
             },
             {
-              "uniqueId": "fg-00000006",
+              "uniqueId": "fg-00000005",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -47,12 +40,12 @@
           "config": {
             "outputSignalCount": 3
           },
-          "uniqueId": "fg-00000007",
+          "uniqueId": "fg-00000006",
           "dataInputs": [],
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000008",
+              "uniqueId": "fg-00000007",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -60,33 +53,33 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000009",
+              "uniqueId": "fg-00000008",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000000a",
+              "uniqueId": "fg-00000009",
               "name": "out_0",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-0000000e"
+                "fg-0000000d"
+              ]
+            },
+            {
+              "uniqueId": "fg-0000000a",
+              "name": "out_1",
+              "_connectionType": 1,
+              "connectedPointIds": [
+                "fg-00000015"
               ]
             },
             {
               "uniqueId": "fg-0000000b",
-              "name": "out_1",
-              "_connectionType": 1,
-              "connectedPointIds": [
-                "fg-00000016"
-              ]
-            },
-            {
-              "uniqueId": "fg-0000000c",
               "name": "out_2",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-0000001e"
+                "fg-0000001d"
               ]
             }
           ],
@@ -99,10 +92,10 @@
           "config": {
             "propertyPath": "box.position.x"
           },
-          "uniqueId": "fg-0000000d",
+          "uniqueId": "fg-0000000c",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000011",
+              "uniqueId": "fg-00000010",
               "name": "object",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -113,11 +106,11 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000012",
+              "uniqueId": "fg-00000011",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-00000026"
+                "fg-00000025"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -126,7 +119,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000013",
+              "uniqueId": "fg-00000012",
               "name": "propertyName",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -137,7 +130,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-00000014",
+              "uniqueId": "fg-00000013",
               "name": "customSetFunction",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -151,7 +144,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-0000000e",
+              "uniqueId": "fg-0000000d",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -159,13 +152,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-0000000f",
+              "uniqueId": "fg-0000000e",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000010",
+              "uniqueId": "fg-0000000f",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -180,10 +173,10 @@
           "config": {
             "propertyPath": "box.position.y"
           },
-          "uniqueId": "fg-00000015",
+          "uniqueId": "fg-00000014",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000019",
+              "uniqueId": "fg-00000018",
               "name": "object",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -194,11 +187,11 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-0000001a",
+              "uniqueId": "fg-00000019",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-00000028"
+                "fg-00000027"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -207,7 +200,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-0000001b",
+              "uniqueId": "fg-0000001a",
               "name": "propertyName",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -218,7 +211,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-0000001c",
+              "uniqueId": "fg-0000001b",
               "name": "customSetFunction",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -232,7 +225,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000016",
+              "uniqueId": "fg-00000015",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -240,13 +233,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000017",
+              "uniqueId": "fg-00000016",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000018",
+              "uniqueId": "fg-00000017",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -261,10 +254,10 @@
           "config": {
             "propertyPath": "box.position.z"
           },
-          "uniqueId": "fg-0000001d",
+          "uniqueId": "fg-0000001c",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000021",
+              "uniqueId": "fg-00000020",
               "name": "object",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -275,11 +268,11 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000022",
+              "uniqueId": "fg-00000021",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-0000002a"
+                "fg-00000029"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -288,7 +281,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000023",
+              "uniqueId": "fg-00000022",
               "name": "propertyName",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -299,7 +292,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-00000024",
+              "uniqueId": "fg-00000023",
               "name": "customSetFunction",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -313,7 +306,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-0000001e",
+              "uniqueId": "fg-0000001d",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -321,13 +314,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-0000001f",
+              "uniqueId": "fg-0000001e",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000020",
+              "uniqueId": "fg-0000001f",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -343,11 +336,11 @@
             "value": 1,
             "type": "number"
           },
-          "uniqueId": "fg-00000025",
+          "uniqueId": "fg-00000024",
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000026",
+              "uniqueId": "fg-00000025",
               "name": "output",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -369,11 +362,11 @@
             "value": 2,
             "type": "number"
           },
-          "uniqueId": "fg-00000027",
+          "uniqueId": "fg-00000026",
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000028",
+              "uniqueId": "fg-00000027",
               "name": "output",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -395,11 +388,11 @@
             "value": 3,
             "type": "number"
           },
-          "uniqueId": "fg-00000029",
+          "uniqueId": "fg-00000028",
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-0000002a",
+              "uniqueId": "fg-00000029",
               "name": "output",
               "_connectionType": 1,
               "connectedPointIds": [],

--- a/packages/tools/flow-graph-mcp-server/examples/TickCounter.flowgraph.json
+++ b/packages/tools/flow-graph-mcp-server/examples/TickCounter.flowgraph.json
@@ -9,7 +9,7 @@
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000007",
+              "uniqueId": "fg-00000006",
               "name": "timeSinceStart",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -20,7 +20,7 @@
               }
             },
             {
-              "uniqueId": "fg-00000008",
+              "uniqueId": "fg-00000007",
               "name": "deltaTime",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -31,31 +31,24 @@
               }
             }
           ],
-          "signalInputs": [
-            {
-              "uniqueId": "fg-00000003",
-              "name": "in",
-              "_connectionType": 0,
-              "connectedPointIds": []
-            }
-          ],
+          "signalInputs": [],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000004",
+              "uniqueId": "fg-00000003",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000005",
+              "uniqueId": "fg-00000004",
               "name": "done",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000013"
+                "fg-00000012"
               ]
             },
             {
-              "uniqueId": "fg-00000006",
+              "uniqueId": "fg-00000005",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -70,11 +63,11 @@
           "config": {
             "variable": "counter"
           },
-          "uniqueId": "fg-00000009",
+          "uniqueId": "fg-00000008",
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-0000000a",
+              "uniqueId": "fg-00000009",
               "name": "value",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -96,11 +89,11 @@
             "value": 1,
             "type": "number"
           },
-          "uniqueId": "fg-0000000b",
+          "uniqueId": "fg-0000000a",
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-0000000c",
+              "uniqueId": "fg-0000000b",
               "name": "output",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -119,14 +112,14 @@
         {
           "className": "FlowGraphAddBlock",
           "config": {},
-          "uniqueId": "fg-0000000d",
+          "uniqueId": "fg-0000000c",
           "dataInputs": [
             {
-              "uniqueId": "fg-0000000e",
+              "uniqueId": "fg-0000000d",
               "name": "a",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-0000000a"
+                "fg-00000009"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -135,11 +128,11 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-0000000f",
+              "uniqueId": "fg-0000000e",
               "name": "b",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-0000000c"
+                "fg-0000000b"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -150,7 +143,7 @@
           ],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000010",
+              "uniqueId": "fg-0000000f",
               "name": "value",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -160,7 +153,7 @@
               }
             },
             {
-              "uniqueId": "fg-00000011",
+              "uniqueId": "fg-00000010",
               "name": "isValid",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -182,14 +175,14 @@
           "config": {
             "variable": "counter"
           },
-          "uniqueId": "fg-00000012",
+          "uniqueId": "fg-00000011",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000016",
+              "uniqueId": "fg-00000015",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-00000010"
+                "fg-0000000f"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -201,7 +194,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000013",
+              "uniqueId": "fg-00000012",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -209,15 +202,15 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000014",
+              "uniqueId": "fg-00000013",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000018"
+                "fg-00000017"
               ]
             },
             {
-              "uniqueId": "fg-00000015",
+              "uniqueId": "fg-00000014",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -230,14 +223,14 @@
         {
           "className": "FlowGraphConsoleLogBlock",
           "config": {},
-          "uniqueId": "fg-00000017",
+          "uniqueId": "fg-00000016",
           "dataInputs": [
             {
-              "uniqueId": "fg-0000001b",
+              "uniqueId": "fg-0000001a",
               "name": "message",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-00000010"
+                "fg-0000000f"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -246,7 +239,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-0000001c",
+              "uniqueId": "fg-0000001b",
               "name": "logType",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -260,7 +253,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000018",
+              "uniqueId": "fg-00000017",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -268,13 +261,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000019",
+              "uniqueId": "fg-00000018",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000001a",
+              "uniqueId": "fg-00000019",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []

--- a/packages/tools/flow-graph-mcp-server/examples/ToggleVisibility.flowgraph.json
+++ b/packages/tools/flow-graph-mcp-server/examples/ToggleVisibility.flowgraph.json
@@ -10,7 +10,7 @@
           "uniqueId": "fg-00000002",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000007",
+              "uniqueId": "fg-00000006",
               "name": "asset",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -21,7 +21,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-00000008",
+              "uniqueId": "fg-00000007",
               "name": "pointerType",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -34,7 +34,7 @@
           ],
           "dataOutputs": [
             {
-              "uniqueId": "fg-00000009",
+              "uniqueId": "fg-00000008",
               "name": "pickedPoint",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -52,7 +52,7 @@
               }
             },
             {
-              "uniqueId": "fg-0000000a",
+              "uniqueId": "fg-00000009",
               "name": "pickOrigin",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -70,7 +70,7 @@
               }
             },
             {
-              "uniqueId": "fg-0000000b",
+              "uniqueId": "fg-0000000a",
               "name": "pointerId",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -81,7 +81,7 @@
               }
             },
             {
-              "uniqueId": "fg-0000000c",
+              "uniqueId": "fg-0000000b",
               "name": "pickedMesh",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -91,31 +91,24 @@
               }
             }
           ],
-          "signalInputs": [
-            {
-              "uniqueId": "fg-00000003",
-              "name": "in",
-              "_connectionType": 0,
-              "connectedPointIds": []
-            }
-          ],
+          "signalInputs": [],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000004",
+              "uniqueId": "fg-00000003",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000005",
+              "uniqueId": "fg-00000004",
               "name": "done",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000010"
+                "fg-0000000f"
               ]
             },
             {
-              "uniqueId": "fg-00000006",
+              "uniqueId": "fg-00000005",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -130,11 +123,11 @@
           "config": {
             "variable": "isVisible"
           },
-          "uniqueId": "fg-0000000d",
+          "uniqueId": "fg-0000000c",
           "dataInputs": [],
           "dataOutputs": [
             {
-              "uniqueId": "fg-0000000e",
+              "uniqueId": "fg-0000000d",
               "name": "value",
               "_connectionType": 1,
               "connectedPointIds": [],
@@ -153,14 +146,14 @@
         {
           "className": "FlowGraphBranchBlock",
           "config": {},
-          "uniqueId": "fg-0000000f",
+          "uniqueId": "fg-0000000e",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000014",
+              "uniqueId": "fg-00000013",
               "name": "condition",
               "_connectionType": 0,
               "connectedPointIds": [
-                "fg-0000000e"
+                "fg-0000000d"
               ],
               "className": "FlowGraphDataConnection",
               "richType": {
@@ -173,7 +166,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000010",
+              "uniqueId": "fg-0000000f",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -181,23 +174,23 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000011",
+              "uniqueId": "fg-00000010",
               "name": "onTrue",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000016"
+                "fg-00000015"
+              ]
+            },
+            {
+              "uniqueId": "fg-00000011",
+              "name": "onFalse",
+              "_connectionType": 1,
+              "connectedPointIds": [
+                "fg-0000001d"
               ]
             },
             {
               "uniqueId": "fg-00000012",
-              "name": "onFalse",
-              "_connectionType": 1,
-              "connectedPointIds": [
-                "fg-0000001e"
-              ]
-            },
-            {
-              "uniqueId": "fg-00000013",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -212,10 +205,10 @@
           "config": {
             "propertyPath": "box.visibility"
           },
-          "uniqueId": "fg-00000015",
+          "uniqueId": "fg-00000014",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000019",
+              "uniqueId": "fg-00000018",
               "name": "object",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -226,7 +219,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-0000001a",
+              "uniqueId": "fg-00000019",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -237,7 +230,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-0000001b",
+              "uniqueId": "fg-0000001a",
               "name": "propertyName",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -248,7 +241,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-0000001c",
+              "uniqueId": "fg-0000001b",
               "name": "customSetFunction",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -262,7 +255,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000016",
+              "uniqueId": "fg-00000015",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -270,15 +263,15 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000017",
+              "uniqueId": "fg-00000016",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-00000026"
+                "fg-00000025"
               ]
             },
             {
-              "uniqueId": "fg-00000018",
+              "uniqueId": "fg-00000017",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -293,10 +286,10 @@
           "config": {
             "propertyPath": "box.visibility"
           },
-          "uniqueId": "fg-0000001d",
+          "uniqueId": "fg-0000001c",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000021",
+              "uniqueId": "fg-00000020",
               "name": "object",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -307,7 +300,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000022",
+              "uniqueId": "fg-00000021",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -318,7 +311,7 @@
               "optional": false
             },
             {
-              "uniqueId": "fg-00000023",
+              "uniqueId": "fg-00000022",
               "name": "propertyName",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -329,7 +322,7 @@
               "optional": true
             },
             {
-              "uniqueId": "fg-00000024",
+              "uniqueId": "fg-00000023",
               "name": "customSetFunction",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -343,7 +336,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-0000001e",
+              "uniqueId": "fg-0000001d",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -351,15 +344,15 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-0000001f",
+              "uniqueId": "fg-0000001e",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": [
-                "fg-0000002b"
+                "fg-0000002a"
               ]
             },
             {
-              "uniqueId": "fg-00000020",
+              "uniqueId": "fg-0000001f",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -374,10 +367,10 @@
           "config": {
             "variable": "isVisible"
           },
-          "uniqueId": "fg-00000025",
+          "uniqueId": "fg-00000024",
           "dataInputs": [
             {
-              "uniqueId": "fg-00000029",
+              "uniqueId": "fg-00000028",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -391,7 +384,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-00000026",
+              "uniqueId": "fg-00000025",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -399,13 +392,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-00000027",
+              "uniqueId": "fg-00000026",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-00000028",
+              "uniqueId": "fg-00000027",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []
@@ -420,10 +413,10 @@
           "config": {
             "variable": "isVisible"
           },
-          "uniqueId": "fg-0000002a",
+          "uniqueId": "fg-00000029",
           "dataInputs": [
             {
-              "uniqueId": "fg-0000002e",
+              "uniqueId": "fg-0000002d",
               "name": "value",
               "_connectionType": 0,
               "connectedPointIds": [],
@@ -437,7 +430,7 @@
           "dataOutputs": [],
           "signalInputs": [
             {
-              "uniqueId": "fg-0000002b",
+              "uniqueId": "fg-0000002a",
               "name": "in",
               "_connectionType": 0,
               "connectedPointIds": []
@@ -445,13 +438,13 @@
           ],
           "signalOutputs": [
             {
-              "uniqueId": "fg-0000002c",
+              "uniqueId": "fg-0000002b",
               "name": "out",
               "_connectionType": 1,
               "connectedPointIds": []
             },
             {
-              "uniqueId": "fg-0000002d",
+              "uniqueId": "fg-0000002c",
               "name": "error",
               "_connectionType": 1,
               "connectedPointIds": []

--- a/packages/tools/flow-graph-mcp-server/src/blockRegistry.ts
+++ b/packages/tools/flow-graph-mcp-server/src/blockRegistry.ts
@@ -65,7 +65,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphSceneReadyEventBlock",
         category: "Event",
         description: "Triggers when the scene is ready (all assets loaded). This is the most common entry point for a flow graph.",
-        signalInputs: [{ name: "in", description: "Inherited signal input (not typically used for events)" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (use for initialization logic)" },
             { name: "done", description: "Fires when the event actually triggers (scene ready). USE THIS for event-driven logic." },
@@ -79,7 +79,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphSceneTickEventBlock",
         category: "Event",
         description: "Triggers every frame (scene render loop). Provides elapsed time and delta time.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires every frame when the tick event occurs. USE THIS for per-frame logic." },
@@ -96,7 +96,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphMeshPickEventBlock",
         category: "Event",
         description: "Triggers when a mesh is picked (clicked) by the user.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization). NOT on each pick." },
             { name: "done", description: "Fires each time the mesh is picked. USE THIS to react to clicks." },
@@ -122,7 +122,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphPointerOverEventBlock",
         category: "Event",
         description: "Triggers when the pointer moves over a mesh.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the pointer enters the mesh. USE THIS for hover logic." },
@@ -140,7 +140,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphPointerOutEventBlock",
         category: "Event",
         description: "Triggers when the pointer moves off a mesh.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the pointer leaves the mesh. USE THIS for hover-out logic." },
@@ -161,7 +161,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphPointerDownEventBlock",
         category: "Event",
         description: "Triggers when a pointer button is pressed down on a mesh.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the pointer is pressed. USE THIS for press logic." },
@@ -180,7 +180,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphPointerUpEventBlock",
         category: "Event",
         description: "Triggers when a pointer button is released on a mesh.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the pointer is released. USE THIS for release logic." },
@@ -199,7 +199,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphPointerMoveEventBlock",
         category: "Event",
         description: "Triggers when the pointer moves over a mesh.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the pointer moves. USE THIS for move logic." },
@@ -218,7 +218,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphKeyDownEventBlock",
         category: "Event",
         description: "Triggers when a keyboard key is pressed down. Can optionally ignore auto-repeat events.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the matching key-down event occurs. USE THIS for keyboard logic." },
@@ -245,7 +245,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphKeyUpEventBlock",
         category: "Event",
         description: "Triggers when a keyboard key is released.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the matching key-up event occurs. USE THIS for keyboard logic." },
@@ -268,7 +268,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphPhysicsCollisionEventBlock",
         category: "Event",
         description: "Triggers when a physics body collides with another body.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time a collision occurs. USE THIS for collision logic." },
@@ -288,7 +288,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphSoundEndedEventBlock",
         category: "Event",
         description: "Triggers when a sound finishes playing.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the sound ends. USE THIS for sound-ended logic." },
@@ -316,7 +316,7 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
         className: "FlowGraphReceiveCustomEventBlock",
         category: "Event",
         description: "Receives a custom event sent by SendCustomEvent blocks. Creates dynamic data outputs from eventData config.",
-        signalInputs: [{ name: "in" }],
+        signalInputs: [],
         signalOutputs: [
             { name: "out", description: "Fires once at graph startup (initialization)" },
             { name: "done", description: "Fires each time the custom event is received. USE THIS for event handling." },
@@ -758,6 +758,9 @@ export const FlowGraphBlockRegistry: Record<string, IFlowGraphBlockTypeInfo> = {
             { name: "isValid", type: "boolean" },
             { name: "object", type: "any" },
             { name: "propertyName", type: "any" },
+            { name: "setFunction", type: "any", description: "Setter function for the resolved property (used internally by interpolation/animation)" },
+            { name: "getFunction", type: "any", description: "Getter function for the resolved property" },
+            { name: "generateAnimationsFunction", type: "any", description: "Builds animation property info for the resolved property" },
         ],
         config: { jsonPointer: "string — the JSON pointer path" },
     },

--- a/packages/tools/flow-graph-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/flow-graph-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Flow Graph MCP Server – Registry Drift Guard
+ *
+ * Loads every real Babylon.js block referenced by the MCP block registry (via the same
+ * async blockFactory the Babylon parser uses) and verifies that the registry's declared
+ * signal/data connection NAMES match the block's actual connections. Connection names are
+ * the wiring contract the AI agent relies on (connections are matched by name), so any
+ * drift here means the agent cannot wire a real connection — or produces a dangling
+ * connection that silently drops on parse. A className the factory cannot resolve is even
+ * worse: the exported graph fails to parse at runtime.
+ *
+ * Notes:
+ * - The guard compares NAMES only (not rich types): the registry uses human-readable type
+ *   labels that intentionally differ from the internal RichType instances.
+ * - Several blocks generate NUMBERED ports from their configuration (e.g. out_0, in_1,
+ *   value_2). The registry documents these in the block's `config` prose rather than as
+ *   fixed ports, so numbered ports (names ending in _<digits>) are excluded from the diff.
+ */
+import { blockFactory } from "core/FlowGraph/Blocks/flowGraphBlockFactory";
+
+// Side-effect import: make the Flow Graph block modules (and the factory) available.
+import "core/FlowGraph/index";
+
+import { FlowGraphBlockRegistry } from "../../src/blockRegistry";
+
+/**
+ * Config used to construct blocks that read required fields in their constructor. Everything
+ * else is constructed with an empty config object (blocks whose constructor reads optional
+ * config fields tolerate `{}`). Configs are chosen to avoid generating numbered ports.
+ */
+const CONSTRUCTION_CONFIG: Record<string, object> = {
+    FlowGraphConstantBlock: { value: 0 },
+    FlowGraphJsonPointerParserBlock: { jsonPointer: "/test", outputValue: true },
+};
+
+// Numbered ports (out_0, in_1, value_2, ...) are generated from config and documented in prose.
+const isDynamicPort = (name: string): boolean => /_\d+$/.test(name);
+
+describe("Flow Graph MCP Server – Registry Drift", () => {
+    it("registry signal/data connection names match the real Babylon blocks", async () => {
+        const problems: string[] = [];
+
+        const diff = (label: string, real: string[], reg: string[]): string[] => {
+            // Numbered ports are excluded from BOTH sides: some blocks omit them from the
+            // registry (documented in `config` prose), while others list a fixed numbered set
+            // (e.g. CombineVector3 → input_0..input_2). Verifying them consistently either way
+            // would be brittle, so the contract check covers fixed-name ports only.
+            const realStatic = real.filter((n) => !isDynamicPort(n));
+            const regStatic = reg.filter((n) => !isDynamicPort(n));
+            const missing = realStatic.filter((n) => !regStatic.includes(n));
+            const extra = regStatic.filter((n) => !realStatic.includes(n));
+            const parts: string[] = [];
+            if (missing.length) {
+                parts.push(`${label} missing from registry: [${missing.join(", ")}]`);
+            }
+            if (extra.length) {
+                parts.push(`${label} in registry but not on block: [${extra.join(", ")}]`);
+            }
+            return parts;
+        };
+
+        for (const [key, info] of Object.entries(FlowGraphBlockRegistry)) {
+            let ctor: any;
+            try {
+                ctor = await blockFactory(info.className)();
+            } catch (e) {
+                problems.push(`${key}: className "${info.className}" is not resolvable by the Babylon block factory (${(e as Error).message})`);
+                continue;
+            }
+
+            let block: any;
+            try {
+                block = new ctor(CONSTRUCTION_CONFIG[info.className] ?? {});
+            } catch (e) {
+                problems.push(`${info.className}: could not construct to verify connections (${(e as Error).message})`);
+                continue;
+            }
+
+            const realSignalIn: string[] = (block.signalInputs ?? []).map((c: any) => c.name);
+            const realSignalOut: string[] = (block.signalOutputs ?? []).map((c: any) => c.name);
+            const realDataIn: string[] = (block.dataInputs ?? []).map((c: any) => c.name);
+            const realDataOut: string[] = (block.dataOutputs ?? []).map((c: any) => c.name);
+
+            const details = [
+                ...diff(
+                    "signal inputs",
+                    realSignalIn,
+                    info.signalInputs.map((i) => i.name)
+                ),
+                ...diff(
+                    "signal outputs",
+                    realSignalOut,
+                    info.signalOutputs.map((o) => o.name)
+                ),
+                ...diff(
+                    "data inputs",
+                    realDataIn,
+                    info.dataInputs.map((i) => i.name)
+                ),
+                ...diff(
+                    "data outputs",
+                    realDataOut,
+                    info.dataOutputs.map((o) => o.name)
+                ),
+            ];
+            if (details.length) {
+                problems.push(`${info.className}: ${details.join("; ")}`);
+            }
+        }
+
+        expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});

--- a/packages/tools/gui-mcp-server/src/catalog.ts
+++ b/packages/tools/gui-mcp-server/src/catalog.ts
@@ -292,9 +292,6 @@ export const ControlRegistry: Record<string, IControlTypeInfo> = {
             thickness: { description: "Border thickness", type: "number", defaultValue: 1 },
             autoStretchHeight: { description: "Auto-resize height to fit content", type: "boolean", defaultValue: true },
             maxHeight: { description: "Maximum height constraint", type: "string" },
-            textHorizontalAlignment: { description: "0=LEFT, 1=RIGHT, 2=CENTER", type: "number", defaultValue: 0 },
-            textVerticalAlignment: { description: "0=TOP, 1=BOTTOM, 2=CENTER", type: "number", defaultValue: 0 },
-            lineSpacing: { description: "Extra line spacing", type: "string" },
         },
     },
 
@@ -438,7 +435,7 @@ export const ControlRegistry: Record<string, IControlTypeInfo> = {
             thumbWidth: { description: "Thumb width (e.g. '20px')", type: "string" },
             background: { description: "Track background color", type: "string", defaultValue: "black" },
             borderColor: { description: "Track border color", type: "string", defaultValue: "white" },
-            thumbColor: { description: "Thumb color", type: "string" },
+            color: { description: "Thumb color", type: "string" },
             invertScrollDirection: { description: "Invert scroll direction", type: "boolean", defaultValue: false },
         },
     },

--- a/packages/tools/gui-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/gui-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,56 @@
+/**
+ * GUI MCP Server – Catalog Drift Guard
+ *
+ * Constructs every real Babylon.js GUI control referenced by the MCP control catalog
+ * and verifies that each property NAME declared in the catalog actually exists as a
+ * settable member on the real control. Property names are the contract the AI agent
+ * relies on (set_control_properties writes them into the serialized GUI JSON), so a
+ * catalog property that does not exist on the real control is silently dropped on
+ * parse — the agent believes it configured the control but nothing happened.
+ *
+ * This test exists because the catalog is hand-maintained (see
+ * .github/instructions/mcp-server-coverage.instructions.md) and previously drifted
+ * out of sync with the real controls without anything catching it.
+ */
+import { GetClass } from "core/Misc/typeStore";
+
+// Side-effect import: register ALL GUI control classes via RegisterClass
+import "gui/2D/index";
+
+import { ControlRegistry, BaseControlProperties } from "../../src/catalog";
+
+describe("GUI MCP Server – Catalog Drift", () => {
+    it("catalog control class names and property names match the real Babylon GUI controls", () => {
+        const problems: string[] = [];
+
+        for (const [key, info] of Object.entries(ControlRegistry)) {
+            const ctor = GetClass(`BABYLON.GUI.${info.className}`);
+            if (!ctor) {
+                problems.push(`${key}: no class registered as "BABYLON.GUI.${info.className}"`);
+                continue;
+            }
+
+            let control: any;
+            try {
+                control = new ctor(`${info.className}_drift`);
+            } catch {
+                try {
+                    control = new ctor();
+                } catch (e) {
+                    problems.push(`${info.className}: could not construct to verify properties (${(e as Error).message})`);
+                    continue;
+                }
+            }
+
+            // Every catalog property (base + control-specific) must exist as a real
+            // member on the control instance (own field or accessor up the prototype chain).
+            const catalogProps = { ...BaseControlProperties, ...info.properties };
+            const missing = Object.keys(catalogProps).filter((p) => !(p in control));
+            if (missing.length) {
+                problems.push(`${info.className}: catalog properties not found on the real control: [${missing.join(", ")}]`);
+            }
+        }
+
+        expect(problems, `Catalog drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});

--- a/packages/tools/gui-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/gui-mcp-server/test/unit/registryDrift.test.ts
@@ -3,10 +3,11 @@
  *
  * Constructs every real Babylon.js GUI control referenced by the MCP control catalog
  * and verifies that each property NAME declared in the catalog actually exists as a
- * settable member on the real control. Property names are the contract the AI agent
- * relies on (set_control_properties writes them into the serialized GUI JSON), so a
- * catalog property that does not exist on the real control is silently dropped on
- * parse — the agent believes it configured the control but nothing happened.
+ * member on the real control (own field or accessor anywhere up the prototype chain).
+ * Property names are the contract the AI agent relies on (set_control_properties writes
+ * them into the serialized GUI JSON), so a catalog property that does not exist on the
+ * real control is silently dropped on parse — the agent believes it configured the
+ * control but nothing happened.
  *
  * This test exists because the catalog is hand-maintained (see
  * .github/instructions/mcp-server-coverage.instructions.md) and previously drifted

--- a/packages/tools/nge-mcp-server/examples/MathPipeline.json
+++ b/packages/tools/nge-mcp-server/examples/MathPipeline.json
@@ -60,8 +60,8 @@
       "name": "decompose",
       "inputs": [
         {
-          "name": "xyzw",
-          "displayName": "xyzw"
+          "name": "xyzw ",
+          "displayName": "xyzw "
         },
         {
           "name": "xyz ",

--- a/packages/tools/nge-mcp-server/src/blockRegistry.ts
+++ b/packages/tools/nge-mcp-server/src/blockRegistry.ts
@@ -1125,7 +1125,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "Converter",
         description: "Splits vectors into components and/or assembles components into vectors.",
         inputs: [
-            { name: "xyzw", type: "Vector4", isOptional: true },
+            { name: "xyzw ", type: "Vector4", isOptional: true },
             { name: "xyz ", type: "Vector3", isOptional: true },
             { name: "xy ", type: "Vector2", isOptional: true },
             { name: "zw ", type: "Vector2", isOptional: true },

--- a/packages/tools/nge-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/nge-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Node Geometry MCP Server – Registry Drift Guard
+ *
+ * Constructs every real Babylon.js block referenced by the MCP block registry and
+ * verifies that the registry's declared input/output connection point NAMES match
+ * the block's actual ports. Port names are the wiring contract the AI agent relies
+ * on (connect_blocks matches by name), so any drift here means the agent cannot
+ * wire a real port — or worse, produces a dangling connection that silently drops.
+ *
+ * This test exists because registries are hand-maintained (see
+ * .github/instructions/mcp-server-coverage.instructions.md) and previously drifted
+ * out of sync with the real blocks without anything catching it.
+ */
+import { GetClass } from "core/Misc/typeStore";
+
+// Side-effect import: register ALL block types via RegisterClass
+import "core/Meshes/Node/index";
+
+import { BlockRegistry } from "../../src/blockRegistry";
+
+describe("Node Geometry MCP Server – Registry Drift", () => {
+    it("registry input/output port names match the real Babylon blocks", () => {
+        const problems: string[] = [];
+
+        for (const [key, info] of Object.entries(BlockRegistry)) {
+            const ctor = GetClass(`BABYLON.${info.className}`);
+            if (!ctor) {
+                problems.push(`${key}: no class registered as "BABYLON.${info.className}"`);
+                continue;
+            }
+
+            let block: any;
+            try {
+                block = new ctor(`${info.className}_drift`);
+            } catch (e) {
+                problems.push(`${info.className}: could not construct to verify ports (${(e as Error).message})`);
+                continue;
+            }
+
+            const realInputs: string[] = (block.inputs ?? []).map((c: any) => c.name);
+            const realOutputs: string[] = (block.outputs ?? []).map((c: any) => c.name);
+            const regInputs = info.inputs.map((i) => i.name);
+            const regOutputs = info.outputs.map((o) => o.name);
+
+            const missingInputs = realInputs.filter((n) => !regInputs.includes(n));
+            const extraInputs = regInputs.filter((n) => !realInputs.includes(n));
+            const missingOutputs = realOutputs.filter((n) => !regOutputs.includes(n));
+            const extraOutputs = regOutputs.filter((n) => !realOutputs.includes(n));
+
+            const details: string[] = [];
+            if (missingInputs.length) {
+                details.push(`inputs missing from registry: [${missingInputs.join(", ")}]`);
+            }
+            if (extraInputs.length) {
+                details.push(`inputs in registry but not on block: [${extraInputs.join(", ")}]`);
+            }
+            if (missingOutputs.length) {
+                details.push(`outputs missing from registry: [${missingOutputs.join(", ")}]`);
+            }
+            if (extraOutputs.length) {
+                details.push(`outputs in registry but not on block: [${extraOutputs.join(", ")}]`);
+            }
+            if (details.length) {
+                problems.push(`${info.className}: ${details.join("; ")}`);
+            }
+        }
+
+        expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});

--- a/packages/tools/nme-mcp-server/src/blockRegistry.ts
+++ b/packages/tools/nme-mcp-server/src/blockRegistry.ts
@@ -369,7 +369,6 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         outputs: [
             { name: "output", type: "Vector4" },
             { name: "xyz", type: "Vector3" },
-            { name: "w", type: "Float" },
         ],
         defaultSerializedProperties: { complementZ: 0, complementW: 1 },
     },
@@ -547,15 +546,15 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
     ConditionalBlock: {
         className: "ConditionalBlock",
         category: "Logic",
-        description: "If/else conditional: outputs ifTrue or ifFalse based on comparing a and b.",
+        description: "If/else conditional: outputs 'true' or 'false' value based on comparing a and b.",
         target: "Neutral",
         inputs: [
             { name: "a", type: "Float" },
             { name: "b", type: "Float" },
-            { name: "ifTrue", type: "AutoDetect" },
-            { name: "ifFalse", type: "AutoDetect" },
+            { name: "true", type: "AutoDetect", isOptional: true },
+            { name: "false", type: "AutoDetect", isOptional: true },
         ],
-        outputs: [{ name: "output", type: "BasedOnInput" }],
+        outputs: [{ name: "output", type: "Float" }],
         properties: {
             condition: "ConditionalBlockConditions — Equal, NotEqual, LessThan, GreaterThan, LessOrEqual, GreaterOrEqual, Xor, Or, And",
         },
@@ -776,12 +775,16 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "normal", type: "Vector3" },
             { name: "tangent", type: "Vector4", isOptional: true },
             { name: "uv", type: "Vector2", isOptional: true },
+            { name: "uv2", type: "Vector2", isOptional: true },
+            { name: "color", type: "Color4", isOptional: true },
         ],
         outputs: [
             { name: "positionOutput", type: "Vector3" },
             { name: "normalOutput", type: "Vector3" },
             { name: "tangentOutput", type: "Vector4" },
             { name: "uvOutput", type: "Vector2" },
+            { name: "uv2Output", type: "Vector2" },
+            { name: "colorOutput", type: "Color4" },
         ],
     },
     LightInformationBlock: {
@@ -794,7 +797,10 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "direction", type: "Vector3" },
             { name: "color", type: "Color3" },
             { name: "intensity", type: "Float" },
-            { name: "shadowAttenuation", type: "Float" },
+            { name: "shadowBias", type: "Float" },
+            { name: "shadowNormalBias", type: "Float" },
+            { name: "shadowDepthScale", type: "Float" },
+            { name: "shadowDepthRange", type: "Vector2" },
         ],
     },
 
@@ -803,12 +809,14 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         className: "FragmentOutputBlock",
         category: "Output",
         description:
-            "The fragment shader output. Connect the final color here. Every material needs exactly one. " + "Has 'rgb' (Color3), 'rgba' (Color4), and 'a' (Float/alpha) inputs.",
+            "The fragment shader output. Connect the final color here. Every material needs exactly one. " +
+            "Has 'rgb' (Color3), 'rgba' (Color4), 'a' (Float/alpha), and 'glow' (Color3) inputs.",
         target: "Fragment",
         inputs: [
             { name: "rgba", type: "Color4", isOptional: true },
             { name: "rgb", type: "Color3", isOptional: true },
             { name: "a", type: "Float", isOptional: true },
+            { name: "glow", type: "Color3", isOptional: true },
         ],
         outputs: [],
     },
@@ -846,8 +854,11 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "uv", type: "Vector2" },
             { name: "normalMapColor", type: "Color3" },
             { name: "strength", type: "Float" },
-            { name: "viewDirection", type: "Vector3" },
+            { name: "viewDirection", type: "Vector3", isOptional: true },
+            { name: "parallaxScale", type: "Float", isOptional: true },
+            { name: "parallaxHeight", type: "Float", isOptional: true },
             { name: "TBN", type: "Object", isOptional: true },
+            { name: "world", type: "Matrix", isOptional: true },
         ],
         outputs: [
             { name: "output", type: "Vector4" },
@@ -911,7 +922,11 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "center", type: "Vector2" },
             { name: "offset", type: "Vector2" },
         ],
-        outputs: [{ name: "output", type: "Vector2" }],
+        outputs: [
+            { name: "output", type: "Vector2" },
+            { name: "x", type: "Float" },
+            { name: "y", type: "Float" },
+        ],
     },
     FragCoordBlock: {
         className: "FragCoordBlock",
@@ -934,20 +949,26 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "Fragment",
         description: "Generates a shadow map output.",
         target: "Fragment",
-        inputs: [{ name: "worldPosition", type: "Vector4" }],
-        outputs: [
-            { name: "output", type: "Object" },
-            { name: "depth", type: "Float" },
+        inputs: [
+            { name: "worldPosition", type: "Vector4" },
+            { name: "viewProjection", type: "Matrix" },
+            { name: "worldNormal", type: "AutoDetect", isOptional: true },
         ],
+        outputs: [{ name: "depth", type: "Vector3" }],
     },
 
     // ─── Dual (Vertex + Fragment) ─────────────────────────────────────────
     TextureBlock: {
         className: "TextureBlock",
         category: "Texture",
-        description: "Samples a 2D texture. Provide a URL via the texture property.",
+        description: "Samples a 2D texture. Provide a URL via the texture property, or feed a shared ImageSourceBlock into the 'source' input instead of an embedded texture.",
         target: "VertexAndFragment",
-        inputs: [{ name: "uv", type: "AutoDetect" }],
+        inputs: [
+            { name: "uv", type: "AutoDetect" },
+            { name: "source", type: "Object", isOptional: true },
+            { name: "layer", type: "Float", isOptional: true },
+            { name: "lod", type: "Float", isOptional: true },
+        ],
         outputs: [
             { name: "rgba", type: "Color4" },
             { name: "rgb", type: "Color3" },
@@ -978,10 +999,11 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         ],
         outputs: [
             { name: "rgb", type: "Color3" },
+            { name: "rgba", type: "Color4" },
             { name: "r", type: "Float" },
             { name: "g", type: "Float" },
             { name: "b", type: "Float" },
-            { name: "hasTexture", type: "Float" },
+            { name: "a", type: "Float" },
         ],
     },
     LightBlock: {
@@ -1039,7 +1061,10 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         description: "Provides a texture source that can be shared by multiple texture blocks.",
         target: "VertexAndFragment",
         inputs: [],
-        outputs: [{ name: "source", type: "Object" }],
+        outputs: [
+            { name: "source", type: "Object" },
+            { name: "dimensions", type: "Vector2" },
+        ],
         properties: {
             texture: "Texture — set via new Texture(url, scene)",
         },
@@ -1050,7 +1075,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         description: "Samples the scene depth texture.",
         target: "VertexAndFragment",
         inputs: [{ name: "uv", type: "AutoDetect" }],
-        outputs: [{ name: "output", type: "Float" }],
+        outputs: [{ name: "depth", type: "Float" }],
     },
 
     // ─── PBR ─────────────────────────────────────────────────────────────
@@ -1140,6 +1165,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         inputs: [
             { name: "intensity", type: "Float", isOptional: true },
             { name: "tintAtDistance", type: "Float", isOptional: true },
+            { name: "volumeIndexOfRefraction", type: "Float", isOptional: true },
         ],
         outputs: [{ name: "refraction", type: "Object" }],
     },
@@ -1165,6 +1191,8 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "direction", type: "Vector2", isOptional: true },
             { name: "uv", type: "Vector2", isOptional: true },
             { name: "worldTangent", type: "Vector4", isOptional: true },
+            { name: "TBN", type: "Object", isOptional: true },
+            { name: "roughness", type: "Float", isOptional: true },
         ],
         outputs: [{ name: "anisotropy", type: "Object" }],
     },
@@ -1183,6 +1211,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "tintAtDistance", type: "Float", isOptional: true },
             { name: "tintThickness", type: "Float", isOptional: true },
             { name: "worldTangent", type: "Vector4", isOptional: true },
+            { name: "worldNormal", type: "AutoDetect", isOptional: true },
             { name: "TBN", type: "Object", isOptional: true },
         ],
         outputs: [{ name: "clearcoat", type: "Object" }],
@@ -1198,6 +1227,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "translucencyIntensity", type: "Float", isOptional: true },
             { name: "translucencyDiffusionDist", type: "Color3", isOptional: true },
             { name: "refraction", type: "Object", isOptional: true },
+            { name: "dispersion", type: "Float", isOptional: true },
         ],
         outputs: [{ name: "subsurface", type: "Object" }],
     },
@@ -1244,6 +1274,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "sharpness", type: "Float", isOptional: true },
             { name: "source", type: "Object", isOptional: true },
             { name: "sourceY", type: "Object", isOptional: true },
+            { name: "sourceZ", type: "Object", isOptional: true },
         ],
         outputs: [
             { name: "rgba", type: "Color4" },
@@ -1280,11 +1311,11 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
     MeshAttributeExistsBlock: {
         className: "MeshAttributeExistsBlock",
         category: "Misc",
-        description: "Outputs ifYes or ifNo based on whether a mesh attribute (UV, color, etc.) exists.",
+        description: "Outputs 'input' or 'fallback' based on whether a mesh attribute (UV, color, etc.) exists.",
         target: "Neutral",
         inputs: [
-            { name: "ifYes", type: "AutoDetect" },
-            { name: "ifNo", type: "AutoDetect" },
+            { name: "input", type: "AutoDetect" },
+            { name: "fallback", type: "AutoDetect" },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
         properties: {
@@ -1523,7 +1554,10 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         description: "Provides a depth texture from the scene's depth renderer as an image source.",
         target: "VertexAndFragment",
         inputs: [],
-        outputs: [{ name: "source", type: "Object" }],
+        outputs: [
+            { name: "source", type: "Object" },
+            { name: "dimensions", type: "Vector2" },
+        ],
     },
 
     // ─── Gaussian Splatting ──────────────────────────────────────────────
@@ -1574,7 +1608,12 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "Output",
         description: "Fragment output for the Smart Filter Editor (SFE) framework. Outputs as nmeMain() function.",
         target: "Fragment",
-        inputs: [{ name: "rgba", type: "Color4" }],
+        inputs: [
+            { name: "rgba", type: "Color4", isOptional: true },
+            { name: "rgb", type: "Color3", isOptional: true },
+            { name: "a", type: "Float", isOptional: true },
+            { name: "glow", type: "Color3", isOptional: true },
+        ],
         outputs: [],
     },
     SmartFilterTextureBlock: {

--- a/packages/tools/nme-mcp-server/src/blockRegistry.ts
+++ b/packages/tools/nme-mcp-server/src/blockRegistry.ts
@@ -554,7 +554,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "true", type: "AutoDetect", isOptional: true },
             { name: "false", type: "AutoDetect", isOptional: true },
         ],
-        outputs: [{ name: "output", type: "Float" }],
+        outputs: [{ name: "output", type: "BasedOnInput" }],
         properties: {
             condition: "ConditionalBlockConditions — Equal, NotEqual, LessThan, GreaterThan, LessOrEqual, GreaterOrEqual, Xor, Or, And",
         },

--- a/packages/tools/nme-mcp-server/test/unit/fixtures/pbrMaterial.json
+++ b/packages/tools/nme-mcp-server/test/unit/fixtures/pbrMaterial.json
@@ -258,10 +258,6 @@
         {
           "name": "xyz",
           "displayName": "xyz"
-        },
-        {
-          "name": "w",
-          "displayName": "w"
         }
       ],
       "complementZ": 0,
@@ -476,6 +472,10 @@
         {
           "name": "a",
           "displayName": "a"
+        },
+        {
+          "name": "glow",
+          "displayName": "glow"
         }
       ],
       "outputs": []

--- a/packages/tools/nme-mcp-server/test/unit/fixtures/simpleColor.json
+++ b/packages/tools/nme-mcp-server/test/unit/fixtures/simpleColor.json
@@ -108,10 +108,6 @@
         {
           "name": "xyz",
           "displayName": "xyz"
-        },
-        {
-          "name": "w",
-          "displayName": "w"
         }
       ],
       "complementZ": 0,
@@ -183,6 +179,10 @@
         {
           "name": "a",
           "displayName": "a"
+        },
+        {
+          "name": "glow",
+          "displayName": "glow"
         }
       ],
       "outputs": []

--- a/packages/tools/nme-mcp-server/test/unit/graphManager.test.ts
+++ b/packages/tools/nme-mcp-server/test/unit/graphManager.test.ts
@@ -347,6 +347,35 @@ describe("Node Material MCP Server – Graph Manager Validation", () => {
         expect(condBlock.condition).toBe(3); // GreaterThan = 3
     });
 
+    // ── ImageSourceBlock → TextureBlock.source wiring ────────────────────
+
+    it("wires an ImageSourceBlock.source output into a TextureBlock.source input", () => {
+        const mgr = new MaterialGraphManager();
+        mgr.createMaterial("sharedSource");
+
+        const imageSource = mgr.addBlock("sharedSource", "ImageSourceBlock", "sharedImage");
+        expect(typeof imageSource).not.toBe("string");
+        const texture = mgr.addBlock("sharedSource", "TextureBlock", "sampledTexture");
+        expect(typeof texture).not.toBe("string");
+
+        const getId = (r: any) => (typeof r !== "string" ? r.block.id : -1);
+
+        // The reported gap: TextureBlock previously exposed no "source" input,
+        // so this connection failed with "Input 'source' not found".
+        const result = mgr.connectBlocks("sharedSource", getId(imageSource), "source", getId(texture), "source");
+        expect(result).toBe("OK");
+
+        const json = mgr.exportJSON("sharedSource");
+        expect(json).toBeDefined();
+        const parsed = JSON.parse(json!);
+        const textureBlock = parsed.blocks.find((b: any) => b.name === "sampledTexture");
+        expect(textureBlock).toBeDefined();
+        const sourceInput = textureBlock.inputs.find((i: any) => i.name === "source");
+        expect(sourceInput).toBeDefined();
+        expect(sourceInput.targetBlockId).toBe(getId(imageSource));
+        expect(sourceInput.targetConnectionName).toBe("source");
+    });
+
     // ── clearAll ────────────────────────────────────────────────────────
 
     it("clearAll removes all materials and resets state", () => {

--- a/packages/tools/nme-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/nme-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Node Material MCP Server – Registry Drift Guard
+ *
+ * Constructs every real Babylon.js block referenced by the MCP block registry and
+ * verifies that the registry's declared input/output connection point NAMES match
+ * the block's actual ports. Port names are the wiring contract the AI agent relies
+ * on (connect_blocks matches by name), so any drift here means the agent cannot
+ * wire a real port — or worse, produces a dangling connection that silently drops.
+ *
+ * This test exists because registries are hand-maintained (see
+ * .github/instructions/mcp-server-coverage.instructions.md) and previously drifted
+ * out of sync with the real blocks without anything catching it.
+ */
+import { GetClass } from "core/Misc/typeStore";
+
+// Side-effect import: register ALL NME block types via RegisterClass
+import "core/Materials/Node/Blocks/index";
+
+import { BlockRegistry } from "../../src/blockRegistry";
+
+describe("Node Material MCP Server – Registry Drift", () => {
+    it("registry input/output port names match the real Babylon blocks", () => {
+        const problems: string[] = [];
+
+        for (const [key, info] of Object.entries(BlockRegistry)) {
+            const ctor = GetClass(`BABYLON.${info.className}`);
+            if (!ctor) {
+                problems.push(`${key}: no class registered as "BABYLON.${info.className}"`);
+                continue;
+            }
+
+            let block: any;
+            try {
+                block = new ctor(`${info.className}_drift`);
+            } catch (e) {
+                problems.push(`${info.className}: could not construct to verify ports (${(e as Error).message})`);
+                continue;
+            }
+
+            const realInputs: string[] = (block.inputs ?? []).map((c: any) => c.name);
+            const realOutputs: string[] = (block.outputs ?? []).map((c: any) => c.name);
+            const regInputs = info.inputs.map((i) => i.name);
+            const regOutputs = info.outputs.map((o) => o.name);
+
+            const missingInputs = realInputs.filter((n) => !regInputs.includes(n));
+            const extraInputs = regInputs.filter((n) => !realInputs.includes(n));
+            const missingOutputs = realOutputs.filter((n) => !regOutputs.includes(n));
+            const extraOutputs = regOutputs.filter((n) => !realOutputs.includes(n));
+
+            const details: string[] = [];
+            if (missingInputs.length) {
+                details.push(`inputs missing from registry: [${missingInputs.join(", ")}]`);
+            }
+            if (extraInputs.length) {
+                details.push(`inputs in registry but not on block: [${extraInputs.join(", ")}]`);
+            }
+            if (missingOutputs.length) {
+                details.push(`outputs missing from registry: [${missingOutputs.join(", ")}]`);
+            }
+            if (extraOutputs.length) {
+                details.push(`outputs in registry but not on block: [${extraOutputs.join(", ")}]`);
+            }
+            if (details.length) {
+                problems.push(`${info.className}: ${details.join("; ")}`);
+            }
+        }
+
+        expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});

--- a/packages/tools/npe-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/npe-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Node Particle MCP Server – Registry Drift Guard
+ *
+ * Constructs every real Babylon.js block referenced by the MCP block registry and
+ * verifies that the registry's declared input/output connection point NAMES match
+ * the block's actual ports. Port names are the wiring contract the AI agent relies
+ * on (connect_blocks matches by name), so any drift here means the agent cannot
+ * wire a real port — or worse, produces a dangling connection that silently drops.
+ *
+ * This test exists because registries are hand-maintained (see
+ * .github/instructions/mcp-server-coverage.instructions.md) and previously drifted
+ * out of sync with the real blocks without anything catching it.
+ */
+import { GetClass } from "core/Misc/typeStore";
+
+// Side-effect import: register ALL block types via RegisterClass
+import "core/Particles/Node/index";
+
+import { BlockRegistry } from "../../src/blockRegistry";
+
+describe("Node Particle MCP Server – Registry Drift", () => {
+    it("registry input/output port names match the real Babylon blocks", () => {
+        const problems: string[] = [];
+
+        for (const [key, info] of Object.entries(BlockRegistry)) {
+            const ctor = GetClass(`BABYLON.${info.className}`);
+            if (!ctor) {
+                problems.push(`${key}: no class registered as "BABYLON.${info.className}"`);
+                continue;
+            }
+
+            let block: any;
+            try {
+                block = new ctor(`${info.className}_drift`);
+            } catch (e) {
+                problems.push(`${info.className}: could not construct to verify ports (${(e as Error).message})`);
+                continue;
+            }
+
+            const realInputs: string[] = (block.inputs ?? []).map((c: any) => c.name);
+            const realOutputs: string[] = (block.outputs ?? []).map((c: any) => c.name);
+            const regInputs = info.inputs.map((i) => i.name);
+            const regOutputs = info.outputs.map((o) => o.name);
+
+            const missingInputs = realInputs.filter((n) => !regInputs.includes(n));
+            const extraInputs = regInputs.filter((n) => !realInputs.includes(n));
+            const missingOutputs = realOutputs.filter((n) => !regOutputs.includes(n));
+            const extraOutputs = regOutputs.filter((n) => !realOutputs.includes(n));
+
+            const details: string[] = [];
+            if (missingInputs.length) {
+                details.push(`inputs missing from registry: [${missingInputs.join(", ")}]`);
+            }
+            if (extraInputs.length) {
+                details.push(`inputs in registry but not on block: [${extraInputs.join(", ")}]`);
+            }
+            if (missingOutputs.length) {
+                details.push(`outputs missing from registry: [${missingOutputs.join(", ")}]`);
+            }
+            if (extraOutputs.length) {
+                details.push(`outputs in registry but not on block: [${extraOutputs.join(", ")}]`);
+            }
+            if (details.length) {
+                problems.push(`${info.className}: ${details.join("; ")}`);
+            }
+        }
+
+        expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});

--- a/packages/tools/nrge-mcp-server/src/blockRegistry.ts
+++ b/packages/tools/nrge-mcp-server/src/blockRegistry.ts
@@ -178,7 +178,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             "Generates all mip-map levels for a texture in-place after prior rendering has been done. " +
             "Required for techniques that sample lower mip levels (e.g. bloom, reflections).",
         inputs: [
-            { name: "source", type: "AutoDetect" },
+            { name: "target", type: "AutoDetect" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -244,6 +244,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             { name: "output", type: "BasedOnInput" },
             { name: "outputDepth", type: "BasedOnInput" },
             { name: "objectRenderer", type: "Object" },
+            { name: "geomIrradiance", type: "TextureIrradiance" },
             { name: "geomViewDepth", type: "TextureViewDepth" },
             { name: "geomNormViewDepth", type: "TextureNormalizedViewDepth" },
             { name: "geomScreenDepth", type: "TextureScreenDepth" },
@@ -276,17 +277,10 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             "Renders the Babylon.js utility layer (gizmos, helpers) on top of the main colour attachment. Used when the inspector / gizmos should appear in the final output.",
         inputs: [
             { name: "target", type: "AutoDetect" },
-            { name: "depth", type: "AutoDetect", isOptional: true },
             { name: "camera", type: "Camera" },
-            { name: "objects", type: "ObjectList" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
-            { name: "shadowGenerators", type: "AutoDetect", isOptional: true },
         ],
-        outputs: [
-            { name: "output", type: "BasedOnInput" },
-            { name: "outputDepth", type: "BasedOnInput" },
-            { name: "objectRenderer", type: "Object" },
-        ],
+        outputs: [{ name: "output", type: "BasedOnInput" }],
         defaultAdditionalConstructionParameters: [true, true],
     },
 
@@ -295,14 +289,18 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "Rendering",
         description:
             "Generates a shadow map for a directional, spot, or point light. " +
-            "Connect its `output` (ShadowGenerator) to the `shadowGenerators` port of an ObjectRendererBlock " +
+            "Connect its `generator` output (ShadowGenerator) to the `shadowGenerators` port of an ObjectRendererBlock " +
             "so rendered objects receive shadows from this light.",
         inputs: [
             { name: "light", type: "ShadowLight" },
             { name: "objects", type: "ObjectList" },
+            { name: "camera", type: "Camera" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
-        outputs: [{ name: "output", type: "ShadowGenerator" }],
+        outputs: [
+            { name: "generator", type: "ShadowGenerator" },
+            { name: "output", type: "Texture" },
+        ],
         properties: {
             mapSize: "number – shadow map resolution (default: 1024)",
             useExponentialShadowMap: "boolean",
@@ -323,14 +321,18 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         description:
             "Generates a Cascaded Shadow Map (CSM) for a directional light. " +
             "CSM provides better quality close-up shadows with a smooth fade to lower quality at distance. " +
-            "Connect its `output` (ShadowGenerator) to the `shadowGenerators` port of an ObjectRendererBlock.",
+            "Connect its `generator` output (ShadowGenerator) to the `shadowGenerators` port of an ObjectRendererBlock.",
         inputs: [
             { name: "light", type: "ShadowLight" },
             { name: "objects", type: "ObjectList" },
             { name: "camera", type: "Camera" },
+            { name: "geomDepth", type: "AutoDetect", isOptional: true },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
-        outputs: [{ name: "output", type: "ShadowGenerator" }],
+        outputs: [
+            { name: "generator", type: "ShadowGenerator" },
+            { name: "output", type: "Texture" },
+        ],
         properties: {
             mapSize: "number – shadow map resolution per cascade (default: 1024)",
             numCascades: "number – number of cascades (default: 4; must be 2–4)",
@@ -556,13 +558,14 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "PostProcess",
         description:
             "Screen-Space Ambient Occlusion v2 (SSAO2). " +
-            "Requires `geomViewDepth` (TextureViewDepth) and optionally `geomViewNormal` (TextureViewNormal) " +
+            "Requires a Camera plus `geomDepth` (TextureViewDepth) and `geomNormal` (TextureViewNormal) " +
             "from a GeometryRendererBlock. additionalConstructionParameters=[ratio (number)].",
         inputs: [
             { name: "source", type: "AutoDetect" },
             { name: "target", type: "AutoDetect", isOptional: true },
-            { name: "geomViewDepth", type: "TextureViewDepth" },
-            { name: "geomViewNormal", type: "TextureViewNormal", isOptional: true },
+            { name: "camera", type: "Camera" },
+            { name: "geomDepth", type: "TextureViewDepth" },
+            { name: "geomNormal", type: "TextureViewNormal" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -583,11 +586,13 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "PostProcess",
         description:
             "Temporal Anti-Aliasing (TAA). Accumulates samples across frames for smooth anti-aliasing. " +
-            "Requires a Camera. additionalConstructionParameters=[samples (number), factor (number)].",
+            "Connect the `objectRenderer` output of an ObjectRendererBlock; optionally provide a `geomVelocity` " +
+            "(TextureLinearVelocity) texture. additionalConstructionParameters=[samples (number), factor (number)].",
         inputs: [
             { name: "source", type: "AutoDetect" },
             { name: "target", type: "AutoDetect", isOptional: true },
-            { name: "camera", type: "Camera" },
+            { name: "objectRenderer", type: "Object" },
+            { name: "geomVelocity", type: "TextureLinearVelocity", isOptional: true },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -601,13 +606,14 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
     NodeRenderGraphMotionBlurPostProcessBlock: {
         className: "NodeRenderGraphMotionBlurPostProcessBlock",
         category: "PostProcess",
-        description: "Applies motion blur based on per-pixel motion vectors. Requires `geomViewDepth` and `geomViewNormal`. Camera is also required.",
+        description:
+            "Applies motion blur based on per-pixel motion vectors. " +
+            "Optionally provide a `geomVelocity` (TextureVelocity) or `geomViewDepth` (TextureViewDepth) texture from a GeometryRendererBlock.",
         inputs: [
             { name: "source", type: "AutoDetect" },
             { name: "target", type: "AutoDetect", isOptional: true },
-            { name: "camera", type: "Camera" },
-            { name: "geomViewDepth", type: "TextureViewDepth" },
-            { name: "geomViewNormal", type: "TextureViewNormal" },
+            { name: "geomVelocity", type: "TextureVelocity", isOptional: true },
+            { name: "geomViewDepth", type: "TextureViewDepth", isOptional: true },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -683,6 +689,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         inputs: [
             { name: "source", type: "AutoDetect" },
             { name: "target", type: "AutoDetect", isOptional: true },
+            { name: "leftTexture", type: "AutoDetect" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -695,6 +702,7 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         inputs: [
             { name: "source", type: "AutoDetect" },
             { name: "target", type: "AutoDetect", isOptional: true },
+            { name: "geomViewNormal", type: "TextureViewNormal" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -762,11 +770,12 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "PostProcess",
         description: "Renders volumetric light shafts (god rays) emanating from a single light source.",
         inputs: [
-            { name: "source", type: "AutoDetect" },
-            { name: "target", type: "AutoDetect", isOptional: true },
-            { name: "geomViewDepth", type: "AutoDetect", isOptional: true },
+            { name: "target", type: "AutoDetect" },
+            { name: "depth", type: "AutoDetect" },
             { name: "camera", type: "Camera" },
-            { name: "objects", type: "ObjectList" },
+            { name: "lightingVolumeMesh", type: "ObjectList" },
+            { name: "light", type: "ShadowLight" },
+            { name: "lightingVolumeTexture", type: "AutoDetect", isOptional: true },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -831,9 +840,9 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         description: "Draws a selection outline around the highlighted mesh. Typically used by the Babylon.js Inspector / gizmo system.",
         inputs: [
             { name: "target", type: "AutoDetect" },
+            { name: "layer", type: "AutoDetect", isOptional: true },
+            { name: "objectRenderer", type: "Object" },
             { name: "depth", type: "AutoDetect", isOptional: true },
-            { name: "camera", type: "Camera" },
-            { name: "objects", type: "ObjectList" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "BasedOnInput" }],
@@ -912,10 +921,14 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
             "Use its output as the `dependencies` input of other blocks to express execution ordering " +
             "without a direct data-flow connection.",
         inputs: [
-            { name: "input0", type: "AutoDetect", isOptional: true },
-            { name: "input1", type: "AutoDetect", isOptional: true },
-            { name: "input2", type: "AutoDetect", isOptional: true },
-            { name: "input3", type: "AutoDetect", isOptional: true },
+            { name: "resource0", type: "AutoDetect", isOptional: true },
+            { name: "resource1", type: "AutoDetect", isOptional: true },
+            { name: "resource2", type: "AutoDetect", isOptional: true },
+            { name: "resource3", type: "AutoDetect", isOptional: true },
+            { name: "resource4", type: "AutoDetect", isOptional: true },
+            { name: "resource5", type: "AutoDetect", isOptional: true },
+            { name: "resource6", type: "AutoDetect", isOptional: true },
+            { name: "resource7", type: "AutoDetect", isOptional: true },
         ],
         outputs: [{ name: "output", type: "ResourceContainer" }],
     },
@@ -961,11 +974,10 @@ export const BlockRegistry: Record<string, IBlockTypeInfo> = {
         category: "Utility",
         description: "Computes a lighting volume used by the volumetric lighting block for light contribution slicing.",
         inputs: [
-            { name: "camera", type: "Camera" },
-            { name: "objects", type: "ObjectList" },
+            { name: "shadowGenerator", type: "ShadowGenerator" },
             { name: "dependencies", type: "AutoDetect", isOptional: true },
         ],
-        outputs: [{ name: "output", type: "AutoDetect" }],
+        outputs: [{ name: "output", type: "ObjectList" }],
     },
 };
 

--- a/packages/tools/nrge-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/nrge-mcp-server/test/unit/registryDrift.test.ts
@@ -70,6 +70,7 @@ describe("Node Render Graph MCP Server – Registry Drift", () => {
     afterEach(() => {
         NodeRenderGraphBlock.prototype.registerInput = originalRegisterInput;
         NodeRenderGraphBlock.prototype.registerOutput = originalRegisterOutput;
+        frameGraph.dispose();
         scene.dispose();
         engine.dispose();
     });

--- a/packages/tools/nrge-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/nrge-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Node Render Graph MCP Server – Registry Drift Guard
+ *
+ * Constructs every real Babylon.js block referenced by the MCP block registry and
+ * verifies that the registry's declared input/output port NAMES match the block's
+ * actual ports. Port names are the wiring contract the AI agent relies on
+ * (connect_blocks matches by name), so any drift here means the agent cannot wire a
+ * real port — or worse, produces a dangling connection that silently drops.
+ *
+ * NodeRenderGraph blocks require a FrameGraph + Scene to construct, and some need
+ * additional construction parameters (mirrored by defaultAdditionalConstructionParameters
+ * in the registry), so this guard builds a NullEngine-backed harness.
+ */
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { FrameGraph } from "core/FrameGraph/frameGraph";
+import { GetClass } from "core/Misc/typeStore";
+import { NodeRenderGraphBlock } from "core/FrameGraph/Node/nodeRenderGraphBlock";
+
+// Side-effect import: register ALL NRGE block types via RegisterClass
+import "core/FrameGraph/Node/Blocks/index";
+// Side-effect import: FrameGraph loads this lazily (async); import it statically so
+// engine methods such as buildTextureLayout exist synchronously for block construction.
+import "core/Engines/Extensions/engine.multiRender";
+
+import { BlockRegistry } from "../../src/blockRegistry";
+
+/**
+ * Renderer/layer/post-process blocks create GPU FrameGraph tasks in their constructor
+ * (e.g. via _createFrameGraphObject / _createTask, or an inline `new FrameGraph*Task(...)`).
+ * Those tasks need a real GL context and throw under NullEngine. Port registration always
+ * happens BEFORE task creation, so to read the full port set headlessly we:
+ *   1. Capture every registerInput/registerOutput name (works even if the constructor throws
+ *      later at the inline task-creation call), and
+ *   2. No-op the task-creation methods on the constructor prototype so a task creation reached
+ *      during super() does not throw before the subclass registers its own ports.
+ * Any residual throw at an inline task creation is caught — all ports are already captured by then.
+ */
+const TASK_CREATION_METHODS = ["_createFrameGraphObject", "_createTask"] as const;
+
+describe("Node Render Graph MCP Server – Registry Drift", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let frameGraph: FrameGraph;
+
+    let capturedInputs: string[];
+    let capturedOutputs: string[];
+    let originalRegisterInput: typeof NodeRenderGraphBlock.prototype.registerInput;
+    let originalRegisterOutput: typeof NodeRenderGraphBlock.prototype.registerOutput;
+
+    beforeEach(() => {
+        engine = new NullEngine({ renderHeight: 256, renderWidth: 256, textureSize: 256, deterministicLockstep: false, lockstepMaxSteps: 1 });
+        scene = new Scene(engine);
+        frameGraph = new FrameGraph(scene);
+
+        capturedInputs = [];
+        capturedOutputs = [];
+        originalRegisterInput = NodeRenderGraphBlock.prototype.registerInput;
+        originalRegisterOutput = NodeRenderGraphBlock.prototype.registerOutput;
+        NodeRenderGraphBlock.prototype.registerInput = function (this: NodeRenderGraphBlock, name: string, ...rest: any[]) {
+            capturedInputs.push(name);
+            return (originalRegisterInput as any).call(this, name, ...rest);
+        } as any;
+        NodeRenderGraphBlock.prototype.registerOutput = function (this: NodeRenderGraphBlock, name: string, ...rest: any[]) {
+            capturedOutputs.push(name);
+            return (originalRegisterOutput as any).call(this, name, ...rest);
+        } as any;
+    });
+
+    afterEach(() => {
+        NodeRenderGraphBlock.prototype.registerInput = originalRegisterInput;
+        NodeRenderGraphBlock.prototype.registerOutput = originalRegisterOutput;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    // Construct a block, capturing its registered port names. Task-creation methods are
+    // temporarily neutralized so a task creation reached during super() cannot throw before
+    // the subclass finishes registering its ports.
+    const collectPorts = (ctor: any, extra: any[]): { inputs: string[]; outputs: string[] } => {
+        capturedInputs = [];
+        capturedOutputs = [];
+
+        const savedDescriptors = new Map<string, PropertyDescriptor | undefined>();
+        for (const method of TASK_CREATION_METHODS) {
+            savedDescriptors.set(method, Object.getOwnPropertyDescriptor(ctor.prototype, method));
+            Object.defineProperty(ctor.prototype, method, { value: () => {}, configurable: true, writable: true });
+        }
+
+        try {
+            // eslint-disable-next-line no-new
+            new ctor(`${ctor.name}_drift`, frameGraph, scene, ...extra);
+        } catch {
+            // Inline task creation may still throw after all ports are registered; ports are already captured.
+        } finally {
+            for (const method of TASK_CREATION_METHODS) {
+                const descriptor = savedDescriptors.get(method);
+                if (descriptor) {
+                    Object.defineProperty(ctor.prototype, method, descriptor);
+                } else {
+                    delete ctor.prototype[method];
+                }
+            }
+        }
+
+        return { inputs: [...new Set(capturedInputs)], outputs: [...new Set(capturedOutputs)] };
+    };
+
+    it("registry input/output port names match the real Babylon blocks", () => {
+        const problems: string[] = [];
+
+        for (const [key, info] of Object.entries(BlockRegistry)) {
+            const ctor = GetClass(`BABYLON.${info.className}`);
+            if (!ctor) {
+                problems.push(`${key}: no class registered as "BABYLON.${info.className}"`);
+                continue;
+            }
+
+            const extra = info.defaultAdditionalConstructionParameters ?? [];
+            const { inputs: realInputs, outputs: realOutputs } = collectPorts(ctor, extra);
+            const regInputs = info.inputs.map((i) => i.name);
+            const regOutputs = info.outputs.map((o) => o.name);
+
+            const missingInputs = realInputs.filter((n) => !regInputs.includes(n));
+            const extraInputs = regInputs.filter((n) => !realInputs.includes(n));
+            const missingOutputs = realOutputs.filter((n) => !regOutputs.includes(n));
+            const extraOutputs = regOutputs.filter((n) => !realOutputs.includes(n));
+
+            const details: string[] = [];
+            if (missingInputs.length) {
+                details.push(`inputs missing from registry: [${missingInputs.join(", ")}]`);
+            }
+            if (extraInputs.length) {
+                details.push(`inputs in registry but not on block: [${extraInputs.join(", ")}]`);
+            }
+            if (missingOutputs.length) {
+                details.push(`outputs missing from registry: [${missingOutputs.join(", ")}]`);
+            }
+            if (extraOutputs.length) {
+                details.push(`outputs in registry but not on block: [${extraOutputs.join(", ")}]`);
+            }
+            if (details.length) {
+                problems.push(`${info.className}: ${details.join("; ")}`);
+            }
+        }
+
+        expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});

--- a/packages/tools/smart-filters-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/smart-filters-mcp-server/test/unit/registryDrift.test.ts
@@ -147,6 +147,8 @@ describe("Smart Filters MCP Server – Registry Drift", () => {
             problems.push(...diff("outputs", realOutputs, regOutputs).map((d) => `${key}: ${d}`));
         }
 
+        engine.dispose();
+
         expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
     });
 });

--- a/packages/tools/smart-filters-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/smart-filters-mcp-server/test/unit/registryDrift.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Smart Filters MCP Server – Registry Drift Guard
+ *
+ * Verifies that the MCP block registry's declared input/output connection point NAMES
+ * match the real Smart Filter blocks. Port names are the wiring contract the AI agent
+ * relies on (connectBlocks matches by name), so any drift means the agent cannot wire a
+ * real port — or produces a connection that is silently dropped on parse.
+ *
+ * Smart Filter blocks come in a few flavours, each with a different authoritative source:
+ *   - Annotated-GLSL blocks (*.block.glsl): parsed with ImportCustomBlockDefinition.
+ *   - Hand-written TS shader/aggregate blocks: constructed via their real factory.
+ *   - Input blocks and the graph OutputBlock: fixed framework invariants.
+ *   - Blocks whose shader is generated from a *.fragment.glsl at build time cannot be
+ *     constructed in the source test environment, so they are presence-checked only.
+ *
+ * This test exists because the registry is hand-maintained (see
+ * .github/instructions/mcp-server-coverage.instructions.md) and can silently drift.
+ */
+import fs from "fs";
+import path from "path";
+import { NullEngine } from "core/Engines/nullEngine";
+import { SmartFilter, SmartFilterDeserializer, ImportCustomBlockDefinition } from "smart-filters";
+import { BuiltInBlockRegistrations } from "smart-filters-blocks/registration/builtInBlockRegistrations";
+import { DirectionalBlurBlock } from "smart-filters-blocks/blocks/babylon/demo/effects/directionalBlurBlock";
+import { BlockRegistry } from "../../src/blockRegistry";
+
+// Blocks whose shader is generated from a *.fragment.glsl at build time and therefore
+// cannot be constructed in the source test environment. Their presence in the registry
+// is still verified, but their ports are not compared against a constructed block.
+const CODEGEN_ONLY = new Set(["CompositionBlock", "SpritesheetBlock"]);
+
+// The single output of every Smart Filter shader block is named "output".
+const SHADER_OUTPUTS = ["output"];
+
+/**
+ * Connection points that exist on a real block but are never exposed for agent wiring:
+ *  - "disabled": the block-disable connection point (managed via block properties).
+ *  - autoBind inputs: values the framework binds automatically (e.g. output aspect ratio).
+ */
+function isHiddenInput(name: string, autoBind?: unknown): boolean {
+    return name === "disabled" || !!autoBind;
+}
+
+function walkGlsl(dir: string): string[] {
+    let result: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            result = result.concat(walkGlsl(full));
+        } else if (entry.name.endsWith(".block.glsl")) {
+            result.push(full);
+        }
+    }
+    return result;
+}
+
+function diff(label: string, real: string[], registry: string[]): string[] {
+    const missing = real.filter((n) => !registry.includes(n));
+    const extra = registry.filter((n) => !real.includes(n));
+    const details: string[] = [];
+    if (missing.length) {
+        details.push(`${label} missing from registry: [${missing.join(", ")}]`);
+    }
+    if (extra.length) {
+        details.push(`${label} in registry but not on block: [${extra.join(", ")}]`);
+    }
+    return details;
+}
+
+describe("Smart Filters MCP Server – Registry Drift", () => {
+    it("registry input/output port names match the real Smart Filter blocks", async () => {
+        const problems: string[] = [];
+
+        // Authoritative ports for annotated-GLSL blocks, keyed by blockType.
+        const glslInputs = new Map<string, string[]>();
+        const blocksRoot = path.resolve(process.cwd(), "packages/dev/smartFilterBlocks/src/blocks");
+        for (const file of walkGlsl(blocksRoot)) {
+            const def: any = ImportCustomBlockDefinition(fs.readFileSync(file, "utf8"));
+            const inputs = (def.inputConnectionPoints ?? []).filter((c: any) => !isHiddenInput(c.name, c.autoBind)).map((c: any) => c.name);
+            glslInputs.set(def.blockType, inputs);
+        }
+
+        const engine = new NullEngine();
+        const deserializer = new SmartFilterDeserializer(() => async () => {
+            throw new Error("no factory");
+        });
+        const registrationsByType = new Map(BuiltInBlockRegistrations.map((r) => [r.blockType, r]));
+
+        // Blocks that are constructable but not exposed as top-level BuiltInBlockRegistrations
+        // (e.g. DirectionalBlurBlock is used internally by the BlurBlock aggregate).
+        const directConstructors: Record<string, (sf: SmartFilter) => any> = {
+            DirectionalBlurBlock: (sf) => new DirectionalBlurBlock(sf, "drift"),
+        };
+
+        for (const [key, info] of Object.entries(BlockRegistry)) {
+            const regInputs = info.inputs.map((i) => i.name);
+            const regOutputs = info.outputs.map((o) => o.name);
+
+            // Input blocks: no inputs, a single "output" (InputBlock invariant).
+            if (info.isInput) {
+                problems.push(...diff("inputs", [], regInputs).map((d) => `${key}: ${d}`));
+                problems.push(...diff("outputs", ["output"], regOutputs).map((d) => `${key}: ${d}`));
+                continue;
+            }
+
+            // The graph output block: a single "input", no outputs (OutputBlock invariant).
+            if (key === "OutputBlock") {
+                problems.push(...diff("inputs", ["input"], regInputs).map((d) => `${key}: ${d}`));
+                problems.push(...diff("outputs", [], regOutputs).map((d) => `${key}: ${d}`));
+                continue;
+            }
+
+            // Annotated-GLSL blocks.
+            if (glslInputs.has(key)) {
+                problems.push(...diff("inputs", glslInputs.get(key)!, regInputs).map((d) => `${key}: ${d}`));
+                problems.push(...diff("outputs", SHADER_OUTPUTS, regOutputs).map((d) => `${key}: ${d}`));
+                continue;
+            }
+
+            // Codegen-only blocks: presence verified above (they are in BlockRegistry); ports skipped.
+            if (CODEGEN_ONLY.has(key)) {
+                continue;
+            }
+
+            // Hand-written TS shader/aggregate blocks: construct via their real factory
+            // (or a direct constructor for blocks not exposed as a top-level registration).
+            let block: any;
+            try {
+                const sf = new SmartFilter("drift");
+                if (directConstructors[key]) {
+                    block = directConstructors[key](sf);
+                } else {
+                    const registration: any = registrationsByType.get(key);
+                    if (!registration?.factory) {
+                        problems.push(`${key}: no annotated-GLSL source and no constructable factory found`);
+                        continue;
+                    }
+                    block = await registration.factory(sf, engine, deserializer, undefined, { suppressAutomaticInputBlocks: true });
+                }
+            } catch (e) {
+                problems.push(`${key}: could not construct to verify ports (${(e as Error).message})`);
+                continue;
+            }
+            const realInputs = (block.inputs ?? []).map((c: any) => c.name).filter((n: string) => !isHiddenInput(n));
+            const realOutputs = (block.outputs ?? []).map((c: any) => c.name);
+            problems.push(...diff("inputs", realInputs, regInputs).map((d) => `${key}: ${d}`));
+            problems.push(...diff("outputs", realOutputs, regOutputs).map((d) => `${key}: ${d}`));
+        }
+
+        expect(problems, `Registry drift detected:\n${problems.join("\n")}`).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Problem

Each graph/GUI MCP server hand-maintains a block registry (or GUI catalog) describing block ports / control properties. Nothing verified these against the real Babylon definitions, so they silently drifted out of sync.

The reported symptom: the **NME** server's `TextureBlock` only declared a `uv` input, so an agent could not wire an `ImageSourceBlock` into `TextureBlock.source` (`connect_blocks` rejected the `source` wire because the port didn't exist in the registry). This is a whole bug *class* — a missing/misnamed port means the agent either can't wire a real port, or produces a connection that is silently dropped on parse.

## What this does

### Registry/catalog fixes (real drift found)
- **NME**: `TextureBlock` now exposes `source`/`layer`/`lod`; **19** entries corrected.
- **NGE**: `VectorConverterBlock` port name corrected (`xyzw` → `"xyzw "`).
- **NRGE**: **14** entries corrected (GPU renderer / shadow / post-process blocks).
- **GUI**: `InputTextArea` no longer lists `TextBlock`-only props (`textHorizontalAlignment`/`textVerticalAlignment`/`lineSpacing`); `Scrollbar`'s non-existent `thumbColor` corrected to the real `color` property.
- **Flow Graph**: 13 event blocks no longer list a non-existent `in` signal input; `JsonPointerParser` gains its `setFunction`/`getFunction`/`generateAnimationsFunction` outputs.
- Smart Filters / NPE had no drift.

### Permanent drift guards (`registryDrift.test.ts` per server)
Each guard builds/parses the **real** Babylon definitions and fails on any port/property drift:
- **NME / NGE / NPE**: construct via `GetClass`, compare input/output port names.
- **NRGE**: construct under a `NullEngine`/`FrameGraph` harness, compare port names.
- **Flow Graph**: resolve each block via the async block factory, compare signal/data input/output names.
- **Smart Filters**: parse annotated-GLSL blocks with `ImportCustomBlockDefinition`, construct hand-written TS blocks via their factory, compare connection point names.
- **GUI**: construct the control, verify every catalog property name exists as a real member.

The guards are name-based (the wiring contract the agent relies on) and were each verified non-vacuous (they fail on injected/real drift, pass after the fixes).

### Docs
- `.github/instructions/mcp-server-coverage.instructions.md` updated to describe the per-server guards.

## CI enforcement (already active — no extra wiring)

These guards run on every PR through the existing monorepo pipeline — no new job was needed:
- `.azure-pipelines/ci-monorepo.yml` runs `npm run test:unit` (the "unit tests" step), which is `vitest run --project=unit`.
- The `unit` project includes `packages/**/test/unit/**/*.test.{ts,tsx}`, and all seven guards live at `packages/tools/*-mcp-server/test/unit/registryDrift.test.ts`, so they are auto-discovered.
- `test:unit` also runs `build:assets:smart-filters` first, so the SF codegen blocks are available in CI (the guard passes without it too).

Net effect: any future PR that renames or changes a block's ports (or a GUI control's properties) without updating the matching registry/catalog will fail the existing unit-tests job — keeping the MCP metadata always in sync with the real definitions.

## Testing
- All seven MCP server unit suites pass (257 tests), including the new guards.
- Regenerated example/fixture JSON (FG examples, NGE `MathPipeline`, NME fixtures) stays in sync with the corrected registries.
- `prettier --check` and `eslint` clean on changed source files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>