### PR TITLE
fix(core): register createDepthStencilTexture side effect for WebGPU engine

### DIFF
--- a/packages/dev/core/src/Engines/webgpuEngine.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.ts
@@ -8,6 +8,7 @@ import "./AbstractEngine/abstractEngine.dom";
 import "./AbstractEngine/abstractEngine.states";
 import "./AbstractEngine/abstractEngine.stencil";
 import "./AbstractEngine/abstractEngine.renderPass";
+import "./AbstractEngine/abstractEngine.texture";
 import "./AbstractEngine/abstractEngine.loadFile";
 import "./AbstractEngine/abstractEngine.textureLoaders";
 import "../Audio/audioEngine";


### PR DESCRIPTION
## Problem

Reported on the forum: [Not enough imports with side effects when importing WebGPU engine separately](https://forum.babylonjs.com/t/not-enough-imports-with-side-effects-when-import-webgpu-engine-separately/63761).

When importing only `@babylonjs/core/Engines/webgpuEngine` (tree-shaken usage), depth-texture based features silently misbehave. Importing `@babylonjs/core/Engines/AbstractEngine/abstractEngine.texture` (which the Inspector happens to pull in) "fixes" it.

## Root cause

The public `AbstractEngine.prototype.createDepthStencilTexture` dispatcher is installed only by the side-effect module `Engines/AbstractEngine/abstractEngine.texture` (via `RegisterAbstractEngineTexture()`):

- **WebGL** — `engine.ts` imports `abstractEngine.texture` ✅
- **Native** — `nativeEngineRegistration.pure.ts` calls `RegisterAbstractEngineTexture()` ✅
- **WebGPU** — `webgpuEngine.ts` never pulled it in ❌

`createRenderTargetTexture` defaults `generateDepthBuffer` to `true`, so the common path is:

```
createRenderTargetTexture (depth on by default)
  -> rtWrapper.createDepthStencilTexture()
  -> RenderTargetWrapper.createDepthStencilTexture()
  -> this._engine.createDepthStencilTexture(...)   // undefined without the side effect
```

This affects shadow maps, the depth renderer, mirror/reflection RTTs, RTTs with depth, and depth-consuming post-processes when only the WebGPU engine is imported. A bare scene that renders straight to the canvas doesn't hit it, which is why it went unnoticed.

## Fix

Add the missing side-effect import to `webgpuEngine.ts`, positioned to match `engine.ts`. WebGPU already ships the internal `_createDepthStencilTexture` / `_createDepthStencilCubeTexture` implementations (via the render-target and cube-texture extensions it imports), so this only wires up the missing public dispatcher and brings WebGPU to parity with the WebGL and native engines. No functional downside.

## Testing

- `prettier --check` on the changed file passes.
- `check:side-effects-sync` drift for core/gui is pre-existing on `master` and unrelated to this one-line import change.