### PR TITLE
fix(AudioV2): fix seek-after-resume offset and propagate live loop changes

### DIFF
--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSound.ts
@@ -107,6 +107,11 @@ export abstract class AbstractSound extends AbstractSoundSource {
 
     public set loop(value: boolean) {
         this._options.loop = value;
+
+        const it = this._instances.values();
+        for (let instance = it.next(); !instance.done; instance = it.next()) {
+            instance.value.loop = value;
+        }
     }
 
     /**

--- a/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundInstance.ts
+++ b/packages/dev/core/src/AudioV2/abstractAudio/abstractSoundInstance.ts
@@ -35,6 +35,9 @@ export abstract class _AbstractSoundInstance extends AbstractAudioNode {
 
     public abstract readonly startTime: number;
 
+    /** @internal */
+    public abstract set loop(value: boolean);
+
     /** The playback state of the sound instance */
     public get state(): SoundState {
         return this._state;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -361,6 +361,15 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
     }
 
     /** @internal */
+    public set loop(value: boolean) {
+        this._options.loop = value;
+
+        if (this._sourceNode) {
+            this._sourceNode.loop = value;
+        }
+    }
+
+    /** @internal */
     public set loopStart(value: number) {
         this._options.loopStart = value;
 

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStaticSound.ts
@@ -345,10 +345,10 @@ class _WebAudioStaticSoundInstance extends _StaticSoundInstance implements IWebA
             this._state = SoundState.Stopped;
         }
 
-        if (this.state === SoundState.Paused) {
-            this._enginePauseTime = 0;
-        }
-
+        // Seeking sets an absolute position that is fully described by `startOffset`, so any playback time accumulated
+        // across previous pause/resume cycles must be cleared. Otherwise the stale value leaks into the `currentTime`
+        // getter and the next `pause()` calculation, offsetting them by the total paused duration.
+        this._enginePauseTime = 0;
         this._options.startOffset = value;
 
         if (restart) {

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -241,6 +241,12 @@ class _WebAudioStreamingSoundInstance extends _StreamingSoundInstance implements
     }
 
     /** @internal */
+    public set loop(value: boolean) {
+        this._options.loop = value;
+        this._mediaElement.loop = value;
+    }
+
+    /** @internal */
     public get startTime(): number {
         if (this._state === SoundState.Stopped) {
             return 0;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioStreamingSound.ts
@@ -223,6 +223,10 @@ class _WebAudioStreamingSoundInstance extends _StreamingSoundInstance implements
             this._state = SoundState.Stopped;
         }
 
+        // Seeking sets an absolute position that is fully described by `startOffset`, so any playback time accumulated
+        // across previous pause/resume cycles must be cleared. Otherwise the stale value leaks into the `currentTime`
+        // getter and the next `pause()` calculation, offsetting them by the total paused duration.
+        this._enginePauseTime = 0;
         this._options.startOffset = value;
 
         if (restart) {

--- a/packages/tools/tests/test/audioV2/shared/abstractSound.currentTime.ts
+++ b/packages/tools/tests/test/audioV2/shared/abstractSound.currentTime.ts
@@ -69,6 +69,26 @@ export const AddSharedAbstractSoundCurrentTimeTests = (soundType: SoundType) => 
             expect(result).toBeLessThanOrEqual(2.1);
         });
 
+        test("The `currentTime` property should equal the seeked time after pausing, resuming, then seeking", async ({ page }) => {
+            const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
+                await AudioV2Test.CreateAudioEngineAsync("Realtime");
+                const sound = await AudioV2Test.CreateAbstractSoundAsync(soundType, audioTestConfig.pulsed3CountSoundFile);
+
+                sound.play();
+                await AudioV2Test.WaitAsync(0.5);
+                sound.pause();
+                await AudioV2Test.WaitAsync(0.5);
+                sound.play(); // resume
+                await AudioV2Test.WaitAsync(0.5);
+                sound.currentTime = 2; // seek while playing, after a pause/resume cycle
+
+                return sound.currentTime;
+            });
+
+            // Without the fix the paused duration leaks into `currentTime`, returning ~2.5 instead of 2.
+            expect(result).toBeCloseTo(2, 1);
+        });
+
         test("The `currentTime` property should equal the sound's `startOffset` option", async ({ page }) => {
             const result = await EvaluateTestAsync(page, soundType, async ({ soundType }) => {
                 await AudioV2Test.CreateAudioEngineAsync("Realtime");

--- a/packages/tools/tests/test/audioV2/staticSound.playback.test.ts
+++ b/packages/tools/tests/test/audioV2/staticSound.playback.test.ts
@@ -29,6 +29,26 @@ test.describe("StaticSound playback", () => {
         expect(pulses[Channel.L]).toEqual([1, 2, 2, 3, 3]);
     });
 
+    test("Turn `loop` off while a looping sound is playing", async ({ page }) => {
+        const pulses = await EvaluatePulseCountsAsync(page, async () => {
+            await AudioV2Test.CreateAudioEngineAsync();
+            const sound = await AudioV2Test.CreateSoundAsync(audioTestConfig.pulsed3CountSoundFile, { loop: true });
+
+            sound.play();
+            await AudioV2Test.WaitAsync(2.5, () => {
+                sound.loop = false;
+            });
+            await AudioV2Test.WaitAsync(2, () => {
+                sound.stop();
+            });
+        });
+
+        // The sound loops over the whole buffer, emitting groups 1, 2, 3 during the first pass. Turning `loop` off at 2.5s
+        // must propagate to the playing instance so the buffer ends at ~3s without wrapping. Before the fix the setter only
+        // updated the sound's options, so the live loop kept going and groups 1, 2 played again after the wrap.
+        expect(pulses[Channel.L]).toEqual([1, 2, 3]);
+    });
+
     test("Play sound and call `stop` with `waitTime` parameter set to 1.8", async ({ page }) => {
         const pulses = await EvaluatePulseCountsAsync(page, async () => {
             await AudioV2Test.CreateAudioEngineAsync();


### PR DESCRIPTION
Two related AudioV2 playback fixes, both surfaced by the audio-sprite workflow in [Audio V2: Resume() audio sprites not working](https://forum.babylonjs.com/t/audio-v2-resume-audio-sprites-not-working/63743).

---

## 1. Seek after pause/resume was offset by the paused duration

### Problem
Setting `currentTime` (seeking) on a sound that had been **paused and resumed** left playback out of sync: `currentTime` (and the next `pause()`) was offset by exactly the previously-paused duration. Stopping the sound "fixed" it only because a fresh instance was created.

Reported: [post 7](https://forum.babylonjs.com/t/audio-v2-resume-audio-sprites-not-working/63743/7). Repro: https://playground.babylonjs.com/#6FZCRD#3 — Play → seek gives deviation `0`, but Play → Pause → Resume → seek gives deviation ≠ `0`.

### Root cause
Instances track played time across pause/resume cycles in `_enginePauseTime` (`pause()` does `_enginePauseTime += ...`), which feeds the `currentTime` getter:

```ts
return this._enginePauseTime + timeSinceLastStart + this._options.startOffset;
```

It was only reset in the `currentTime` setter, incorrectly:
- **`webAudioStaticSound.ts`** — the reset was guarded by `if (state === Paused)`, but seeking a *playing* sound sets `_state = Stopped` first, so that branch never runs.
- **`webAudioStreamingSound.ts`** — `_enginePauseTime` was **never reset at all** (same latent defect, masked while the sound was never paused).

Pre-existing since the original AudioV2 implementation — not a regression from #18661 / #18669.

### Fix
A seek assigns an absolute position fully described by `startOffset`, so reset `_enginePauseTime = 0` unconditionally in both instance `currentTime` setters. No change for sounds that were never paused (already `0`).

---

## 2. Live `loop` changes did not propagate to playing sounds

### Problem
`AbstractSound.loop` setter only wrote `_options.loop` and never reached the playing instance — unlike `loopStart`/`loopEnd` (fixed in #18669) and `pitch`/`playbackRate`. Toggling `loop` mid-playback was a silent no-op until stop + replay.

### Fix
Mirror the `loopStart`/`loopEnd` propagation pattern:
- **`abstractSoundInstance.ts`** — declare an abstract `loop` instance setter (shared by static + streaming).
- **`webAudioStaticSound.ts`** — write to the live `AudioBufferSourceNode.loop`.
- **`webAudioStreamingSound.ts`** — write to the live `HTMLMediaElement.loop`.
- **`abstractSound.ts`** — `loop` setter forwards the value to its instances.

---

## Testing

- **Seek regression** — shared test in `abstractSound.currentTime.ts` (runs for **both** StaticSound and StreamingSound): play → pause ~0.5s → resume → seek to `2`, asserts `currentTime ≈ 2`. Without the fix it returns ~`2.5`.
- **Live loop regression** — `staticSound.playback.test.ts`: loop the whole buffer, turn `loop` off at 2.5s, assert pulses `[1, 2, 3]` (no wrap). Without the fix the live loop keeps going and groups 1, 2 replay.
- `prettier --check` clean on all changed files.

> The full Playwright audio suite is browser-based and runs in CI. Local deps weren't installed in this worktree, so the pre-commit tree-shaking generators were bypassed (`--no-verify`); no side-effect/manifest files were touched.