### PR TITLE
fix(loaders): auto-register SceneLoader plugin when importing glTF/2.0

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.ts
@@ -1,5 +1,12 @@
 export * from "./glTFLoader.pure";
 
 import { RegisterGLTF2Loader } from "./glTFLoader.pure";
+import { RegisterGLTFFileLoader } from "../glTFFileLoader.pure";
 
 RegisterGLTF2Loader();
+
+// Auto-register the .gltf/.glb SceneLoader plugin so that importing
+// "@babylonjs/loaders/glTF/2.0" restores the pre-9.15 behavior of making
+// SceneLoader able to load glTF 2.0 assets. This registers the version-aware
+// GLTFFileLoader plugin only; it does not pull in the legacy glTF 1.0 loader.
+RegisterGLTFFileLoader();

--- a/packages/dev/loaders/test/unit/glTF/gltf2SceneLoaderRegistration.test.ts
+++ b/packages/dev/loaders/test/unit/glTF/gltf2SceneLoaderRegistration.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { FreeCamera } from "core/Cameras/freeCamera";
+import { Vector3 } from "core/Maths/math.vector";
+import { GetRegisteredSceneLoaderPluginMetadata, ImportMeshAsync } from "core/Loading/sceneLoader";
+// The pure module has no side effects, so importing the class here does not register anything.
+import { GLTFFileLoader } from "loaders/glTF/glTFFileLoader.pure";
+
+// Builds a minimal, self-contained glTF 2.0 asset (a single triangle) as a data string.
+function buildMinimalGltf(): string {
+    const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    const bytes = new Uint8Array(positions.buffer);
+    let binary = "";
+    for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    const base64 = btoa(binary);
+
+    const gltf = {
+        asset: { version: "2.0", generator: "test" },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [{ mesh: 0 }],
+        meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
+        accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: "VEC3", max: [1, 1, 0], min: [0, 0, 0] }],
+        bufferViews: [{ buffer: 0, byteLength: 36, byteOffset: 0 }],
+        buffers: [{ byteLength: 36, uri: `data:application/octet-stream;base64,${base64}` }],
+    };
+    return JSON.stringify(gltf);
+}
+
+function isExtensionRegistered(extension: string): boolean {
+    return GetRegisteredSceneLoaderPluginMetadata().some((plugin) => plugin.extensions.some((e) => e.extension.toLowerCase() === extension));
+}
+
+/**
+ * Guards the pre-9.15 behavior that importing only "\@babylonjs/loaders/glTF/2.0"
+ * auto-registers the .gltf/.glb SceneLoader plugin, without dragging in the
+ * legacy glTF 1.0 loader.
+ */
+describe("glTF 2.0 SceneLoader plugin auto-registration", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({ renderHeight: 256, renderWidth: 256, textureSize: 256, deterministicLockstep: false, lockstepMaxSteps: 1 });
+        scene = new Scene(engine);
+        new FreeCamera("camera", new Vector3(0, 0, 0), scene);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("registers the .gltf/.glb plugin and does not pull in glTF 1.0 when importing only glTF/2.0", async () => {
+        // Before importing the 2.0 entry point, nothing has registered the gltf plugin
+        // and the version registry has no loader factories yet.
+        expect(isExtensionRegistered(".gltf")).toBe(false);
+        expect(isExtensionRegistered(".glb")).toBe(false);
+        expect(GLTFFileLoader._CreateGLTF2Loader).toBeUndefined();
+        expect(GLTFFileLoader._CreateGLTF1Loader).toBeUndefined();
+
+        // Importing ONLY the 2.0 entry point must restore auto-registration.
+        await import("loaders/glTF/2.0");
+
+        expect(isExtensionRegistered(".gltf")).toBe(true);
+        expect(isExtensionRegistered(".glb")).toBe(true);
+
+        // The 2.0 parser factory must be registered...
+        expect(GLTFFileLoader._CreateGLTF2Loader).toBeDefined();
+        // ...but the legacy glTF 1.0 loader must NOT have been imported/instantiated.
+        expect(GLTFFileLoader._CreateGLTF1Loader).toBeUndefined();
+    });
+
+    it("loads a minimal glTF 2.0 asset through SceneLoader after importing only glTF/2.0", async () => {
+        await import("loaders/glTF/2.0");
+
+        const gltf = buildMinimalGltf();
+        const result = await ImportMeshAsync(`data:${gltf}`, scene);
+
+        // A __root__ node plus at least one mesh with geometry should have loaded.
+        const loadedMeshes = result.meshes.filter((m) => m.getTotalVertices() > 0);
+        expect(loadedMeshes.length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/packages/dev/loaders/test/unit/glTF/gltf2SceneLoaderRegistration.test.ts
+++ b/packages/dev/loaders/test/unit/glTF/gltf2SceneLoaderRegistration.test.ts
@@ -36,7 +36,7 @@ function isExtensionRegistered(extension: string): boolean {
 }
 
 /**
- * Guards the pre-9.15 behavior that importing only "\@babylonjs/loaders/glTF/2.0"
+ * Guards the pre-9.15 behavior that importing only `@babylonjs/loaders/glTF/2.0`
  * auto-registers the .gltf/.glb SceneLoader plugin, without dragging in the
  * legacy glTF 1.0 loader.
  */


### PR DESCRIPTION
## Summary

Since the 9.15 "pure/non-pure" side-effect split, `import "@babylonjs/loaders/glTF/2.0"` no longer registered the `.gltf`/`.glb` plugin with `SceneLoader`. Downstream code that loaded a glTF 2.0 asset via `SceneLoader.Append`/`ImportMesh` after importing only `@babylonjs/loaders/glTF/2.0` failed with *"no plugin for .gltf/.glb"*. The only workaround was importing the whole `@babylonjs/loaders/glTF` barrel, which over-includes the legacy glTF 1.0 loader consumers don't want.

This restores the pre-9.15 behavior: **importing `@babylonjs/loaders/glTF/2.0` again auto-registers the SceneLoader plugin.**

## Root cause

- **9.5.0:** `glTF/2.0/glTFLoader.js` statically imported `../glTFFileLoader.js`, whose module top level ran `RegisterSceneLoaderPlugin(new GLTFFileLoader())`, so importing `glTF/2.0` transitively registered the file-loader plugin.
- **9.15+:** every module was split into a side-effect-free `*.pure` and a thin non-pure wrapper. `RegisterGLTFFileLoader()` (the `RegisterSceneLoaderPlugin(...)` call) now lives only in the non-pure `glTF/glTFFileLoader` wrapper. The non-pure `glTF/2.0` entry only called `RegisterGLTF2Loader()` (which registers the 2.0 parser factory in the version registry), not the SceneLoader file plugin.

## Fix

The non-pure `glTF/2.0/glTFLoader.ts` wrapper — which already owned the `RegisterGLTF2Loader()` side-effect and sits behind `@babylonjs/loaders/glTF/2.0` — now also calls `RegisterGLTFFileLoader()`.

```ts
import { RegisterGLTF2Loader } from "./glTFLoader.pure";
import { RegisterGLTFFileLoader } from "../glTFFileLoader.pure";

RegisterGLTF2Loader();
RegisterGLTFFileLoader();
```

## Constraints honored

- ✅ **`.pure` modules stay strictly side-effect-free** — the registration call lives only in the non-pure wrapper; no `Register*` call was added to any `.pure` or shared low-level module.
- ✅ **No static import of the glTF 1.0 loader from the 2.0 path** — `glTFFileLoader.pure` dispatches via the version registry (`createLoaders[version.major]`) with `_CreateGLTF1Loader`/`_CreateGLTF2Loader` static hooks set externally; it contains no static 1.0/2.0 parser imports (verified).
- ✅ **`.pure` entry points preserved** as the side-effect-free option (`2.0/pure.ts` re-exports `glTFLoader.pure`, unaffected).
- ✅ **No change to public API surface or default export shape.**

## Verification

- ✅ `@babylonjs/loaders` builds (`tsc -b`).
- ✅ Existing loaders tree-shaking / side-effect tests stay green.
- ✅ All-packages tree-shaking checks pass (manifest drift, side-effect import closure, pure barrels, side-effect stubs) and side-effects manifest sync is unchanged — bundle-size/side-effect snapshots for `.pure` consumers are untouched.
- ✅ All 331 loaders unit tests pass.

### New test

`packages/dev/loaders/test/unit/glTF/gltf2SceneLoaderRegistration.test.ts`:
- After importing **only** `@babylonjs/loaders/glTF/2.0`, asserts `SceneLoader` has a registered plugin accepting `.glb`/`.gltf`.
- Asserts a minimal glb/gltf import succeeds through `SceneLoader`.
- Asserts importing `glTF/2.0` does **not** register/instantiate the glTF 1.0 loader (`GLTFFileLoader._CreateGLTF1Loader` stays `undefined`).

A revert-check confirmed the new test fails without the one-line fix.

## Broader pattern (follow-up, not fixed here)

This is one instance of a class of regressions where the pure-split decoupled transitive side-effect registrations from their entry points. Sibling cases observed downstream (WebGPU): `createDepthStencilTexture` needing `@babylonjs/core/Engines/AbstractEngine/abstractEngine.texture`; the depth renderer's WGSL shaders (`ShadersWGSL/depth.*`, `ShadersWGSL/gaussianSplattingDepth.*`) 404ing because they're no longer registered; and `.babylon` parsing needing explicit `pointLight`/`standardMaterial`/`cubeTexture` imports. The same principle applies: re-attach each dropped side-effect to its **non-pure** entry point, never to a `.pure` module. Worth auditing other format/feature entry points that lost their transitive `Register*` side-effect.