### PR TITLE
Update material plugin regex replacement implementation

### DIFF
--- a/packages/dev/core/src/Materials/materialPluginManager.pure.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.pure.ts
@@ -426,15 +426,14 @@ export class MaterialPluginManager {
                             regexFlags += "g";
                         }
 
-                        const sourceCode = code;
                         const rx = new RegExp(pointName, regexFlags);
-                        let match = rx.exec(sourceCode);
+                        let match = rx.exec(code);
                         while (match !== null) {
                             const { index } = match;
                             const newCode = replaceRegExpSubstitutions(injectedCode, match);
                             code = code.substring(0, index) + newCode + code.substring(index + match[0].length);
                             rx.lastIndex = index + newCode.length;
-                            match = rx.exec(sourceCode);
+                            match = rx.exec(code);
                         }
                     } else {
                         const fullPointName = "#define " + pointName;
@@ -529,7 +528,7 @@ export function UnregisterAllMaterialPlugins(): void {
 /**
  * Replace regex substitution patterns (e.g. $1, $2, etc.)
  */
-function replaceRegExpSubstitutions(value: string, match: ReadonlyArray<string>) {
+function replaceRegExpSubstitutions(value: string, match: ReadonlyArray<string>): string {
     return value.replace(/\$(\d+)/g, (group0: string, group1: string): string => {
         const index = Number(group1);
         return index < match.length ? match[index] : "";

--- a/packages/dev/core/src/Materials/materialPluginManager.pure.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.pure.ts
@@ -430,7 +430,7 @@ export class MaterialPluginManager {
                         let match = rx.exec(code);
                         while (match !== null) {
                             const { index } = match;
-                            const newCode = replaceRegExpSubstitutions(injectedCode, match);
+                            const newCode = ReplaceRegExpSubstitutions(injectedCode, match);
                             code = code.substring(0, index) + newCode + code.substring(index + match[0].length);
                             rx.lastIndex = index + newCode.length;
                             match = rx.exec(code);
@@ -527,8 +527,11 @@ export function UnregisterAllMaterialPlugins(): void {
 
 /**
  * Replace regex substitution patterns (e.g. $1, $2, etc.)
+ * @param value The replacement string
+ * @param match The regex match array
+ * @returns Value having $X substitutions replaced with the equivalent `match[X]`
  */
-function replaceRegExpSubstitutions(value: string, match: ReadonlyArray<string>): string {
+function ReplaceRegExpSubstitutions(value: string, match: ReadonlyArray<string>): string {
     return value.replace(/\$(\d+)/g, (group0: string, group1: string): string => {
         const index = Number(group1);
         return index < match.length ? match[index] : "";

--- a/packages/dev/core/src/Materials/materialPluginManager.pure.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.pure.ts
@@ -430,11 +430,10 @@ export class MaterialPluginManager {
                         const rx = new RegExp(pointName, regexFlags);
                         let match = rx.exec(sourceCode);
                         while (match !== null) {
-                            let newCode = injectedCode;
-                            for (let i = 0; i < match.length; ++i) {
-                                newCode = newCode.replaceAll("$" + i, match[i]);
-                            }
-                            code = code.replace(match[0], newCode);
+                            const { index } = match;
+                            const newCode = replaceRegExpSubstitutions(injectedCode, match);
+                            code = code.substring(0, index) + newCode + code.substring(index + match[0].length);
+                            rx.lastIndex = index + newCode.length;
                             match = rx.exec(sourceCode);
                         }
                     } else {
@@ -525,4 +524,14 @@ export function UnregisterAllMaterialPlugins(): void {
     Inited = false;
     Material.OnEventObservable.remove(MaterialObserver);
     MaterialObserver = null;
+}
+
+/**
+ * Replace regex substitution patterns (e.g. $1, $2, etc.)
+ */
+function replaceRegExpSubstitutions(value: string, match: ReadonlyArray<string>) {
+    return value.replace(/\$(\d+)/g, (group0: string, group1: string): string => {
+        const index = Number(group1);
+        return index < match.length ? match[index] : "";
+    });
 }

--- a/packages/dev/core/src/Materials/materialPluginManager.pure.ts
+++ b/packages/dev/core/src/Materials/materialPluginManager.pure.ts
@@ -432,7 +432,7 @@ export class MaterialPluginManager {
                         while (match !== null) {
                             let newCode = injectedCode;
                             for (let i = 0; i < match.length; ++i) {
-                                newCode = newCode.replace("$" + i, match[i]);
+                                newCode = newCode.replaceAll("$" + i, match[i]);
                             }
                             code = code.replace(match[0], newCode);
                             match = rx.exec(sourceCode);


### PR DESCRIPTION
This fixes a few issues:

1. In material plugins, the `getCustomCode` function can return objects with regular expression match targets. Inside of the replacement string, regex-like keywords such as `$1`, `$2`, etc. can be used. However, only the first instance of each index is replaced, which can cause problems/undesirable workarounds for some use cases. This change supports replacing all instances.
2. Replaces an inefficient `.replace` call with a more explicit substring replacement. This should be more efficient and less error prone.