### PR TITLE
Fix WGSL water shader using undefined toLinearSpace on vec3

### DIFF
--- a/packages/dev/materials/src/water/wgsl/water.fragment.fx
+++ b/packages/dev/materials/src/water/wgsl/water.fragment.fx
@@ -258,9 +258,9 @@ var color: vec4f =  vec4f(finalDiffuse + finalSpecular, alpha);
 // Apply image processing if relevant. As this applies in linear space,
 // We first move from gamma to linear.
 #ifdef IMAGEPROCESSINGPOSTPROCESS
-	color = vec4f(toLinearSpace(color.rgb), color.a);
+	color = vec4f(toLinearSpaceVec3(color.rgb), color.a);
 #elif defined(IMAGEPROCESSING)
-    color = vec4f(toLinearSpace(color.rgb), color.a);
+    color = vec4f(toLinearSpaceVec3(color.rgb), color.a);
     color = applyImageProcessing(color);
 #endif
 


### PR DESCRIPTION
## Problem

Fixes #18681

Enabling image processing (e.g. `DefaultRenderingPipeline`) together with `WaterMaterial` on the WebGPU backend fails shader compilation:

```
Error while parsing WGSL: error: type mismatch for argument 1 in call to 'toLinearSpace', expected 'f32', got 'vec3<f32>'
color=vec4f(toLinearSpace(color.rgb),color.a);
```

## Root cause

The native WGSL water fragment shader (added in #18393) called `toLinearSpace(color.rgb)`. In WGSL the helper is split by type — `toLinearSpace(f32)`, `toLinearSpaceVec3(vec3f)`, `toLinearSpaceVec4(vec4f)` — unlike GLSL where `toLinearSpace` is overloaded. Passing a `vec3` to the `f32` overload fails to compile.

The two broken lines live inside `#ifdef IMAGEPROCESSINGPOSTPROCESS` / `#elif defined(IMAGEPROCESSING)`, so a plain WaterMaterial compiles fine — the failure only surfaces on WebGPU when image processing is also enabled.

## Fix

Use `toLinearSpaceVec3(color.rgb)` in `packages/dev/materials/src/water/wgsl/water.fragment.fx`, matching how core WGSL shaders (e.g. `particles.fragment.fx`, `geometry.fragment.fx`) call it. The GLSL shader is unaffected.

Repro playground: https://playground.babylonjs.com/#K1Y1Q8#113