### PR TITLE
fix(sandbox): play correct animation when the animation list is filtered

### DIFF
--- a/packages/tools/sandbox/src/components/dropUpButton.tsx
+++ b/packages/tools/sandbox/src/components/dropUpButton.tsx
@@ -79,10 +79,11 @@ export class DropUpButton extends React.Component<IDropUpButtonProps, { isOpen: 
                     <div className={"dropup-content" + (this.props.selectedOption ? " long-mode" : "")}>
                         <input type="text" placeholder={searchPlaceholder} value={this.state.searchText} onChange={this.onChangeSearchText} />
                         {this.props.options
-                            .filter((o) => {
-                                return !this.state.searchText || o.toLowerCase().indexOf(this.state.searchText.toLowerCase().trim()) > -1;
+                            .map((o, i) => ({ option: o, index: i }))
+                            .filter(({ option }) => {
+                                return !this.state.searchText || option.toLowerCase().indexOf(this.state.searchText.toLowerCase().trim()) > -1;
                             })
-                            .map((o, i) => {
+                            .map(({ option: o, index: i }) => {
                                 return (
                                     <div title={o} key={o} onClick={() => this.clickOption(o, i)} className="dropup-content-line">
                                         <div


### PR DESCRIPTION
## Problem

Reported on the forum: [Animation filter playing wrong animation (sandbox.babylonjs.com)](https://forum.babylonjs.com/t/animation-filter-playing-wrong-animation-sandbox-babylonjs-com/63782).

In the Sandbox, when you type a search filter in the animation group drop-up and then click an animation name, the **wrong** animation plays — it behaves as if the list were still unfiltered.

## Root cause

In `dropUpButton.tsx`, the options were `.filter()`ed by the search text and then `.map((o, i) => ...)`. The index `i` was the position within the **filtered** array, but it is passed up through `onOptionPicked` and used directly as `scene.animationGroups[index].play(...)` in `animationBar.tsx`. Once a filter narrowed the list, the filtered index no longer matched the original array, so the wrong animation group played.

## Fix

Capture each option's original index before filtering, then filter and render using that preserved index. The correct animation group now plays regardless of any active search filter.

## Testing

- `prettier --check` passes on the changed file.
- Verified the logic: the index handed to `onOptionPicked` is now always the original array index.