### PR TITLE
Serialization adjustments

### DIFF
--- a/packages/dev/core/src/Materials/imageProcessing.ts
+++ b/packages/dev/core/src/Materials/imageProcessing.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { GetDirectStoreFromMetadata } from "../Misc/decorators.functions";
+import { SerializedFieldType } from "../Misc/decorators.serializationUtilities";
 import { type Nullable } from "../types";
 import { type ImageProcessingConfiguration } from "./imageProcessingConfiguration";
 import { type Observer } from "../Misc/observable";
@@ -29,7 +30,7 @@ export function ImageProcessingMixin<Tbase extends ImageProcessingMixinConstruct
             }
             const store = GetDirectStoreFromMetadata(ctor[Symbol.metadata]);
             if (!store["_imageProcessingConfiguration"]) {
-                store["_imageProcessingConfiguration"] = { type: 9, sourceName: undefined };
+                store["_imageProcessingConfiguration"] = { type: SerializedFieldType.IMAGE_PROCESSING, sourceName: undefined };
             }
         }
         /**

--- a/packages/dev/core/src/Misc/decorators.functions.ts
+++ b/packages/dev/core/src/Misc/decorators.functions.ts
@@ -5,6 +5,7 @@
  * required for `Symbol.metadata` lives in `symbolMetadataPolyfill.ts` and is applied at package
  * entry points.
  */
+import { type SerializedPropertyMetadataMap } from "./decorators.serializationUtilities";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __bjsSerializableKey = "__bjs_serializable__";
@@ -83,7 +84,7 @@ function GetOwnMetadata(ctor: any): any {
  * Used by the TC39 decorators, which receive `context.metadata` directly.
  * @internal
  */
-export function GetDirectStoreFromMetadata(metadata: DecoratorMetadataObject): Record<string, any> {
+export function GetDirectStoreFromMetadata(metadata: DecoratorMetadataObject): SerializedPropertyMetadataMap {
     if (!metadata) {
         // `metadata` is `context.metadata`, which is `void 0` when `Symbol.metadata` was not installed
         // before the class was evaluated. Referencing `MetadataSymbol` here (a) produces an actionable
@@ -98,7 +99,7 @@ export function GetDirectStoreFromMetadata(metadata: DecoratorMetadataObject): R
 }
 
 /** @internal */
-export function GetDirectStore(target: any): any {
+export function GetDirectStore(target: any): SerializedPropertyMetadataMap {
     const metadata = GetOwnMetadata(GetConstructor(target));
     if (!metadata) {
         return {};
@@ -113,7 +114,7 @@ export function GetDirectStore(target: any): any {
  * @returns the list of properties flagged as serializable
  * @param target host object
  */
-export function GetMergedStore(target: any): any {
+export function GetMergedStore(target: any): SerializedPropertyMetadataMap {
     const ctor = GetConstructor(target);
     const metadata = ctor ? ctor[MetadataSymbol] : undefined;
     if (!metadata) {
@@ -125,7 +126,7 @@ export function GetMergedStore(target: any): any {
         return cached;
     }
 
-    const store: any = {};
+    const store: SerializedPropertyMetadataMap = {};
     // Walk the metadata prototype chain (most derived first); parents overwrite children to match the
     // original class-name-keyed merge order.
     const chain: any[] = [];
@@ -136,7 +137,7 @@ export function GetMergedStore(target: any): any {
     }
     for (const meta of chain) {
         if (HasOwn(meta, __bjsSerializableKey)) {
-            const initialStore = meta[__bjsSerializableKey];
+            const initialStore = meta[__bjsSerializableKey] as SerializedPropertyMetadataMap;
             for (const property in initialStore) {
                 store[property] = initialStore[property];
             }

--- a/packages/dev/core/src/Misc/decorators.serialization.ts
+++ b/packages/dev/core/src/Misc/decorators.serialization.ts
@@ -8,7 +8,7 @@ import { type BaseTexture } from "../Materials/Textures/baseTexture";
 import { type IAnimatable } from "../Animations/animatable.interface";
 import { Tags } from "./tags";
 import { Color3, Color4 } from "../Maths/math.color.pure";
-import { Matrix, Quaternion, Vector2, Vector3 } from "../Maths/math.vector.pure";
+import { Matrix, Quaternion, Vector2, Vector3, Vector4 } from "../Maths/math.vector.pure";
 import { type Camera } from "../Cameras/camera";
 import { GetMergedStore } from "./decorators.functions";
 import { SerializedFieldType } from "./decorators.serializationUtilities";
@@ -69,6 +69,7 @@ const CopySource = function <T>(creationFunction: () => T, source: T, instanciat
                 case SerializedFieldType.COLOR4:
                 case SerializedFieldType.QUATERNION:
                 case SerializedFieldType.MATRIX:
+                case SerializedFieldType.VECTOR4:
                     (<any>destination)[property] = instanciate ? sourceProperty : sourceProperty.clone();
                     break;
             }
@@ -201,6 +202,9 @@ export class SerializationHelper {
                     case SerializedFieldType.MATRIX:
                         serializationObject[targetPropertyName] = (<Matrix>sourceProperty).asArray();
                         break;
+                    case SerializedFieldType.VECTOR4:
+                        serializationObject[targetPropertyName] = (<Vector4>sourceProperty).asArray();
+                        break;
                 }
             }
         }
@@ -275,6 +279,9 @@ export class SerializationHelper {
                         break;
                     case SerializedFieldType.MATRIX:
                         dest[property] = Matrix.FromArray(sourceProperty);
+                        break;
+                    case SerializedFieldType.VECTOR4:
+                        dest[property] = Vector4.FromArray(sourceProperty);
                         break;
                 }
             }

--- a/packages/dev/core/src/Misc/decorators.serialization.ts
+++ b/packages/dev/core/src/Misc/decorators.serialization.ts
@@ -11,6 +11,7 @@ import { Color3, Color4 } from "../Maths/math.color.pure";
 import { Matrix, Quaternion, Vector2, Vector3 } from "../Maths/math.vector.pure";
 import { type Camera } from "../Cameras/camera";
 import { GetMergedStore } from "./decorators.functions";
+import { SerializedFieldType } from "./decorators.serializationUtilities";
 
 /** @internal */
 export interface ICopySourceOptions {
@@ -42,17 +43,17 @@ const CopySource = function <T>(creationFunction: () => T, source: T, instanciat
 
         if (sourceProperty !== undefined && sourceProperty !== null && (property !== "uniqueId" || SerializationHelper.AllowLoadingUniqueId)) {
             switch (propertyType) {
-                case 0: // Value
-                case 6: // Mesh reference
-                case 9: // Image processing configuration reference
-                case 11: // Camera reference
+                case SerializedFieldType.VALUE:
+                case SerializedFieldType.MESH:
+                case SerializedFieldType.IMAGE_PROCESSING:
+                case SerializedFieldType.CAMERA:
                     if (typeof sourceProperty.slice === "function") {
                         (<any>destination)[property] = sourceProperty.slice();
                     } else {
                         (<any>destination)[property] = sourceProperty;
                     }
                     break;
-                case 1: // Texture
+                case SerializedFieldType.TEXTURE:
                     if (options.cloneTexturesOnlyOnce && textureMap[sourceProperty.uniqueId]) {
                         (<any>destination)[property] = textureMap[sourceProperty.uniqueId];
                     } else {
@@ -60,14 +61,14 @@ const CopySource = function <T>(creationFunction: () => T, source: T, instanciat
                         textureMap[sourceProperty.uniqueId] = (<any>destination)[property];
                     }
                     break;
-                case 2: // Color3
-                case 3: // FresnelParameters
-                case 4: // Vector2
-                case 5: // Vector3
-                case 7: // Color Curves
-                case 8: // Color 4
-                case 10: // Quaternion
-                case 12: // Matrix
+                case SerializedFieldType.COLOR3:
+                case SerializedFieldType.FRESNEL_PARAMETERS:
+                case SerializedFieldType.VECTOR2:
+                case SerializedFieldType.VECTOR3:
+                case SerializedFieldType.COLOR_CURVES:
+                case SerializedFieldType.COLOR4:
+                case SerializedFieldType.QUATERNION:
+                case SerializedFieldType.MATRIX:
                     (<any>destination)[property] = instanciate ? sourceProperty : sourceProperty.clone();
                     break;
             }
@@ -157,47 +158,47 @@ export class SerializationHelper {
 
             if (sourceProperty !== undefined && sourceProperty !== null && (property !== "uniqueId" || SerializationHelper.AllowLoadingUniqueId)) {
                 switch (propertyType) {
-                    case 0: // Value
+                    case SerializedFieldType.VALUE:
                         if (Array.isArray(sourceProperty)) {
                             serializationObject[targetPropertyName] = sourceProperty.slice();
                         } else {
                             serializationObject[targetPropertyName] = sourceProperty;
                         }
                         break;
-                    case 1: // Texture
+                    case SerializedFieldType.TEXTURE:
                         serializationObject[targetPropertyName] = sourceProperty.serialize();
                         break;
-                    case 2: // Color3
+                    case SerializedFieldType.COLOR3:
                         serializationObject[targetPropertyName] = sourceProperty.asArray();
                         break;
-                    case 3: // FresnelParameters
+                    case SerializedFieldType.FRESNEL_PARAMETERS:
                         serializationObject[targetPropertyName] = sourceProperty.serialize();
                         break;
-                    case 4: // Vector2
+                    case SerializedFieldType.VECTOR2:
                         serializationObject[targetPropertyName] = sourceProperty.asArray();
                         break;
-                    case 5: // Vector3
+                    case SerializedFieldType.VECTOR3:
                         serializationObject[targetPropertyName] = sourceProperty.asArray();
                         break;
-                    case 6: // Mesh reference
+                    case SerializedFieldType.MESH:
                         serializationObject[targetPropertyName] = sourceProperty.id;
                         break;
-                    case 7: // Color Curves
+                    case SerializedFieldType.COLOR_CURVES:
                         serializationObject[targetPropertyName] = sourceProperty.serialize();
                         break;
-                    case 8: // Color 4
+                    case SerializedFieldType.COLOR4:
                         serializationObject[targetPropertyName] = (<Color4>sourceProperty).asArray();
                         break;
-                    case 9: // Image Processing
+                    case SerializedFieldType.IMAGE_PROCESSING:
                         serializationObject[targetPropertyName] = (<ImageProcessingConfiguration>sourceProperty).serialize();
                         break;
-                    case 10: // Quaternion
+                    case SerializedFieldType.QUATERNION:
                         serializationObject[targetPropertyName] = (<Quaternion>sourceProperty).asArray();
                         break;
-                    case 11: // Camera reference
+                    case SerializedFieldType.CAMERA:
                         serializationObject[targetPropertyName] = (<Camera>sourceProperty).id;
                         break;
-                    case 12: // Matrix
+                    case SerializedFieldType.MATRIX:
                         serializationObject[targetPropertyName] = (<Matrix>sourceProperty).asArray();
                         break;
                 }
@@ -230,49 +231,49 @@ export class SerializationHelper {
             if (sourceProperty !== undefined && sourceProperty !== null && (property !== "uniqueId" || SerializationHelper.AllowLoadingUniqueId)) {
                 const dest = destination;
                 switch (propertyType) {
-                    case 0: // Value
+                    case SerializedFieldType.VALUE:
                         dest[property] = sourceProperty;
                         break;
-                    case 1: // Texture
+                    case SerializedFieldType.TEXTURE:
                         if (scene) {
                             dest[property] = SerializationHelper._TextureParser(sourceProperty, scene, rootUrl);
                         }
                         break;
-                    case 2: // Color3
+                    case SerializedFieldType.COLOR3:
                         dest[property] = Color3.FromArray(sourceProperty);
                         break;
-                    case 3: // FresnelParameters
+                    case SerializedFieldType.FRESNEL_PARAMETERS:
                         dest[property] = SerializationHelper._FresnelParametersParser(sourceProperty);
                         break;
-                    case 4: // Vector2
+                    case SerializedFieldType.VECTOR2:
                         dest[property] = Vector2.FromArray(sourceProperty);
                         break;
-                    case 5: // Vector3
+                    case SerializedFieldType.VECTOR3:
                         dest[property] = Vector3.FromArray(sourceProperty);
                         break;
-                    case 6: // Mesh reference
+                    case SerializedFieldType.MESH:
                         if (scene) {
                             dest[property] = scene.getLastMeshById(sourceProperty);
                         }
                         break;
-                    case 7: // Color Curves
+                    case SerializedFieldType.COLOR_CURVES:
                         dest[property] = SerializationHelper._ColorCurvesParser(sourceProperty);
                         break;
-                    case 8: // Color 4
+                    case SerializedFieldType.COLOR4:
                         dest[property] = Color4.FromArray(sourceProperty);
                         break;
-                    case 9: // Image Processing
+                    case SerializedFieldType.IMAGE_PROCESSING:
                         dest[property] = SerializationHelper._ImageProcessingConfigurationParser(sourceProperty);
                         break;
-                    case 10: // Quaternion
+                    case SerializedFieldType.QUATERNION:
                         dest[property] = Quaternion.FromArray(sourceProperty);
                         break;
-                    case 11: // Camera reference
+                    case SerializedFieldType.CAMERA:
                         if (scene) {
                             dest[property] = scene.getCameraById(sourceProperty);
                         }
                         break;
-                    case 12: // Matrix
+                    case SerializedFieldType.MATRIX:
                         dest[property] = Matrix.FromArray(sourceProperty);
                         break;
                 }

--- a/packages/dev/core/src/Misc/decorators.serializationUtilities.ts
+++ b/packages/dev/core/src/Misc/decorators.serializationUtilities.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/** @internal */
+export const enum SerializedFieldType {
+    VALUE = 0,
+    TEXTURE = 1,
+    COLOR3 = 2,
+    FRESNEL_PARAMETERS = 3,
+    VECTOR2 = 4,
+    VECTOR3 = 5,
+    MESH = 6,
+    COLOR_CURVES = 7,
+    COLOR4 = 8,
+    IMAGE_PROCESSING = 9,
+    QUATERNION = 10,
+    CAMERA = 11,
+    MATRIX = 12,
+}
+
+/** @internal */
+export interface SerializedPropertyMetadata {
+    type: SerializedFieldType;
+    sourceName: string | undefined;
+}
+
+/** @internal */
+export type SerializedPropertyMetadataMap = Record<string, SerializedPropertyMetadata>;

--- a/packages/dev/core/src/Misc/decorators.serializationUtilities.ts
+++ b/packages/dev/core/src/Misc/decorators.serializationUtilities.ts
@@ -14,6 +14,7 @@ export const enum SerializedFieldType {
     QUATERNION = 10,
     CAMERA = 11,
     MATRIX = 12,
+    VECTOR4 = 13,
 }
 
 /** @internal */

--- a/packages/dev/core/src/Misc/decorators.ts
+++ b/packages/dev/core/src/Misc/decorators.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { type Nullable } from "../types";
 import { GetDirectStoreFromMetadata } from "./decorators.functions";
+import { SerializedFieldType } from "./decorators.serializationUtilities";
 import { _WarnImport } from "./devTools";
 
 /**
@@ -13,7 +14,7 @@ import { _WarnImport } from "./devTools";
  */
 type SerializableContext = { name: string | symbol; metadata: DecoratorMetadataObject | undefined };
 
-function generateSerializableMember(type: number, sourceName?: string) {
+function generateSerializableMember(type: SerializedFieldType, sourceName?: string) {
     return (_value: unknown, context: SerializableContext) => {
         if (!context.metadata) {
             return;
@@ -64,51 +65,51 @@ export function expandToProperty(callback: string, targetKey: Nullable<string> =
 }
 
 export function serialize(sourceName?: string) {
-    return generateSerializableMember(0, sourceName); // value member
+    return generateSerializableMember(SerializedFieldType.VALUE, sourceName);
 }
 
 export function serializeAsTexture(sourceName?: string) {
-    return generateSerializableMember(1, sourceName); // texture member
+    return generateSerializableMember(SerializedFieldType.TEXTURE, sourceName);
 }
 
 export function serializeAsColor3(sourceName?: string) {
-    return generateSerializableMember(2, sourceName); // color3 member
+    return generateSerializableMember(SerializedFieldType.COLOR3, sourceName);
 }
 
 export function serializeAsFresnelParameters(sourceName?: string) {
-    return generateSerializableMember(3, sourceName); // fresnel parameters member
+    return generateSerializableMember(SerializedFieldType.FRESNEL_PARAMETERS, sourceName);
 }
 
 export function serializeAsVector2(sourceName?: string) {
-    return generateSerializableMember(4, sourceName); // vector2 member
+    return generateSerializableMember(SerializedFieldType.VECTOR2, sourceName);
 }
 
 export function serializeAsVector3(sourceName?: string) {
-    return generateSerializableMember(5, sourceName); // vector3 member
+    return generateSerializableMember(SerializedFieldType.VECTOR3, sourceName);
 }
 
 export function serializeAsMeshReference(sourceName?: string) {
-    return generateSerializableMember(6, sourceName); // mesh reference member
+    return generateSerializableMember(SerializedFieldType.MESH, sourceName);
 }
 
 export function serializeAsColorCurves(sourceName?: string) {
-    return generateSerializableMember(7, sourceName); // color curves
+    return generateSerializableMember(SerializedFieldType.COLOR_CURVES, sourceName);
 }
 
 export function serializeAsColor4(sourceName?: string) {
-    return generateSerializableMember(8, sourceName); // color 4
+    return generateSerializableMember(SerializedFieldType.COLOR4, sourceName);
 }
 
 export function serializeAsImageProcessingConfiguration(sourceName?: string) {
-    return generateSerializableMember(9, sourceName); // image processing
+    return generateSerializableMember(SerializedFieldType.IMAGE_PROCESSING, sourceName);
 }
 
 export function serializeAsQuaternion(sourceName?: string) {
-    return generateSerializableMember(10, sourceName); // quaternion member
+    return generateSerializableMember(SerializedFieldType.QUATERNION, sourceName);
 }
 
 export function serializeAsMatrix(sourceName?: string) {
-    return generateSerializableMember(12, sourceName); // matrix member
+    return generateSerializableMember(SerializedFieldType.MATRIX, sourceName);
 }
 
 /**
@@ -117,7 +118,7 @@ export function serializeAsMatrix(sourceName?: string) {
  * @returns Property Decorator
  */
 export function serializeAsCameraReference(sourceName?: string) {
-    return generateSerializableMember(11, sourceName); // camera reference member
+    return generateSerializableMember(SerializedFieldType.CAMERA, sourceName);
 }
 
 /** @internal */

--- a/packages/dev/core/src/Misc/decorators.ts
+++ b/packages/dev/core/src/Misc/decorators.ts
@@ -112,6 +112,10 @@ export function serializeAsMatrix(sourceName?: string) {
     return generateSerializableMember(SerializedFieldType.MATRIX, sourceName);
 }
 
+export function serializeAsVector4(sourceName?: string) {
+    return generateSerializableMember(SerializedFieldType.VECTOR4, sourceName);
+}
+
 /**
  * Decorator used to define property that can be serialized as reference to a camera
  * @param sourceName defines the name of the property to decorate


### PR DESCRIPTION
I noticed that a `serializeAsVector4` function was missing from the decorators API as I was trying to use it in a project that I was working on, so I went to try to add one to Babylon.js itself. In doing so, I noticed that serialization uses hardcoded indices across a couple of files, which seems to be error prone, so I created some TS types for the relevant serialization structures I was seeing. Not sure if there was a reason that it was done the way it was done initially, but happy to have this PR as a discussion if needed.