### PR TITLE
Add writeToDepthBuffer option to MSDF TextRenderer

### DIFF
--- a/packages/dev/addons/src/msdfText/shaders/msdf.fragment.fx
+++ b/packages/dev/addons/src/msdfText/shaders/msdf.fragment.fx
@@ -31,13 +31,21 @@ void main(void)
 
     float border = outset * inset;
 
-    // When writing to the depth buffer, discard the transparent background of the glyph quads so they do not occlude other geometry.
-    if (uDepthWrite > 0.5 && max(alpha, border) < 0.5) {
-        discard;
+    // In depth-write mode, hard-cut the coverage (alpha test) so glyphs sort like solid geometry:
+    // fully transparent pixels are discarded and the remaining pixels are made opaque, so no
+    // semi-transparent edge pixels write depth (which would halo geometry drawn behind them).
+    float fillCoverage = alpha;
+    float strokeCoverage = border;
+    if (uDepthWrite > 0.5) {
+        if (max(alpha, border) < 0.5) {
+            discard;
+        }
+        fillCoverage = step(0.5, alpha);
+        strokeCoverage = step(0.5, border);
     }
 
-    vec4 filledFragColor = vec4(uColor.rgb, alpha * uColor.a);
-    vec4 strokedFragColor = vec4(uStrokeColor.rgb, border * uStrokeColor.a);
+    vec4 filledFragColor = vec4(uColor.rgb, fillCoverage * uColor.a);
+    vec4 strokedFragColor = vec4(uStrokeColor.rgb, strokeCoverage * uStrokeColor.a);
 
-    gl_FragColor = mix(filledFragColor, strokedFragColor, border);
+    gl_FragColor = mix(filledFragColor, strokedFragColor, strokeCoverage);
 }

--- a/packages/dev/addons/src/msdfText/shaders/msdf.fragment.fx
+++ b/packages/dev/addons/src/msdfText/shaders/msdf.fragment.fx
@@ -8,6 +8,7 @@ uniform vec4 uStrokeColor;
 uniform float uStrokeInsetWidth;
 uniform float uStrokeOutsetWidth;
 uniform float thickness;
+uniform float uDepthWrite;
 
 varying vec2 atlasUV;
 
@@ -29,6 +30,11 @@ void main(void)
     float inset = 1.0 - clamp(sigDistInset / fwidth(sigDistInset) + 0.5, 0.0, 1.0);
 
     float border = outset * inset;
+
+    // When writing to the depth buffer, discard the transparent background of the glyph quads so they do not occlude other geometry.
+    if (uDepthWrite > 0.5 && max(alpha, border) < 0.5) {
+        discard;
+    }
 
     vec4 filledFragColor = vec4(uColor.rgb, alpha * uColor.a);
     vec4 strokedFragColor = vec4(uStrokeColor.rgb, border * uStrokeColor.a);

--- a/packages/dev/addons/src/msdfText/shaders/msdf.fragment.fx
+++ b/packages/dev/addons/src/msdfText/shaders/msdf.fragment.fx
@@ -31,21 +31,14 @@ void main(void)
 
     float border = outset * inset;
 
-    // In depth-write mode, hard-cut the coverage (alpha test) so glyphs sort like solid geometry:
-    // fully transparent pixels are discarded and the remaining pixels are made opaque, so no
-    // semi-transparent edge pixels write depth (which would halo geometry drawn behind them).
-    float fillCoverage = alpha;
-    float strokeCoverage = border;
-    if (uDepthWrite > 0.5) {
-        if (max(alpha, border) < 0.5) {
-            discard;
-        }
-        fillCoverage = step(0.5, alpha);
-        strokeCoverage = step(0.5, border);
+    // When writing to the depth buffer, discard only the fully-transparent background of the glyph
+    // quads (so they don't occlude other geometry). Visible pixels keep their anti-aliased coverage.
+    if (uDepthWrite > 0.5 && max(alpha, border) <= 0.0) {
+        discard;
     }
 
-    vec4 filledFragColor = vec4(uColor.rgb, fillCoverage * uColor.a);
-    vec4 strokedFragColor = vec4(uStrokeColor.rgb, strokeCoverage * uStrokeColor.a);
+    vec4 filledFragColor = vec4(uColor.rgb, alpha * uColor.a);
+    vec4 strokedFragColor = vec4(uStrokeColor.rgb, border * uStrokeColor.a);
 
-    gl_FragColor = mix(filledFragColor, strokedFragColor, strokeCoverage);
+    gl_FragColor = mix(filledFragColor, strokedFragColor, border);
 }

--- a/packages/dev/addons/src/msdfText/shadersWGSL/msdf.fragment.fx
+++ b/packages/dev/addons/src/msdfText/shadersWGSL/msdf.fragment.fx
@@ -5,6 +5,7 @@ uniform thickness: f32;
 uniform uStrokeColor: vec4f;
 uniform uStrokeInsetWidth: f32;
 uniform uStrokeOutsetWidth: f32;
+uniform uDepthWrite: f32;
 
 varying atlasUV: vec2f;
 
@@ -32,6 +33,11 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
     let inset = 1.0 - clamp(sigDistInset / afwidthInset + 0.5, 0.0, 1.0);
 
     let border = outset * inset;
+
+    // When writing to the depth buffer, discard the transparent background of the glyph quads so they do not occlude other geometry.
+    if (uniforms.uDepthWrite > 0.5 && max(alpha, border) < 0.5) {
+        discard;
+    }
 
     let filledFragColor = vec4<f32>(uniforms.uColor.rgb, alpha * uniforms.uColor.a);
     let strokedFragColor = vec4<f32>(uniforms.uStrokeColor.rgb, border * uniforms.uStrokeColor.a);

--- a/packages/dev/addons/src/msdfText/shadersWGSL/msdf.fragment.fx
+++ b/packages/dev/addons/src/msdfText/shadersWGSL/msdf.fragment.fx
@@ -34,13 +34,21 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 
     let border = outset * inset;
 
-    // When writing to the depth buffer, discard the transparent background of the glyph quads so they do not occlude other geometry.
-    if (uniforms.uDepthWrite > 0.5 && max(alpha, border) < 0.5) {
-        discard;
+    // In depth-write mode, hard-cut the coverage (alpha test) so glyphs sort like solid geometry:
+    // fully transparent pixels are discarded and the remaining pixels are made opaque, so no
+    // semi-transparent edge pixels write depth (which would halo geometry drawn behind them).
+    var fillCoverage = alpha;
+    var strokeCoverage = border;
+    if (uniforms.uDepthWrite > 0.5) {
+        if (max(alpha, border) < 0.5) {
+            discard;
+        }
+        fillCoverage = step(0.5, alpha);
+        strokeCoverage = step(0.5, border);
     }
 
-    let filledFragColor = vec4<f32>(uniforms.uColor.rgb, alpha * uniforms.uColor.a);
-    let strokedFragColor = vec4<f32>(uniforms.uStrokeColor.rgb, border * uniforms.uStrokeColor.a);
+    let filledFragColor = vec4<f32>(uniforms.uColor.rgb, fillCoverage * uniforms.uColor.a);
+    let strokedFragColor = vec4<f32>(uniforms.uStrokeColor.rgb, strokeCoverage * uniforms.uStrokeColor.a);
 
-    fragmentOutputs.color = mix(filledFragColor, strokedFragColor, border);
+    fragmentOutputs.color = mix(filledFragColor, strokedFragColor, strokeCoverage);
 }

--- a/packages/dev/addons/src/msdfText/shadersWGSL/msdf.fragment.fx
+++ b/packages/dev/addons/src/msdfText/shadersWGSL/msdf.fragment.fx
@@ -34,21 +34,14 @@ fn main(input: FragmentInputs) -> FragmentOutputs {
 
     let border = outset * inset;
 
-    // In depth-write mode, hard-cut the coverage (alpha test) so glyphs sort like solid geometry:
-    // fully transparent pixels are discarded and the remaining pixels are made opaque, so no
-    // semi-transparent edge pixels write depth (which would halo geometry drawn behind them).
-    var fillCoverage = alpha;
-    var strokeCoverage = border;
-    if (uniforms.uDepthWrite > 0.5) {
-        if (max(alpha, border) < 0.5) {
-            discard;
-        }
-        fillCoverage = step(0.5, alpha);
-        strokeCoverage = step(0.5, border);
+    // When writing to the depth buffer, discard only the fully-transparent background of the glyph
+    // quads (so they don't occlude other geometry). Visible pixels keep their anti-aliased coverage.
+    if (uniforms.uDepthWrite > 0.5 && max(alpha, border) <= 0.0) {
+        discard;
     }
 
-    let filledFragColor = vec4<f32>(uniforms.uColor.rgb, fillCoverage * uniforms.uColor.a);
-    let strokedFragColor = vec4<f32>(uniforms.uStrokeColor.rgb, strokeCoverage * uniforms.uStrokeColor.a);
+    let filledFragColor = vec4<f32>(uniforms.uColor.rgb, alpha * uniforms.uColor.a);
+    let strokedFragColor = vec4<f32>(uniforms.uStrokeColor.rgb, border * uniforms.uStrokeColor.a);
 
-    fragmentOutputs.color = mix(filledFragColor, strokedFragColor, strokeCoverage);
+    fragmentOutputs.color = mix(filledFragColor, strokedFragColor, border);
 }

--- a/packages/dev/addons/src/msdfText/textRenderer.ts
+++ b/packages/dev/addons/src/msdfText/textRenderer.ts
@@ -143,6 +143,14 @@ export class TextRenderer implements IDisposable {
      */
     public ignoreDepthBuffer = false;
 
+    /**
+     * Gets or sets if the text renderer should write to the depth buffer (default is false).
+     * When enabled, transparent pixels are discarded so that separate text renderers (and other meshes)
+     * occlude each other according to their position in the 3D scene instead of their render order.
+     * This has no effect when ignoreDepthBuffer is true.
+     */
+    public writeToDepthBuffer = false;
+
     private constructor(engine: AbstractEngine, shaderLanguage: ShaderLanguage = ShaderLanguage.GLSL, font: FontAsset) {
         this._engine = engine;
         this._shaderLanguage = shaderLanguage;
@@ -198,7 +206,7 @@ export class TextRenderer implements IDisposable {
                 fragmentSource: fragment,
             },
             ["offsets", "world0", "world1", "world2", "world3", "uvs"],
-            ["parentWorld", "view", "projection", "uColor", "thickness", "uStrokeColor", "uStrokeInsetWidth", "uStrokeOutsetWidth", "mode", "transform"],
+            ["parentWorld", "view", "projection", "uColor", "thickness", "uStrokeColor", "uStrokeInsetWidth", "uStrokeOutsetWidth", "mode", "transform", "uDepthWrite"],
             ["fontAtlas"],
             defines,
             undefined,
@@ -318,6 +326,9 @@ export class TextRenderer implements IDisposable {
         effect.setFloat("uStrokeInsetWidth", this.strokeInsetWidth);
         effect.setFloat("uStrokeOutsetWidth", this.strokeOutsetWidth);
 
+        const writeDepth = this.writeToDepthBuffer && !this.ignoreDepthBuffer;
+        effect.setFloat("uDepthWrite", writeDepth ? 1.0 : 0.0);
+
         const instanceCount = this._charMatrices.length / 16;
 
         // Need update?
@@ -342,7 +353,11 @@ export class TextRenderer implements IDisposable {
             engine.bindBuffers(this._vertexBuffers, null, effect);
         }
 
-        engine.setAlphaMode(Constants.ALPHA_COMBINE);
+        // When writing to the depth buffer, keep depth writes enabled (setAlphaMode would otherwise disable them for the ALPHA_COMBINE mode).
+        engine.setAlphaMode(Constants.ALPHA_COMBINE, writeDepth);
+        if (writeDepth) {
+            engine.setDepthWrite(true);
+        }
         engine.drawArraysType(Constants.MATERIAL_TriangleStripDrawMode, 0, 4, instanceCount);
         engine.unbindInstanceAttributes();
         engine.setAlphaMode(Constants.ALPHA_DISABLE);


### PR DESCRIPTION
MSDF text is rendered with `ALPHA_COMBINE`, which disables depth writing, so a `TextRenderer` never wrote to the depth buffer. Multiple text renderers could therefore only be ordered by draw-call sequence — they behaved like 2D layers regardless of their position in 3D space (reported on the forum linked below).

This adds an opt-in `writeToDepthBuffer` flag on `TextRenderer` (default `false`, so existing behavior is unchanged). When enabled, the renderer keeps depth writing on and the GLSL/WGSL fragment shaders discard the fully-transparent parts of each glyph quad, so separate text renderers occlude each other according to their real 3D position instead of their render order.

```js
textRenderer.writeToDepthBuffer = true;
```

Because the text is now depth-tested, glyph edges are cut at the MSDF contour, so anti-aliasing is slightly crisper than in the default blended mode — the expected trade-off for solid-mesh-style depth sorting.

**Motivation:** forum request https://forum.babylonjs.com/t/msdf-how-to-draw-order-with-2-texts/63760

**Testing:** validated live on WebGL2 — two overlapping text blocks at different depths now occlude correctly only when the flag is enabled; default rendering is unchanged. The WGSL path mirrors the GLSL change for WebGPU.
