### PR TITLE
fix(gui): InputText paste replaces highlighted selection

### DIFF
--- a/packages/dev/gui/src/2D/controls/inputText.pure.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.pure.ts
@@ -883,8 +883,14 @@ export class InputText extends Control {
             //get the cached data; returns blank string by default
             data = this._host.clipboardData;
         }
-        const insertPosition = this._textWrapper.length - this._cursorOffset;
-        this._textWrapper.removePart(insertPosition, insertPosition, data);
+        if (this.isTextHighlightOn) {
+            this._textWrapper.removePart(this._startHighlightIndex, this._endHighlightIndex, data);
+            this._cursorOffset = this._textWrapper.length - (this._startHighlightIndex + data.length);
+            this.isTextHighlightOn = false;
+        } else {
+            const insertPosition = this._textWrapper.length - this._cursorOffset;
+            this._textWrapper.removePart(insertPosition, insertPosition, data);
+        }
         this._textHasChanged();
     }
 

--- a/packages/dev/gui/test/unit/inputText.test.ts
+++ b/packages/dev/gui/test/unit/inputText.test.ts
@@ -61,3 +61,39 @@ describe("InputText processKey", () => {
         expect(evt.preventDefault).not.toHaveBeenCalled();
     });
 });
+
+function createPasteEvent(data: string): ClipboardEvent {
+    return {
+        clipboardData: {
+            types: ["text/plain"],
+            getData: () => data,
+        },
+    } as unknown as ClipboardEvent;
+}
+
+describe("InputText _onPasteText", () => {
+    it("replaces the highlighted selection with the pasted text", () => {
+        const input = new InputText("test", "123456");
+        // Highlight "56" (indices 4..6).
+        const internal = input as any;
+        internal._isTextHighlightOn = true;
+        internal._startHighlightIndex = 4;
+        internal._endHighlightIndex = 6;
+
+        internal._onPasteText(createPasteEvent("23"));
+
+        expect(input.text).toBe("123423");
+        expect(input.isTextHighlightOn).toBe(false);
+    });
+
+    it("inserts the pasted text at the cursor when nothing is highlighted", () => {
+        const input = new InputText("test", "123456");
+        const internal = input as any;
+        // Cursor at the end (offset 0) means append.
+        internal._cursorOffset = 0;
+
+        internal._onPasteText(createPasteEvent("78"));
+
+        expect(input.text).toBe("12345678");
+    });
+});


### PR DESCRIPTION
## Problem

Reported on the forum: [GUI InputText.prototype.\_onPasteText ignores highlight part of text](https://forum.babylonjs.com/t/gui-inputtext-prototype-onpastetext-ignores-highlight-part-of-text/63788).

Pasting over a highlighted selection in a GUI `InputText` inserts the pasted text at the cursor **without removing the highlighted portion first**.

Repro: fill an `InputText` with `123456`, highlight `56`, then paste `23`. You get `12342356` (or `12345623`) instead of the expected `123423`.

## Root cause

`InputText.prototype._onPasteText` always did a plain insert at the cursor position and never consulted the active highlight state — unlike normal key entry (`processKey`) and `InputTextArea._onPasteText`, both of which remove the current selection before inserting.

## Fix

`_onPasteText` now checks `isTextHighlightOn`. When a selection is active it replaces the highlighted range with the pasted text via `removePart(start, end, data)`, updates the cursor offset, and clears the highlight — mirroring the existing key-entry logic. Non-highlighted paste behavior is unchanged. `InputTextArea` already handled this correctly and is untouched.

## Tests

- Added unit tests in `packages/dev/gui/test/unit/inputText.test.ts` for paste-over-highlight (→ `123423`) and normal append paste.
- All GUI `inputText` unit tests pass; Prettier and ESLint clean.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>