### PR TITLE
ci: reclaim disk space on hosted agents to fix Cache "No space left on device"

### DIFF
--- a/.azure-pipelines/templates/cache-steps.yml
+++ b/.azure-pipelines/templates/cache-steps.yml
@@ -28,6 +28,13 @@ parameters:
       default: false
 
 steps:
+    # Reclaim disk space first. On Microsoft-hosted Linux agents the OS disk can
+    # already be >95% full before any cache is written (unused preinstalled
+    # toolchains + full-history checkout), which makes the Cache@2 tar writes
+    # below fail with "No space left on device". Freeing space up front is what
+    # keeps the caches and build outputs from overflowing `/`.
+    - template: free-disk-space.yml
+
     - task: Cache@2
       displayName: "Cache npm packages"
       inputs:

--- a/.azure-pipelines/templates/free-disk-space.yml
+++ b/.azure-pipelines/templates/free-disk-space.yml
@@ -23,17 +23,20 @@ steps:
           echo "Disk usage before cleanup:"
           df -h /
           # Largest, safe-to-remove preinstalled toolchains for a JS monorepo.
-          sudo rm -rf /usr/local/lib/android || true          # ~9 GB  Android SDK/NDK
-          sudo rm -rf /usr/share/dotnet || true               # ~3 GB  .NET SDK
-          sudo rm -rf /opt/ghc /usr/local/.ghcup || true      # ~5 GB  Haskell
-          sudo rm -rf /opt/hostedtoolcache/CodeQL || true     # ~5 GB  CodeQL bundles
-          sudo rm -rf /usr/local/share/boost || true          # ~1 GB  Boost
-          sudo rm -rf /usr/share/swift || true                # ~2 GB  Swift
-          sudo rm -rf /usr/local/share/powershell || true     # ~1 GB  PowerShell
-          sudo rm -rf /usr/local/graalvm || true              #        GraalVM
+          # `sudo -n` never prompts for a password: Microsoft-hosted agents have
+          # passwordless sudo, and non-standard/self-hosted agents fail fast
+          # instead of hanging (the `|| true` keeps the step best-effort).
+          sudo -n rm -rf /usr/local/lib/android || true          # ~9 GB  Android SDK/NDK
+          sudo -n rm -rf /usr/share/dotnet || true               # ~3 GB  .NET SDK
+          sudo -n rm -rf /opt/ghc /usr/local/.ghcup || true      # ~5 GB  Haskell
+          sudo -n rm -rf /opt/hostedtoolcache/CodeQL || true     # ~5 GB  CodeQL bundles
+          sudo -n rm -rf /usr/local/share/boost || true          # ~1 GB  Boost
+          sudo -n rm -rf /usr/share/swift || true                # ~2 GB  Swift
+          sudo -n rm -rf /usr/local/share/powershell || true     # ~1 GB  PowerShell
+          sudo -n rm -rf /usr/local/graalvm || true              #        GraalVM
           # Prebuilt Docker images shipped on the image (~10-15 GB).
-          sudo docker image prune --all --force || true
-          sudo apt-get clean || true
+          sudo -n docker image prune --all --force || true
+          sudo -n apt-get clean || true
           echo "Disk usage after cleanup:"
           df -h /
       displayName: "Free up disk space"

--- a/.azure-pipelines/templates/free-disk-space.yml
+++ b/.azure-pipelines/templates/free-disk-space.yml
@@ -1,0 +1,41 @@
+# =============================================================================
+# Template: Reclaim disk space on Microsoft-hosted Linux agents
+#
+# The ubuntu-latest image ships with ~40 GB of preinstalled toolchains that a
+# JS/TS monorepo never uses (Android SDK, .NET, GHC/Haskell, CodeQL, Swift,
+# prebuilt Docker images, ...). Combined with a full-history checkout
+# (fetchDepth: 0) and the restored npm/Nx/Playwright caches, the OS disk (`/`)
+# can hit >95% usage BEFORE the build even starts. The first step that needs to
+# write a large file then dies with "No space left on device" — most visibly
+# the Cache@2 tasks, which fail while writing their tar archive.
+#
+# Deleting the unused toolchains up front frees ~25-40 GB and makes the caches
+# and build outputs fit. Every removal is best-effort (|| true) so a changed
+# image layout can never fail the job. Node itself
+# (/opt/hostedtoolcache/node, installed by UseNode@1) is deliberately kept.
+#
+# Include this immediately BEFORE the cache/restore + npm install steps.
+# =============================================================================
+
+steps:
+    - bash: |
+          set -uo pipefail
+          echo "Disk usage before cleanup:"
+          df -h /
+          # Largest, safe-to-remove preinstalled toolchains for a JS monorepo.
+          sudo rm -rf /usr/local/lib/android || true          # ~9 GB  Android SDK/NDK
+          sudo rm -rf /usr/share/dotnet || true               # ~3 GB  .NET SDK
+          sudo rm -rf /opt/ghc /usr/local/.ghcup || true      # ~5 GB  Haskell
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true     # ~5 GB  CodeQL bundles
+          sudo rm -rf /usr/local/share/boost || true          # ~1 GB  Boost
+          sudo rm -rf /usr/share/swift || true                # ~2 GB  Swift
+          sudo rm -rf /usr/local/share/powershell || true     # ~1 GB  PowerShell
+          sudo rm -rf /usr/local/graalvm || true              #        GraalVM
+          # Prebuilt Docker images shipped on the image (~10-15 GB).
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          echo "Disk usage after cleanup:"
+          df -h /
+      displayName: "Free up disk space"
+      continueOnError: true
+      condition: eq(variables['Agent.OS'], 'Linux')


### PR DESCRIPTION
## Problem

Some Monorepo CI runs fail intermittently on the `Cache Nx computation` step, e.g. [build 56273](https://dev.azure.com/babylonjs/ContinousIntegration/_build/results?buildId=56273&view=results):

```
##[warning]Free disk space on / is lower than 5%; Currently used: 95.26%
tar: ..._archive.tar: Cannot write: No space left on device
tar: Error is not recoverable: exiting now
##[error]Process returned non-zero exit code: 2
```

This looks like an Nx cache problem but it isn't. The Microsoft-hosted `ubuntu-latest` agent's OS disk (`/`) is already **~95% full before the build even starts**: full-history checkout (`fetchDepth: 0`) + restored npm/Nx/Playwright caches + ~40 GB of preinstalled toolchains a JS/TS monorepo never uses. The `Cache@2` task is simply the first step that writes a large tar, so it's the first to die. Re-runs pass only when the agent happens to have marginally more free space, which is why the failures look random.

## Fix

- Add `.azure-pipelines/templates/free-disk-space.yml` — a best-effort step that deletes unused preinstalled toolchains (Android SDK, .NET, Haskell/GHC, CodeQL, Swift, PowerShell, GraalVM, prebuilt Docker images) and runs `apt-get clean`. Frees ~25–40 GB. Every removal is `|| true`, the step is `continueOnError: true`, and it's gated to `Agent.OS == 'Linux'`. Node (`/opt/hostedtoolcache/node`) is deliberately kept.
- Wire it into `.azure-pipelines/templates/cache-steps.yml` as the first step. Because every heavy job (Build, ES6, UnitTests, Visualization, ViewerTests, …) already includes `cache-steps.yml` right before `npm install`, this single change gives them all disk headroom before caches and build outputs are written.

## Notes

- `NativeTests` and `Deploy` don't include `cache-steps.yml`, so they're untouched — they weren't the failure, but the new template is reusable if they ever hit the same wall.
- Both templates were validated as well-formed YAML.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>