### PR TITLE
Inspector v2: Allow FBX files in Project Authoring asset add/swap

### DIFF
--- a/packages/dev/inspector-v2/src/services/panes/babylonProjectAuthoringService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/babylonProjectAuthoringService.tsx
@@ -39,7 +39,7 @@ import { ApplyAllOverrides, GetOverrideManager, GetOverrides } from "shared-ui-c
 
 const ProjectAuthoringPaneKey = "Project Authoring";
 
-const SceneFileAccept = [".glb", ".gltf", ".babylon", ".obj"];
+const SceneFileAccept = [".glb", ".gltf", ".babylon", ".obj", ".fbx"];
 const TextureFileAccept = Array.from(GetSmartAssetTextureExtensions());
 const AllAcceptString = [...SceneFileAccept, ...TextureFileAccept].join(",");
 

--- a/packages/dev/inspector-v2/src/services/smartAssetPromptService.tsx
+++ b/packages/dev/inspector-v2/src/services/smartAssetPromptService.tsx
@@ -18,7 +18,7 @@ type PendingMissingAsset = {
     resolve: (value: string | File | null) => void;
 };
 
-const SceneFileExtensions = [".glb", ".gltf", ".babylon", ".obj"];
+const SceneFileExtensions = [".glb", ".gltf", ".babylon", ".obj", ".fbx"];
 const PromptAcceptString = [...SceneFileExtensions, ...Array.from(GetSmartAssetTextureExtensions())].join(",");
 
 const useStyles = makeStyles({


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## What

The Inspector v2 **Project Authoring** pane (and the Smart Asset "locate missing file" prompt) restricted addable/swappable scene assets to `.glb`, `.gltf`, `.babylon`, and `.obj`. This PR adds `.fbx` to both scene-file accept lists so users can add and swap FBX models — including their embedded animations — directly from the Inspector.

## Why

The TypeScript FBX loader is already registered in engine (#18483). The smart-asset load path forwards the file extension to `LoadAssetContainerAsync` as `pluginExtension`, so FBX resolves through the existing loader with no additional wiring. The only thing preventing FBX from being added was the hardcoded accept lists in the Inspector UI.

## Changes

- `babylonProjectAuthoringService.tsx`: add `.fbx` to `SceneFileAccept` (drives the add-asset file picker and the swap picker).
- `smartAssetPromptService.tsx`: add `.fbx` to `SceneFileExtensions` (drives the "Asset not found → Locate File…" dialog).

## Testing

Validated locally in the Inspector v2 test app: added an `.fbx` model via Project Authoring and confirmed the mesh loads and its embedded animations play.

## Behavioral changes

None beyond exposing `.fbx` in the file pickers; existing formats are unchanged.
