### PR TITLE
fix(inspector-v2): don't flood scene explorer with per-frame active camera notifications

### DIFF
--- a/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/scene/nodeExplorerService.tsx
@@ -286,9 +286,18 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
             getCommand: (camera) => {
                 const scene = camera.getScene();
                 const onChangeObservable = new Observable<void>();
-                const activeCameraChangedObserver = scene.onActiveCameraChanged.add(() => {
-                    onChangeObservable.notifyObservers();
-                });
+
+                // Render target rendering transiently reassigns scene.activeCamera (potentially every frame), so defer
+                // the check to a microtask (letting mid-frame swaps settle) and only notify on real active-state changes.
+                let lastIsActive = getActiveCamera() === camera;
+                const notifyIfActiveStateChanged = () => {
+                    const isActive = getActiveCamera() === camera;
+                    if (isActive !== lastIsActive) {
+                        lastIsActive = isActive;
+                        onChangeObservable.notifyObservers();
+                    }
+                };
+                const activeCameraChangedObserver = scene.onActiveCameraChanged.add(() => queueMicrotask(notifyIfActiveStateChanged));
 
                 return {
                     type: "toggle",
@@ -319,7 +328,7 @@ export const NodeExplorerServiceDefinition: ServiceDefinition<[], [ISceneExplore
                                     if (updated) {
                                         activeCamera?.detachControl();
                                         camera.attachControl(true);
-                                        onChangeObservable.notifyObservers();
+                                        notifyIfActiveStateChanged();
                                     }
                                 })(scene.frameGraph);
                             } else {


### PR DESCRIPTION
### Issue

With Inspector V2 open, any scene where `scene.activeCamera` is transiently reassigned during rendering — e.g. a `RenderTargetTexture` with its own `activeCamera` and `REFRESHRATE_RENDER_ONEVERYFRAME` — floods the browser console with periodic React warnings:

```
Maximum update depth exceeded. This can happen when a component calls setState inside useEffect...
```

### Cause

The scene explorer's camera entity command ("Activate and Attach Controls") notifies its `onChange` observable unconditionally on every `scene.onActiveCameraChanged`. Render target rendering swaps `scene.activeCamera` to the RTT camera and back each frame, so the observable fires (at least) twice per frame, and each notification setStates in the scene explorer's aside `useEffect` — a per-frame React update loop even though nothing user-visible changed.

### Fix

Defer the active-state check to a microtask so synchronous mid-frame swaps have settled by the time it runs, and only notify when the camera's effective active state (`getActiveCamera() === camera`) actually changed. Transient RTT swaps settle back to the same camera within the same task, so they no longer produce any notifications; genuine camera activations still notify (now at most once per change).

The frame graph activation path now goes through the same guarded notify so the cached state can't go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)