### PR TITLE
[GUI] Fix Line.connectedControl with adaptive scaling

### DIFF
--- a/packages/dev/gui/src/2D/controls/line.pure.ts
+++ b/packages/dev/gui/src/2D/controls/line.pure.ts
@@ -156,12 +156,12 @@ export class Line extends Control {
 
     /** @internal */
     public get _effectiveX2(): number {
-        return (this._connectedControl ? this._connectedControl.centerX : 0) + this._x2.getValue(this._host);
+        return (this._connectedControl ? this._connectedControl.centerX - this._cachedParentMeasure.left : 0) + this._x2.getValue(this._host);
     }
 
     /** @internal */
     public get _effectiveY2(): number {
-        return (this._connectedControl ? this._connectedControl.centerY : 0) + this._y2.getValue(this._host);
+        return (this._connectedControl ? this._connectedControl.centerY - this._cachedParentMeasure.top : 0) + this._y2.getValue(this._host);
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/line.pure.ts
+++ b/packages/dev/gui/src/2D/controls/line.pure.ts
@@ -212,6 +212,10 @@ export class Line extends Control {
         this._currentMeasure.height = Math.abs(this._y1.getValue(this._host) - this._effectiveY2) + this._lineWidth;
     }
 
+    protected override _preMeasure(parentMeasure: Measure): void {
+        this._cachedParentMeasure.copyFrom(parentMeasure);
+    }
+
     public override _layout(parentMeasure: Measure, context: ICanvasRenderingContext): boolean {
         if (this._connectedControl) {
             // If we have a connected control, we need to let it layout first so we can ensure our layout math uses its latest position

--- a/packages/dev/gui/test/unit/line.test.ts
+++ b/packages/dev/gui/test/unit/line.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { Line } from "../../src/2D/controls/line";
+import { Rectangle } from "../../src/2D/controls/rectangle";
+
+describe("Line connectedControl", () => {
+    it("uses the connected control center relative to the line parent", () => {
+        const line = new Line("line");
+        const connectedControl = new Rectangle("connectedControl");
+
+        line._cachedParentMeasure.copyFromFloats(600, 400, 800, 600);
+        connectedControl._currentMeasure.copyFromFloats(750, 500, 100, 40);
+        line.connectedControl = connectedControl;
+        line.x2 = 20;
+        line.y2 = -10;
+
+        expect(line._effectiveX2).toBe(220);
+        expect(line._effectiveY2).toBe(110);
+    });
+});

--- a/packages/dev/gui/test/unit/lineLayout.test.ts
+++ b/packages/dev/gui/test/unit/lineLayout.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { type ICanvasRenderingContext } from "core/Engines/ICanvas";
 import { Line } from "../../src/2D/controls/line";
 import { Rectangle } from "../../src/2D/controls/rectangle";
 import { Measure } from "../../src/2D/measure";
 
 class TestLine extends Line {
     public prepareMeasure(parentMeasure: Measure): void {
-        this._preMeasure(parentMeasure, {} as ICanvasRenderingContext);
+        this._preMeasure(parentMeasure);
     }
 }
 

--- a/packages/dev/gui/test/unit/lineLayout.test.ts
+++ b/packages/dev/gui/test/unit/lineLayout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { type ICanvasRenderingContext } from "core/Engines/ICanvas";
+import { Line } from "../../src/2D/controls/line";
+import { Rectangle } from "../../src/2D/controls/rectangle";
+import { Measure } from "../../src/2D/measure";
+
+class TestLine extends Line {
+    public prepareMeasure(parentMeasure: Measure): void {
+        this._preMeasure(parentMeasure, {} as ICanvasRenderingContext);
+    }
+}
+
+describe("Line layout", () => {
+    it("uses the current parent origin while measuring a connected control", () => {
+        const line = new TestLine("line");
+        const connectedControl = new Rectangle("connectedControl");
+        const parentMeasure = new Measure(600, 400, 800, 600);
+
+        connectedControl._currentMeasure.copyFromFloats(750, 500, 100, 40);
+        line.connectedControl = connectedControl;
+        line.x2 = 20;
+        line.y2 = -10;
+        line.prepareMeasure(parentMeasure);
+
+        expect(line._effectiveX2).toBe(220);
+        expect(line._effectiveY2).toBe(110);
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

Fixes `GUI.Line.connectedControl` when a fullscreen `AdvancedDynamicTexture` adapts to the engine hardware scaling level.

Forum report: https://forum.babylonjs.com/t/63804  
Deterministic repro: https://playground.babylonjs.com/#NX7KQL#0

The connected control center is expressed in global GUI layout coordinates, while the line endpoint is drawn relative to the line parent. Adaptive scaling gives the root container a nonzero layout origin, causing that origin to be applied twice. The fix converts the connected center to parent-local coordinates and makes the current parent measurement available before the line's first measurement pass.

Adds regression coverage for both coordinate conversion and first-layout behavior.
