### PR TITLE
Fix NodeMaterial overlighting under HDR from default image-processing config

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -66,7 +66,7 @@ import { type NodeMaterialTeleportInBlock } from "./Blocks/Teleport/teleportInBl
 import { Logger } from "core/Misc/logger";
 import { PrepareDefinesForCamera, PrepareDefinesForPrePass, AreLightsTexturesReady } from "../materialHelper.functions";
 import { ImageProcessingDefinesMixin } from "../imageProcessingConfiguration.defines";
-import { RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
+import { ImageProcessingConfiguration, RegisterImageProcessingConfiguration } from "../imageProcessingConfiguration.pure";
 import { ShaderLanguage } from "../shaderLanguage";
 import { AbstractEngine } from "../../Engines/abstractEngine.pure";
 import { type LoopBlock } from "./Blocks/loopBlock.pure";
@@ -2423,6 +2423,20 @@ export class NodeMaterial extends NodeMaterialBase {
         }
     }
 
+    private static _DefaultImageProcessingConfigurationSerialized: string;
+
+    /**
+     * Determines whether a parsed image processing configuration only holds default values.
+     * @param configuration the configuration to test
+     * @returns true if the configuration matches a freshly created default configuration
+     */
+    private static _IsDefaultImageProcessingConfiguration(configuration: ImageProcessingConfiguration): boolean {
+        if (!NodeMaterial._DefaultImageProcessingConfigurationSerialized) {
+            NodeMaterial._DefaultImageProcessingConfigurationSerialized = JSON.stringify(new ImageProcessingConfiguration().serialize());
+        }
+        return JSON.stringify(configuration.serialize()) === NodeMaterial._DefaultImageProcessingConfigurationSerialized;
+    }
+
     /**
      * Clear the current graph and load a new one from a serialization object
      * @param source defines the JSON representation of the material
@@ -2447,7 +2461,14 @@ export class NodeMaterial extends NodeMaterialBase {
         if (hasSerializedImageProcessingConfiguration) {
             this._imageProcessingConfiguration = previousImageProcessingConfiguration;
             this._imageProcessingObserver = previousImageProcessingObserver;
-            this._attachImageProcessingConfiguration(parsedImageProcessingConfiguration);
+            // A serialized configuration that only holds default values (the common case for Node Material
+            // snippets that never customized image processing) must not detach the material from the scene
+            // configuration. A detached private configuration is never updated by full-screen post-processes
+            // (e.g. the HDR DefaultRenderingPipeline sets applyByPostProcess on the scene configuration only),
+            // so image processing would end up applied both in the material shader and in the post-process.
+            // Only honor a genuinely customized configuration; otherwise fall back to the scene configuration.
+            const useParsedConfiguration = parsedImageProcessingConfiguration && !NodeMaterial._IsDefaultImageProcessingConfiguration(parsedImageProcessingConfiguration);
+            this._attachImageProcessingConfiguration(useParsedConfiguration ? parsedImageProcessingConfiguration : null);
         }
 
         this.id = id;

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -2423,7 +2423,7 @@ export class NodeMaterial extends NodeMaterialBase {
         }
     }
 
-    private static _DefaultImageProcessingConfigurationSerialized: string;
+    private static _DefaultImageProcessingConfigurationSerialized?: string;
 
     /**
      * Determines whether a parsed image processing configuration only holds default values.

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts
@@ -1,7 +1,14 @@
 import { NullEngine } from "core/Engines/nullEngine";
 import { NodeMaterial } from "core/Materials/Node/nodeMaterial";
+import { InputBlock } from "core/Materials/Node/Blocks/Input/inputBlock";
+import { TransformBlock } from "core/Materials/Node/Blocks/transformBlock";
+import { VertexOutputBlock } from "core/Materials/Node/Blocks/Vertex/vertexOutputBlock";
+import { FragmentOutputBlock } from "core/Materials/Node/Blocks/Fragment/fragmentOutputBlock";
+import { ImageProcessingBlock } from "core/Materials/Node/Blocks/Fragment/imageProcessingBlock";
+import { NodeMaterialSystemValues } from "core/Materials/Node/Enums/nodeMaterialSystemValues";
+import { ImageProcessingConfiguration } from "core/Materials/imageProcessingConfiguration";
+import { Color4 } from "core/Maths/math.color";
 import { Scene } from "core/scene";
-import "core/Materials/imageProcessingConfiguration";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const _getActiveImageProcessingObserverCount = (scene: Scene): number => {
@@ -70,3 +77,125 @@ describe("Babylon NodeMaterial image processing observer lifecycle", () => {
         expect(finalObserverCount).toBe(initialObserverCount);
     });
 });
+
+describe("Babylon NodeMaterial image processing configuration parsing", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("keeps the scene configuration when the serialized image processing configuration only holds default values", () => {
+        // A default Node Material never customizes image processing, so its serialized configuration
+        // only holds default values. Restoring it as a private configuration would detach the material
+        // from the scene configuration and break the applyByPostProcess coordination used by the HDR
+        // DefaultRenderingPipeline (leading to image processing being applied twice).
+        const template = new NodeMaterial("template", scene);
+        const serialized = template.serialize();
+        template.dispose();
+
+        expect(serialized._imageProcessingConfiguration).toBeDefined();
+
+        const material = new NodeMaterial("nodeMaterial", scene);
+        material.parseSerializedObject(serialized);
+
+        expect(material.imageProcessingConfiguration).toBe(scene.imageProcessingConfiguration);
+
+        material.dispose();
+    });
+
+    it("honors a serialized image processing configuration that was genuinely customized", () => {
+        const template = new NodeMaterial("template", scene);
+        const customConfiguration = new ImageProcessingConfiguration();
+        customConfiguration.exposure = 2;
+        template.imageProcessingConfiguration = customConfiguration;
+        const serialized = template.serialize();
+        template.dispose();
+
+        const material = new NodeMaterial("nodeMaterial", scene);
+        material.parseSerializedObject(serialized);
+
+        expect(material.imageProcessingConfiguration).not.toBe(scene.imageProcessingConfiguration);
+        expect(material.imageProcessingConfiguration.exposure).toBe(2);
+
+        material.dispose();
+    });
+
+    it("keeps the scene configuration through NodeMaterial.Parse when the serialized configuration only holds default values", () => {
+        // NodeMaterial.Parse first runs SerializationHelper.Parse (which already deserializes
+        // _imageProcessingConfiguration into a detached private configuration) and then parseSerializedObject.
+        // This double-parse must still resolve to the scene configuration for a default configuration,
+        // otherwise the material renders overlighted under the HDR DefaultRenderingPipeline.
+        const template = buildImageProcessingNodeMaterial(scene);
+        const serialized = template.serialize();
+        template.dispose();
+
+        const material = NodeMaterial.Parse(serialized, scene, "");
+
+        expect(material.imageProcessingConfiguration).toBe(scene.imageProcessingConfiguration);
+
+        material.dispose();
+    });
+
+    it("honors a customized configuration through NodeMaterial.Parse", () => {
+        const template = buildImageProcessingNodeMaterial(scene);
+        const customConfiguration = new ImageProcessingConfiguration();
+        customConfiguration.exposure = 2;
+        template.imageProcessingConfiguration = customConfiguration;
+        const serialized = template.serialize();
+        template.dispose();
+
+        const material = NodeMaterial.Parse(serialized, scene, "");
+
+        expect(material.imageProcessingConfiguration).not.toBe(scene.imageProcessingConfiguration);
+        expect(material.imageProcessingConfiguration.exposure).toBe(2);
+
+        material.dispose();
+    });
+});
+
+function buildImageProcessingNodeMaterial(scene: Scene): NodeMaterial {
+    const material = new NodeMaterial("nodeMaterial", scene);
+
+    const position = new InputBlock("position");
+    position.setAsAttribute("position");
+    const world = new InputBlock("world");
+    world.setAsSystemValue(NodeMaterialSystemValues.World);
+    const worldPosition = new TransformBlock("worldPosition");
+    position.connectTo(worldPosition);
+    world.connectTo(worldPosition);
+    const viewProjection = new InputBlock("viewProjection");
+    viewProjection.setAsSystemValue(NodeMaterialSystemValues.ViewProjection);
+    const worldViewProjection = new TransformBlock("worldViewProjection");
+    worldPosition.connectTo(worldViewProjection);
+    viewProjection.connectTo(worldViewProjection);
+    const vertexOutput = new VertexOutputBlock("vertexOutput");
+    worldViewProjection.connectTo(vertexOutput);
+
+    const color = new InputBlock("color");
+    color.value = new Color4(0.5, 0.5, 0.5, 1);
+    const imageProcessing = new ImageProcessingBlock("imageProcessing");
+    color.connectTo(imageProcessing);
+    const fragmentOutput = new FragmentOutputBlock("fragmentOutput");
+    imageProcessing.connectTo(fragmentOutput);
+
+    material.addOutputNode(vertexOutput);
+    material.addOutputNode(fragmentOutput);
+    material.build();
+
+    return material;
+}


### PR DESCRIPTION
## Context

Reported on the forum: [Regression between 8.55.3 and 8.55.4 – shader is overlighted](https://forum.babylonjs.com/t/regression-between-8-55-3-and-8-55-4-shader-is-overlighted/63802) 

A NodeMaterial water shader renders **overlighted** starting from 8.55.4, but only when the `DefaultRenderingPipeline` HDR flag is enabled.

## Root cause

The regression comes from #18126, which fixed `serializeAsImageProcessingConfiguration` so that `_imageProcessingConfiguration` is actually serialized/deserialized. NodeMaterial uses `ImageProcessingMixin`, so from 8.55.4 it restores its **own** image-processing configuration from the snippet.

The catch: existing Node Material snippets persisted a configuration that only holds **default** values (the author never intentionally customized image processing — it just got persisted once serialization started working). On parse, the material is now detached onto a **private** configuration instead of sharing the scene's.

The HDR `DefaultRenderingPipeline` sets `applyByPostProcess = true` on the **scene** image-processing configuration only. A material with its own detached config keeps `applyByPostProcess = false`, so image processing (gamma/tone mapping) is applied **in the material shader** and then **again** by the full-screen `ImageProcessingPostProcess` → double encoding → overlighted, washed-out output. Without the HDR flag there is no second pass, which is exactly why the HDR flag is the trigger.

## Fix

During parse, if the serialized image-processing configuration only holds default values, keep the **scene** configuration (do not detach). Only a genuinely customized configuration is honored as a detached private config, so the rare, code-driven per-material image-processing feature still works.

This handles both parse paths:
- the direct `parseSerializedObject` path, and
- the `NodeMaterial.Parse` path, which first runs `SerializationHelper.Parse` (already deserializing the config into a detached instance) and then `parseSerializedObject` — the actual path used when loading snippets, and the one that had to be covered explicitly.

The observer-lifecycle handling added in #18435 is preserved.

## Workaround (for users on affected versions)

```js
mat.imageProcessingConfiguration = scene.imageProcessingConfiguration;
```

## Tests

Added unit tests in `babylon.nodeMaterials.parse.test.ts` covering both parse paths:
- a serialized **default** config resolves to the scene configuration (regression guard — fails without this fix),
- a genuinely **customized** config (e.g. `exposure = 2`) is honored as a detached private config.

Existing image-processing observer-leak tests still pass.

> [!NOTE]
> No visualization test is included in this PR — the fix is guarded deterministically by the unit tests above. Happy to add a Playwright HDR reference test if reviewers would like one.