### PR TITLE
Fix: GaussianSplattingStream misclassified as an ordinary mesh, causing severe rendering slowdowns

### DIFF
--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -9,6 +9,7 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { type IShaderMaterialOptions, ShaderMaterial } from "core/Materials/shaderMaterial.pure";
 import { GaussianSplattingMaterial } from "core/Materials/GaussianSplatting/gaussianSplattingMaterial.pure";
 import { GaussianSplattingGpuPickingMaterialPlugin } from "core/Materials/GaussianSplatting/gaussianSplattingGpuPickingMaterialPlugin.pure";
+import { IsGaussianSplattingClassName } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { Color4 } from "core/Maths/math.color.pure";
 import { Epsilon } from "core/Maths/math.constants";
 import { type IVector2Like } from "core/Maths/math.like";
@@ -237,7 +238,7 @@ export class GPUPicker {
                 if (
                     material instanceof ShaderMaterial &&
                     !this._pickingMaterialCache.includes(material) &&
-                    className !== "GaussianSplattingMesh" &&
+                    !IsGaussianSplattingClassName(className) &&
                     className !== "GaussianSplattingPartProxyMesh"
                 ) {
                     return { mesh, material };
@@ -465,8 +466,8 @@ export class GPUPicker {
                     continue;
                 }
 
-                // Skip thin instance cleanup for GaussianSplattingMesh (thin instances are for batching, not picking)
-                if (className !== "GaussianSplattingMesh") {
+                // Skip thin instance cleanup for Gaussian Splatting meshes (thin instances are for batching, not picking)
+                if (!IsGaussianSplattingClassName(className)) {
                     if (mesh.hasInstances) {
                         (mesh as Mesh).removeVerticesData(GPUPicker._AttributeName);
                     }
@@ -563,7 +564,7 @@ export class GPUPicker {
                 newPickableMeshes[i] = item.mesh;
             } else {
                 const className = item.getClassName();
-                if (className === "GaussianSplattingMesh" || className === "GaussianSplattingPartProxyMesh") {
+                if (IsGaussianSplattingClassName(className) || className === "GaussianSplattingPartProxyMesh") {
                     // GS meshes get special picking materials - handled in the ID assignment loop below
                     newPickableMeshes[i] = item;
                 } else {
@@ -605,8 +606,8 @@ export class GPUPicker {
                 continue; // Don't add to render list - the compound mesh will render for all parts
             }
 
-            // Handle non-compound GaussianSplatting meshes
-            if (className === "GaussianSplattingMesh") {
+            // Handle non-compound GaussianSplatting meshes (including streamed)
+            if (IsGaussianSplattingClassName(className)) {
                 const globalIndex = index + pickableMeshOffset;
                 const pickId = nextFreeId;
                 this._idMap[pickId] = globalIndex;

--- a/packages/dev/core/src/Materials/Node/Blocks/GaussianSplatting/gaussianSplattingBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/GaussianSplatting/gaussianSplattingBlock.pure.ts
@@ -6,7 +6,7 @@ import { type NodeMaterialBuildState } from "../../nodeMaterialBuildState";
 import { NodeMaterialBlockTargets } from "../../Enums/nodeMaterialBlockTargets";
 import { type NodeMaterialConnectionPoint } from "../../nodeMaterialBlockConnectionPoint";
 import { VertexBuffer } from "core/Meshes/buffer";
-import { type GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
+import { type GaussianSplattingMesh, IsGaussianSplattingClassName } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { type AbstractMesh } from "core/Meshes/abstractMesh.pure";
 import { type NodeMaterial, type NodeMaterialDefines } from "../../nodeMaterial.pure";
@@ -137,7 +137,7 @@ export class GaussianSplattingBlock extends NodeMaterialBlock {
             return;
         }
 
-        if (mesh.getClassName() == "GaussianSplattingMesh") {
+        if (IsGaussianSplattingClassName(mesh.getClassName())) {
             defines.setValue("SH_DEGREE", (<GaussianSplattingMesh>mesh).shDegree, true);
         }
     }

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.pure.ts
@@ -1369,6 +1369,22 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
     }
 }
 
+/**
+ * True when `className` (from `AbstractMesh.getClassName()`) identifies a Gaussian Splatting mesh whose
+ * `position.z` vertex attribute encodes a splat index rather than world-space Z: `"GaussianSplattingMesh"`
+ * (also returned by {@link GaussianSplattingCompoundMesh}, which deliberately does not override
+ * `getClassName()`) and `"GaussianSplattingStream"` (which does override it, to remain distinguishable for
+ * other purposes). Rendering-pipeline code that must treat any Gaussian Splatting mesh differently from an
+ * ordinary mesh (geometry buffer, depth pre-pass, GPU picking, IBL voxelization, snapshot rendering, ...)
+ * should use this instead of a literal string comparison, so a future splat mesh subclass only needs to be
+ * added here once.
+ * @param className the mesh class name to test, e.g. from `AbstractMesh.getClassName()`
+ * @returns true if the class name identifies a Gaussian Splatting mesh
+ */
+export function IsGaussianSplattingClassName(className: string): boolean {
+    return className === "GaussianSplattingMesh" || className === "GaussianSplattingStream";
+}
+
 let _Registered = false;
 /**
  * Register side effects for gaussianSplattingMesh.

--- a/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
+++ b/packages/dev/core/src/Misc/snapshotRenderingHelper.ts
@@ -8,7 +8,7 @@ import { type Scene, ScenePerformancePriority } from "core/scene.pure";
 import { type WebGPUDrawContext } from "core/Engines/WebGPU/webgpuDrawContext";
 import { type WebGPUShaderProcessor } from "core/Engines/WebGPU/webgpuShaderProcessor";
 import { type WebGPUPipelineContext } from "core/Engines/WebGPU/webgpuPipelineContext";
-import { type GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
+import { type GaussianSplattingMesh, IsGaussianSplattingClassName } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { type DrawWrapper } from "core/Materials/drawWrapper";
 import { type Camera } from "core/Cameras/camera.pure";
 import { type SpriteManager } from "core/Sprites/spriteManager";
@@ -124,7 +124,7 @@ export class SnapshotRenderingHelper {
                     mesh.transferToEffect(mesh.computeWorldMatrix(true));
                 }
 
-                if (mesh.getClassName() === "GaussianSplattingMesh") {
+                if (IsGaussianSplattingClassName(mesh.getClassName())) {
                     (mesh as GaussianSplattingMesh)._postToWorker();
                 }
 

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.pure.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsRenderPipeline.pure.ts
@@ -4,7 +4,7 @@ import { Constants } from "../../Engines/constants";
 import { EngineStore } from "../../Engines/engineStore";
 import { Matrix, Vector3, Vector4, Quaternion } from "../../Maths/math.vector.pure";
 import { type Mesh } from "../../Meshes/mesh.pure";
-import { type GaussianSplattingMesh } from "../../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
+import { type GaussianSplattingMesh, IsGaussianSplattingClassName } from "../../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { type Scene } from "../../scene.pure";
 import { Texture } from "../../Materials/Textures/texture.pure";
 import { Logger } from "../../Misc/logger";
@@ -515,7 +515,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             for (const m of mesh) {
                 if (m && this._shadowCastingMeshes.indexOf(m) === -1) {
                     this._shadowCastingMeshes.push(m);
-                    if (m.getClassName() === "GaussianSplattingMesh") {
+                    if (IsGaussianSplattingClassName(m.getClassName())) {
                         (m as GaussianSplattingMesh).needsRotationScaleTextures = true;
                     }
                 }
@@ -523,7 +523,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
         } else {
             if (mesh && this._shadowCastingMeshes.indexOf(mesh) === -1) {
                 this._shadowCastingMeshes.push(mesh);
-                if (mesh.getClassName() === "GaussianSplattingMesh") {
+                if (IsGaussianSplattingClassName(mesh.getClassName())) {
                     (mesh as GaussianSplattingMesh).needsRotationScaleTextures = true;
                 }
             }
@@ -541,7 +541,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
                 const index = this._shadowCastingMeshes.indexOf(m);
                 if (index !== -1) {
                     this._shadowCastingMeshes.splice(index, 1);
-                    if (m.getClassName() === "GaussianSplattingMesh") {
+                    if (IsGaussianSplattingClassName(m.getClassName())) {
                         (m as GaussianSplattingMesh).needsRotationScaleTextures = false;
                     }
                 }
@@ -550,7 +550,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
             const index = this._shadowCastingMeshes.indexOf(mesh);
             if (index !== -1) {
                 this._shadowCastingMeshes.splice(index, 1);
-                if (mesh.getClassName() === "GaussianSplattingMesh") {
+                if (IsGaussianSplattingClassName(mesh.getClassName())) {
                     (mesh as GaussianSplattingMesh).needsRotationScaleTextures = false;
                 }
             }
@@ -562,7 +562,7 @@ export class IblShadowsRenderPipeline extends PostProcessRenderPipeline {
      */
     public clearShadowCastingMeshes(): void {
         for (const m of this._shadowCastingMeshes) {
-            if (m.getClassName() === "GaussianSplattingMesh") {
+            if (IsGaussianSplattingClassName(m.getClassName())) {
                 (m as GaussianSplattingMesh).needsRotationScaleTextures = false;
             }
         }

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.pure.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelRenderer.pure.ts
@@ -20,7 +20,7 @@ import { EffectRenderer, EffectWrapper } from "../../Materials/effectRenderer.pu
 import { type IblShadowsRenderPipeline } from "./iblShadowsRenderPipeline.pure";
 import { type RenderTargetWrapper } from "core/Engines/renderTargetWrapper";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
-import { type GaussianSplattingMesh } from "../../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
+import { type GaussianSplattingMesh, IsGaussianSplattingClassName } from "../../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { type GaussianSplattingMaterial } from "../../Materials/GaussianSplatting/gaussianSplattingMaterial.pure";
 
 // Max frames _renderVoxelGrid waits for splat depth sorts to settle before voxelizing anyway
@@ -624,7 +624,7 @@ export class _IblShadowsVoxelRenderer {
                     continue;
                 }
                 for (const mesh of renderList) {
-                    if (mesh.getClassName() === "GaussianSplattingMesh" && !(mesh as GaussianSplattingMesh)._isDepthSortSettled) {
+                    if (IsGaussianSplattingClassName(mesh.getClassName()) && !(mesh as GaussianSplattingMesh)._isDepthSortSettled) {
                         gsSortPending = true;
                         break;
                     }
@@ -751,7 +751,7 @@ export class _IblShadowsVoxelRenderer {
             for (let i = 0; i < subMeshes.length; i++) {
                 const sm = subMeshes.data[i];
                 const effective = sm.getEffectiveMesh();
-                if (effective.getClassName() === "GaussianSplattingMesh") {
+                if (IsGaussianSplattingClassName(effective.getClassName())) {
                     renderGsSplat(sm);
                 } else {
                     sm.render(enableAlphaMode);
@@ -840,7 +840,7 @@ export class _IblShadowsVoxelRenderer {
                 }
                 // Push per-slab uniforms to each GS voxel material in this MRT's render list.
                 for (const m of mrt.renderList ?? []) {
-                    if (m.getClassName() === "GaussianSplattingMesh") {
+                    if (IsGaussianSplattingClassName(m.getClassName())) {
                         const gsVoxelMat = this._gsVoxelMaterialCache.get(m.uniqueId);
                         if (gsVoxelMat) {
                             gsVoxelMat.setMatrix("invWorldScale", this._invWorldScaleMatrix);
@@ -866,7 +866,7 @@ export class _IblShadowsVoxelRenderer {
                 if (!mesh) {
                     continue;
                 }
-                if (mesh.getClassName() === "GaussianSplattingMesh") {
+                if (IsGaussianSplattingClassName(mesh.getClassName())) {
                     this._addGsMeshToVoxelRT(mrt, mesh as GaussianSplattingMesh);
                 } else if (mesh.subMeshes && mesh.subMeshes.length > 0) {
                     mrt.renderList?.push(mesh);
@@ -874,7 +874,7 @@ export class _IblShadowsVoxelRenderer {
                 }
                 const meshes = mesh.getChildMeshes();
                 for (const childMesh of meshes) {
-                    if (childMesh.getClassName() === "GaussianSplattingMesh") {
+                    if (IsGaussianSplattingClassName(childMesh.getClassName())) {
                         this._addGsMeshToVoxelRT(mrt, childMesh as GaussianSplattingMesh);
                     } else if (childMesh.subMeshes && childMesh.subMeshes.length > 0) {
                         mrt.renderList?.push(childMesh);

--- a/packages/dev/core/src/Rendering/depthRenderer.pure.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.pure.ts
@@ -22,7 +22,7 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { EffectFallbacks } from "core/Materials/effectFallbacks";
 import { type IEffectCreationOptions } from "core/Materials/effect.pure";
 import { type GaussianSplattingMaterial } from "../Materials/GaussianSplatting/gaussianSplattingMaterial.pure";
-import { type GaussianSplattingMesh } from "../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
+import { type GaussianSplattingMesh, IsGaussianSplattingClassName } from "../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { RegisterDepthRendererSceneComponent } from "./depthRendererSceneComponent.pure";
 
 /**
@@ -295,7 +295,7 @@ export class DepthRenderer {
                 subMesh._renderId = scene.getRenderId();
 
                 const gsClassName = effectiveMesh.getClassName();
-                if (gsClassName === "GaussianSplattingMesh") {
+                if (IsGaussianSplattingClassName(gsClassName)) {
                     const gsMaterial = this._ensureGaussianSplattingDepthMaterial(effectiveMesh, engine.currentRenderPassId);
                     if (gsMaterial && !gsMaterial.isReadyForSubMesh(effectiveMesh, subMesh, hardwareInstancedRendering)) {
                         return;
@@ -483,7 +483,7 @@ export class DepthRenderer {
 
         // For GaussianSplatting meshes, eagerly create the depth material so that
         // the scene's isReady check properly blocks until it is compiled.
-        if (mesh.getClassName() === "GaussianSplattingMesh") {
+        if (IsGaussianSplattingClassName(mesh.getClassName())) {
             renderingMaterial = this._ensureGaussianSplattingDepthMaterial(mesh, renderPassId);
         }
 

--- a/packages/dev/core/src/Rendering/geometryBufferRenderer.pure.ts
+++ b/packages/dev/core/src/Rendering/geometryBufferRenderer.pure.ts
@@ -31,6 +31,7 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { type OpenPBRMaterial } from "../Materials/PBR/openpbrMaterial.pure";
 import { type IblShadowsRenderPipeline } from "./IBLShadows/iblShadowsRenderPipeline.pure";
 import { RegisterGeometryBufferRendererSceneComponent } from "./geometryBufferRendererSceneComponent.pure";
+import { IsGaussianSplattingClassName } from "../Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 
 /** @internal */
 interface ISavedTransformationMatrix {
@@ -628,12 +629,11 @@ export class GeometryBufferRenderer {
             return false;
         }
 
-        // GaussianSplattingMesh stores splat indices in position.z (not world-space Z).
+        // Gaussian Splatting meshes store splat indices in position.z (not world-space Z).
         // The generic geometry.vertex shader misreads this as world coordinates, producing
-        // garbage positions and normals, and thus it should be excluded from the G-buffer
-        // rendering. GaussianSplattingCompoundMesh returns the same class name intentionally,
-        // so this single check covers both variants.
-        if (subMesh.getMesh().getClassName() === "GaussianSplattingMesh") {
+        // garbage positions and normals, and thus they should be excluded from the G-buffer
+        // rendering.
+        if (IsGaussianSplattingClassName(subMesh.getMesh().getClassName())) {
             return false;
         }
 

--- a/packages/dev/loaders/src/SPLAT/gaussianSplattingWorkBuffer.ts
+++ b/packages/dev/loaders/src/SPLAT/gaussianSplattingWorkBuffer.ts
@@ -96,20 +96,25 @@ export class GaussianSplattingWorkBuffer {
     }
 
     /**
-     * Creates a 4-attachment MRT (centers F32 / covA F32 / covB F32 / colors U8) sized to the work buffer.
+     * Creates a 4-attachment MRT (centers F32 / covA / covB / colors U8) sized to the work buffer. covA/covB
+     * use HALF_FLOAT when the engine can render to it, matching the precision the non-streamed
+     * GaussianSplattingMesh path already uses for these same two textures (see
+     * `gaussianSplattingMeshBase.pure.ts`'s `createTextureFromDataF16` covA/covB textures); centers stays F32
+     * and colors stays U8 in both paths.
      * @param name MRT and attachment base name
      * @param disableClear when true, clearing is suppressed so renders accumulate (the decode buffer); when
      *   false the MRT clears to zero on each render (the temporary relayout buffer, so gaps stay zeroed)
      * @returns the created MRT
      */
     private _createMrt(name: string, disableClear: boolean): MultiRenderTarget {
+        const covType = this._scene.getEngine()._caps.textureHalfFloatRender ? Constants.TEXTURETYPE_HALF_FLOAT : Constants.TEXTURETYPE_FLOAT;
         const mrt = new MultiRenderTarget(
             name,
             { width: this._textureSize, height: this._textureSize },
             4,
             this._scene,
             {
-                types: [Constants.TEXTURETYPE_FLOAT, Constants.TEXTURETYPE_FLOAT, Constants.TEXTURETYPE_FLOAT, Constants.TEXTURETYPE_UNSIGNED_BYTE],
+                types: [Constants.TEXTURETYPE_FLOAT, covType, covType, Constants.TEXTURETYPE_UNSIGNED_BYTE],
                 samplingModes: [
                     Constants.TEXTURE_NEAREST_SAMPLINGMODE,
                     Constants.TEXTURE_NEAREST_SAMPLINGMODE,

--- a/packages/tools/viewer/src/viewer.ts
+++ b/packages/tools/viewer/src/viewer.ts
@@ -45,6 +45,7 @@ import { Matrix, Vector2, Vector3 } from "core/Maths/math.vector";
 import { Viewport } from "core/Maths/math.viewport";
 import { GetHotSpotToRef } from "core/Meshes/abstractMesh.hotSpot";
 import { CreateBox } from "core/Meshes/Builders/boxBuilder";
+import { IsGaussianSplattingClassName } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh.pure";
 import { Mesh } from "core/Meshes/mesh";
 import { computeMaxExtents, RemoveUnreferencedVerticesData } from "core/Meshes/meshUtils";
 import { BuildTuple } from "core/Misc/arrayTools";
@@ -152,7 +153,7 @@ type ShadowState = {
 
 function IsGaussianSplattingMesh(mesh: AbstractMesh): boolean {
     const className = mesh.getClassName();
-    return className === "GaussianSplattingMesh" || className === "GaussianSplattingPartProxyMesh";
+    return IsGaussianSplattingClassName(className) || className === "GaussianSplattingPartProxyMesh";
 }
 
 function IsPBRMaterial(material: Material): boolean {


### PR DESCRIPTION
`GaussianSplattingStream` overrides `getClassName()` to return `"GaussianSplattingStream"` rather than `"GaussianSplattingMesh"`, so it stays distinguishable from its base class. But several rendering systems in core detect Gaussian Splatting meshes via the literal check `getClassName() === "GaussianSplattingMesh"` — needed because these meshes store a splat index in `position.z` instead of world-space Z, which a generic pass will misread as real geometry. Since the check didn't recognize `"GaussianSplattingStream"`, streamed splat meshes slipped through every one of these guards and got treated like ordinary meshes.

Worst offender: the **Geometry Buffer Renderer** rendered every streamed splat mesh into its G-buffer every frame with the generic shader on garbage vertex data — an extra, expensive draw call, active whenever a `GeometryBufferRenderer` exists in the scene (IBL shadows, SSAO, SSR, motion blur). Depth pre-pass, GPU picking, IBL voxelization, the GS node material block, and snapshot rendering had the same blind spot. Root-caused via a PIX capture on Windows/D3D12 showing this extra draw running every frame, even with a static camera.

### Fix

This PR added a shared helper `IsGaussianSplattingClassName(className)` (`gaussianSplattingMesh.pure.ts`), used at all 9 affected call sites: geometry buffer renderer, depth renderer (2), GPU picker (4), IBL voxel renderer (5), IBL shadow pipeline (5), GS node material block, snapshot rendering helper, and the Viewer package's own independent copy of the same check (`tools/viewer/src/viewer.ts`, gating auto-SSAO).

### When it triggers

Any scene with a `GaussianSplattingStream` mesh + an active `GeometryBufferRenderer`.

### Impact

| Platform | Before | After |
|---|---|---|
| Windows / WebGPU / D3D12 | ~1.3 FPS | more than 60 FPS (capped by VSync) |
| Mac / WebGPU / Metal | ~30 FPS | ~80 FPS |

### Additional

In addition, we change the format of the covariance textures to FP16 to align with the non-stream Gsplat rendering path, which is already proved sufficient in the non-stream path, and saves video memory footprint.