### PR TITLE
Fix: IBL shadow procedural textures keep rendering every frame after being toggled off

### DIFF
--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsAccumulationPass.ts
@@ -28,10 +28,33 @@ export class _IblShadowsAccumulationPass {
     /** Enable the debug view for this pass */
     public debugEnabled: boolean = false;
 
+    private _enabled: boolean = true;
+
     /**
      * Is the effect enabled
      */
-    public enabled: boolean = true;
+    public get enabled(): boolean {
+        return this._enabled;
+    }
+
+    public set enabled(value: boolean) {
+        this._enabled = value;
+        // _render() already gates on `enabled` for _outputTexture, but _oldAccumulationCopy and
+        // _oldPositionCopy have refreshRate = 1 and are rendered by Babylon's generic per-frame
+        // ProceduralTexture refresh loop, entirely independent of `enabled` / `_render()`. Without
+        // disabling them directly here, they keep rendering (and paying a real per-frame texture-view
+        // creation cost) every frame forever, even when the whole pass — and the rest of the IBL
+        // shadows pipeline — has been toggled off (e.g. no shadow casters or receivers in the scene).
+        if (this._outputTexture) {
+            this._outputTexture.isEnabled = value;
+        }
+        if (this._oldAccumulationCopy) {
+            this._oldAccumulationCopy.isEnabled = value;
+        }
+        if (this._oldPositionCopy) {
+            this._oldPositionCopy.isEnabled = value;
+        }
+    }
 
     /**
      * Returns the output texture of the pass.

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsSpatialBlurPass.ts
@@ -22,10 +22,24 @@ export class _IblShadowsSpatialBlurPass {
     private _worldScale: number = 1.0;
     private _blurParameters: Vector4 = new Vector4(0.0, 0.0, 0.0, 0.0);
 
+    private _enabled: boolean = true;
+
     /**
      * Is the effect enabled
      */
-    public enabled: boolean = true;
+    public get enabled(): boolean {
+        return this._enabled;
+    }
+
+    public set enabled(value: boolean) {
+        this._enabled = value;
+        // _render() already gates on `enabled`, but also disable the underlying ProceduralTexture
+        // directly so it can't be rendered through any other path (e.g. Babylon's generic
+        // per-frame ProceduralTexture refresh loop) while the pass is toggled off.
+        if (this._outputTexture) {
+            this._outputTexture.isEnabled = value;
+        }
+    }
 
     /**
      * Returns the output texture of the pass.

--- a/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
+++ b/packages/dev/core/src/Rendering/IBLShadows/iblShadowsVoxelTracingPass.ts
@@ -142,10 +142,24 @@ export class _IblShadowsVoxelTracingPass {
         this._voxelDirectionBias = value;
     }
 
+    private _enabled: boolean = true;
+
     /**
      * Is the effect enabled
      */
-    public enabled: boolean = true;
+    public get enabled(): boolean {
+        return this._enabled;
+    }
+
+    public set enabled(value: boolean) {
+        this._enabled = value;
+        // _render() already gates on `enabled`, but also disable the underlying ProceduralTexture
+        // directly so it can't be rendered through any other path (e.g. Babylon's generic
+        // per-frame ProceduralTexture refresh loop) while the pass is toggled off.
+        if (this._outputTexture) {
+            this._outputTexture.isEnabled = value;
+        }
+    }
 
     /**
      * The number of directions to sample for the voxel tracing.


### PR DESCRIPTION
`IblShadowsRenderPipeline` disables its three passes (voxel tracing, spatial blur, accumulation) via each pass's `enabled` flag when shadows have no visible effect (no eligible caster/receiver). But each pass's `_outputTexture` (and, for accumulation, its two history copies) is a `ProceduralTexture` registered with the scene's generic per-frame procedural-texture refresh loop, which is entirely independent of the pass's own `enabled` flag. So even while a pass is toggled off, its texture(s) kept re-rendering every frame, including the associated texture-view creation cost, for as long as the pipeline existed.

### Fix

Turned `enabled` into a getter/setter on each of the three passes (`iblShadowsAccumulationPass.ts`, `iblShadowsSpatialBlurPass.ts`, `iblShadowsVoxelTracingPass.ts`). The setter now also sets `isEnabled` directly on the underlying `ProceduralTexture`(s), so the scene's generic refresh loop skips them while the pass is toggled off, rather than relying solely on each pass's own `_render()` gate.

### When it triggers

Any scene where the IBL shadows pipeline exists but is currently toggled off (no eligible shadow caster/receiver), the wasted per-frame texture rendering ran for the lifetime of the pipeline.
