### PR TITLE
Coerce native dynamic texture dimensions before allocation

### DIFF
--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -1731,10 +1731,10 @@ export class ThinNativeEngine extends ThinEngine {
     }
 
     public override createDynamicTexture(width: number, height: number, generateMipMaps: boolean, samplingMode: number): InternalTexture {
-        // it's not possible to create 0x0 texture sized. Many bgfx methods assume texture size is at least 1x1(best case).
-        // Worst case is getting a crash/assert.
-        width = Math.max(width, 1);
-        height = Math.max(height, 1);
+        // Canvas dimensions are integral in browsers. Coerce before allocating so the native dimensions and byte length agree.
+        // Keep at least 1x1 because many bgfx methods assume a non-zero texture size.
+        width = Math.max(Math.floor(width), 1);
+        height = Math.max(Math.floor(height), 1);
         return this.createRawTexture(new Uint8Array(width * height * 4), width, height, Constants.TEXTUREFORMAT_RGBA, false, false, samplingMode);
     }
 

--- a/packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts
@@ -1,5 +1,6 @@
 import { ThinNativeEngine } from "core/Engines/thinNativeEngine";
-import { describe, expect, it } from "vitest";
+import { type InternalTexture } from "core/Materials/Textures/internalTexture";
+import { describe, expect, it, vi } from "vitest";
 
 type NativeFrameRequester = {
     requestAnimationFrame: (callback: () => void) => number;
@@ -13,6 +14,21 @@ type TestThinNativeEngine = {
 };
 
 describe("ThinNativeEngine", () => {
+    describe("dynamic textures", () => {
+        it("coerces fractional canvas dimensions before allocating native texture data", () => {
+            const thinNativeEngine = Object.create(ThinNativeEngine.prototype) as ThinNativeEngine;
+            const createRawTexture = vi.spyOn(thinNativeEngine, "createRawTexture").mockReturnValue({} as InternalTexture);
+
+            thinNativeEngine.createDynamicTexture(3379.2, 102.4, false, 3);
+
+            const [data, width, height] = createRawTexture.mock.calls[0];
+            expect(width).toBe(3379);
+            expect(height).toBe(102);
+            expect(data).toBeInstanceOf(Uint8Array);
+            expect(data?.byteLength).toBe(3379 * 102 * 4);
+        });
+    });
+
     describe("render loop", () => {
         it("returns the custom animation frame request id", () => {
             const thinNativeEngine = Object.create(ThinNativeEngine.prototype) as TestThinNativeEngine;


### PR DESCRIPTION
## Summary

- coerce NativeEngine dynamic texture dimensions to integers before allocating the initial RGBA buffer
- add a focused regression test for fractional canvas dimensions

HolographicSlate requests a 3379.2 x 102.4 title texture. The previous code allocated from the fractional product, then NativeEngine truncated each dimension independently, leaving the buffer 5,488 bytes larger than the declared texture. Browser canvas dimensions are integer-valued, so coercing once before allocation keeps both sides consistent.

## Validation

- `npx vitest run packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts`
- `npx prettier --check packages/dev/core/src/Engines/thinNativeEngine.pure.ts packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts`
- `npx eslint --quiet packages/dev/core/src/Engines/thinNativeEngine.pure.ts packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts`
- BabylonNative GUI Slate on Metal/bgfx proceeds through rendering and screenshot comparison instead of throwing the raw-texture size error