### PR TITLE
[WebGPU-XR] Check XRGPUBinding before native fallback

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -368,12 +368,12 @@ export class WebXRLayers extends WebXRAbstractFeature {
     }
 
     public override isCompatible(): boolean {
-        // TODO (rgerd): Add native support.
-        if (this._xrSessionManager.isNative) {
-            return false;
-        }
         if (this._xrSessionManager.scene.getEngine().isWebGPU) {
             return typeof XRGPUBinding !== "undefined" && !!XRGPUBinding.prototype.createProjectionLayer;
+        }
+        // Native WebGL continues to use NativeXRRenderTarget instead of WebXR Layers.
+        if (this._xrSessionManager.isNative) {
+            return false;
         }
         return typeof XRWebGLBinding !== "undefined" && !!XRWebGLBinding.prototype.createProjectionLayer;
     }

--- a/packages/dev/core/test/unit/XR/webXRLayers.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayers.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { WebXRLayers } from "core/XR/features/WebXRLayers";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ProjectionLayerBindingConstructor {
+    prototype: {
+        createProjectionLayer?: () => void;
+    };
+}
+
+type TestGlobals = typeof globalThis & {
+    XRGPUBinding?: ProjectionLayerBindingConstructor;
+    XRWebGLBinding?: ProjectionLayerBindingConstructor;
+};
+
+describe("WebXRLayers", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    const testGlobals = globalThis as TestGlobals;
+    let originalGPUBinding: ProjectionLayerBindingConstructor | undefined;
+    let originalWebGLBinding: ProjectionLayerBindingConstructor | undefined;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        originalGPUBinding = testGlobals.XRGPUBinding;
+        originalWebGLBinding = testGlobals.XRWebGLBinding;
+    });
+
+    afterEach(() => {
+        if (originalGPUBinding) {
+            testGlobals.XRGPUBinding = originalGPUBinding;
+        } else {
+            delete testGlobals.XRGPUBinding;
+        }
+        if (originalWebGLBinding) {
+            testGlobals.XRWebGLBinding = originalWebGLBinding;
+        } else {
+            delete testGlobals.XRWebGLBinding;
+        }
+        vi.restoreAllMocks();
+        scene.dispose();
+        engine.dispose();
+    });
+
+    function setEnvironment(isNative: boolean, isWebGPU: boolean): void {
+        vi.spyOn(sessionManager, "isNative", "get").mockReturnValue(isNative);
+        vi.spyOn(engine, "isWebGPU", "get").mockReturnValue(isWebGPU);
+    }
+
+    function installGPUBinding(): void {
+        const binding = vi.fn() as unknown as ProjectionLayerBindingConstructor;
+        binding.prototype.createProjectionLayer = vi.fn();
+        testGlobals.XRGPUBinding = binding;
+    }
+
+    function installWebGLBinding(): void {
+        const binding = vi.fn() as unknown as ProjectionLayerBindingConstructor;
+        binding.prototype.createProjectionLayer = vi.fn();
+        testGlobals.XRWebGLBinding = binding;
+    }
+
+    describe("isCompatible", () => {
+        it("accepts native WebGPU when XRGPUBinding exposes projection layers", () => {
+            setEnvironment(true, true);
+            installGPUBinding();
+
+            expect(new WebXRLayers(sessionManager).isCompatible()).toBe(true);
+        });
+
+        it("rejects native WebGPU when XRGPUBinding is absent", () => {
+            setEnvironment(true, true);
+            delete testGlobals.XRGPUBinding;
+
+            expect(new WebXRLayers(sessionManager).isCompatible()).toBe(false);
+        });
+
+        it("keeps native WebGL on the legacy render-target path", () => {
+            setEnvironment(true, false);
+            installWebGLBinding();
+
+            expect(new WebXRLayers(sessionManager).isCompatible()).toBe(false);
+        });
+
+        it("accepts browser WebGPU when XRGPUBinding exposes projection layers", () => {
+            setEnvironment(false, true);
+            installGPUBinding();
+
+            expect(new WebXRLayers(sessionManager).isCompatible()).toBe(true);
+        });
+
+        it("accepts browser WebGL when XRWebGLBinding exposes projection layers", () => {
+            setEnvironment(false, false);
+            installWebGLBinding();
+
+            expect(new WebXRLayers(sessionManager).isCompatible()).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Background

Broader WebGPU runtime testing showed that `WebXRLayers.isCompatible()` rejects every native session before checking the active engine and `XRGPUBinding` capabilities. A standards-compatible WebGPU runtime can therefore expose `XRGPUBinding.createProjectionLayer` and still be prevented from selecting the existing WebGPU projection-layer path.

## Change

- Check WebGPU and `XRGPUBinding.createProjectionLayer` before the native WebGL fallback.
- Keep native WebGL sessions on the existing `NativeXRRenderTarget` path.
- Preserve browser WebGPU and WebGL behavior.
- Make no public API changes.

## Tests

Adds five explicit compatibility cases:

- native WebGPU with projection-layer support
- native WebGPU without `XRGPUBinding`
- native WebGL with `XRWebGLBinding`
- browser WebGPU with projection-layer support
- browser WebGL with projection-layer support

Local validation:

- focused fixture: 5/5 tests passed
- XR unit suite: 280/280 tests passed across 16 files
- exact-file ESLint and Prettier checks passed
- production core TypeScript build passed

## Relation to #18688

cc @RaananW. This is intentionally separate from #18688: this PR makes the WebGPU layer provider reachable when the runtime advertises the required capability, while #18688 addresses projection/NDC and upright rendering after that layer path is active. The changes do not overlap files.