### PR TITLE
fix(inspector): correct malformed gif.worker.js CDN URL

### DIFF
--- a/packages/dev/inspector-v2/src/components/tools/capture/gifCaptureTool.tsx
+++ b/packages/dev/inspector-v2/src/components/tools/capture/gifCaptureTool.tsx
@@ -30,7 +30,7 @@ export const GIFCaptureTool = MakeLazyComponent(
         const gif = (await import("gif.js.optimized")).default;
 
         // TODO: Figure out how to grab this from NPM package instead of CDN
-        const workerContent = await Tools.LoadFileAsync("https://cdn.jsdelivr.net/gh//terikon/gif.js.optimized@0.1.6/dist/gif.worker.js");
+        const workerContent = await Tools.LoadFileAsync("https://cdn.jsdelivr.net/gh/terikon/gif.js.optimized@0.1.6/dist/gif.worker.js");
         const workerBlob = new Blob([workerContent], { type: "application/javascript" });
         const workerUrl = URL.createObjectURL(workerBlob);
 

--- a/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
+++ b/packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx
@@ -221,7 +221,7 @@ export class ToolsTabComponent extends PaneComponent {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises, github/no-then
-        Tools.LoadFileAsync("https://cdn.jsdelivr.net/gh//terikon/gif.js.optimized@0.1.6/dist/gif.worker.js").then((value) => {
+        Tools.LoadFileAsync("https://cdn.jsdelivr.net/gh/terikon/gif.js.optimized@0.1.6/dist/gif.worker.js").then((value) => {
             this._gifWorkerBlob = new Blob([value], {
                 type: "application/javascript",
             });


### PR DESCRIPTION
## Problem

Opening the **Tools** tab in the Inspector (e.g. in the Playground) throws:

```
LoadFileError: Error status: 400 - Unable to load
https://cdn.jsdelivr.net/gh//terikon/gif.js.optimized@0.1.6/dist/gif.worker.js
```

Reported on the forum: https://forum.babylonjs.com/t/error-loading-inspector-tools-in-the-babylon-js-playground/63822

## Root cause

The GIF capture worker URL had a **double slash** after `gh` (`gh//terikon`). jsDelivr's GitHub endpoint rejects the empty path segment with HTTP 400, so the Tools tab throws as soon as it's opened.

Verified:
- `gh//terikon/...` → **400**
- `gh/terikon/...` → **200** ✅

## Fix

Removed the extra slash in both the new and legacy inspectors:
- `packages/dev/inspector-v2/src/components/tools/capture/gifCaptureTool.tsx`
- `packages/dev/inspector/src/components/actionTabs/tabs/toolsTabComponent.tsx`