### PR TITLE
Fix ES6 build failure when checkout path contains "src"

### DIFF
--- a/packages/dev/buildTools/src/pathTransform.ts
+++ b/packages/dev/buildTools/src/pathTransform.ts
@@ -13,17 +13,27 @@ import {
 
 const AddJS = (to: string, forceAppend?: boolean | string): string => (forceAppend && !to.endsWith(".js") ? to + (forceAppend === true ? ".js" : forceAppend) : to);
 
-// This function was adjusted for generated/src process
-const GetPathForComputed = (computedPath: string, sourceFilename: string) => {
-    let p = computedPath;
-    const generatedIndex = sourceFilename.indexOf("src");
-    const srcIndex = sourceFilename.indexOf("src");
-    if (generatedIndex !== -1) {
-        p = sourceFilename.substring(0, generatedIndex) + "src/" + p;
-    } else if (srcIndex !== -1) {
-        p = p.substring(0, srcIndex) + "src/" + p;
+// This function was adjusted for generated/src process.
+/**
+ * Anchors a package-relative computed path at the source file's own "src" directory.
+ *
+ * The "src" must be matched as a whole path segment, not as a raw substring: otherwise
+ * an ancestor directory whose name merely contains "src" (for example a checkout located
+ * under ".../babylonjs-src/...") is picked as the anchor, producing a path that escapes
+ * the package and breaks the emitted import.
+ * @param computedPath the package-relative path (e.g. "./fluent/hoc/x")
+ * @param sourceFilename the file currently being transformed
+ * @returns the computed path anchored at the real "src" segment, or unchanged when there is none
+ */
+export const GetPathForComputed = (computedPath: string, sourceFilename: string) => {
+    // Normalize to posix separators so the segment match works on Windows too.
+    const normalized = sourceFilename.split(path.sep).join(path.posix.sep);
+    // Use the last real "/src/" segment (the package source root closest to the file).
+    const srcSegment = normalized.lastIndexOf("/src/");
+    if (srcSegment === -1) {
+        return computedPath;
     }
-    return p;
+    return normalized.substring(0, srcSegment) + "/src/" + computedPath;
 };
 const GetRelativePath = (computedPath: string, sourceFilename: string) => {
     let p = path.relative(path.dirname(sourceFilename), computedPath).split(path.sep).join(path.posix.sep);

--- a/packages/tools/tests/test/unit/pathTransform.test.ts
+++ b/packages/tools/tests/test/unit/pathTransform.test.ts
@@ -1,0 +1,52 @@
+import { GetPathForComputed, transformPackageLocation } from "../../../../dev/buildTools/src/pathTransform";
+
+describe("buildTools pathTransform", () => {
+    describe("GetPathForComputed", () => {
+        it("returns the computed path unchanged when the source file is not under a src directory", () => {
+            const source = "/tmp/babylonjs-repro/packages/public/@babylonjs/shared-ui-components/tabs/lineWithFileButtonComponent.js";
+            expect(GetPathForComputed("./fluent/hoc/fluentToolWrapper", source)).toBe("./fluent/hoc/fluentToolWrapper");
+        });
+
+        it("does not treat an ancestor directory that merely contains 'src' as the src anchor", () => {
+            // Regression: a checkout located under ".../babylonjs-src/..." used to make
+            // indexOf("src") match inside the ancestor directory name, producing an
+            // absolute path that escaped the package and broke the emitted import.
+            const deepSource = "/mnt/vss/_work/1/s/babylonjs-src/packages/public/@babylonjs/shared-ui-components/tabs/lineWithFileButtonComponent.js";
+            const shallowSource = "/tmp/repro/packages/public/@babylonjs/shared-ui-components/tabs/lineWithFileButtonComponent.js";
+            const computed = "./fluent/hoc/fluentToolWrapper";
+            expect(GetPathForComputed(computed, deepSource)).toBe(computed);
+            // The result must be independent of where the checkout sits on disk.
+            expect(GetPathForComputed(computed, deepSource)).toBe(GetPathForComputed(computed, shallowSource));
+        });
+
+        it("anchors at a real 'src' path segment when the source file lives under one", () => {
+            const source = "/mnt/vss/_work/1/s/babylonjs-src/packages/dev/sharedUiComponents/src/tabs/lineWithFileButtonComponent.ts";
+            expect(GetPathForComputed("./fluent/hoc/fluentToolWrapper", source)).toBe(
+                "/mnt/vss/_work/1/s/babylonjs-src/packages/dev/sharedUiComponents/src/./fluent/hoc/fluentToolWrapper"
+            );
+        });
+    });
+
+    describe("transformPackageLocation", () => {
+        const options = {
+            buildType: "es6" as const,
+            basePackage: "@babylonjs/shared-ui-components",
+            packageOnly: false,
+            appendJS: false,
+        };
+
+        it("produces the same relative import regardless of checkout depth", () => {
+            // Use src-anchored source paths so the result is fully determined by the
+            // input (independent of the test runner's cwd), while still exercising a
+            // deep checkout whose ancestor directory name contains "src".
+            const location = "shared-ui-components/fluent/hoc/fluentToolWrapper";
+            const shallow = "/tmp/repro/packages/dev/sharedUiComponents/src/tabs/lineWithFileButtonComponent.ts";
+            const deep = "/mnt/vss/_work/1/s/babylonjs-src/packages/dev/sharedUiComponents/src/tabs/lineWithFileButtonComponent.ts";
+            const resultShallow = transformPackageLocation(location, options, shallow);
+            const resultDeep = transformPackageLocation(location, options, deep);
+            expect(resultShallow).toBe("../fluent/hoc/fluentToolWrapper");
+            expect(resultDeep).toBe(resultShallow);
+            expect(resultDeep).not.toContain("babylonjs-src");
+        });
+    });
+});


### PR DESCRIPTION
## Problem

The ES6 build (`build-tools -c transform-paths`, run after `tsc`) rewrites path-alias imports such as `shared-ui-components/fluent/hoc/fluentToolWrapper` into real relative paths for the emitted output. That rewrite could produce a broken relative import — one that escapes the package — causing the build to fail, but only for some checkout locations.

The failure is deterministic and reproducible: cloning the repo into a directory whose path contains a segment ending in `src` (e.g. `.../babylonjs-src/...`) fails every time, while an otherwise-identical checkout in a path without `src` builds fine.

## Root cause

In `packages/dev/buildTools/src/pathTransform.ts`, `GetPathForComputed` anchored the rewritten import at the source file's own `src` directory using a raw substring search:

```js
const generatedIndex = sourceFilename.indexOf("src");
```

`indexOf("src")` matches the **first** occurrence of the substring `src` anywhere in the absolute path. When an ancestor directory name merely contains `src` (for example a checkout under `.../babylonjs-src/...`), it matches inside that ancestor name instead of the package's real `.../src/` segment. It then builds an absolute path from the wrong boundary, and the subsequent relative-path calculation emits an import that points outside the package — breaking module resolution.

So the emitted output depended on where the repository happened to sit on disk, which is a bug: the transform should be location-independent.

## Fix

Match `src` as a whole path segment (`/src/`) rather than a raw substring, so ancestor directory names that merely contain `src` are ignored. This also removes a dead, buggy duplicate branch (the old `else` operated on the wrong variable and was unreachable).

```js
const normalized = sourceFilename.split(path.sep).join(path.posix.sep);
const srcSegment = normalized.lastIndexOf("/src/");
if (srcSegment === -1) return computedPath;
return normalized.substring(0, srcSegment) + "/src/" + computedPath;
```

With this change the emitted import is identical regardless of the checkout location, while genuine `src`-anchored source files still resolve correctly. Separators are normalized to posix so the segment match also works on Windows.

## Testing

- Added `packages/tools/tests/test/unit/pathTransform.test.ts` — a regression test that pins the segment-anchoring behavior and asserts the output is independent of checkout depth/location (4 tests, all pass).
- `@dev/build-tools` compiles cleanly; the edited region is lint- and format-clean.