### PR TITLE
fix(build): resolve TS2304 in bundled .module.d.ts for XRBody and SPZ types

### DIFF
--- a/packages/dev/buildTools/src/generateDeclaration.ts
+++ b/packages/dev/buildTools/src/generateDeclaration.ts
@@ -181,7 +181,7 @@ function GetModuleDeclaration(
         // TODO - make a list of dependencies that are accepted by each package
         if (!devPackageName) {
             if (externalName) {
-                if (externalName === "@fortawesome" || externalName === "@fluentui" || externalName === "@recast-navigation") {
+                if (externalName === "@fortawesome" || externalName === "@fluentui" || externalName === "@recast-navigation" || externalName === "@adobe") {
                     // Replace type references with "any", but skip declaration sites (e.g. "export type ThemeMode")
                     // to avoid producing invalid syntax like "export type any = ...".
                     const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");
@@ -433,7 +433,7 @@ function GetPackageDeclaration(
             // TODO - make a list of dependencies that are accepted by each package
             if (!localDevPackageMap) {
                 if (externalName) {
-                    if (externalName === "@fortawesome" || externalName === "@fluentui" || externalName === "@recast-navigation") {
+                    if (externalName === "@fortawesome" || externalName === "@fluentui" || externalName === "@recast-navigation" || externalName === "@adobe") {
                         // Replace type references with "any", but skip declaration sites (e.g. "export type ThemeMode")
                         // to avoid producing invalid syntax like "export type any = ...".
                         const matchRegex = new RegExp(`([ <])(${alias})([^\\w])`, "g");

--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -313,9 +313,39 @@ interface XRFrame {
      * @param referenceSpace
      */
     getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
+
+    /**
+     * The tracked body for this frame, when the body tracking feature is enabled.
+     * ref: https://immersive-web.github.io/body-tracking/#xrframe-interface
+     */
+    body?: XRBody;
 }
 
 declare abstract class XRFrame implements XRFrame {}
+
+/**
+ * Represents the XRBodySpace native interface as defined by the spec.
+ * An XRBodySpace is an XRSpace that additionally exposes a jointName.
+ * ref: https://immersive-web.github.io/body-tracking/#xrjointspace-interface
+ */
+interface XRBodySpace extends XRSpace {
+    readonly jointName: string;
+}
+
+/**
+ * Represents the native XRBody interface as defined by the spec.
+ * An XRBody is an iterable map of XRBodyJoint to XRBodySpace.
+ * ref: https://immersive-web.github.io/body-tracking/#xrbody-interface
+ */
+interface XRBody {
+    readonly size: number;
+    get(key: string): XRBodySpace | undefined;
+    forEach(callbackfn: (value: XRBodySpace, key: string, map: XRBody) => void): void;
+    [Symbol.iterator](): IterableIterator<[string, XRBodySpace]>;
+    entries(): IterableIterator<[string, XRBodySpace]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<XRBodySpace>;
+}
 
 /**
  * Type of XR events available

--- a/packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRBodyTracking.pure.ts
@@ -571,46 +571,6 @@ const BodyPartsDefinition: { [key in BodyPart]: WebXRBodyJoint[] } = {
 export type XRBodyMeshRigMapping = { [jointName in WebXRBodyJoint]?: string };
 
 // ────────────────────────────────────────────────────────────────────────────
-// XRBody / XRBodySpace WebXR API type declarations
-// These types are not yet part of the standard TypeScript lib, so we declare them
-// locally. They mirror the interfaces defined in the WebXR Body Tracking spec.
-// ────────────────────────────────────────────────────────────────────────────
-
-/**
- * Represents the XRBodySpace native interface as defined by the spec.
- * An XRBodySpace is an XRSpace that additionally exposes a jointName.
- * @see https://immersive-web.github.io/body-tracking/#xrjointspace-interface
- */
-// eslint-disable-next-line @typescript-eslint/naming-convention
-interface XRBodySpace extends XRSpace {
-    readonly jointName: string;
-}
-
-/**
- * Represents the native XRBody interface as defined by the spec.
- * An XRBody is an iterable map of XRBodyJoint → XRBodySpace.
- * @see https://immersive-web.github.io/body-tracking/#xrbody-interface
- */
-// eslint-disable-next-line @typescript-eslint/naming-convention
-interface XRBody {
-    readonly size: number;
-    get(key: string): XRBodySpace | undefined;
-    forEach(callbackfn: (value: XRBodySpace, key: string, map: XRBody) => void): void;
-    [Symbol.iterator](): IterableIterator<[string, XRBodySpace]>;
-    entries(): IterableIterator<[string, XRBodySpace]>;
-    keys(): IterableIterator<string>;
-    values(): IterableIterator<XRBodySpace>;
-}
-
-// Augment the XRFrame interface so TypeScript knows about the `body` property.
-declare global {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    interface XRFrame {
-        body?: XRBody;
-    }
-}
-
-// ────────────────────────────────────────────────────────────────────────────
 // Configuration
 // ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Consumers compiling against the bundled UMD declaration files hit `Cannot find name` errors (reported in [forum thread 63826](https://forum.babylonjs.com/t/compile-errors-after-switch-to-ts6-0-3-babylon-version/63826)):

```
babylonjs-loaders/babylonjs.loaders.module.d.ts: TS2304: Cannot find name 'SpzModule'.
babylonjs-loaders/babylonjs.loaders.module.d.ts: TS2304: Cannot find name 'GaussianCloud'.
babylonjs/babylon.module.d.ts: TS2552: Cannot find name 'XRBody'. Did you mean 'Body'?
```

The runtime code is fine — the flattened `.module.d.ts` bundles leaked type names that aren't in scope. This surfaced after the TS 6 upgrade (#18202), which removed `ts-patch` and reworked the declaration pipeline; the string-based bundler doesn't handle two constructs that the previous toolchain did.

## Root causes & fixes

**1. `XRBody` / `XRBodySpace` (core bundle)**
These interfaces were declared *module-local* in `WebXRBodyTracking.pure.ts` and referenced from a `declare global` `XRFrame.body` augmentation. When the bundler hoists the global augmentation to global scope, the module-local types don't come along, leaving `body?: XRBody` dangling.

→ Moved `XRBody` / `XRBodySpace` (and `XRFrame.body`) into the ambient `LibDeclarations/webxr.d.ts`, which is appended verbatim at global scope alongside the other WebXR types (`XRFrame`, `XRSpace`, …). Removed the now-redundant local declarations from `WebXRBodyTracking.pure.ts`.

**2. `SpzModule` / `GaussianCloud` (loaders bundle)**
These types come from the external `@adobe/spz` package and appear in exported signatures. The declaration bundler strips external imports but left the references dangling.

→ Added `@adobe` to the external-type allowlist in `generateDeclaration.ts` so the references collapse to `any`, matching the existing handling for `@fortawesome` / `@fluentui` / `@recast-navigation`.

## Verification

- `tsc -b ./tsconfig.devpackages.json` — clean.
- Regenerated `core.d.ts` / `loaders.d.ts`: `XRBody`, `XRBodySpace`, `XRFrame.body` now sit at global scope; loaders emit `Promise<any>` / `cloud: any`.
- `tsc --noEmit` on both generated bundles: **0 `TS2304` errors** (down from the 5 reported).
- Prettier clean, ESLint 0 errors.