### PR TITLE
Fix .pure.ts transitive side-effect regressions (SceneLoader, depth-stencil, WGSL depth shaders)

### DIFF
--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.pure.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.pure.ts
@@ -7,8 +7,9 @@ import { Geometry } from "../../Meshes/geometry";
 import { TransformNode } from "../../Meshes/transformNode.pure";
 import { Material } from "../../Materials/material.pure";
 import { MultiMaterial } from "../../Materials/multiMaterial.pure";
-import { CubeTexture, CubeTextureCreateFromPrefilteredData, CubeTextureParse } from "../../Materials/Textures/cubeTexture.pure";
+import { CubeTexture, CubeTextureCreateFromPrefilteredData, CubeTextureParse, RegisterCubeTexture } from "../../Materials/Textures/cubeTexture.pure";
 import { HDRCubeTexture } from "../../Materials/Textures/hdrCubeTexture.pure";
+import { RegisterTexture } from "../../Materials/Textures/texture.pure";
 import { AnimationGroupParse } from "../../Animations/animationGroup.pure";
 import { Light } from "../../Lights/light";
 import { SceneLoaderFlags } from "../sceneLoaderFlags";
@@ -809,6 +810,15 @@ export function RegisterBabylonFileLoader(): void {
     // build that only imports the .babylon loader can still parse cameras. Without
     // this, Camera.Parse throws mid-load and the scene ends up with no active camera.
     RegisterCamera();
+
+    // The loader parses textures through SerializationHelper._TextureParser and cube
+    // textures through Texture._CubeTextureParser. These hooks are installed by the
+    // texture / cube texture registrations. Because this module imports the pure
+    // texture modules (side-effect free), pull the registrations in here so material
+    // textures (diffuse, reflection, etc.) actually load. Without this, materials
+    // parse but their textures are silently dropped (meshes render untextured).
+    RegisterTexture();
+    RegisterCubeTexture();
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const ParseMaterialByPredicate = (predicate: (parsedMaterial: any) => boolean, parsedData: any, scene: Scene, rootUrl: string) => {

--- a/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
+++ b/packages/dev/core/src/Loading/Plugins/babylonFileLoader.ts
@@ -6,3 +6,22 @@ export * from "./babylonFileLoader.pure";
 
 import { RegisterBabylonFileLoader } from "./babylonFileLoader.pure";
 RegisterBabylonFileLoader();
+
+// The .babylon loader resolves concrete camera / light / material types by name
+// through the type store, and falls back to a UniversalCamera / StandardMaterial for
+// untyped entries. Before the tree-shaking split these built-ins were registered
+// transitively, so importing the loader was enough to load a standard scene. Now each
+// concrete class only self-registers when its own side-effect wrapper is imported, so
+// pull in the standard built-ins here to preserve that contract. Consumers who want a
+// fully tree-shaken loader can import babylonFileLoader.pure and register only the
+// types their scenes actually use.
+import "../../Cameras/universalCamera";
+import "../../Cameras/arcRotateCamera";
+import "../../Lights/hemisphericLight";
+import "../../Lights/pointLight";
+import "../../Lights/directionalLight";
+import "../../Lights/spotLight";
+import "../../Materials/standardMaterial";
+import "../../Materials/PBR/pbrMaterial";
+import "../../Materials/Background/backgroundMaterial";
+import "../../Materials/multiMaterial";

--- a/packages/dev/core/src/Materials/Textures/renderTargetTexture.pure.ts
+++ b/packages/dev/core/src/Materials/Textures/renderTargetTexture.pure.ts
@@ -20,6 +20,7 @@ import { type Material } from "../material.pure";
 import { FloorPOT, NearestPOT } from "../../Misc/tools.functions";
 
 import { type AbstractEngine } from "../../Engines/abstractEngine.pure";
+import { RegisterAbstractEngineTexture } from "../../Engines/AbstractEngine/abstractEngine.texture.pure";
 import { type IParticleSystem } from "core/Particles/IParticleSystem";
 import { Logger } from "../../Misc/logger";
 import { ObjectRenderer } from "core/Rendering/objectRenderer";
@@ -1412,6 +1413,13 @@ export function RegisterRenderTargetTexture(): void {
         return;
     }
     _Registered = true;
+
+    // Depth-stencil render targets (shadow maps, RTT depth, etc.) call
+    // AbstractEngine.createDepthStencilTexture, which is only installed by the
+    // abstractEngine.texture registration. This module imports the pure engine
+    // (side-effect free), so pull the registration in here to guarantee the method
+    // exists whenever a render target texture is used.
+    RegisterAbstractEngineTexture();
 
     /**
      * Sets a depth stencil texture from a render target on the engine to be used in the shader.

--- a/packages/dev/core/src/Rendering/depthRenderer.ts
+++ b/packages/dev/core/src/Rendering/depthRenderer.ts
@@ -2,3 +2,5 @@ export * from "./depthRenderer.pure";
 
 import "../Shaders/depth.fragment";
 import "../Shaders/depth.vertex";
+import "../ShadersWGSL/depth.fragment";
+import "../ShadersWGSL/depth.vertex";

--- a/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderer.pure.ts
+++ b/packages/dev/core/src/Rendering/fluidRenderer/fluidRenderer.pure.ts
@@ -2,6 +2,7 @@
 
 import { Scene } from "core/scene.pure";
 import { type AbstractEngine } from "core/Engines/abstractEngine.pure";
+import { RegisterAbstractEngineTexture } from "core/Engines/AbstractEngine/abstractEngine.texture.pure";
 import { type FloatArray, type Nullable } from "core/types";
 import { type Observer } from "core/Misc/observable.pure";
 import { type Camera } from "core/Cameras/camera.pure";
@@ -547,6 +548,12 @@ export function RegisterFluidRenderer(): void {
         return;
     }
     _Registered = true;
+
+    // The fluid renderer creates depth-stencil textures on its render targets via
+    // AbstractEngine.createDepthStencilTexture, which is only installed by the
+    // abstractEngine.texture registration. This module imports the pure engine
+    // (side-effect free), so pull the registration in here.
+    RegisterAbstractEngineTexture();
 
     Object.defineProperty(Scene.prototype, "fluidRenderer", {
         get: function (this: Scene) {

--- a/packages/dev/core/test/unit/Engines/createDepthStencilTexture.registration.test.ts
+++ b/packages/dev/core/test/unit/Engines/createDepthStencilTexture.registration.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+// Regression coverage for the tree-shaking split dropping the createDepthStencilTexture
+// prototype augmentation. That method is installed by the abstractEngine.texture
+// registration. Concrete engines (engine.ts / webgpuEngine.ts) import it, but the
+// tree-shakeable features that actually create depth-stencil textures (render target
+// textures, shadow generators, the fluid renderer) must not rely on that — they must
+// pull the registration in themselves so they work with any engine build.
+//
+// We deliberately import the pure AbstractEngine base class (which does NOT run the
+// registration) instead of a concrete engine, so the prototype method is present ONLY
+// because importing the render target texture entry point registered it.
+import { AbstractEngine } from "core/Engines/abstractEngine.pure";
+import "core/Materials/Textures/renderTargetTexture";
+
+describe("createDepthStencilTexture registration", () => {
+    it("is installed on AbstractEngine by importing the render target texture entry point", () => {
+        expect(typeof (AbstractEngine.prototype as unknown as { createDepthStencilTexture?: unknown }).createDepthStencilTexture).toBe("function");
+    });
+});

--- a/packages/dev/core/test/unit/Loading/babylonFileLoader.sideEffects.test.ts
+++ b/packages/dev/core/test/unit/Loading/babylonFileLoader.sideEffects.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { LoadAssetContainer } from "core/Loading/Plugins/babylonFileLoader";
+
+// Regression coverage for the 9.8→9.16 tree-shaking (`*.pure.ts`) split, which dropped
+// the transitive side-effect registrations that used to make importing the .babylon
+// loader enough to load a standard scene. This test imports ONLY the public loader
+// entry point (no manual `universalCamera` / `pointLight` / `standardMaterial` /
+// `texture` side-effect imports) and asserts that cameras, lights, materials and their
+// textures all parse. Before the fix, cameras/lights/materials fell back to defaults or
+// threw, and material textures were silently dropped (meshes rendered untextured)
+// because `SerializationHelper._TextureParser` was never installed.
+
+function makeBabylonScene(): string {
+    return JSON.stringify({
+        producer: { name: "Babylon.js", version: "1.0", exporter_version: "1.0" },
+        cameras: [{ name: "cam", id: "camId", uniqueId: 1, type: "UniversalCamera", position: [0, 0, -10] }],
+        activeCameraID: "camId",
+        // Light_Type_0 === PointLight
+        lights: [{ name: "point", id: "lightId", uniqueId: 2, type: 0, position: [0, 10, 0] }],
+        materials: [
+            {
+                name: "mat",
+                id: "matId",
+                uniqueId: 3,
+                diffuse: [1, 1, 1],
+                diffuseTexture: { name: "diffuse.png", hasAlpha: false, level: 1, coordinatesMode: 0 },
+            },
+        ],
+        meshes: [],
+    });
+}
+
+describe("Babylon file loader transitive side effects", () => {
+    it("parses cameras, lights, materials and their textures without manual side-effect imports", () => {
+        const engine = new NullEngine();
+        const scene = new Scene(engine);
+
+        const container = LoadAssetContainer(scene, makeBabylonScene(), "", (message) => {
+            throw new Error(message);
+        });
+
+        // Camera: a UniversalCamera must parse (default parser previously threw).
+        expect(container.cameras.length).toBe(1);
+        expect(container.cameras[0].getClassName()).toBe("UniversalCamera");
+
+        // Light: a PointLight (Light_Type_0) must resolve to the concrete class.
+        expect(container.lights.length).toBe(1);
+        expect(container.lights[0].getClassName()).toBe("PointLight");
+
+        // Material: must resolve to a StandardMaterial.
+        expect(container.materials.length).toBe(1);
+        const material = container.materials[0] as unknown as { diffuseTexture: unknown; getClassName(): string };
+        expect(material.getClassName()).toBe("StandardMaterial");
+
+        // Texture: the material's diffuse texture must be created. This is the core of
+        // symptom 2 — without the loader installing SerializationHelper._TextureParser,
+        // the texture is dropped and the mesh renders untextured.
+        expect(material.diffuseTexture).not.toBeNull();
+        expect((material.diffuseTexture as { name: string }).name).toBe("diffuse.png");
+
+        engine.dispose();
+    });
+});

--- a/packages/dev/core/test/unit/Rendering/depthRenderer.shaders.test.ts
+++ b/packages/dev/core/test/unit/Rendering/depthRenderer.shaders.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { ShaderStore } from "core/Engines/shaderStore";
+
+// Regression coverage for the tree-shaking split dropping the WGSL depth shader
+// registration. Importing the public DepthRenderer entry point must register the depth
+// shaders for BOTH shader languages so WebGPU depth rendering works. Before the fix only
+// the GLSL depth shaders were statically imported, so under WebGPU the WGSL depth shaders
+// 404'd and the depth buffer rendered black.
+import "core/Rendering/depthRenderer";
+
+describe("DepthRenderer shader registration", () => {
+    it("registers the GLSL depth shaders", () => {
+        expect(ShaderStore.ShadersStore["depthVertexShader"]).toBeDefined();
+        expect(ShaderStore.ShadersStore["depthPixelShader"]).toBeDefined();
+    });
+
+    it("registers the WGSL depth shaders", () => {
+        expect(ShaderStore.ShadersStoreWGSL["depthVertexShader"]).toBeDefined();
+        expect(ShaderStore.ShadersStoreWGSL["depthPixelShader"]).toBeDefined();
+    });
+});

--- a/scripts/treeshaking/side-effects-manifest/core/Loading.json
+++ b/scripts/treeshaking/side-effects-manifest/core/Loading.json
@@ -1,7 +1,7 @@
 {
     "version": 1,
     "files": {
-        "Loading/Plugins/babylonFileLoader.ts": ["top-level-call"],
+        "Loading/Plugins/babylonFileLoader.ts": ["bare-import", "top-level-call"],
         "Loading/loadingScreen.ts": ["top-level-call"]
     }
 }


### PR DESCRIPTION
## Problem

The progressive `*.pure.ts` tree-shaking split (≈9.8→9.16) is legitimate, but it dropped several **transitive side-effect registrations** that used to happen automatically. Importing a high-level entry point (a loader/renderer) is no longer sufficient to use the feature — consumers had to manually add low-level side-effect imports. That is a regression in those entry points' public contract.

**Fix pattern (unchanged tree-shaking guarantees):** each public feature entry module imports/registers its *own* required side-effects, following the existing `.pure` convention. **No global side-effects are added to core's barrel**, so unrelated imports stay side-effect-free. All new tests import **only the public entry point** — no manual side-effect imports — and each was verified to fail without the fix and pass with it.

## Buckets fixed

### A — `.babylon` / SceneLoader parsers (regression) ✅
Two gaps, both fixed:
1. **Parsers threw mid-load** (camera/light/material) because concrete built-in classes only self-register through their own `.ts` wrappers. Name-based type resolution and the `UniversalCamera`/`StandardMaterial` fallbacks failed.
2. **Sponza rendered untextured / flat-orange.** `RegisterTexture()` installs `SerializationHelper._TextureParser = Texture.Parse`; only `texture.ts` calls it. The loader imports `texture.pure` (side-effect-free), so material-texture deserialization silently dropped every texture. Importing `standardMaterial` did *not* fix it — confirming the gap was the texture parser hook.

**Fix:**
- `babylonFileLoader.pure.ts` → `RegisterBabylonFileLoader()` now calls `RegisterTexture()` and `RegisterCubeTexture()` (the loader's own parser hooks).
- `babylonFileLoader.ts` wrapper imports the standard built-in cameras/lights/materials (`universalCamera`, `arcRotateCamera`, `hemisphericLight`, `pointLight`, `directionalLight`, `spotLight`, `standardMaterial`, `pbrMaterial`, `backgroundMaterial`, `multiMaterial`). Consumers who want a fully tree-shaken loader can still import `babylonFileLoader.pure` and register only what they use.

### B — `createDepthStencilTexture` (regression) ✅
`AbstractEngine.prototype.createDepthStencilTexture` is installed by `RegisterAbstractEngineTexture()`; RTT/shadow/fluid pure files called the method without triggering that registration.

**Fix:** `RegisterRenderTargetTexture()` and `RegisterFluidRenderer()` now chain `RegisterAbstractEngineTexture()`. ShadowGenerator / CascadedShadowGenerator are covered transitively (their ctor calls `RegisterRenderTargetTexture()` before using `createDepthStencilTexture`).

> Note: `engine.ts` / `webgpuEngine.ts` already `import "./AbstractEngine/abstractEngine.texture"`, so full engine builds never saw the failure — only minimal/tree-shaken engine builds that bypass `engine.ts`. The fix restores the correct "feature owns its side-effect" contract regardless.

### C — DepthRenderer WGSL shaders 404 under WebGPU (regression) ✅
`depthRenderer.ts` statically imported only the **GLSL** depth shaders; the WGSL path relied on racy dynamic imports, producing black depth under WebGPU.

**Fix:** the wrapper now statically imports both GLSL and WGSL `depth.vertex` / `depth.fragment` (mirroring the `effectRenderer.ts` pattern).

## Determinations — NOT `.pure` regressions ⚠️

### D — custom WGSL ShaderMaterial + thin-instance renders blank → **intentional / inherent, no code change**
The instance-attribute path is fully intact and language-agnostic (`shaderMaterial.pure.ts`: `PushAttributesForInstances` + `INSTANCES`/`THIN_INSTANCES` defines). There is **no dropped registration**. A *custom* WGSL `ShaderMaterial` must declare `world0..world3` in its vertex input struct (or use `#include<instancesDeclaration>` + `#include<instancesVertex>`) — the same requirement GLSL custom shaders always had. This is an inherent property of custom shaders, not a regression.

**Migration note for users:** custom WGSL shaders used with (thin) instances must declare the instance world-matrix attributes themselves, or include the `instancesDeclaration` / `instancesVertex` helpers.

### E — Havok `PhysicsCharacterController` scene hangs → **Havok 1.3.13 exposes a pre-existing solver bug, not `.pure`**
`characterController.ts` `_simplexSolverExamineActivePlanes` case 4: the "search a plane to drop" loop can leave `numSupportPlanes = 4` and `continue` forever (hang); the adjacent 3D-combination `if/else-if` chain has four identical conditions (dead code, `no-dupe-else-if` suppressed). This is physics-solver logic requiring a Havok repro and physics testing — **out of scope for the `.pure` work** and intentionally not fixed speculatively here. Flagged for a separate PR.

## Tests
- `babylonFileLoader.sideEffects.test.ts` (A) — imports only the loader wrapper; asserts `UniversalCamera`/`PointLight`/`StandardMaterial` parse and `diffuseTexture` is created.
- `createDepthStencilTexture.registration.test.ts` (B) — imports the pure `AbstractEngine` + `renderTargetTexture`; asserts `createDepthStencilTexture` is installed.
- `depthRenderer.shaders.test.ts` (C) — imports `core/Rendering/depthRenderer`; asserts both GLSL and WGSL depth shaders are in the ShaderStore.

Each test was verified red-without-fix / green-with-fix.

## Validation
- 3 new tests pass; broader Loading/Rendering/Engines suites: 145 pass + 1 expected fail, no regressions.
- `prettier` clean; ESLint 0 errors (`no-side-effect-imports-in-pure` does not fire — `.pure` files only import other `.pure` registrations).
- Tree-shaking: **all 16 checks pass**; side-effects manifest regenerated (`Loading.json` gains `bare-import`) and `sideEffects` in sync.