### PR TITLE
[MSDF Text] Fix alpha-to-coverage edge artifacts

### DIFF
--- a/packages/dev/addons/src/msdfText/textRenderer.ts
+++ b/packages/dev/addons/src/msdfText/textRenderer.ts
@@ -364,7 +364,7 @@ export class TextRenderer implements IDisposable {
 
         try {
             // When writing to the depth buffer, keep depth writes enabled (setAlphaMode would otherwise disable them for the ALPHA_COMBINE mode).
-            engine.setAlphaMode(useAlphaToCoverage ? Constants.ALPHA_DISABLE : Constants.ALPHA_COMBINE, writeDepth);
+            engine.setAlphaMode(useAlphaToCoverage ? Constants.ALPHA_REPLACE_COLOR : Constants.ALPHA_COMBINE, writeDepth);
             if (writeDepth) {
                 engine.setDepthWrite(true);
             }

--- a/packages/dev/core/src/Engines/Native/nativeHelpers.ts
+++ b/packages/dev/core/src/Engines/Native/nativeHelpers.ts
@@ -303,13 +303,13 @@ export function getNativeStencilDepthPass(opPass: number): number {
 const _warnedUnsupportedAlphaModes = new Set<number>();
 
 // Some alpha modes were introduced alongside newer Babylon Native features. When running against an older
-// native binary the corresponding _native.Engine constant is undefined; warn once and fall back to ALPHA_ONEONE.
-function _getFallbackAlphaMode(mode: number, unsupportedName: string): number {
+// native binary the corresponding _native.Engine constant is undefined; warn once and use a supported fallback.
+function _getFallbackAlphaMode(mode: number, unsupportedName: string, fallback = _native.Engine.ALPHA_ONEONE, fallbackName = "ALPHA_ONEONE"): number {
     if (!_warnedUnsupportedAlphaModes.has(mode)) {
         _warnedUnsupportedAlphaModes.add(mode);
-        Logger.Warn(`Alpha mode ${unsupportedName} is not supported by this version of Babylon Native; falling back to ALPHA_ONEONE.`);
+        Logger.Warn(`Alpha mode ${unsupportedName} is not supported by this version of Babylon Native; falling back to ${fallbackName}.`);
     }
-    return _native.Engine.ALPHA_ONEONE;
+    return fallback;
 }
 
 export function getNativeAlphaMode(mode: number): number {
@@ -340,6 +340,8 @@ export function getNativeAlphaMode(mode: number): number {
             return _native.Engine.ALPHA_INTERPOLATE;
         case Constants.ALPHA_SCREENMODE:
             return _native.Engine.ALPHA_SCREENMODE;
+        case Constants.ALPHA_REPLACE_COLOR:
+            return _native.Engine.ALPHA_REPLACE_COLOR ?? _getFallbackAlphaMode(mode, "ALPHA_REPLACE_COLOR", _native.Engine.ALPHA_COMBINE, "ALPHA_COMBINE");
         default:
             throw new Error(`Unsupported alpha mode: ${mode}.`);
     }

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -307,6 +307,7 @@ interface INativeEngineConstructor {
     readonly ALPHA_PREMULTIPLIED_PORTERDUFF: number;
     readonly ALPHA_INTERPOLATE: number;
     readonly ALPHA_SCREENMODE: number;
+    readonly ALPHA_REPLACE_COLOR?: number;
 
     readonly STENCIL_TEST_LESS: number;
     readonly STENCIL_TEST_LEQUAL: number;

--- a/packages/dev/core/src/Engines/constants.ts
+++ b/packages/dev/core/src/Engines/constants.ts
@@ -95,6 +95,11 @@ export class Constants {
      */
     public static readonly ALPHA_DUAL_SRC0_ADD_SRC1xDST = 20;
 
+    /**
+     * Defines that alpha blending is COLOR=SRC, ALPHA=SRC_ALPHA + (1 - SRC_ALPHA) * DEST_ALPHA
+     */
+    public static readonly ALPHA_REPLACE_COLOR = 21;
+
     /** Defines that alpha blending equation a SUM */
     public static readonly ALPHA_EQUATION_ADD = 0;
     /** Defines that alpha blending equation a SUBSTRACTION */

--- a/packages/dev/core/src/Materials/material.pure.ts
+++ b/packages/dev/core/src/Materials/material.pure.ts
@@ -669,6 +669,7 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      * | 18 | ALPHA_MIN | Defines that alpha blending is COLOR=MIN(SRC, DEST), ALPHA=MIN(SRC_ALPHA, DEST_ALPHA) |
      * | 19 | ALPHA_MAX | Defines that alpha blending is COLOR=MAX(SRC, DEST), ALPHA=MAX(SRC_ALPHA, DEST_ALPHA) |
      * | 20 | ALPHA_DUAL_SRC0_ADD_SRC1xDST | Defines that alpha blending uses dual source blending and is COLOR=SRC + SRC1 * DEST, ALPHA=DST_ALPHA |
+     * | 21 | ALPHA_REPLACE_COLOR | Defines that alpha blending is COLOR=SRC, ALPHA=SRC_ALPHA + (1 - SRC_ALPHA) * DEST_ALPHA |
      *
      */
     public set alphaMode(value: number) {

--- a/packages/dev/core/src/States/alphaCullingState.ts
+++ b/packages/dev/core/src/States/alphaCullingState.ts
@@ -317,6 +317,9 @@ export class AlphaState {
             case Constants.ALPHA_DUAL_SRC0_ADD_SRC1xDST:
                 this.setAlphaBlendFunctionParameters(1, Constants.GL_ALPHA_FUNCTION_SRC1_COLOR, 0, 1, targetIndex);
                 break;
+            case Constants.ALPHA_REPLACE_COLOR:
+                this.setAlphaBlendFunctionParameters(1, 0, 1, Constants.GL_ALPHA_FUNCTION_ONE_MINUS_SRC_ALPHA, targetIndex);
+                break;
         }
 
         this.setAlphaEquationParameters(equation, equation, targetIndex);

--- a/packages/dev/core/test/unit/States/alphaCullingState.test.ts
+++ b/packages/dev/core/test/unit/States/alphaCullingState.test.ts
@@ -1,4 +1,5 @@
 import { AlphaState } from "core/States/alphaCullingState";
+import { Constants } from "core/Engines/constants";
 import { describe, expect, it, vi } from "vitest";
 
 function createMockContext(): WebGLRenderingContext {
@@ -30,5 +31,13 @@ describe("AlphaState", () => {
 
         expect(context.disable).toHaveBeenCalledTimes(1);
         expect(context.disable).toHaveBeenCalledWith(context.SAMPLE_ALPHA_TO_COVERAGE);
+    });
+
+    it("configures RGB replacement with source-over alpha", () => {
+        const alphaState = new AlphaState(false);
+
+        alphaState.setAlphaMode(Constants.ALPHA_REPLACE_COLOR, 0);
+
+        expect(alphaState._blendFunctionParameters.slice(0, 4)).toEqual([1, 0, 1, Constants.GL_ALPHA_FUNCTION_ONE_MINUS_SRC_ALPHA]);
     });
 });


### PR DESCRIPTION
## Description

Fixes bright outlines around MSDF text when `writeToDepthBuffer` uses alpha-to-coverage.

A2C correctly generated sample coverage, but fractional MSDF alpha was also written to the premultiplied-alpha canvas. Browser compositing then produced bright edge artifacts.

This change:

- Adds `ALPHA_REPLACE_COLOR`, which replaces RGB while accumulating alpha source-over.
- Uses the new mode for multisampled MSDF depth-writing draws.
- Preserves A2C coverage and per-sample depth without applying alpha twice.
- Keeps framebuffer alpha opaque when rendering over an opaque scene.
- Adds Native fallback and alpha-state test coverage.

## Validation

- Verified WebGL2 and WebGPU with 4× MSAA.
- Verified opposite draw orders produce identical output.
- Verified the #6RLCWP#104 edge artifact is removed.
- Focused tests, lint, formatting, tree-shaking, and side-effect checks pass.

## Screenshots
Before, look at the bottom letters border:
<img width="318" height="971" alt="image" src="https://github.com/user-attachments/assets/33d46e76-753d-498a-8003-df02cbfafcd6" />

After, the bottom letters look correct now:
<img width="306" height="967" alt="image" src="https://github.com/user-attachments/assets/ee4ed3cb-5e56-4bc8-b82a-31898d071061" />

