### PR TITLE
Fix PerfCounter min/max initialization

### DIFF
--- a/packages/dev/core/src/Misc/perfCounter.ts
+++ b/packages/dev/core/src/Misc/perfCounter.ts
@@ -151,19 +151,20 @@ export class PerfCounter {
 
     /** @internal */
     public _fetchResult() {
+        if (!this._hasCurrentValue) {
+            return;
+        }
         this._totalAccumulated += this._current;
         this._lastSecAccumulated += this._current;
 
         // Min/Max update
-        if (this._hasCurrentValue) {
-            if (this._hasResult) {
-                this._min = Math.min(this._min, this._current);
-                this._max = Math.max(this._max, this._current);
-            } else {
-                this._min = this._current;
-                this._max = this._current;
-                this._hasResult = true;
-            }
+        if (this._hasResult) {
+            this._min = Math.min(this._min, this._current);
+            this._max = Math.max(this._max, this._current);
+        } else {
+            this._min = this._current;
+            this._max = this._current;
+            this._hasResult = true;
         }
         this._average = this._totalAccumulated / this._totalValueCount;
 

--- a/packages/dev/core/src/Misc/perfCounter.ts
+++ b/packages/dev/core/src/Misc/perfCounter.ts
@@ -70,6 +70,7 @@ export class PerfCounter {
         this._startMonitoringTime = 0;
         this._min = 0;
         this._max = 0;
+        this._hasResult = false;
         this._average = 0;
         this._lastSecAverage = 0;
         this._current = 0;
@@ -150,12 +151,13 @@ export class PerfCounter {
         this._lastSecAccumulated += this._current;
 
         // Min/Max update
-        if (this._totalValueCount === 1) {
-            this._min = this._current;
-            this._max = this._current;
-        } else {
+        if (this._hasResult) {
             this._min = Math.min(this._min, this._current);
             this._max = Math.max(this._max, this._current);
+        } else if (this._totalValueCount > 0) {
+            this._min = this._current;
+            this._max = this._current;
+            this._hasResult = true;
         }
         this._average = this._totalAccumulated / this._totalValueCount;
 
@@ -172,6 +174,7 @@ export class PerfCounter {
     private _startMonitoringTime: number;
     private _min: number;
     private _max: number;
+    private _hasResult: boolean;
     private _average: number;
     private _current: number;
     private _totalValueCount: number;

--- a/packages/dev/core/src/Misc/perfCounter.ts
+++ b/packages/dev/core/src/Misc/perfCounter.ts
@@ -150,8 +150,13 @@ export class PerfCounter {
         this._lastSecAccumulated += this._current;
 
         // Min/Max update
-        this._min = Math.min(this._min, this._current);
-        this._max = Math.max(this._max, this._current);
+        if (this._totalValueCount === 1) {
+            this._min = this._current;
+            this._max = this._current;
+        } else {
+            this._min = Math.min(this._min, this._current);
+            this._max = Math.max(this._max, this._current);
+        }
         this._average = this._totalAccumulated / this._totalValueCount;
 
         // Reset last sec?

--- a/packages/dev/core/src/Misc/perfCounter.ts
+++ b/packages/dev/core/src/Misc/perfCounter.ts
@@ -71,6 +71,7 @@ export class PerfCounter {
         this._min = 0;
         this._max = 0;
         this._hasResult = false;
+        this._hasCurrentValue = false;
         this._average = 0;
         this._lastSecAverage = 0;
         this._current = 0;
@@ -86,11 +87,9 @@ export class PerfCounter {
      * This scenario is typically used when you accumulate monitoring time many times for a single frame, you call this method at the start of the frame, then beginMonitoring to start recording and endMonitoring(false) to accumulated the recorded time to the PerfCounter or addCount() to accumulate a monitored count.
      */
     public fetchNewFrame() {
-        if (!PerfCounter.Enabled) {
-            return;
-        }
         this._totalValueCount++;
         this._current = 0;
+        this._hasCurrentValue = PerfCounter.Enabled;
         this._lastSecValueCount++;
     }
 
@@ -104,6 +103,7 @@ export class PerfCounter {
             return;
         }
         this._current += newCount;
+        this._hasCurrentValue = true;
         if (fetchResult) {
             this._fetchResult();
         }
@@ -134,6 +134,7 @@ export class PerfCounter {
 
         const currentTime = PrecisionDate.Now;
         this._current = currentTime - this._startMonitoringTime;
+        this._hasCurrentValue = true;
 
         if (newFrame) {
             this._fetchResult();
@@ -150,20 +151,19 @@ export class PerfCounter {
 
     /** @internal */
     public _fetchResult() {
-        if (!PerfCounter.Enabled) {
-            return;
-        }
         this._totalAccumulated += this._current;
         this._lastSecAccumulated += this._current;
 
         // Min/Max update
-        if (this._hasResult) {
-            this._min = Math.min(this._min, this._current);
-            this._max = Math.max(this._max, this._current);
-        } else if (this._totalValueCount > 0) {
-            this._min = this._current;
-            this._max = this._current;
-            this._hasResult = true;
+        if (this._hasCurrentValue) {
+            if (this._hasResult) {
+                this._min = Math.min(this._min, this._current);
+                this._max = Math.max(this._max, this._current);
+            } else {
+                this._min = this._current;
+                this._max = this._current;
+                this._hasResult = true;
+            }
         }
         this._average = this._totalAccumulated / this._totalValueCount;
 
@@ -181,6 +181,7 @@ export class PerfCounter {
     private _min: number;
     private _max: number;
     private _hasResult: boolean;
+    private _hasCurrentValue: boolean;
     private _average: number;
     private _current: number;
     private _totalValueCount: number;

--- a/packages/dev/core/src/Misc/perfCounter.ts
+++ b/packages/dev/core/src/Misc/perfCounter.ts
@@ -86,6 +86,9 @@ export class PerfCounter {
      * This scenario is typically used when you accumulate monitoring time many times for a single frame, you call this method at the start of the frame, then beginMonitoring to start recording and endMonitoring(false) to accumulated the recorded time to the PerfCounter or addCount() to accumulate a monitored count.
      */
     public fetchNewFrame() {
+        if (!PerfCounter.Enabled) {
+            return;
+        }
         this._totalValueCount++;
         this._current = 0;
         this._lastSecValueCount++;
@@ -147,6 +150,9 @@ export class PerfCounter {
 
     /** @internal */
     public _fetchResult() {
+        if (!PerfCounter.Enabled) {
+            return;
+        }
         this._totalAccumulated += this._current;
         this._lastSecAccumulated += this._current;
 

--- a/packages/dev/core/test/unit/Misc/perfCounter.test.ts
+++ b/packages/dev/core/test/unit/Misc/perfCounter.test.ts
@@ -1,0 +1,30 @@
+import { PerfCounter } from "core/Misc/perfCounter";
+
+describe("PerfCounter", () => {
+    it("tracks the minimum for positive values", () => {
+        const counter = new PerfCounter();
+
+        expect(counter.min).toBe(0);
+        expect(counter.max).toBe(0);
+
+        counter.fetchNewFrame();
+        counter.addCount(20, true);
+        counter.fetchNewFrame();
+        counter.addCount(10, true);
+
+        expect(counter.min).toBe(10);
+        expect(counter.max).toBe(20);
+    });
+
+    it("tracks the maximum for negative values", () => {
+        const counter = new PerfCounter();
+
+        counter.fetchNewFrame();
+        counter.addCount(-20, true);
+        counter.fetchNewFrame();
+        counter.addCount(-10, true);
+
+        expect(counter.min).toBe(-20);
+        expect(counter.max).toBe(-10);
+    });
+});

--- a/packages/dev/core/test/unit/Misc/perfCounter.test.ts
+++ b/packages/dev/core/test/unit/Misc/perfCounter.test.ts
@@ -1,6 +1,19 @@
 import { PerfCounter } from "core/Misc/perfCounter";
 
 describe("PerfCounter", () => {
+    it("keeps statistics stable before the first frame", () => {
+        const counter = new PerfCounter();
+
+        counter._fetchResult();
+
+        expect(counter.min).toBe(0);
+        expect(counter.max).toBe(0);
+        expect(counter.average).toBe(0);
+        expect(counter.lastSecAverage).toBe(0);
+        expect(counter.total).toBe(0);
+        expect(counter.count).toBe(0);
+    });
+
     it("tracks the minimum for positive values", () => {
         const counter = new PerfCounter();
 

--- a/packages/dev/core/test/unit/Misc/perfCounter.test.ts
+++ b/packages/dev/core/test/unit/Misc/perfCounter.test.ts
@@ -47,4 +47,27 @@ describe("PerfCounter", () => {
             PerfCounter.Enabled = enabled;
         }
     });
+
+    it("ignores a disabled frame finalized before the next WebGPU frame", () => {
+        const counter = new PerfCounter();
+        const enabled = PerfCounter.Enabled;
+
+        try {
+            PerfCounter.Enabled = false;
+            counter._fetchResult();
+            counter.fetchNewFrame();
+            counter.addCount(10, false);
+
+            PerfCounter.Enabled = true;
+            counter._fetchResult();
+            counter.fetchNewFrame();
+            counter.addCount(20, false);
+            counter._fetchResult();
+
+            expect(counter.min).toBe(20);
+            expect(counter.max).toBe(20);
+        } finally {
+            PerfCounter.Enabled = enabled;
+        }
+    });
 });

--- a/packages/dev/core/test/unit/Misc/perfCounter.test.ts
+++ b/packages/dev/core/test/unit/Misc/perfCounter.test.ts
@@ -27,4 +27,24 @@ describe("PerfCounter", () => {
         expect(counter.min).toBe(-20);
         expect(counter.max).toBe(-10);
     });
+
+    it("initializes extrema from the first recorded value after disabled frames", () => {
+        const counter = new PerfCounter();
+        const enabled = PerfCounter.Enabled;
+
+        try {
+            PerfCounter.Enabled = false;
+            counter.fetchNewFrame();
+            counter.addCount(10, true);
+
+            PerfCounter.Enabled = true;
+            counter.fetchNewFrame();
+            counter.addCount(20, true);
+
+            expect(counter.min).toBe(20);
+            expect(counter.max).toBe(20);
+        } finally {
+            PerfCounter.Enabled = enabled;
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- initialize `PerfCounter.min` and `max` from the first valid recorded value instead of the constructor's zero defaults
- preserve valid zero-valued frames while excluding constructor and disabled-frame placeholders from extrema
- add unit coverage for positive, negative, disabled, and WebGPU-style deferred results

## Context
- Forum report: https://forum.babylonjs.com/t/perfcounter-min-value-not-working-as-expected/63841
- Reproduction: https://playground.babylonjs.com/#5KMIIP#0

## Validation
- Prettier formatting check
- ESLint on the changed source file
- Local test execution intentionally omitted; CI will run the test suite