### PR TITLE
fix: scene can be nil in rgbd post process

### DIFF
--- a/packages/dev/core/src/Misc/rgbdTextureTools.ts
+++ b/packages/dev/core/src/Misc/rgbdTextureTools.ts
@@ -96,7 +96,7 @@ export class RGBDTextureTools {
                         effect._bindTexture("textureSampler", internalTexture);
                         effect.setFloat2("scale", 1, 1);
                     };
-                    texture.getScene()!.postProcessManager.directRender([rgbdPostProcess], expandedTexture, true);
+                    texture.getScene()?.postProcessManager.directRender([rgbdPostProcess], expandedTexture, true);
 
                     // Cleanup
                     engine.restoreDefaultFramebuffer();


### PR DESCRIPTION
Compiler is right in this case: when scene or engine is quickly destroyed before the effects are initialized the `texture.getScene()` actually can be already undefined.

Happens in our app when the user quickly navigates back from a component with the babylon scene (component is destroyed and engine disposed before fully intialized).



<img width="637" height="316" alt="image" src="https://github.com/user-attachments/assets/d0151ebc-4688-4437-86a4-3ef88a61de83" />
