### PR TITLE
Add onEffectiveEnabledStateChangedObservable to node class

### DIFF
--- a/packages/dev/core/src/node.ts
+++ b/packages/dev/core/src/node.ts
@@ -33,6 +33,8 @@ class _InternalNodeDataInfo {
     public _isParentEnabled = true;
     public _isReady = true;
     public _onEnabledStateChangedObservable = new Observable<boolean>();
+    // Lazily allocated so nodes that never observe effective enabled changes pay no allocation cost.
+    public _onEffectiveEnabledStateChangedObservable: Nullable<Observable<boolean>> = null;
     public _onClonedObservable = new Observable<Node>();
     public _inheritVisibility = false;
     public _isVisible = true;
@@ -361,10 +363,21 @@ export class Node implements IBehaviorAware<Node> {
     }
 
     /**
-     * An event triggered when the enabled state of the node changes
+     * An event triggered when the enabled state of the node changes.
+     * This only reflects changes to the node's own enabled flag (as set via {@link setEnabled}), not changes inherited from an ancestor.
+     * Use {@link onEffectiveEnabledStateChangedObservable} to also be notified when an ancestor's enabled state changes the effective enabled state.
      */
     public get onEnabledStateChangedObservable(): Observable<boolean> {
         return this._nodeDataStorage._onEnabledStateChangedObservable;
+    }
+
+    /**
+     * An event triggered when the effective enabled state of the node changes, i.e. whenever the value returned by {@link isEnabled} changes.
+     * Unlike {@link onEnabledStateChangedObservable}, this fires for changes caused by an ancestor's enabled state as well as this node's own state.
+     * The observable is created on first access, so no cost is incurred for nodes that never observe it.
+     */
+    public get onEffectiveEnabledStateChangedObservable(): Observable<boolean> {
+        return (this._nodeDataStorage._onEffectiveEnabledStateChangedObservable ??= new Observable<boolean>());
     }
 
     /**
@@ -613,6 +626,9 @@ export class Node implements IBehaviorAware<Node> {
      * If the node has a parent, all ancestors will be checked and false will be returned if any are false (not enabled), otherwise will return true
      * @param checkAncestors indicates if this method should check the ancestors. The default is to check the ancestors. If set to false, the method will return the value of this node without checking ancestors
      * @returns whether this node (and its parent) is enabled
+     * @remarks
+     * To observe changes to the value returned when calling this with `checkAncestors` set to true (the default, i.e. the effective enabled state), subscribe to {@link onEffectiveEnabledStateChangedObservable}.
+     * To observe changes to the value returned when calling this with `checkAncestors` set to false (i.e. this node's own enabled state only), subscribe to {@link onEnabledStateChangedObservable}.
      */
     public isEnabled(checkAncestors: boolean = true): boolean {
         if (checkAncestors === false) {
@@ -626,13 +642,38 @@ export class Node implements IBehaviorAware<Node> {
         return this._nodeDataStorage._isParentEnabled;
     }
 
+    /**
+     * Whether the effective enabled observable exists and has at least one observer.
+     * Used to skip the extra work of tracking effective enabled transitions when nobody is listening.
+     * @returns true if the effective enabled observable exists and has at least one observer, false otherwise
+     */
+    private _hasEffectiveEnabledStateObservers(): boolean {
+        const observable = this._nodeDataStorage._onEffectiveEnabledStateChangedObservable;
+        return !!observable && observable.hasObservers();
+    }
+
     /** @internal */
     protected _syncParentEnabledState() {
+        // Only track the effective enabled transition when a listener is attached to this specific node.
+        // When untracked, the previous state is null to make it clear it is not a real enabled value.
+        const notify = this._hasEffectiveEnabledStateObservers();
+        const wasEnabled = notify ? this.isEnabled() : null;
+
         this._nodeDataStorage._isParentEnabled = this._parentNode ? this._parentNode.isEnabled() : true;
 
         if (this._children) {
             for (const c of this._children) {
                 c._syncParentEnabledState(); // Force children to update accordingly
+            }
+        }
+
+        // An ancestor's enabled change (or a re-parent) can change this node's effective enabled state
+        // without its own flag changing. Notify observers of that inherited transition here. The direct
+        // setEnabled case is handled in setEnabled itself, so it does not double-fire from here.
+        if (notify) {
+            const isEnabled = this.isEnabled();
+            if (isEnabled !== wasEnabled) {
+                this._nodeDataStorage._onEffectiveEnabledStateChangedObservable!.notifyObservers(isEnabled);
             }
         }
     }
@@ -645,9 +686,22 @@ export class Node implements IBehaviorAware<Node> {
         if (this._nodeDataStorage._isEnabled === value) {
             return;
         }
+        // Capture the effective state before mutating so we can report if the current node's effective
+        // enabled state changed as a result of this direct change.
+        // When untracked, the previous state is null to make it clear it is not a real enabled value.
+        const notifyEffective = this._hasEffectiveEnabledStateObservers();
+        const wasEffectivelyEnabled = notifyEffective ? this.isEnabled() : null;
+
         this._nodeDataStorage._isEnabled = value;
         this._syncParentEnabledState();
         this._nodeDataStorage._onEnabledStateChangedObservable.notifyObservers(value);
+
+        if (notifyEffective) {
+            const isEnabled = this.isEnabled();
+            if (isEnabled !== wasEffectivelyEnabled) {
+                this._nodeDataStorage._onEffectiveEnabledStateChangedObservable!.notifyObservers(isEnabled);
+            }
+        }
     }
 
     /**
@@ -967,6 +1021,8 @@ export class Node implements IBehaviorAware<Node> {
         this.onDisposeObservable.clear();
 
         this.onEnabledStateChangedObservable.clear();
+        // Access the backing field directly to avoid lazily allocating the observable during disposal.
+        this._nodeDataStorage._onEffectiveEnabledStateChangedObservable?.clear();
         this.onClonedObservable.clear();
 
         // Behaviors

--- a/packages/dev/core/test/unit/babylon.nodeEnabledState.test.ts
+++ b/packages/dev/core/test/unit/babylon.nodeEnabledState.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { type Engine } from "core/Engines/engine";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Mesh } from "core/Meshes/mesh";
+import { Scene } from "core/scene";
+
+describe("Node enabled state", () => {
+    let subject: Engine;
+
+    beforeEach(function () {
+        subject = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+    });
+
+    describe("onEnabledStateChangedObservable (own state only)", () => {
+        it("should not notify a child when only its parent's enabled state changes", () => {
+            const scene = new Scene(subject);
+            const parent = new Mesh("Parent", scene);
+            const child = new Mesh("Child", scene);
+            child.parent = parent;
+
+            const notifications: boolean[] = [];
+            child.onEnabledStateChangedObservable.add((value) => notifications.push(value));
+
+            parent.setEnabled(false);
+            parent.setEnabled(true);
+
+            // The child's own enabled flag never changed, so the legacy observable stays silent.
+            expect(notifications).toEqual([]);
+        });
+
+        it("should notify the node whose enabled state is set directly", () => {
+            const scene = new Scene(subject);
+            const node = new Mesh("Node", scene);
+
+            const notifications: boolean[] = [];
+            node.onEnabledStateChangedObservable.add((value) => notifications.push(value));
+
+            node.setEnabled(false);
+
+            expect(notifications).toEqual([false]);
+        });
+    });
+
+    describe("onEffectiveEnabledStateChangedObservable", () => {
+        it("should notify a child when its parent's enabled state changes", () => {
+            const scene = new Scene(subject);
+            const parent = new Mesh("Parent", scene);
+            const child = new Mesh("Child", scene);
+            child.parent = parent;
+
+            const notifications: boolean[] = [];
+            child.onEffectiveEnabledStateChangedObservable.add((value) => notifications.push(value));
+
+            expect(child.isEnabled()).toBe(true);
+
+            parent.setEnabled(false);
+            expect(child.isEnabled()).toBe(false);
+
+            parent.setEnabled(true);
+            expect(child.isEnabled()).toBe(true);
+
+            expect(notifications).toEqual([false, true]);
+        });
+
+        it("should notify descendants across multiple levels", () => {
+            const scene = new Scene(subject);
+            const grandParent = new Mesh("GrandParent", scene);
+            const parent = new Mesh("Parent", scene);
+            const child = new Mesh("Child", scene);
+            parent.parent = grandParent;
+            child.parent = parent;
+
+            const parentNotifications: boolean[] = [];
+            const childNotifications: boolean[] = [];
+            parent.onEffectiveEnabledStateChangedObservable.add((value) => parentNotifications.push(value));
+            child.onEffectiveEnabledStateChangedObservable.add((value) => childNotifications.push(value));
+
+            grandParent.setEnabled(false);
+            expect(parent.isEnabled()).toBe(false);
+            expect(child.isEnabled()).toBe(false);
+
+            expect(parentNotifications).toEqual([false]);
+            expect(childNotifications).toEqual([false]);
+        });
+
+        it("should notify the node whose enabled state is set directly exactly once", () => {
+            const scene = new Scene(subject);
+            const node = new Mesh("Node", scene);
+
+            const notifications: boolean[] = [];
+            node.onEffectiveEnabledStateChangedObservable.add((value) => notifications.push(value));
+
+            node.setEnabled(false);
+
+            expect(notifications).toEqual([false]);
+        });
+
+        it("should not notify a child whose effective enabled state does not change", () => {
+            const scene = new Scene(subject);
+            const parent = new Mesh("Parent", scene);
+            const child = new Mesh("Child", scene);
+            child.parent = parent;
+
+            // Disable the child explicitly first.
+            child.setEnabled(false);
+
+            const notifications: boolean[] = [];
+            child.onEffectiveEnabledStateChangedObservable.add((value) => notifications.push(value));
+
+            // Toggling the parent should not change the child's effective enabled state, which stays disabled.
+            parent.setEnabled(false);
+            parent.setEnabled(true);
+
+            expect(child.isEnabled()).toBe(false);
+            expect(notifications).toEqual([]);
+        });
+
+        it("should notify when a node is re-parented under a disabled parent", () => {
+            const scene = new Scene(subject);
+            const disabledParent = new Mesh("DisabledParent", scene);
+            const child = new Mesh("Child", scene);
+            disabledParent.setEnabled(false);
+
+            const notifications: boolean[] = [];
+            child.onEffectiveEnabledStateChangedObservable.add((value) => notifications.push(value));
+
+            expect(child.isEnabled()).toBe(true);
+            child.parent = disabledParent;
+
+            expect(child.isEnabled()).toBe(false);
+            expect(notifications).toEqual([false]);
+        });
+    });
+});


### PR DESCRIPTION
The existing onEnabledStateChangedObservable only notifies when the local enabled value changes, but if the effective value changes (due to a parent become disabled), it doesn't notify. The new onEffectiveEnabledStateChangedObservable will in both cases.  It is lazy loaded to reduce extra work for those not using it.