### PR TITLE
Fix EXT_lights_ies profile texture naming

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_lights_ies.pure.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/EXT_lights_ies.pure.ts
@@ -106,7 +106,7 @@ export class EXT_lights_ies implements IGLTFLoaderExtension {
                 bufferData = await this._loader.loadBufferViewAsync(`/bufferViews/${bufferView.index}`, bufferView);
             }
             babylonSpotLight!.iesProfileTexture = new Texture(
-                name + "_iesProfile",
+                babylonSpotLight!.name + "_iesProfile",
                 this._loader.babylonScene,
                 true,
                 false,

--- a/packages/dev/loaders/test/unit/glTF/EXT_lights_ies.test.ts
+++ b/packages/dev/loaders/test/unit/glTF/EXT_lights_ies.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { ImportMeshAsync } from "core/Loading/sceneLoader";
+import { Scene } from "core/scene";
+import { SpotLight } from "core/Lights/spotLight";
+import "loaders/glTF/2.0/glTFLoader";
+import "loaders/glTF/2.0/Extensions/EXT_lights_ies";
+
+const IES_DATA = ["IESNA:LM-63-2002", "TILT=NONE", "1 1000 1 2 2 1 1 1 1 1", "1 1 1", "0 180", "0 360", "1 1", "1 1"].join("\n");
+
+function buildExtLightsIesGltf(): string {
+    const profile = btoa(IES_DATA);
+    return JSON.stringify({
+        asset: { version: "2.0" },
+        extensionsUsed: ["EXT_lights_ies"],
+        extensions: {
+            EXT_lights_ies: {
+                lights: [
+                    {
+                        name: "Photometric light",
+                        uri: `data:application/octet-stream;base64,${profile}`,
+                    },
+                ],
+            },
+        },
+        scene: 0,
+        scenes: [{ nodes: [0] }],
+        nodes: [
+            {
+                name: "Light node",
+                extensions: {
+                    EXT_lights_ies: {
+                        light: 0,
+                    },
+                },
+            },
+        ],
+    });
+}
+
+describe("EXT_lights_ies", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let globalNameDescriptor: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+        globalNameDescriptor = Object.getOwnPropertyDescriptor(globalThis, "name");
+        Reflect.deleteProperty(globalThis, "name");
+        engine = new NullEngine();
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+        if (globalNameDescriptor) {
+            Object.defineProperty(globalThis, "name", globalNameDescriptor);
+        } else {
+            Reflect.deleteProperty(globalThis, "name");
+        }
+    });
+
+    it("names the IES profile from the created light without relying on a browser global", async () => {
+        await ImportMeshAsync(`data:${buildExtLightsIesGltf()}`, scene);
+
+        expect(scene.lights).toHaveLength(1);
+        const light = scene.lights[0] as SpotLight;
+        expect(light.name).toBe("Photometric light");
+        expect(light.iesProfileTexture?.name).toBe("Photometric light_iesProfile");
+    });
+});


### PR DESCRIPTION
## Summary

- Name the IES profile texture from the `SpotLight` created by the extension.
- Add a loader regression test that runs without a browser `name` global.

The previous free `name` reference compiled because DOM typings declare `window.name`, but throws in non-browser runtimes.

## Validation

- New test fails on the previous implementation with `name is not defined`.
- `npx vitest run packages/dev/loaders/test/unit/glTF/EXT_lights_ies.test.ts`