### PR TITLE
Fix pure engine disposal without loading screen registration

### DIFF
--- a/packages/dev/core/src/Engines/engine.pure.ts
+++ b/packages/dev/core/src/Engines/engine.pure.ts
@@ -1055,7 +1055,7 @@ export class Engine extends ThinEngine {
     }
 
     public override dispose(): void {
-        this.hideLoadingUI();
+        this.hideLoadingUI?.();
 
         // Rescale PP
         if (this._rescalePostProcess) {

--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -4014,7 +4014,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
      */
     public override dispose(): void {
         this._isDisposed = true;
-        this.hideLoadingUI();
+        this.hideLoadingUI?.();
         this._timestampQuery.dispose();
         this._mainTexture?.destroy();
         this._depthTexture?.destroy();

--- a/packages/dev/core/src/Loading/loadingScreen.pure.ts
+++ b/packages/dev/core/src/Loading/loadingScreen.pure.ts
@@ -2,6 +2,7 @@
 
 import { type Nullable } from "../types";
 import { AbstractEngine } from "../Engines/abstractEngine.pure";
+import { RegisterAbstractEngineLoadingScreen } from "../Engines/AbstractEngine/abstractEngine.loadingScreen.pure";
 import { EngineStore } from "../Engines/engineStore";
 import { type Observer } from "../Misc/observable.pure";
 
@@ -356,6 +357,7 @@ export function RegisterLoadingScreen(): void {
     }
     _Registered = true;
 
+    RegisterAbstractEngineLoadingScreen();
     AbstractEngine.DefaultLoadingScreenFactory = (canvas: HTMLCanvasElement) => {
         return new DefaultLoadingScreen(canvas);
     };

--- a/packages/dev/core/test/unit/Engines/engine.loadingScreen.test.ts
+++ b/packages/dev/core/test/unit/Engines/engine.loadingScreen.test.ts
@@ -1,0 +1,36 @@
+import { Engine } from "core/Engines/engine.pure";
+import { ThinEngine } from "core/Engines/thinEngine.pure";
+import { WebGPUEngine } from "core/Engines/webgpuEngine.pure";
+import { AbstractEngine } from "core/Engines/abstractEngine.pure";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("engine disposal without loading screen registration", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("disposes Engine when hideLoadingUI is not registered", () => {
+        const engine = Object.create(Engine.prototype) as Engine;
+        engine._rescalePostProcess = null;
+        engine._renderingCanvas = null;
+        vi.spyOn(ThinEngine.prototype, "dispose").mockImplementation(() => {});
+
+        expect(engine.hideLoadingUI).toBeUndefined();
+        expect(() => engine.dispose()).not.toThrow();
+    });
+
+    it("disposes WebGPUEngine when hideLoadingUI is not registered", () => {
+        const engine = Object.create(WebGPUEngine.prototype) as WebGPUEngine;
+        engine._timestampQuery = { dispose: vi.fn() } as WebGPUEngine["_timestampQuery"];
+        engine._mainTexture = null;
+        engine._depthTexture = null;
+        engine._textureHelper = { destroyDeferredTextures: vi.fn() } as unknown as WebGPUEngine["_textureHelper"];
+        engine._bufferManager = { destroyDeferredBuffers: vi.fn() } as unknown as WebGPUEngine["_bufferManager"];
+        engine._device = { destroy: vi.fn() } as unknown as GPUDevice;
+        engine._renderingCanvas = null;
+        vi.spyOn(AbstractEngine.prototype, "dispose").mockImplementation(() => {});
+
+        expect(engine.hideLoadingUI).toBeUndefined();
+        expect(() => engine.dispose()).not.toThrow();
+    });
+});

--- a/packages/dev/core/test/unit/Engines/engine.loadingScreen.test.ts
+++ b/packages/dev/core/test/unit/Engines/engine.loadingScreen.test.ts
@@ -4,33 +4,56 @@ import { WebGPUEngine } from "core/Engines/webgpuEngine.pure";
 import { AbstractEngine } from "core/Engines/abstractEngine.pure";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+function withUnregisteredLoadingScreen(callback: () => void): void {
+    const descriptor = Object.getOwnPropertyDescriptor(AbstractEngine.prototype, "hideLoadingUI");
+    Object.defineProperty(AbstractEngine.prototype, "hideLoadingUI", {
+        configurable: true,
+        value: undefined,
+        writable: true,
+    });
+
+    try {
+        callback();
+    } finally {
+        if (descriptor) {
+            Object.defineProperty(AbstractEngine.prototype, "hideLoadingUI", descriptor);
+        } else {
+            delete (AbstractEngine.prototype as { hideLoadingUI?: () => void }).hideLoadingUI;
+        }
+    }
+}
+
 describe("engine disposal without loading screen registration", () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
     it("disposes Engine when hideLoadingUI is not registered", () => {
-        const engine = Object.create(Engine.prototype) as Engine;
-        engine._rescalePostProcess = null;
-        engine._renderingCanvas = null;
+        const engine = Object.assign(Object.create(Engine.prototype) as Engine, {
+            _rescalePostProcess: null,
+            _renderingCanvas: null,
+        });
         vi.spyOn(ThinEngine.prototype, "dispose").mockImplementation(() => {});
 
-        expect(engine.hideLoadingUI).toBeUndefined();
-        expect(() => engine.dispose()).not.toThrow();
+        withUnregisteredLoadingScreen(() => {
+            expect(() => engine.dispose()).not.toThrow();
+        });
     });
 
     it("disposes WebGPUEngine when hideLoadingUI is not registered", () => {
-        const engine = Object.create(WebGPUEngine.prototype) as WebGPUEngine;
-        engine._timestampQuery = { dispose: vi.fn() } as WebGPUEngine["_timestampQuery"];
-        engine._mainTexture = null;
-        engine._depthTexture = null;
-        engine._textureHelper = { destroyDeferredTextures: vi.fn() } as unknown as WebGPUEngine["_textureHelper"];
-        engine._bufferManager = { destroyDeferredBuffers: vi.fn() } as unknown as WebGPUEngine["_bufferManager"];
-        engine._device = { destroy: vi.fn() } as unknown as GPUDevice;
-        engine._renderingCanvas = null;
+        const engine = Object.assign(Object.create(WebGPUEngine.prototype) as WebGPUEngine, {
+            _timestampQuery: { dispose: vi.fn() } as WebGPUEngine["_timestampQuery"],
+            _mainTexture: null,
+            _depthTexture: null,
+            _textureHelper: { destroyDeferredTextures: vi.fn() } as unknown as WebGPUEngine["_textureHelper"],
+            _bufferManager: { destroyDeferredBuffers: vi.fn() } as unknown as WebGPUEngine["_bufferManager"],
+            _device: { destroy: vi.fn() } as unknown as GPUDevice,
+            _renderingCanvas: null,
+        });
         vi.spyOn(AbstractEngine.prototype, "dispose").mockImplementation(() => {});
 
-        expect(engine.hideLoadingUI).toBeUndefined();
-        expect(() => engine.dispose()).not.toThrow();
+        withUnregisteredLoadingScreen(() => {
+            expect(() => engine.dispose()).not.toThrow();
+        });
     });
 });

--- a/packages/dev/core/test/unit/Loading/loadingScreen.test.ts
+++ b/packages/dev/core/test/unit/Loading/loadingScreen.test.ts
@@ -4,8 +4,6 @@ import { describe, expect, it } from "vitest";
 
 describe("RegisterLoadingScreen", () => {
     it("registers the AbstractEngine loading screen APIs", () => {
-        expect(AbstractEngine.prototype.hideLoadingUI).toBeUndefined();
-
         RegisterLoadingScreen();
 
         expect(typeof AbstractEngine.prototype.displayLoadingUI).toBe("function");

--- a/packages/dev/core/test/unit/Loading/loadingScreen.test.ts
+++ b/packages/dev/core/test/unit/Loading/loadingScreen.test.ts
@@ -1,0 +1,15 @@
+import { AbstractEngine } from "core/Engines/abstractEngine.pure";
+import { RegisterLoadingScreen } from "core/Loading/loadingScreen.pure";
+import { describe, expect, it } from "vitest";
+
+describe("RegisterLoadingScreen", () => {
+    it("registers the AbstractEngine loading screen APIs", () => {
+        expect(AbstractEngine.prototype.hideLoadingUI).toBeUndefined();
+
+        RegisterLoadingScreen();
+
+        expect(typeof AbstractEngine.prototype.displayLoadingUI).toBe("function");
+        expect(typeof AbstractEngine.prototype.hideLoadingUI).toBe("function");
+        expect(Object.getOwnPropertyDescriptor(AbstractEngine.prototype, "loadingScreen")).toBeDefined();
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Make `Engine.dispose()` and `WebGPUEngine.dispose()` tolerate pure builds that intentionally omit loading-screen registration.
- Make `RegisterLoadingScreen()` also register the `AbstractEngine` loading-screen APIs, so the legacy loading-screen deep import remains self-contained.
- Add regression tests for both disposal paths and composed registration.

## Motivation

Pure WebGPU consumers could hit `TypeError: this.hideLoadingUI is not a function` during engine disposal after the generated fallback stubs were removed. Importing the loading-screen entrypoint also registered only the default factory, not the engine APIs that expose it.

Related forum report: https://forum.babylonjs.com/t/this-hideloadingui-is-not-a-function/63863
