### PR TITLE
Fix GitHub release creation for version tags

### DIFF
--- a/.azure-pipelines/cd-publish.yml
+++ b/.azure-pipelines/cd-publish.yml
@@ -114,6 +114,14 @@ jobs:
             displayName: "push to git"
 
           - bash: |
+                set -euo pipefail
+                pv=$(jq -r '.version' ./packages/public/umd/babylonjs/package.json)
+                releaseCommit=$(git rev-parse "${pv}^{commit}")
+                echo "##vso[task.setvariable variable=PackageVersion]${pv}"
+                echo "##vso[task.setvariable variable=ReleaseCommit]${releaseCommit}"
+            displayName: "Get release version and commit"
+
+          - bash: |
                 npm run prepare-snapshot
 
                 zip -r $(Build.ArtifactStagingDirectory)/cdnSnapshot.zip .snapshot
@@ -128,19 +136,14 @@ jobs:
                 gitHubConnection: "$(GITHUB_SERVICE_CONNECTION)"
                 repositoryName: "BabylonJS/Babylon.js"
                 action: create
-                target: master
-                tagSource: gitTag
+                target: "$(ReleaseCommit)"
+                tagSource: userSpecifiedTag
+                tag: "$(PackageVersion)"
                 assets: "$(Build.ArtifactStagingDirectory)/cdnSnapshot.zip"
                 isDraft: false
                 isPreRelease: false
                 addChangeLog: false
                 releaseNotesFilePath: ".build/release-notes.md"
-
-          - bash: |
-                pv=$(jq -r '.version' ./packages/public/umd/babylonjs/package.json)
-                echo "##vso[task.setvariable variable=PackageVersion]${pv}"
-            displayName: "Get version"
-            continueOnError: true
 
           - script: |
                 cd .snapshot


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Resolve the published package version and its exact tagged commit before creating the release.
- Pass the version as an explicit GitHub release tag instead of searching the moving `master` branch for an associated tag.
- Reuse the package version variable for snapshot deployment.

## Motivation

The `9.18.1` publish run skipped GitHub release creation because `master` advanced after the version tag was pushed. `GitHubRelease@1` searched the newer `master` commit for a tag and emitted: `Release will not be created as the tags for the target commit do not match with the given tag pattern`.
