### PR TITLE
Allow disabling Havok floating origin world regions

### DIFF
--- a/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
+++ b/packages/dev/core/src/Physics/v2/Plugins/havokPlugin.ts
@@ -332,6 +332,12 @@ export interface HavokPluginParameters {
      */
     maxQueryCollectorHits?: number;
     /**
+     * Whether to disable Havok world regions when floating origin mode is enabled.
+     * Set this when the application manages physics precision through its own rebasing system.
+     * Default is false.
+     */
+    disableWorldRegions?: boolean;
+    /**
      * Radius of each floating origin world region.
      * Bodies within this radius of a world region's origin will use that world.
      * Bodies created outside existing regions will create a new region.
@@ -403,6 +409,18 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * Bodies within this radius of a world region's origin will use that world.
      */
     private _floatingOriginWorldRadius: number = 100000;
+    /**
+     * Whether Havok world regions are disabled.
+     */
+    private _disableWorldRegions: boolean = false;
+
+    /**
+     * Whether floating origin world regions are enabled for the current scene.
+     * @returns true when the scene uses floating origin mode and world regions are not disabled
+     */
+    private _areFloatingOriginWorldRegionsEnabled(): boolean {
+        return !this._disableWorldRegions && !!FloatingOriginCurrentScene.getScene()?.floatingOriginMode;
+    }
 
     /**
      * Finds an existing world region that contains the given world position,
@@ -417,8 +435,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      */
     private _getOrCreateWorldRegion(worldPosition: Vector3): PhysicsWorldRegion {
         // Check if floating origin mode is enabled
-        const scene = FloatingOriginCurrentScene.getScene();
-        if (!scene?.floatingOriginMode) {
+        if (!this._areFloatingOriginWorldRegionsEnabled()) {
             // When floating origin mode is disabled, use the default world region
             return this._worldRegions[0];
         }
@@ -533,8 +550,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
      * @returns null if no existing region contains it (does NOT create a new one).
      */
     private _findExistingRegion(worldPosition: Vector3): PhysicsWorldRegion | null {
-        const scene = FloatingOriginCurrentScene.getScene();
-        if (!scene?.floatingOriginMode) {
+        if (!this._areFloatingOriginWorldRegionsEnabled()) {
             return this._worldRegions[0];
         }
 
@@ -612,6 +628,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
 
         this._queryCollector = this._hknp.HP_QueryCollector_Create(1)[1];
         this.setMaxQueryCollectorHits(parameters.maxQueryCollectorHits ?? 1);
+        this._disableWorldRegions = parameters.disableWorldRegions ?? false;
         this._floatingOriginWorldRadius = parameters.floatingOriginWorldRadius ?? 100000;
     }
     /**
@@ -727,7 +744,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
         // Re-region bodies that have moved outside their current world region
         // BEFORE pre-step and stepping, so the body participates in the correct
         // world's step and its body buffer transform is valid when sync reads it.
-        if (this._worldRegions.length > 1 || FloatingOriginCurrentScene.getScene()?.floatingOriginMode) {
+        if (this._areFloatingOriginWorldRegionsEnabled()) {
             for (const physicsBody of physicsBodies) {
                 if (physicsBody._pluginDataInstances.length > 0) {
                     for (const instance of physicsBody._pluginDataInstances) {
@@ -1587,7 +1604,7 @@ export class HavokPlugin implements IPhysicsEnginePluginV2 {
                 // the transform node) immediately land in the correct region with
                 // correct local coordinates, avoiding a one-frame precision glitch.
                 const pluginData = body._pluginData;
-                if (pluginData.worldRegion && (this._worldRegions.length > 1 || FloatingOriginCurrentScene.getScene()?.floatingOriginMode)) {
+                if (pluginData.worldRegion && this._areFloatingOriginWorldRegionsEnabled()) {
                     // Get world position of the node
                     const worldPos = TmpVectors.Vector3[3];
                     if (node.parent) {

--- a/packages/dev/core/test/unit/Physics/havokPlugin.test.ts
+++ b/packages/dev/core/test/unit/Physics/havokPlugin.test.ts
@@ -61,6 +61,7 @@ function createPlugin(worldRegions: TestWorldRegion[], initialBodyCounts: Readon
         _bodies: new Map(),
         _fixedTimeStep: 1 / 60,
         _floatingOriginWorldRadius: 100_000,
+        _disableWorldRegions: false,
         _useDeltaForWorldStep: false,
     }) as HavokPlugin;
 
@@ -73,6 +74,28 @@ function createBody(worldRegion: TestWorldRegion): PhysicsBody {
         _pluginDataInstances: [],
     } as unknown as PhysicsBody;
 }
+
+describe("HavokPlugin world region configuration", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("uses the default world when floating origin world regions are disabled", () => {
+        const defaultWorld = 1n;
+        const hknp = {
+            HP_QueryCollector_Create: vi.fn(() => [0, 2n]),
+            HP_World_Create: vi.fn(() => [0, defaultWorld]),
+            HP_World_SetGravity: vi.fn(),
+        };
+        const plugin = new HavokPlugin(true, hknp, { disableWorldRegions: true });
+        vi.spyOn(FloatingOriginCurrentScene, "getScene").mockReturnValue({ floatingOriginMode: true } as Scene);
+
+        plugin.setGravity(new Vector3(0, -9.81, 0), new Vector3(200_000, 0, 0));
+
+        expect(hknp.HP_World_Create).toHaveBeenCalledOnce();
+        expect(hknp.HP_World_SetGravity).toHaveBeenCalledExactlyOnceWith(defaultWorld, [0, -9.81, 0]);
+    });
+});
 
 describe("HavokPlugin world region lifecycle", () => {
     afterEach(() => {


### PR DESCRIPTION
Hey there, 

I have been toying with havok world regions recently, and learned there is no perfect solution for physics handling in large scale worlds.

World regions have edge cases around world migrations (2 bodies close in space should interact but are in fact in 2 separate worlds like in [this PG](https://playground.babylonjs.com/#0HYLMQ#1)), origin rebasing only works when physics happen close to the camera and double precision has a performance and memory hit (although I saw Jolt only uses f64 for positions to limit the penalty to ~10% https://github.com/jrouwe/JoltPhysics/issues/94#issuecomment-1324347464).

So my point is Babylon should let havok users make their own large world implementation if they want to.

Hence this small PR adds a config flag to disable havok world regions even when floating origin is enabled.

Let me know how you feel about it!