### PR TITLE
Fix: Gaussian Splatting sort padding reuses real splat data, causing splats stuck in front of the model

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -3121,8 +3121,9 @@ export class GaussianSplattingMeshBase extends Mesh {
         );
 
         const positions = Float32Array.from(this._splatPositions!);
+        const vertexCount = this._vertexCount;
 
-        this._worker.postMessage({ command: GaussianSplattingSortWorkerCommand.POSITIONS, positions }, [positions.buffer]);
+        this._worker.postMessage({ command: GaussianSplattingSortWorkerCommand.POSITIONS, positions, vertexCount }, [positions.buffer]);
         // The main thread owns the active interval set: send it explicitly (covering all indices when
         // no LOD filter is active) rather than letting the worker assume the full source set.
         this._postIntervalsToWorker();
@@ -3223,8 +3224,24 @@ export class GaussianSplattingMeshBase extends Mesh {
             while (width * height < length) {
                 height *= 2;
             }
+            // See the WebGL2/WebGPU branch below for why this guarantees an extra row when `length`
+            // exactly fills every row. A power-of-2 height has to double to add any slack at all.
+            // Usually this is a no-op since it is rare that the asset exactly contains a power-of-2
+            // number of splats.
+            if (length > 0 && width * height === length) {
+                height *= 2;
+            }
         } else {
             height = Math.ceil(length / width);
+            // When `length` exactly fills every row, force one extra (fully zeroed) row so the atlas
+            // always has at least one genuinely-empty splat slot past the real data, at index `length`.
+            // The sort worker (gaussianSplattingSortWorker.ts) relies on that slot always existing to
+            // safely pad the 16-aligned draw order — without it, the only "spare" index would be the
+            // last real splat, which range-filtering (setSplatIndexRanges/opacity/size culling) can
+            // leave fully visible and opaque, reproducing the same "stuck in front" bug on that splat.
+            if (length > 0 && height * width === length) {
+                height += 1;
+            }
         }
 
         if (height > width) {

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -2981,8 +2981,10 @@ export class GaussianSplattingMeshBase extends Mesh {
                     splatIndex[index++] = sourceIndex;
                 }
             }
+            // Pad with `vertexCount` itself, not 0: splat 0 is real data, not a reserved empty slot, and
+            // range filtering can leave it fully visible — see gaussianSplattingSortWorker.ts.
             for (; index < paddedVertexCount; index++) {
-                splatIndex[index] = 0;
+                splatIndex[index] = vertexCount;
             }
         } else {
             for (let i = 0; i < paddedVertexCount; i++) {

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingSortWorker.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingSortWorker.ts
@@ -42,6 +42,8 @@ export const GaussianSplattingSortWorkerCommand = {
  */
 export const GaussianSplattingSortWorker = function (self: Worker) {
     let positions: Float32Array;
+    // Real (unpadded) splat count backing `positions` — see emptySplatIndex below for why this matters.
+    let vertexCount = 0;
     let depthMix: BigInt64Array;
     let partIndices: Uint8Array;
     let partMatrices: Float32Array[];
@@ -61,6 +63,7 @@ export const GaussianSplattingSortWorker = function (self: Worker) {
         const command = e.data.command;
         if (command === "positions") {
             positions = e.data.positions;
+            vertexCount = e.data.vertexCount;
         } else if (command === "positionsUpdate") {
             // Patch only the changed sub-range in place, avoiding a full re-copy/transfer of the entire
             // (potentially hundreds-of-MB) position buffer on every streamed LOD decode.
@@ -107,6 +110,11 @@ export const GaussianSplattingSortWorker = function (self: Worker) {
             // but fall back to "all source splats" if a sort somehow arrives before it.
             const activeIntervals = intervals;
             const totalSplats = positions.length / 4;
+            // Index to use when 16-aligning the sorted output needs extra filler entries. Real data never
+            // lives at or past `vertexCount` — with or without range filtering — and `_getTextureSize`
+            // (gaussianSplattingMeshBase.pure.ts) always reserves at least one empty slot there, even when
+            // `vertexCount` would otherwise exactly fill every texture row.
+            const emptySplatIndex = vertexCount;
             let renderSplatCount = totalSplats;
             if (activeIntervals) {
                 renderSplatCount = 0;
@@ -260,9 +268,13 @@ export const GaussianSplattingSortWorker = function (self: Worker) {
                         outIndices[2 * dest] = sortSourceIndices[k];
                     }
 
-                    // Pad the remainder up to the 16-multiple with the reserved (invisible) splat index 0.
+                    // Pad the remainder up to the 16-multiple with a guaranteed-empty index (see
+                    // emptySplatIndex above) — NOT splat index 0, which is just the first real splat of
+                    // whatever source data was loaded. Padding with a real, opaque splat draws it an extra
+                    // 15 times at the very end of the (back-to-front) draw order — i.e. always on top,
+                    // regardless of camera.
                     for (let dest = renderSplatCount; dest < vertexCountPadded; dest++) {
-                        outIndices[2 * dest] = 0;
+                        outIndices[2 * dest] = emptySplatIndex;
                     }
                 } else {
                     // ===== Legacy comparison sort: pack (index, ~depthBits) into each 64-bit lane and sort it =====
@@ -279,9 +291,10 @@ export const GaussianSplattingSortWorker = function (self: Worker) {
                                 indices[2 * writeIndex++] = sourceIndex;
                             }
                         }
-                        // Pad up to a multiple of 16 with the reserved (invisible) splat index 0.
+                        // Pad up to a multiple of 16. Splat index 0 isn't guaranteed invisible (see the
+                        // counting-sort branch above) — use the same guaranteed-empty index instead.
                         for (; writeIndex < vertexCountPadded; writeIndex++) {
-                            indices[2 * writeIndex] = 0;
+                            indices[2 * writeIndex] = emptySplatIndex;
                         }
                     } else {
                         for (let j = 0; j < vertexCountPadded; j++) {


### PR DESCRIPTION
The depth-sort worker draws splats in fixed batches of 16 per GPU instance, so whenever the active splat count isn't a multiple of 16, the sorted draw-order buffer pads out the remainder. That padding was hardcoded to splat index `0` — not a reserved/invisible slot, just the first real splat of whatever data was loaded. Padding with it draws that real splat an extra ~15 times at the very end of the back-to-front draw order, i.e. always on top, regardless of camera. Any asset whose active splat count isn't a multiple of 16 hits this.

### Fix

- Send the sort worker the real (unpadded) `vertexCount` alongside `positions` (one call site, `_instantiateWorker`, was missing it).
- `_getTextureSize` now guarantees the splat atlas always has at least one provably-zeroed slot past `vertexCount`, even when a mesh's splat count exactly fills the texture.
- The sort worker pads with that genuinely-empty `vertexCount` index instead of `0`, in both the counting-sort and legacy comparison-sort paths.

### When it triggers

Any Gaussian Splatting mesh whose active splat count (full load, or after range filtering/culling) isn't a multiple of 16 — a handful of splats appear permanently stuck in front of the model, independent of viewing angle.