### PR TITLE
Fix native tests artifact name conflict on job rerun

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -947,7 +947,7 @@ jobs:
             condition: not(canceled())
             inputs:
                 targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\Results"
-                artifact: "native-rendered-pictures"
+                artifact: "native-rendered-pictures-$(System.JobAttempt)"
                 publishLocation: "pipeline"
 
           - task: PublishPipelineArtifact@1
@@ -955,7 +955,7 @@ jobs:
             condition: failed()
             inputs:
                 targetPath: "$(Build.SourcesDirectory)\\..\\BabylonNativeNightlyPlayground\\Errors"
-                artifact: "native-error-pictures"
+                artifact: "native-error-pictures-$(System.JobAttempt)"
                 publishLocation: "pipeline"
 
     # ============================================================================


### PR DESCRIPTION
## Problem

CI on the `NativeTests` job fails with:

```
##[error]Artifact native-rendered-pictures already exists for build 57242.
```

`PublishPipelineArtifact@1` publishes artifacts scoped to the whole build/run and has no overwrite option (unlike the older `PublishBuildArtifacts@1`). If the `NativeTests` job is rerun within the same build (e.g. via "Rerun failed jobs" in the Azure DevOps UI, or an automatic retry), the second attempt tries to publish `native-rendered-pictures` / `native-error-pictures` again under the same build ID and Azure DevOps rejects it because those artifact names already exist.

This is an Azure DevOps platform limitation, not something configurable from project settings — it has to be handled in the pipeline YAML.

## Fix

Scope both artifact names by `$(System.JobAttempt)`, which increments each time the job is rerun within the same build. This mirrors an existing pattern already used elsewhere in this pipeline for BrowserStack local identifiers (`es6vis-$(Build.BuildId)-$(System.JobAttempt)`).

- `native-rendered-pictures` → `native-rendered-pictures-$(System.JobAttempt)`
- `native-error-pictures` → `native-error-pictures-$(System.JobAttempt)`

No downstream job consumes these artifacts by their fixed name, so this rename is safe.

## Testing

This is a CI pipeline YAML change; validated by reading the pipeline definition and confirming the artifact naming pattern used elsewhere in the same file (`$(System.JobAttempt)`). No app code changed, so no unit/build/lint validation applies.