### PR TITLE
Fix one-frame render flash when recreating a mesh in the same tick

### DIFF
--- a/packages/dev/core/src/Meshes/abstractMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.pure.ts
@@ -2437,7 +2437,11 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
 
         // SubMeshes
         if (this.getClassName() !== "InstancedMesh" || this.getClassName() !== "InstancedLinesMesh") {
-            this.releaseSubMeshes(true);
+            // Defer the effect release to the next frame so that a mesh recreated in the same tick with the same
+            // (or a cloned) material can reuse the still-cached compiled effect instead of triggering a recompile
+            // (which would skip a frame and cause a visible flash). During scene teardown we release immediately,
+            // since there may be no further frame to run the deferred disposal.
+            this.releaseSubMeshes(scene._isDisposing);
         }
 
         // Query

--- a/packages/dev/core/src/Meshes/abstractMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/abstractMesh.pure.ts
@@ -2436,13 +2436,11 @@ export abstract class AbstractMesh extends TransformNode implements IDisposable,
         }
 
         // SubMeshes
-        if (this.getClassName() !== "InstancedMesh" || this.getClassName() !== "InstancedLinesMesh") {
-            // Defer the effect release to the next frame so that a mesh recreated in the same tick with the same
-            // (or a cloned) material can reuse the still-cached compiled effect instead of triggering a recompile
-            // (which would skip a frame and cause a visible flash). During scene teardown we release immediately,
-            // since there may be no further frame to run the deferred disposal.
-            this.releaseSubMeshes(scene._isDisposing);
-        }
+        // Defer the effect release to the next frame so that a mesh recreated in the same tick with the same
+        // (or a cloned) material can reuse the still-cached compiled effect instead of triggering a recompile
+        // (which would skip a frame and cause a visible flash). During scene teardown we release immediately,
+        // since there may be no further frame to run the deferred disposal.
+        this.releaseSubMeshes(scene._isDisposing);
 
         // Query
         const engine = scene.getEngine();

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -1762,8 +1762,9 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     private _isDisposed = false;
     /**
      * @internal
-     * True while the scene is being disposed. Used so that resources released during teardown (e.g. mesh effects)
-     * are freed immediately instead of being deferred to the next frame, which may never happen once rendering stops.
+     * Set to true once scene disposal has begun (it stays true afterwards). Used so that resources released during
+     * teardown (e.g. mesh effects) are freed immediately instead of being deferred to the next frame, which may never
+     * happen once rendering stops.
      */
     public _isDisposing = false;
     private _isReadyChecks: { isReady(): boolean }[] = [];

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -1760,6 +1760,12 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     /** @internal */
     public _pendingData = [] as any[];
     private _isDisposed = false;
+    /**
+     * @internal
+     * True while the scene is being disposed. Used so that resources released during teardown (e.g. mesh effects)
+     * are freed immediately instead of being deferred to the next frame, which may never happen once rendering stops.
+     */
+    public _isDisposing = false;
     private _isReadyChecks: { isReady(): boolean }[] = [];
 
     /**
@@ -5736,6 +5742,8 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         if (this.isDisposed) {
             return;
         }
+
+        this._isDisposing = true;
 
         this.beforeRender = null;
         this.afterRender = null;


### PR DESCRIPTION
## Problem

Reported on the forum: [Objects are not rendered the frame they are created](https://forum.babylonjs.com/t/objects-are-not-rendered-the-frame-they-are-created/63878).

When a mesh is recreated in the same tick using the common pattern:

```js
const s2 = MeshBuilder.CreateSphere("sphere2", {...}, scene);
s2.material = mat;      // material assignment is lazy — the effect isn't referenced yet
sphere.dispose();       // drops the shared effect's refcount to 0 → evicts the cached GL program
sphere = s2;
```

the recreated mesh is skipped for one frame, producing a visible flash.

## Root cause

Since the `DrawWrapper` weak-ref change (v7.35.2), `DrawWrapper.dispose()` disposes the ref-counted compiled `Effect`. Effects are cached in `engine._compiledEffects` keyed by shader source + defines. Because assigning a material is lazy (the effect isn't referenced until the next `isReadyForSubMesh`), disposing the old mesh drops the shared effect's refcount to 0 and evicts the cached GL program **before** the new mesh claims it.

The next frame has to build a *fresh* effect. With synchronous shader compilation that effect is ready the same frame (no flash), but under **async/parallel shader compilation** (or a cloned material, whose `_shadersLoaded` resets to `false`) it isn't ready that frame — so the submesh is skipped and the mesh flashes.

A deferred-dispose safeguard was already added in #15910 for material swaps (`resetDrawCache`), giving user code a chance to reuse the effect on the next frame. But `AbstractMesh.dispose()` called `releaseSubMeshes(true)` (**immediate**), which bypassed that safeguard.

## Fix

- `AbstractMesh.dispose()` now defers the effect release (`immediate = false`) so a mesh recreated in the same tick can reuse the still-cached compiled effect, consistent with the existing deferred material-swap path.
- To avoid leaking effects during teardown (where no future frame runs the deferred disposal), a new internal `Scene._isDisposing` flag is set at the start of `Scene.dispose()`, and mesh disposal releases **immediately** while the scene is being torn down. Engine disposal already force-frees all effects via `releaseEffects()` before disposing its scenes, so the deferred path is a safe no-op there too.

Net diff is 13 lines across 2 files.

## Validation

- Headless draw-call harness (swiftshader) measuring drawn frames across the recreate, on a local build of `@babylonjs/core`:
  - Before: `missedFrames = 1` (flash) for parallel-compile and cloned-material cases.
  - After: `missedFrames = 0` for all four combinations (parallel on/off × reuse/clone).
- Scene-dispose leak check: `engine._compiledEffects` goes 1 → 0 on `scene.dispose()` (effects still freed immediately during teardown — no leak).
- `npm run test:unit`: 4306 passed, 0 failures.
- Formatting, lint (0 errors), and `build:source` all clean.