### PR TITLE
fix(physics): correct inverse inertia tensor rows in PhysicsCharacterController

### DIFF
--- a/packages/dev/core/src/Physics/v2/characterController.ts
+++ b/packages/dev/core/src/Physics/v2/characterController.ts
@@ -1887,9 +1887,9 @@ export class PhysicsCharacterController {
         const ir = invOrientation.getRowToRef(0, TmpVectors.Vector4[0]);
         it.setRowFromFloats(0, mp.inertia.x * ir.x, mp.inertia.x * ir.y, mp.inertia.x * ir.z, 0);
         invOrientation.getRowToRef(1, ir);
-        it.setRowFromFloats(0, mp.inertia.y * ir.x, mp.inertia.y * ir.y, mp.inertia.y * ir.z, 0);
+        it.setRowFromFloats(1, mp.inertia.y * ir.x, mp.inertia.y * ir.y, mp.inertia.y * ir.z, 0);
         invOrientation.getRowToRef(2, ir);
-        it.setRowFromFloats(0, mp.inertia.z * ir.x, mp.inertia.z * ir.y, mp.inertia.z * ir.z, 0);
+        it.setRowFromFloats(2, mp.inertia.z * ir.x, mp.inertia.z * ir.y, mp.inertia.z * ir.z, 0);
         invOrientation.multiplyToRef(it, this._tmpMatrix);
         return this._tmpMatrix;
     }


### PR DESCRIPTION
## Problem

Fixes #18736.

`PhysicsCharacterController._getInverseInertiaWorld()` built the inverse-inertia tensor incorrectly: all three inertia components were written to **row 0** of the working matrix.

```ts
const it = TmpVectors.Matrix[1];
it.setRowFromFloats(0, mp.inertia.x * ...); // row 0
it.setRowFromFloats(0, mp.inertia.y * ...); // should be row 1
it.setRowFromFloats(0, mp.inertia.z * ...); // should be row 2
```

Because `it` is the shared scratch matrix `TmpVectors.Matrix[1]`, rows 1 and 2 retained stale values left by whatever unrelated code last used that temp. This made the impulse the character applies to dynamic bodies depend on prior matrix math — e.g. loading a skinned glTF model (which processes inverse-bind matrices) changed the leftover temp contents, causing the reporter's character to sometimes fail to push a box, or to launch it across the scene.

## Fix

Write each inertia component to its correct row (0, 1, 2). This matches the workaround verified by the issue reporter across every tested model.

The result is consumed only via `Vector3.TransformNormalToRef` (upper-left 3×3), and `invOrientation` is a pure rotation with a zero translation column, so no stale temp data can leak into the result once rows 0–2 are correct.

## Testing

Minimal one-line-per-row index correction; no behavioral change other than fixing the tensor construction.