### PR TITLE
chore(deps): npm audit fix — resolve all security advisories (0 vulnerabilities)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,6 +166,7 @@
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -1980,6 +1981,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -2028,6 +2030,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -2130,6 +2133,7 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -2186,6 +2190,7 @@
             "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
@@ -2197,6 +2202,7 @@
             "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -2813,9 +2819,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2981,6 +2987,7 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
             "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.5",
                 "@floating-ui/utils": "^0.2.11"
@@ -2997,6 +3004,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-resize-handle/-/react-resize-handle-0.8.4.tgz",
             "integrity": "sha512-g3cJ3q+nn32BB5b5mEtuSh6sGNYOGcKvRxQljvfg+UAhStceCPZYRM8gF+HswPPhQ0LUR6h780WMe072ndR6Lw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/react-utilities": "^9.16.0",
                 "@swc/helpers": "~0.5.11"
@@ -3014,6 +3022,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-1.0.0.tgz",
             "integrity": "sha512-z1KE+OyCTICkOeyCmFI0nlNRTPAhCv2ZhCIDjebnlkNQMIcMtTrI/ogy4Fu8UgbFP+WReE50JeduLtM+Sst+1A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.0.29",
                 "@fluentui/react-utilities": "^9.16.0",
@@ -3343,6 +3352,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.4.tgz",
             "integrity": "sha512-/8IxyJiQ7J0R3rF/T6InuVffT72dJjt506WaAFt1ndnpEAu2zpjYD6Vjhv4+Xvye20ix2j4dHDs6OUXS/vlrpg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/react-accordion": "^9.12.1",
                 "@fluentui/react-alert": "9.0.0-beta.142",
@@ -3532,6 +3542,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.333.tgz",
             "integrity": "sha512-HvS5kKw9tGweI3Poy6OGAiFqrt6HGElO46DFhNBeoIQRK/q35mZ2ep0u762MFuvOfLX3bVGSB8frORFTjh1E7A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@griffel/react": "^1.6.1",
                 "tslib": "^2.1.0"
@@ -3784,6 +3795,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
             "integrity": "sha512-9aNzHAHNdfbH/8/mYGy5YVrUOGnpiru3YrqQ7KhCRWXvlce7yV3WF5CzN1g/uNh3MFmKGwQeW4ui6xJOfEaI4Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/react-motion": "*",
                 "@fluentui/react-utilities": "*",
@@ -4076,6 +4088,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
             "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/react-theme": "^9.2.1",
                 "@swc/helpers": "^0.5.1"
@@ -4536,6 +4549,7 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
             "integrity": "sha512-lLWhnfMVEu+cWx3o9uTA5sDwo4U9PnpDJGVtheZ1bOCdh1YiQsJxeFM7n6nLE72UK2w+ATkGZQPYZA4QW1JLPQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
                 "@fluentui/react-shared-contexts": "^9.26.2",
@@ -4588,6 +4602,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
             "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@fortawesome/fontawesome-common-types": "6.7.2"
             },
@@ -4612,6 +4627,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
             "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
             "license": "(CC-BY-4.0 AND MIT)",
+            "peer": true,
             "dependencies": {
                 "@fortawesome/fontawesome-common-types": "6.7.2"
             },
@@ -4624,6 +4640,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.5.0.tgz",
             "integrity": "sha512-63mlRr6fiBbJ0wjr1Cf6dsDGtP2lNvk9lnatKgxs/fIkhslsZT291hIUzJkuUkI9yr69ZvWnWfgb2qXm4QyVaA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -4690,12 +4707,12 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+            "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -5753,12 +5770,12 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
             "license": "MIT",
             "dependencies": {
-                "@hono/node-server": "^1.19.9",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
@@ -5860,9 +5877,9 @@
             }
         },
         "node_modules/@nx/nx-darwin-arm64": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.7.tgz",
-            "integrity": "sha512-HGu8Bc3DzmIFeKHzIEDBDScgI8/hOjVIj/EzJBE5289dUf+CQ5OSXc6kw2NL9SiCMAPKa0clqcJgLJLqP5t/DQ==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-22.7.8.tgz",
+            "integrity": "sha512-IM1geDyWPFsS565de9dByYNZ5I3j8FQZvNUp9LIYw1dNu70sCWbAT0glw0anholOwlAb7JWEscoUeV7ouRBW0A==",
             "cpu": [
                 "arm64"
             ],
@@ -5874,9 +5891,9 @@
             ]
         },
         "node_modules/@nx/nx-darwin-x64": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.7.tgz",
-            "integrity": "sha512-J7z/Hh+bEKB9xvHdmtO5sK7YytFx8Ry6YpvYI2PoSl2/xDBca7q69fzHKTtm4S/8FvA1Qoi/m//JTIMQUB7cKA==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-22.7.8.tgz",
+            "integrity": "sha512-X/AyooJCmAwHyp9f//bspkAmtaPsv2lPEKe6OiOScsyxJITP4nw+rOfIAJ4Ar64WQcMAY8WLP+ys4ah0K6DZSw==",
             "cpu": [
                 "x64"
             ],
@@ -5888,9 +5905,9 @@
             ]
         },
         "node_modules/@nx/nx-freebsd-x64": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.7.tgz",
-            "integrity": "sha512-9H4bbI3fBr8Ct+6xmF6dqDKEvER60XV3tanXTSVtUBxyAVw3cPmRh7aMAu5PNyN+ewzRAJvV6KI4Rx1kA+s9jw==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-22.7.8.tgz",
+            "integrity": "sha512-mgdqiFag8txon4XugDtNj+hq+X9Whn8LBMuqwJSez93L1fralzpQFSUip7XnE7ejQRr5Zewg3BFscGlsk8Cy3A==",
             "cpu": [
                 "x64"
             ],
@@ -5902,9 +5919,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-arm-gnueabihf": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.7.tgz",
-            "integrity": "sha512-QsGaaZ7PI18c7rFgvUe0F0UYa5oErSKY6Yff6HVXy2zAAWluM4F/TXIRYbtXlvSq++CHhFXxk29Xb3+/zGR/rg==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-22.7.8.tgz",
+            "integrity": "sha512-g7ojIloHGFI7wuMnUdg7io42EL7C7ae4zAolNVj7eXZM54amn3qoNjwbyqaVbBQvUNRiAKJizGyn1IhKpzvG9A==",
             "cpu": [
                 "arm"
             ],
@@ -5916,9 +5933,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-arm64-gnu": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz",
-            "integrity": "sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.8.tgz",
+            "integrity": "sha512-Kws8e7W4epfqpTWYaV7KLKaj33o+9JtJa2rErx/XFTtMXhfVzOs5hC4oIrZsYpgk1DuT0APp7UDvX06q2kdAVQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5930,9 +5947,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-arm64-musl": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz",
-            "integrity": "sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.8.tgz",
+            "integrity": "sha512-fpnyVFL+mSqLdKBPk8+n/rHUEXiem7Xwr9cIOd2Dd5zxQ5wcwj4qSYTNRsBPI2qDFo3esHliwaoFJZULbTHldw==",
             "cpu": [
                 "arm64"
             ],
@@ -5944,9 +5961,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-x64-gnu": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz",
-            "integrity": "sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.8.tgz",
+            "integrity": "sha512-KRbkSthClEwkbpt/LLJmBJhIOvOsyrp9OICisF9p3mOODjaxAuYmyOgrVreg09BT2F4hXN3JXpvt9eIZpTCRsw==",
             "cpu": [
                 "x64"
             ],
@@ -5958,9 +5975,9 @@
             ]
         },
         "node_modules/@nx/nx-linux-x64-musl": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz",
-            "integrity": "sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.8.tgz",
+            "integrity": "sha512-pdPMWko1yZI5ZNI6/t2Y5rQPGgV/ah5DW+mlHo2aFKav4lnxvgisEh9e4HtOsYBfK/9PyYZ5u3M9hLSaMiJ75w==",
             "cpu": [
                 "x64"
             ],
@@ -5972,9 +5989,9 @@
             ]
         },
         "node_modules/@nx/nx-win32-arm64-msvc": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz",
-            "integrity": "sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.8.tgz",
+            "integrity": "sha512-yYDu3pj7AXu7LtN/T/bA4TMWWWbmvEE4wa8UW8ZU5JeWYblyXQA7HyYpPAb4fLzCtHb/dIrNDghVBRIeAAcnSw==",
             "cpu": [
                 "arm64"
             ],
@@ -5986,9 +6003,9 @@
             ]
         },
         "node_modules/@nx/nx-win32-x64-msvc": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.7.tgz",
-            "integrity": "sha512-AHVjXkreXjVKAKpMNCsF5nQC/et6lpQcERRm8AYOCncI59hTjYOLpdCMBLrIHA3hgc6SUYU8n5+tMAbv7zXXiQ==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-22.7.8.tgz",
+            "integrity": "sha512-cSr0qMt/GgM2aOBFsapxllnIv55j0gAz/6eWvqEOx5sS8d3X1G0IgazZnPbjW2c8gfSYaBZ9UmYnfapWIO/jqg==",
             "cpu": [
                 "x64"
             ],
@@ -7554,6 +7571,7 @@
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -7848,7 +7866,8 @@
             "version": "0.7.54",
             "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
             "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
@@ -7956,6 +7975,7 @@
             "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
@@ -7982,6 +8002,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -7992,6 +8013,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -8049,6 +8071,7 @@
             "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
                 "@typescript-eslint/scope-manager": "8.65.0",
@@ -8078,6 +8101,7 @@
             "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.65.0",
                 "@typescript-eslint/types": "8.65.0",
@@ -8318,6 +8342,7 @@
             "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.3",
@@ -8739,6 +8764,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8813,6 +8839,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -9806,15 +9833,15 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -9850,6 +9877,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -10969,6 +10997,7 @@
             "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
             "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "graphlib": "^2.1.8",
                 "lodash": "^4.17.15"
@@ -11275,7 +11304,8 @@
             "version": "0.0.1521046",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
             "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/diff": {
             "version": "4.0.4",
@@ -11480,7 +11510,8 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/embla-carousel-autoplay": {
             "version": "8.6.0",
@@ -11881,6 +11912,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
             "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
             "license": "MIT",
+            "peer": true,
             "workspaces": [
                 "packages/*"
             ],
@@ -12220,9 +12252,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12330,9 +12362,9 @@
             "license": "MIT"
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13664,6 +13696,7 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
             "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -16417,9 +16450,9 @@
             }
         },
         "node_modules/nx": {
-            "version": "22.7.7",
-            "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.7.tgz",
-            "integrity": "sha512-T4hq5PMAPXeqAmm0Y6Gr5ApeI2I+T8MflWEKN1cZ12R1Rnq2uEpfOgiwAZ74bHONmNgv6LRG9P9+x8SX2tDIlw==",
+            "version": "22.7.8",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-22.7.8.tgz",
+            "integrity": "sha512-ceEhmaGCvY7oi7L7G/Nm/UZSnbfwaJxU1XbDLro7CTmVcnrmxAnxExCp0J/Tpf1xQaMZtwxgV7QATdKA/7vLQw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -16432,16 +16465,17 @@
                 "@tybys/wasm-util": "0.9.0",
                 "@yarnpkg/lockfile": "1.1.0",
                 "@zkochan/js-yaml": "0.0.7",
+                "agent-base": "6.0.2",
                 "ansi-colors": "4.1.3",
                 "ansi-regex": "5.0.1",
                 "ansi-styles": "4.3.0",
                 "argparse": "2.0.1",
                 "asynckit": "0.4.0",
-                "axios": "1.16.0",
+                "axios": "1.18.1",
                 "balanced-match": "4.0.3",
                 "base64-js": "1.5.1",
                 "bl": "4.1.0",
-                "brace-expansion": "5.0.6",
+                "brace-expansion": "5.0.8",
                 "buffer": "5.7.1",
                 "call-bind-apply-helpers": "1.0.2",
                 "chalk": "4.1.2",
@@ -16452,6 +16486,7 @@
                 "color-convert": "2.0.1",
                 "color-name": "1.1.4",
                 "combined-stream": "1.0.8",
+                "debug": "4.4.3",
                 "defaults": "1.0.4",
                 "define-lazy-prop": "2.0.0",
                 "delayed-stream": "1.0.0",
@@ -16482,6 +16517,7 @@
                 "has-symbols": "1.1.0",
                 "has-tostringtag": "1.0.2",
                 "hasown": "2.0.4",
+                "https-proxy-agent": "5.0.1",
                 "ieee754": "1.2.1",
                 "ignore": "7.0.5",
                 "inherits": "2.0.4",
@@ -16500,6 +16536,7 @@
                 "mimic-fn": "2.1.0",
                 "minimatch": "10.2.5",
                 "minimist": "1.2.8",
+                "ms": "2.1.3",
                 "npm-run-path": "4.0.1",
                 "once": "1.4.0",
                 "onetime": "5.1.2",
@@ -16540,16 +16577,16 @@
                 "nx-cloud": "dist/bin/nx-cloud.js"
             },
             "optionalDependencies": {
-                "@nx/nx-darwin-arm64": "22.7.7",
-                "@nx/nx-darwin-x64": "22.7.7",
-                "@nx/nx-freebsd-x64": "22.7.7",
-                "@nx/nx-linux-arm-gnueabihf": "22.7.7",
-                "@nx/nx-linux-arm64-gnu": "22.7.7",
-                "@nx/nx-linux-arm64-musl": "22.7.7",
-                "@nx/nx-linux-x64-gnu": "22.7.7",
-                "@nx/nx-linux-x64-musl": "22.7.7",
-                "@nx/nx-win32-arm64-msvc": "22.7.7",
-                "@nx/nx-win32-x64-msvc": "22.7.7"
+                "@nx/nx-darwin-arm64": "22.7.8",
+                "@nx/nx-darwin-x64": "22.7.8",
+                "@nx/nx-freebsd-x64": "22.7.8",
+                "@nx/nx-linux-arm-gnueabihf": "22.7.8",
+                "@nx/nx-linux-arm64-gnu": "22.7.8",
+                "@nx/nx-linux-arm64-musl": "22.7.8",
+                "@nx/nx-linux-x64-gnu": "22.7.8",
+                "@nx/nx-linux-x64-musl": "22.7.8",
+                "@nx/nx-win32-arm64-msvc": "22.7.8",
+                "@nx/nx-win32-x64-msvc": "22.7.8"
             },
             "peerDependencies": {
                 "@swc-node/register": "^1.11.1",
@@ -16601,6 +16638,19 @@
             "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/nx/node_modules/brace-expansion": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
             "engines": {
                 "node": "20 || >=22"
             }
@@ -17817,6 +17867,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
@@ -18474,6 +18525,7 @@
             "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -18807,6 +18859,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -18819,6 +18872,7 @@
             "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.0.1.tgz",
             "integrity": "sha512-qUqVY+KlG4ZX3eSFTcOHU2HcVa6B9x6bKmyDfji8AkOl15/3gkbEyIARCyJVByFjTjwUPF1VnRiEcvVHYw8APA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
                 "@react-dnd/shallowequal": "^2.0.0",
@@ -18849,6 +18903,7 @@
             "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-15.0.1.tgz",
             "integrity": "sha512-DoigPaIAs70DRy4qd+i1U5+wLyyhtiuydqHuhXTObxjQzimG70UN7L3Qzx/3SXYQroOIj9fEOXvb9yzMsD2TMA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
                 "dnd-core": "15.0.1"
@@ -18859,6 +18914,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -19199,6 +19255,7 @@
             "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@oxc-project/types": "=0.138.0",
                 "@rolldown/pluginutils": "^1.0.0"
@@ -19233,6 +19290,7 @@
             "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.9"
             },
@@ -19665,6 +19723,7 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -19812,9 +19871,9 @@
             "license": "MIT"
         },
         "node_modules/serve-handler/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -21312,6 +21371,7 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -21590,6 +21650,7 @@
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -21861,6 +21922,7 @@
             "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -21954,6 +22016,7 @@
             "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.3",
                 "@vitest/mocker": "4.1.3",
@@ -22096,6 +22159,7 @@
             "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
@@ -22662,6 +22726,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }


### PR DESCRIPTION
## Summary
Runs `npm audit fix` to resolve **all** current npm audit findings. `npm audit` now reports **0 vulnerabilities** (was 4: 2 high, 2 moderate).

Lockfile-only change — root `package.json` is untouched.

## Findings resolved
| Package | Severity | Advisory | Fix |
|---|---|---|---|
| `brace-expansion` | high | GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg (DoS) | 1.1.16 → 1.1.18, 5.0.6 → 5.0.9 |
| `@hono/node-server` (via `@modelcontextprotocol/sdk`) | moderate | GHSA-frvp-7c67-39w9 (path traversal) | 1.19.14 → 2.0.12 |
| `@modelcontextprotocol/sdk` | (dep bump) | — | 1.29.0 → 1.30.0 |
| `nx` (transitive brace-expansion) | high | — | brace-expansion bumped |

No breaking-change bumps were forced (`npm audit fix` without `--force`).

## Reproduce
```
npm install
npm audit        # before: 4 vulnerabilities
npm audit fix
npm audit        # after: found 0 vulnerabilities
```

## Verification
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm install` succeeds and produces a stable lockfile
- [ ] CI green

_Generated by the morning-dev-briefing skill._