### PR TITLE
chore(deps): pin @adobe/spz to exact 0.2.0 in @dev/loaders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,9 +69,9 @@
             "license": "MIT"
         },
         "node_modules/@adobe/spz": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@adobe/spz/-/spz-0.2.2.tgz",
-            "integrity": "sha512-KUCw5R52rCBnfyvOOIa9nUQGfR6TEcHjYzuWDYRGb1fpkpnkci6VXFqCx/xFJ1yEN7V5gc9YxU2zIY6sEjIbhw==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/@adobe/spz/-/spz-0.2.0.tgz",
+            "integrity": "sha512-k+iWAzSm9F2MK/tRJXHnicpC79IB26L7oJkweFaVbrrbmMpI+haet1CRXhPPFHHNXzG3NLuTQH/fHQjpvZRBZg==",
             "dev": true,
             "license": "ISC"
         },
@@ -22834,7 +22834,7 @@
             "name": "@dev/loaders",
             "version": "1.0.0",
             "devDependencies": {
-                "@adobe/spz": "^0.2.0",
+                "@adobe/spz": "0.2.0",
                 "@dev/core": "^1.0.0"
             }
         },

--- a/packages/dev/loaders/package.json
+++ b/packages/dev/loaders/package.json
@@ -19,7 +19,7 @@
     },
     "devDependencies": {
         "@dev/core": "^1.0.0",
-        "@adobe/spz": "^0.2.0"
+        "@adobe/spz": "0.2.0"
     },
     "sideEffects": true,
     "dependencies": {}


### PR DESCRIPTION
## What

Pins the `@adobe/spz` devDependency in `@dev/loaders` from `^0.2.0` to an exact `0.2.0`.

## Why

`@adobe/spz` is a **type-only, dev-only** dependency. `packages/dev/loaders/src/SPLAT/spz.ts` imports it purely for types:

```ts
import { type GaussianCloud, type SpzModule, type SpzExtensionSafeOrbitCameraAdobe } from "@adobe/spz";
```

Nothing from the npm package is bundled or shipped — at runtime the WASM module is fetched dynamically from a CDN via `_LoadScriptModuleAsync`, and `generateDeclaration.ts` already collapses `@adobe` types to `any` in the published `.d.ts` bundles.

Under `^0.2.0` the resolved version silently floated to `0.2.2`. Pinning makes the type surface deterministic.

## Is 0.2.0 sufficient?

Yes. Diffing the published `dist/spz.d.ts` across versions:

| Range | Type changes |
| --- | --- |
| 0.2.0 → 0.2.1 | none (byte-identical) |
| 0.2.1 → 0.2.2 | adds `SpzExtensionCoordinateSystemAdobe`, `SPZ_ADOBE_coordinate_system`, and 8 new `CoordinateSystem` enum members |

The loaders package uses none of the 0.2.2 additions. Everything it touches — `SpzModule.loadSpzFromBuffer`, `CoordinateSystem.RUB`, `GaussianCloud`, and the `SpzExtensionSafeOrbitCameraAdobe` fields — is present and unchanged in 0.2.0.

## Note on the runtime version

The default `spzLibraryUrl` in `splatFileLoader.pure.ts` still points at `unpkg.com/@adobe/spz@0.2.2/dist/spz.js`, and is intentionally left alone. 0.2.2 is what users actually download and it carries the functional additions (SH4 / extension support) the loader depends on; 0.2.0's `spz.js` is 299 KB vs 851 KB. Since the 0.2.0 type surface is a strict subset of 0.2.2, compiling against 0.2.0 while running 0.2.2 is sound.

## Testing

- `npm ci` succeeds → lockfile is in sync with the manifest, `@adobe/spz@0.2.0` installs.
- Standalone `tsc --noEmit --strict` over the full `@adobe/spz` API surface used by the SPLAT loader passes against the 0.2.0 typings.
- `prettier --check` clean on both changed files.

The lockfile was hand-edited rather than regenerated: locally available npm versions rewrite ~50 unrelated `"peer": true` entries, which would have buried the real change in noise.