### PR TITLE
chore(deps): npm audit fix — resolve ip-address and postcss advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -166,7 +166,6 @@
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -1981,7 +1980,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -2030,7 +2028,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -2133,7 +2130,6 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -2190,7 +2186,6 @@
             "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
@@ -2202,7 +2197,6 @@
             "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -2987,7 +2981,6 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
             "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.5",
                 "@floating-ui/utils": "^0.2.11"
@@ -3004,7 +2997,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-resize-handle/-/react-resize-handle-0.8.4.tgz",
             "integrity": "sha512-g3cJ3q+nn32BB5b5mEtuSh6sGNYOGcKvRxQljvfg+UAhStceCPZYRM8gF+HswPPhQ0LUR6h780WMe072ndR6Lw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fluentui/react-utilities": "^9.16.0",
                 "@swc/helpers": "~0.5.11"
@@ -3022,7 +3014,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui-contrib/react-virtualizer/-/react-virtualizer-1.0.0.tgz",
             "integrity": "sha512-z1KE+OyCTICkOeyCmFI0nlNRTPAhCv2ZhCIDjebnlkNQMIcMtTrI/ogy4Fu8UgbFP+WReE50JeduLtM+Sst+1A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fluentui/react-jsx-runtime": "^9.0.29",
                 "@fluentui/react-utilities": "^9.16.0",
@@ -3352,7 +3343,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.74.4.tgz",
             "integrity": "sha512-/8IxyJiQ7J0R3rF/T6InuVffT72dJjt506WaAFt1ndnpEAu2zpjYD6Vjhv4+Xvye20ix2j4dHDs6OUXS/vlrpg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fluentui/react-accordion": "^9.12.1",
                 "@fluentui/react-alert": "9.0.0-beta.142",
@@ -3542,7 +3532,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.333.tgz",
             "integrity": "sha512-HvS5kKw9tGweI3Poy6OGAiFqrt6HGElO46DFhNBeoIQRK/q35mZ2ep0u762MFuvOfLX3bVGSB8frORFTjh1E7A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@griffel/react": "^1.6.1",
                 "tslib": "^2.1.0"
@@ -3795,7 +3784,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.6.tgz",
             "integrity": "sha512-9aNzHAHNdfbH/8/mYGy5YVrUOGnpiru3YrqQ7KhCRWXvlce7yV3WF5CzN1g/uNh3MFmKGwQeW4ui6xJOfEaI4Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fluentui/react-motion": "*",
                 "@fluentui/react-utilities": "*",
@@ -4088,7 +4076,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
             "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fluentui/react-theme": "^9.2.1",
                 "@swc/helpers": "^0.5.1"
@@ -4549,7 +4536,6 @@
             "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
             "integrity": "sha512-lLWhnfMVEu+cWx3o9uTA5sDwo4U9PnpDJGVtheZ1bOCdh1YiQsJxeFM7n6nLE72UK2w+ATkGZQPYZA4QW1JLPQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fluentui/keyboard-keys": "^9.0.8",
                 "@fluentui/react-shared-contexts": "^9.26.2",
@@ -4602,7 +4588,6 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
             "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fortawesome/fontawesome-common-types": "6.7.2"
             },
@@ -4627,7 +4612,6 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
             "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
             "license": "(CC-BY-4.0 AND MIT)",
-            "peer": true,
             "dependencies": {
                 "@fortawesome/fontawesome-common-types": "6.7.2"
             },
@@ -4640,7 +4624,6 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.5.0.tgz",
             "integrity": "sha512-63mlRr6fiBbJ0wjr1Cf6dsDGtP2lNvk9lnatKgxs/fIkhslsZT291hIUzJkuUkI9yr69ZvWnWfgb2qXm4QyVaA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -7571,7 +7554,6 @@
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -7866,8 +7848,7 @@
             "version": "0.7.54",
             "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
             "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/deep-eql": {
             "version": "4.0.2",
@@ -7975,7 +7956,6 @@
             "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
@@ -8002,7 +7982,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
             "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -8013,7 +7992,6 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
             "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -8071,7 +8049,6 @@
             "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
                 "@typescript-eslint/scope-manager": "8.65.0",
@@ -8101,7 +8078,6 @@
             "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.65.0",
                 "@typescript-eslint/types": "8.65.0",
@@ -8342,7 +8318,6 @@
             "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
                 "@vitest/utils": "4.1.3",
@@ -8764,7 +8739,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8839,7 +8813,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -9877,7 +9850,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -10997,7 +10969,6 @@
             "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
             "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graphlib": "^2.1.8",
                 "lodash": "^4.17.15"
@@ -11304,8 +11275,7 @@
             "version": "0.0.1521046",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1521046.tgz",
             "integrity": "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w==",
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
             "version": "4.0.4",
@@ -11510,8 +11480,7 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/embla-carousel-autoplay": {
             "version": "8.6.0",
@@ -11912,7 +11881,6 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
             "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
             "license": "MIT",
-            "peer": true,
             "workspaces": [
                 "packages/*"
             ],
@@ -13696,7 +13664,6 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
             "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -13977,9 +13944,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -17848,9 +17815,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.22",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-            "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+            "version": "8.5.24",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+            "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
             "dev": true,
             "funding": [
                 {
@@ -17867,7 +17834,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
@@ -18525,7 +18491,6 @@
             "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -18859,7 +18824,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -18872,7 +18836,6 @@
             "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.0.1.tgz",
             "integrity": "sha512-qUqVY+KlG4ZX3eSFTcOHU2HcVa6B9x6bKmyDfji8AkOl15/3gkbEyIARCyJVByFjTjwUPF1VnRiEcvVHYw8APA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
                 "@react-dnd/shallowequal": "^2.0.0",
@@ -18903,7 +18866,6 @@
             "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-15.0.1.tgz",
             "integrity": "sha512-DoigPaIAs70DRy4qd+i1U5+wLyyhtiuydqHuhXTObxjQzimG70UN7L3Qzx/3SXYQroOIj9fEOXvb9yzMsD2TMA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@react-dnd/invariant": "^2.0.0",
                 "dnd-core": "15.0.1"
@@ -18914,7 +18876,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -19255,7 +19216,6 @@
             "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@oxc-project/types": "=0.138.0",
                 "@rolldown/pluginutils": "^1.0.0"
@@ -19290,7 +19250,6 @@
             "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.9"
             },
@@ -19723,7 +19682,6 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -21371,7 +21329,6 @@
             "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -21650,7 +21607,6 @@
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -21922,7 +21878,6 @@
             "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -22016,7 +21971,6 @@
             "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.3",
                 "@vitest/mocker": "4.1.3",
@@ -22159,7 +22113,6 @@
             "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.8",
                 "@types/json-schema": "^7.0.15",
@@ -22726,7 +22679,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }


### PR DESCRIPTION
## Summary

Runs `npm audit fix` to clear the security advisories that can be resolved today. **Lockfile-only change** — root `package.json` is untouched.

`npm audit`: **6 vulnerabilities (2 moderate, 4 high) → 4 (1 moderate, 3 high)**.

## Resolved

| Package | Severity | Advisory | Fix |
|---|---|---|---|
| `ip-address` | high ×3 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr), [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh), [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) — SSRF / trust-boundary bypass | 10.2.0 → 10.3.1 |
| `postcss` | moderate | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) — arbitrary `.map` read via `sourceMappingURL` | 8.5.22 → 8.5.24 |

## Not resolved — blocked by our 7-day release-age policy

The remaining four findings all require versions published within the last 7 days, which `.npmrc`'s `min-release-age=7` (added in #18683) intentionally holds back:

| Package | Needs | Published | Unblocks |
|---|---|---|---|
| `brace-expansion` (pinned by `nx`) | 5.0.9 | 2026-07-30 | 2026-08-06 |
| `fast-uri` (via `ajv`) | 3.1.5 | 2026-07-31 | 2026-08-07 |
| `hono` (via `@modelcontextprotocol/sdk`) | 4.12.34 | 2026-08-03 | 2026-08-10 |

These should clear with a follow-up `npm audit fix` once the window elapses. `nx` pins `brace-expansion` exactly, so it will additionally need an `overrides` entry (`nx: { "brace-expansion": "^5.0.9" }`).

### Note on `nx`

Plain `npm audit fix` wants to **downgrade `nx` 22.7.8 → 22.6.5** to escape the pinned vulnerable `brace-expansion@5.0.8`. That trade is not worth it — 22.6.5 is itself affected by [GHSA-g2r8-wvmj-jf5w](https://github.com/advisories/GHSA-g2r8-wvmj-jf5w) (`nx graph` permissive CORS), so the vulnerability count is unchanged while the build orchestrator regresses. This PR deliberately keeps `nx` at 22.7.8.

## Diff noise

The lockfile also drops ~51 `"peer": true` metadata flags. This is not caused by this change — a plain `npm install` on `master` reproduces it, and the flag count has oscillated in lockfile history (1 → 41 → 1 → 49). This restores it to the state the automated "Version update" commits produce.

## Validation

- `npm install` is idempotent against the committed lockfile
- `npm run format:check` passes