### PR TITLE
Fix: respect camera layerMask in the transmission opaque texture

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/Extensions/transmissionHelper.ts
+++ b/packages/dev/loaders/src/glTF/2.0/Extensions/transmissionHelper.ts
@@ -400,6 +400,10 @@ export class TransmissionHelper {
         );
         this._opaqueRenderTarget.ignoreCameraViewport = true;
         this._opaqueRenderTarget.renderList = this._opaqueMeshesCache;
+        // The opaque cache holds every opaque mesh of the scene, regardless of the camera currently rendering.
+        // Providing a renderList normally disables the layerMask check, which would make meshes hidden from the
+        // active camera show up in the refraction texture, so force the check back on.
+        this._opaqueRenderTarget.forceLayerMaskCheck = true;
         this._opaqueRenderTarget.clearColor = this._options.clearColor?.clone() ?? this._scene.clearColor.clone();
         this._opaqueRenderTarget.clearColor.a = 0.0;
         this._opaqueRenderTarget.gammaSpace = false;

--- a/packages/dev/loaders/test/unit/glTF/KHR_materials_transmission.test.ts
+++ b/packages/dev/loaders/test/unit/glTF/KHR_materials_transmission.test.ts
@@ -7,6 +7,7 @@ import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { ImportMeshAsync } from "core/Loading";
 import { FreeCamera } from "core/Cameras/freeCamera";
 import { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
+import type { ObjectRenderer } from "core/Rendering/objectRenderer";
 import { Vector3 } from "core/Maths/math.vector";
 import "loaders/glTF";
 
@@ -234,17 +235,21 @@ describe("KHR_materials_transmission – MergeMeshes with MultiMaterial", () => 
         expect(opaqueMesh).toBeDefined();
 
         const camera = scene.activeCamera!;
-        const objectRenderer = (opaqueRenderTarget as any)._objectRenderer;
+        const objectRenderer = (opaqueRenderTarget as any)._objectRenderer as ObjectRenderer;
+        const getRenderedMeshes = () => {
+            const activeMeshes = objectRenderer.getActiveMeshes();
+            return activeMeshes.data.slice(0, activeMeshes.length);
+        };
 
         // With matching masks, the opaque mesh is rendered into the refraction texture.
         camera.layerMask = 0x1;
         opaqueMesh.layerMask = 0x1;
         opaqueRenderTarget.render();
-        expect(objectRenderer._activeMeshes.data.slice(0, objectRenderer._activeMeshes.length)).toContain(opaqueMesh);
+        expect(getRenderedMeshes()).toContain(opaqueMesh);
 
         // With disjoint masks, it must not leak into the refraction texture.
         camera.layerMask = 0x2;
         opaqueRenderTarget.render();
-        expect(objectRenderer._activeMeshes.data.slice(0, objectRenderer._activeMeshes.length)).not.toContain(opaqueMesh);
+        expect(getRenderedMeshes()).not.toContain(opaqueMesh);
     });
 });

--- a/packages/dev/loaders/test/unit/glTF/KHR_materials_transmission.test.ts
+++ b/packages/dev/loaders/test/unit/glTF/KHR_materials_transmission.test.ts
@@ -6,6 +6,7 @@ import { MultiMaterial } from "core/Materials/multiMaterial";
 import { PBRMaterial } from "core/Materials/PBR/pbrMaterial";
 import { ImportMeshAsync } from "core/Loading";
 import { FreeCamera } from "core/Cameras/freeCamera";
+import { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 import { Vector3 } from "core/Maths/math.vector";
 import "loaders/glTF";
 
@@ -212,5 +213,38 @@ describe("KHR_materials_transmission – MergeMeshes with MultiMaterial", () => 
         expect(helper._translucentMaterialIndices.has(merged)).toBe(false);
         expect(helper._opaqueOnlySubMeshes.has(merged)).toBe(false);
         expect(helper._opaqueMeshesCache).not.toContain(merged);
+    });
+
+    it("should exclude meshes filtered out by the camera layerMask from the opaque render target", async () => {
+        const gltf = buildTransmissionGltf();
+        await ImportMeshAsync(`data:${gltf}`, scene);
+
+        // Wait for SetImmediate in _addMesh to execute
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const helper = getTransmissionHelper(scene);
+        const opaqueRenderTarget = helper.getOpaqueTarget() as RenderTargetTexture;
+        expect(opaqueRenderTarget).toBeTruthy();
+
+        // The opaque cache is camera agnostic, so the layerMask check must stay enabled
+        // even though a renderList is provided.
+        expect(opaqueRenderTarget.forceLayerMaskCheck).toBe(true);
+
+        const opaqueMesh = helper._opaqueMeshesCache[0] as Mesh;
+        expect(opaqueMesh).toBeDefined();
+
+        const camera = scene.activeCamera!;
+        const objectRenderer = (opaqueRenderTarget as any)._objectRenderer;
+
+        // With matching masks, the opaque mesh is rendered into the refraction texture.
+        camera.layerMask = 0x1;
+        opaqueMesh.layerMask = 0x1;
+        opaqueRenderTarget.render();
+        expect(objectRenderer._activeMeshes.data.slice(0, objectRenderer._activeMeshes.length)).toContain(opaqueMesh);
+
+        // With disjoint masks, it must not leak into the refraction texture.
+        camera.layerMask = 0x2;
+        opaqueRenderTarget.render();
+        expect(objectRenderer._activeMeshes.data.slice(0, objectRenderer._activeMeshes.length)).not.toContain(opaqueMesh);
     });
 });


### PR DESCRIPTION
Fixes [PBR materials with refraction have issues with layer masks](https://forum.babylonjs.com/t/pbr-materials-with-refraction-have-issues-with-layer-masks/63894).

## Problem

When using multiple cameras with different `layerMask` values, meshes that are excluded from the rendering camera still show up in the refraction of transmissive (`KHR_materials_transmission`) meshes.

Repro: https://playground.babylonjs.com/#WBUEI8#22 — the textured plane is on `layerMask2` and the refractive cube on `layerMask1`, yet the plane appears "inside" the cube.

## Root cause

`TransmissionHelper` creates the `opaqueSceneTexture` render target with `renderList = _opaqueMeshesCache`, which holds every opaque mesh of the scene regardless of camera.

In `ObjectRenderer._prepareRenderingManager`, providing a `renderList` disables the layerMask check:

```ts
checkLayerMask = !this.renderList || this.forceLayerMaskCheck;
```

So the RTT rendered everything in the cache, ignoring the active camera's `layerMask`.

## Fix

Enable `forceLayerMaskCheck` on the opaque render target. The opaque cache is camera-agnostic while the RTT is rendered once per active camera, so the mask check has to stay on for the texture to match what that camera actually sees.

This is a no-op for the common single-camera case, since the default mesh and camera layer masks are both `0x0FFFFFFF`.

## Tests

Added a regression test in `KHR_materials_transmission.test.ts` that renders the opaque RTT with matching and then disjoint layer masks and asserts the opaque mesh is included/excluded accordingly. Verified it fails without the fix and passes with it.
