### PR TITLE
Fix RawCubeTexture invertY crash on WebGPU

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.cubeTexture.pure.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.cubeTexture.pure.ts
@@ -92,7 +92,7 @@ export function RegisterEnginesWebGPUExtensionsEngineCubeTexture(): void {
 
                 const gpuTextureWrapper = this._textureHelper.createGPUTextureForInternalTexture(texture, width, height);
 
-                this._textureHelper.updateCubeTextures(imageBitmaps, gpuTextureWrapper.underlyingResource!, width, height, gpuTextureWrapper.format, false, false, 0, 0);
+                this._textureHelper.updateCubeTextures(imageBitmaps, texture, width, height, gpuTextureWrapper.format, false, false, 0, 0);
 
                 if (!noMipmap) {
                     this._generateMipmaps(texture, this._uploadEncoder);

--- a/packages/dev/core/src/Engines/WebGPU/Extensions/engine.rawTexture.pure.ts
+++ b/packages/dev/core/src/Engines/WebGPU/Extensions/engine.rawTexture.pure.ts
@@ -235,7 +235,7 @@ export function RegisterEnginesWebGPUExtensionsEngineRawTexture(): void {
             data.push(new Uint8Array(faceData.buffer, faceData.byteOffset, faceData.byteLength));
         }
 
-        this._textureHelper.updateCubeTextures(data, gpuTextureWrapper.underlyingResource!, texture.width, texture.height, gpuTextureWrapper.format, invertY, false, 0, 0);
+        this._textureHelper.updateCubeTextures(data, texture, texture.width, texture.height, gpuTextureWrapper.format, invertY, false, 0, 0);
         if (texture.generateMipMaps) {
             this._generateMipmaps(texture, this._uploadEncoder);
         }
@@ -295,7 +295,7 @@ export function RegisterEnginesWebGPUExtensionsEngineRawTexture(): void {
                         }
                         allFaces.push(new Uint8Array(mipFaceData.buffer, mipFaceData.byteOffset, mipFaceData.byteLength));
                     }
-                    this._textureHelper.updateCubeTextures(allFaces, gpuTextureWrapper.underlyingResource!, mipSize, mipSize, gpuTextureWrapper.format, invertY, false, 0, 0);
+                    this._textureHelper.updateCubeTextures(allFaces, texture, mipSize, mipSize, gpuTextureWrapper.format, invertY, false, 0, 0);
                 }
             } else {
                 this.updateRawCubeTexture(texture, faceDataArrays, format, type, invertY);

--- a/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuTextureManager.ts
@@ -1243,7 +1243,7 @@ export class WebGPUTextureManager {
 
     public updateCubeTextures(
         imageBitmaps: ImageBitmap[] | Uint8Array[],
-        gpuTexture: GPUTexture,
+        texture: GPUTexture | InternalTexture,
         width: number,
         height: number,
         format: GPUTextureFormat,
@@ -1257,10 +1257,11 @@ export class WebGPUTextureManager {
         for (let f = 0; f < faces.length; ++f) {
             const imageBitmap = imageBitmaps[faces[f]];
 
-            this.updateTexture(imageBitmap, gpuTexture, width, height, 1, format, f, 0, invertY, premultiplyAlpha, offsetX, offsetY);
+            // Prefer InternalTexture when available: updateTexture needs it to run invertY/premultiplyAlpha
+            // GPU post-processing on raw (Uint8Array) uploads. Passing only a GPUTexture throws in that path.
+            this.updateTexture(imageBitmap, texture, width, height, 1, format, f, 0, invertY, premultiplyAlpha, offsetX, offsetY);
         }
     }
-
     // TODO WEBGPU handle data source not being in the same format than the destination texture?
     public updateTexture(
         imageBitmap: ImageBitmap | Uint8Array | ImageData | HTMLImageElement | HTMLVideoElement | VideoFrame | HTMLCanvasElement | OffscreenCanvas,

--- a/packages/dev/core/test/unit/Engines/WebGPU/rawCubeTextureInvertY.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/rawCubeTextureInvertY.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { ThinWebGPUEngine } from "core/Engines/thinWebGPUEngine";
+import { Constants } from "core/Engines/constants";
+import { RegisterEnginesWebGPUExtensionsEngineRawTexture } from "core/Engines/WebGPU/Extensions/engine.rawTexture.pure";
+import type {} from "core/Engines/WebGPU/Extensions/engine.rawTexture.types";
+import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { describe, expect, it, vi } from "vitest";
+
+describe("WebGPU updateRawCubeTexture invertY", () => {
+    it("passes InternalTexture (not GPUTexture) into updateCubeTextures when invertY is true", () => {
+        RegisterEnginesWebGPUExtensionsEngineRawTexture();
+
+        const updateCubeTextures = vi.fn();
+        const engine = Object.create(ThinWebGPUEngine.prototype) as ThinWebGPUEngine & {
+            _textureHelper: { updateCubeTextures: typeof updateCubeTextures };
+            _generateMipmaps: ReturnType<typeof vi.fn>;
+            _uploadEncoder: unknown;
+        };
+        engine._textureHelper = { updateCubeTextures };
+        engine._generateMipmaps = vi.fn();
+        engine._uploadEncoder = {};
+
+        // Minimal InternalTexture + hardware texture stub — enough for updateRawCubeTexture.
+        const texture = Object.create(InternalTexture.prototype) as InternalTexture;
+        texture.width = 2;
+        texture.height = 2;
+        texture.generateMipMaps = false;
+        (texture as any)._source = InternalTextureSource.CubeRaw;
+        texture._hardwareTexture = {
+            format: "rgba8unorm",
+            _originalFormatIsRGB: false,
+            underlyingResource: { label: "fake-gpu-texture" },
+        } as any;
+
+        const face = new Uint8Array(2 * 2 * 4);
+        const faces = [face, face, face, face, face, face];
+
+        engine.updateRawCubeTexture(texture, faces, Constants.TEXTUREFORMAT_RGBA, Constants.TEXTURETYPE_UNSIGNED_BYTE, true);
+
+        expect(updateCubeTextures).toHaveBeenCalledTimes(1);
+        const [, textureArg, , , , invertYArg] = updateCubeTextures.mock.calls[0];
+        expect(textureArg).toBe(texture);
+        expect(textureArg).not.toBe(texture._hardwareTexture!.underlyingResource);
+        expect(invertYArg).toBe(true);
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
Fixes a WebGPU crash when creating/updating a `RawCubeTexture` with `invertY: true`.

## Root cause
On WebGPU, Y-flip is done after upload via a GPU post-process (`invertYPreMultiplyAlpha`). That path requires an `InternalTexture` (to create a hardware texture wrapper).

`updateRawCubeTexture` was passing the raw `GPUTexture` (`texture._hardwareTexture.underlyingResource`) into `updateCubeTextures` / `updateTexture`. When `invertY` was true, the engine threw:

> Invalid texture! Babylons internal engine is still not fully compatible with native GPU objects

WebGL was unaffected because it can flip at upload time via `UNPACK_FLIP_Y_WEBGL`. The raw 2D WebGPU path already passed `InternalTexture`; only the cube path was wrong.

## Fix
- Pass the `InternalTexture` into `updateCubeTextures` from `updateRawCubeTexture` and `createCubeTexture`
- Widen `updateCubeTextures` to accept `GPUTexture | InternalTexture` (same pattern as `updateTexture`)

## Forum
https://forum.babylonjs.com/t/setting-invert-y-when-creating-a-rawcubetexture-in-webgpu-crashes/63895
