### PR TITLE
[WebGPU-XR][Phase 4A] Reuse graphics bindings and disable raw camera access

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
+++ b/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
@@ -146,6 +146,17 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
     }
 
     /**
+     * Disables future automatic attachment when a runtime capability required by the feature is unavailable.
+     * @param warning the specific warning explaining why the feature was disabled
+     * @returns false so feature attach implementations can return the result directly
+     */
+    protected _disableAutoAttach(warning: string): false {
+        Logger.Warn(warning);
+        this.disableAutoAttach = true;
+        return false;
+    }
+
+    /**
      * This is used to register callbacks that will automatically be removed when detach is called.
      * @param observable the observable to which the observer will be attached
      * @param callback the callback to register

--- a/packages/dev/core/src/XR/features/WebXRImageTracking.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRImageTracking.pure.ts
@@ -7,7 +7,6 @@ import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
 import { Matrix } from "../../Maths/math.vector.pure";
 import { type Nullable } from "../../types";
 import { Logger } from "../../Misc/logger";
-import { type Engine } from "../../Engines/engine.pure";
 
 /**
  * Options interface for the background remover plugin
@@ -179,7 +178,7 @@ export class WebXRImageTracking extends WebXRAbstractFeature {
         }
         const promises = this.options.images.map(async (image) => {
             if (typeof image.src === "string") {
-                return await (this._xrSessionManager.scene.getEngine() as Engine)._createImageBitmapFromSource(image.src);
+                return await this._xrSessionManager.scene.getEngine()._createImageBitmapFromSource(image.src);
             } else {
                 return image.src;
             }

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -8,7 +8,7 @@ import { WebXRWebGLLayerWrapper } from "../webXRWebGLLayer";
 import { WebXRProjectionLayerWrapper, DefaultXRProjectionLayerInit } from "./Layers/WebXRProjectionLayer";
 import { WebXRCompositionLayerRenderTargetTextureProvider, WebXRCompositionLayerWrapper } from "./Layers/WebXRCompositionLayer";
 import { WebXRWebGPUProjectionLayerWrapper, CreateDefaultXRGPUProjectionLayerInit } from "./Layers/WebXRWebGPUProjectionLayer";
-import { WebXRGraphicsBindingType, type WebXRWebGPUGraphicsBinding } from "../webXRGraphicsBinding";
+import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 import { type ThinTexture } from "../../Materials/Textures/thinTexture";
 import { type DynamicTexture } from "../../Materials/Textures/dynamicTexture.pure";
 import { Color4 } from "../../Maths/math.color.pure";
@@ -90,7 +90,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
             if (binding.bindingType !== WebXRGraphicsBindingType.WebGPU) {
                 throw new Error("Expected a WebGPU graphics binding for a WebGPU engine.");
             }
-            this._xrGPUBinding = (binding as WebXRWebGPUGraphicsBinding).binding;
+            this._xrGPUBinding = binding.binding;
             // Multiview is not yet supported on the WebGPU XR path; force single-view (two sub-images).
             this._isMultiviewEnabled = false;
             this._createWebGPUProjectionLayer();

--- a/packages/dev/core/src/XR/features/WebXRRawCameraAccess.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRRawCameraAccess.pure.ts
@@ -8,7 +8,7 @@ import { Constants } from "../../Engines/constants";
 import { WebGLHardwareTexture } from "../../Engines/WebGL/webGLHardwareTexture";
 import { InternalTexture, InternalTextureSource } from "../../Materials/Textures/internalTexture";
 import { BaseTexture } from "../../Materials/Textures/baseTexture.pure";
-import { type ThinEngine } from "../../Engines";
+import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 
 /**
  * Options for raw camera access
@@ -88,12 +88,22 @@ export class WebXRRawCameraAccess extends WebXRAbstractFeature {
     }
 
     public override attach(force?: boolean): boolean {
+        if (this._xrSessionManager.scene.getEngine().isWebGPU) {
+            return this._disableAutoAttach(
+                "WebXR Raw Camera Access is unavailable with WebGPU XR because camera images are exposed only by XRWebGLBinding; the feature was disabled."
+            );
+        }
+
         if (!super.attach(force)) {
             return false;
         }
 
-        this._glContext = (this._xrSessionManager.scene.getEngine() as ThinEngine)._gl;
-        this._glBinding = new XRWebGLBinding(this._xrSessionManager.session, this._glContext);
+        const graphicsBinding = this._xrSessionManager._getGraphicsBinding();
+        if (graphicsBinding.bindingType !== WebXRGraphicsBindingType.WebGL) {
+            throw new Error("Expected a WebGL graphics binding for WebXR Raw Camera Access.");
+        }
+        this._glContext = graphicsBinding.context;
+        this._glBinding = graphicsBinding.binding;
 
         return true;
     }

--- a/packages/dev/core/src/XR/features/WebXRWalkingLocomotion.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRWalkingLocomotion.pure.ts
@@ -1,6 +1,6 @@
 /** This file must only contain pure code and pure imports */
 
-import { type Engine } from "../../Engines/engine.pure";
+import { type AbstractEngine } from "../../Engines/abstractEngine.pure";
 import { TmpVectors, Vector2, Vector3 } from "../../Maths/math.vector.pure";
 import { type TransformNode } from "../../Meshes/transformNode.pure";
 import { Logger } from "../../Misc/logger";
@@ -280,7 +280,7 @@ class WalkingTracker {
 }
 
 class Walker {
-    private _engine: Engine;
+    private _engine: AbstractEngine;
     private _detector = new FirstStepDetector();
     private _walker: Nullable<WalkingTracker> = null;
     private _movement = new Vector2();
@@ -293,7 +293,7 @@ class Walker {
 
     public movementThisFrame: Vector3 = Vector3.Zero();
 
-    constructor(engine: Engine) {
+    constructor(engine: AbstractEngine) {
         this._engine = engine;
         this._detector.onFirstStepDetected.add((event) => {
             if (!this._walker) {
@@ -433,7 +433,7 @@ export class WebXRWalkingLocomotion extends WebXRAbstractFeature {
             return false;
         }
 
-        this._walker = new Walker(this._sessionManager.scene.getEngine() as Engine);
+        this._walker = new Walker(this._sessionManager.scene.getEngine());
         return true;
     }
 

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -460,8 +460,14 @@ export class WebXRFeaturesManager implements IDisposable {
     public attachFeature(featureName: string) {
         const feature = this._features[featureName];
         if (feature && feature.enabled && !feature.featureImplementation.attached) {
+            const disableAutoAttachBeforeAttach = feature.featureImplementation.disableAutoAttach;
+            feature.featureImplementation.disableAutoAttach = false;
             const attached = feature.featureImplementation.attach();
-            if (!attached) {
+            const intentionallyDisabledDuringAttach = feature.featureImplementation.disableAutoAttach;
+            if (!intentionallyDisabledDuringAttach) {
+                feature.featureImplementation.disableAutoAttach = disableAutoAttachBeforeAttach;
+            }
+            if (!attached && !intentionallyDisabledDuringAttach) {
                 Tools.Warn(`Feature ${featureName} failed to attach`);
             }
         }

--- a/packages/dev/core/src/XR/webXRGraphicsBinding.ts
+++ b/packages/dev/core/src/XR/webXRGraphicsBinding.ts
@@ -22,23 +22,18 @@ export const enum WebXRGraphicsBindingType {
  * Abstraction over the native WebXR graphics binding used to interact with the XR compositor.
  * @internal
  */
-export interface IWebXRGraphicsBinding<BindingType extends WebXRGraphicsBindingType, Binding> {
+export interface IWebXRGraphicsBinding {
     /**
      * The kind of native binding that is wrapped.
      */
-    readonly bindingType: BindingType;
-
-    /**
-     * The wrapped native graphics binding.
-     */
-    readonly binding: Binding;
+    readonly bindingType: WebXRGraphicsBindingType;
 }
 
 /**
  * WebGL implementation of {@link IWebXRGraphicsBinding}, wrapping an `XRWebGLBinding`.
  * @internal
  */
-export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding<WebXRGraphicsBindingType.WebGL, XRWebGLBinding> {
+export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding {
     /**
      * The kind of native binding that is wrapped.
      */
@@ -87,7 +82,7 @@ export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding<WebXRGra
  * descriptor) and a `GPUDevice` obtained from an `xrCompatible` adapter, otherwise its constructor throws.
  * @internal
  */
-export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding<WebXRGraphicsBindingType.WebGPU, XRGPUBinding> {
+export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding {
     /**
      * The kind of native binding that is wrapped.
      */

--- a/packages/dev/core/src/XR/webXRGraphicsBinding.ts
+++ b/packages/dev/core/src/XR/webXRGraphicsBinding.ts
@@ -19,25 +19,26 @@ export const enum WebXRGraphicsBindingType {
 }
 
 /**
- * Abstraction over the WebXR graphics binding used to interact with the XR compositor
- * (XRWebGLBinding today, an XRGPUBinding-based binding for a future WebGPU backend).
- *
- * This is introduced as a seam so the XR features can be migrated off the concrete
- * `XRWebGLBinding` in a later phase without changing behavior today.
+ * Abstraction over the native WebXR graphics binding used to interact with the XR compositor.
  * @internal
  */
-export interface IWebXRGraphicsBinding {
+export interface IWebXRGraphicsBinding<BindingType extends WebXRGraphicsBindingType, Binding> {
     /**
      * The kind of native binding that is wrapped.
      */
-    readonly bindingType: WebXRGraphicsBindingType;
+    readonly bindingType: BindingType;
+
+    /**
+     * The wrapped native graphics binding.
+     */
+    readonly binding: Binding;
 }
 
 /**
  * WebGL implementation of {@link IWebXRGraphicsBinding}, wrapping an `XRWebGLBinding`.
  * @internal
  */
-export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding {
+export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding<WebXRGraphicsBindingType.WebGL, XRWebGLBinding> {
     /**
      * The kind of native binding that is wrapped.
      */
@@ -53,7 +54,13 @@ export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding {
      * @param session the XR session the binding is created for
      * @param context the WebGL rendering context to bind to
      */
-    constructor(session: XRSession, context: WebGLRenderingContext | WebGL2RenderingContext) {
+    constructor(
+        session: XRSession,
+        /**
+         * The WebGL rendering context used by the native binding.
+         */
+        public readonly context: WebGLRenderingContext | WebGL2RenderingContext
+    ) {
         this.binding = new XRWebGLBinding(session, context);
     }
 
@@ -76,13 +83,11 @@ export class WebXRWebGLGraphicsBinding implements IWebXRGraphicsBinding {
 /**
  * WebGPU implementation of {@link IWebXRGraphicsBinding}, wrapping an `XRGPUBinding`.
  *
- * This is introduced as part of the WebGPU-for-WebXR plumbing and is not consumed yet:
- * the per-frame layer/sub-image operations are wired up by later phases. The `XRGPUBinding`
- * requires a WebGPU-compatible XR session (created with the `webgpu` feature descriptor) and a
- * `GPUDevice` obtained from an `xrCompatible` adapter, otherwise its constructor throws.
+ * The `XRGPUBinding` requires a WebGPU-compatible XR session (created with the `webgpu` feature
+ * descriptor) and a `GPUDevice` obtained from an `xrCompatible` adapter, otherwise its constructor throws.
  * @internal
  */
-export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding {
+export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding<WebXRGraphicsBindingType.WebGPU, XRGPUBinding> {
     /**
      * The kind of native binding that is wrapped.
      */
@@ -117,3 +122,9 @@ export class WebXRWebGPUGraphicsBinding implements IWebXRGraphicsBinding {
         return new WebXRWebGPUGraphicsBinding(session, device);
     }
 }
+
+/**
+ * The graphics bindings supported by the WebXR session manager.
+ * @internal
+ */
+export type WebXRGraphicsBinding = WebXRWebGLGraphicsBinding | WebXRWebGPUGraphicsBinding;

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -10,7 +10,7 @@ import { type Viewport } from "../Maths/math.viewport";
 import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
 import { NativeXRLayerWrapper, NativeXRRenderTarget } from "./native/nativeXRRenderTarget";
 import { WebXRWebGLLayerWrapper } from "./webXRWebGLLayer";
-import { type IWebXRGraphicsBinding, WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "./webXRGraphicsBinding";
+import { type WebXRGraphicsBinding, WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "./webXRGraphicsBinding";
 import { type AbstractEngine } from "../Engines/abstractEngine";
 
 /**
@@ -22,7 +22,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
     private _referenceSpace: XRReferenceSpace;
     private _baseLayerWrapper: Nullable<WebXRLayerWrapper>;
     private _baseLayerRTTProvider: Nullable<WebXRLayerRenderTargetTextureProvider>;
-    private _graphicsBinding: Nullable<IWebXRGraphicsBinding> = null;
+    private _graphicsBinding: Nullable<WebXRGraphicsBinding> = null;
     private _xrNavigator: any;
     private _sessionMode: XRSessionMode;
     private _onEngineDisposedObserver: Nullable<Observer<AbstractEngine>>;
@@ -225,13 +225,11 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
 
     /**
      * Obtains the XR graphics binding for the current session, creating it lazily.
-     * This is the API-agnostic seam a future non-WebGL backend uses to provide its own binding
-     * (XRWebGLBinding vs a future XRGPUBinding); the XR features are migrated onto it in a later
-     * phase, so it is not consumed yet.
+     * This is the API-agnostic seam used by WebGL and WebGPU XR features to share a binding.
      * @returns the XR graphics binding for the current session
      * @internal
      */
-    public _getGraphicsBinding(): IWebXRGraphicsBinding {
+    public _getGraphicsBinding(): WebXRGraphicsBinding {
         if (!this._engine) {
             throw new Error("Cannot create the XR graphics binding: the engine has been disposed.");
         }

--- a/packages/dev/core/test/unit/XR/webXRAbstractFeature.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRAbstractFeature.test.ts
@@ -7,6 +7,7 @@ import { Scene } from "core/scene";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { WebXRAbstractFeature } from "core/XR/features/WebXRAbstractFeature";
 import { type IWebXRFeature } from "core/XR/webXRFeaturesManager";
+import { Logger } from "core/Misc/logger";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 
 /**
@@ -18,6 +19,10 @@ class TestFeature extends WebXRAbstractFeature {
 
     constructor(sessionManager: WebXRSessionManager) {
         super(sessionManager);
+    }
+
+    public disableForRuntimeCapability(warning: string): false {
+        return this._disableAutoAttach(warning);
     }
 
     protected _onXRFrame(_xrFrame: XRFrame): void {
@@ -123,6 +128,22 @@ describe("WebXRAbstractFeature", () => {
 
             expect(feature.onXRFrameCalled).toBe(true);
             expect(feature.lastFrame).toBe(mockFrame);
+        });
+
+        it("can intentionally disable attachment before observers or notifications are registered", () => {
+            const warning = "A required runtime capability is unavailable.";
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+            const attachObserver = vi.fn();
+            feature.onFeatureAttachObservable.add(attachObserver);
+
+            expect(feature.disableForRuntimeCapability(warning)).toBe(false);
+
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(warning);
+            expect(feature.disableAutoAttach).toBe(true);
+            expect(feature.attached).toBe(false);
+            expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(false);
+            expect(attachObserver).not.toHaveBeenCalled();
+            warnSpy.mockRestore();
         });
     });
 

--- a/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
@@ -7,6 +7,7 @@ import { Scene } from "core/scene";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { WebXRFeaturesManager, WebXRFeatureName, type IWebXRFeature, type WebXRFeatureConstructor } from "core/XR/webXRFeaturesManager";
 import { Observable } from "core/Misc/observable";
+import { Logger } from "core/Misc/logger";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 
 let featureCounter = 0;
@@ -331,6 +332,54 @@ describe("WebXRFeaturesManager – extended", () => {
         it("attachFeature does nothing for non-enabled feature", () => {
             // Should not throw
             featuresManager.attachFeature("nonexistent-feature");
+        });
+
+        it("warns generically when an ordinary attachment fails", () => {
+            const name = uniqueFeatureName() as any;
+            const mockFeature = createMockFeature({ attach: vi.fn(() => false) });
+            WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(mockFeature), 1, true);
+            featuresManager.enableFeature(name, 1);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+            featuresManager.attachFeature(name);
+
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(`Feature ${name} failed to attach`);
+            warnSpy.mockRestore();
+        });
+
+        it("does not suppress an ordinary failure when auto-attach was already disabled", () => {
+            const name = uniqueFeatureName() as any;
+            const mockFeature = createMockFeature({ attach: vi.fn(() => false), disableAutoAttach: true });
+            WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(mockFeature), 1, true);
+            featuresManager.enableFeature(name, 1);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+            featuresManager.attachFeature(name);
+
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(`Feature ${name} failed to attach`);
+            expect(mockFeature.disableAutoAttach).toBe(true);
+            warnSpy.mockRestore();
+        });
+
+        it("does not duplicate a specific warning when attachment intentionally disables auto-attach", () => {
+            const name = uniqueFeatureName() as any;
+            const warning = "The feature was disabled because a runtime capability is unavailable.";
+            const mockFeature = createMockFeature();
+            mockFeature.attach = vi.fn(() => {
+                Logger.Warn(warning);
+                mockFeature.disableAutoAttach = true;
+                return false;
+            });
+            WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(mockFeature), 1, true);
+            featuresManager.enableFeature(name, 1);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+            featuresManager.attachFeature(name);
+            featuresManager.attachFeature(name);
+
+            expect(warnSpy).toHaveBeenCalledTimes(2);
+            expect(warnSpy.mock.calls).toEqual([[warning], [warning]]);
+            warnSpy.mockRestore();
         });
 
         it("detachFeature does nothing for non-enabled feature", () => {

--- a/packages/dev/core/test/unit/XR/webXRRawCameraAccess.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRRawCameraAccess.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Logger } from "core/Misc/logger";
+import { Scene } from "core/scene";
+import { WebXRRawCameraAccess } from "core/XR/features/WebXRRawCameraAccess";
+import { WebXRFeaturesManager } from "core/XR/webXRFeaturesManager";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WebGPUWarning = "WebXR Raw Camera Access is unavailable with WebGPU XR because camera images are exposed only by XRWebGLBinding; the feature was disabled.";
+
+describe("WebXRRawCameraAccess", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let originalWebGLBinding: unknown;
+    let originalGPUBinding: unknown;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        (sessionManager as any)._xrNavigator = { xr: { native: false } };
+        originalWebGLBinding = (globalThis as any).XRWebGLBinding;
+        originalGPUBinding = (globalThis as any).XRGPUBinding;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        (globalThis as any).XRWebGLBinding = originalWebGLBinding;
+        (globalThis as any).XRGPUBinding = originalGPUBinding;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("reuses the cached WebGL binding and updates camera textures", () => {
+        const cameraTexture = {};
+        const getCameraImage = vi.fn(() => cameraTexture);
+        const nativeBinding = { getCameraImage };
+        const xrWebGLBinding = vi.fn().mockImplementation(function () {
+            return nativeBinding;
+        });
+        const glContext = {
+            deleteTexture: vi.fn(),
+        } as unknown as WebGLRenderingContext;
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (engine as any)._gl = glContext;
+        (sessionManager as any).session = {
+            enabledFeatures: ["camera-access"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        const feature = new WebXRRawCameraAccess(sessionManager);
+
+        expect(feature.attach()).toBe(true);
+        expect(xrWebGLBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, glContext);
+        expect(sessionManager._getGraphicsBinding().binding).toBe(nativeBinding);
+
+        const projectionMatrix = new Float32Array(16);
+        projectionMatrix[0] = 2;
+        projectionMatrix[5] = 2;
+        const camera = { width: 640, height: 480 } as XRCamera;
+        const view = {
+            camera,
+            eye: "none",
+            projectionMatrix,
+        } as XRView;
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame);
+
+        expect(getCameraImage).toHaveBeenCalledExactlyOnceWith(camera);
+        expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
+        expect(feature.texturesData).toHaveLength(1);
+        expect(feature.viewIndex).toEqual(["none"]);
+        expect(feature.cameraIntrinsics[0]).toMatchObject({
+            width: 640,
+            height: 480,
+            u0: 320,
+            v0: 240,
+            ax: 640,
+            ay: 480,
+        });
+    });
+
+    it("disables once on WebGPU without WebGL binding, camera calls, observers, or textures", () => {
+        const getCameraImage = vi.fn();
+        const xrWebGLBinding = vi.fn().mockImplementation(function () {
+            return { getCameraImage };
+        });
+        const xrGPUBinding = vi.fn().mockImplementation(function () {
+            return {};
+        });
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (globalThis as any).XRGPUBinding = xrGPUBinding;
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {} as XRSession;
+        const featuresManager = new WebXRFeaturesManager(sessionManager);
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        const feature = featuresManager.enableFeature(WebXRRawCameraAccess.Name, 1);
+
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUWarning);
+        expect(xrGPUBinding).not.toHaveBeenCalled();
+        expect(xrWebGLBinding).not.toHaveBeenCalled();
+        expect(getCameraImage).not.toHaveBeenCalled();
+        expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(false);
+        expect(feature.texturesData).toHaveLength(0);
+        expect(feature.cameraIntrinsics).toHaveLength(0);
+
+        sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        const getViewerPose = vi.fn();
+        sessionManager.onXRFrameObservable.notifyObservers({ getViewerPose } as unknown as XRFrame);
+        expect(getViewerPose).not.toHaveBeenCalled();
+        expect(feature.texturesData).toHaveLength(0);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        featuresManager.dispose();
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSessionManager.test.ts
@@ -5,7 +5,7 @@
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
-import { WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "core/XR/webXRGraphicsBinding";
+import { WebXRGraphicsBindingType, WebXRWebGLGraphicsBinding, WebXRWebGPUGraphicsBinding } from "core/XR/webXRGraphicsBinding";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 
 describe("WebXRSessionManager", () => {
@@ -283,18 +283,32 @@ describe("WebXRSessionManager", () => {
             });
 
             it("returns a WebGL binding for a non-WebGPU engine", () => {
+                const nativeBinding = {};
+                (globalThis as any).XRWebGLBinding.mockImplementation(function () {
+                    return nativeBinding;
+                });
                 (engine as any)._gl = {};
                 expect(engine.isWebGPU).toBe(false);
 
-                expect(sessionManager._getGraphicsBinding()).toBeInstanceOf(WebXRWebGLGraphicsBinding);
+                const binding = sessionManager._getGraphicsBinding();
+                expect(binding).toBeInstanceOf(WebXRWebGLGraphicsBinding);
+                expect(binding.bindingType).toBe(WebXRGraphicsBindingType.WebGL);
+                expect(binding.binding).toBe(nativeBinding);
             });
 
             it("returns a WebGPU binding for a WebGPU engine", () => {
+                const nativeBinding = {};
+                (globalThis as any).XRGPUBinding.mockImplementation(function () {
+                    return nativeBinding;
+                });
                 (engine as any)._isWebGPU = true;
                 (engine as any)._device = {};
                 expect(engine.isWebGPU).toBe(true);
 
-                expect(sessionManager._getGraphicsBinding()).toBeInstanceOf(WebXRWebGPUGraphicsBinding);
+                const binding = sessionManager._getGraphicsBinding();
+                expect(binding).toBeInstanceOf(WebXRWebGPUGraphicsBinding);
+                expect(binding.bindingType).toBe(WebXRGraphicsBindingType.WebGPU);
+                expect(binding.binding).toBe(nativeBinding);
             });
 
             it("caches the binding across calls", () => {
@@ -304,6 +318,7 @@ describe("WebXRSessionManager", () => {
                 const second = sessionManager._getGraphicsBinding();
 
                 expect(second).toBe(first);
+                expect((globalThis as any).XRWebGLBinding).toHaveBeenCalledTimes(1);
             });
         });
     });


### PR DESCRIPTION
Closes #18768

Related to parent #18636 and epic #18635.

## Summary
- Turn the cached XR graphics-binding seam into a discriminated WebGL/WebGPU union that exposes the wrapped native binding and safely narrows at call sites.
- Add an intentional runtime-disable path for XR features: the feature emits its specific warning, sets `disableAutoAttach`, and returns before observers or attach notifications are registered; the manager suppresses its generic attach-failed warning only when attachment intentionally sets that flag.
- Reuse the cached WebGL binding/context in Raw Camera Access and disable Raw Camera Access on WebGPU XR with exactly one specific warning and no native binding, camera-image, frame-observer, or texture work.
- Remove unnecessary concrete `Engine` casts from Image Tracking and Walking Locomotion.

## WebGL no-op guarantees
- Raw Camera still calls `super.attach()` first on WebGL, uses the same `XRWebGLBinding.getCameraImage` path, and creates the same `WebGLHardwareTexture`/Babylon texture metadata; only binding construction is deduplicated through the session cache.
- The WebGPU guard is isolated before attachment. Existing WebGL layer, texture, and native camera behavior is unchanged.
- The cached binding remains session-scoped and is cleared on session end as before.

## Warning lifecycle
An intentional runtime capability failure emits the feature-specific warning and sets `disableAutoAttach`. `WebXRFeaturesManager.attachFeature` opens a fresh transition for each explicit attempt, restores preexisting auto-attach state after ordinary failures/successes, and suppresses the generic warning only when the attach implementation intentionally disables itself. Ordinary attach failures still emit `Feature <name> failed to attach`.

## Tests
- Focused XR selection: 4 files, 100 tests passed (binding/session manager, abstract feature lifecycle, feature manager lifecycle, Raw Camera positive/negative controls).
- Full XR unit suite: 17 files, 294 tests passed.
- `npx tsc -b packages/dev/core/tsconfig.build.json` passed.
- `npm --prefix packages/dev/core run lint:check` passed with 0 errors.
- Targeted Prettier check passed.
- `npm run check:treeshaking` passed all 16 checks.
- `npm run check:side-effects-sync` passed for core/gui/loaders/serializers.
- `npm run build:source && npm run test:treeshaking` passed all core and serializer bundle smoke tests.

## Remaining XR WebGL coupling audit
The centralized `new XRWebGLBinding` in `webXRGraphicsBinding.ts` is intentional. Remaining feature-owned direct bindings are deliberately deferred:
- Layers (`WebXRLayers.pure.ts`) — #18769
- Light Estimation (`WebXRLightEstimation.pure.ts`) — #18770
- Depth Sensing (`WebXRDepthSensing.pure.ts`) — #18771
- Space Warp (`WebXRSpaceWarp.pure.ts`) — #18772

The exhaustive `_gl` and `Engine`/`ThinEngine` cast audit found only the centralized graphics-binding/WebGL render-target backend seams plus those four deferred features. Remaining WebGL object types are confined to the WebGL layer/render-target/native compatibility infrastructure, Raw Camera's intentionally WebGL-only texture path, and the four deferred features above.