### PR TITLE
Fix Tools.LoadScript treating ES module source as a URL on Babylon Native

### DIFF
--- a/packages/dev/core/src/Misc/tools.pure.ts
+++ b/packages/dev/core/src/Misc/tools.pure.ts
@@ -594,13 +594,7 @@ export class Tools {
         return await Tools.LoadScriptAsync(scriptUrl);
     }
 
-    private static _LoadScriptNative(
-        scriptUrl: string,
-        onSuccess?: () => void,
-        onError?: (message?: string, exception?: any) => void,
-        _scriptId?: string,
-        useModule = false
-    ) {
+    private static _LoadScriptNative(scriptUrl: string, onSuccess?: () => void, onError?: (message?: string, exception?: any) => void, _scriptId?: string, useModule = false) {
         if (_native) {
             if (useModule) {
                 // When useModule is set, scriptUrl is not a url at all: it is ES module
@@ -608,10 +602,10 @@ export class Tools {
                 // <script type="module"> element (see _LoadScriptWeb). Babylon Native has
                 // no DOM and no ES module loader, so there is nothing to inject it into.
                 // Without this guard the module source was handed to Tools.LoadFile as if
-                // it were a url, producing errors such as
-                // "Unable to open URL 'import createSpzModule from '...';'" that gave no
-                // hint about the real problem.
-                onError?.("Loading a script as an ES module is not supported in Babylon Native");
+                // it were a url, producing confusing "Unable to open URL" failures that
+                // quoted the module source back instead of naming a url.
+                const message = "Loading a script as an ES module is not supported in Babylon Native";
+                onError?.(message, new Error(message));
                 return;
             }
             Tools.LoadFile(

--- a/packages/dev/core/src/Misc/tools.pure.ts
+++ b/packages/dev/core/src/Misc/tools.pure.ts
@@ -594,8 +594,26 @@ export class Tools {
         return await Tools.LoadScriptAsync(scriptUrl);
     }
 
-    private static _LoadScriptNative(scriptUrl: string, onSuccess?: () => void, onError?: (message?: string, exception?: any) => void) {
+    private static _LoadScriptNative(
+        scriptUrl: string,
+        onSuccess?: () => void,
+        onError?: (message?: string, exception?: any) => void,
+        _scriptId?: string,
+        useModule = false
+    ) {
         if (_native) {
+            if (useModule) {
+                // When useModule is set, scriptUrl is not a url at all: it is ES module
+                // source code that the web implementation injects into a
+                // <script type="module"> element (see _LoadScriptWeb). Babylon Native has
+                // no DOM and no ES module loader, so there is nothing to inject it into.
+                // Without this guard the module source was handed to Tools.LoadFile as if
+                // it were a url, producing errors such as
+                // "Unable to open URL 'import createSpzModule from '...';'" that gave no
+                // hint about the real problem.
+                onError?.("Loading a script as an ES module is not supported in Babylon Native");
+                return;
+            }
             Tools.LoadFile(
                 scriptUrl,
                 (data) => {


### PR DESCRIPTION
## Problem

`Tools.LoadScript` is aliased to one of two implementations depending on the environment:

```ts
public static LoadScript: (scriptUrl, onSuccess?, onError?, scriptId?, useModule?) => void =
    typeof _native === "undefined" ? this._LoadScriptWeb : this._LoadScriptNative;
```

The two implementations disagree about what the **first argument** means when `useModule` is `true`:

| | signature | meaning of arg 1 when `useModule` |
|---|---|---|
| `_LoadScriptWeb` | `(scriptUrl, onSuccess?, onError?, scriptId?, useModule = false)` | ES module **source code** — assigned to `script.innerText` of a `<script type="module">` |
| `_LoadScriptNative` | `(scriptUrl, onSuccess?, onError?)` | a **URL** — passed straight to `Tools.LoadFile` |

`_LoadScriptNative` does not declare `useModule` at all, so on Babylon Native every `_LoadScriptModuleAsync` caller ends up trying to *fetch the module source text as if it were a URL*.

## Impact

Affects every `_LoadScriptModuleAsync` caller on Babylon Native, including:

* the SPZ Gaussian Splatting loader (`spzLibraryUrl`)
* CSG2 (`manifoldUrl`)
* the navigation plugin (recast)

The resulting error is impossible to interpret, e.g.

```
Unable to open URL 'import createSpzModule from 'https://unpkg.com/@adobe/spz@0.2.2/dist/spz.js';
            const module = await createSpzModule();
            const returnedValue = module;
            ...'
```

This was found while triaging Gaussian Splatting failures in Babylon Native, where it accounts for a large cluster of tests failing with an opaque `Unknown error opening URL`.

## Fix

Babylon Native has no DOM and no ES module loader, so there is nothing the native path can inject the source into — this cannot be made to work by fetching. Declare the parameter and fail fast with a descriptive message instead, so `_LoadScriptModuleAsync` rejects with:

```
Loading a script as an ES module is not supported in Babylon Native
```

That turns a misleading "bad URL" error into an accurate statement of the actual limitation. The non-module path is unchanged.
