### PR TITLE
fix(XR): clear WebGPU AR projection textures

### DIFF
--- a/packages/dev/core/src/XR/features/Layers/WebXRWebGPUCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRWebGPUCompositionLayer.ts
@@ -49,12 +49,12 @@ export class WebXRWebGPUCompositionLayerRenderTargetTextureProvider extends WebX
     public onRenderTargetTextureCreatedObservable = new Observable<{ texture: RenderTargetTexture; eye?: XREye }>();
 
     constructor(
-        protected readonly _xrSessionManager: WebXRSessionManager,
+        _xrSessionManager: WebXRSessionManager,
         protected readonly _xrGPUBinding: XRGPUBinding,
         public override readonly layerWrapper: WebXRWebGPUCompositionLayerWrapper,
         protected readonly _depthStencilFormat?: GPUTextureFormat
     ) {
-        super(_xrSessionManager.scene, layerWrapper);
+        super(_xrSessionManager, layerWrapper);
         this._compositionLayer = layerWrapper.layer;
     }
 

--- a/packages/dev/core/src/XR/webXRWebGPURenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRWebGPURenderTargetTextureProvider.ts
@@ -3,9 +3,12 @@ import { type WebGPUEngine } from "../Engines/webgpuEngine";
 import { type WebGPURenderTargetWrapper } from "../Engines/WebGPU/webgpuRenderTargetWrapper";
 import { type InternalTexture } from "../Materials/Textures/internalTexture";
 import { type RenderTargetTexture } from "../Materials/Textures/renderTargetTexture.pure";
+import { Color4 } from "../Maths/math.color.pure";
 import { type Nullable } from "../types";
 import { WebXRLayerRenderTargetTexture } from "./webXRLayerRenderTargetTexture";
+import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
 import { WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetTextureProvider";
+import { type WebXRSessionManager } from "./webXRSessionManager";
 
 /**
  * Maps a WebGPU depth/stencil {@link GPUTextureFormat} to the matching Babylon `TEXTUREFORMAT_*` constant.
@@ -44,6 +47,15 @@ function GetBabylonDepthFormat(format: GPUTextureFormat): number {
  * @internal
  */
 export abstract class WebXRWebGPURenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+    private readonly _transparentClearColor = new Color4(0, 0, 0, 0);
+
+    constructor(
+        protected readonly _xrSessionManager: WebXRSessionManager,
+        layerWrapper: WebXRLayerWrapper
+    ) {
+        super(_xrSessionManager.scene, layerWrapper);
+    }
+
     private get _webgpuEngine(): WebGPUEngine {
         return this._engine as WebGPUEngine;
     }
@@ -131,6 +143,11 @@ export abstract class WebXRWebGPURenderTargetTextureProvider extends WebXRLayerR
      * only advances in `endFrame`, once per XR frame, so unlike `_cleared` it cannot be reset by another
      * scene rendering the same camera.
      *
+     * In immersive AR, color is cleared to transparent when `WebXRExperienceHelper` disables
+     * `Scene.autoClear`. WebGL XR framebuffers are cleared to transparent by the user agent, but WebGPU render
+     * passes require the application to request that clear explicitly. Skipping it leaves pixels from prior
+     * frames in passthrough regions, producing trails behind moving objects.
+     *
      * Depth and stencil are still cleared on every notification, matching the previous behavior and the
      * expectations of overlay scenes that draw on top of the main scene.
      * @param renderTargetTexture the per-eye render target to clear each frame
@@ -143,13 +160,16 @@ export abstract class WebXRWebGPURenderTargetTextureProvider extends WebXRLayerR
                 return;
             }
             const scene = renderTargetTexture.getScene();
+            const isImmersiveAR = this._xrSessionManager.sessionMode === "immersive-ar";
             // When autoClear is disabled the scene does not clear render targets; match that so this observer
-            // does not force a clear the user opted out of.
-            if (scene && !scene.autoClear) {
+            // does not force a clear the user opted out of. Immersive AR is the exception: the experience
+            // helper disables autoClear because WebGL XR is cleared by the user agent, while WebGPU is not.
+            if (scene && !scene.autoClear && !isImmersiveAR) {
                 return;
             }
             const clearColor = engine.frameId !== lastColorClearedFrameId;
-            engine.clear(renderTargetTexture.clearColor ?? scene?.clearColor ?? null, clearColor, true, true);
+            const color = isImmersiveAR && scene && !scene.autoClear ? this._transparentClearColor : (renderTargetTexture.clearColor ?? scene?.clearColor ?? null);
+            engine.clear(color, clearColor, true, true);
             if (clearColor) {
                 lastColorClearedFrameId = engine.frameId;
             }

--- a/packages/dev/core/test/unit/XR/webXRWebGPUProjectionLayer.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRWebGPUProjectionLayer.test.ts
@@ -7,6 +7,7 @@ import { NullEngine } from "core/Engines/nullEngine";
 import { WebGPURenderTargetWrapper } from "core/Engines/WebGPU/webgpuRenderTargetWrapper";
 import { FreeCamera } from "core/Cameras/freeCamera";
 import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { Color4 } from "core/Maths/math.color";
 import { Vector3 } from "core/Maths/math.vector";
 import { Viewport } from "core/Maths/math.viewport";
 import { Scene } from "core/scene";
@@ -50,14 +51,14 @@ describe("WebXRWebGPUProjectionLayer", () => {
         let wrapSpy: ReturnType<typeof vi.fn>;
         let updateSpy: ReturnType<typeof vi.fn>;
 
-        function createProvider(subImage: any) {
+        function createProvider(subImage: any, sessionMode: "immersive-vr" | "immersive-ar" = "immersive-vr") {
             const binding: any = {
                 getViewSubImage: vi.fn(() => subImage),
                 getSubImage: vi.fn(() => subImage),
             };
             const layer: any = { textureWidth: 512, textureHeight: 512 };
             const wrapper = new WebXRWebGPUProjectionLayerWrapper(layer, false, binding, "depth24plus-stencil8");
-            const sessionManager = { scene } as unknown as WebXRSessionManager;
+            const sessionManager = { scene, sessionMode } as unknown as WebXRSessionManager;
             return wrapper.createRenderTargetTextureProvider(sessionManager);
         }
 
@@ -246,6 +247,17 @@ describe("WebXRWebGPUProjectionLayer", () => {
             rtt!.onClearObservable.notifyObservers(engine);
 
             expect(clearSpy).not.toHaveBeenCalled();
+        });
+
+        it("clears immersive AR projection textures to transparent when scene.autoClear is disabled", () => {
+            const provider = createProvider(createSubImage(512, 512), "immersive-ar");
+            const rtt = provider.getRenderTargetTextureForView({ eye: "left" } as XRView);
+            scene.autoClear = false;
+
+            const clearSpy = vi.spyOn(engine, "clear");
+            rtt!.onClearObservable.notifyObservers(engine);
+
+            expect(clearSpy).toHaveBeenCalledWith(new Color4(0, 0, 0, 0), true, true, true);
         });
 
         it("the per-eye clear observer clears color only once per engine frame", () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Fixes stale projection-layer pixels in immersive WebGPU AR. On Quest Browser, moving opaque geometry could leave stretched copies over passthrough because transparent regions were not cleared between frames.

Closes #18777.
Part of #18636.

## Root cause

`WebXRExperienceHelper.enterXRAsync("immersive-ar")` disables `scene.autoClear`. That is safe for WebGL XR because the user agent clears the opaque XR framebuffer to transparent each frame.

WebGPU projection-layer attachments do not receive that browser-managed clear. The WebGPU per-eye clear observer honored `autoClear === false`, so immersive AR skipped its frame-start color clear and retained pixels previously covered by moving geometry.

## Fix

- Retain the XR session mode in the WebGPU render-target provider.
- For immersive AR with helper-disabled auto-clear, explicitly clear each eye's color attachment to transparent `(0, 0, 0, 0)`.
- Preserve the existing once-per-engine-frame color guard, per-eye behavior, depth/stencil clears, and `skipInitialClear`.
- Add focused regression coverage for immersive AR with `scene.autoClear === false`.

## Behavior boundaries

- WebGPU immersive AR receives the missing transparent clear.
- WebGPU VR with user-disabled `autoClear` remains unchanged.
- WebGL XR remains unchanged.
- Non-XR WebGL and WebGPU rendering remain unchanged.

## Validation

- Focused WebGPU XR projection-layer tests: **18/18 passed**
- Full core XR unit tests: **295/295 passed**
- Core TypeScript compile: **passed**
- Changed-file ESLint and Prettier: **passed**
- Core tree-shaking verification: **4/4 passed**
- Core side-effects sync: **passed**
- Real Meta Quest Browser WebGPU immersive-AR test: **PASS** — one clean moving sphere over passthrough with no trails or stretched copies

Independent review found no issues.
