### PR TITLE
feat(XR): add WebGPU quad layer path

### DIFF
--- a/packages/dev/core/src/XR/features/Layers/WebXRWebGPUCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRWebGPUCompositionLayer.ts
@@ -2,27 +2,28 @@ import { type RenderTargetTexture } from "core/Materials/Textures/renderTargetTe
 import { type Viewport } from "core/Maths/math.viewport";
 import { Observable } from "core/Misc/observable";
 import { type WebXRLayerRenderTargetTexture } from "core/XR/webXRLayerRenderTargetTexture";
-import { type WebXRLayerType, WebXRLayerWrapper } from "core/XR/webXRLayerWrapper";
+import { type WebXRLayerType } from "core/XR/webXRLayerWrapper";
 import { type WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
 import { WebXRWebGPURenderTargetTextureProvider } from "core/XR/webXRWebGPURenderTargetTextureProvider";
 import { type WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { type Nullable } from "core/types";
+import { WebXRCompositionLayerWrapper } from "./WebXRCompositionLayer";
 
 /**
  * Wraps xr composition layers for the WebGPU (XRGPUBinding) backend.
  * Mirrors {@link WebXRCompositionLayerWrapper} for WebGPU.
  * @internal
  */
-export class WebXRWebGPUCompositionLayerWrapper extends WebXRLayerWrapper {
+export class WebXRWebGPUCompositionLayerWrapper extends WebXRCompositionLayerWrapper {
     constructor(
-        public override getWidth: () => number,
-        public override getHeight: () => number,
-        public override readonly layer: XRCompositionLayer,
-        public override readonly layerType: WebXRLayerType,
-        public readonly isMultiview: boolean,
-        public createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider
+        getWidth: () => number,
+        getHeight: () => number,
+        layer: XRCompositionLayer,
+        layerType: WebXRLayerType,
+        isMultiview: boolean,
+        createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider
     ) {
-        super(getWidth, getHeight, layer, layerType, createRTTProvider);
+        super(getWidth, getHeight, layer, layerType, isMultiview, createRTTProvider);
     }
 }
 

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -8,14 +8,20 @@ import { WebXRWebGLLayerWrapper } from "../webXRWebGLLayer";
 import { WebXRProjectionLayerWrapper, DefaultXRProjectionLayerInit } from "./Layers/WebXRProjectionLayer";
 import { WebXRCompositionLayerRenderTargetTextureProvider, WebXRCompositionLayerWrapper } from "./Layers/WebXRCompositionLayer";
 import { WebXRWebGPUProjectionLayerWrapper, CreateDefaultXRGPUProjectionLayerInit } from "./Layers/WebXRWebGPUProjectionLayer";
+import { WebXRWebGPUCompositionLayerRenderTargetTextureProvider, WebXRWebGPUCompositionLayerWrapper } from "./Layers/WebXRWebGPUCompositionLayer";
 import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 import { type ThinTexture } from "../../Materials/Textures/thinTexture";
 import { type DynamicTexture } from "../../Materials/Textures/dynamicTexture.pure";
 import { Color4 } from "../../Maths/math.color.pure";
 import { type LensFlareSystem } from "../../LensFlares/lensFlareSystem";
-import { type ThinEngine } from "../../Engines";
+import { Logger } from "../../Misc/logger";
+import { type Nullable } from "../../types";
 
 const DefaultXRWebGLLayerInit: XRWebGLLayerInit = {};
+const WebGPUQuadLayerCreateWarning =
+    "WebGPU XR quad layers are unavailable because XRGPUBinding.createQuadLayer is not supported; the requested quad layer was skipped and projection rendering remains active.";
+const WebGPUQuadLayerSubImageWarning =
+    "WebGPU XR quad layers are unavailable because XRGPUBinding.getSubImage is not supported; the requested quad layer was skipped and projection rendering remains active.";
 
 /**
  * Configuration options of the layers feature
@@ -60,7 +66,8 @@ export class WebXRLayers extends WebXRAbstractFeature {
     private _projectionLayerInitialized = false;
 
     private _compositionLayerTextureMapping: WeakMap<XRCompositionLayer, ThinTexture> = new WeakMap();
-    private _layerToRTTProviderMapping: WeakMap<XRCompositionLayer, WebXRCompositionLayerRenderTargetTextureProvider> = new WeakMap();
+    private _layerToRTTProviderMapping: WeakMap<XRCompositionLayer, WebXRCompositionLayerRenderTargetTextureProvider | WebXRWebGPUCompositionLayerRenderTargetTextureProvider> =
+        new WeakMap();
 
     constructor(
         _xrSessionManager: WebXRSessionManager,
@@ -95,8 +102,12 @@ export class WebXRLayers extends WebXRAbstractFeature {
             this._isMultiviewEnabled = false;
             this._createWebGPUProjectionLayer();
         } else {
-            this._glContext = (engine as ThinEngine)._gl;
-            this._xrWebGLBinding = new XRWebGLBinding(this._xrSessionManager.session, this._glContext);
+            const binding = this._xrSessionManager._getGraphicsBinding();
+            if (binding.bindingType !== WebXRGraphicsBindingType.WebGL) {
+                throw new Error("Expected a WebGL graphics binding for a WebGL engine.");
+            }
+            this._glContext = binding.context;
+            this._xrWebGLBinding = binding.binding;
 
             const projectionLayerInit = { ...DefaultXRProjectionLayerInit, ...this._options.projectionLayerInit };
             this._isMultiviewEnabled = this._options.preferMultiviewOnInit && engine.getCaps().multiview;
@@ -188,9 +199,9 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * Note about making it private - this function will be exposed once I decide on a proper API to support all of the XR layers' options
      * @param options an object providing configuration options for the new XRQuadLayer.
      * @param babylonTexture the texture to display in the layer
-     * @returns the quad layer
+     * @returns the quad layer, or null when the WebGPU binding lacks quad-layer support
      */
-    private _createQuadLayer(options: { params: Partial<XRQuadLayerInit> } = { params: {} }, babylonTexture?: ThinTexture): WebXRCompositionLayerWrapper {
+    private _createQuadLayer(options: { params: Partial<XRQuadLayerInit> } = { params: {} }, babylonTexture?: ThinTexture): Nullable<WebXRCompositionLayerWrapper> {
         this._extendXRLayerInit(options.params, false);
         const width = (this._existingLayers[0].layer as XRProjectionLayer).textureWidth;
         const height = (this._existingLayers[0].layer as XRProjectionLayer).textureHeight;
@@ -202,24 +213,76 @@ export class WebXRLayers extends WebXRAbstractFeature {
             ...options.params,
         };
         this._validateLayerInit(populatedParams, false);
-        const quadLayer = this._xrWebGLBinding.createQuadLayer(populatedParams);
+        let quadLayer: XRQuadLayer;
+        let wrapper: WebXRCompositionLayerWrapper;
+
+        if (this._isWebGPU) {
+            const binding = this._xrGPUBinding!;
+            if (typeof binding.createQuadLayer !== "function") {
+                Logger.Warn(WebGPUQuadLayerCreateWarning);
+                return null;
+            }
+            if (typeof binding.getSubImage !== "function") {
+                Logger.Warn(WebGPUQuadLayerSubImageWarning);
+                return null;
+            }
+
+            const gpuParams: XRGPUQuadLayerInit = {
+                colorFormat: binding.getPreferredColorFormat(),
+                // GPUTextureUsage.RENDER_ATTACHMENT (0x10) is requested explicitly. The usage of a
+                // compositor-owned sub-image texture is not a valid source for layer creation flags.
+                textureUsage: 0x10,
+                space: populatedParams.space,
+                viewPixelWidth: populatedParams.viewPixelWidth,
+                viewPixelHeight: populatedParams.viewPixelHeight,
+            };
+            if (populatedParams.layout !== undefined) {
+                gpuParams.layout = populatedParams.layout;
+            }
+            if (populatedParams.mipLevels !== undefined) {
+                gpuParams.mipLevels = populatedParams.mipLevels;
+            }
+            if (populatedParams.isStatic !== undefined) {
+                gpuParams.isStatic = populatedParams.isStatic;
+            }
+            if (populatedParams.transform !== undefined) {
+                gpuParams.transform = populatedParams.transform;
+            }
+            if (populatedParams.width !== undefined) {
+                gpuParams.width = populatedParams.width;
+            }
+            if (populatedParams.height !== undefined) {
+                gpuParams.height = populatedParams.height;
+            }
+            quadLayer = binding.createQuadLayer(gpuParams);
+            wrapper = new WebXRWebGPUCompositionLayerWrapper(
+                () => quadLayer.width,
+                () => quadLayer.height,
+                quadLayer,
+                "XRQuadLayer",
+                false,
+                (sessionManager) => new WebXRWebGPUCompositionLayerRenderTargetTextureProvider(sessionManager, binding, wrapper)
+            );
+        } else {
+            quadLayer = this._xrWebGLBinding.createQuadLayer(populatedParams);
+            wrapper = new WebXRCompositionLayerWrapper(
+                () => quadLayer.width,
+                () => quadLayer.height,
+                quadLayer,
+                "XRQuadLayer",
+                false,
+                (sessionManager) => new WebXRCompositionLayerRenderTargetTextureProvider(sessionManager, this._xrWebGLBinding, wrapper)
+            );
+        }
 
         quadLayer.width = this._isMultiviewEnabled ? 1 : 2;
         quadLayer.height = 1;
-        // this wrapper is not really needed, but it's here for consistency
-        const wrapper: WebXRCompositionLayerWrapper = new WebXRCompositionLayerWrapper(
-            () => quadLayer.width,
-            () => quadLayer.height,
-            quadLayer,
-            "XRQuadLayer",
-            false,
-            (sessionManager) => new WebXRCompositionLayerRenderTargetTextureProvider(sessionManager, this._xrWebGLBinding, wrapper)
-        );
 
         if (babylonTexture) {
             this._compositionLayerTextureMapping.set(quadLayer, babylonTexture);
         }
-        const rtt = wrapper.createRenderTargetTextureProvider(this._xrSessionManager) as WebXRCompositionLayerRenderTargetTextureProvider;
+        const rtt = wrapper.createRenderTargetTextureProvider(this._xrSessionManager) as
+            WebXRCompositionLayerRenderTargetTextureProvider | WebXRWebGPUCompositionLayerRenderTargetTextureProvider;
         this._layerToRTTProviderMapping.set(quadLayer, rtt);
         this.addXRSessionLayer(wrapper);
         return wrapper;
@@ -231,9 +294,12 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * Note that no interaction will be available with the ADT when using this method
      * @param texture the texture to display in the layer
      * @param options optional parameters for the layer
-     * @returns a composition layer containing the texture
+     * @returns a composition layer containing the texture, or null when WebGPU quad layers are unavailable
      */
-    public addFullscreenAdvancedDynamicTexture(texture: DynamicTexture, options: { distanceFromHeadset: number } = { distanceFromHeadset: 1.5 }): WebXRCompositionLayerWrapper {
+    public addFullscreenAdvancedDynamicTexture(
+        texture: DynamicTexture,
+        options: { distanceFromHeadset: number } = { distanceFromHeadset: 1.5 }
+    ): Nullable<WebXRCompositionLayerWrapper> {
         const wrapper = this._createQuadLayer(
             {
                 params: {
@@ -244,6 +310,9 @@ export class WebXRLayers extends WebXRAbstractFeature {
             },
             texture
         );
+        if (!wrapper) {
+            return null;
+        }
 
         const layer = wrapper.layer as XRQuadLayer;
         const distance = Math.max(0.1, options.distanceFromHeadset);
@@ -289,9 +358,9 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * Note - this will remove the lens flare system from the scene and add it to the XR scene.
      * This feature is experimental and might change in the future.
      * @param flareSystem the flare system to add
-     * @returns a composition layer containing the flare system
+     * @returns a composition layer containing the flare system, or null when WebGPU quad layers are unavailable
      */
-    protected _addLensFlareSystem(flareSystem: LensFlareSystem): WebXRCompositionLayerWrapper {
+    protected _addLensFlareSystem(flareSystem: LensFlareSystem): Nullable<WebXRCompositionLayerWrapper> {
         const wrapper = this._createQuadLayer({
             params: {
                 space: this._xrSessionManager.viewerReferenceSpace,
@@ -299,6 +368,9 @@ export class WebXRLayers extends WebXRAbstractFeature {
                 layout: "mono",
             },
         });
+        if (!wrapper) {
+            return null;
+        }
 
         const layer = wrapper.layer as XRQuadLayer;
         layer.width = 2;

--- a/packages/dev/core/test/unit/XR/webXRLayers.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayers.test.ts
@@ -3,7 +3,10 @@
  */
 
 import { NullEngine } from "core/Engines/nullEngine";
+import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
+import { WebXRCompositionLayerWrapper } from "core/XR/features/Layers/WebXRCompositionLayer";
+import { WebXRWebGPUCompositionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUCompositionLayer";
 import { WebXRLayers } from "core/XR/features/WebXRLayers";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,7 +20,13 @@ interface ProjectionLayerBindingConstructor {
 type TestGlobals = typeof globalThis & {
     XRGPUBinding?: ProjectionLayerBindingConstructor;
     XRWebGLBinding?: ProjectionLayerBindingConstructor;
+    XRRigidTransform?: typeof XRRigidTransform;
 };
+
+const WebGPUQuadLayerCreateWarning =
+    "WebGPU XR quad layers are unavailable because XRGPUBinding.createQuadLayer is not supported; the requested quad layer was skipped and projection rendering remains active.";
+const WebGPUQuadLayerSubImageWarning =
+    "WebGPU XR quad layers are unavailable because XRGPUBinding.getSubImage is not supported; the requested quad layer was skipped and projection rendering remains active.";
 
 describe("WebXRLayers", () => {
     let engine: NullEngine;
@@ -26,6 +35,7 @@ describe("WebXRLayers", () => {
     const testGlobals = globalThis as TestGlobals;
     let originalGPUBinding: ProjectionLayerBindingConstructor | undefined;
     let originalWebGLBinding: ProjectionLayerBindingConstructor | undefined;
+    let originalRigidTransform: typeof XRRigidTransform | undefined;
 
     beforeEach(() => {
         engine = new NullEngine({
@@ -37,8 +47,11 @@ describe("WebXRLayers", () => {
         });
         scene = new Scene(engine);
         sessionManager = new WebXRSessionManager(scene);
+        (sessionManager as any)._xrNavigator = { xr: { native: false } };
         originalGPUBinding = testGlobals.XRGPUBinding;
         originalWebGLBinding = testGlobals.XRWebGLBinding;
+        originalRigidTransform = testGlobals.XRRigidTransform;
+        testGlobals.XRRigidTransform = vi.fn(function () {}) as unknown as typeof XRRigidTransform;
     });
 
     afterEach(() => {
@@ -51,6 +64,11 @@ describe("WebXRLayers", () => {
             testGlobals.XRWebGLBinding = originalWebGLBinding;
         } else {
             delete testGlobals.XRWebGLBinding;
+        }
+        if (originalRigidTransform) {
+            testGlobals.XRRigidTransform = originalRigidTransform;
+        } else {
+            delete testGlobals.XRRigidTransform;
         }
         vi.restoreAllMocks();
         scene.dispose();
@@ -72,6 +90,28 @@ describe("WebXRLayers", () => {
         const binding = vi.fn() as unknown as ProjectionLayerBindingConstructor;
         binding.prototype.createProjectionLayer = vi.fn();
         testGlobals.XRWebGLBinding = binding;
+    }
+
+    function initializeSession(): ReturnType<typeof vi.fn> {
+        const updateRenderState = vi.fn();
+        sessionManager.session = {
+            enabledFeatures: ["layers"],
+            renderState: {},
+            updateRenderState,
+            end: vi.fn(),
+        } as unknown as XRSession;
+        sessionManager.inXRSession = true;
+        sessionManager.referenceSpace = { name: "reference" } as unknown as XRReferenceSpace;
+        sessionManager.viewerReferenceSpace = { name: "viewer" } as unknown as XRReferenceSpace;
+        return updateRenderState;
+    }
+
+    function addBabylonLayer(texture: object): void {
+        scene.layers.push({
+            texture,
+            renderTargetTextures: [],
+            renderOnlyInRenderTargetTextures: false,
+        } as any);
     }
 
     describe("isCompatible", () => {
@@ -108,6 +148,142 @@ describe("WebXRLayers", () => {
             installWebGLBinding();
 
             expect(new WebXRLayers(sessionManager).isCompatible()).toBe(true);
+        });
+    });
+
+    describe("quad layers", () => {
+        it("reuses the cached WebGL binding and preserves the native projection and quad init dictionaries", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { width: 0, height: 0 };
+            const createProjectionLayer = vi.fn(() => projectionLayer);
+            const createQuadLayer = vi.fn(() => quadLayer);
+            const nativeBinding = { createProjectionLayer, createQuadLayer, getSubImage: vi.fn() };
+            const xrWebGLBinding = vi.fn().mockImplementation(function () {
+                return nativeBinding;
+            });
+            testGlobals.XRWebGLBinding = xrWebGLBinding as unknown as ProjectionLayerBindingConstructor;
+            const glContext = {} as WebGLRenderingContext;
+            (engine as any)._gl = glContext;
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager, { projectionLayerInit: { scaleFactor: 0.75 } });
+
+            expect(feature.attach()).toBe(true);
+
+            const texture = {};
+            addBabylonLayer(texture);
+            const wrapper = feature.addFullscreenAdvancedDynamicTexture(texture as any);
+
+            expect(wrapper).toBeInstanceOf(WebXRCompositionLayerWrapper);
+            expect(wrapper).not.toBeInstanceOf(WebXRWebGPUCompositionLayerWrapper);
+            expect(xrWebGLBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, glContext);
+            expect(sessionManager._getGraphicsBinding().binding).toBe(nativeBinding);
+            expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
+            expect(createProjectionLayer).toHaveBeenCalledExactlyOnceWith({
+                textureType: "texture",
+                colorFormat: 0x1908,
+                depthFormat: 0x88f0,
+                scaleFactor: 0.75,
+                clearOnAccess: false,
+            });
+            expect(createQuadLayer).toHaveBeenCalledExactlyOnceWith({
+                space: sessionManager.viewerReferenceSpace,
+                viewPixelWidth: 1024,
+                viewPixelHeight: 512,
+                clearOnAccess: true,
+                textureType: "texture",
+                layout: "mono",
+            });
+            expect(quadLayer.width).toBe(2);
+            expect(quadLayer.height).toBe(1);
+        });
+
+        it("uses native WebGPU quad creation with explicit render-attachment usage", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { width: 0, height: 0 };
+            const createProjectionLayer = vi.fn(() => projectionLayer);
+            const createQuadLayer = vi.fn(() => quadLayer);
+            const nativeBinding = {
+                createProjectionLayer,
+                createQuadLayer,
+                getSubImage: vi.fn(),
+                getPreferredColorFormat: vi.fn(() => "rgba8unorm"),
+            };
+            testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
+                return nativeBinding;
+            }) as unknown as ProjectionLayerBindingConstructor;
+            (engine as any)._isWebGPU = true;
+            (engine as any)._device = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+
+            expect(feature.attach()).toBe(true);
+
+            const texture = {};
+            addBabylonLayer(texture);
+            const wrapper = feature.addFullscreenAdvancedDynamicTexture(texture as any);
+
+            expect(wrapper).toBeInstanceOf(WebXRWebGPUCompositionLayerWrapper);
+            expect(wrapper).toBeInstanceOf(WebXRCompositionLayerWrapper);
+            expect(createQuadLayer).toHaveBeenCalledExactlyOnceWith({
+                colorFormat: "rgba8unorm",
+                textureUsage: 0x10,
+                space: sessionManager.viewerReferenceSpace,
+                viewPixelWidth: 1024,
+                viewPixelHeight: 512,
+                layout: "mono",
+            });
+            expect(quadLayer.width).toBe(2);
+            expect(quadLayer.height).toBe(1);
+        });
+
+        it("skips only the WebGPU quad path when createQuadLayer is unavailable", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const nativeBinding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                getSubImage: vi.fn(),
+                getPreferredColorFormat: vi.fn(() => "rgba8unorm"),
+            };
+            testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
+                return nativeBinding;
+            }) as unknown as ProjectionLayerBindingConstructor;
+            (engine as any)._isWebGPU = true;
+            (engine as any)._device = {};
+            const updateRenderState = initializeSession();
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+            const feature = new WebXRLayers(sessionManager);
+
+            expect(feature.attach()).toBe(true);
+            expect(feature.addFullscreenAdvancedDynamicTexture({} as any)).toBeNull();
+            expect(feature.attached).toBe(true);
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUQuadLayerCreateWarning);
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+            expect(updateRenderState.mock.calls[0][0].layers).toEqual([projectionLayer]);
+        });
+
+        it("skips only the WebGPU quad path when getSubImage is unavailable", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const createQuadLayer = vi.fn();
+            const nativeBinding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer,
+                getPreferredColorFormat: vi.fn(() => "rgba8unorm"),
+            };
+            testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
+                return nativeBinding;
+            }) as unknown as ProjectionLayerBindingConstructor;
+            (engine as any)._isWebGPU = true;
+            (engine as any)._device = {};
+            const updateRenderState = initializeSession();
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+            const feature = new WebXRLayers(sessionManager);
+
+            expect(feature.attach()).toBe(true);
+            expect(feature.addFullscreenAdvancedDynamicTexture({} as any)).toBeNull();
+            expect(feature.attached).toBe(true);
+            expect(createQuadLayer).not.toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUQuadLayerSubImageWarning);
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+            expect(updateRenderState.mock.calls[0][0].layers).toEqual([projectionLayer]);
         });
     });
 });

--- a/packages/dev/core/test/unit/XR/webXRWebGPUCompositionLayer.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRWebGPUCompositionLayer.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { Viewport } from "core/Maths/math.viewport";
+import { Scene } from "core/scene";
+import { WebXRWebGPUCompositionLayerRenderTargetTextureProvider, WebXRWebGPUCompositionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUCompositionLayer";
+import { type WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type CompositionLayer = ConstructorParameters<typeof WebXRWebGPUCompositionLayerWrapper>[2];
+type GPUBinding = ConstructorParameters<typeof WebXRWebGPUCompositionLayerRenderTargetTextureProvider>[1];
+type GPUSubImage = ReturnType<GPUBinding["getSubImage"]>;
+type Eye = NonNullable<Parameters<GPUBinding["getSubImage"]>[2]>;
+
+function createTexture(name: string, width: number, height: number): GPUTexture {
+    return { label: name, width, height } as GPUTexture;
+}
+
+function createSubImage(
+    colorTexture: GPUTexture,
+    depthStencilTexture: GPUTexture,
+    viewport = { x: 0, y: 0, width: colorTexture.width, height: colorTexture.height },
+    baseArrayLayer = 0
+): GPUSubImage {
+    return {
+        colorTexture,
+        depthStencilTexture,
+        viewport,
+        getViewDescriptor: () => ({ baseArrayLayer }),
+    } as GPUSubImage;
+}
+
+describe("WebXRWebGPUCompositionLayerRenderTargetTextureProvider", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let currentFrame: XRFrame;
+    let layer: CompositionLayer;
+    let binding: { getSubImage: ReturnType<typeof vi.fn> };
+    let wrapSpy: ReturnType<typeof vi.fn>;
+    let updateSpy: ReturnType<typeof vi.fn>;
+
+    function createRenderTargetProvider() {
+        const wrapper = new WebXRWebGPUCompositionLayerWrapper(
+            () => 2,
+            () => 1,
+            layer,
+            "XRQuadLayer",
+            false,
+            (sessionManager) => new WebXRWebGPUCompositionLayerRenderTargetTextureProvider(sessionManager, binding as unknown as GPUBinding, wrapper)
+        );
+        return wrapper.createRenderTargetTextureProvider({ scene, currentFrame } as unknown as WebXRSessionManager);
+    }
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        currentFrame = {} as XRFrame;
+        layer = { width: 2, height: 1 } as unknown as CompositionLayer;
+        binding = { getSubImage: vi.fn() };
+        wrapSpy = vi.fn((texture: GPUTexture) => {
+            const internalTexture = new InternalTexture(engine, InternalTextureSource.External, true);
+            internalTexture.width = internalTexture.baseWidth = texture.width;
+            internalTexture.height = internalTexture.baseHeight = texture.height;
+            return internalTexture;
+        });
+        updateSpy = vi.fn();
+        (engine as any).wrapWebGPUTexture = wrapSpy;
+        (engine as any).updateWrappedWebGPUTexture = updateSpy;
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("queries the current frame with the wrapped quad layer and requested eye", () => {
+        const subImage = createSubImage(createTexture("color", 512, 256), createTexture("depth", 512, 256));
+        binding.getSubImage.mockReturnValue(subImage);
+        const provider = createRenderTargetProvider();
+        const wrongLayer = {} as CompositionLayer;
+
+        expect(provider.getRenderTargetTextureForView({ eye: "right" } as XRView)).not.toBeNull();
+
+        expect(binding.getSubImage).toHaveBeenCalledExactlyOnceWith(layer, currentFrame, "right");
+        expect(binding.getSubImage).not.toHaveBeenCalledWith(wrongLayer, currentFrame, "right");
+    });
+
+    it("repoints rotating compositor textures while preserving render target identity", () => {
+        const firstColor = createTexture("color-1", 512, 256);
+        const firstDepth = createTexture("depth-1", 512, 256);
+        const secondColor = createTexture("color-2", 512, 256);
+        const secondDepth = createTexture("depth-2", 512, 256);
+        binding.getSubImage.mockReturnValueOnce(createSubImage(firstColor, firstDepth)).mockReturnValueOnce(createSubImage(secondColor, secondDepth));
+        const provider = createRenderTargetProvider();
+
+        const first = provider.getRenderTargetTextureForEye("left");
+        const second = provider.getRenderTargetTextureForEye("left");
+
+        expect(second).toBe(first);
+        expect(wrapSpy).toHaveBeenCalledTimes(1);
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+        expect(updateSpy.mock.calls[0][1]).toBe(secondColor);
+        expect(updateSpy).not.toHaveBeenCalledWith(expect.anything(), firstColor);
+        expect(updateSpy).not.toHaveBeenCalledWith(expect.anything(), firstDepth);
+        expect(updateSpy).not.toHaveBeenCalledWith(expect.anything(), secondDepth);
+    });
+
+    it("disposes and rebuilds the render target when compositor texture size changes", () => {
+        binding.getSubImage
+            .mockReturnValueOnce(createSubImage(createTexture("color-1", 512, 256), createTexture("depth-1", 512, 256)))
+            .mockReturnValueOnce(createSubImage(createTexture("color-2", 256, 128), createTexture("depth-2", 256, 128)));
+        const provider = createRenderTargetProvider();
+
+        const first = provider.getRenderTargetTextureForEye("left");
+        const disposeSpy = vi.spyOn(first!, "dispose");
+        const second = provider.getRenderTargetTextureForEye("left");
+
+        expect(second).not.toBe(first);
+        expect(second!.getRenderWidth()).toBe(256);
+        expect(second!.getRenderHeight()).toBe(128);
+        expect(disposeSpy).toHaveBeenCalledTimes(1);
+        expect(wrapSpy).toHaveBeenCalledTimes(2);
+        expect((provider as any)._renderTargetTextures).toEqual([second]);
+    });
+
+    it("normalizes the quad sub-image viewport by its color texture dimensions", () => {
+        const color = createTexture("color", 800, 400);
+        binding.getSubImage.mockReturnValue(createSubImage(color, createTexture("depth", 800, 400), { x: 200, y: 100, width: 400, height: 200 }));
+        const provider = createRenderTargetProvider();
+        const viewport = new Viewport(0, 0, 1, 1);
+
+        expect(provider.trySetViewportForView(viewport, { eye: "left" } as XRView)).toBe(true);
+        expect(viewport).toMatchObject({ x: 0.25, y: 0.25, width: 0.5, height: 0.5 });
+    });
+
+    it("routes each eye to the array layer from its sub-image descriptor", () => {
+        binding.getSubImage.mockImplementation((_layer: CompositionLayer, _frame: XRFrame, eye: Eye) => {
+            const arrayLayer = eye === "right" ? 1 : 0;
+            return createSubImage(createTexture(`color-${eye}`, 512, 256), createTexture(`depth-${eye}`, 512, 256), undefined, arrayLayer);
+        });
+        const provider = createRenderTargetProvider();
+
+        const left = provider.getRenderTargetTextureForEye("left");
+        const right = provider.getRenderTargetTextureForEye("right");
+
+        expect(left).not.toBe(right);
+        expect((left as any).layerIndex).toBe(0);
+        expect((right as any).layerIndex).toBe(1);
+        expect(binding.getSubImage).toHaveBeenNthCalledWith(1, layer, currentFrame, "left");
+        expect(binding.getSubImage).toHaveBeenNthCalledWith(2, layer, currentFrame, "right");
+    });
+
+    it("does not query the binding without a current XR frame", () => {
+        const wrapper = new WebXRWebGPUCompositionLayerWrapper(
+            () => 2,
+            () => 1,
+            layer,
+            "XRQuadLayer",
+            false,
+            (sessionManager) => new WebXRWebGPUCompositionLayerRenderTargetTextureProvider(sessionManager, binding as unknown as GPUBinding, wrapper)
+        );
+        const provider = wrapper.createRenderTargetTextureProvider({ scene, currentFrame: null } as unknown as WebXRSessionManager);
+
+        expect(provider.getRenderTargetTextureForEye("left")).toBeNull();
+        expect(binding.getSubImage).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Route Babylon's existing fullscreen ADT and lens-flare quad paths through the cached WebXR graphics binding.
- Add guarded WebGPU quad-layer creation using `XRGPUBinding.createQuadLayer` and `getSubImage` only when both methods are present.
- Reuse the existing WebGPU composition wrapper/provider so rotating compositor textures, eye/array-layer descriptors, viewports, and size-change disposal retain their established behavior.
- Preserve the existing WebGL native dictionaries and provider path while reusing the cached binding.

Closes #18769.
Part of #18636.

## Quest validation

- WebGPU XR projection entry and rendering: **PASS**
- Graceful quad fallback: **PASS**
- The tested Quest UA exposed neither draft method (`createQuadLayer=false`, `getSubImage=false`), so native WebGPU quad rendering remains runtime-unvalidated.
- The attempted quad path emitted exactly one precise capability warning, hid only the quad, and did not tear down projection rendering.

The `addFullscreenAdvancedDynamicTexture` experimental return is deliberately nullable. When the UA cannot create a native quad layer, there is no valid wrapper to return; `null` preserves projection and lets callers distinguish the supported path from graceful fallback without a throw or a misleading dummy wrapper.

## Automated checks

- Focused Phase 4B XR tests: 3 files, 32 tests passed
- Full core XR unit selection: 18 files, 304 tests passed
- Core TypeScript build
- Targeted ESLint and Prettier
- Tree-shaking checks
- Side-effect synchronization checks
- Tree-shaking bundle smoke tests
