### PR TITLE
[WebGPU XR] Disable Space Warp before session creation

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
+++ b/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
@@ -1,4 +1,5 @@
 import { type IWebXRFeature } from "../webXRFeaturesManager";
+import { _MarkWebXRFeatureWithSpecificDisableWarning } from "../webXRFeatureWarningRegistry";
 import { type Observer, type EventState, Observable } from "../../Misc/observable";
 import { type Nullable } from "../../types";
 import { type WebXRSessionManager } from "../webXRSessionManager";
@@ -156,6 +157,7 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
             Logger.Warn(warning);
             this._disableAutoAttachWarningEmitted = true;
         }
+        _MarkWebXRFeatureWithSpecificDisableWarning(this);
         this.disableAutoAttach = true;
         return false;
     }

--- a/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
+++ b/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
@@ -11,6 +11,7 @@ import { Logger } from "core/Misc/logger";
  */
 export abstract class WebXRAbstractFeature implements IWebXRFeature {
     private _attached: boolean = false;
+    private _disableAutoAttachWarningEmitted: boolean = false;
     private _removeOnDetach: {
         observer: Nullable<Observer<any>>;
         observable: Observable<any>;
@@ -151,7 +152,10 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
      * @returns false so feature attach implementations can return the result directly
      */
     protected _disableAutoAttach(warning: string): false {
-        Logger.Warn(warning);
+        if (!this._disableAutoAttachWarningEmitted) {
+            Logger.Warn(warning);
+            this._disableAutoAttachWarningEmitted = true;
+        }
         this.disableAutoAttach = true;
         return false;
     }

--- a/packages/dev/core/src/XR/features/WebXRSpaceWarp.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRSpaceWarp.pure.ts
@@ -16,7 +16,7 @@ import { ShaderMaterial } from "../../Materials/shaderMaterial.pure";
 import { type AbstractMesh } from "../../Meshes/abstractMesh.pure";
 import { type Material } from "../../Materials/material.pure";
 import { type Observer } from "../../Misc/observable.pure";
-import { type ThinEngine } from "../../Engines/thinEngine.pure";
+import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 
 /**
  * Used for Space Warp render process
@@ -278,7 +278,6 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
      * The space warp provider
      */
     public spaceWarpRTTProvider: Nullable<WebXRSpaceWarpRenderTargetTextureProvider>;
-    private _glContext: WebGLRenderingContext | WebGL2RenderingContext;
     private _xrWebGLBinding: XRWebGLBinding;
     private _renderTargetTexture: Nullable<RenderTargetTexture>;
     private _onAfterRenderObserver: Nullable<Observer<Scene>> = null;
@@ -300,13 +299,21 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
      * @returns true if successful.
      */
     public override attach(): boolean {
+        if (this._xrSessionManager.scene.getEngine().isWebGPU) {
+            return this._disableAutoAttach(
+                "WebXR Space Warp is unavailable with WebGPU XR because this runtime does not expose usable motion-vector/depth sub-images; the feature was disabled."
+            );
+        }
+
         if (!super.attach()) {
             return false;
         }
 
-        const engine = this._xrSessionManager.scene.getEngine();
-        this._glContext = (engine as ThinEngine)._gl;
-        this._xrWebGLBinding = new XRWebGLBinding(this._xrSessionManager.session, this._glContext);
+        const graphicsBinding = this._xrSessionManager._getGraphicsBinding();
+        if (graphicsBinding.bindingType !== WebXRGraphicsBindingType.WebGL) {
+            throw new Error("Expected a WebGL graphics binding for WebXR Space Warp.");
+        }
+        this._xrWebGLBinding = graphicsBinding.binding;
 
         this.spaceWarpRTTProvider = new WebXRSpaceWarpRenderTargetTextureProvider(this._xrSessionManager.scene, this._xrSessionManager, this._xrWebGLBinding);
 

--- a/packages/dev/core/src/XR/features/WebXRSpaceWarp.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRSpaceWarp.pure.ts
@@ -18,6 +18,9 @@ import { type Material } from "../../Materials/material.pure";
 import { type Observer } from "../../Misc/observable.pure";
 import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 
+const _WebGPUUnavailableWarning =
+    "WebXR Space Warp is unavailable with WebGPU XR because this runtime does not expose usable motion-vector/depth sub-images; the feature was disabled.";
+
 /**
  * Used for Space Warp render process
  */
@@ -289,7 +292,6 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
     constructor(_xrSessionManager: WebXRSessionManager) {
         super(_xrSessionManager);
         this.xrNativeFeatureName = "space-warp";
-        this._xrSessionManager.scene.needsPreviousWorldMatrices = true;
     }
 
     /**
@@ -300,14 +302,13 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
      */
     public override attach(): boolean {
         if (this._xrSessionManager.scene.getEngine().isWebGPU) {
-            return this._disableAutoAttach(
-                "WebXR Space Warp is unavailable with WebGPU XR because this runtime does not expose usable motion-vector/depth sub-images; the feature was disabled."
-            );
+            return this._disableAutoAttach(_WebGPUUnavailableWarning);
         }
 
         if (!super.attach()) {
             return false;
         }
+        this._xrSessionManager.scene.needsPreviousWorldMatrices = true;
 
         const graphicsBinding = this._xrSessionManager._getGraphicsBinding();
         if (graphicsBinding.bindingType !== WebXRGraphicsBindingType.WebGL) {
@@ -336,6 +337,9 @@ export class WebXRSpaceWarp extends WebXRAbstractFeature {
     public override dependsOn: string[] = [WebXRFeatureName.LAYERS];
 
     public override isCompatible(): boolean {
+        if (this._xrSessionManager.scene.getEngine().isWebGPU) {
+            return this._disableAutoAttach(_WebGPUUnavailableWarning);
+        }
         return this._xrSessionManager.scene.getEngine().getCaps().colorBufferHalfFloat || false;
     }
 

--- a/packages/dev/core/src/XR/webXRFeatureWarningRegistry.ts
+++ b/packages/dev/core/src/XR/webXRFeatureWarningRegistry.ts
@@ -1,0 +1,22 @@
+import { type IWebXRFeature } from "./webXRFeaturesManager";
+
+let _FeaturesWithSpecificDisableWarning: WeakSet<IWebXRFeature> | undefined;
+
+/**
+ * Records that a feature used the warning-emitting intentional-disable path.
+ * @param feature the feature that reported its intentional disable
+ * @internal
+ */
+export function _MarkWebXRFeatureWithSpecificDisableWarning(feature: IWebXRFeature): void {
+    (_FeaturesWithSpecificDisableWarning ??= new WeakSet()).add(feature);
+}
+
+/**
+ * Clears and returns whether a feature used the warning-emitting intentional-disable path.
+ * @param feature the feature to query
+ * @returns whether the feature reported its intentional disable since the previous query
+ * @internal
+ */
+export function _ConsumeWebXRFeatureSpecificDisableWarning(feature: IWebXRFeature): boolean {
+    return _FeaturesWithSpecificDisableWarning?.delete(feature) ?? false;
+}

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -583,7 +583,10 @@ export class WebXRFeaturesManager implements IDisposable {
                 throw new Error(`Dependant features missing. Make sure the following features are enabled - ${constructed.dependsOn.join(", ")}`);
             }
         }
-        if (constructed.isCompatible()) {
+        const disableAutoAttachBeforeCompatibility = constructed.disableAutoAttach;
+        const isCompatible = constructed.isCompatible();
+        const intentionallyDisabledDuringCompatibility = !disableAutoAttachBeforeCompatibility && constructed.disableAutoAttach;
+        if (isCompatible) {
             this._features[name] = {
                 featureImplementation: constructed,
                 enabled: true,
@@ -607,7 +610,7 @@ export class WebXRFeaturesManager implements IDisposable {
             if (required) {
                 throw new Error("required feature not compatible");
             } else {
-                if (!constructed.disableAutoAttach) {
+                if (!intentionallyDisabledDuringCompatibility) {
                     Tools.Warn(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
                 }
                 return constructed as ResolveWebXRFeature<T>;

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -607,7 +607,9 @@ export class WebXRFeaturesManager implements IDisposable {
             if (required) {
                 throw new Error("required feature not compatible");
             } else {
-                Tools.Warn(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
+                if (!constructed.disableAutoAttach) {
+                    Tools.Warn(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
+                }
                 return constructed as ResolveWebXRFeature<T>;
             }
         }

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -23,6 +23,7 @@ import { type IWebXRPlaneDetectorOptions, type WebXRPlaneDetector } from "./feat
 import { type IWebXRRawCameraAccessOptions, type WebXRRawCameraAccess } from "./features/WebXRRawCameraAccess";
 import { type WebXRSpaceWarp } from "./features/WebXRSpaceWarp";
 import { type IWebXRWalkingLocomotionOptions, type WebXRWalkingLocomotion } from "./features/WebXRWalkingLocomotion";
+import { _ConsumeWebXRFeatureSpecificDisableWarning } from "./webXRFeatureWarningRegistry";
 import { type WebXRSessionManager } from "./webXRSessionManager";
 
 /**
@@ -583,9 +584,9 @@ export class WebXRFeaturesManager implements IDisposable {
                 throw new Error(`Dependant features missing. Make sure the following features are enabled - ${constructed.dependsOn.join(", ")}`);
             }
         }
-        const disableAutoAttachBeforeCompatibility = constructed.disableAutoAttach;
+        _ConsumeWebXRFeatureSpecificDisableWarning(constructed);
         const isCompatible = constructed.isCompatible();
-        const intentionallyDisabledDuringCompatibility = !disableAutoAttachBeforeCompatibility && constructed.disableAutoAttach;
+        const emittedSpecificDisableWarning = _ConsumeWebXRFeatureSpecificDisableWarning(constructed);
         if (isCompatible) {
             this._features[name] = {
                 featureImplementation: constructed,
@@ -610,7 +611,7 @@ export class WebXRFeaturesManager implements IDisposable {
             if (required) {
                 throw new Error("required feature not compatible");
             } else {
-                if (!intentionallyDisabledDuringCompatibility) {
+                if (!emittedSpecificDisableWarning) {
                     Tools.Warn(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
                 }
                 return constructed as ResolveWebXRFeature<T>;

--- a/packages/dev/core/test/unit/XR/webXRAbstractFeature.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRAbstractFeature.test.ts
@@ -143,6 +143,9 @@ describe("WebXRAbstractFeature", () => {
             expect(feature.attached).toBe(false);
             expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(false);
             expect(attachObserver).not.toHaveBeenCalled();
+
+            expect(feature.disableForRuntimeCapability(warning)).toBe(false);
+            expect(warnSpy).toHaveBeenCalledTimes(1);
             warnSpy.mockRestore();
         });
     });

--- a/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
@@ -5,6 +5,7 @@
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { WebXRAbstractFeature } from "core/XR/features/WebXRAbstractFeature";
 import { WebXRFeaturesManager, WebXRFeatureName, type IWebXRFeature, type WebXRFeatureConstructor } from "core/XR/webXRFeaturesManager";
 import { Observable } from "core/Misc/observable";
 import { Logger } from "core/Misc/logger";
@@ -55,6 +56,21 @@ function createMockFeatureConstructor(feature: IWebXRFeature): WebXRFeatureConst
     return (_xrSessionManager: WebXRSessionManager, _options?: any) => {
         return () => feature;
     };
+}
+
+class TestIntentionallyDisabledFeature extends WebXRAbstractFeature {
+    constructor(
+        sessionManager: WebXRSessionManager,
+        private readonly _warning: string
+    ) {
+        super(sessionManager);
+    }
+
+    public override isCompatible(): boolean {
+        return this._disableAutoAttach(this._warning);
+    }
+
+    protected override _onXRFrame(): void {}
 }
 
 describe("WebXRFeaturesManager – extended", () => {
@@ -240,9 +256,22 @@ describe("WebXRFeaturesManager – extended", () => {
         it("does not duplicate the warning from an intentionally disabled incompatible optional feature", () => {
             const name = uniqueFeatureName() as any;
             const warning = "The feature was disabled because a runtime capability is unavailable.";
+            const feature = new TestIntentionallyDisabledFeature(sessionManager, warning);
+            WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(feature), 1, true);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+            const result = featuresManager.enableFeature(name, 1, undefined, true, false);
+
+            expect(result).toBe(feature);
+            expect(featuresManager.getEnabledFeatures()).not.toContain(name);
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(warning);
+            warnSpy.mockRestore();
+        });
+
+        it("warns generically when an incompatible optional feature silently disables auto-attach during compatibility", () => {
+            const name = uniqueFeatureName() as any;
             const mockFeature = createMockFeature();
             mockFeature.isCompatible = vi.fn(() => {
-                Logger.Warn(warning);
                 mockFeature.disableAutoAttach = true;
                 return false;
             });
@@ -253,7 +282,7 @@ describe("WebXRFeaturesManager – extended", () => {
 
             expect(result).toBe(mockFeature);
             expect(featuresManager.getEnabledFeatures()).not.toContain(name);
-            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(warning);
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
             warnSpy.mockRestore();
         });
 

--- a/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
@@ -227,11 +227,34 @@ describe("WebXRFeaturesManager – extended", () => {
             const name = uniqueFeatureName() as any;
             const mockFeature = createMockFeature({ isCompatible: vi.fn(() => false) });
             WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(mockFeature), 1, true);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
 
             const result = featuresManager.enableFeature(name, 1, undefined, true, false);
             expect(result).toBeDefined();
             // It should NOT be in the enabled features list since it's incompatible
             expect(featuresManager.getEnabledFeatures()).not.toContain(name);
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
+            warnSpy.mockRestore();
+        });
+
+        it("does not duplicate the warning from an intentionally disabled incompatible optional feature", () => {
+            const name = uniqueFeatureName() as any;
+            const warning = "The feature was disabled because a runtime capability is unavailable.";
+            const mockFeature = createMockFeature();
+            mockFeature.isCompatible = vi.fn(() => {
+                Logger.Warn(warning);
+                mockFeature.disableAutoAttach = true;
+                return false;
+            });
+            WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(mockFeature), 1, true);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+            const result = featuresManager.enableFeature(name, 1, undefined, true, false);
+
+            expect(result).toBe(mockFeature);
+            expect(featuresManager.getEnabledFeatures()).not.toContain(name);
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(warning);
+            warnSpy.mockRestore();
         });
 
         it("sets disableAutoAttach when attachIfPossible is false", () => {

--- a/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRFeaturesManagerExtended.test.ts
@@ -257,6 +257,20 @@ describe("WebXRFeaturesManager – extended", () => {
             warnSpy.mockRestore();
         });
 
+        it("warns generically when an incompatible optional feature was already marked disableAutoAttach", () => {
+            const name = uniqueFeatureName() as any;
+            const mockFeature = createMockFeature({ disableAutoAttach: true, isCompatible: vi.fn(() => false) });
+            WebXRFeaturesManager.AddWebXRFeature(name, createMockFeatureConstructor(mockFeature), 1, true);
+            const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+            const result = featuresManager.enableFeature(name, 1, undefined, true, false);
+
+            expect(result).toBe(mockFeature);
+            expect(featuresManager.getEnabledFeatures()).not.toContain(name);
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(`Feature ${name} not compatible with the current environment/browser and was not enabled.`);
+            warnSpy.mockRestore();
+        });
+
         it("sets disableAutoAttach when attachIfPossible is false", () => {
             const name = uniqueFeatureName() as any;
             const mockFeature = createMockFeature();

--- a/packages/dev/core/test/unit/XR/webXRSpaceWarp.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSpaceWarp.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import "core/Engines/Extensions/engine.multiview";
+import { RenderTargetWrapper } from "core/Engines/renderTargetWrapper";
+import { InternalTexture, InternalTextureSource } from "core/Materials/Textures/internalTexture";
+import { type RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
+import { Viewport } from "core/Maths/math.viewport";
+import { Logger } from "core/Misc/logger";
+import { Scene } from "core/scene";
+import { XRSpaceWarpRenderTarget, WebXRSpaceWarp, WebXRSpaceWarpRenderTargetTextureProvider } from "core/XR/features/WebXRSpaceWarp";
+import { WebXRFeaturesManager } from "core/XR/webXRFeaturesManager";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WebGPUWarning = "WebXR Space Warp is unavailable with WebGPU XR because this runtime does not expose usable motion-vector/depth sub-images; the feature was disabled.";
+
+class TestWebXRSpaceWarpRenderTargetTextureProvider extends WebXRSpaceWarpRenderTargetTextureProvider {
+    public readonly renderTargetTexture = { dispose: vi.fn() } as unknown as RenderTargetTexture;
+    public readonly createRenderTargetTexture = vi.fn();
+
+    protected override _createRenderTargetTexture(
+        width: number,
+        height: number,
+        framebuffer: WebGLFramebuffer | null,
+        motionVectorTexture: WebGLTexture,
+        depthStencilTexture: WebGLTexture
+    ): RenderTargetTexture {
+        this.createRenderTargetTexture(width, height, framebuffer, motionVectorTexture, depthStencilTexture);
+        return this.renderTargetTexture;
+    }
+}
+
+describe("WebXRSpaceWarp", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let originalWebGLBinding: unknown;
+    let originalGPUBinding: unknown;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        (sessionManager as unknown as { _xrNavigator: unknown })._xrNavigator = { xr: { native: false } };
+        originalWebGLBinding = (globalThis as unknown as { XRWebGLBinding?: unknown }).XRWebGLBinding;
+        originalGPUBinding = (globalThis as unknown as { XRGPUBinding?: unknown }).XRGPUBinding;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        (globalThis as unknown as { XRWebGLBinding?: unknown }).XRWebGLBinding = originalWebGLBinding;
+        (globalThis as unknown as { XRGPUBinding?: unknown }).XRGPUBinding = originalGPUBinding;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("disables once on WebGPU before creating bindings, render targets, framebuffers, or observers", () => {
+        const xrWebGLBinding = vi.fn();
+        const xrGPUBinding = vi.fn();
+        (globalThis as unknown as { XRWebGLBinding: unknown }).XRWebGLBinding = xrWebGLBinding;
+        (globalThis as unknown as { XRGPUBinding: unknown }).XRGPUBinding = xrGPUBinding;
+        (engine as unknown as { _isWebGPU: boolean })._isWebGPU = true;
+        (engine as unknown as { _device: GPUDevice })._device = {} as GPUDevice;
+        sessionManager.session = {} as XRSession;
+
+        const getGraphicsBindingSpy = vi.spyOn(sessionManager, "_getGraphicsBinding");
+        const createMultiviewRenderTargetTextureSpy = vi.spyOn(engine, "createMultiviewRenderTargetTexture");
+        const bindSpaceWarpFramebufferSpy = vi.spyOn(engine, "bindSpaceWarpFramebuffer");
+        const frameObserverSpy = vi.spyOn(sessionManager.onXRFrameObservable, "add");
+        const afterRenderObserverSpy = vi.spyOn(scene.onAfterRenderObservable, "add");
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        const feature = new WebXRSpaceWarp(sessionManager);
+        const featuresManager = new WebXRFeaturesManager(sessionManager);
+        (
+            featuresManager as unknown as {
+                _features: Record<string, { featureImplementation: WebXRSpaceWarp; enabled: boolean; version: number; required: boolean }>;
+            }
+        )._features[WebXRSpaceWarp.Name] = {
+            featureImplementation: feature,
+            enabled: true,
+            version: 1,
+            required: false,
+        };
+
+        featuresManager.attachFeature(WebXRSpaceWarp.Name);
+
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUWarning);
+        expect(getGraphicsBindingSpy).not.toHaveBeenCalled();
+        expect(xrGPUBinding).not.toHaveBeenCalled();
+        expect(xrWebGLBinding).not.toHaveBeenCalled();
+        expect(createMultiviewRenderTargetTextureSpy).not.toHaveBeenCalled();
+        expect(bindSpaceWarpFramebufferSpy).not.toHaveBeenCalled();
+        expect(frameObserverSpy).not.toHaveBeenCalled();
+        expect(afterRenderObserverSpy).not.toHaveBeenCalled();
+        expect(feature.spaceWarpRTTProvider).toBeUndefined();
+
+        sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        featuresManager.dispose();
+    });
+
+    it("reuses the cached WebGL binding when attaching", () => {
+        const nativeBinding = { getViewSubImage: vi.fn() };
+        const xrWebGLBinding = vi.fn().mockImplementation(function () {
+            return nativeBinding;
+        });
+        const glContext = {} as WebGLRenderingContext;
+        (globalThis as unknown as { XRWebGLBinding: unknown }).XRWebGLBinding = xrWebGLBinding;
+        (engine as unknown as { _gl: WebGLRenderingContext })._gl = glContext;
+        sessionManager.session = {
+            enabledFeatures: ["space-warp"],
+        } as XRSession;
+        const feature = new WebXRSpaceWarp(sessionManager);
+
+        expect(feature.attach()).toBe(true);
+        expect(xrWebGLBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, glContext);
+        expect(sessionManager._getGraphicsBinding().binding).toBe(nativeBinding);
+        expect(
+            (
+                feature.spaceWarpRTTProvider as unknown as {
+                    _xrWebGLBinding: XRWebGLBinding;
+                }
+            )._xrWebGLBinding
+        ).toBe(nativeBinding);
+        expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(true);
+        expect(scene.onAfterRenderObservable.hasObservers()).toBe(true);
+
+        expect(feature.detach()).toBe(true);
+        expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(false);
+        expect(scene.onAfterRenderObservable.hasObservers()).toBe(false);
+    });
+
+    it("keeps the native projection-layer sub-image provider behavior", () => {
+        const projectionLayer = {};
+        const view = { eye: "left" } as XRView;
+        const motionVectorTexture = {} as WebGLTexture;
+        const depthStencilTexture = {} as WebGLTexture;
+        const subImage = {
+            motionVectorTexture,
+            motionVectorTextureWidth: 640,
+            motionVectorTextureHeight: 480,
+            depthStencilTexture,
+        };
+        const nativeBinding = {
+            getViewSubImage: vi.fn(() => subImage),
+        } as unknown as XRWebGLBinding;
+        (
+            sessionManager as unknown as {
+                _baseLayerWrapper: { layerType: "XRProjectionLayer"; layer: object };
+            }
+        )._baseLayerWrapper = {
+            layerType: "XRProjectionLayer",
+            layer: projectionLayer,
+        };
+        const provider = new TestWebXRSpaceWarpRenderTargetTextureProvider(scene, sessionManager, nativeBinding);
+
+        expect(provider.getRenderTargetTextureForView(view)).toBe(provider.renderTargetTexture);
+        expect(nativeBinding.getViewSubImage).toHaveBeenCalledExactlyOnceWith(projectionLayer, view);
+        expect(provider.createRenderTargetTexture).toHaveBeenCalledExactlyOnceWith(640, 480, null, motionVectorTexture, depthStencilTexture);
+
+        const viewport = new Viewport(0, 0, 0, 0);
+        expect(provider.trySetViewportForView(viewport, view)).toBe(true);
+        expect(viewport).toMatchObject({ x: 0, y: 0, width: 640, height: 480 });
+        expect(nativeBinding.getViewSubImage).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the WebGL multiview render target and Space Warp framebuffer binding path", () => {
+        const motionVectorTexture = {} as WebGLTexture;
+        const depthStencilTexture = {} as WebGLTexture;
+        const multiviewRenderTarget = new RenderTargetWrapper(false, false, { width: 640, height: 480 }, engine);
+        const internalTexture = new InternalTexture(engine, InternalTextureSource.Unknown, true);
+        internalTexture.width = internalTexture.baseWidth = 640;
+        internalTexture.height = internalTexture.baseHeight = 480;
+        multiviewRenderTarget.setTexture(internalTexture);
+        const framebuffer = {} as WebGLFramebuffer;
+        Object.assign(multiviewRenderTarget, {
+            _framebuffer: framebuffer,
+            _colorTextureArray: motionVectorTexture,
+            _depthStencilTextureArray: depthStencilTexture,
+        });
+        const createMultiviewRenderTargetTextureSpy = vi.spyOn(engine, "createMultiviewRenderTargetTexture").mockReturnValue(multiviewRenderTarget);
+        const bindSpaceWarpFramebufferSpy = vi.spyOn(engine, "bindSpaceWarpFramebuffer").mockImplementation(() => {});
+
+        const renderTarget = new XRSpaceWarpRenderTarget(motionVectorTexture, depthStencilTexture, scene, { width: 640, height: 480 });
+
+        expect(createMultiviewRenderTargetTextureSpy).toHaveBeenCalledExactlyOnceWith(640, 480, motionVectorTexture, depthStencilTexture);
+        expect(renderTarget.renderTarget).toBe(multiviewRenderTarget);
+        expect(
+            renderTarget.renderTarget as unknown as {
+                _disposeOnlyFramebuffers: boolean;
+                _framebuffer: WebGLFramebuffer;
+                _colorTextureArray: WebGLTexture;
+                _depthStencilTextureArray: WebGLTexture;
+            }
+        ).toMatchObject({
+            _disposeOnlyFramebuffers: true,
+            _framebuffer: framebuffer,
+            _colorTextureArray: motionVectorTexture,
+            _depthStencilTextureArray: depthStencilTexture,
+        });
+
+        renderTarget._bindFrameBuffer();
+        expect(bindSpaceWarpFramebufferSpy).toHaveBeenCalledExactlyOnceWith(multiviewRenderTarget);
+
+        renderTarget.dispose();
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRSpaceWarp.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRSpaceWarp.test.ts
@@ -11,6 +11,7 @@ import { Viewport } from "core/Maths/math.viewport";
 import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
 import { XRSpaceWarpRenderTarget, WebXRSpaceWarp, WebXRSpaceWarpRenderTargetTextureProvider } from "core/XR/features/WebXRSpaceWarp";
+import { WebXRLayers } from "core/XR/features/WebXRLayers";
 import { WebXRFeaturesManager } from "core/XR/webXRFeaturesManager";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -104,10 +105,83 @@ describe("WebXRSpaceWarp", () => {
         expect(frameObserverSpy).not.toHaveBeenCalled();
         expect(afterRenderObserverSpy).not.toHaveBeenCalled();
         expect(feature.spaceWarpRTTProvider).toBeUndefined();
+        expect(scene.needsPreviousWorldMatrices).toBe(false);
 
         sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
         expect(warnSpy).toHaveBeenCalledTimes(1);
 
+        featuresManager.dispose();
+    });
+
+    it("disables before WebGPU session creation without requesting native Space Warp or disturbing projection layers", async () => {
+        const projectionLayer = {};
+        const getPreferredColorFormat = vi.fn(() => "rgba8unorm");
+        const createProjectionLayer = vi.fn(() => projectionLayer);
+        const xrGPUBinding = vi.fn().mockImplementation(function () {
+            return {
+                getPreferredColorFormat,
+                createProjectionLayer,
+            };
+        });
+        xrGPUBinding.prototype.createProjectionLayer = createProjectionLayer;
+        (globalThis as unknown as { XRGPUBinding: unknown }).XRGPUBinding = xrGPUBinding;
+        (engine as unknown as { _isWebGPU: boolean })._isWebGPU = true;
+        (engine as unknown as { _device: GPUDevice })._device = {} as GPUDevice;
+        const featuresManager = new WebXRFeaturesManager(sessionManager);
+        const layers = featuresManager.enableFeature(WebXRLayers.Name, 1, { preferMultiviewOnInit: false }, true, false);
+        const getGraphicsBindingSpy = vi.spyOn(sessionManager, "_getGraphicsBinding");
+        const createMultiviewRenderTargetTextureSpy = vi.spyOn(engine, "createMultiviewRenderTargetTexture");
+        const bindSpaceWarpFramebufferSpy = vi.spyOn(engine, "bindSpaceWarpFramebuffer");
+        const frameObserverSpy = vi.spyOn(sessionManager.onXRFrameObservable, "add");
+        const afterRenderObserverSpy = vi.spyOn(scene.onAfterRenderObservable, "add");
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        const feature = featuresManager.enableFeature(WebXRSpaceWarp.Name, 1, undefined, true, false);
+        const sessionInit = await featuresManager._extendXRSessionInitObject({ optionalFeatures: ["local-floor"] });
+
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        expect(featuresManager.getEnabledFeature(WebXRSpaceWarp.Name)).toBeUndefined();
+        expect(sessionInit.optionalFeatures).toEqual(["local-floor", "layers"]);
+        expect(sessionInit.requiredFeatures).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUWarning);
+        expect(getGraphicsBindingSpy).not.toHaveBeenCalled();
+        expect(createMultiviewRenderTargetTextureSpy).not.toHaveBeenCalled();
+        expect(bindSpaceWarpFramebufferSpy).not.toHaveBeenCalled();
+        expect(frameObserverSpy).not.toHaveBeenCalled();
+        expect(afterRenderObserverSpy).not.toHaveBeenCalled();
+        expect(scene.needsPreviousWorldMatrices).toBe(false);
+        expect(feature.spaceWarpRTTProvider).toBeUndefined();
+
+        expect(feature.attach()).toBe(false);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(getGraphicsBindingSpy).not.toHaveBeenCalled();
+        expect(frameObserverSpy).not.toHaveBeenCalled();
+        expect(afterRenderObserverSpy).not.toHaveBeenCalled();
+
+        const updateRenderState = vi.fn();
+        sessionManager.session = {
+            enabledFeatures: ["layers"],
+            renderState: {},
+            updateRenderState,
+        } as unknown as XRSession;
+        sessionManager.inXRSession = true;
+        sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
+
+        expect(layers.attached).toBe(true);
+        expect(sessionManager._getBaseLayerWrapper()?.layerType).toBe("XRProjectionLayer");
+        expect(getGraphicsBindingSpy).toHaveBeenCalledTimes(1);
+        expect(xrGPUBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, {});
+        expect(getPreferredColorFormat).toHaveBeenCalledTimes(1);
+        expect(createProjectionLayer).toHaveBeenCalledTimes(1);
+        expect(updateRenderState).toHaveBeenCalledTimes(1);
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        expect(feature.spaceWarpRTTProvider).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(scene.needsPreviousWorldMatrices).toBe(false);
+
+        sessionManager.inXRSession = false;
         featuresManager.dispose();
     });
 
@@ -136,6 +210,7 @@ describe("WebXRSpaceWarp", () => {
         ).toBe(nativeBinding);
         expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(true);
         expect(scene.onAfterRenderObservable.hasObservers()).toBe(true);
+        expect(scene.needsPreviousWorldMatrices).toBe(true);
 
         expect(feature.detach()).toBe(true);
         expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(false);


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- migrate the existing WebGL Space Warp provider to the session-scoped cached WebGL graphics binding
- disable Space Warp on WebGPU during compatibility evaluation, before XR session descriptor generation
- keep later WebGPU attach probes warning-idempotent and resource-free
- preserve WebGL native sub-image, multiview render-target, framebuffer, and previous-world-matrix behavior

## Quest A/B/C validation

A Quest A/B gate exposed that attach-time fallback was too late. The baseline mode rendered the blue sphere and ground, while an otherwise identical mode that requested native optional `space-warp` showed passthrough only. The native feature had already entered the session descriptor before the fallback could run.

The final implementation disables WebGPU Space Warp in `isCompatible()`. The feature is returned to the caller with `disableAutoAttach=true`, but is not registered with the features manager and therefore cannot add `space-warp` to optional or required session features.

The final Mode C gate constructed and probed the production fallback without requesting native `space-warp`. On Quest, the blue sphere and ground rendered normally and the post-exit verdict was exactly:

`PASS_WEBGPU_FALLBACK_NO_NATIVE_REQUEST_POST_EXIT`

The fallback emits exactly one warning:

`WebXR Space Warp is unavailable with WebGPU XR because this runtime does not expose usable motion-vector/depth sub-images; the feature was disabled.`

## Compatibility

WebGL behavior is unchanged: Space Warp still uses the cached WebGL graphics binding and retains the native projection-layer provider, multiview render target, framebuffer binding, and previous-world-matrix tracking paths. Previous-world-matrix tracking now begins only after a successful WebGL attach, keeping rejected WebGPU feature objects inert.

Generic incompatibility warnings remain intact for ordinary/custom optional features. They are suppressed only when compatibility itself transitions `disableAutoAttach` from false to true after emitting an intentional feature-specific warning.

## Validation

- focused XR tests: 65/65, then 44/44 after the warning-transition follow-up
- full XR unit tests: 301/301
- core TypeScript and UMD builds
- targeted Prettier and ESLint
- tree-shaking checks for all packages
- side-effect manifest synchronization
- tree-shaking bundle smoke tests
- final independent code review: no findings
- real Quest Mode C: healthy projection, visible sphere and ground, exact fallback PASS verdict

## Commits

- `2784af342f` — gate Space Warp on WebGPU and reuse the cached WebGL binding
- `13d505de8c` — disable Space Warp before WebGPU session creation
- `a2b6d729f1` — preserve generic incompatibility warnings

Fixes #18772.
Related to #18636 and #18635.
