### PR TITLE
Fix GreasedLine corrupting the shared TmpVectors scratch slot and Vector3.UpReadOnly

### DIFF
--- a/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/GreasedLine/greasedLineRibbonMesh.pure.ts
@@ -387,7 +387,11 @@ export class GreasedLineRibbonMesh extends GreasedLineBaseMesh {
                 throw "In GreasedLineRibbonAutoDirectionMode.AUTO_DIRECTIONS_FACE_TO 'GreasedLineMeshOptions.ribbonOptions.directions' must be a Vector3.";
             }
 
-            TmpVectors.Vector3[1] = ribbonInfo.directions instanceof Vector3 ? ribbonInfo.directions : GreasedLineRibbonMesh.DIRECTION_XZ;
+            // Copy into the scratch vector instead of rebinding the slot. Assigning would make
+            // TmpVectors.Vector3[1] alias either the caller's vector or one of the DIRECTION_*
+            // constants (which are themselves Vector3.UpReadOnly / LeftReadOnly / ...), so the next
+            // write to that shared scratch slot anywhere in the engine would silently corrupt them.
+            TmpVectors.Vector3[1].copyFrom(ribbonInfo.directions instanceof Vector3 ? ribbonInfo.directions : GreasedLineRibbonMesh.DIRECTION_XZ);
             for (let i = 0; i < pointVectors.length - (directionPlane ? 0 : 1); i++) {
                 const p1 = pointVectors[i];
                 const p2 = pointVectors[i + 1];

--- a/packages/dev/core/src/Misc/greasedLineTools.ts
+++ b/packages/dev/core/src/Misc/greasedLineTools.ts
@@ -414,7 +414,7 @@ export class GreasedLineTools {
         const s = (lengthVisibilityRatio - sumSegmentLengths) / lineSegments[segmentIndex].length;
 
         lineSegments[segmentIndex].point2.subtractToRef(lineSegments[segmentIndex].point1, TmpVectors.Vector3[0]);
-        TmpVectors.Vector3[1] = TmpVectors.Vector3[0].multiplyByFloats(s, s, s);
+        TmpVectors.Vector3[0].scaleToRef(s, TmpVectors.Vector3[1]);
         if (!localSpace) {
             TmpVectors.Vector3[1].addInPlace(lineSegments[segmentIndex].point1);
         }


### PR DESCRIPTION
## Problem

`GreasedLineRibbonMesh` and `GreasedLineTools` both assign to a `TmpVectors` slot rather than writing through it:

```ts
// greasedLineRibbonMesh.pure.ts
TmpVectors.Vector3[1] = ribbonInfo.directions instanceof Vector3 ? ribbonInfo.directions : GreasedLineRibbonMesh.DIRECTION_XZ;

// greasedLineTools.ts
TmpVectors.Vector3[1] = TmpVectors.Vector3[0].multiplyByFloats(s, s, s);
```

Assigning **rebinds the shared scratch slot** to another object instead of updating the scratch vector. After that line runs, `TmpVectors.Vector3[1]` *is* whatever was on the right-hand side, for the rest of the process.

That is bad on its own, but the ribbon mesh case is considerably worse, because the `DIRECTION_*` constants are aliases of the global readonly constants:

```ts
public static DIRECTION_XY = Vector3.LeftHandedForwardReadOnly;
public static DIRECTION_XZ = Vector3.UpReadOnly;
public static DIRECTION_YZ = Vector3.LeftReadOnly;
```

So drawing a single ribbon line makes `TmpVectors.Vector3[1]` and `Vector3.UpReadOnly` the same object. The next write to that scratch slot anywhere in the engine then silently overwrites `Vector3.UpReadOnly`.

## Impact

`Vector3.UpReadOnly` is what `TargetCamera` hands to `Matrix.LookAtLHToRef` / `LookAtRHToRef` as the up vector whenever the camera has no explicit `upVector` override. Once it has been corrupted, **every camera in the process builds a wrong view matrix** and renders rolled about its forward axis.

We hit this in the Babylon Native validation suite: a GreasedLine test ran, and four completely unrelated glTF-serializer camera tests started failing ~75 tests later. `Vector3.UpReadOnly` had become `(3, 0, 3)`. The failures are order-dependent and reproduce in the browser too -- anything long-lived that draws a ribbon line and later creates a camera is exposed. When the caller passes `ribbonOptions.directions` as a `Vector3`, their own vector gets corrupted the same way.

## Fix

Write through the scratch slot instead of rebinding it.

- `greasedLineRibbonMesh.pure.ts`: `TmpVectors.Vector3[1].copyFrom(...)`. The only downstream use is as a source operand of `Vector3.CrossToRef`, so nothing depended on the aliasing.
- `greasedLineTools.ts`: `TmpVectors.Vector3[0].scaleToRef(s, TmpVectors.Vector3[1])`, which also drops a per-call `Vector3` allocation that `multiplyByFloats` was making.

No behavioral change for the GreasedLine code paths themselves -- both sites read the same values as before.

## Finding others

This anti-pattern is worth watching for in review; it is invisible at the call site and only shows up as corruption somewhere else entirely:

```
git grep -nE 'TmpVectors\.(Vector2|Vector3|Vector4|Matrix|Quaternion)\[[0-9]+\]\s*=[^=]'
```

These two were the only remaining hits.
