### PR TITLE
feat(XR): support CPU depth sensing on WebGPU

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
+++ b/packages/dev/core/src/XR/features/WebXRAbstractFeature.ts
@@ -26,6 +26,9 @@ export abstract class WebXRAbstractFeature implements IWebXRFeature {
      */
     public disableAutoAttach: boolean = false;
 
+    /** @internal */
+    public _autoAttachPolicyBeforeAttach?: boolean;
+
     protected _xrNativeFeatureName: string = "";
 
     /**

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -90,16 +90,31 @@ class DepthSensingMaterialDefines extends MaterialDefines {
 
 let IsPluginEnabled = false;
 let DepthTexture: Nullable<RawTexture> = null;
+let DepthTextureRight: Nullable<RawTexture> = null;
 let AlphaLuminanceTexture = false;
 const ScreenSize = { width: 512, height: 512 };
 const ShaderViewport = { x: 0, y: 0, width: 1, height: 1 };
 let GlobalRawValueToMeters = 1;
+let GlobalRawValueToMetersRight = 1;
+let GlobalDepthAvailableLeft = 0;
+let GlobalDepthAvailableRight = 0;
+let GlobalWorldScale = 1;
 let ViewIndex = 0;
 let EnableDiscard = true;
 const UvTransform = /*#__PURE__*/ Matrix.Identity();
+const UvTransformRight = /*#__PURE__*/ Matrix.Identity();
 const ManagedMaterialPlugins: WebXRDepthSensingMaterialPlugin[] = [];
 const WebGPUGPUDepthWarning =
     "WebXR Depth Sensing is unavailable with WebGPU XR when the session negotiates gpu-optimized depth because XRGPUBinding has no environment-depth equivalent; request cpu-optimized depth to use the feature.";
+
+interface IWebXRCPUDepthViewState {
+    available: boolean;
+    height: number;
+    rawValueToMeters: number;
+    texture: Nullable<RawTexture>;
+    uvTransform: Matrix;
+    width: number;
+}
 
 /**
  * @internal
@@ -166,15 +181,25 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
     }
 
     public override getUniforms(shaderLanguage = ShaderLanguage.GLSL) {
+        const ubo = [
+            { name: "ds_invScreenSize", size: 2, type: "vec2" },
+            { name: "ds_rawValueToMeters", size: 1, type: "float" },
+            { name: "ds_viewIndex", size: 1, type: "float" },
+            { name: "ds_shaderViewport", size: 4, type: "vec4" },
+            { name: "ds_uvTransform", size: 16, type: "mat4" },
+        ];
+        if (shaderLanguage === ShaderLanguage.WGSL) {
+            ubo.push(
+                { name: "ds_rawValueToMetersRight", size: 1, type: "float" },
+                { name: "ds_depthAvailableLeft", size: 1, type: "float" },
+                { name: "ds_depthAvailableRight", size: 1, type: "float" },
+                { name: "ds_worldScale", size: 1, type: "float" },
+                { name: "ds_uvTransformRight", size: 16, type: "mat4" }
+            );
+        }
         return {
             // first, define the UBO with the correct type and size.
-            ubo: [
-                { name: "ds_invScreenSize", size: 2, type: "vec2" },
-                { name: "ds_rawValueToMeters", size: 1, type: "float" },
-                { name: "ds_viewIndex", size: 1, type: "float" },
-                { name: "ds_shaderViewport", size: 4, type: "vec4" },
-                { name: "ds_uvTransform", size: 16, type: "mat4" },
-            ],
+            ubo,
             // now, on the fragment shader, add the uniform itself in case uniform buffers are not supported by the engine
             fragment:
                 shaderLanguage === ShaderLanguage.GLSL
@@ -192,16 +217,23 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
 
     public override getSamplers(samplers: string[]): void {
         samplers.push("ds_depthSampler");
+        samplers.push("ds_depthSamplerRight");
     }
 
     public override bindForSubMesh(uniformBuffer: UniformBuffer) {
         if (IsPluginEnabled && DepthTexture) {
             uniformBuffer.updateFloat2("ds_invScreenSize", 1 / ScreenSize.width, 1 / ScreenSize.height);
             uniformBuffer.updateFloat("ds_rawValueToMeters", GlobalRawValueToMeters);
+            uniformBuffer.updateFloat("ds_rawValueToMetersRight", GlobalRawValueToMetersRight);
+            uniformBuffer.updateFloat("ds_depthAvailableLeft", GlobalDepthAvailableLeft);
+            uniformBuffer.updateFloat("ds_depthAvailableRight", GlobalDepthAvailableRight);
+            uniformBuffer.updateFloat("ds_worldScale", GlobalWorldScale);
             uniformBuffer.updateFloat("ds_viewIndex", ViewIndex);
             uniformBuffer.updateFloat4("ds_shaderViewport", ShaderViewport.x, ShaderViewport.y, ShaderViewport.width, ShaderViewport.height);
             uniformBuffer.setTexture("ds_depthSampler", DepthTexture);
+            uniformBuffer.setTexture("ds_depthSamplerRight", DepthTextureRight);
             uniformBuffer.updateMatrix("ds_uvTransform", UvTransform);
+            uniformBuffer.updateMatrix("ds_uvTransformRight", UvTransformRight);
         }
     }
 
@@ -237,6 +269,10 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
                             var ds_depthSampler: texture_2d<f32>;
                         #endif
                         var ds_depthSamplerSampler: sampler;
+                        #if defined(MULTIVIEW) && !defined(DEPTH_SENSING_TEXTURE_ARRAY)
+                            var ds_depthSamplerRight: texture_2d<f32>;
+                            var ds_depthSamplerRightSampler: sampler;
+                        #endif
                         #ifdef MULTIVIEW
                             varying ds_viewIndexMultiview: f32;
                         #endif
@@ -251,14 +287,34 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
         let ds_viewIndexSet: f32 = uniforms.ds_viewIndex;
         let ds_compensation: vec2f = vec2f(ds_viewIndexSet, 0.0);
     #endif
-    let ds_baseUv: vec2f = fragmentInputs.position.xy * uniforms.ds_invScreenSize;
-    #ifdef DEPTH_SENSING_TEXTURE_ARRAY
-        let ds_uv: vec2f = ds_baseUv - ds_compensation;
-        let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_uv, 0.0, 1.0)).xy;
-        let ds_depthSample: vec4f = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, i32(ds_viewIndexSet));
+    let ds_baseUv: vec2f = (fragmentInputs.position.xy * uniforms.ds_invScreenSize - uniforms.ds_shaderViewport.xy) / uniforms.ds_shaderViewport.zw;
+    var ds_depthSample: vec4f = vec4f(0.0);
+    var ds_rawValueToMetersSet: f32 = uniforms.ds_rawValueToMeters;
+    #if defined(MULTIVIEW) && !defined(DEPTH_SENSING_TEXTURE_ARRAY)
+        var ds_depthAvailable: f32 = uniforms.ds_depthAvailableLeft;
+        if (ds_viewIndexSet < 0.5) {
+            if (ds_depthAvailable > 0.5) {
+                let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_baseUv, 0.0, 1.0)).xy;
+                ds_depthSample = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv);
+            }
+        } else {
+            ds_depthAvailable = uniforms.ds_depthAvailableRight;
+            if (ds_depthAvailable > 0.5) {
+                let ds_depthUv: vec2f = (uniforms.ds_uvTransformRight * vec4f(ds_baseUv, 0.0, 1.0)).xy;
+                ds_depthSample = textureSample(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv);
+            }
+            ds_rawValueToMetersSet = uniforms.ds_rawValueToMetersRight;
+        }
     #else
-        let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_baseUv.x, 1.0 - ds_baseUv.y, 0.0, 1.0)).xy;
-        let ds_depthSample: vec4f = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv);
+        let ds_depthAvailable: f32 = 1.0;
+        #ifdef DEPTH_SENSING_TEXTURE_ARRAY
+            let ds_uv: vec2f = ds_baseUv - ds_compensation;
+            let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_uv, 0.0, 1.0)).xy;
+            ds_depthSample = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, i32(ds_viewIndexSet));
+        #else
+            let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_baseUv, 0.0, 1.0)).xy;
+            ds_depthSample = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv);
+        #endif
     #endif
     var ds_cameraDepth: f32;
     #ifdef DEPTH_SENSING_TEXTURE_AL
@@ -268,11 +324,11 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
         ds_cameraDepth = ds_depthSample.r;
     #endif
 
-    ds_cameraDepth = ds_cameraDepth * uniforms.ds_rawValueToMeters;
+    ds_cameraDepth = ds_cameraDepth * ds_rawValueToMetersSet;
 
-    let ds_assetDepth: f32 = fragmentInputs.position.z;
+    let ds_assetDepth: f32 = (1.0 / fragmentInputs.position.w) / uniforms.ds_worldScale;
     #ifdef DEPTH_SENSING_DISCARD
-    if (ds_cameraDepth < ds_assetDepth) {
+    if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth) {
         discard;
     }
     #endif
@@ -281,10 +337,12 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
                       CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: `
 #ifdef DEPTH_SENSING
     #ifndef DEPTH_SENSING_DISCARD
-        let ds_depthTolerancePerM: f32 = 0.005;
-        let ds_occlusion: f32 = clamp(1.0 - 0.5 * (ds_cameraDepth - ds_assetDepth) / (ds_depthTolerancePerM * ds_assetDepth) +
-            0.5, 0.0, 1.0);
-        ${this._varColorName} *= (1.0 - ds_occlusion);
+        if (ds_depthAvailable > 0.5) {
+            let ds_depthTolerancePerM: f32 = 0.005;
+            let ds_occlusion: f32 = clamp(1.0 - 0.5 * (ds_cameraDepth - ds_assetDepth) / (ds_depthTolerancePerM * ds_assetDepth) +
+                0.5, 0.0, 1.0);
+            ${this._varColorName} *= (1.0 - ds_occlusion);
+        }
     #endif
 #endif
                   `,
@@ -390,7 +448,11 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
     private _cachedDepthBuffer: Nullable<ArrayBuffer> = null;
     private _cachedWebGLTexture: Nullable<WebGLTexture> = null;
     private _cachedDepthImageTexture: Nullable<RawTexture> = null;
+    private _cpuDepthViewStates: IWebXRCPUDepthViewState[] = [];
+    private _disableAutoAttachBeforeWebGPUGPUDepth = false;
+    private _disabledForWebGPUGPUDepth = false;
     private _onCameraObserver: Nullable<Observer<Camera>> = null;
+    private _onSessionEndedObserver: Nullable<Observer<any>> = null;
 
     /**
      * Width of depth data. If depth data is not exist, returns null.
@@ -519,6 +581,12 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         EnableDiscard = !options.useToleranceFactorForDepthSensing;
 
         RegisterMaterialPlugin("WebXRDepthSensingMaterialPlugin", (material) => new WebXRDepthSensingMaterialPlugin(material));
+        this._onSessionEndedObserver = this._xrSessionManager.onXRSessionEnded.add(() => {
+            if (this._disabledForWebGPUGPUDepth) {
+                this._disabledForWebGPUGPUDepth = false;
+                this.disableAutoAttach = this._disableAutoAttachBeforeWebGPUGPUDepth;
+            }
+        });
     }
 
     /**
@@ -533,6 +601,12 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         const depthDataFormat = this._xrSessionManager.session.depthDataFormat;
 
         if (engine.isWebGPU && depthUsage === "gpu-optimized") {
+            if (this._disabledForWebGPUGPUDepth) {
+                this.disableAutoAttach = true;
+                return false;
+            }
+            this._disableAutoAttachBeforeWebGPUGPUDepth = this.disableAutoAttach;
+            this._disabledForWebGPUGPUDepth = true;
             return this._disableAutoAttach(WebGPUGPUDepthWarning);
         }
 
@@ -564,17 +638,24 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 // make sure this is a webxr camera
                 if (camera.outputRenderTarget) {
                     const viewport = camera.rigCameras.length > 0 ? camera.rigCameras[0].viewport : camera.viewport;
-                    ScreenSize.width = camera.outputRenderTarget.getRenderWidth() / (camera.rigParent ? camera.rigParent.rigCameras.length || 1 : 1);
+                    ScreenSize.width = camera.outputRenderTarget.getRenderWidth() / (!engine.isWebGPU && camera.rigParent ? camera.rigParent.rigCameras.length || 1 : 1);
                     ScreenSize.height = camera.outputRenderTarget.getRenderHeight();
                     ShaderViewport.x = viewport.x;
                     ShaderViewport.y = viewport.y;
                     ShaderViewport.width = viewport.width;
                     ShaderViewport.height = viewport.height;
+                    GlobalWorldScale = this._xrSessionManager.worldScalingFactor;
 
                     // find the viewIndex
                     if (camera.rigParent) {
-                        // should use the viewIndexes array!
-                        ViewIndex = camera.isLeftCamera ? 0 : 1;
+                        const viewIndex = camera.rigParent.rigCameras.indexOf(camera);
+                        ViewIndex = viewIndex === -1 ? 0 : viewIndex;
+                        if (engine.isWebGPU && this.depthUsage === "cpu") {
+                            this._bindCPUDepthView(ViewIndex, false);
+                        }
+                    } else if (camera._renderingMultiview && engine.isWebGPU && this.depthUsage === "cpu") {
+                        ViewIndex = 0;
+                        this._bindCPUDepthView(0, true);
                     }
                 }
             });
@@ -586,13 +667,30 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
     public override detach() {
         IsPluginEnabled = false;
         DepthTexture = null;
+        DepthTextureRight = null;
         this._cachedWebGLTexture = null;
         this._cachedDepthBuffer = null;
+        this._width = null;
+        this._height = null;
+        this._rawValueToMeters = null;
+        this._textureType = null;
+        this._normDepthBufferFromNormView = null;
+        let cachedTextureDisposed = false;
+        for (const viewState of this._cpuDepthViewStates) {
+            viewState.texture?.dispose();
+            cachedTextureDisposed ||= viewState.texture === this._cachedDepthImageTexture;
+        }
+        this._cpuDepthViewStates.length = 0;
+        if (!cachedTextureDisposed) {
+            this._cachedDepthImageTexture?.dispose();
+        }
+        this._cachedDepthImageTexture = null;
         for (const plugin of ManagedMaterialPlugins) {
             plugin.isEnabled = false;
         }
         if (this._onCameraObserver) {
             this._xrSessionManager.scene.onBeforeCameraRenderObservable.remove(this._onCameraObserver);
+            this._onCameraObserver = null;
         }
         return super.detach();
     }
@@ -601,9 +699,12 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
      * Dispose this feature and all of the resources attached
      */
     public override dispose(): void {
+        if (this._onSessionEndedObserver) {
+            this._xrSessionManager.onXRSessionEnded.remove(this._onSessionEndedObserver);
+            this._onSessionEndedObserver = null;
+        }
         super.dispose();
         UnregisterMaterialPlugin("WebXRDepthSensingMaterialPlugin");
-        this._cachedDepthImageTexture?.dispose();
         this.onGetDepthInMetersAvailable.clear();
         // cleanup
         if (this._onCameraObserver) {
@@ -621,10 +722,17 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         if (pose == null) {
             return;
         }
-        for (const view of pose.views) {
-            switch (this.depthUsage) {
+        const depthUsage = this.depthUsage;
+        if (depthUsage === "cpu") {
+            for (const viewState of this._cpuDepthViewStates) {
+                viewState.available = false;
+            }
+        }
+        for (let viewIndex = 0; viewIndex < pose.views.length; viewIndex++) {
+            const view = pose.views[viewIndex];
+            switch (depthUsage) {
                 case "cpu":
-                    this._updateDepthInformationAndTextureCPUDepthUsage(_xrFrame, view, this.depthDataFormat);
+                    this._updateDepthInformationAndTextureCPUDepthUsage(_xrFrame, view, viewIndex, this.depthDataFormat);
                     break;
                 case "gpu":
                     if (!this._glBinding) {
@@ -640,28 +748,45 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         }
     }
 
-    private _updateDepthInformationAndTextureCPUDepthUsage(frame: XRFrame, view: XRView, dataFormat: WebXRDepthDataFormat): void {
+    private _updateDepthInformationAndTextureCPUDepthUsage(frame: XRFrame, view: XRView, viewIndex: number, dataFormat: WebXRDepthDataFormat): void {
         const depthInfo = frame.getDepthInformation(view);
-        if (depthInfo === null) {
+        if (depthInfo == null) {
             return;
         }
 
         const { data, width, height, rawValueToMeters, getDepthInMeters, normDepthBufferFromNormView } = depthInfo as XRCPUDepthInformation;
+        let viewState = this._cpuDepthViewStates[viewIndex];
+        if (!viewState) {
+            viewState = {
+                available: true,
+                height,
+                rawValueToMeters,
+                texture: null,
+                uvTransform: Matrix.Identity(),
+                width,
+            };
+            this._cpuDepthViewStates[viewIndex] = viewState;
+        }
 
+        const textureSizeChanged = viewState.width !== width || viewState.height !== height;
         this._width = width;
         this._height = height;
         this._rawValueToMeters = rawValueToMeters;
         this._normDepthBufferFromNormView = normDepthBufferFromNormView;
         this._cachedDepthBuffer = data;
-        GlobalRawValueToMeters = rawValueToMeters;
         AlphaLuminanceTexture = dataFormat === "luminance-alpha";
-        UvTransform.fromArray(normDepthBufferFromNormView.matrix);
+        viewState.height = height;
+        viewState.available = true;
+        viewState.rawValueToMeters = rawValueToMeters;
+        viewState.uvTransform.fromArray(normDepthBufferFromNormView.matrix);
+        viewState.width = width;
 
         // to avoid Illegal Invocation error, bind `this`
         this.onGetDepthInMetersAvailable.notifyObservers(getDepthInMeters.bind(depthInfo));
 
-        if (!this._cachedDepthImageTexture) {
-            this._cachedDepthImageTexture = RawTexture.CreateRTexture(
+        if (!viewState.texture || textureSizeChanged) {
+            viewState.texture?.dispose();
+            viewState.texture = RawTexture.CreateRTexture(
                 null,
                 width,
                 height,
@@ -671,9 +796,8 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 Texture.NEAREST_SAMPLINGMODE,
                 Constants.TEXTURETYPE_FLOAT
             );
-            DepthTexture = this._cachedDepthImageTexture;
-            this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
         }
+        this._cachedDepthImageTexture = viewState.texture;
 
         let float32Array: Float32Array | null = null;
         switch (dataFormat) {
@@ -693,7 +817,55 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
             if (this.options.prepareTextureForVisualization) {
                 float32Array = float32Array.map((val) => val * rawValueToMeters);
             }
-            this._cachedDepthImageTexture.update(float32Array);
+            viewState.texture.update(float32Array);
+        }
+    }
+
+    private _bindCPUDepthView(viewIndex: number, multiview: boolean): void {
+        const leftViewState = this._cpuDepthViewStates[0];
+        const rightViewState = multiview ? this._cpuDepthViewStates[1] : null;
+        const viewState = multiview
+            ? leftViewState?.available && leftViewState.texture
+                ? leftViewState
+                : rightViewState?.available && rightViewState.texture
+                  ? rightViewState
+                  : null
+            : this._cpuDepthViewStates[viewIndex];
+        if (!viewState?.available || !viewState.texture) {
+            if (DepthTexture) {
+                DepthTexture = null;
+                DepthTextureRight = null;
+                this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+            }
+            return;
+        }
+
+        const hadDepthTexture = !!DepthTexture;
+        if (multiview && leftViewState?.available && leftViewState.texture) {
+            GlobalDepthAvailableLeft = 1;
+            DepthTexture = leftViewState.texture;
+            GlobalRawValueToMeters = leftViewState.rawValueToMeters;
+            UvTransform.copyFrom(leftViewState.uvTransform);
+        } else {
+            GlobalDepthAvailableLeft = multiview ? 0 : 1;
+            DepthTexture = viewState.texture;
+            GlobalRawValueToMeters = viewState.rawValueToMeters;
+            UvTransform.copyFrom(viewState.uvTransform);
+        }
+        if (multiview && rightViewState?.available && rightViewState.texture) {
+            GlobalDepthAvailableRight = 1;
+            DepthTextureRight = rightViewState.texture;
+            GlobalRawValueToMetersRight = rightViewState.rawValueToMeters;
+            UvTransformRight.copyFrom(rightViewState.uvTransform);
+        } else {
+            GlobalDepthAvailableRight = 0;
+            DepthTextureRight = viewState.texture;
+            GlobalRawValueToMetersRight = viewState.rawValueToMeters;
+            UvTransformRight.copyFrom(viewState.uvTransform);
+        }
+
+        if (!hadDepthTexture) {
+            this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
         }
     }
 

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -225,20 +225,23 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
 
     public override bindForSubMesh(uniformBuffer: UniformBuffer) {
         if (IsPluginEnabled && DepthTexture) {
+            const isWGSL = this._material.shaderLanguage === ShaderLanguage.WGSL;
             uniformBuffer.updateFloat2("ds_invScreenSize", 1 / ScreenSize.width, 1 / ScreenSize.height);
             uniformBuffer.updateFloat("ds_rawValueToMeters", GlobalRawValueToMeters);
-            uniformBuffer.updateFloat("ds_rawValueToMetersRight", GlobalRawValueToMetersRight);
-            uniformBuffer.updateFloat("ds_depthAvailableLeft", GlobalDepthAvailableLeft);
-            uniformBuffer.updateFloat("ds_depthAvailableRight", GlobalDepthAvailableRight);
-            uniformBuffer.updateFloat("ds_worldScale", GlobalWorldScale);
-            uniformBuffer.updateFloat("ds_viewDepthSign", this._material.getScene().useRightHandedSystem ? -1 : 1);
             uniformBuffer.updateFloat("ds_viewIndex", ViewIndex);
             uniformBuffer.updateFloat4("ds_shaderViewport", ShaderViewport.x, ShaderViewport.y, ShaderViewport.width, ShaderViewport.height);
             uniformBuffer.setTexture("ds_depthSampler", DepthTexture);
-            uniformBuffer.setTexture("ds_depthSamplerRight", DepthTextureRight);
             uniformBuffer.updateMatrix("ds_uvTransform", UvTransform);
-            uniformBuffer.updateMatrix("ds_uvTransformRight", UvTransformRight);
-            uniformBuffer.updateMatrix("ds_viewRight", RightView);
+            if (isWGSL) {
+                uniformBuffer.updateFloat("ds_rawValueToMetersRight", GlobalRawValueToMetersRight);
+                uniformBuffer.updateFloat("ds_depthAvailableLeft", GlobalDepthAvailableLeft);
+                uniformBuffer.updateFloat("ds_depthAvailableRight", GlobalDepthAvailableRight);
+                uniformBuffer.updateFloat("ds_worldScale", GlobalWorldScale);
+                uniformBuffer.updateFloat("ds_viewDepthSign", this._material.getScene().useRightHandedSystem ? -1 : 1);
+                uniformBuffer.setTexture("ds_depthSamplerRight", DepthTextureRight);
+                uniformBuffer.updateMatrix("ds_uvTransformRight", UvTransformRight);
+                uniformBuffer.updateMatrix("ds_viewRight", RightView);
+            }
         }
     }
 
@@ -292,7 +295,8 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
         let ds_viewIndexSet: f32 = uniforms.ds_viewIndex;
         let ds_compensation: vec2f = vec2f(ds_viewIndexSet, 0.0);
     #endif
-    let ds_baseUv: vec2f = (fragmentInputs.position.xy * uniforms.ds_invScreenSize - uniforms.ds_shaderViewport.xy) / uniforms.ds_shaderViewport.zw;
+    let ds_baseUvBottomLeft: vec2f = (fragmentInputs.position.xy * uniforms.ds_invScreenSize - uniforms.ds_shaderViewport.xy) / uniforms.ds_shaderViewport.zw;
+    let ds_baseUv: vec2f = vec2f(ds_baseUvBottomLeft.x, 1.0 - ds_baseUvBottomLeft.y);
     var ds_depthSample: vec4f = vec4f(0.0);
     var ds_rawValueToMetersSet: f32 = uniforms.ds_rawValueToMeters;
     #if defined(MULTIVIEW) && !defined(DEPTH_SENSING_TEXTURE_ARRAY)
@@ -300,13 +304,13 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
         if (ds_viewIndexSet < 0.5) {
             if (ds_depthAvailable > 0.5) {
                 let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_baseUv, 0.0, 1.0)).xy;
-                ds_depthSample = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv);
+                ds_depthSample = textureSampleLevel(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, 0.0);
             }
         } else {
             ds_depthAvailable = uniforms.ds_depthAvailableRight;
             if (ds_depthAvailable > 0.5) {
                 let ds_depthUv: vec2f = (uniforms.ds_uvTransformRight * vec4f(ds_baseUv, 0.0, 1.0)).xy;
-                ds_depthSample = textureSample(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv);
+                ds_depthSample = textureSampleLevel(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv, 0.0);
             }
             ds_rawValueToMetersSet = uniforms.ds_rawValueToMetersRight;
         }
@@ -616,7 +620,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 this.disableAutoAttach = true;
                 return false;
             }
-            this._disableAutoAttachBeforeWebGPUGPUDepth = this.disableAutoAttach;
+            this._disableAutoAttachBeforeWebGPUGPUDepth = this._autoAttachPolicyBeforeAttach ?? this.disableAutoAttach;
             this._disabledForWebGPUGPUDepth = true;
             return this._disableAutoAttach(WebGPUGPUDepthWarning);
         }
@@ -733,15 +737,18 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
 
     protected _onXRFrame(_xrFrame: XRFrame): void {
         const referenceSPace = this._xrSessionManager.referenceSpace;
-        const pose = _xrFrame.getViewerPose(referenceSPace);
-        if (pose == null) {
-            return;
-        }
         const depthUsage = this.depthUsage;
         if (depthUsage === "cpu") {
             for (const viewState of this._cpuDepthViewStates) {
                 viewState.available = false;
             }
+        }
+        const pose = _xrFrame.getViewerPose(referenceSPace);
+        if (pose == null) {
+            if (depthUsage === "cpu") {
+                this._clearCPUDepthBinding();
+            }
+            return;
         }
         for (let viewIndex = 0; viewIndex < pose.views.length; viewIndex++) {
             const view = pose.views[viewIndex];
@@ -760,6 +767,9 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                     this.detach();
                     break;
             }
+        }
+        if (depthUsage === "cpu" && !this._cpuDepthViewStates.some((viewState) => viewState.available)) {
+            this._clearCPUDepthBinding();
         }
     }
 
@@ -834,6 +844,27 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
             }
             viewState.texture.update(float32Array);
         }
+
+        if (!this._xrSessionManager.scene.getEngine().isWebGPU) {
+            const hadDepthTexture = !!DepthTexture;
+            DepthTexture = viewState.texture;
+            DepthTextureRight = null;
+            GlobalDepthAvailableLeft = 1;
+            GlobalDepthAvailableRight = 0;
+            GlobalRawValueToMeters = viewState.rawValueToMeters;
+            UvTransform.copyFrom(viewState.uvTransform);
+            if (!hadDepthTexture) {
+                this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+            }
+        }
+    }
+
+    private _clearCPUDepthBinding(): void {
+        if (DepthTexture) {
+            DepthTexture = null;
+            DepthTextureRight = null;
+            this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
+        }
     }
 
     private _bindCPUDepthView(viewIndex: number, multiview: boolean): void {
@@ -847,11 +878,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                   : null
             : this._cpuDepthViewStates[viewIndex];
         if (!viewState?.available || !viewState.texture) {
-            if (DepthTexture) {
-                DepthTexture = null;
-                DepthTextureRight = null;
-                this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
-            }
+            this._clearCPUDepthBinding();
             return;
         }
 

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -24,6 +24,7 @@ import { type Camera } from "core/Cameras/camera.pure";
 import { Matrix } from "core/Maths/math.vector.pure";
 import { type Engine } from "core/Engines/engine.pure";
 import { RegisterClass } from "../../Misc/typeStore";
+import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 
 export type WebXRDepthUsage = "cpu" | "gpu";
 export type WebXRDepthDataFormat = "ushort" | "float" | "luminance-alpha";
@@ -97,6 +98,8 @@ let ViewIndex = 0;
 let EnableDiscard = true;
 const UvTransform = /*#__PURE__*/ Matrix.Identity();
 const ManagedMaterialPlugins: WebXRDepthSensingMaterialPlugin[] = [];
+const WebGPUGPUDepthWarning =
+    "WebXR Depth Sensing is unavailable with WebGPU XR when the session negotiates gpu-optimized depth because XRGPUBinding has no environment-depth equivalent; request cpu-optimized depth to use the feature.";
 
 /**
  * @internal
@@ -137,11 +140,10 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
     public override isCompatible(shaderLanguage: ShaderLanguage): boolean {
         switch (shaderLanguage) {
             case ShaderLanguage.GLSL:
+            case ShaderLanguage.WGSL:
                 return true;
             default:
-                // no webgpu for webxr yet, however - if this is not true the plugin fails to load.
-                // webxr is currently only supported on webgl, and the plugin is disabled per default.
-                return true;
+                return false;
         }
     }
 
@@ -163,7 +165,7 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
         defines.DEPTH_SENSING_DISCARD = EnableDiscard;
     }
 
-    public override getUniforms() {
+    public override getUniforms(shaderLanguage = ShaderLanguage.GLSL) {
         return {
             // first, define the UBO with the correct type and size.
             ubo: [
@@ -174,14 +176,17 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
                 { name: "ds_uvTransform", size: 16, type: "mat4" },
             ],
             // now, on the fragment shader, add the uniform itself in case uniform buffers are not supported by the engine
-            fragment: `#ifdef DEPTH_SENSING
+            fragment:
+                shaderLanguage === ShaderLanguage.GLSL
+                    ? `#ifdef DEPTH_SENSING
                 uniform vec2 ds_invScreenSize;
                 uniform float ds_rawValueToMeters;
                 uniform float ds_viewIndex;
                 uniform vec4 ds_shaderViewport;
                 uniform mat4 ds_uvTransform;
                 #endif
-                `,
+                `
+                    : "",
         };
     }
 
@@ -204,7 +209,88 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
         return "DepthSensingMaterialPlugin";
     }
 
-    public override getCustomCode(shaderType: string): Nullable<{ [pointName: string]: string }> {
+    public override getCustomCode(shaderType: string, shaderLanguage = ShaderLanguage.GLSL): Nullable<{ [pointName: string]: string }> {
+        if (shaderLanguage === ShaderLanguage.WGSL) {
+            return shaderType === "vertex"
+                ? {
+                      CUSTOM_VERTEX_MAIN_BEGIN: `
+                #ifdef DEPTH_SENSING
+                #ifdef MULTIVIEW
+                    vertexOutputs.ds_viewIndexMultiview = f32(gl_ViewID_OVR);
+                #endif
+                #endif
+                `,
+                      CUSTOM_VERTEX_DEFINITIONS: `
+                #ifdef DEPTH_SENSING
+                #ifdef MULTIVIEW
+                    varying ds_viewIndexMultiview: f32;
+                #endif
+                #endif
+                `,
+                  }
+                : {
+                      CUSTOM_FRAGMENT_DEFINITIONS: `
+                    #ifdef DEPTH_SENSING
+                        #ifdef DEPTH_SENSING_TEXTURE_ARRAY
+                            var ds_depthSampler: texture_2d_array<f32>;
+                        #else
+                            var ds_depthSampler: texture_2d<f32>;
+                        #endif
+                        var ds_depthSamplerSampler: sampler;
+                        #ifdef MULTIVIEW
+                            varying ds_viewIndexMultiview: f32;
+                        #endif
+                    #endif
+                  `,
+                      CUSTOM_FRAGMENT_MAIN_BEGIN: `
+#ifdef DEPTH_SENSING
+    #ifdef MULTIVIEW
+        let ds_viewIndexSet: f32 = fragmentInputs.ds_viewIndexMultiview;
+        let ds_compensation: vec2f = vec2f(0.0, 0.0);
+    #else
+        let ds_viewIndexSet: f32 = uniforms.ds_viewIndex;
+        let ds_compensation: vec2f = vec2f(ds_viewIndexSet, 0.0);
+    #endif
+    let ds_baseUv: vec2f = fragmentInputs.position.xy * uniforms.ds_invScreenSize;
+    #ifdef DEPTH_SENSING_TEXTURE_ARRAY
+        let ds_uv: vec2f = ds_baseUv - ds_compensation;
+        let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_uv, 0.0, 1.0)).xy;
+        let ds_depthSample: vec4f = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, i32(ds_viewIndexSet));
+    #else
+        let ds_depthUv: vec2f = (uniforms.ds_uvTransform * vec4f(ds_baseUv.x, 1.0 - ds_baseUv.y, 0.0, 1.0)).xy;
+        let ds_depthSample: vec4f = textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv);
+    #endif
+    var ds_cameraDepth: f32;
+    #ifdef DEPTH_SENSING_TEXTURE_AL
+        let ds_alphaLuminance: vec2f = ds_depthSample.ra;
+        ds_cameraDepth = dot(ds_alphaLuminance, vec2f(255.0, 256.0 * 255.0));
+    #else
+        ds_cameraDepth = ds_depthSample.r;
+    #endif
+
+    ds_cameraDepth = ds_cameraDepth * uniforms.ds_rawValueToMeters;
+
+    let ds_assetDepth: f32 = fragmentInputs.position.z;
+    #ifdef DEPTH_SENSING_DISCARD
+    if (ds_cameraDepth < ds_assetDepth) {
+        discard;
+    }
+    #endif
+#endif
+                  `,
+                      CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: `
+#ifdef DEPTH_SENSING
+    #ifndef DEPTH_SENSING_DISCARD
+        let ds_depthTolerancePerM: f32 = 0.005;
+        let ds_occlusion: f32 = clamp(1.0 - 0.5 * (ds_cameraDepth - ds_assetDepth) / (ds_depthTolerancePerM * ds_assetDepth) +
+            0.5, 0.0, 1.0);
+        ${this._varColorName} *= (1.0 - ds_occlusion);
+    #endif
+#endif
+                  `,
+                  };
+        }
+
         return shaderType === "vertex"
             ? {
                   CUSTOM_VERTEX_MAIN_BEGIN: `
@@ -427,7 +513,9 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         this.xrNativeFeatureName = "depth-sensing";
 
         // https://immersive-web.github.io/depth-sensing/
-        Logger.Warn("depth-sensing is an experimental and unstable feature.");
+        if (!this._xrSessionManager.scene.getEngine().isWebGPU) {
+            Logger.Warn("depth-sensing is an experimental and unstable feature.");
+        }
         EnableDiscard = !options.useToleranceFactorForDepthSensing;
 
         RegisterMaterialPlugin("WebXRDepthSensingMaterialPlugin", (material) => new WebXRDepthSensingMaterialPlugin(material));
@@ -440,16 +528,29 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
      * @returns true if successful.
      */
     public override attach(force?: boolean): boolean {
+        const engine = this._xrSessionManager.scene.getEngine();
+        const depthUsage = this._xrSessionManager.session.depthUsage;
+        const depthDataFormat = this._xrSessionManager.session.depthDataFormat;
+
+        if (engine.isWebGPU && depthUsage === "gpu-optimized") {
+            return this._disableAutoAttach(WebGPUGPUDepthWarning);
+        }
+
+        if (depthUsage == null || depthDataFormat == null) {
+            return false;
+        }
+
         if (!super.attach(force)) {
             return false;
         }
 
-        const isBothDepthUsageAndFormatNull = this._xrSessionManager.session.depthDataFormat == null || this._xrSessionManager.session.depthUsage == null;
-        if (isBothDepthUsageAndFormatNull) {
-            return false;
+        if (!engine.isWebGPU) {
+            const graphicsBinding = this._xrSessionManager._getGraphicsBinding();
+            if (graphicsBinding.bindingType !== WebXRGraphicsBindingType.WebGL) {
+                throw new Error("Expected a WebGL graphics binding for WebXR Depth Sensing.");
+            }
+            this._glBinding = graphicsBinding.binding;
         }
-
-        this._glBinding = new XRWebGLBinding(this._xrSessionManager.session, (this._xrSessionManager.scene.getEngine() as ThinEngine)._gl);
 
         IsPluginEnabled = !this.options.disableDepthSensingOnMaterials;
         if (IsPluginEnabled) {
@@ -550,6 +651,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         this._width = width;
         this._height = height;
         this._rawValueToMeters = rawValueToMeters;
+        this._normDepthBufferFromNormView = normDepthBufferFromNormView;
         this._cachedDepthBuffer = data;
         GlobalRawValueToMeters = rawValueToMeters;
         AlphaLuminanceTexture = dataFormat === "luminance-alpha";
@@ -570,6 +672,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 Constants.TEXTURETYPE_FLOAT
             );
             DepthTexture = this._cachedDepthImageTexture;
+            this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
         }
 
         let float32Array: Float32Array | null = null;

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -114,6 +114,7 @@ interface IWebXRCPUDepthViewState {
     rawValueToMeters: number;
     texture: Nullable<RawTexture>;
     uvTransform: Matrix;
+    visualizationDepthBuffer: Nullable<Float32Array>;
     width: number;
 }
 
@@ -793,6 +794,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 rawValueToMeters,
                 texture: null,
                 uvTransform: Matrix.Identity(),
+                visualizationDepthBuffer: null,
                 width,
             };
             this._cpuDepthViewStates[viewIndex] = viewState;
@@ -830,25 +832,32 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         this._cachedDepthImageTextureWrapsExternalTexture = false;
         this._cachedDepthImageTexture = viewState.texture;
 
-        let float32Array: Float32Array | null = null;
+        let depthValues: Float32Array | Uint16Array | null = null;
         switch (dataFormat) {
             case "ushort":
             case "luminance-alpha":
-                float32Array = Float32Array.from(new Uint16Array(data));
-
+                depthValues = new Uint16Array(data);
                 break;
             case "float":
-                float32Array = new Float32Array(data);
+                depthValues = new Float32Array(data);
                 break;
-
             default:
                 break;
         }
-        if (float32Array) {
+        if (depthValues) {
+            let uploadData: Float32Array;
             if (this.options.prepareTextureForVisualization) {
-                float32Array = float32Array.map((val) => val * rawValueToMeters);
+                if (!viewState.visualizationDepthBuffer || viewState.visualizationDepthBuffer.length !== depthValues.length) {
+                    viewState.visualizationDepthBuffer = new Float32Array(depthValues.length);
+                }
+                uploadData = viewState.visualizationDepthBuffer;
+                for (let index = 0; index < depthValues.length; index++) {
+                    uploadData[index] = depthValues[index] * rawValueToMeters;
+                }
+            } else {
+                uploadData = depthValues instanceof Float32Array ? depthValues : Float32Array.from(depthValues);
             }
-            viewState.texture.update(float32Array);
+            viewState.texture.update(uploadData);
         }
 
         if (!this._xrSessionManager.scene.getEngine().isWebGPU) {

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -103,6 +103,7 @@ let ViewIndex = 0;
 let EnableDiscard = true;
 const UvTransform = /*#__PURE__*/ Matrix.Identity();
 const UvTransformRight = /*#__PURE__*/ Matrix.Identity();
+const RightView = /*#__PURE__*/ Matrix.Identity();
 const ManagedMaterialPlugins: WebXRDepthSensingMaterialPlugin[] = [];
 const WebGPUGPUDepthWarning =
     "WebXR Depth Sensing is unavailable with WebGPU XR when the session negotiates gpu-optimized depth because XRGPUBinding has no environment-depth equivalent; request cpu-optimized depth to use the feature.";
@@ -194,7 +195,9 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
                 { name: "ds_depthAvailableLeft", size: 1, type: "float" },
                 { name: "ds_depthAvailableRight", size: 1, type: "float" },
                 { name: "ds_worldScale", size: 1, type: "float" },
-                { name: "ds_uvTransformRight", size: 16, type: "mat4" }
+                { name: "ds_viewDepthSign", size: 1, type: "float" },
+                { name: "ds_uvTransformRight", size: 16, type: "mat4" },
+                { name: "ds_viewRight", size: 16, type: "mat4" }
             );
         }
         return {
@@ -228,12 +231,14 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
             uniformBuffer.updateFloat("ds_depthAvailableLeft", GlobalDepthAvailableLeft);
             uniformBuffer.updateFloat("ds_depthAvailableRight", GlobalDepthAvailableRight);
             uniformBuffer.updateFloat("ds_worldScale", GlobalWorldScale);
+            uniformBuffer.updateFloat("ds_viewDepthSign", this._material.getScene().useRightHandedSystem ? -1 : 1);
             uniformBuffer.updateFloat("ds_viewIndex", ViewIndex);
             uniformBuffer.updateFloat4("ds_shaderViewport", ShaderViewport.x, ShaderViewport.y, ShaderViewport.width, ShaderViewport.height);
             uniformBuffer.setTexture("ds_depthSampler", DepthTexture);
             uniformBuffer.setTexture("ds_depthSamplerRight", DepthTextureRight);
             uniformBuffer.updateMatrix("ds_uvTransform", UvTransform);
             uniformBuffer.updateMatrix("ds_uvTransformRight", UvTransformRight);
+            uniformBuffer.updateMatrix("ds_viewRight", RightView);
         }
     }
 
@@ -326,7 +331,13 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
 
     ds_cameraDepth = ds_cameraDepth * ds_rawValueToMetersSet;
 
-    let ds_assetDepth: f32 = (1.0 / fragmentInputs.position.w) / uniforms.ds_worldScale;
+    var ds_viewPosition: vec4f = scene.view * vec4f(fragmentInputs.vPositionW, 1.0);
+    #ifdef MULTIVIEW
+        if (ds_viewIndexSet >= 0.5) {
+            ds_viewPosition = uniforms.ds_viewRight * vec4f(fragmentInputs.vPositionW, 1.0);
+        }
+    #endif
+    let ds_assetDepth: f32 = (ds_viewPosition.z * uniforms.ds_viewDepthSign) / uniforms.ds_worldScale;
     #ifdef DEPTH_SENSING_DISCARD
     if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth) {
         discard;
@@ -655,6 +666,10 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                         }
                     } else if (camera._renderingMultiview && engine.isWebGPU && this.depthUsage === "cpu") {
                         ViewIndex = 0;
+                        const rightCamera = camera.rigCameras[1];
+                        if (rightCamera) {
+                            RightView.copyFrom(rightCamera.getViewMatrix());
+                        }
                         this._bindCPUDepthView(0, true);
                     }
                 }

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -343,7 +343,7 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
     #endif
     let ds_assetDepth: f32 = (ds_viewPosition.z * uniforms.ds_viewDepthSign) / uniforms.ds_worldScale;
     #ifdef DEPTH_SENSING_DISCARD
-    if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth) {
+    if (ds_depthAvailable > 0.5 && ds_cameraDepth > 0.0 && ds_cameraDepth < ds_assetDepth) {
         discard;
     }
     #endif
@@ -352,7 +352,7 @@ class WebXRDepthSensingMaterialPlugin extends MaterialPluginBase {
                       CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR: `
 #ifdef DEPTH_SENSING
     #ifndef DEPTH_SENSING_DISCARD
-        if (ds_depthAvailable > 0.5) {
+        if (ds_depthAvailable > 0.5 && ds_cameraDepth > 0.0) {
             let ds_depthTolerancePerM: f32 = 0.005;
             let ds_occlusion: f32 = clamp(1.0 - 0.5 * (ds_cameraDepth - ds_assetDepth) / (ds_depthTolerancePerM * ds_assetDepth) +
                 0.5, 0.0, 1.0);
@@ -463,6 +463,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
     private _cachedDepthBuffer: Nullable<ArrayBuffer> = null;
     private _cachedWebGLTexture: Nullable<WebGLTexture> = null;
     private _cachedDepthImageTexture: Nullable<RawTexture> = null;
+    private _cachedDepthImageTextureWrapsExternalTexture = false;
     private _cpuDepthViewStates: IWebXRCPUDepthViewState[] = [];
     private _disableAutoAttachBeforeWebGPUGPUDepth = false;
     private _disabledForWebGPUGPUDepth = false;
@@ -701,9 +702,13 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
         }
         this._cpuDepthViewStates.length = 0;
         if (!cachedTextureDisposed) {
+            if (this._cachedDepthImageTextureWrapsExternalTexture && this._cachedDepthImageTexture?._texture) {
+                this._cachedDepthImageTexture._texture._hardwareTexture = null;
+            }
             this._cachedDepthImageTexture?.dispose();
         }
         this._cachedDepthImageTexture = null;
+        this._cachedDepthImageTextureWrapsExternalTexture = false;
         for (const plugin of ManagedMaterialPlugins) {
             plugin.isEnabled = false;
         }
@@ -822,6 +827,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 Constants.TEXTURETYPE_FLOAT
             );
         }
+        this._cachedDepthImageTextureWrapsExternalTexture = false;
         this._cachedDepthImageTexture = viewState.texture;
 
         let float32Array: Float32Array | null = null;
@@ -945,9 +951,11 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
                 Texture.NEAREST_SAMPLINGMODE,
                 dataFormat === "float" ? Constants.TEXTURETYPE_FLOAT : Constants.TEXTURETYPE_UNSIGNED_BYTE
             );
+            this._cachedDepthImageTexture._texture?.dispose();
         }
 
         this._cachedDepthImageTexture._texture = internalTexture;
+        this._cachedDepthImageTextureWrapsExternalTexture = true;
         DepthTexture = this._cachedDepthImageTexture;
         this._xrSessionManager.scene.markAllMaterialsAsDirty(Constants.MATERIAL_TextureDirtyFlag);
     }

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -37,6 +37,11 @@ export interface IWebXRFeature extends IDisposable {
      * Should auto-attach be disabled?
      */
     disableAutoAttach: boolean;
+    /**
+     * The auto-attach policy in effect before the features manager starts a manual attachment.
+     * @internal
+     */
+    _autoAttachPolicyBeforeAttach?: boolean;
 
     /**
      * Attach the feature to the session
@@ -461,8 +466,14 @@ export class WebXRFeaturesManager implements IDisposable {
         const feature = this._features[featureName];
         if (feature && feature.enabled && !feature.featureImplementation.attached) {
             const disableAutoAttachBeforeAttach = feature.featureImplementation.disableAutoAttach;
+            feature.featureImplementation._autoAttachPolicyBeforeAttach = disableAutoAttachBeforeAttach;
             feature.featureImplementation.disableAutoAttach = false;
-            const attached = feature.featureImplementation.attach();
+            let attached: boolean;
+            try {
+                attached = feature.featureImplementation.attach();
+            } finally {
+                delete feature.featureImplementation._autoAttachPolicyBeforeAttach;
+            }
             const intentionallyDisabledDuringAttach = feature.featureImplementation.disableAutoAttach;
             if (!intentionallyDisabledDuringAttach) {
                 feature.featureImplementation.disableAutoAttach = disableAutoAttachBeforeAttach;

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
@@ -4,6 +4,8 @@
 
 import { createHash } from "node:crypto";
 import { NullEngine } from "core/Engines/nullEngine";
+import { WebGPUShaderProcessingContext } from "core/Engines/WebGPU/webgpuShaderProcessingContext";
+import { WebGPUShaderProcessorWGSL } from "core/Engines/WebGPU/webgpuShaderProcessorsWGSL";
 import { MaterialPluginBase } from "core/Materials/materialPluginBase";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { StandardMaterial } from "core/Materials/standardMaterial";
@@ -78,17 +80,18 @@ describe("WebXRDepthSensing material shaders", () => {
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain(
             "(fragmentInputs.position.xy * uniforms.ds_invScreenSize - uniforms.ds_shaderViewport.xy) / uniforms.ds_shaderViewport.zw"
         );
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("vec2f(ds_baseUvBottomLeft.x, 1.0 - ds_baseUvBottomLeft.y)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransform * vec4f");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransformRight * vec4f");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, i32(ds_viewIndexSet))");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv)");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSampleLevel(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, 0.0)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSampleLevel(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv, 0.0)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("ds_cameraDepth = ds_cameraDepth * ds_rawValueToMetersSet;");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("scene.view * vec4f(fragmentInputs.vPositionW, 1.0)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_viewRight * vec4f(fragmentInputs.vPositionW, 1.0)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = (ds_viewPosition.z * uniforms.ds_viewDepthSign) / uniforms.ds_worldScale;");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth)");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 - ds_baseUv.y");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("discard;");
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("let ds_depthTolerancePerM: f32 = 0.005;");
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("color *= (1.0 - ds_occlusion);");
@@ -115,12 +118,31 @@ describe("WebXRDepthSensing material shaders", () => {
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("fragmentInputs.position.z;");
     });
 
-    it("keeps top-left WebGPU fragment coordinates aligned with unflipped CPU depth uploads", () => {
+    it("compensates for Babylon's assembled fragment-coordinate flip to address top-left CPU depth rows", () => {
         const plugin = createPlugin(ShaderLanguage.WGSL);
         const fragment = plugin.getCustomCode("fragment", ShaderLanguage.WGSL)!;
+        const uvCode = fragment.CUSTOM_FRAGMENT_MAIN_BEGIN.match(
+            /let ds_baseUvBottomLeft:[\s\S]+?let ds_baseUv: vec2f = vec2f\(ds_baseUvBottomLeft\.x, 1\.0 - ds_baseUvBottomLeft\.y\);/
+        )?.[0];
+        expect(uvCode).toBeDefined();
 
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransform * vec4f(ds_baseUv, 0.0, 1.0)");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 - ds_baseUv.y");
+        const processor = new WebGPUShaderProcessorWGSL();
+        processor.pureMode = false;
+        processor.initializeShaders(new WebGPUShaderProcessingContext(ShaderLanguage.WGSL, true));
+        const processed = processor.finalizeShaders(
+            `@vertex fn main(input: VertexInputs) -> FragmentInputs {
+                vertexOutputs.position = vec4f(0.0);
+            }`,
+            `@fragment fn main(input: FragmentInputs) -> FragmentOutputs {
+                ${uvCode}
+                fragmentOutputs.color = vec4f(ds_baseUv, 0.0, 1.0);
+            }`
+        ).fragmentCode;
+
+        const processorFlip = "fragmentInputs.position.y = internals.textureOutputHeight_ - fragmentInputs.position.y;";
+        const depthRowCorrection = "let ds_baseUv: vec2f = vec2f(ds_baseUvBottomLeft.x, 1.0 - ds_baseUvBottomLeft.y);";
+        expect(processed).toContain(processorFlip);
+        expect(processed.indexOf(processorFlip)).toBeLessThan(processed.indexOf(depthRowCorrection));
     });
 
     it("preserves the GLSL injection strings byte for byte", () => {

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
@@ -62,7 +62,9 @@ describe("WebXRDepthSensing material shaders", () => {
             "ds_depthAvailableLeft",
             "ds_depthAvailableRight",
             "ds_worldScale",
+            "ds_viewDepthSign",
             "ds_uvTransformRight",
+            "ds_viewRight",
         ]);
         expect(vertex.CUSTOM_VERTEX_DEFINITIONS).toContain("varying ds_viewIndexMultiview: f32;");
         expect(vertex.CUSTOM_VERTEX_MAIN_BEGIN).toContain("vertexOutputs.ds_viewIndexMultiview = f32(gl_ViewID_OVR);");
@@ -82,7 +84,9 @@ describe("WebXRDepthSensing material shaders", () => {
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("ds_cameraDepth = ds_cameraDepth * ds_rawValueToMetersSet;");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = (1.0 / fragmentInputs.position.w) / uniforms.ds_worldScale;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("scene.view * vec4f(fragmentInputs.vPositionW, 1.0)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_viewRight * vec4f(fragmentInputs.vPositionW, 1.0)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = (ds_viewPosition.z * uniforms.ds_viewDepthSign) / uniforms.ds_worldScale;");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 - ds_baseUv.y");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("discard;");
@@ -90,7 +94,7 @@ describe("WebXRDepthSensing material shaders", () => {
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("color *= (1.0 - ds_occlusion);");
     });
 
-    it("compares meter depth against positive linear view depth instead of nonlinear device depth", () => {
+    it("compares meter depth against handedness-correct linear view-space depth instead of nonlinear device depth", () => {
         const plugin = createPlugin(ShaderLanguage.WGSL);
         const fragment = plugin.getCustomCode("fragment", ShaderLanguage.WGSL)!;
         const near = 0.1;
@@ -99,11 +103,15 @@ describe("WebXRDepthSensing material shaders", () => {
         const environmentDepthMeters = 1;
         const clipZ = (far / (far - near)) * viewDepthMeters - (near * far) / (far - near);
         const deviceDepth = clipZ / viewDepthMeters;
-        const fragmentPositionW = 1 / viewDepthMeters;
+        const leftHandedViewZ = viewDepthMeters;
+        const rightHandedViewZ = -viewDepthMeters;
 
         expect(environmentDepthMeters < deviceDepth).toBe(false);
-        expect(environmentDepthMeters < 1 / fragmentPositionW).toBe(true);
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("1.0 / fragmentInputs.position.w");
+        expect(environmentDepthMeters < leftHandedViewZ).toBe(true);
+        expect(environmentDepthMeters < -rightHandedViewZ).toBe(true);
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("fragmentInputs.vPositionW");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_viewDepthSign");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 / fragmentInputs.position.w");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("fragmentInputs.position.z;");
     });
 

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
@@ -52,21 +52,67 @@ describe("WebXRDepthSensing material shaders", () => {
 
         expect(plugin.isCompatible(ShaderLanguage.WGSL)).toBe(true);
         expect(uniforms.fragment).toBe("");
-        expect(uniforms.ubo?.map(({ name }) => name)).toEqual(["ds_invScreenSize", "ds_rawValueToMeters", "ds_viewIndex", "ds_shaderViewport", "ds_uvTransform"]);
+        expect(uniforms.ubo?.map(({ name }) => name)).toEqual([
+            "ds_invScreenSize",
+            "ds_rawValueToMeters",
+            "ds_viewIndex",
+            "ds_shaderViewport",
+            "ds_uvTransform",
+            "ds_rawValueToMetersRight",
+            "ds_depthAvailableLeft",
+            "ds_depthAvailableRight",
+            "ds_worldScale",
+            "ds_uvTransformRight",
+        ]);
         expect(vertex.CUSTOM_VERTEX_DEFINITIONS).toContain("varying ds_viewIndexMultiview: f32;");
         expect(vertex.CUSTOM_VERTEX_MAIN_BEGIN).toContain("vertexOutputs.ds_viewIndexMultiview = f32(gl_ViewID_OVR);");
         expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSampler: texture_2d<f32>;");
         expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSampler: texture_2d_array<f32>;");
         expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSamplerSampler: sampler;");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("fragmentInputs.position.xy * uniforms.ds_invScreenSize");
+        expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSamplerRight: texture_2d<f32>;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("var ds_depthAvailable: f32 = uniforms.ds_depthAvailableLeft;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("ds_depthAvailable = uniforms.ds_depthAvailableRight;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("if (ds_depthAvailable > 0.5)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain(
+            "(fragmentInputs.position.xy * uniforms.ds_invScreenSize - uniforms.ds_shaderViewport.xy) / uniforms.ds_shaderViewport.zw"
+        );
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransform * vec4f");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransformRight * vec4f");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, i32(ds_viewIndexSet))");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv)");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("ds_cameraDepth = ds_cameraDepth * uniforms.ds_rawValueToMeters;");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = fragmentInputs.position.z;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSamplerRight, ds_depthSamplerRightSampler, ds_depthUv)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("ds_cameraDepth = ds_cameraDepth * ds_rawValueToMetersSet;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = (1.0 / fragmentInputs.position.w) / uniforms.ds_worldScale;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 - ds_baseUv.y");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("discard;");
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("let ds_depthTolerancePerM: f32 = 0.005;");
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("color *= (1.0 - ds_occlusion);");
+    });
+
+    it("compares meter depth against positive linear view depth instead of nonlinear device depth", () => {
+        const plugin = createPlugin(ShaderLanguage.WGSL);
+        const fragment = plugin.getCustomCode("fragment", ShaderLanguage.WGSL)!;
+        const near = 0.1;
+        const far = 10;
+        const viewDepthMeters = 2;
+        const environmentDepthMeters = 1;
+        const clipZ = (far / (far - near)) * viewDepthMeters - (near * far) / (far - near);
+        const deviceDepth = clipZ / viewDepthMeters;
+        const fragmentPositionW = 1 / viewDepthMeters;
+
+        expect(environmentDepthMeters < deviceDepth).toBe(false);
+        expect(environmentDepthMeters < 1 / fragmentPositionW).toBe(true);
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("1.0 / fragmentInputs.position.w");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("fragmentInputs.position.z;");
+    });
+
+    it("keeps top-left WebGPU fragment coordinates aligned with unflipped CPU depth uploads", () => {
+        const plugin = createPlugin(ShaderLanguage.WGSL);
+        const fragment = plugin.getCustomCode("fragment", ShaderLanguage.WGSL)!;
+
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransform * vec4f(ds_baseUv, 0.0, 1.0)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 - ds_baseUv.y");
     });
 
     it("preserves the GLSL injection strings byte for byte", () => {

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
@@ -91,7 +91,9 @@ describe("WebXRDepthSensing material shaders", () => {
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("scene.view * vec4f(fragmentInputs.vPositionW, 1.0)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_viewRight * vec4f(fragmentInputs.vPositionW, 1.0)");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = (ds_viewPosition.z * uniforms.ds_viewDepthSign) / uniforms.ds_worldScale;");
-        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("if (ds_depthAvailable > 0.5 && ds_cameraDepth < ds_assetDepth)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain(
+            "if (ds_depthAvailable > 0.5 && ds_cameraDepth > 0.0 && ds_cameraDepth < ds_assetDepth)"
+        );
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("discard;");
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("let ds_depthTolerancePerM: f32 = 0.005;");
         expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("color *= (1.0 - ds_occlusion);");
@@ -116,6 +118,16 @@ describe("WebXRDepthSensing material shaders", () => {
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_viewDepthSign");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("1.0 / fragmentInputs.position.w");
         expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).not.toContain("fragmentInputs.position.z;");
+    });
+
+    it("treats zero-valued CPU depth as unavailable in both WGSL occlusion modes", () => {
+        const plugin = createPlugin(ShaderLanguage.WGSL);
+        const fragment = plugin.getCustomCode("fragment", ShaderLanguage.WGSL)!;
+
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain(
+            "if (ds_depthAvailable > 0.5 && ds_cameraDepth > 0.0 && ds_cameraDepth < ds_assetDepth)"
+        );
+        expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("if (ds_depthAvailable > 0.5 && ds_cameraDepth > 0.0)");
     });
 
     it("compensates for Babylon's assembled fragment-coordinate flip to address top-left CPU depth rows", () => {

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { createHash } from "node:crypto";
+import { NullEngine } from "core/Engines/nullEngine";
+import { MaterialPluginBase } from "core/Materials/materialPluginBase";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Scene } from "core/scene";
+import { WebXRDepthSensing } from "core/XR/features/WebXRDepthSensing";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("WebXRDepthSensing material shaders", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let feature: WebXRDepthSensing | undefined;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        (sessionManager as any)._xrNavigator = { xr: { native: false } };
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["cpu"],
+        });
+    });
+
+    afterEach(() => {
+        feature?.dispose();
+        scene.dispose();
+        engine.dispose();
+    });
+
+    function createPlugin(shaderLanguage: ShaderLanguage): MaterialPluginBase {
+        (engine as any)._isWebGPU = shaderLanguage === ShaderLanguage.WGSL;
+        const material = new StandardMaterial(`depth-${shaderLanguage}`, scene);
+        const plugin = material.pluginManager?.getPlugin("DepthSensing");
+        expect(material.shaderLanguage).toBe(shaderLanguage);
+        expect(plugin).not.toBeNull();
+        return plugin!;
+    }
+
+    it("generates WGSL for uniforms, multiview, texture sampling, UV transforms, discard, and tolerance", () => {
+        const plugin = createPlugin(ShaderLanguage.WGSL);
+        const uniforms = plugin.getUniforms(ShaderLanguage.WGSL);
+        const vertex = plugin.getCustomCode("vertex", ShaderLanguage.WGSL)!;
+        const fragment = plugin.getCustomCode("fragment", ShaderLanguage.WGSL)!;
+
+        expect(plugin.isCompatible(ShaderLanguage.WGSL)).toBe(true);
+        expect(uniforms.fragment).toBe("");
+        expect(uniforms.ubo?.map(({ name }) => name)).toEqual(["ds_invScreenSize", "ds_rawValueToMeters", "ds_viewIndex", "ds_shaderViewport", "ds_uvTransform"]);
+        expect(vertex.CUSTOM_VERTEX_DEFINITIONS).toContain("varying ds_viewIndexMultiview: f32;");
+        expect(vertex.CUSTOM_VERTEX_MAIN_BEGIN).toContain("vertexOutputs.ds_viewIndexMultiview = f32(gl_ViewID_OVR);");
+        expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSampler: texture_2d<f32>;");
+        expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSampler: texture_2d_array<f32>;");
+        expect(fragment.CUSTOM_FRAGMENT_DEFINITIONS).toContain("var ds_depthSamplerSampler: sampler;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("fragmentInputs.position.xy * uniforms.ds_invScreenSize");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("uniforms.ds_uvTransform * vec4f");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv, i32(ds_viewIndexSet))");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("textureSample(ds_depthSampler, ds_depthSamplerSampler, ds_depthUv)");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("ds_cameraDepth = ds_cameraDepth * uniforms.ds_rawValueToMeters;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("let ds_assetDepth: f32 = fragmentInputs.position.z;");
+        expect(fragment.CUSTOM_FRAGMENT_MAIN_BEGIN).toContain("discard;");
+        expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("let ds_depthTolerancePerM: f32 = 0.005;");
+        expect(fragment.CUSTOM_FRAGMENT_BEFORE_FRAGCOLOR).toContain("color *= (1.0 - ds_occlusion);");
+    });
+
+    it("preserves the GLSL injection strings byte for byte", () => {
+        const plugin = createPlugin(ShaderLanguage.GLSL);
+        const shaderSource = JSON.stringify({
+            fragment: plugin.getCustomCode("fragment", ShaderLanguage.GLSL),
+            uniforms: plugin.getUniforms(ShaderLanguage.GLSL),
+            vertex: plugin.getCustomCode("vertex", ShaderLanguage.GLSL),
+        });
+
+        expect(createHash("sha256").update(shaderSource).digest("hex")).toBe("04512bdd67e7ff7ecb513ba4168874a5bf2bb76266daf21b783521d622fa9e03");
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
@@ -337,7 +337,7 @@ describe("WebXRDepthSensing", () => {
         feature = undefined;
     });
 
-    it("preserves a caller-disabled auto-attach policy after WebGPU GPU-depth fallback", () => {
+    it("preserves manager-controlled caller auto-attach policy after WebGPU GPU-depth fallback", () => {
         (engine as any)._isWebGPU = true;
         (engine as any)._device = {};
         (sessionManager as any).session = {
@@ -346,16 +346,71 @@ describe("WebXRDepthSensing", () => {
             enabledFeatures: ["depth-sensing"],
         } as XRSession;
         vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        const featuresManager = new WebXRFeaturesManager(sessionManager);
+
+        feature = featuresManager.enableFeature(
+            WebXRDepthSensing.Name,
+            1,
+            {
+                dataFormatPreference: ["float"],
+                usagePreference: ["gpu", "cpu"],
+            },
+            false
+        );
+
+        expect(feature.disableAutoAttach).toBe(true);
+        featuresManager.attachFeature(WebXRDepthSensing.Name);
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        sessionManager.onXRSessionEnded.notifyObservers(null);
+        expect(feature.disableAutoAttach).toBe(true);
+
+        featuresManager.dispose();
+        feature = undefined;
+    });
+
+    it("invalidates cached CPU depth when the current XR frame has no viewer pose", () => {
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        const view = {} as XRView;
+        const matrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const depthInformation = createDepthInformation(Float32Array.from([1, 1, 1, 1]), 1, matrix);
+        const { leftCamera } = createRigCameras();
+        const markMaterialsDirtySpy = vi.spyOn(scene, "markAllMaterialsAsDirty");
 
         feature = new WebXRDepthSensing(sessionManager, {
             dataFormatPreference: ["float"],
-            usagePreference: ["gpu", "cpu"],
+            usagePreference: ["cpu"],
         });
-        feature.disableAutoAttach = true;
+        const material = new StandardMaterial("pose-null-depth", scene);
+        const plugin = material.pluginManager?.getPlugin("DepthSensing") as MaterialPluginBase;
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn(() => depthInformation),
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame);
+        scene.onBeforeCameraRenderObservable.notifyObservers(leftCamera);
+        const availableDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(availableDefines);
+        expect(availableDefines.DEPTH_SENSING).toBe(true);
 
-        expect(feature.attach()).toBe(false);
-        sessionManager.onXRSessionEnded.notifyObservers(null);
-        expect(feature.disableAutoAttach).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn(),
+            getViewerPose: vi.fn(() => null),
+        } as unknown as XRFrame);
+        const unavailableDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(unavailableDefines);
+        expect(unavailableDefines.DEPTH_SENSING).toBe(false);
+        expect(feature.latestDepthImageTexture).not.toBeNull();
+        expect(markMaterialsDirtySpy).toHaveBeenCalledTimes(2);
+
+        material.dispose();
     });
 
     it("recreates and restores the CPU depth texture after detach and reattach", () => {
@@ -432,6 +487,46 @@ describe("WebXRDepthSensing", () => {
         expect(xrWebGLBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, glContext);
         expect(sessionManager._getGraphicsBinding().binding).toBe(nativeBinding);
         expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
+    });
+
+    it("binds WebGL CPU depth without updating WGSL-only uniforms or the right-eye sampler", () => {
+        const nativeBinding = { getDepthInformation: vi.fn(() => null) };
+        (globalThis as any).XRWebGLBinding = vi.fn().mockImplementation(function () {
+            return nativeBinding;
+        });
+        (engine as any)._gl = {} as WebGLRenderingContext;
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        const view = {} as XRView;
+        const matrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const depthInformation = createDepthInformation(Float32Array.from([1, 1, 1, 1]), 1, matrix);
+        const { leftCamera } = createRigCameras();
+        vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["cpu"],
+        });
+        const material = new StandardMaterial("webgl-cpu-depth", scene);
+        const plugin = material.pluginManager?.getPlugin("DepthSensing") as MaterialPluginBase;
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn(() => depthInformation),
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame);
+        scene.onBeforeCameraRenderObservable.notifyObservers(leftCamera);
+
+        const binding = createUniformBufferRecorder();
+        plugin.bindForSubMesh(binding.uniformBuffer);
+        expect(Array.from(binding.floats.keys())).toEqual(["ds_rawValueToMeters", "ds_viewIndex"]);
+        expect(Array.from(binding.textures.keys())).toEqual(["ds_depthSampler"]);
+        expect(Array.from(binding.matrices.keys())).toEqual(["ds_uvTransform"]);
+
+        material.dispose();
     });
 
     it("preserves caller depth usage and format preference order", async () => {

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
@@ -7,6 +7,7 @@ import { type Camera } from "core/Cameras/camera";
 import { type MaterialPluginBase } from "core/Materials/materialPluginBase";
 import { StandardMaterial } from "core/Materials/standardMaterial";
 import { type UniformBuffer } from "core/Materials/uniformBuffer";
+import { Matrix } from "core/Maths/math.vector";
 import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
 import { WebXRDepthSensing } from "core/XR/features/WebXRDepthSensing";
@@ -65,21 +66,25 @@ describe("WebXRDepthSensing", () => {
             getRenderHeight: () => 4,
             getRenderWidth: () => 8,
         };
+        const leftViewMatrix = Matrix.Translation(-0.03, 0, 0);
+        const rightViewMatrix = Matrix.Translation(0.03, 0, 0);
         const rigParent = { rigCameras: [] as Camera[] };
         const leftCamera = {
+            getViewMatrix: () => leftViewMatrix,
             outputRenderTarget,
             rigParent,
             rigCameras: [],
             viewport: { height: 1, width: 0.5, x: 0, y: 0 },
         } as unknown as Camera;
         const rightCamera = {
+            getViewMatrix: () => rightViewMatrix,
             outputRenderTarget,
             rigParent,
             rigCameras: [],
             viewport: { height: 1, width: 0.5, x: 0.5, y: 0 },
         } as unknown as Camera;
         rigParent.rigCameras.push(leftCamera, rightCamera);
-        return { leftCamera, outputRenderTarget, rightCamera, rigParent };
+        return { leftCamera, leftViewMatrix, outputRenderTarget, rightCamera, rightViewMatrix, rigParent };
     }
 
     function createUniformBufferRecorder() {
@@ -175,7 +180,7 @@ describe("WebXRDepthSensing", () => {
         const rightMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.625, 0, 0, 1]);
         const leftDepth = createDepthInformation(Float32Array.from([1, 1, 1, 1]), 1, leftMatrix);
         const rightDepth = createDepthInformation(Float32Array.from([3, 3, 3, 3]), 2, rightMatrix);
-        const { leftCamera, outputRenderTarget, rightCamera, rigParent } = createRigCameras();
+        const { leftCamera, outputRenderTarget, rightCamera, rightViewMatrix, rigParent } = createRigCameras();
 
         feature = new WebXRDepthSensing(sessionManager, {
             dataFormatPreference: ["float"],
@@ -219,7 +224,15 @@ describe("WebXRDepthSensing", () => {
         expect(multiviewBinding.floats.get("ds_rawValueToMetersRight")).toBe(2);
         expect(multiviewBinding.floats.get("ds_depthAvailableLeft")).toBe(1);
         expect(multiviewBinding.floats.get("ds_depthAvailableRight")).toBe(1);
+        expect(multiviewBinding.floats.get("ds_viewDepthSign")).toBe(1);
         expect(multiviewBinding.matrices.get("ds_uvTransformRight")).toEqual(Array.from(rightMatrix));
+        expect(multiviewBinding.matrices.get("ds_viewRight")).toEqual(Array.from(rightViewMatrix.asArray()));
+
+        scene.useRightHandedSystem = true;
+        const rightHandedBinding = createUniformBufferRecorder();
+        plugin.bindForSubMesh(rightHandedBinding.uniformBuffer);
+        expect(rightHandedBinding.floats.get("ds_viewDepthSign")).toBe(-1);
+        scene.useRightHandedSystem = false;
 
         const markMaterialsDirtySpy = vi.spyOn(scene, "markAllMaterialsAsDirty");
         sessionManager.onXRFrameObservable.notifyObservers({

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Logger } from "core/Misc/logger";
+import { Scene } from "core/scene";
+import { WebXRDepthSensing } from "core/XR/features/WebXRDepthSensing";
+import { WebXRFeaturesManager } from "core/XR/webXRFeaturesManager";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WebGPUGPUDepthWarning =
+    "WebXR Depth Sensing is unavailable with WebGPU XR when the session negotiates gpu-optimized depth because XRGPUBinding has no environment-depth equivalent; request cpu-optimized depth to use the feature.";
+
+describe("WebXRDepthSensing", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let feature: WebXRDepthSensing | undefined;
+    let originalWebGLBinding: unknown;
+    let originalGPUBinding: unknown;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 4,
+            renderWidth: 4,
+            textureSize: 4,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        (sessionManager as any)._xrNavigator = { xr: { native: false } };
+        originalWebGLBinding = (globalThis as any).XRWebGLBinding;
+        originalGPUBinding = (globalThis as any).XRGPUBinding;
+    });
+
+    afterEach(() => {
+        feature?.dispose();
+        vi.restoreAllMocks();
+        (globalThis as any).XRWebGLBinding = originalWebGLBinding;
+        (globalThis as any).XRGPUBinding = originalGPUBinding;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("updates CPU depth buffers, metadata, and the depth texture on WebGPU without a graphics binding", () => {
+        const xrWebGLBinding = vi.fn();
+        const xrGPUBinding = vi.fn();
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (globalThis as any).XRGPUBinding = xrGPUBinding;
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            depthDataFormat: "unsigned-short",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+
+        const matrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const normDepthBufferFromNormView = { matrix } as unknown as XRRigidTransform;
+        const depthValues = new Uint16Array([100, 200, 300, 400]);
+        const getDepthInMeters = vi.fn(function (this: XRCPUDepthInformation, x: number, y: number) {
+            return this.rawValueToMeters * depthValues[y * 2 + x];
+        });
+        const depthInformation = {
+            data: depthValues.buffer,
+            getDepthInMeters,
+            height: 2,
+            normDepthBufferFromNormView,
+            rawValueToMeters: 0.001,
+            width: 2,
+        } as unknown as XRCPUDepthInformation;
+        const view = {} as XRView;
+        const updateRawTextureSpy = vi.spyOn(engine, "updateRawTexture");
+        const markMaterialsDirtySpy = vi.spyOn(scene, "markAllMaterialsAsDirty");
+        let depthReader: ((x: number, y: number) => number) | undefined;
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["ushort"],
+            usagePreference: ["cpu"],
+        });
+        feature.onGetDepthInMetersAvailable.add((reader) => {
+            depthReader = reader;
+        });
+
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn(() => depthInformation),
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame);
+
+        expect(xrWebGLBinding).not.toHaveBeenCalled();
+        expect(xrGPUBinding).not.toHaveBeenCalled();
+        expect(feature.width).toBe(2);
+        expect(feature.height).toBe(2);
+        expect(feature.rawValueToMeters).toBe(0.001);
+        expect(feature.normDepthBufferFromNormView).toBe(normDepthBufferFromNormView);
+        expect(feature.latestDepthBuffer).toEqual(depthValues);
+        expect(feature.latestDepthImageTexture?.getSize()).toEqual({ width: 2, height: 2 });
+        expect(updateRawTextureSpy).toHaveBeenCalledTimes(1);
+        expect(updateRawTextureSpy.mock.calls[0][1]).toEqual(Float32Array.from(depthValues));
+        expect(markMaterialsDirtySpy).toHaveBeenCalledTimes(1);
+        expect(depthReader?.(1, 1)).toBeCloseTo(0.4);
+        expect(getDepthInMeters).toHaveBeenCalledExactlyOnceWith(1, 1);
+    });
+
+    it("disables once for WebGPU GPU depth without bindings, wrapping, or observers", () => {
+        const xrWebGLBinding = vi.fn();
+        const xrGPUBinding = vi.fn();
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (globalThis as any).XRGPUBinding = xrGPUBinding;
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (engine as any).wrapWebGLTexture = vi.fn();
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "gpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        const featuresManager = new WebXRFeaturesManager(sessionManager);
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        feature = featuresManager.enableFeature(WebXRDepthSensing.Name, 1, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["gpu", "cpu"],
+        });
+
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUGPUDepthWarning);
+        expect(xrWebGLBinding).not.toHaveBeenCalled();
+        expect(xrGPUBinding).not.toHaveBeenCalled();
+        expect((engine as any).wrapWebGLTexture).not.toHaveBeenCalled();
+        expect(sessionManager.onXRFrameObservable.hasObservers()).toBe(false);
+        expect(scene.onBeforeCameraRenderObservable.hasObservers()).toBe(false);
+        expect(feature.latestDepthBuffer).toBeNull();
+        expect(feature.latestDepthImageTexture).toBeNull();
+
+        sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn(),
+            getViewerPose: vi.fn(),
+        } as unknown as XRFrame);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
+        featuresManager.dispose();
+        feature = undefined;
+    });
+
+    it("reuses the cached WebGL binding for WebGL GPU depth", () => {
+        const nativeBinding = { getDepthInformation: vi.fn(() => null) };
+        const xrWebGLBinding = vi.fn().mockImplementation(function () {
+            return nativeBinding;
+        });
+        const glContext = {} as WebGLRenderingContext;
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (engine as any)._gl = glContext;
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "gpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["gpu"],
+        });
+
+        expect(feature.attach()).toBe(true);
+        expect(xrWebGLBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, glContext);
+        expect(sessionManager._getGraphicsBinding().binding).toBe(nativeBinding);
+        expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves caller depth usage and format preference order", async () => {
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float", "ushort", "luminance-alpha"],
+            usagePreference: ["gpu", "cpu"],
+        });
+
+        await expect(feature.getXRSessionInitExtension()).resolves.toEqual({
+            depthSensing: {
+                dataFormatPreference: ["float32", "unsigned-short", "luminance-alpha"],
+                usagePreference: ["gpu-optimized", "cpu-optimized"],
+            },
+        });
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
@@ -489,6 +489,62 @@ describe("WebXRDepthSensing", () => {
         expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
     });
 
+    it("releases WebGL GPU depth wrappers without deleting runtime-owned textures across reattach", () => {
+        let runtimeTexture = {} as WebGLTexture;
+        const matrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const getDepthInformation = vi.fn(
+            () =>
+                ({
+                    height: 2,
+                    normDepthBufferFromNormView: { matrix },
+                    rawValueToMeters: 1,
+                    texture: runtimeTexture,
+                    textureType: "texture",
+                    width: 2,
+                }) as unknown as XRWebGLDepthInformation
+        );
+        const nativeBinding = { getDepthInformation };
+        (globalThis as any).XRWebGLBinding = vi.fn().mockImplementation(function () {
+            return nativeBinding;
+        });
+        const deleteTexture = vi.fn();
+        (engine as any)._gl = { deleteTexture } as unknown as WebGLRenderingContext;
+        vi.spyOn(engine, "_releaseTexture").mockImplementation((texture) => {
+            texture._hardwareTexture?.release();
+        });
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "gpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        const view = {} as XRView;
+        const frame = {
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame;
+        vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["gpu"],
+        });
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers(frame);
+        const firstWrapper = feature.latestDepthImageTexture;
+        expect(firstWrapper).not.toBeNull();
+        expect(deleteTexture.mock.calls.some(([texture]) => texture === runtimeTexture)).toBe(false);
+        deleteTexture.mockClear();
+        expect(feature.detach()).toBe(true);
+        expect(deleteTexture.mock.calls.some(([texture]) => texture === runtimeTexture)).toBe(false);
+
+        runtimeTexture = {} as WebGLTexture;
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers(frame);
+        expect(feature.latestDepthImageTexture).not.toBe(firstWrapper);
+        expect(feature.detach()).toBe(true);
+        expect(deleteTexture.mock.calls.some(([texture]) => texture === runtimeTexture)).toBe(false);
+    });
+
     it("binds WebGL CPU depth without updating WGSL-only uniforms or the right-eye sampler", () => {
         const nativeBinding = { getDepthInformation: vi.fn(() => null) };
         (globalThis as any).XRWebGLBinding = vi.fn().mockImplementation(function () {

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
@@ -165,6 +165,49 @@ describe("WebXRDepthSensing", () => {
         expect(getDepthInMeters).toHaveBeenCalledExactlyOnceWith(1, 1);
     });
 
+    it("reuses the per-view visualization buffer across CPU depth frames", () => {
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+
+        const matrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const firstDepthValues = Float32Array.from([1, 2, 3, 4]);
+        const secondDepthValues = Float32Array.from([4, 3, 2, 1]);
+        const getDepthInformation = vi
+            .fn()
+            .mockReturnValueOnce(createDepthInformation(firstDepthValues, 0.5, matrix))
+            .mockReturnValueOnce(createDepthInformation(secondDepthValues, 2, matrix));
+        const view = {} as XRView;
+        const frame = {
+            getDepthInformation,
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame;
+        const updateRawTextureSpy = vi.spyOn(engine, "updateRawTexture");
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            prepareTextureForVisualization: true,
+            usagePreference: ["cpu"],
+        });
+
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers(frame);
+        const firstUpload = updateRawTextureSpy.mock.calls[0][1] as Float32Array;
+        const firstUploadSnapshot = firstUpload.slice();
+        sessionManager.onXRFrameObservable.notifyObservers(frame);
+        const secondUpload = updateRawTextureSpy.mock.calls[1][1] as Float32Array;
+
+        expect(firstUpload).not.toBe(firstDepthValues);
+        expect(firstUpload).toBe(secondUpload);
+        expect(firstUploadSnapshot).toEqual(Float32Array.from([0.5, 1, 1.5, 2]));
+        expect(secondUpload).toEqual(Float32Array.from([8, 6, 4, 2]));
+    });
+
     it("binds distinct CPU depth buffers and transforms for each WebGPU XR view", () => {
         (engine as any)._isWebGPU = true;
         (engine as any)._device = {};

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts
@@ -3,6 +3,10 @@
  */
 
 import { NullEngine } from "core/Engines/nullEngine";
+import { type Camera } from "core/Cameras/camera";
+import { type MaterialPluginBase } from "core/Materials/materialPluginBase";
+import { StandardMaterial } from "core/Materials/standardMaterial";
+import { type UniformBuffer } from "core/Materials/uniformBuffer";
 import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
 import { WebXRDepthSensing } from "core/XR/features/WebXRDepthSensing";
@@ -45,6 +49,53 @@ describe("WebXRDepthSensing", () => {
         engine.dispose();
     });
 
+    function createDepthInformation(values: Float32Array, rawValueToMeters: number, matrix: Float32Array): XRCPUDepthInformation {
+        return {
+            data: values.buffer,
+            getDepthInMeters: vi.fn(),
+            height: 2,
+            normDepthBufferFromNormView: { matrix } as unknown as XRRigidTransform,
+            rawValueToMeters,
+            width: 2,
+        } as unknown as XRCPUDepthInformation;
+    }
+
+    function createRigCameras() {
+        const outputRenderTarget = {
+            getRenderHeight: () => 4,
+            getRenderWidth: () => 8,
+        };
+        const rigParent = { rigCameras: [] as Camera[] };
+        const leftCamera = {
+            outputRenderTarget,
+            rigParent,
+            rigCameras: [],
+            viewport: { height: 1, width: 0.5, x: 0, y: 0 },
+        } as unknown as Camera;
+        const rightCamera = {
+            outputRenderTarget,
+            rigParent,
+            rigCameras: [],
+            viewport: { height: 1, width: 0.5, x: 0.5, y: 0 },
+        } as unknown as Camera;
+        rigParent.rigCameras.push(leftCamera, rightCamera);
+        return { leftCamera, outputRenderTarget, rightCamera, rigParent };
+    }
+
+    function createUniformBufferRecorder() {
+        const matrices = new Map<string, number[]>();
+        const textures = new Map<string, unknown>();
+        const floats = new Map<string, number>();
+        const uniformBuffer = {
+            setTexture: vi.fn((name: string, texture: unknown) => textures.set(name, texture)),
+            updateFloat: vi.fn((name: string, value: number) => floats.set(name, value)),
+            updateFloat2: vi.fn(),
+            updateFloat4: vi.fn(),
+            updateMatrix: vi.fn((name: string, matrix: { asArray: () => number[] }) => matrices.set(name, Array.from(matrix.asArray()))),
+        } as unknown as UniformBuffer;
+        return { floats, matrices, textures, uniformBuffer };
+    }
+
     it("updates CPU depth buffers, metadata, and the depth texture on WebGPU without a graphics binding", () => {
         const xrWebGLBinding = vi.fn();
         const xrGPUBinding = vi.fn();
@@ -85,12 +136,14 @@ describe("WebXRDepthSensing", () => {
         feature.onGetDepthInMetersAvailable.add((reader) => {
             depthReader = reader;
         });
+        const { leftCamera } = createRigCameras();
 
         expect(feature.attach()).toBe(true);
         sessionManager.onXRFrameObservable.notifyObservers({
             getDepthInformation: vi.fn(() => depthInformation),
             getViewerPose: vi.fn(() => ({ views: [view] })),
         } as unknown as XRFrame);
+        scene.onBeforeCameraRenderObservable.notifyObservers(leftCamera);
 
         expect(xrWebGLBinding).not.toHaveBeenCalled();
         expect(xrGPUBinding).not.toHaveBeenCalled();
@@ -107,7 +160,116 @@ describe("WebXRDepthSensing", () => {
         expect(getDepthInMeters).toHaveBeenCalledExactlyOnceWith(1, 1);
     });
 
-    it("disables once for WebGPU GPU depth without bindings, wrapping, or observers", () => {
+    it("binds distinct CPU depth buffers and transforms for each WebGPU XR view", () => {
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        const leftView = {} as XRView;
+        const rightView = {} as XRView;
+        const leftMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.125, 0, 0, 1]);
+        const rightMatrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0.625, 0, 0, 1]);
+        const leftDepth = createDepthInformation(Float32Array.from([1, 1, 1, 1]), 1, leftMatrix);
+        const rightDepth = createDepthInformation(Float32Array.from([3, 3, 3, 3]), 2, rightMatrix);
+        const { leftCamera, outputRenderTarget, rightCamera, rigParent } = createRigCameras();
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["cpu"],
+        });
+        const material = new StandardMaterial("stereo-depth", scene);
+        const plugin = material.pluginManager?.getPlugin("DepthSensing") as MaterialPluginBase;
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn((view) => (view === leftView ? leftDepth : rightDepth)),
+            getViewerPose: vi.fn(() => ({ views: [leftView, rightView] })),
+        } as unknown as XRFrame);
+
+        const leftBinding = createUniformBufferRecorder();
+        scene.onBeforeCameraRenderObservable.notifyObservers(leftCamera);
+        plugin.bindForSubMesh(leftBinding.uniformBuffer);
+        const leftTexture = leftBinding.textures.get("ds_depthSampler");
+        expect(leftTexture).toBeTruthy();
+        expect(leftBinding.floats.get("ds_rawValueToMeters")).toBe(1);
+        expect(leftBinding.matrices.get("ds_uvTransform")).toEqual(Array.from(leftMatrix));
+
+        const rightBinding = createUniformBufferRecorder();
+        scene.onBeforeCameraRenderObservable.notifyObservers(rightCamera);
+        plugin.bindForSubMesh(rightBinding.uniformBuffer);
+        const rightTexture = rightBinding.textures.get("ds_depthSampler");
+        expect(rightTexture).toBeTruthy();
+        expect(rightTexture).not.toBe(leftTexture);
+        expect(rightBinding.floats.get("ds_rawValueToMeters")).toBe(2);
+        expect(rightBinding.matrices.get("ds_uvTransform")).toEqual(Array.from(rightMatrix));
+
+        const multiviewCamera = {
+            _renderingMultiview: true,
+            outputRenderTarget,
+            rigCameras: rigParent.rigCameras,
+        } as unknown as Camera;
+        const multiviewBinding = createUniformBufferRecorder();
+        scene.onBeforeCameraRenderObservable.notifyObservers(multiviewCamera);
+        plugin.bindForSubMesh(multiviewBinding.uniformBuffer);
+        expect(multiviewBinding.textures.get("ds_depthSampler")).toBe(leftTexture);
+        expect(multiviewBinding.textures.get("ds_depthSamplerRight")).toBe(rightTexture);
+        expect(multiviewBinding.floats.get("ds_rawValueToMetersRight")).toBe(2);
+        expect(multiviewBinding.floats.get("ds_depthAvailableLeft")).toBe(1);
+        expect(multiviewBinding.floats.get("ds_depthAvailableRight")).toBe(1);
+        expect(multiviewBinding.matrices.get("ds_uvTransformRight")).toEqual(Array.from(rightMatrix));
+
+        const markMaterialsDirtySpy = vi.spyOn(scene, "markAllMaterialsAsDirty");
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn((view) => (view === leftView ? leftDepth : null)),
+            getViewerPose: vi.fn(() => ({ views: [leftView, rightView] })),
+        } as unknown as XRFrame);
+        const partialMultiviewBinding = createUniformBufferRecorder();
+        scene.onBeforeCameraRenderObservable.notifyObservers(multiviewCamera);
+        plugin.bindForSubMesh(partialMultiviewBinding.uniformBuffer);
+        const partialMultiviewDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(partialMultiviewDefines);
+        expect(partialMultiviewDefines.DEPTH_SENSING).toBe(true);
+        expect(partialMultiviewBinding.textures.get("ds_depthSamplerRight")).toBe(leftTexture);
+        expect(partialMultiviewBinding.floats.get("ds_depthAvailableLeft")).toBe(1);
+        expect(partialMultiviewBinding.floats.get("ds_depthAvailableRight")).toBe(0);
+
+        scene.onBeforeCameraRenderObservable.notifyObservers(rightCamera);
+        const unavailableDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(unavailableDefines);
+        expect(unavailableDefines.DEPTH_SENSING).toBe(false);
+
+        markMaterialsDirtySpy.mockClear();
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn((view) => (view === rightView ? rightDepth : null)),
+            getViewerPose: vi.fn(() => ({ views: [leftView, rightView] })),
+        } as unknown as XRFrame);
+        const rightOnlyMultiviewBinding = createUniformBufferRecorder();
+        scene.onBeforeCameraRenderObservable.notifyObservers(multiviewCamera);
+        plugin.bindForSubMesh(rightOnlyMultiviewBinding.uniformBuffer);
+        expect(rightOnlyMultiviewBinding.textures.get("ds_depthSampler")).toBe(rightTexture);
+        expect(rightOnlyMultiviewBinding.textures.get("ds_depthSamplerRight")).toBe(rightTexture);
+        expect(rightOnlyMultiviewBinding.floats.get("ds_depthAvailableLeft")).toBe(0);
+        expect(rightOnlyMultiviewBinding.floats.get("ds_depthAvailableRight")).toBe(1);
+        expect(markMaterialsDirtySpy).toHaveBeenCalledTimes(1);
+
+        markMaterialsDirtySpy.mockClear();
+        sessionManager.onXRFrameObservable.notifyObservers({
+            getDepthInformation: vi.fn((view) => (view === leftView ? leftDepth : rightDepth)),
+            getViewerPose: vi.fn(() => ({ views: [leftView, rightView] })),
+        } as unknown as XRFrame);
+        scene.onBeforeCameraRenderObservable.notifyObservers(rightCamera);
+        const restoredDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(restoredDefines);
+        expect(restoredDefines.DEPTH_SENSING).toBe(true);
+        expect(markMaterialsDirtySpy).not.toHaveBeenCalled();
+
+        material.dispose();
+    });
+
+    it("disables once for WebGPU GPU depth and can attach a later CPU-depth session", () => {
         const xrWebGLBinding = vi.fn();
         const xrGPUBinding = vi.fn();
         (globalThis as any).XRWebGLBinding = xrWebGLBinding;
@@ -146,8 +308,92 @@ describe("WebXRDepthSensing", () => {
         } as unknown as XRFrame);
         expect(warnSpy).toHaveBeenCalledTimes(1);
 
+        sessionManager.onXRSessionEnded.notifyObservers(null);
+        expect(feature.disableAutoAttach).toBe(false);
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
+        expect(feature.attached).toBe(true);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+
         featuresManager.dispose();
         feature = undefined;
+    });
+
+    it("preserves a caller-disabled auto-attach policy after WebGPU GPU-depth fallback", () => {
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "gpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["gpu", "cpu"],
+        });
+        feature.disableAutoAttach = true;
+
+        expect(feature.attach()).toBe(false);
+        sessionManager.onXRSessionEnded.notifyObservers(null);
+        expect(feature.disableAutoAttach).toBe(true);
+    });
+
+    it("recreates and restores the CPU depth texture after detach and reattach", () => {
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+        } as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        const view = {} as XRView;
+        const matrix = Float32Array.from([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+        const depthInformation = createDepthInformation(Float32Array.from([1, 1, 1, 1]), 1, matrix);
+        const { leftCamera } = createRigCameras();
+        const frame = {
+            getDepthInformation: vi.fn(() => depthInformation),
+            getViewerPose: vi.fn(() => ({ views: [view] })),
+        } as unknown as XRFrame;
+        const markMaterialsDirtySpy = vi.spyOn(scene, "markAllMaterialsAsDirty");
+
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["cpu"],
+        });
+        const material = new StandardMaterial("reattach-depth", scene);
+        const plugin = material.pluginManager?.getPlugin("DepthSensing") as MaterialPluginBase;
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers(frame);
+        const firstTexture = feature.latestDepthImageTexture;
+        scene.onBeforeCameraRenderObservable.notifyObservers(leftCamera);
+        const firstDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(firstDefines);
+        expect(firstDefines.DEPTH_SENSING).toBe(true);
+
+        expect(feature.detach()).toBe(true);
+        expect(feature.latestDepthImageTexture).toBeNull();
+        const detachedDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(detachedDefines);
+        expect(detachedDefines.DEPTH_SENSING).toBe(false);
+
+        expect(feature.attach()).toBe(true);
+        sessionManager.onXRFrameObservable.notifyObservers(frame);
+        scene.onBeforeCameraRenderObservable.notifyObservers(leftCamera);
+        const reattachedDefines = {} as Record<string, boolean>;
+        plugin.prepareDefines(reattachedDefines);
+        expect(reattachedDefines.DEPTH_SENSING).toBe(true);
+        expect(feature.latestDepthImageTexture).not.toBe(firstTexture);
+        expect(markMaterialsDirtySpy).toHaveBeenCalledTimes(2);
+
+        material.dispose();
     });
 
     it("reuses the cached WebGL binding for WebGL GPU depth", () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Supports WebXR depth sensing on WebGPU when the session negotiates `cpu-optimized` depth, reusing the existing material plugin with WGSL occlusion injection.
- Intentionally disables attachment with one actionable warning when WebGPU negotiates `gpu-optimized`, because `XRGPUBinding` has no environment-depth equivalent.
- Preserves WebGL CPU/GPU behavior, caller preference order, native metadata, wrapped textures, and the existing GLSL injection.

## Correctness follow-ups

- Compares XR axial depth in meters with handedness-correct linear eye-space depth, including `worldScalingFactor`.
- Aligns CPU depth rows with Babylon's assembled WGSL `yFactor_` preprocessing.
- Keeps distinct depth buffers, transforms, scales, and view matrices per eye, including missing-eye and multiview handling.
- Uses explicit-LOD sampling in the multiview-varying path.
- Resets GPU fallback per session while preserving caller auto-attach policy, invalidates stale depth when the viewer pose is unavailable, and restores state across detach/reattach.
- Treats raw depth `0` as unavailable in both discard and tolerance modes.
- Releases Babylon wrappers without deleting runtime-owned `XRWebGLDepthInformation.texture` resources.

## Device result and limitation

Quest negotiated only `gpu-optimized` depth with `unsigned-short` data. The real-device fallback passed: attachment returned `false`, `disableAutoAttach` changed `false → true`, exactly one warning was emitted, and XR projection remained healthy with the test boxes visible.

CPU depth negotiation was unavailable on the tested Quest runtime, so the CPU XR path could not be exercised with live device depth.

## Shared manager overlap

The small `WebXRAbstractFeature.ts` and `webXRFeaturesManager.ts` changes pass the caller's pre-attach auto-attach policy through the manager's temporary `disableAutoAttach` clearing. This is required so the WebGPU GPU-depth fallback can reset per session without losing a caller-disabled policy.

PR #18780 has separate warning-registry and `enableFeature` work in the same shared manager area, so the PRs are likely to overlap or require restacking/conflict resolution even though their behavioral changes are additive.

## CPU-path validation

- Strict real-WebGPU pixel/readback oracle with asymmetric 2D depth, distinct left/right-eye buffers, and invalid zero-depth coverage in both discard and tolerance modes.
- Negative mutations for nonlinear device depth, missing Y compensation, shared-eye state, and zero-depth gating all fail as expected.
- Babylon-assembled multiview fragment WGSL compiles with explicit-level per-eye sampling; the local compile harness supplies a vertex eye-index stub because current WebGPU WGSL has no `view_index` builtin.
- Focused depth tests: 15 passed.
- Full XR tests: 309 passed.
- Full unit suite: 4,368 passed with 1 expected failure.
- Core TypeScript/UMD build, formatting, lint, tree-shaking, and side-effect synchronization pass.

Closes #18771

Related: #18636