### PR TITLE
Fix: texture view leak on WebGPU backend

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheTextureView.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheTextureView.ts
@@ -29,6 +29,6 @@ export class WebGPUCacheTextureView {
     }
 
     private static _GetKey(descriptor: GPUTextureViewDescriptor): string {
-        return `${descriptor.format}_${descriptor.dimension}_${descriptor.baseMipLevel}_${descriptor.mipLevelCount}_${descriptor.baseArrayLayer}_${descriptor.arrayLayerCount}_${descriptor.aspect}`;
+        return `${descriptor.format}_${descriptor.dimension}_${descriptor.baseMipLevel}_${descriptor.mipLevelCount}_${descriptor.baseArrayLayer}_${descriptor.arrayLayerCount}_${descriptor.aspect}_${descriptor.usage}_${descriptor.swizzle}`;
     }
 }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheTextureView.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheTextureView.ts
@@ -1,0 +1,34 @@
+/* eslint-disable babylonjs/available */
+
+/**
+ * Caches GPUTextureView objects so that render-pass attachments (color, MSAA resolve, depth/stencil)
+ * don't recreate a fresh view every time a render target is bound/cleared.
+ * Views are keyed on the live GPUTexture object via a WeakMap: once a texture is recreated (e.g. on resize)
+ * the old texture becomes unreachable and its cached views are collected along with it, so no manual
+ * invalidation is required.
+ * @internal
+ */
+export class WebGPUCacheTextureView {
+    private _cache = new WeakMap<GPUTexture, Map<string, GPUTextureView>>();
+
+    public getView(texture: GPUTexture, descriptor: GPUTextureViewDescriptor): GPUTextureView {
+        let viewsForTexture = this._cache.get(texture);
+        if (!viewsForTexture) {
+            viewsForTexture = new Map();
+            this._cache.set(texture, viewsForTexture);
+        }
+
+        const key = WebGPUCacheTextureView._GetKey(descriptor);
+        let view = viewsForTexture.get(key);
+        if (!view) {
+            view = texture.createView(descriptor);
+            viewsForTexture.set(key, view);
+        }
+
+        return view;
+    }
+
+    private static _GetKey(descriptor: GPUTextureViewDescriptor): string {
+        return `${descriptor.format}_${descriptor.dimension}_${descriptor.baseMipLevel}_${descriptor.mipLevelCount}_${descriptor.baseArrayLayer}_${descriptor.arrayLayerCount}_${descriptor.aspect}`;
+    }
+}

--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -38,6 +38,7 @@ import { type DrawWrapper } from "../Materials/drawWrapper";
 import { WebGPUMaterialContext } from "./WebGPU/webgpuMaterialContext";
 import { WebGPUDrawContext } from "./WebGPU/webgpuDrawContext";
 import { WebGPUCacheBindGroups } from "./WebGPU/webgpuCacheBindGroups";
+import { WebGPUCacheTextureView } from "./WebGPU/webgpuCacheTextureView";
 import { WebGPUClearQuad } from "./WebGPU/webgpuClearQuad.pure";
 import { type IStencilState } from "../States/IStencilState";
 import { WebGPURenderItemBlendColor, WebGPURenderItemScissor, WebGPURenderItemStencilRef, WebGPURenderItemViewport, WebGPUBundleList } from "./WebGPU/webgpuBundleList";
@@ -328,6 +329,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     /** @internal */
     public _cacheSampler: WebGPUCacheSampler;
     private _cacheBindGroups: WebGPUCacheBindGroups;
+    private _cacheTextureViews: WebGPUCacheTextureView;
     private _emptyVertexBuffer: VertexBuffer;
     /** @internal */
     public _mrtAttachments: number[];
@@ -829,6 +831,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
                     this._textureHelper = new WebGPUTextureManager(this, this._device, this._bufferManager, this._deviceEnabledExtensions);
                     this._cacheSampler = new WebGPUCacheSampler(this._device);
                     this._cacheBindGroups = new WebGPUCacheBindGroups(this._device, this._cacheSampler, this);
+                    this._cacheTextureViews = new WebGPUCacheTextureView();
                     this._timestampQuery = new WebGPUTimestampQuery(this, this._device, this._bufferManager);
                     this._occlusionQuery = (this._device as any).createQuerySet ? new WebGPUOcclusionQuery(this, this._device, this._bufferManager) : (undefined as any);
                     this._bundleList = new WebGPUBundleList(this._device);
@@ -3222,12 +3225,12 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         if (useMSAA) {
             const gpuMSAATexture = gpuDepthStencilWrapper?.getMSAATexture(sampleCount);
 
-            depthStencilView = gpuMSAATexture?.createView(this._rttRenderPassWrapper.depthAttachmentViewDescriptor!);
+            depthStencilView = gpuMSAATexture ? this._cacheTextureViews.getView(gpuMSAATexture, this._rttRenderPassWrapper.depthAttachmentViewDescriptor!) : undefined;
             format = gpuMSAATexture?.format;
         }
 
         if (!depthStencilView && gpuDepthStencilTexture) {
-            depthStencilView = gpuDepthStencilTexture.createView(this._rttRenderPassWrapper.depthAttachmentViewDescriptor!);
+            depthStencilView = this._cacheTextureViews.getView(gpuDepthStencilTexture, this._rttRenderPassWrapper.depthAttachmentViewDescriptor!);
         }
 
         if (!format && gpuDepthStencilWrapper) {
@@ -3284,8 +3287,8 @@ export class WebGPUEngine extends ThinWebGPUEngine {
                     };
                     const isRtInteger = mrtTexture.type === Constants.TEXTURETYPE_UNSIGNED_INTEGER || mrtTexture.type === Constants.TEXTURETYPE_UNSIGNED_SHORT;
 
-                    const colorTextureView = gpuMRTTexture.createView(viewDescriptor);
-                    const colorMSAATextureView = gpuMSAATexture?.createView(msaaViewDescriptor);
+                    const colorTextureView = this._cacheTextureViews.getView(gpuMRTTexture, viewDescriptor);
+                    const colorMSAATextureView = gpuMSAATexture ? this._cacheTextureViews.getView(gpuMSAATexture, msaaViewDescriptor) : undefined;
 
                     colorAttachments.push({
                         view: colorMSAATextureView ? colorMSAATextureView : colorTextureView,
@@ -3315,8 +3318,10 @@ export class WebGPUEngine extends ThinWebGPUEngine {
                 }
 
                 const gpuMSAATexture = useMSAA ? gpuWrapper.getMSAATexture(sampleCount, layerIndex) : undefined;
-                const colorTextureView = gpuTexture.createView(this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
-                const colorMSAATextureView = gpuMSAATexture?.createView(this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
+                const colorTextureView = this._cacheTextureViews.getView(gpuTexture, this._rttRenderPassWrapper.colorAttachmentViewDescriptor!);
+                const colorMSAATextureView = gpuMSAATexture
+                    ? this._cacheTextureViews.getView(gpuMSAATexture, this._rttRenderPassWrapper.colorAttachmentViewDescriptor!)
+                    : undefined;
                 const isRtInteger = internalTexture.type === Constants.TEXTURETYPE_UNSIGNED_INTEGER || internalTexture.type === Constants.TEXTURETYPE_UNSIGNED_SHORT;
 
                 colorAttachments.push({

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuCacheTextureView.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuCacheTextureView.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { WebGPUCacheTextureView } from "core/Engines/WebGPU/webgpuCacheTextureView";
+
+type ViewDescriptor = Exclude<Parameters<GPUTexture["createView"]>[0], undefined>;
+
+function createMockTexture(): GPUTexture {
+    return {
+        createView: vi.fn(() => ({}) as ReturnType<GPUTexture["createView"]>),
+    } as unknown as GPUTexture;
+}
+
+function createDescriptor(overrides: Partial<ViewDescriptor> = {}): ViewDescriptor {
+    return {
+        format: "rgba8unorm",
+        dimension: "2d",
+        baseMipLevel: 0,
+        mipLevelCount: 1,
+        baseArrayLayer: 0,
+        arrayLayerCount: 1,
+        aspect: "all",
+        ...overrides,
+    } as ViewDescriptor;
+}
+
+describe("WebGPUCacheTextureView", () => {
+    let cache: WebGPUCacheTextureView;
+
+    beforeEach(() => {
+        cache = new WebGPUCacheTextureView();
+    });
+
+    it("should create a view on cache miss", () => {
+        const texture = createMockTexture();
+        const descriptor = createDescriptor();
+
+        const view = cache.getView(texture, descriptor);
+
+        expect(view).toBeDefined();
+        expect(texture.createView).toHaveBeenCalledTimes(1);
+        expect(texture.createView).toHaveBeenCalledWith(descriptor);
+    });
+
+    it("should return the cached view on a second call with the same descriptor", () => {
+        const texture = createMockTexture();
+        const descriptor = createDescriptor();
+
+        const view1 = cache.getView(texture, descriptor);
+        const view2 = cache.getView(texture, createDescriptor());
+
+        expect(view2).toBe(view1);
+        expect(texture.createView).toHaveBeenCalledTimes(1);
+    });
+
+    it("should create a new view when a descriptor field changes", () => {
+        const texture = createMockTexture();
+
+        const view1 = cache.getView(texture, createDescriptor({ baseArrayLayer: 0 }));
+        const view2 = cache.getView(texture, createDescriptor({ baseArrayLayer: 1 }));
+
+        expect(view2).not.toBe(view1);
+        expect(texture.createView).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not share cache entries between different textures", () => {
+        const textureA = createMockTexture();
+        const textureB = createMockTexture();
+        const descriptor = createDescriptor();
+
+        cache.getView(textureA, descriptor);
+        cache.getView(textureB, descriptor);
+
+        expect(textureA.createView).toHaveBeenCalledTimes(1);
+        expect(textureB.createView).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuCacheTextureView.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuCacheTextureView.test.ts
@@ -72,4 +72,24 @@ describe("WebGPUCacheTextureView", () => {
         expect(textureA.createView).toHaveBeenCalledTimes(1);
         expect(textureB.createView).toHaveBeenCalledTimes(1);
     });
+
+    it("should create a new view when only usage differs", () => {
+        const texture = createMockTexture();
+
+        const view1 = cache.getView(texture, createDescriptor({ usage: 0x10 }));
+        const view2 = cache.getView(texture, createDescriptor({ usage: 0x20 }));
+
+        expect(view2).not.toBe(view1);
+        expect(texture.createView).toHaveBeenCalledTimes(2);
+    });
+
+    it("should create a new view when only swizzle differs", () => {
+        const texture = createMockTexture();
+
+        const view1 = cache.getView(texture, createDescriptor({ swizzle: "rgba" }));
+        const view2 = cache.getView(texture, createDescriptor({ swizzle: "bgra" }));
+
+        expect(view2).not.toBe(view1);
+        expect(texture.createView).toHaveBeenCalledTimes(2);
+    });
 });


### PR DESCRIPTION
We observed this issue during profiling:
`_startRenderTargetRenderPass` called raw `GPUTexture.createView()` on every render-target bind (~1,800/sec), with no caching, for color/MSAA/depth attachments, and with no `destroy()`. The native view objects (subresource descriptors, not pixel data) pile up faster than they're reclaimed: an unbounded, GC-shaped leak in Dawn/driver's memory.

## Fix
Added `WebGPUCacheTextureView`: a `WeakMap<GPUTexture, Map<descriptorKey, GPUTextureView>>` cache. Keying on the live texture object makes invalidation automatic (old texture → unreachable → cache entry collected with it). Wired into the 6 attachment call sites in `_startRenderTargetRenderPass`. Mirrors the existing sampler/bind-group/pipeline cache pattern.

## Testing
- New unit tests for the cache (hit/miss, invalidation, per-texture isolation) — passing