### PR TITLE
Enable Babylon Lite device-lost recovery in the Lite Viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
             "devDependencies": {
                 "@babel/core": "^7.29.7",
                 "@babel/preset-env": "^7.29.7",
-                "@babylonjs/lite": "1.14.0",
+                "@babylonjs/lite": "1.18.0",
                 "@dev/build-tools": "^1.0.0",
                 "@eslint/js": "^10.0.1",
                 "@playwright/test": "1.57.0",
@@ -1760,9 +1760,9 @@
             "link": true
         },
         "node_modules/@babylonjs/lite": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@babylonjs/lite/-/lite-1.14.0.tgz",
-            "integrity": "sha512-W85vVEd2fJbwm7HzyNpLpY//0CJ9SGB8IeyoWqGZOARmMg6kMhYpTKUJQ20xc5h5x/nKNLauNsh0cEKtNQcoig==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@babylonjs/lite/-/lite-1.18.0.tgz",
+            "integrity": "sha512-Jc4s254Gdk/f78x2wNexwQibVDKBbJ0Zk41mYLwuGZkLbm1AqD51PLMtrnV8msTsF+qoRIeMN5B+s780VcER1A==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@babylonjs/havok": "^1.3.0",
@@ -23242,7 +23242,7 @@
             },
             "devDependencies": {
                 "@babylonjs/core": "9.19.1",
-                "@babylonjs/lite": "^1.14.0",
+                "@babylonjs/lite": "^1.18.0",
                 "@babylonjs/loaders": "9.19.1",
                 "@dev/build-tools": "^1.0.0",
                 "@rollup/plugin-alias": "^5.1.0",
@@ -23261,7 +23261,7 @@
             },
             "peerDependencies": {
                 "@babylonjs/core": "^9.0.0",
-                "@babylonjs/lite": "^1.14.0",
+                "@babylonjs/lite": "^1.18.0",
                 "@babylonjs/loaders": "^9.0.0"
             },
             "peerDependenciesMeta": {
@@ -24273,7 +24273,7 @@
             "name": "@tools/viewer",
             "version": "1.0.0",
             "dependencies": {
-                "@babylonjs/lite": "^1.14.0",
+                "@babylonjs/lite": "^1.18.0",
                 "@dev/core": "1.0.0",
                 "@dev/loaders": "1.0.0",
                 "lit": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
-        "@babylonjs/lite": "1.14.0",
+        "@babylonjs/lite": "1.18.0",
         "@dev/build-tools": "^1.0.0",
         "@eslint/js": "^10.0.1",
         "@playwright/test": "1.57.0",

--- a/packages/public/@babylonjs/viewer/package.json
+++ b/packages/public/@babylonjs/viewer/package.json
@@ -46,7 +46,7 @@
     },
     "peerDependencies": {
         "@babylonjs/core": "^9.0.0",
-        "@babylonjs/lite": "^1.14.0",
+        "@babylonjs/lite": "^1.18.0",
         "@babylonjs/loaders": "^9.0.0"
     },
     "peerDependenciesMeta": {
@@ -56,7 +56,7 @@
     },
     "devDependencies": {
         "@babylonjs/core": "9.19.1",
-        "@babylonjs/lite": "^1.14.0",
+        "@babylonjs/lite": "^1.18.0",
         "@babylonjs/loaders": "9.19.1",
         "@dev/build-tools": "^1.0.0",
         "@rollup/plugin-alias": "^5.1.0",

--- a/packages/tools/viewer/package.json
+++ b/packages/tools/viewer/package.json
@@ -23,7 +23,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@babylonjs/lite": "^1.14.0",
+        "@babylonjs/lite": "^1.18.0",
         "@dev/core": "1.0.0",
         "@dev/loaders": "1.0.0",
         "lit": "^3.2.0"

--- a/packages/tools/viewer/src/lite/viewer.ts
+++ b/packages/tools/viewer/src/lite/viewer.ts
@@ -20,6 +20,7 @@ import {
     disposeMeshGpu,
     disposePicker,
     disposeScene,
+    enableDeviceLostSceneRecovery,
     getCameraPosition,
     getContainerMeshes,
     computeDeformedPositionToRef,
@@ -53,6 +54,7 @@ import {
     type ArcRotateCamera,
     type AssetContainer,
     type DirectionalLight as LiteDirectionalLight,
+    type DeviceLostRecoveryHandle,
     type EngineContext,
     type GpuPicker,
     type ImageProcessingUpdate,
@@ -162,6 +164,7 @@ export class Viewer extends ViewerBase implements IViewer {
 
     private readonly _scene: SceneContext;
     private readonly _camera: ArcRotateCamera;
+    private readonly _deviceLostRecovery: DeviceLostRecoveryHandle;
     private _detachControl: (() => void) | null = null;
     private _renderLoopRunning = false;
 
@@ -244,6 +247,16 @@ export class Viewer extends ViewerBase implements IViewer {
         protected readonly _options?: ViewerOptions
     ) {
         super();
+        this._deviceLostRecovery = enableDeviceLostSceneRecovery(_engine, {
+            onRecoveryFailed: (error) => {
+                const recoveryError = error instanceof Error ? error : new Error("Babylon Lite device recovery failed.", { cause: error });
+                if (this._options?.onFaulted) {
+                    this._options.onFaulted(recoveryError);
+                } else {
+                    Logger.Error(recoveryError.message);
+                }
+            },
+        });
         this._shadowQuality = this._options?.shadowConfig?.quality ?? DefaultViewerOptions.shadowConfig.quality;
         this._environmentIntensity = this._options?.environmentConfig?.intensity ?? DefaultViewerOptions.environmentConfig.intensity;
         this._environmentBlur = this._options?.environmentConfig?.blur ?? DefaultViewerOptions.environmentConfig.blur;
@@ -1847,6 +1860,7 @@ export class Viewer extends ViewerBase implements IViewer {
         this._unloadCurrentModel();
 
         // Stop and dispose engine/scene
+        this._deviceLostRecovery.disable();
         stopEngine(this._engine);
         unregisterScene(this._scene);
         disposeScene(this._scene);

--- a/packages/tools/viewer/src/lite/viewer.ts
+++ b/packages/tools/viewer/src/lite/viewer.ts
@@ -249,11 +249,13 @@ export class Viewer extends ViewerBase implements IViewer {
         super();
         this._deviceLostRecovery = enableDeviceLostSceneRecovery(_engine, {
             onRecoveryFailed: (error) => {
-                const recoveryError = error instanceof Error ? error : new Error("Babylon Lite device recovery failed.", { cause: error });
+                const recoveryError = error instanceof Error ? error : new Error(`Babylon Lite device recovery failed: ${String(error)}`, { cause: error });
                 if (this._options?.onFaulted) {
                     this._options.onFaulted(recoveryError);
                 } else {
-                    Logger.Error(recoveryError.message);
+                    // Prefer the stack: an unhandled recovery failure is only diagnosable from where it was
+                    // thrown, and the message alone gives no indication of which rebuild step failed.
+                    Logger.Error(recoveryError.stack ?? recoveryError.message);
                 }
             },
         });
@@ -1836,6 +1838,11 @@ export class Viewer extends ViewerBase implements IViewer {
             return;
         }
 
+        // Disable device-lost recovery before any teardown below: everything that follows frees GPU
+        // resources (picker, model, scene, engine), and a loss arriving mid-teardown would otherwise
+        // kick off a rebuild against resources that are in the process of being destroyed.
+        this._deviceLostRecovery.disable();
+
         // Detach camera controls
         this._detachControl?.();
         this._detachControl = null;
@@ -1860,7 +1867,6 @@ export class Viewer extends ViewerBase implements IViewer {
         this._unloadCurrentModel();
 
         // Stop and dispose engine/scene
-        this._deviceLostRecovery.disable();
         stopEngine(this._engine);
         unregisterScene(this._scene);
         disposeScene(this._scene);


### PR DESCRIPTION
## What

Wires the Lite Viewer into Babylon Lite's WebGPU device-lost recovery, and bumps `@babylonjs/lite` to `1.18.0`.

## Why

When the WebGPU device is lost — GPU reset, driver update, or the tab being backgrounded under memory pressure — every GPU resource in the scene is invalidated. Until now the Lite Viewer had no response to this: rendering continued against the dead device, so the canvas froze on its last frame or went blank, and the only way out was a full page reload.

## How

Babylon Lite owns the recovery machinery, so the Viewer side is deliberately tiny:

- **`enableDeviceLostSceneRecovery(engine, ...)` in the constructor**, immediately after `super()` and before `createSceneContext`. This is the earliest point at which the engine exists and no Viewer-owned GPU resources have been created yet, so recovery is armed before anything it would need to rebuild can be allocated. Putting it in the constructor rather than in `CreateViewerForCanvas` also covers callers that construct `new Viewer(engine, options)` directly.
- **`handle.disable()` at the start of `dispose()`**, before `stopEngine` and scene teardown, so a loss racing disposal can't kick off a rebuild against resources that are being torn down.
- **`onRecoveryFailed` routes to the existing `ViewerBaseOptions.onFaulted`**, so an unrecoverable loss surfaces through the same path as other fatal viewer errors. Falls back to `Logger.Error` when no handler is supplied.

Recovery itself is entirely Lite-side: it acquires the replacement device, reconfigures the surface, rebuilds scene-owned GPU resources (materials, textures, environment, shadows, and loader-owned background renderables), and resumes rendering. The Viewer holds no recovery state and does no teardown or sequencing of its own.

## Why 1.18.0 specifically

`1.18.0` adds the rebuild path for loader-owned `.env` background renderables (skybox/ground) — [BabylonJS/Babylon-Lite#535](https://github.com/BabylonJS/Babylon-Lite/pull/535). Without it, recovery in a Viewer scene using `environment-skybox` fails with:

> Device-lost Scene recovery does not support loadEnvironment backgrounds

## Verification

Tested in-browser against the published `1.18.0` with an environment-lit PBR model plus ESM directional shadows, forcing a real device loss:

| Check | Result |
| --- | --- |
| Replacement device installed | ✅ |
| Post-recovery frames rendered | 60 |
| Uncaptured WebGPU validation errors | 0 |
| `onFaulted` invoked | never |
| Environment + shadow generator after recovery | preserved |
| Post-recovery frame vs. pre-loss frame | pixel-identical (mean abs diff `0`) |

The loader-env background renderable — the exact resource `1.18.0` fixes — is present both before and after recovery, confirming the rebuild path is exercised rather than skipped.

`tsc -b` and ESLint are clean on the merged tree.

## Notes

No new tests here: device-lost recovery is covered by Lite's own test suite, and forcing a real device loss in Viewer CI would risk flakiness depending on the test GPU.
