### PR TITLE
GPU particles: re-bake gradient lookup textures in place for value edits

### DIFF
--- a/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
@@ -592,16 +592,42 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         return false;
     }
 
-    /** Force the system to rebuild all gradients that need to be resync */
+    /**
+     * Force the system to rebuild all gradients that need to be resync.
+     *
+     * This is the live-edit entry point both Inspectors call from their gradient onChange handlers, so a
+     * value-only edit must preserve the running simulation: every family whose lookup texture can be re-baked
+     * in place is updated without touching the particle buffers. Only a STRUCTURAL change — a family that has
+     * no texture to re-bake yet, one that was emptied, or a color2 row-layout flip — rebuilds the pool.
+     *
+     * An ABSENT family is not a structural change: it has nothing to resync, and counting it as one would
+     * reset the pool on every call (the destruction this method exists to avoid).
+     */
     public forceRefreshGradients() {
-        this._refreshColorGradient();
-        this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture");
-        this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture");
-        this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture");
-        this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture");
-        this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture");
+        let structural = false;
 
-        this.reset();
+        if (this._colorGradients && !this._refreshColorGradient()) {
+            structural = true;
+        }
+        if (this._sizeGradients && !this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture")) {
+            structural = true;
+        }
+        if (this._angularSpeedGradients && !this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture")) {
+            structural = true;
+        }
+        if (this._velocityGradients && !this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture")) {
+            structural = true;
+        }
+        if (this._limitVelocityGradients && !this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture")) {
+            structural = true;
+        }
+        if (this._dragGradients && !this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture")) {
+            structural = true;
+        }
+
+        if (structural) {
+            this.reset();
+        }
     }
 
     /**

--- a/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
@@ -601,33 +601,67 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * no texture to re-bake yet, one that was emptied, or a color2 row-layout flip — rebuilds the pool.
      *
      * An ABSENT family is not a structural change: it has nothing to resync, and counting it as one would
-     * reset the pool on every call (the destruction this method exists to avoid).
+     * reset the pool on every call (the destruction this method exists to avoid). Absence has two spellings —
+     * see _gradientFamilyNeedsResync.
      */
     public forceRefreshGradients() {
         let structural = false;
 
-        if (this._colorGradients && !this._refreshColorGradient()) {
+        if (this._gradientFamilyNeedsResync(this._colorGradients, "_colorGradientsTexture") && !this._refreshColorGradient()) {
             structural = true;
         }
-        if (this._sizeGradients && !this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture")) {
+        if (this._gradientFamilyNeedsResync(this._sizeGradients, "_sizeGradientsTexture") && !this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture")) {
             structural = true;
         }
-        if (this._angularSpeedGradients && !this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture")) {
+        if (
+            this._gradientFamilyNeedsResync(this._angularSpeedGradients, "_angularSpeedGradientsTexture") &&
+            !this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture")
+        ) {
             structural = true;
         }
-        if (this._velocityGradients && !this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture")) {
+        if (
+            this._gradientFamilyNeedsResync(this._velocityGradients, "_velocityGradientsTexture") &&
+            !this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture")
+        ) {
             structural = true;
         }
-        if (this._limitVelocityGradients && !this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture")) {
+        if (
+            this._gradientFamilyNeedsResync(this._limitVelocityGradients, "_limitVelocityGradientsTexture") &&
+            !this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture")
+        ) {
             structural = true;
         }
-        if (this._dragGradients && !this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture")) {
+        if (this._gradientFamilyNeedsResync(this._dragGradients, "_dragGradientsTexture") && !this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture")) {
             structural = true;
         }
 
         if (structural) {
             this.reset();
         }
+    }
+
+    /**
+     * Whether a gradient family still has anything for a resync pass to do.
+     *
+     * Absence has TWO spellings: a family that was never initialized is `null`, but one that has been emptied
+     * stays `[]`. Only the first is falsy, so a bare truthiness test reads an emptied family as unfinished
+     * business on every later call — its refresh finds nothing to re-bake, reports "structural", and
+     * forceRefreshGradients resets the live pool forever after, which is precisely the destruction it exists
+     * to prevent.
+     *
+     * Entries always mean work (re-bake in place, or build when there is no texture yet). An EMPTY family is
+     * work only while it still owns a texture: that is the just-emptied transition, whose stale texture must
+     * be disposed. `[]` with no texture is settled absence — nothing left to resync.
+     * @param gradients the gradient family to test, or null when it was never initialized
+     * @param textureName the name of the lookup texture property backing that family
+     * @returns true when the family still has work for a resync pass, false when its absence is settled
+     */
+    private _gradientFamilyNeedsResync(gradients: Nullable<IValueGradient[]>, textureName: string): boolean {
+        if (!gradients) {
+            return false;
+        }
+
+        return gradients.length > 0 || !!(<any>this)[textureName];
     }
 
     /**

--- a/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
+++ b/packages/dev/core/src/Particles/gpuParticleSystem.pure.ts
@@ -534,14 +534,22 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         const colorGradient = new ColorGradient(gradient, color1, color2);
         this._colorGradients.push(colorGradient);
 
-        this._refreshColorGradient(true);
-
-        this._releaseBuffers();
+        if (!this._refreshColorGradient(true)) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
 
-    private _refreshColorGradient(reorder = false) {
+    /**
+     * Resyncs the color gradient state after a change.
+     * @param reorder true to re-sort the gradient list by position
+     * @returns true when the existing lookup texture was re-baked in place (value-only change — nothing to
+     * release, the live particle pool survives), false when the change is structural (family emptied, color2 row
+     * layout flipped, or no texture yet) and the caller must release the buffers; in that case the outdated
+     * texture is disposed for lazy recreation.
+     */
+    private _refreshColorGradient(reorder = false): boolean {
         if (this._colorGradients) {
             if (reorder) {
                 this._colorGradients.sort((a, b) => {
@@ -566,6 +574,13 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
                 }
             }
 
+            // When the texture layout is unchanged, re-bake the existing texture's pixels in place: identity is
+            // preserved, so retained bindings (e.g. the WebGPU update compute shader's) stay valid and no buffer
+            // release is needed.
+            if (this._rebakeColorGradientTexture()) {
+                return true;
+            }
+
             if (this._colorGradientsTexture) {
                 this._colorGradientsTexture.dispose();
                 (<any>this._colorGradientsTexture) = null;
@@ -573,6 +588,8 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         } else {
             this._hasColorGradientColor2 = false;
         }
+
+        return false;
     }
 
     /** Force the system to rebuild all gradients that need to be resync */
@@ -593,11 +610,13 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * @returns the current particle system
      */
     public removeColorGradient(gradient: number): GPUParticleSystem {
-        this._removeGradientAndTexture(gradient, this._colorGradients, this._colorGradientsTexture);
-        (<any>this._colorGradientsTexture) = null;
+        super._removeGradientAndTexture(gradient, this._colorGradients, null);
 
-        // The set of remaining gradients may no longer contain a color2; recompute the flag.
-        this._refreshColorGradient();
+        // The set of remaining gradients may no longer contain a color2; _refreshColorGradient recomputes the flag
+        // and either re-bakes the texture in place (value-only change) or signals a structural change.
+        if (!this._refreshColorGradient()) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -637,9 +656,9 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
 
         this._addFactorGradient(this._sizeGradients, gradient, factor, factor2);
 
-        this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture");
-
-        this._releaseBuffers();
+        if (!this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -650,15 +669,30 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * @returns the current particle system
      */
     public removeSizeGradient(gradient: number): GPUParticleSystem {
-        this._removeGradientAndTexture(gradient, this._sizeGradients, this._sizeGradientsTexture);
-        (<any>this._sizeGradientsTexture) = null;
+        this._removeFactorGradient(this._sizeGradients, gradient);
+
+        if (!this._refreshFactorGradient(this._sizeGradients, "_sizeGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
 
-    private _refreshFactorGradient(factorGradients: Nullable<FactorGradient[]>, textureName: string) {
+    /**
+     * Resyncs a factor gradient family's lookup texture after a change.
+     * @param factorGradients defines the gradient family that changed
+     * @param textureName defines the name of the property holding the family's lookup texture
+     * @returns true when the existing texture was re-baked in place (value-only change — nothing to release, the
+     * live particle pool survives), false when the caller must release the buffers (no texture to re-bake, or the
+     * family was emptied); in that case the outdated texture is disposed for lazy recreation.
+     */
+    private _refreshFactorGradient(factorGradients: Nullable<FactorGradient[]>, textureName: string): boolean {
         if (!factorGradients) {
-            return;
+            return false;
+        }
+
+        if (this._rebakeFactorGradientTexture(factorGradients, textureName)) {
+            return true;
         }
 
         const that = this as any;
@@ -666,6 +700,8 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
             that[textureName].dispose();
             that[textureName] = null;
         }
+
+        return false;
     }
 
     /**
@@ -681,9 +717,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         this._addFactorGradient(this._angularSpeedGradients, gradient, factor, factor2);
-        this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture");
 
-        this._releaseBuffers();
+        if (!this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -694,8 +731,11 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * @returns the current particle system
      */
     public removeAngularSpeedGradient(gradient: number): GPUParticleSystem {
-        this._removeGradientAndTexture(gradient, this._angularSpeedGradients, this._angularSpeedGradientsTexture);
-        (<any>this._angularSpeedGradientsTexture) = null;
+        this._removeFactorGradient(this._angularSpeedGradients, gradient);
+
+        if (!this._refreshFactorGradient(this._angularSpeedGradients, "_angularSpeedGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -713,9 +753,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         this._addFactorGradient(this._velocityGradients, gradient, factor, factor2);
-        this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture");
 
-        this._releaseBuffers();
+        if (!this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -726,8 +767,11 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * @returns the current particle system
      */
     public removeVelocityGradient(gradient: number): GPUParticleSystem {
-        this._removeGradientAndTexture(gradient, this._velocityGradients, this._velocityGradientsTexture);
-        (<any>this._velocityGradientsTexture) = null;
+        this._removeFactorGradient(this._velocityGradients, gradient);
+
+        if (!this._refreshFactorGradient(this._velocityGradients, "_velocityGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -745,9 +789,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         this._addFactorGradient(this._limitVelocityGradients, gradient, factor, factor2);
-        this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture");
 
-        this._releaseBuffers();
+        if (!this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -758,8 +803,11 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * @returns the current particle system
      */
     public removeLimitVelocityGradient(gradient: number): GPUParticleSystem {
-        this._removeGradientAndTexture(gradient, this._limitVelocityGradients, this._limitVelocityGradientsTexture);
-        (<any>this._limitVelocityGradientsTexture) = null;
+        this._removeFactorGradient(this._limitVelocityGradients, gradient);
+
+        if (!this._refreshFactorGradient(this._limitVelocityGradients, "_limitVelocityGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -777,9 +825,10 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
 
         this._addFactorGradient(this._dragGradients, gradient, factor, factor2);
-        this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture");
 
-        this._releaseBuffers();
+        if (!this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -790,8 +839,11 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
      * @returns the current particle system
      */
     public removeDragGradient(gradient: number): GPUParticleSystem {
-        this._removeGradientAndTexture(gradient, this._dragGradients, this._dragGradientsTexture);
-        (<any>this._dragGradientsTexture) = null;
+        this._removeFactorGradient(this._dragGradients, gradient);
+
+        if (!this._refreshFactorGradient(this._dragGradients, "_dragGradientsTexture")) {
+            this._releaseBuffers();
+        }
 
         return this;
     }
@@ -1704,13 +1756,7 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         }
     }
 
-    private _createFactorGradientTexture(factorGradients: Nullable<IValueGradient[]>, textureName: string) {
-        const texture: RawTexture = (<any>this)[textureName];
-
-        if (!factorGradients || !factorGradients.length || texture) {
-            return;
-        }
-
+    private _bakeFactorGradientData(factorGradients: IValueGradient[]): Float32Array {
         const data = new Float32Array(this._rawTextureWidth * 2);
 
         for (let x = 0; x < this._rawTextureWidth; x++) {
@@ -1723,6 +1769,40 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
                 data[x * 2 + 1] = Lerp(cg.factor2 ?? cg.factor1, ng.factor2 ?? ng.factor1, scale);
             });
         }
+
+        return data;
+    }
+
+    /**
+     * Re-bakes an active factor gradient family's lookup texture pixels in place. The texture identity is
+     * preserved, so retained bindings (e.g. the WebGPU update compute shader's) stay valid and no buffer
+     * release is needed — the live particle pool survives the edit. The texture layout is independent of the
+     * number of stops (fixed _rawTextureWidth x 1), so any change within an active family can be re-baked.
+     * @param factorGradients defines the gradient family to bake
+     * @param textureName defines the name of the property holding the family's lookup texture
+     * @returns false when there is nothing to re-bake (no texture yet, or the family was emptied) — callers
+     * fall back to the dispose + release path.
+     */
+    private _rebakeFactorGradientTexture(factorGradients: Nullable<FactorGradient[]>, textureName: string): boolean {
+        const texture: Nullable<RawTexture> = (<any>this)[textureName];
+
+        if (!texture || !factorGradients || !factorGradients.length) {
+            return false;
+        }
+
+        texture.update(this._bakeFactorGradientData(factorGradients));
+
+        return true;
+    }
+
+    private _createFactorGradientTexture(factorGradients: Nullable<IValueGradient[]>, textureName: string) {
+        const texture: RawTexture = (<any>this)[textureName];
+
+        if (!factorGradients || !factorGradients.length || texture) {
+            return;
+        }
+
+        const data = this._bakeFactorGradientData(factorGradients);
 
         (<any>this)[textureName] = new RawTexture(
             data,
@@ -1896,22 +1976,14 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
         this._meshEmitterUsedNormals = useNormals;
     }
 
-    private _createColorGradientTexture() {
-        if (!this._colorGradients || !this._colorGradients.length || this._colorGradientsTexture) {
-            return;
-        }
-
-        // When any stop has a color2, pack color1 into row 0 and color2 into row 1. The render shader
-        // samples both rows and lerps using the particle's persistent seed.x for per-particle randomness.
-        const hasColor2 = this._hasColorGradientColor2;
-        const height = hasColor2 ? 2 : 1;
+    private _bakeColorGradientData(height: number): Uint8Array {
         const data = new Uint8Array(this._rawTextureWidth * 4 * height);
         const tmpColor = TmpColors.Color4[0];
 
         for (let x = 0; x < this._rawTextureWidth; x++) {
             const ratio = x / this._rawTextureWidth;
 
-            GradientHelper.GetCurrentGradient(ratio, this._colorGradients, (currentGradient, nextGradient, scale) => {
+            GradientHelper.GetCurrentGradient(ratio, this._colorGradients!, (currentGradient, nextGradient, scale) => {
                 Color4.LerpToRef((<ColorGradient>currentGradient).color1, (<ColorGradient>nextGradient).color1, scale, tmpColor);
                 data[x * 4] = tmpColor.r * 255;
                 data[x * 4 + 1] = tmpColor.g * 255;
@@ -1920,12 +1992,12 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
             });
         }
 
-        if (hasColor2) {
+        if (height === 2) {
             const rowOffset = this._rawTextureWidth * 4;
             for (let x = 0; x < this._rawTextureWidth; x++) {
                 const ratio = x / this._rawTextureWidth;
 
-                GradientHelper.GetCurrentGradient(ratio, this._colorGradients, (currentGradient, nextGradient, scale) => {
+                GradientHelper.GetCurrentGradient(ratio, this._colorGradients!, (currentGradient, nextGradient, scale) => {
                     const cg = currentGradient as ColorGradient;
                     const ng = nextGradient as ColorGradient;
                     // Fall back to color1 for stops without a color2 so the row stays continuous.
@@ -1937,6 +2009,43 @@ export class GPUParticleSystem extends BaseParticleSystem implements IDisposable
                 });
             }
         }
+
+        return data;
+    }
+
+    /**
+     * Re-bakes the color gradient lookup texture pixels in place (same texture identity, so retained bindings —
+     * e.g. the WebGPU update compute shader's — stay valid and the live particle pool survives the edit). Only
+     * valid while the row layout is unchanged: a color2 range appearing or disappearing changes the texture
+     * height and the render vertex buffer layout, which must go through the structural dispose + release path.
+     * @returns false when the re-bake cannot handle the change (no texture yet, family emptied, or row layout flip)
+     */
+    private _rebakeColorGradientTexture(): boolean {
+        const texture = this._colorGradientsTexture;
+
+        if (!texture || !this._colorGradients || !this._colorGradients.length) {
+            return false;
+        }
+
+        const height = this._hasColorGradientColor2 ? 2 : 1;
+        if (texture.getSize().height !== height) {
+            return false;
+        }
+
+        texture.update(this._bakeColorGradientData(height));
+
+        return true;
+    }
+
+    private _createColorGradientTexture() {
+        if (!this._colorGradients || !this._colorGradients.length || this._colorGradientsTexture) {
+            return;
+        }
+
+        // When any stop has a color2, pack color1 into row 0 and color2 into row 1. The render shader
+        // samples both rows and lerps using the particle's persistent seed.x for per-particle randomness.
+        const height = this._hasColorGradientColor2 ? 2 : 1;
+        const data = this._bakeColorGradientData(height);
 
         this._colorGradientsTexture = RawTexture.CreateRGBATexture(data, this._rawTextureWidth, height, this._scene, false, false, Constants.TEXTURE_NEAREST_SAMPLINGMODE);
         this._colorGradientsTexture.name = "colorGradients";

--- a/packages/dev/core/test/unit/Particles/gpuParticleSystemGradientRebake.test.ts
+++ b/packages/dev/core/test/unit/Particles/gpuParticleSystemGradientRebake.test.ts
@@ -373,5 +373,72 @@ describe("GPUParticleSystem gradient edits re-bake the lookup texture in place",
 
             ps.dispose();
         });
+
+        it("an ALREADY-EMPTIED family does not make later value edits structural", () => {
+            // Absence has two spellings: a family never initialized is null, but one that has been emptied
+            // stays []. A bare truthiness guard reads [] as unfinished business forever, so every subsequent
+            // forceRefreshGradients() reset the live pool — the destruction the method exists to prevent.
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 3);
+
+            ps._recreateUpdateEffect();
+            expect((ps as any)._colorGradientsTexture).toBeTruthy();
+            expect((ps as any)._sizeGradientsTexture).toBeTruthy();
+
+            // Remove the final color stop. The removal path owns this structural transition: the family is
+            // left as [] and its texture is disposed.
+            ps.removeColorGradient(0);
+            expect(ps.getColorGradients()).toEqual([]);
+            expect((ps as any)._colorGradientsTexture).toBeNull();
+
+            // Rebuild/reactivate after that structural change.
+            ps._recreateUpdateEffect();
+            const sizeTexture = (ps as any)._sizeGradientsTexture;
+            expect(sizeTexture).toBeTruthy();
+
+            const reset = vi.spyOn(ps, "reset");
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+
+            // A value-only edit on a DIFFERENT family. The settled-empty color family must be skipped.
+            ps.getSizeGradients()![1].factor1 = 7;
+            ps.forceRefreshGradients();
+
+            expect(reset).not.toHaveBeenCalled();
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            // The pool survives: the size texture kept its identity and was re-baked in place.
+            expect((ps as any)._sizeGradientsTexture).toBe(sizeTexture);
+
+            // Still true on repeat calls — the empty family must never accumulate into a structural verdict.
+            ps.forceRefreshGradients();
+            expect(reset).not.toHaveBeenCalled();
+
+            ps.dispose();
+        });
+
+        it("a JUST-emptied family that still owns its texture is still structural", () => {
+            // The other side of the same guard: [] is only settled absence once the texture is gone. While the
+            // stale texture is still owned, the transition has real work left and must reset.
+            const ps = createSystem();
+
+            ps.addSizeGradient(0, 1);
+            ps._recreateUpdateEffect();
+            expect((ps as any)._sizeGradientsTexture).toBeTruthy();
+
+            // Empty the array WITHOUT going through removeSizeGradient(), so the texture is deliberately
+            // left behind — the state an interrupted/external edit can produce.
+            (ps as any)._sizeGradients.length = 0;
+
+            const reset = vi.spyOn(ps, "reset");
+
+            ps.forceRefreshGradients();
+
+            expect(reset).toHaveBeenCalled();
+            expect((ps as any)._sizeGradientsTexture).toBeNull();
+
+            ps.dispose();
+        });
     });
 });

--- a/packages/dev/core/test/unit/Particles/gpuParticleSystemGradientRebake.test.ts
+++ b/packages/dev/core/test/unit/Particles/gpuParticleSystemGradientRebake.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { GPUParticleSystem } from "core/Particles/gpuParticleSystem";
+import { Scene } from "core/scene";
+import { Color4 } from "core/Maths/math.color";
+
+// Side-effect import to register the WebGL2ParticleSystem class
+import "core/Particles/webgl2ParticleSystem";
+
+describe("GPUParticleSystem gradient edits re-bake the lookup texture in place", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    function createSystem(): GPUParticleSystem {
+        return new GPUParticleSystem("test", { capacity: 100 }, scene);
+    }
+
+    describe("factor gradients (size shown, all factor families share the path)", () => {
+        it("re-bakes the existing texture in place on a value edit instead of releasing the buffers", () => {
+            const ps = createSystem();
+
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 3);
+
+            // Force the lazy texture creation that normally happens on the first update
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._sizeGradientsTexture;
+            expect(texture).toBeTruthy();
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            const update = vi.spyOn(texture, "update");
+
+            // A slider-style value edit: remove the stop and re-add it at the same position with a new value
+            ps.removeSizeGradient(1);
+            ps.addSizeGradient(1, 5);
+
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            expect(update).toHaveBeenCalledTimes(2);
+            expect((ps as any)._sizeGradientsTexture).toBe(texture);
+
+            ps.dispose();
+        });
+
+        it("bakes the same pixels the initial texture creation would produce", () => {
+            const ps = createSystem();
+
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 1);
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._sizeGradientsTexture;
+            const update = vi.spyOn(texture, "update");
+
+            ps.removeSizeGradient(1);
+            ps.addSizeGradient(1, 5);
+
+            const data = update.mock.calls[update.mock.calls.length - 1][0] as Float32Array;
+            const width = (ps as any)._rawTextureWidth;
+            expect(data.length).toBe(width * 2);
+            // Interleaved RG texels: factor1 at even indices. Ratio 0 -> 1, ratio 0.5 -> lerp(1, 5, 0.5) = 3
+            expect(data[0]).toBeCloseTo(1);
+            expect(data[width]).toBeCloseTo(3); // texel x = width / 2
+            expect(data[(width - 1) * 2]).toBeCloseTo(1 + ((5 - 1) * (width - 1)) / width);
+
+            ps.dispose();
+        });
+
+        it("re-bakes in place when a stop is removed but the family stays active", () => {
+            const ps = createSystem();
+
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(0.5, 2);
+            ps.addSizeGradient(1, 3);
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._sizeGradientsTexture;
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+
+            ps.removeSizeGradient(0.5);
+
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            expect((ps as any)._sizeGradientsTexture).toBe(texture);
+
+            ps.dispose();
+        });
+
+        it("still releases the buffers when the family appears (no texture to re-bake)", () => {
+            const ps = createSystem();
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+
+            ps.addSizeGradient(0, 1);
+
+            expect(releaseBuffers).toHaveBeenCalled();
+
+            ps.dispose();
+        });
+
+        it("still releases the buffers and disposes the texture when the family is emptied", () => {
+            const ps = createSystem();
+
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 3);
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._sizeGradientsTexture;
+            const disposeTexture = vi.spyOn(texture, "dispose");
+
+            ps.removeSizeGradient(0);
+            expect((ps as any)._sizeGradientsTexture).toBe(texture); // one stop left: still re-baked in place
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            ps.removeSizeGradient(1);
+
+            expect(releaseBuffers).toHaveBeenCalled();
+            expect(disposeTexture).toHaveBeenCalled();
+            expect((ps as any)._sizeGradientsTexture).toBeNull();
+
+            ps.dispose();
+        });
+    });
+
+    describe("color gradients", () => {
+        it("re-bakes the existing texture in place on a value edit instead of releasing the buffers", () => {
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addColorGradient(1, new Color4(1, 0, 0, 1));
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._colorGradientsTexture;
+            expect(texture).toBeTruthy();
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            const update = vi.spyOn(texture, "update");
+
+            ps.removeColorGradient(1);
+            ps.addColorGradient(1, new Color4(0, 1, 0, 1));
+
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            expect(update).toHaveBeenCalledTimes(2);
+            expect((ps as any)._colorGradientsTexture).toBe(texture);
+
+            const data = update.mock.calls[update.mock.calls.length - 1][0] as Uint8Array;
+            const width = (ps as any)._rawTextureWidth;
+            expect(data.length).toBe(width * 4); // single row: no stop uses color2
+            // Ratio 0 -> pure red
+            expect(data[0]).toBe(255);
+            expect(data[1]).toBe(0);
+            // Last texel -> almost pure green
+            expect(data[(width - 1) * 4]).toBeLessThan(8);
+            expect(data[(width - 1) * 4 + 1]).toBeGreaterThan(247);
+
+            ps.dispose();
+        });
+
+        it("re-bakes both rows in place when every layout stays two-row (color2 present)", () => {
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1), new Color4(0, 0, 1, 1));
+            ps.addColorGradient(1, new Color4(1, 0, 0, 1), new Color4(0, 0, 1, 1));
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._colorGradientsTexture;
+            expect(texture.getSize().height).toBe(2);
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            const update = vi.spyOn(texture, "update");
+
+            ps.addColorGradient(0.5, new Color4(0, 1, 0, 1), new Color4(1, 1, 0, 1));
+
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            expect((ps as any)._colorGradientsTexture).toBe(texture);
+
+            const data = update.mock.calls[0][0] as Uint8Array;
+            const width = (ps as any)._rawTextureWidth;
+            expect(data.length).toBe(width * 4 * 2);
+            // Row 0 midpoint -> color1 of the new stop (pure green)
+            expect(data[(width / 2) * 4 + 1]).toBe(255);
+            // Row 1 midpoint -> color2 of the new stop (yellow)
+            expect(data[width * 4 + (width / 2) * 4]).toBe(255);
+            expect(data[width * 4 + (width / 2) * 4 + 1]).toBe(255);
+
+            ps.dispose();
+        });
+
+        it("still releases the buffers when a color2 stop flips the texture to the two-row layout", () => {
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addColorGradient(1, new Color4(0, 1, 0, 1));
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._colorGradientsTexture;
+            expect(texture.getSize().height).toBe(1);
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            const disposeTexture = vi.spyOn(texture, "dispose");
+
+            ps.addColorGradient(0.5, new Color4(0, 0, 1, 1), new Color4(1, 1, 1, 1));
+
+            expect(releaseBuffers).toHaveBeenCalled();
+            expect(disposeTexture).toHaveBeenCalled();
+            expect((ps as any)._colorGradientsTexture).toBeNull();
+
+            // The lazily recreated texture picks up the two-row layout
+            ps._recreateUpdateEffect();
+            expect((ps as any)._colorGradientsTexture.getSize().height).toBe(2);
+
+            ps.dispose();
+        });
+
+        it("still releases the buffers when removing the only color2 stop flips the layout back to one row", () => {
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addColorGradient(0.5, new Color4(0, 0, 1, 1), new Color4(1, 1, 1, 1));
+            ps.addColorGradient(1, new Color4(0, 1, 0, 1));
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._colorGradientsTexture;
+            expect(texture.getSize().height).toBe(2);
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+
+            ps.removeColorGradient(0.5);
+
+            expect(releaseBuffers).toHaveBeenCalled();
+            expect((ps as any)._colorGradientsTexture).toBeNull();
+
+            ps._recreateUpdateEffect();
+            expect((ps as any)._colorGradientsTexture.getSize().height).toBe(1);
+
+            ps.dispose();
+        });
+
+        it("still releases the buffers when the color family is emptied", () => {
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addColorGradient(1, new Color4(0, 1, 0, 1));
+
+            ps._recreateUpdateEffect();
+            const texture = (ps as any)._colorGradientsTexture;
+            const disposeTexture = vi.spyOn(texture, "dispose");
+
+            ps.removeColorGradient(0);
+            expect((ps as any)._colorGradientsTexture).toBe(texture); // one stop left: still re-baked in place
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            ps.removeColorGradient(1);
+
+            expect(releaseBuffers).toHaveBeenCalled();
+            expect(disposeTexture).toHaveBeenCalled();
+            expect((ps as any)._colorGradientsTexture).toBeNull();
+
+            ps.dispose();
+        });
+    });
+});

--- a/packages/dev/core/test/unit/Particles/gpuParticleSystemGradientRebake.test.ts
+++ b/packages/dev/core/test/unit/Particles/gpuParticleSystemGradientRebake.test.ts
@@ -274,4 +274,104 @@ describe("GPUParticleSystem gradient edits re-bake the lookup texture in place",
             ps.dispose();
         });
     });
+
+    describe("forceRefreshGradients (the Inspector live-edit path)", () => {
+        it("preserves the particle pool when an in-place value edit is followed by forceRefreshGradients", () => {
+            const ps = createSystem();
+
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 3);
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addColorGradient(1, new Color4(0, 1, 0, 1));
+
+            ps._recreateUpdateEffect();
+            const sizeTexture = (ps as any)._sizeGradientsTexture;
+            const colorTexture = (ps as any)._colorGradientsTexture;
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            const reset = vi.spyOn(ps, "reset");
+            const sizeUpdate = vi.spyOn(sizeTexture, "update");
+            const colorUpdate = vi.spyOn(colorTexture, "update");
+
+            // Exactly what both Inspectors do: mutate the gradient objects, then ask for a resync.
+            ps.getSizeGradients()![1].factor1 = 5;
+            ps.getColorGradients()![1].color1 = new Color4(0, 0, 1, 1);
+            ps.forceRefreshGradients();
+
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            expect(reset).not.toHaveBeenCalled();
+            // Both families re-baked in place — same texture identity, new pixels
+            expect(sizeUpdate).toHaveBeenCalledTimes(1);
+            expect(colorUpdate).toHaveBeenCalledTimes(1);
+            expect((ps as any)._sizeGradientsTexture).toBe(sizeTexture);
+            expect((ps as any)._colorGradientsTexture).toBe(colorTexture);
+
+            // The edited values reached the texture
+            const sizeData = sizeUpdate.mock.calls[0][0] as Float32Array;
+            const width = (ps as any)._rawTextureWidth;
+            expect(sizeData[(width - 1) * 2]).toBeCloseTo(1 + ((5 - 1) * (width - 1)) / width);
+
+            ps.dispose();
+        });
+
+        it("does not reset for the families that are simply absent", () => {
+            const ps = createSystem();
+
+            // Only one family exists; the other five are null and have nothing to resync. Counting an absent
+            // family as a structural change would reset the pool on every call.
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 3);
+            ps._recreateUpdateEffect();
+
+            const releaseBuffers = vi.spyOn(ps as any, "_releaseBuffers");
+            const reset = vi.spyOn(ps, "reset");
+
+            ps.forceRefreshGradients();
+
+            expect(releaseBuffers).not.toHaveBeenCalled();
+            expect(reset).not.toHaveBeenCalled();
+
+            ps.dispose();
+        });
+
+        it("resets when a family has no texture to re-bake yet (first bake is structural)", () => {
+            const ps = createSystem();
+
+            // No _recreateUpdateEffect(): the lookup texture has never been created.
+            ps.addSizeGradient(0, 1);
+            ps.addSizeGradient(1, 3);
+
+            const reset = vi.spyOn(ps, "reset");
+
+            ps.forceRefreshGradients();
+
+            expect(reset).toHaveBeenCalled();
+
+            ps.dispose();
+        });
+
+        it("resets when an edit flips the color2 row layout", () => {
+            const ps = createSystem();
+
+            ps.addColorGradient(0, new Color4(1, 0, 0, 1));
+            ps.addColorGradient(1, new Color4(0, 1, 0, 1));
+
+            ps._recreateUpdateEffect();
+            expect((ps as any)._colorGradientsTexture.getSize().height).toBe(1);
+
+            const reset = vi.spyOn(ps, "reset");
+
+            // Adding a color2 in place is a layout change, not a value edit — the texture cannot be re-baked.
+            ps.getColorGradients()![1].color2 = new Color4(0, 0, 1, 1);
+            ps.forceRefreshGradients();
+
+            expect(reset).toHaveBeenCalled();
+            expect((ps as any)._colorGradientsTexture).toBeNull();
+
+            ps._recreateUpdateEffect();
+            expect((ps as any)._colorGradientsTexture.getSize().height).toBe(2);
+
+            ps.dispose();
+        });
+    });
 });


### PR DESCRIPTION
Value-only gradient changes within an active family now update the existing lookup texture's pixels via RawTexture.update() instead of disposing it and releasing the sim buffers, so the live particle pool survives the edit and retained WebGPU compute bindings stay valid. Structural transitions (family appearing/disappearing, color2 row-layout flip) keep the release path unchanged.

Associated forum thread: https://forum.babylonjs.com/t/pop-free-gradient-edits-on-gpuparticlesystem/63917