### PR TITLE
Fix NativeEngine command scope leaking when a render throws

### DIFF
--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { type Nullable, type IndicesArray, type DataArray, type FloatArray, type DeepImmutable, type int } from "../types";
 
+import { type Scene } from "../scene.pure";
 import { type VertexBuffer } from "../Buffers/buffer.pure";
 import { RegisterBufferAlign } from "../Buffers/buffer.align.pure";
 import { InternalTexture, InternalTextureSource } from "../Materials/Textures/internalTexture";
@@ -464,20 +465,36 @@ export class ThinNativeEngine extends ThinEngine {
         this._shaderProcessor = new NativeShaderProcessor();
 
         this.onNewSceneAddedObservable.add((scene) => {
-            const originalRender = scene.render;
-            scene.render = (...args: Parameters<typeof originalRender>) => {
-                this._commandBufferEncoder.beginCommandScope();
-                try {
-                    originalRender.apply(scene, args);
-                } finally {
-                    // Must run even if the render throws. Otherwise the scope stays
-                    // open forever and every later frame fails with "Command scope
-                    // already active.", so a single recoverable error permanently
-                    // breaks the engine instead of affecting just that frame.
-                    this._commandBufferEncoder.endCommandScope();
-                }
-            };
+            this._wrapSceneRenderWithCommandScope(scene);
         });
+    }
+
+    /**
+     * Brackets a scene's render with a command scope, so the commands it encodes are submitted together.
+     * @param scene the scene whose render should be wrapped
+     */
+    private _wrapSceneRenderWithCommandScope(scene: Scene): void {
+        const originalRender = scene.render;
+        scene.render = (...args: Parameters<typeof originalRender>) => {
+            this._commandBufferEncoder.beginCommandScope();
+            try {
+                originalRender.apply(scene, args);
+            } catch (renderException) {
+                // The scope must be closed even when the render throws. Otherwise it stays
+                // open forever and every later frame fails with "Command scope already
+                // active.", so one recoverable error permanently breaks the engine instead
+                // of affecting just this frame.
+                try {
+                    this._commandBufferEncoder.endCommandScope();
+                } catch (endException) {
+                    // Never let this replace the root cause; report it separately instead.
+                    Logger.Error(`Failed to end the command scope while unwinding a render error: ${endException}`);
+                }
+                throw renderException;
+            }
+
+            this._commandBufferEncoder.endCommandScope();
+        };
     }
 
     public override setHardwareScalingLevel(level: number): void {

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -467,8 +467,15 @@ export class ThinNativeEngine extends ThinEngine {
             const originalRender = scene.render;
             scene.render = (...args: Parameters<typeof originalRender>) => {
                 this._commandBufferEncoder.beginCommandScope();
-                originalRender.apply(scene, args);
-                this._commandBufferEncoder.endCommandScope();
+                try {
+                    originalRender.apply(scene, args);
+                } finally {
+                    // Must run even if the render throws. Otherwise the scope stays
+                    // open forever and every later frame fails with "Command scope
+                    // already active.", so a single recoverable error permanently
+                    // breaks the engine instead of affecting just that frame.
+                    this._commandBufferEncoder.endCommandScope();
+                }
             };
         });
     }

--- a/packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts
+++ b/packages/dev/core/test/unit/Engines/thinNativeEngine.test.ts
@@ -13,6 +13,19 @@ type TestThinNativeEngine = {
     _queueNewFrame: (callback: () => void, requester?: NativeFrameRequester) => number;
 };
 
+// Structurally typed so the test does not have to import the full Scene module.
+type TestScene = {
+    render: () => void;
+};
+
+type TestCommandScopeEngine = {
+    _commandBufferEncoder: {
+        beginCommandScope: () => void;
+        endCommandScope: () => void;
+    };
+    _wrapSceneRenderWithCommandScope: (scene: TestScene) => void;
+};
+
 describe("ThinNativeEngine", () => {
     describe("dynamic textures", () => {
         it("coerces fractional canvas dimensions before allocating native texture data", () => {
@@ -52,6 +65,88 @@ describe("ThinNativeEngine", () => {
             expect(requestId).toBe(23);
             expect(requestedCallback).toBe(renderFunction);
             expect(nativeRequestUsed).toBe(false);
+        });
+    });
+
+    describe("command scope", () => {
+        const createEngineWithScope = (onSubmit?: () => void) => {
+            const engine = Object.create(ThinNativeEngine.prototype) as TestCommandScopeEngine;
+            let active = false;
+
+            engine._commandBufferEncoder = {
+                beginCommandScope: () => {
+                    if (active) {
+                        throw new Error("Command scope already active.");
+                    }
+                    active = true;
+                },
+                endCommandScope: () => {
+                    if (!active) {
+                        throw new Error("Command scope is not active.");
+                    }
+                    active = false;
+                    onSubmit?.();
+                },
+            };
+
+            return engine;
+        };
+
+        it("closes the command scope when the scene render throws, so later frames still work", () => {
+            const engine = createEngineWithScope();
+            const renderError = new Error("render failed");
+            let shouldThrow = true;
+            let renderCount = 0;
+
+            const scene = {
+                render: () => {
+                    renderCount++;
+                    if (shouldThrow) {
+                        throw renderError;
+                    }
+                },
+            };
+
+            engine._wrapSceneRenderWithCommandScope(scene);
+
+            // The original error must still reach the caller.
+            expect(() => scene.render()).toThrow(renderError);
+
+            // Without closing the scope, this second render would fail with
+            // "Command scope already active." instead of running.
+            shouldThrow = false;
+            expect(() => scene.render()).not.toThrow();
+            expect(renderCount).toBe(2);
+        });
+
+        it("does not let a failure closing the scope mask the render error", () => {
+            const engine = createEngineWithScope(() => {
+                throw new Error("submit failed");
+            });
+            const renderError = new Error("render failed");
+
+            const scene = {
+                render: () => {
+                    throw renderError;
+                },
+            };
+
+            engine._wrapSceneRenderWithCommandScope(scene);
+
+            expect(() => scene.render()).toThrow(renderError);
+        });
+
+        it("propagates errors from closing the scope when the render succeeds", () => {
+            const submitError = new Error("submit failed");
+            const engine = createEngineWithScope(() => {
+                throw submitError;
+            });
+
+            const scene = { render: () => {} };
+
+            engine._wrapSceneRenderWithCommandScope(scene);
+
+            expect(() => scene.render()).toThrow(submitError);
         });
     });
 });


### PR DESCRIPTION
## Problem

`ThinNativeEngine` wraps every scene's `render` so it is bracketed by `beginCommandScope()` / `endCommandScope()`, but the two calls are not protected by `try`/`finally`:

```ts
scene.render = (...args: Parameters<typeof originalRender>) => {
    this._commandBufferEncoder.beginCommandScope();
    originalRender.apply(scene, args);
    this._commandBufferEncoder.endCommandScope();
};
```

If `originalRender` throws, `endCommandScope()` never runs and `_isCommandBufferScopeActive` stays `true`. Because `beginCommandScope()` throws when the flag is already set:

```ts
public beginCommandScope() {
    if (this._isCommandBufferScopeActive) {
        throw new Error("Command scope already active.");
    }
    ...
}
```

...**every subsequent frame** then fails with `Command scope already active.` A single recoverable error permanently breaks the engine instead of affecting just the frame that failed.

## Impact

Found while running the Babylon Native visual validation suite, which executes twelve scenes per process. One genuinely failing scene cascaded into up to eleven spurious failures behind it, because the engine stayed poisoned for the rest of the process.

Concretely, a full 680-test sweep reported **348 occurrences** of `Command scope already active.` and scored 320 passes. Re-running every non-passing test **one per process** produced **zero** occurrences and scored 349 — i.e. roughly 29 of the reported failures were purely this cascade, and the real failure count was far smaller.

This also makes the error genuinely misleading: the reported failure is attributed to whatever scene ran later, not to the one that actually threw.

## Fix

Move `endCommandScope()` into a `finally`, so begin/end stay paired on the error path:

```ts
this._commandBufferEncoder.beginCommandScope();
try {
    originalRender.apply(scene, args);
} finally {
    this._commandBufferEncoder.endCommandScope();
}
```

The original exception still propagates unchanged; the only behavioural difference is that the command scope is correctly closed, so later frames can run.

`endCommandScope()` clears the flag *before* calling `_submit()`:

```ts
public endCommandScope() {
    if (!this._isCommandBufferScopeActive) {
        throw new Error("Command scope is not active.");
    }
    this._isCommandBufferScopeActive = false;
    this._submit();
}
```

so the invariant is restored even in the unlikely case that `_submit()` itself throws.

## Notes

- Affects the `NativeEngine` / Babylon Native path only; no change for WebGL or WebGPU.
- No public API change.
