### PR TITLE
Fix WebGPU vertex layout pipeline cache collisions

### DIFF
--- a/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuCacheRenderPipeline.ts
@@ -77,6 +77,8 @@ const stencilOpToIndex: { [name: number]: number } = {
 };
 
 const colorStates = [0, 0, 0, 0];
+// VertexBuffer.hashCode uses at most bit 23 for WebGPU's maximum 2048-byte stride.
+const vertexBufferLayoutContinuation = 1 << 26;
 
 /** @internal */
 export abstract class WebGPUCacheRenderPipeline {
@@ -147,7 +149,8 @@ export abstract class WebGPUCacheRenderPipeline {
     constructor(device: GPUDevice, emptyVertexBuffer: VertexBuffer) {
         this._device = device;
         this._useTextureStage = true; // we force usage because we must handle depth textures with "float" filtering, which can't be fixed by a caps (like "textureFloatLinearFiltering" can for float textures)
-        this._states = new Array(30); // pre-allocate enough room so that no new allocation will take place afterwards
+        // Each attribute can add a format state and a non-zero descriptor offset state.
+        this._states = new Array(StatePosition.VertexState + 2 * (device.limits.maxVertexAttributes || 16));
         this._statesLength = 0;
         this._stateDirtyLowestIndex = 0;
         this._emptyVertexBuffer = emptyVertexBuffer;
@@ -918,16 +921,24 @@ export abstract class WebGPUCacheRenderPipeline {
                     (offset + formatSize <= this._kMaxVertexBufferStride && byteStride === 0) || (byteStride !== 0 && offset + formatSize <= byteStride);
             }
 
-            if (!(currentGPUBuffer && currentGPUBuffer === buffer && vertexBuffer._validOffsetRange)) {
+            const canMergeWithCurrentBuffer = WebGPUCacheRenderPipeline._CanMergeVertexBuffer(currentGPUBuffer, buffer, vertexBuffer);
+            if (!canMergeWithCurrentBuffer) {
                 // we can't combine the previous vertexBuffer with the current one
                 this.vertexBuffers[numVertexBuffers++] = vertexBuffer;
                 currentGPUBuffer = vertexBuffer._validOffsetRange ? buffer : null;
             }
 
-            const vid = vertexBuffer.hashCode + (location << 7);
+            const vid = vertexBuffer.hashCode + (location << 7) + (canMergeWithCurrentBuffer ? vertexBufferLayoutContinuation : 0);
+            const descriptorOffset = vertexBuffer._validOffsetRange ? vertexBuffer.effectiveByteOffset : 0;
 
             this._isDirty = this._isDirty || this._states[newNumStates] !== vid;
             this._states[newNumStates++] = vid;
+            if (descriptorOffset !== 0) {
+                // Offset states are negative so they cannot collide with vertex format states.
+                const offsetState = -descriptorOffset;
+                this._isDirty = this._isDirty || this._states[newNumStates] !== offsetState;
+                this._states[newNumStates++] = offsetState;
+            }
         }
 
         this.vertexBuffers.length = numVertexBuffers;
@@ -1044,7 +1055,7 @@ export abstract class WebGPUCacheRenderPipeline {
             // We reuse the same GPUVertexBufferLayout for all attributes that use the same underlying GPU buffer (and for attributes that follow each other in the attributes array)
             let offset = vertexBuffer.effectiveByteOffset;
             const invalidOffsetRange = !vertexBuffer._validOffsetRange;
-            if (!(currentGPUBuffer && currentGPUAttributes && currentGPUBuffer === buffer) || invalidOffsetRange) {
+            if (!WebGPUCacheRenderPipeline._CanMergeVertexBuffer(currentGPUBuffer, buffer, vertexBuffer)) {
                 const vertexBufferDescriptor: GPUVertexBufferLayout = {
                     arrayStride: vertexBuffer.effectiveByteStride,
                     stepMode: vertexBuffer.getIsInstanced() ? WebGPUConstants.VertexStepMode.Instance : WebGPUConstants.VertexStepMode.Vertex,
@@ -1059,7 +1070,7 @@ export abstract class WebGPUCacheRenderPipeline {
                 }
             }
 
-            currentGPUAttributes.push({
+            currentGPUAttributes!.push({
                 shaderLocation: location,
                 offset,
                 format: WebGPUCacheRenderPipeline._GetVertexInputDescriptorFormat(vertexBuffer),
@@ -1069,6 +1080,10 @@ export abstract class WebGPUCacheRenderPipeline {
         }
 
         return descriptors;
+    }
+
+    private static _CanMergeVertexBuffer(currentGPUBuffer: unknown, buffer: unknown, vertexBuffer: VertexBuffer): boolean {
+        return !!currentGPUBuffer && currentGPUBuffer === buffer && vertexBuffer._validOffsetRange;
     }
 
     private _buildRenderPipelineDescriptor(effect: Effect, topology: GPUPrimitiveTopology, sampleCount: number): GPURenderPipelineDescriptor {

--- a/packages/dev/core/test/unit/Engines/WebGPU/webgpuCacheRenderPipeline.test.ts
+++ b/packages/dev/core/test/unit/Engines/WebGPU/webgpuCacheRenderPipeline.test.ts
@@ -8,29 +8,30 @@ import { RegisterEnginesWebGPUExtensionsEngineAlphaToCoverage } from "core/Engin
 
 // Minimal mock types for the pipeline cache tests
 function createMockDevice(): GPUDevice {
-    const mockPipeline = { label: "mock-pipeline" } as unknown as GPURenderPipeline;
     const asyncMockPipeline = { label: "mock-pipeline-async" } as unknown as GPURenderPipeline;
+    let pipelineId = 0;
 
     return {
-        limits: { maxVertexBufferArrayStride: 2048 },
-        createRenderPipeline: vi.fn(() => mockPipeline),
+        limits: { maxVertexBufferArrayStride: 2048, maxVertexAttributes: 16 },
+        createRenderPipeline: vi.fn(() => ({ label: `mock-pipeline-${pipelineId++}` }) as unknown as GPURenderPipeline),
         createRenderPipelineAsync: vi.fn(() => Promise.resolve(asyncMockPipeline)),
         createPipelineLayout: vi.fn(() => ({})),
         createBindGroupLayout: vi.fn(() => ({})),
     } as unknown as GPUDevice;
 }
 
-function createMockEffect(uniqueId: number): Effect {
+function createMockEffect(uniqueId: number, attributes: string[] = []): Effect {
     return {
         uniqueId,
+        getEngine: () => ({}),
         _pipelineContext: {
             stages: {
                 vertexStage: { module: {}, entryPoint: "main" },
                 fragmentStage: { module: {}, entryPoint: "main" },
             },
             shaderProcessingContext: {
-                attributeNamesFromEffect: [],
-                attributeLocationsFromEffect: [],
+                attributeNamesFromEffect: attributes,
+                attributeLocationsFromEffect: attributes.map((_, index) => index),
                 bindGroupLayoutEntries: [],
                 bindGroupEntries: [],
                 bindGroupLayoutEntryInfo: [],
@@ -40,16 +41,19 @@ function createMockEffect(uniqueId: number): Effect {
     } as unknown as Effect;
 }
 
-function createMockVertexBuffer(): VertexBuffer {
+function createMockVertexBuffer(buffer: unknown = null, effectiveByteOffset = 0, effectiveByteStride = 12): VertexBuffer {
     return {
-        getSize: () => 12,
-        byteStride: 12,
-        byteOffset: 0,
-        effectiveByteStride: 12,
-        effectiveByteOffset: 0,
-        effectiveBuffer: null,
-        hashCode: 1,
-        _validOffsetRange: true,
+        getSize: (sizeInBytes?: boolean) => (sizeInBytes ? 4 : 1),
+        getIsInstanced: () => false,
+        type: Constants.FLOAT,
+        normalized: false,
+        byteStride: effectiveByteStride,
+        byteOffset: effectiveByteOffset,
+        effectiveByteStride,
+        effectiveByteOffset,
+        effectiveBuffer: buffer ? { underlyingResource: buffer } : null,
+        hashCode: effectiveByteStride << 12,
+        _validOffsetRange: undefined,
     } as unknown as VertexBuffer;
 }
 
@@ -98,6 +102,114 @@ describe("WebGPUCacheRenderPipeline", () => {
             cache.getRenderPipeline(Constants.MATERIAL_WireFrameFillMode, effect, 1, 0);
 
             expect(device.createRenderPipeline).toHaveBeenCalledTimes(2);
+        });
+
+        it("should create a new pipeline when the vertex buffer merge structure changes", () => {
+            effect = createMockEffect(1, ["position", "normal"]);
+            const sharedBuffer = {};
+
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer(sharedBuffer, 0, 16),
+                    normal: createMockVertexBuffer(sharedBuffer, 4, 16),
+                },
+                null,
+                null
+            );
+            cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer({}, 0, 16),
+                    normal: createMockVertexBuffer({}, 4, 16),
+                },
+                null,
+                null
+            );
+            cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            expect(device.createRenderPipeline).toHaveBeenCalledTimes(2);
+        });
+
+        it("should create a new pipeline when merged vertex attribute offsets change", () => {
+            effect = createMockEffect(1, ["position", "normal"]);
+            const firstBuffer = {};
+
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer(firstBuffer, 0, 16),
+                    normal: createMockVertexBuffer(firstBuffer, 4, 16),
+                },
+                null,
+                null
+            );
+            cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            const secondBuffer = {};
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer(secondBuffer, 4, 16),
+                    normal: createMockVertexBuffer(secondBuffer, 8, 16),
+                },
+                null,
+                null
+            );
+            cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            expect(device.createRenderPipeline).toHaveBeenCalledTimes(2);
+        });
+
+        it("should reuse a pipeline when only the underlying vertex buffer changes", () => {
+            effect = createMockEffect(1, ["position", "normal"]);
+            const firstBuffer = {};
+
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer(firstBuffer, 0, 16),
+                    normal: createMockVertexBuffer(firstBuffer, 4, 16),
+                },
+                null,
+                null
+            );
+            const firstPipeline = cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            const differentLayoutBuffer = {};
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer(differentLayoutBuffer, 4, 16),
+                    normal: createMockVertexBuffer(differentLayoutBuffer, 8, 16),
+                },
+                null,
+                null
+            );
+            cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            const secondBuffer = {};
+            cache.setBuffers(
+                {
+                    position: createMockVertexBuffer(secondBuffer, 0, 16),
+                    normal: createMockVertexBuffer(secondBuffer, 4, 16),
+                },
+                null,
+                null
+            );
+            const reusedPipeline = cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            expect(reusedPipeline).toBe(firstPipeline);
+            expect(device.createRenderPipeline).toHaveBeenCalledTimes(2);
+        });
+
+        it("should reuse a pipeline when invalid vertex offsets change", () => {
+            effect = createMockEffect(1, ["position"]);
+
+            cache.setBuffers({ position: createMockVertexBuffer({}, 16, 16) }, null, null);
+            const firstPipeline = cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            cache.setBuffers({ position: createMockVertexBuffer({}, 32, 16) }, null, null);
+            const reusedPipeline = cache.getRenderPipeline(Constants.MATERIAL_TriangleFillMode, effect, 1, 0);
+
+            expect(reusedPipeline).toBe(firstPipeline);
+            expect(device.createRenderPipeline).toHaveBeenCalledTimes(1);
         });
 
         it("should enable alpha-to-coverage in multisampled pipelines", () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- include vertex-buffer merge boundaries in the WebGPU render-pipeline cache key
- include effective attribute offsets when they are part of `GPUVertexBufferLayout`
- keep cache reuse when only the underlying GPU buffer changes
- share merge-decision logic between cache-key generation and descriptor construction
- add regression coverage for merged layouts, differing offsets, buffer replacement, and bind-time offsets

## Motivation
The pipeline cache could reuse a pipeline whose vertex-buffer slot layout did not match the current mesh. This corrupted vertex attributes for glTF assets using shared buffer views, producing exploded geometry under WebGPU while WebGL2 rendered correctly.

Forum report: https://forum.babylonjs.com/t/webgpu-model-error-works-on-webgl2/63908
