### PR TITLE
Fix WebGPU rendering nothing when maxSimultaneousLights exceeds the uniform buffer budget

### DIFF
--- a/packages/dev/core/src/Engines/engineCapabilities.ts
+++ b/packages/dev/core/src/Engines/engineCapabilities.ts
@@ -27,6 +27,11 @@ export interface EngineCapabilities {
     maxVertexUniformVectors: number;
     /** Maximum number of uniforms per fragment shader */
     maxFragmentUniformVectors: number;
+    /**
+     * Maximum number of uniform buffers that can be bound to a single shader stage.
+     * Only reported by engines where this is a hard, enforced limit (WebGPU). Left undefined elsewhere.
+     */
+    maxUniformBuffersPerShaderStage?: number;
     /** The number of bits that can be accurately represented in shader floats */
     shaderFloatPrecision: number;
     /** Defines if standard derivatives (dx/dy) are supported */

--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -941,6 +941,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
             maxVaryingVectors: this._deviceLimits.maxInterStageShaderVariables,
             maxFragmentUniformVectors: Math.floor(this._deviceLimits.maxUniformBufferBindingSize / 4),
             maxVertexUniformVectors: Math.floor(this._deviceLimits.maxUniformBufferBindingSize / 4),
+            maxUniformBuffersPerShaderStage: this._deviceLimits.maxUniformBuffersPerShaderStage,
             shaderFloatPrecision: 23, // WGSL always uses IEEE-754 binary32 floats (which have 23 bits of significand)
             standardDerivatives: true,
             astc: (this._deviceEnabledExtensions.indexOf(WebGPUConstants.FeatureName.TextureCompressionASTC) >= 0 ? true : undefined) as any,

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -507,7 +507,7 @@ export function BindLight(light: Light, lightIndex: number, scene: Scene, effect
  */
 const _NonLightVertexUniformBufferCount = 3;
 
-/** Requested maxSimultaneousLights value already warned about, per engine, so the warning is emitted once. */
+/** Light counts already warned about, per engine, so the warning is emitted once. */
 const _LightBudgetWarnedEngines = new WeakMap<AbstractEngine, Set<number>>();
 
 /**
@@ -527,7 +527,8 @@ export function GetSupportedSimultaneousLights(scene: Scene, maxSimultaneousLigh
     const maxUniformBuffersPerShaderStage = scene.getEngine().getCaps().maxUniformBuffersPerShaderStage;
 
     // Engines that do not report the limit (WebGL, native) do not enforce it: leave the count untouched.
-    if (!maxUniformBuffersPerShaderStage) {
+    // Tested against null rather than for truthiness so that a limit of 0, however unlikely, still clamps.
+    if (maxUniformBuffersPerShaderStage == null) {
         return maxSimultaneousLights;
     }
 
@@ -538,23 +539,26 @@ export function GetSupportedSimultaneousLights(scene: Scene, maxSimultaneousLigh
     return Math.min(maxSimultaneousLights, supported);
 }
 
-function WarnAboutClampedLights(engine: AbstractEngine, requested: number, supported: number): void {
+function WarnAboutClampedLights(engine: AbstractEngine, requested: number, supported: number, lightsInUse: number): void {
     let warned = _LightBudgetWarnedEngines.get(engine);
     if (!warned) {
         warned = new Set<number>();
         _LightBudgetWarnedEngines.set(engine, warned);
     }
-    if (warned.has(requested)) {
+    if (warned.has(lightsInUse)) {
         return;
     }
-    warned.add(requested);
+    warned.add(lightsInUse);
 
+    // Report the lights actually affecting the mesh, not maxSimultaneousLights: the per-light uniform buffers
+    // are declared per light in use, so a very high cap on a mesh with fewer lights would overstate the cost.
     Logger.Warn(
         `maxSimultaneousLights is ${requested} but this engine supports at most ${supported} simultaneous lights. ` +
-            `Each light declares its own uniform buffer in the vertex shader, so ${requested} lights plus the scene, mesh and material ` +
-            `buffers would need ${requested + _NonLightVertexUniformBufferCount} uniform buffers, over the device limit of ` +
-            `${engine.getCaps().maxUniformBuffersPerShaderStage} per shader stage. The light count has been clamped to ${supported}, ` +
-            `so the extra lights will not contribute to the render. Set maxSimultaneousLights to ${supported} or less to silence this warning.`
+            `Each light declares its own uniform buffer in the vertex shader, so the ${lightsInUse} lights affecting this mesh plus ` +
+            `the scene, mesh and material buffers would need ${lightsInUse + _NonLightVertexUniformBufferCount} uniform buffers, over ` +
+            `the device limit of ${engine.getCaps().maxUniformBuffersPerShaderStage} per shader stage. The light count has been clamped ` +
+            `to ${supported}, so the extra lights will not contribute to the render. Set maxSimultaneousLights to ${supported} or less ` +
+            `to silence this warning.`
     );
 }
 
@@ -734,7 +738,9 @@ export function AreLightsTexturesReady(scene: Scene, mesh: AbstractMesh, maxSimu
         return true;
     }
     const lights = mesh.lightSources;
-    const count = Math.min(lights.length, maxSimultaneousLights);
+    // Mirror the clamp PrepareDefinesForLights applies, so readiness is not gated on a light the shader
+    // will never use.
+    const count = Math.min(lights.length, GetSupportedSimultaneousLights(scene, maxSimultaneousLights));
     for (let i = 0; i < count; i++) {
         if (!lights[i].areLightTexturesReady()) {
             return false;
@@ -776,7 +782,7 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
         // Only worth telling the user about the clamp when lights are actually being dropped because of it:
         // the per-light uniform buffers are declared per light in use, not per maxSimultaneousLights.
         if (mesh.lightSources.length > maxSimultaneousLights && maxSimultaneousLights < requestedSimultaneousLights) {
-            WarnAboutClampedLights(scene.getEngine(), requestedSimultaneousLights, maxSimultaneousLights);
+            WarnAboutClampedLights(scene.getEngine(), requestedSimultaneousLights, maxSimultaneousLights, Math.min(mesh.lightSources.length, requestedSimultaneousLights));
         }
 
         for (const light of mesh.lightSources) {

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -502,10 +502,17 @@ export function BindLight(light: Light, lightIndex: number, scene: Scene, effect
 }
 
 /**
- * Uniform buffers the vertex stage binds in addition to the per-light ones: Scene, Mesh and Material.
- * Used to work out how many lights still fit within the device's per-stage uniform buffer limit.
+ * Uniform buffers the vertex stage binds in addition to the per-light ones: Scene, Mesh, Material and
+ * LeftOver. Used to work out how many lights still fit within the device's per-stage uniform buffer limit.
+ *
+ * LeftOver is the buffer WebGPU's shader processor synthesises for uniforms declared outside of a uniform
+ * block; it is given both vertex and fragment visibility as soon as any such uniform exists in either stage,
+ * which is the case for virtually every material (per-light shadow matrices, logarithmicDepthConstant,
+ * vClipPlane and so on).
+ * It is counted unconditionally: reserving one buffer too many merely costs a light in the rare shader that
+ * has no leftover uniforms, whereas reserving one too few brings back the black screen this guards against.
  */
-const _NonLightVertexUniformBufferCount = 3;
+const _NonLightVertexUniformBufferCount = 4;
 
 /** Light counts already warned about, per engine, so the warning is emitted once. */
 const _LightBudgetWarnedEngines = new WeakMap<AbstractEngine, Set<number>>();
@@ -555,7 +562,7 @@ function WarnAboutClampedLights(engine: AbstractEngine, requested: number, suppo
     Logger.Warn(
         `maxSimultaneousLights is ${requested} but this engine supports at most ${supported} simultaneous lights. ` +
             `Each light declares its own uniform buffer in the vertex shader, so the ${lightsInUse} lights affecting this mesh plus ` +
-            `the scene, mesh and material buffers would need ${lightsInUse + _NonLightVertexUniformBufferCount} uniform buffers, over ` +
+            `the scene, mesh, material and leftover buffers would need ${lightsInUse + _NonLightVertexUniformBufferCount} uniform buffers, over ` +
             `the device limit of ${engine.getCaps().maxUniformBuffersPerShaderStage} per shader stage. The light count has been clamped ` +
             `to ${supported}, so the extra lights will not contribute to the render. Set maxSimultaneousLights to ${supported} or less ` +
             `to silence this warning.`
@@ -571,9 +578,7 @@ function WarnAboutClampedLights(engine: AbstractEngine, requested: number, suppo
  * @param maxSimultaneousLights The maximum number of light that can be bound to the effect
  */
 export function BindLights(scene: Scene, mesh: AbstractMesh, effect: Effect, defines: any, maxSimultaneousLights = 4): void {
-    // Match the clamp PrepareDefinesForLights applied when it generated the defines, so we never bind more
-    // lights than the effect actually declares.
-    const len = Math.min(mesh.lightSources.length, GetSupportedSimultaneousLights(scene, maxSimultaneousLights));
+    const len = Math.min(mesh.lightSources.length, maxSimultaneousLights);
 
     for (let i = 0; i < len; i++) {
         const light = mesh.lightSources[i];
@@ -738,9 +743,7 @@ export function AreLightsTexturesReady(scene: Scene, mesh: AbstractMesh, maxSimu
         return true;
     }
     const lights = mesh.lightSources;
-    // Mirror the clamp PrepareDefinesForLights applies, so readiness is not gated on a light the shader
-    // will never use.
-    const count = Math.min(lights.length, GetSupportedSimultaneousLights(scene, maxSimultaneousLights));
+    const count = Math.min(lights.length, maxSimultaneousLights);
     for (let i = 0; i < count; i++) {
         if (!lights[i].areLightTexturesReady()) {
             return false;

--- a/packages/dev/core/src/Materials/materialHelper.functions.ts
+++ b/packages/dev/core/src/Materials/materialHelper.functions.ts
@@ -502,6 +502,63 @@ export function BindLight(light: Light, lightIndex: number, scene: Scene, effect
 }
 
 /**
+ * Uniform buffers the vertex stage binds in addition to the per-light ones: Scene, Mesh and Material.
+ * Used to work out how many lights still fit within the device's per-stage uniform buffer limit.
+ */
+const _NonLightVertexUniformBufferCount = 3;
+
+/** Requested maxSimultaneousLights value already warned about, per engine, so the warning is emitted once. */
+const _LightBudgetWarnedEngines = new WeakMap<AbstractEngine, Set<number>>();
+
+/**
+ * Returns the number of simultaneous lights the engine can actually render, which may be lower than the
+ * requested maximum.
+ *
+ * Engines that declare one uniform buffer per light in the vertex shader (WebGPU, through
+ * lightVxUboDeclaration) are bounded by maxUniformBuffersPerShaderStage: past that limit every pipeline
+ * creation is rejected by the WebGPU validator and nothing renders at all, with only a CreateBindGroupLayout
+ * validation error to go on. maxUniformBuffersPerShaderStage is 12 both as the WebGPU spec default and as
+ * the maximum a D3D12 adapter reports, so it cannot be raised through requiredLimits either.
+ * @param scene The scene that will be rendered
+ * @param maxSimultaneousLights The requested maximum number of simultaneous lights
+ * @returns The number of simultaneous lights supported, clamped to the engine's capabilities
+ */
+export function GetSupportedSimultaneousLights(scene: Scene, maxSimultaneousLights: number): number {
+    const maxUniformBuffersPerShaderStage = scene.getEngine().getCaps().maxUniformBuffersPerShaderStage;
+
+    // Engines that do not report the limit (WebGL, native) do not enforce it: leave the count untouched.
+    if (!maxUniformBuffersPerShaderStage) {
+        return maxSimultaneousLights;
+    }
+
+    // Keep at least one light: a scene lit by a single light is far more useful than an unlit one, and it
+    // matches what the device can do even with an unusually low reported limit.
+    const supported = Math.max(maxUniformBuffersPerShaderStage - _NonLightVertexUniformBufferCount, 1);
+
+    return Math.min(maxSimultaneousLights, supported);
+}
+
+function WarnAboutClampedLights(engine: AbstractEngine, requested: number, supported: number): void {
+    let warned = _LightBudgetWarnedEngines.get(engine);
+    if (!warned) {
+        warned = new Set<number>();
+        _LightBudgetWarnedEngines.set(engine, warned);
+    }
+    if (warned.has(requested)) {
+        return;
+    }
+    warned.add(requested);
+
+    Logger.Warn(
+        `maxSimultaneousLights is ${requested} but this engine supports at most ${supported} simultaneous lights. ` +
+            `Each light declares its own uniform buffer in the vertex shader, so ${requested} lights plus the scene, mesh and material ` +
+            `buffers would need ${requested + _NonLightVertexUniformBufferCount} uniform buffers, over the device limit of ` +
+            `${engine.getCaps().maxUniformBuffersPerShaderStage} per shader stage. The light count has been clamped to ${supported}, ` +
+            `so the extra lights will not contribute to the render. Set maxSimultaneousLights to ${supported} or less to silence this warning.`
+    );
+}
+
+/**
  * Binds the lights information from the scene to the effect for the given mesh.
  * @param scene The scene the lights belongs to
  * @param mesh The mesh we are binding the information to render
@@ -510,7 +567,9 @@ export function BindLight(light: Light, lightIndex: number, scene: Scene, effect
  * @param maxSimultaneousLights The maximum number of light that can be bound to the effect
  */
 export function BindLights(scene: Scene, mesh: AbstractMesh, effect: Effect, defines: any, maxSimultaneousLights = 4): void {
-    const len = Math.min(mesh.lightSources.length, maxSimultaneousLights);
+    // Match the clamp PrepareDefinesForLights applied when it generated the defines, so we never bind more
+    // lights than the effect actually declares.
+    const len = Math.min(mesh.lightSources.length, GetSupportedSimultaneousLights(scene, maxSimultaneousLights));
 
     for (let i = 0; i < len; i++) {
         const light = mesh.lightSources[i];
@@ -699,6 +758,11 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
         return defines._needNormals;
     }
 
+    // Some engines cannot render as many lights as requested (see GetSupportedSimultaneousLights). Clamp the
+    // count so the scene renders with fewer lights, rather than failing pipeline creation and rendering nothing.
+    const requestedSimultaneousLights = maxSimultaneousLights;
+    maxSimultaneousLights = GetSupportedSimultaneousLights(scene, maxSimultaneousLights);
+
     let lightIndex = 0;
     const state = {
         needNormals: defines._needNormals, // prevents overriding previous reflection or other needs for normals
@@ -709,6 +773,12 @@ export function PrepareDefinesForLights(scene: Scene, mesh: AbstractMesh, define
     };
 
     if (scene.lightsEnabled && !disableLighting) {
+        // Only worth telling the user about the clamp when lights are actually being dropped because of it:
+        // the per-light uniform buffers are declared per light in use, not per maxSimultaneousLights.
+        if (mesh.lightSources.length > maxSimultaneousLights && maxSimultaneousLights < requestedSimultaneousLights) {
+            WarnAboutClampedLights(scene.getEngine(), requestedSimultaneousLights, maxSimultaneousLights);
+        }
+
         for (const light of mesh.lightSources) {
             PrepareDefinesForLight(scene, mesh, light, lightIndex, defines, specularSupported, state);
 

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
-import { PrepareUniformsAndSamplersForLight, PrepareDefinesForBones } from "core/Materials/materialHelper.functions";
+import {
+    PrepareUniformsAndSamplersForLight,
+    PrepareDefinesForBones,
+    PrepareDefinesForLights,
+    GetSupportedSimultaneousLights,
+    BindLights,
+} from "core/Materials/materialHelper.functions";
 import { Logger } from "core/Misc/logger";
 import { type AbstractMesh } from "core/Meshes/abstractMesh";
+import { type Scene } from "core/scene";
 
 describe("PrepareUniformsAndSamplersForLight", () => {
     it("keeps clustered light tile masks as textures by default", () => {
@@ -86,5 +93,117 @@ describe("PrepareDefinesForBones uniform-budget warning", () => {
         PrepareDefinesForBones(mesh, { BONETEXTURE: false, MULTIVIEW: true });
         expect(warn).toHaveBeenCalledTimes(1);
         warn.mockRestore();
+    });
+});
+
+describe("maxSimultaneousLights clamping against the per-stage uniform buffer limit", () => {
+    // One uniform buffer per light in the vertex stage, plus the scene, mesh and material buffers, so a
+    // device reporting the WebGPU/D3D12 maximum of 12 supports 12 - 3 = 9 simultaneous lights.
+    const webGpuLimit = 12;
+    const supportedForWebGpu = 9;
+
+    const makeScene = (maxUniformBuffersPerShaderStage?: number): Scene => {
+        // A single engine instance per scene: the warning is deduped per engine, so handing out a fresh
+        // object on every getEngine() call would defeat it.
+        const engine = { getCaps: () => ({ maxUniformBuffersPerShaderStage }) };
+        return {
+            lightsEnabled: true,
+            shadowsEnabled: false,
+            activeCamera: null,
+            getEngine: () => engine,
+        } as unknown as Scene;
+    };
+
+    const spyOnWarn = () => {
+        const warn = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        warn.mockClear();
+        return warn;
+    };
+
+    const makeLight = () =>
+        ({
+            prepareLightSpecificDefines: () => {},
+            falloffType: 0,
+            specular: { equalsFloats: () => true },
+            shadowEnabled: false,
+            getShadowGenerator: () => null,
+            lightmapMode: 0,
+            _bindLight: () => {},
+        }) as any;
+
+    const makeMesh = (lightCount: number): AbstractMesh =>
+        ({
+            lightSources: new Array(lightCount).fill(null).map(makeLight),
+            receiveShadows: false,
+        }) as unknown as AbstractMesh;
+
+    const makeDefines = () => ({ _areLightsDirty: true, _needNormals: false, rebuild: () => {} }) as any;
+
+    it("reports the requested count unchanged on engines that do not report the limit", () => {
+        // WebGL and native do not enforce a per-stage uniform buffer count, so nothing should be clamped.
+        expect(GetSupportedSimultaneousLights(makeScene(undefined), 10)).toBe(10);
+    });
+
+    it("clamps the requested count to the device budget", () => {
+        expect(GetSupportedSimultaneousLights(makeScene(webGpuLimit), 10)).toBe(supportedForWebGpu);
+    });
+
+    it("leaves a request that already fits alone", () => {
+        expect(GetSupportedSimultaneousLights(makeScene(webGpuLimit), 4)).toBe(4);
+    });
+
+    it("always keeps at least one light, even on an unusually low limit", () => {
+        expect(GetSupportedSimultaneousLights(makeScene(2), 4)).toBe(1);
+    });
+
+    it("caps the generated defines at the supported count so pipeline creation stays within the limit", () => {
+        const warn = spyOnWarn();
+        const defines = makeDefines();
+        PrepareDefinesForLights(makeScene(webGpuLimit), makeMesh(10), defines, true, 10);
+        expect(defines["LIGHTCOUNT"]).toBe(supportedForWebGpu);
+        expect(defines["MAXLIGHTCOUNT"]).toBe(supportedForWebGpu);
+        expect(defines["LIGHT" + (supportedForWebGpu - 1)]).toBe(true);
+        expect(defines["LIGHT" + supportedForWebGpu]).toBeFalsy();
+        warn.mockRestore();
+    });
+
+    it("warns once, naming maxSimultaneousLights and the supported count", () => {
+        const warn = spyOnWarn();
+        const scene = makeScene(webGpuLimit);
+        PrepareDefinesForLights(scene, makeMesh(10), makeDefines(), true, 10);
+        PrepareDefinesForLights(scene, makeMesh(10), makeDefines(), true, 10); // same engine and request -> deduped
+        expect(warn).toHaveBeenCalledTimes(1);
+        const message = String(warn.mock.calls[0][0]);
+        expect(message).toContain("maxSimultaneousLights");
+        expect(message).toContain(String(supportedForWebGpu));
+        warn.mockRestore();
+    });
+
+    it("does not warn when the clamp drops no light", () => {
+        const warn = spyOnWarn();
+        // maxSimultaneousLights is over the budget, but the mesh has few enough lights that the per-light
+        // uniform buffers stay well within the limit, so there is nothing to report.
+        PrepareDefinesForLights(makeScene(webGpuLimit), makeMesh(3), makeDefines(), true, 10);
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("does not warn on engines that do not report the limit", () => {
+        const warn = spyOnWarn();
+        const defines = makeDefines();
+        PrepareDefinesForLights(makeScene(undefined), makeMesh(10), defines, true, 10);
+        expect(warn).not.toHaveBeenCalled();
+        expect(defines["LIGHTCOUNT"]).toBe(10);
+        warn.mockRestore();
+    });
+
+    it("binds no more lights than the defines declare", () => {
+        const mesh = makeMesh(10);
+        const bound: number[] = [];
+        for (const light of mesh.lightSources) {
+            light._bindLight = (index: number) => bound.push(index);
+        }
+        BindLights(makeScene(webGpuLimit), mesh, {} as any, { SPECULARTERM: false }, 10);
+        expect(bound).toHaveLength(supportedForWebGpu);
     });
 });

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -98,10 +98,10 @@ describe("PrepareDefinesForBones uniform-budget warning", () => {
 });
 
 describe("maxSimultaneousLights clamping against the per-stage uniform buffer limit", () => {
-    // One uniform buffer per light in the vertex stage, plus the scene, mesh and material buffers, so a
-    // device reporting the WebGPU/D3D12 maximum of 12 supports 12 - 3 = 9 simultaneous lights.
+    // One uniform buffer per light in the vertex stage, plus the scene, mesh, material and leftover buffers,
+    // so a device reporting the WebGPU/D3D12 maximum of 12 supports 12 - 4 = 8 simultaneous lights.
     const webGpuLimit = 12;
-    const supportedForWebGpu = 9;
+    const supportedForWebGpu = 8;
 
     const makeScene = (maxUniformBuffersPerShaderStage?: number): Scene => {
         // A single engine instance per scene: the warning is deduped per engine, so handing out a fresh
@@ -182,13 +182,13 @@ describe("maxSimultaneousLights clamping against the per-stage uniform buffer li
 
     it("reports the buffer cost of the lights in use, not of maxSimultaneousLights", () => {
         const warn = spyOnWarn();
-        // A very high cap on a mesh with 10 lights costs 10 + 3 buffers, not 64 + 3.
+        // A very high cap on a mesh with 10 lights costs 10 + 4 buffers, not 64 + 4.
         PrepareDefinesForLights(makeScene(webGpuLimit), makeMesh(10), makeDefines(), true, 64);
         expect(warn).toHaveBeenCalledTimes(1);
         const message = String(warn.mock.calls[0][0]);
         expect(message).toContain("the 10 lights affecting this mesh");
-        expect(message).toContain("13 uniform buffers");
-        expect(message).not.toContain("67 uniform buffers");
+        expect(message).toContain("14 uniform buffers");
+        expect(message).not.toContain("68 uniform buffers");
         warn.mockRestore();
     });
 
@@ -210,26 +210,29 @@ describe("maxSimultaneousLights clamping against the per-stage uniform buffer li
         warn.mockRestore();
     });
 
-    it("binds no more lights than the defines declare", () => {
+    it("binds every light the material asked for, leaving the clamp to the defines", () => {
         const mesh = makeMesh(10);
         const bound: number[] = [];
         for (const light of mesh.lightSources) {
             light._bindLight = (index: number) => bound.push(index);
         }
         BindLights(makeScene(webGpuLimit), mesh, {} as any, { SPECULARTERM: false }, 10);
-        expect(bound).toHaveLength(supportedForWebGpu);
+        // Binding is deliberately left unclamped: only PrepareDefinesForLights knows the shader was built for
+        // fewer lights, and Effect.bindUniformBuffer ignores a Light{X} buffer the effect does not declare, so
+        // the extra binds are no-ops rather than errors. Keeping this hot path free of a capability lookup
+        // matters more than the handful of redundant buffer updates.
+        expect(bound).toHaveLength(10);
     });
 
-    it("does not gate readiness on a light the shader will never use", () => {
+    it("gates readiness on every light the material asked for", () => {
         const mesh = makeMesh(10);
-        // Only the light that the clamp drops is not ready: the material should still report ready.
         for (const light of mesh.lightSources) {
             light.areLightTexturesReady = () => true;
         }
+        // Same reasoning as BindLights: readiness stays unclamped so this hot path keeps its original cost.
         mesh.lightSources[9].areLightTexturesReady = () => false;
-        expect(AreLightsTexturesReady(makeScene(webGpuLimit), mesh, 10)).toBe(true);
-        // A light that is actually used still gates readiness.
-        mesh.lightSources[0].areLightTexturesReady = () => false;
         expect(AreLightsTexturesReady(makeScene(webGpuLimit), mesh, 10)).toBe(false);
+        mesh.lightSources[9].areLightTexturesReady = () => true;
+        expect(AreLightsTexturesReady(makeScene(webGpuLimit), mesh, 10)).toBe(true);
     });
 });

--- a/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
+++ b/packages/dev/core/test/unit/Materials/materialHelper.functions.test.ts
@@ -5,6 +5,7 @@ import {
     PrepareDefinesForLights,
     GetSupportedSimultaneousLights,
     BindLights,
+    AreLightsTexturesReady,
 } from "core/Materials/materialHelper.functions";
 import { Logger } from "core/Misc/logger";
 import { type AbstractMesh } from "core/Meshes/abstractMesh";
@@ -171,11 +172,23 @@ describe("maxSimultaneousLights clamping against the per-stage uniform buffer li
         const warn = spyOnWarn();
         const scene = makeScene(webGpuLimit);
         PrepareDefinesForLights(scene, makeMesh(10), makeDefines(), true, 10);
-        PrepareDefinesForLights(scene, makeMesh(10), makeDefines(), true, 10); // same engine and request -> deduped
+        PrepareDefinesForLights(scene, makeMesh(10), makeDefines(), true, 10); // same engine and light count -> deduped
         expect(warn).toHaveBeenCalledTimes(1);
         const message = String(warn.mock.calls[0][0]);
         expect(message).toContain("maxSimultaneousLights");
         expect(message).toContain(String(supportedForWebGpu));
+        warn.mockRestore();
+    });
+
+    it("reports the buffer cost of the lights in use, not of maxSimultaneousLights", () => {
+        const warn = spyOnWarn();
+        // A very high cap on a mesh with 10 lights costs 10 + 3 buffers, not 64 + 3.
+        PrepareDefinesForLights(makeScene(webGpuLimit), makeMesh(10), makeDefines(), true, 64);
+        expect(warn).toHaveBeenCalledTimes(1);
+        const message = String(warn.mock.calls[0][0]);
+        expect(message).toContain("the 10 lights affecting this mesh");
+        expect(message).toContain("13 uniform buffers");
+        expect(message).not.toContain("67 uniform buffers");
         warn.mockRestore();
     });
 
@@ -205,5 +218,18 @@ describe("maxSimultaneousLights clamping against the per-stage uniform buffer li
         }
         BindLights(makeScene(webGpuLimit), mesh, {} as any, { SPECULARTERM: false }, 10);
         expect(bound).toHaveLength(supportedForWebGpu);
+    });
+
+    it("does not gate readiness on a light the shader will never use", () => {
+        const mesh = makeMesh(10);
+        // Only the light that the clamp drops is not ready: the material should still report ready.
+        for (const light of mesh.lightSources) {
+            light.areLightTexturesReady = () => true;
+        }
+        mesh.lightSources[9].areLightTexturesReady = () => false;
+        expect(AreLightsTexturesReady(makeScene(webGpuLimit), mesh, 10)).toBe(true);
+        // A light that is actually used still gates readiness.
+        mesh.lightSources[0].areLightTexturesReady = () => false;
+        expect(AreLightsTexturesReady(makeScene(webGpuLimit), mesh, 10)).toBe(false);
     });
 });


### PR DESCRIPTION
## Problem

On WebGPU, a scene with more lights than the device's `maxUniformBuffersPerShaderStage` budget renders **nothing at all**. `lightVxUboDeclaration` declares one uniform buffer per light in the vertex stage, so past the limit every pipeline creation is rejected by the validator, leaving only a `CreateBindGroupLayout` error to go on. The limit is 12 both as the WebGPU spec default and as the maximum a D3D12 adapter reports, so it cannot be raised through `requiredLimits`.

Fixes #18796.

## Fix

`GetSupportedSimultaneousLights(scene, maxSimultaneousLights)` returns how many lights the engine can actually render, and is called from **`PrepareDefinesForLights` only** — the cold path that decides how many per-light uniform buffers the shader declares. The scene renders with fewer lights instead of not rendering at all, and a one-off `Logger.Warn` names the requested count, the supported count and the value to set to silence it.

Engines that do not report the limit (WebGL, native) do not enforce it, so nothing is clamped there.

The vertex stage binds **4** non-light uniform buffers: `Scene`, `Mesh`, `Material` and `LeftOver`. `LeftOver` is synthesised for uniforms declared outside a uniform block and `_buildLeftOverUBO` gives it *both* vertex and fragment visibility, so it counts against the vertex budget; it exists for virtually every material (per-light shadow matrices, `logarithmicDepthConstant`, `vClipPlane`, `morphTargetCount`). On a 12-buffer device the supported count is therefore 12 − 4 = **8**. It is counted unconditionally on purpose: reserving one buffer too many costs a light in the rare shader with no leftover uniforms, whereas reserving one too few brings back the black screen.

## Why the hot paths are left unclamped

`BindLights` and `AreLightsTexturesReady` keep the raw `maxSimultaneousLights`, so neither pays for a `getCaps()` lookup per draw. `BindLights` may then bind more lights than the effect declares, which is a no-op:

- `Effect.bindUniformBuffer` returns early when `_uniformBuffersNames` has no entry for the `Light{X}` name.
- A light's uniform buffer field names carry no index (`vLightData`, not `vLightData0`), so binding at an undeclared index cannot corrupt its layout.
- `setTexture` / `setMatrix` on undeclared names are already no-ops.

The cost is a few redundant buffer updates in scenes that are over budget.

## Tests

18 unit tests in `materialHelper.functions.test.ts` cover the clamp, the "at least one light" floor, the pass-through on engines that do not report the limit, the warning text and its per-engine dedup, and the deliberate lack of clamping in the two hot paths.
