### PR TITLE
Native nightly: downlevel every bundle, not just babylon.max.js

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -1008,9 +1008,16 @@ jobs:
           # migration forces the core UMD bundle to an ES2015 target (the `accessor` keyword requires
           # it), so it must be downleveled to ES5 for BOTH the unit tests and the playground before
           # either is executed.
+          #
+          # The directory is passed rather than a single file. The step above refills every
+          # `babylon*` file in these directories from the CDN snapshot, so naming one file makes the
+          # downlevel an allowlist of one: a bundle added to the Native script set later is refilled
+          # from the snapshot but never downleveled, and fails at parse time on Chakra with nothing
+          # pointing at the cause. `downlevelNativeScripts.mjs` walks a directory and selects
+          # `babylon*.js` itself, which is the same set the refill loop uses.
           - script: |
-                npm run downlevel:native-scripts -- ..\BabylonNativeNightlyUnitTests\RelWithDebInfo\Assets\babylon.max.js
-            displayName: "Downlevel core script for Native (unit tests)"
+                npm run downlevel:native-scripts -- ..\BabylonNativeNightlyUnitTests\RelWithDebInfo\Assets
+            displayName: "Downlevel scripts for Native (unit tests)"
 
           - script: |
                 cd
@@ -1020,8 +1027,8 @@ jobs:
             retryCountOnTaskFailure: 3
 
           - script: |
-                npm run downlevel:native-scripts -- ..\BabylonNativeNightlyPlayground\RelWithDebInfo\Scripts\babylon.max.js
-            displayName: "Downlevel core script for Native (visualization)"
+                npm run downlevel:native-scripts -- ..\BabylonNativeNightlyPlayground\RelWithDebInfo\Scripts
+            displayName: "Downlevel scripts for Native (visualization)"
 
           - script: |
                 cd


### PR DESCRIPTION
The "Update scripts from snapshot" step refills **every** `babylon*` file in the two Babylon Native artifact directories from the CDN snapshot:

```bat
set destDir=..\BabylonNativeNightlyPlayground\RelWithDebInfo\Scripts
for /f %%i in ('dir /b %destDir%\babylon*') do (
  unzip -p snapshot.zip "**%%i" > %destDir%\%%i
)
```

...but the downlevel that follows names a single file:

```bat
npm run downlevel:native-scripts -- ..\BabylonNativeNightlyPlayground\RelWithDebInfo\Scripts\babylon.max.js
```

So the refill is a glob and the downlevel is an allowlist of one. Any bundle added to the Native script set later gets refilled from the snapshot and then executed **un-downleveled**, which on Chakra surfaces as a parse error at load with nothing pointing at the cause.

This passes the directory instead. `scripts/downlevelNativeScripts.mjs` already walks a directory and selects files itself with `/^babylon.*\.js$/i` — the same set the refill loop uses — so no change to the script is needed.

### Please note: this is not a pure no-op

Six bundles are currently refilled from the snapshot but never downleveled, and this makes them transpiled too. Syntax actually present in each bundle on the CDN today:

| bundle | downleveled today | `?.` | `#priv` | `**` | `async` | `function*` |
|---|---|---|---|---|---|---|
| `babylon.max.js` | **yes** | 19 | 2 | 74 | 1 | 631 |
| `babylonjs.loaders.js` | no | 2 | 0 | 0 | 0 | 148 |
| `babylonjs.serializers.js` | no | 2 | 0 | 0 | 0 | 62 |
| `babylonjs.addons.js` | no | 1 | 0 | 6 | 0 | 17 |
| `babylonjs.materials.js` | no | 0 | 0 | 3 | 0 | 14 |
| `babylon.gui.js` | no | 0 | 0 | 0 | 0 | 18 |
| `babylonjs.proceduralTextures.js` | n/a (not yet shipped) | 0 | 0 | 0 | 0 | 0 |

All seven are emitted at an ES2015 target, so transpiling them is the intended direction rather than a workaround — but it is a behavior change, and it costs some CI time. Flagging it explicitly rather than describing this as a no-op.

### Verification

Ran the existing script against a directory laid out like the artifact:

```
babylon.max.js                    -> downleveled  (var / function / Math.pow)
babylonjs.proceduralTextures.js   -> downleveled  (var / function)
babylon.max.js.map                -> untouched    (.js anchor excludes maps)
earcut.min.js                     -> untouched    (not babylon*)
ammo.js                           -> untouched    (not babylon*)
```

`ci-monorepo.yml` still parses as YAML.

### Context

Prompted by BabylonJS/BabylonNative#1823, which adds `babylonjs.proceduralTextures.js` to the Playground script set. Per review there, this needs to land first: naming the new file on this side would fail until it exists in the Native artifact, whereas globbing the directory is correct both before and after.
