### PR TITLE
Fix Reflector bridge relay dropping and crashing on client messages

### DIFF
--- a/packages/dev/inspector-v2/src/extensibility/defaultInspectorExtensionFeed.ts
+++ b/packages/dev/inspector-v2/src/extensibility/defaultInspectorExtensionFeed.ts
@@ -30,8 +30,9 @@ export const DefaultInspectorExtensionFeed = new BuiltInsExtensionFeed("Inspecto
     },
     {
         name: "Reflector",
-        description: "Connects to the Reflector Bridge for real-time scene synchronization with the Babylon.js Sandbox.",
-        keywords: ["reflector", "bridge", "sync", "sandbox", "tools"],
+        description:
+            "Sends a serialized snapshot of the scene to the Babylon.js Sandbox through the Reflector Bridge. The snapshot is sent once and is read-only, so it does not stay in sync with this scene.",
+        keywords: ["reflector", "bridge", "snapshot", "sync", "sandbox", "tools"],
         ...BabylonWebResources,
         getExtensionModuleAsync: async () => await import("../services/panes/tools/reflectorService"),
     },

--- a/packages/tools/reflector/src/index.ts
+++ b/packages/tools/reflector/src/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { WebSocketServer } from "ws";
+import { type RawData, type WebSocket, WebSocketServer } from "ws";
 import { readFileSync } from "fs";
 import { createServer } from "https";
 import { resolve } from "path";
@@ -31,7 +31,9 @@ class Server {
 
             this._checkClients();
 
-            this._server.on("message", (message: string) => {
+            client.on("message", (data: RawData) => {
+                // ws delivers a Buffer/ArrayBuffer, so convert to text before inspecting or relaying it.
+                const message = data.toString();
                 console.log(`Received message from client ${client._id}: ${message.substring(0, 64)}`);
 
                 if (!client._other) {
@@ -43,7 +45,7 @@ class Server {
                 client._other.send(message);
             });
 
-            this._server.on("close", (code: any, reason: any) => {
+            client.on("close", (code: number, reason: Buffer) => {
                 console.log(`Client ${client._id} disconnected: ${code} ${reason}`);
                 if (client._other) {
                     delete client._other._other;

--- a/packages/tools/reflector/src/index.ts
+++ b/packages/tools/reflector/src/index.ts
@@ -9,6 +9,20 @@ interface IWebSocketInfo extends WebSocket {
     _other?: IWebSocketInfo;
 }
 
+function ToMessageText(data: RawData): string {
+    // ws can deliver a single Buffer, an ArrayBuffer, or an array of Buffer fragments, depending on
+    // the binaryType and how the message was framed, so normalize all of them to text.
+    if (Array.isArray(data)) {
+        return Buffer.concat(data).toString();
+    }
+
+    if (Buffer.isBuffer(data)) {
+        return data.toString();
+    }
+
+    return Buffer.from(data).toString();
+}
+
 class Server {
     private _nextClientId = 0;
     private _server: WebSocketServer;
@@ -32,8 +46,7 @@ class Server {
             this._checkClients();
 
             client.on("message", (data: RawData) => {
-                // ws delivers a Buffer/ArrayBuffer, so convert to text before inspecting or relaying it.
-                const message = data.toString();
+                const message = ToMessageText(data);
                 console.log(`Received message from client ${client._id}: ${message.substring(0, 64)}`);
 
                 if (!client._other) {


### PR DESCRIPTION
## Problem

The Reflector bridge has been completely broken since the relay was moved into `packages/tools/reflector` in 4bd154db56 (March 2022). No scene payload has ever reached the sandbox since then.

Two separate bugs in the relay, the second hidden behind the first:

**1. Handlers registered on the server instead of the client socket**

`packages/tools/reflector/src/index.ts` registered the `message` and `close` handlers on the `WebSocketServer` (`this._server`) rather than on the individual client socket. `WebSocketServer` never emits `"message"` or `"close"`, so every payload a client sent was silently dropped and disconnects were never detected.

The root cause is the `IWebSocketInfo` interface, which extended the **DOM** `WebSocket` type rather than the one from `ws`, because the root tsconfig includes the DOM lib. The DOM type has no `on()` method, so `client.on(...)` failed to typecheck and was changed to `this._server.on(...)`, which compiles but never fires.

**2. `ws` v8 delivers a `Buffer`, not a `string`**

Once the handler is attached to the right object, `message.substring(0, 64)` throws a `TypeError` and takes the relay process down.

## Fix

- `IWebSocketInfo` now extends the `WebSocket` type imported from `ws`, so `client.on(...)` typechecks correctly.
- `message` and `close` are registered on the client socket.
- Incoming `RawData` is converted with `toString()` before being logged and relayed. This also ensures the payload arrives at the sandbox as text rather than as a `Blob`, which the sandbox's `message.startsWith` check requires.

## Extension description

Also corrects the Inspector Reflector extension description, which claimed "real-time scene synchronization". The Reflector sends a single serialized snapshot when the bridge reports `connected`, and ignores everything it receives afterwards (`_handleClientMessage` is a no-op), so it is neither real-time nor a synchronization.

## Testing

Verified end to end with a Babylon scene running in a web worker with no DOM (`typeof document === "undefined"`), which was the scenario from https://forum.babylonjs.com/t/how-can-i-activate-the-babylon-inspector-when-my-game-is-running-in-a-web-worker/63937:

1. Worker calls `new BABYLON.Reflector(scene, "localhost", 1234)` and sends a 441 KB `load|{...}` payload.
2. Relay logs `Received message from client 1: load|{...` and forwards it. Neither line appeared before this change.
3. Sandbox at `http://localhost:1339/?reflector` loads the scene and opens the Inspector, showing both meshes from the worker scene.
4. Closing the worker tab produces `Client 1 disconnected: 1001` followed by the `disconnected` broadcast, exercising the previously dead `close` handler.

Note that the Reflector remains a one-time, read-only snapshot. This PR restores the feature to its intended behaviour; it does not make it live.
