### PR TITLE
Fix particle node material async shader creation

### DIFF
--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -1579,8 +1579,12 @@ export class NodeMaterial extends NodeMaterialBase {
         // ParticleTextureBlock loads shader includes asynchronously. Wait for the build to produce
         // shader code instead of registering an empty fragment shader that falls back to a URL.
         if (!this._buildWasSuccessful) {
-            this.onBuildObservable.addOnce(() => {
+            const buildObserver = this.onBuildObservable.addOnce(() => {
+                this.onBuildErrorObservable.remove(errorObserver);
                 this.createEffectForParticles(particleSystem, onCompiled, onError);
+            });
+            const errorObserver = this.onBuildErrorObservable.addOnce(() => {
+                this.onBuildObservable.remove(buildObserver);
             });
 
             if (!this._buildIsInProgress) {

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -1563,7 +1563,9 @@ export class NodeMaterial extends NodeMaterialBase {
     }
 
     /**
-     * Create the effect to be used as the custom effect for a particle system
+     * Create the effect to be used as the custom effect for a particle system.
+     * If the material has not been built successfully yet, the build is started when needed and the effect is only
+     * created once it completes, so the effect may not be set on the particle system when this method returns.
      * @param particleSystem Particle system to create the effect for
      * @param onCompiled defines a function to call when the effect creation is successful
      * @param onError defines a function to call when the effect creation has failed

--- a/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
+++ b/packages/dev/core/src/Materials/Node/nodeMaterial.pure.ts
@@ -1574,6 +1574,20 @@ export class NodeMaterial extends NodeMaterialBase {
             return;
         }
 
+        // ParticleTextureBlock loads shader includes asynchronously. Wait for the build to produce
+        // shader code instead of registering an empty fragment shader that falls back to a URL.
+        if (!this._buildWasSuccessful) {
+            this.onBuildObservable.addOnce(() => {
+                this.createEffectForParticles(particleSystem, onCompiled, onError);
+            });
+
+            if (!this._buildIsInProgress) {
+                this.build();
+            }
+
+            return;
+        }
+
         this._createEffectForParticles(particleSystem, BaseParticleSystem.BLENDMODE_ONEONE, onCompiled, onError);
         this._createEffectForParticles(particleSystem, BaseParticleSystem.BLENDMODE_MULTIPLY, onCompiled, onError);
     }

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
@@ -125,6 +125,32 @@ describe("NodeMaterial effect creation with an asynchronous build", () => {
         registerSpy.mockRestore();
     });
 
+    it("starts the build itself when creating a particle effect on a material that was never built", async () => {
+        const material = new NodeMaterial("node", scene);
+        material.setToDefaultParticle();
+
+        const registerSpy = vi.spyOn(Effect, "RegisterShader");
+        const particleEffect = { onBindObservable: { add: vi.fn() } } as unknown as Effect;
+        vi.spyOn(engine, "createEffectForParticles").mockReturnValue(particleEffect);
+        const setCustomEffect = vi.fn();
+        const particleSystem = {
+            fillDefines: vi.fn(),
+            setCustomEffect,
+        } as unknown as IParticleSystem;
+
+        material.createEffectForParticles(particleSystem);
+
+        expect(material.buildIsInProgress).toBe(true);
+        expect(registerSpy.mock.calls.filter(([, pixelShader]) => !pixelShader)).toHaveLength(0);
+
+        await waitForBuild(material);
+
+        // One custom effect per blend mode, created only once the build produced real shader code.
+        expect(setCustomEffect).toHaveBeenCalledTimes(2);
+
+        registerSpy.mockRestore();
+    });
+
     it("registers the post process shaders with the material shader language (WGSL)", async () => {
         vi.spyOn(engine, "isWebGPU", "get").mockReturnValue(true);
         const material = new NodeMaterial("node", scene, { shaderLanguage: ShaderLanguage.WGSL });

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
@@ -151,6 +151,22 @@ describe("NodeMaterial effect creation with an asynchronous build", () => {
         registerSpy.mockRestore();
     });
 
+    it("removes the deferred particle observer when the build fails", async () => {
+        const material = new NodeMaterial("node", scene);
+        material.setToDefaultParticle();
+        const particleSystem = {} as IParticleSystem;
+        const buildSpy = vi.spyOn(material, "build").mockImplementation(() => {
+            material.onBuildErrorObservable.notifyObservers("build failed");
+        });
+
+        material.createEffectForParticles(particleSystem);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(buildSpy).toHaveBeenCalledOnce();
+        expect(material.onBuildObservable.observers).toHaveLength(0);
+        expect(material.onBuildErrorObservable.observers).toHaveLength(0);
+    });
+
     it("registers the post process shaders with the material shader language (WGSL)", async () => {
         vi.spyOn(engine, "isWebGPU", "get").mockReturnValue(true);
         const material = new NodeMaterial("node", scene, { shaderLanguage: ShaderLanguage.WGSL });

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.asyncBuild.test.ts
@@ -5,13 +5,15 @@ import { ShaderLanguage } from "core/Materials/shaderLanguage";
 import { FreeCamera } from "core/Cameras/freeCamera";
 import { Vector3 } from "core/Maths/math.vector";
 import { Scene } from "core/scene";
+import { type IParticleSystem } from "core/Particles/IParticleSystem";
+import "core/Particles/particleSystemComponent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Some node material blocks (e.g. CurrentScreenBlock) load their shader code through an asynchronous
+// Some node material blocks (e.g. CurrentScreenBlock and ParticleTextureBlock) load their shader code through an asynchronous
 // dynamic import, so NodeMaterial.build() can finish after it returns. createPostProcess /
-// createProceduralTexture used to read the (still empty) compilation strings synchronously and register
+// createProceduralTexture / createEffectForParticles used to read the (still empty) compilation strings synchronously and register
 // empty shaders, which made the engine try to fetch the shaders from a URL and fail with a 404 - leaving
-// the NME preview blank in Post Process / Smart Filter / Procedural modes. These tests lock in that the
+// the NME preview blank in Post Process / Smart Filter / Procedural / Particle modes. These tests lock in that the
 // effect creation is deferred until the build has produced real (non-empty) shader code.
 describe("NodeMaterial effect creation with an asynchronous build", () => {
     let engine: NullEngine;
@@ -93,6 +95,34 @@ describe("NodeMaterial effect creation with an asynchronous build", () => {
 
         registerSpy.mockRestore();
         proceduralTexture?.dispose();
+    });
+
+    it("defers particle shader registration until the asynchronous build completes", async () => {
+        const material = new NodeMaterial("node", scene);
+        material.setToDefaultParticle();
+        material.build();
+
+        expect(material.buildIsInProgress).toBe(true);
+
+        const registerSpy = vi.spyOn(Effect, "RegisterShader");
+        const particleEffect = { onBindObservable: { add: vi.fn() } } as unknown as Effect;
+        vi.spyOn(engine, "createEffectForParticles").mockReturnValue(particleEffect);
+        const particleSystem = {
+            fillDefines: vi.fn(),
+            setCustomEffect: vi.fn(),
+        } as unknown as IParticleSystem;
+
+        material.createEffectForParticles(particleSystem);
+
+        const emptyShaderRegistrations = registerSpy.mock.calls.filter(([, pixelShader]) => !pixelShader);
+
+        await waitForBuild(material);
+
+        const registeredRealShader = registerSpy.mock.calls.some(([name, pixelShader]) => typeof name === "string" && name.startsWith("node") && !!pixelShader);
+        expect(emptyShaderRegistrations).toHaveLength(0);
+        expect(registeredRealShader).toBe(true);
+
+        registerSpy.mockRestore();
     });
 
     it("registers the post process shaders with the material shader language (WGSL)", async () => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Wait for asynchronous node material builds before creating particle effects.
- Prevent empty particle fragment shaders from falling back to shader URL requests.
- Remove deferred build observers when particle material builds fail.
- Add regression coverage for in-progress, build-on-demand, and failed particle builds.

## Motivation
NME Particle mode can create its effects before `ParticleTextureBlock` finishes loading shader includes. This registers empty fragment sources, causing `/src/Shaders/*.fragment.fx` requests and a broken particle preview in production.

## Testing
- Async node material build tests: 7/7 passed
- Materials unit tests: 253/253 passed
- Particles unit tests: 202/202 passed
- Core TypeScript build passed
- Repository format and lint checks passed
- Full unit run: 4,611 tests passed; remaining failures reproduce existing Windows path and unrelated timeout issues
