### PR TITLE
Fix three IBL rendering bugs: AreaLights prefilter type, OpenPBR anisotropic inlining, black diffuse fallback

### DIFF
--- a/packages/dev/core/src/Materials/Textures/envCubeTexture.pure.ts
+++ b/packages/dev/core/src/Materials/Textures/envCubeTexture.pure.ts
@@ -224,8 +224,13 @@ export abstract class EnvCubeTexture extends BaseTexture {
             // Extract the raw linear data.
             const data = await this._getCubeMapTextureDataAsync(buffer, this._size, this._supersample);
 
-            // Generate harmonics if needed.
-            if (this._generateHarmonics) {
+            // Generate harmonics if needed. When prefiltering was requested but the engine cannot
+            // prefilter textures (e.g. Babylon Native or WebGL1), neither a prefiltered irradiance
+            // map nor a prefiltered radiance cube is produced. In that case fall back to
+            // CPU-computed spherical harmonics so diffuse IBL still has a source; without this the
+            // reflection texture keeps an empty spherical polynomial and diffuse IBL renders black.
+            const prefilterUnavailable = (this._prefilterOnLoad || this._prefilterIrradianceOnLoad) && !engine._features.allowTexturePrefiltering;
+            if (this._generateHarmonics || prefilterUnavailable) {
                 const sphericalPolynomial = CubeMapToSphericalPolynomialTools.ConvertCubeMapToSphericalPolynomial(data, this._sphericalPolynomialTargetSize);
                 this.sphericalPolynomial = sphericalPolynomial;
             }

--- a/packages/dev/core/src/Misc/areaLightsTextureTools.ts
+++ b/packages/dev/core/src/Misc/areaLightsTextureTools.ts
@@ -153,7 +153,7 @@ export class AreaLightTextureTools {
                 generateMipMaps: true,
                 generateStencilBuffer: false,
                 samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE,
-                type: Constants.TEXTURE_2D,
+                type: Constants.TEXTURETYPE_UNSIGNED_BYTE,
                 format: Constants.TEXTUREFORMAT_RGBA,
             }
         );

--- a/packages/dev/core/src/Shaders/ShadersInclude/hdrFilteringFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/hdrFilteringFunctions.fx
@@ -397,7 +397,7 @@
             // Compute effective dimension scaled by anisotropy for proper solid angle
             float effectiveDim = dim0 * sqrt(clampedAlphaT * clampedAlphaB);
             float omegaP = (4. * PI) / (6. * effectiveDim * effectiveDim);
-            const float noiseScale = clamp(log2(float(NUM_SAMPLES)) / 12.0f, 0.0f, 1.0f);
+            const float noiseScale = clamp(log2(float(NUM_SAMPLES)) / 12.0, 0.0, 1.0);
             float weight = 0.;
             
             #if defined(WEBGL2) || defined(WEBGPU) || defined(NATIVE)
@@ -409,7 +409,7 @@
                 vec2 Xi = hammersley(i, NUM_SAMPLES);
                 
                 // Add noise to sample coordinates to break up sampling artifacts
-                Xi = fract(Xi + noiseInput * mix(0.5f, 0.015f, noiseScale)); // Wrap around to stay in [0,1] range
+                Xi = fract(Xi + noiseInput * mix(0.5, 0.015, noiseScale)); // Wrap around to stay in [0,1] range
 
                 // Generate anisotropic half vector using importance sampling
                 vec3 H_tangent = hemisphereImportanceSampleDggxAnisotropic(Xi, clampedAlphaT, clampedAlphaB);

--- a/packages/dev/core/src/Shaders/ShadersInclude/openpbrIblFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/openpbrIblFunctions.fx
@@ -248,12 +248,7 @@
                 bitangent.z *= -1.0;
                 normal.z *= -1.0;
             #endif
-            environmentRadiance =
-                vec4(radianceAnisotropic(alphaT, alphaB, reflectionSampler,
-                                     view, tangent,
-                                     bitangent, normal,
-                                     vReflectionFilteringInfo, noise.xy, isRefraction, ior),
-                 1.0);
+            environmentRadiance = vec4(radianceAnisotropic(alphaT, alphaB, reflectionSampler, view, tangent, bitangent, normal, vReflectionFilteringInfo, noise.xy, isRefraction, ior), 1.0);
         #else
             // We will sample multiple reflections using interpolated surface normals along
             // the tangent direction from -tangent to +tangent.


### PR DESCRIPTION
Three small, independent rendering fixes found while bringing Babylon Native to parity with Babylon.js. None changes WebGL or WebGPU output.

1. **`AreaLights` prefilter render target** — `areaLightsTextureTools.ts` passed a texture *format* where a texture *type* was expected.

2. **OpenPBR anisotropic IBL: one-line `radianceAnisotropic` call.** Purely syntactic. Babylon's shader inliner (`#define inline`) mishandles multi-line call statements: it dropped the `environmentRadiance =` assignment target and emitted a bare `vec4(radianceAnisotropic_0, 1.0);`. On Babylon Native that is a fragment compile error, which sent `_prepareEffect`/`_processCompilationErrors` into an infinite retry loop and hung the scene. Collapsing the call matches the already-single-line `radiance()` call. Also drops `f` float suffixes (`0.5f` → `0.5`), which GLSL ES rejects — same values.

3. **Black diffuse IBL without texture prefiltering.** When a cube texture requests `prefilterOnLoad`/`prefilterIrradianceOnLoad` but the engine reports `allowTexturePrefiltering = false` (Babylon Native, WebGL 1), no prefiltered irradiance or radiance is produced, the spherical polynomial stays empty, and diffuse IBL renders pure black. Falls back to CPU spherical harmonics. Gated on `!allowTexturePrefiltering`, which is `true` on WebGL 2 and WebGPU, so it is inert there by construction.

**Testing** — `tsc --noEmit`, `eslint` and `vitest --project=unit` (4603 tests) all equal to the `master` baseline; visualization tests green on WebGL 2 and WebGPU.

> **Note:** an earlier revision also capped HDR radiance prefiltering to source mip 0 for float cubes. That was a WebGL regression — it made the GGX convolution sample only the top mip and shifted 13 OpenPBR IBL reference images — and has been removed. See the comment below.
