### PR TITLE
[Native] Load single-file prefiltered cube containers and implement setStateCullFaceType

### DIFF
--- a/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
+++ b/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
@@ -126,7 +126,15 @@ export function RegisterNativeEngineCubeTexture(): void {
                 // eslint-disable-next-line github/no-then
                 .then(async (data) => {
                     return await new Promise<void>((resolve, reject) => {
-                        this._engine.loadCubeTexture(texture._hardwareTexture!.underlyingResource, data, !noMipmap, true, texture._useSRGBBuffer, () => resolve(), reject);
+                        this._engine.loadCubeTexture(
+                            texture._hardwareTexture!.underlyingResource,
+                            data,
+                            !noMipmap,
+                            true,
+                            texture._useSRGBBuffer,
+                            () => resolve(),
+                            () => reject(new Error("Native engine failed to load the cubemap faces"))
+                        );
                     });
                 })
                 // eslint-disable-next-line github/no-then
@@ -139,7 +147,7 @@ export function RegisterNativeEngineCubeTexture(): void {
                     },
                     (error) => {
                         if (onError) {
-                            onError(`Failed to load cubemap: ${error?.message}`, error);
+                            onError(`Failed to load cubemap: ${error?.message ?? String(error)}`, error);
                         }
                     }
                 );
@@ -149,7 +157,7 @@ export function RegisterNativeEngineCubeTexture(): void {
             // the native engine, which parses the container directly and returns the diffuse spherical
             // harmonics (as a 27-float SphericalPolynomial) so PBR irradiance matches the web engines.
             const singleUrl = files && files.length > 0 ? files[0] : rootUrl;
-            // eslint-disable-next-line github/no-then
+
             this._loadFileAsync(singleUrl, undefined, true)
                 // eslint-disable-next-line github/no-then
                 .then(async (data) => {
@@ -177,7 +185,7 @@ export function RegisterNativeEngineCubeTexture(): void {
                                 }
                                 resolve();
                             },
-                            reject
+                            () => reject(new Error(`Native engine failed to parse the cubemap container '${singleUrl}'`))
                         );
                     });
                 })
@@ -191,7 +199,7 @@ export function RegisterNativeEngineCubeTexture(): void {
                     },
                     (error) => {
                         if (onError) {
-                            onError(`Failed to load cubemap: ${error?.message}`, error);
+                            onError(`Failed to load cubemap: ${error?.message ?? String(error)}`, error);
                         }
                     }
                 );

--- a/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
+++ b/packages/dev/core/src/Engines/Native/Extensions/nativeEngine.cubeTexture.pure.ts
@@ -6,6 +6,7 @@ import { CreateRadianceImageDataArrayBufferViews, GetEnvInfo, UploadEnvSpherical
 import { type IWebRequest } from "../../../Misc/interfaces/iWebRequest";
 import { type Scene } from "../../../scene.pure";
 import { type Nullable } from "../../../types";
+import { SphericalPolynomial } from "../../../Maths/sphericalPolynomial.pure";
 import { Constants } from "../../constants";
 import { ThinNativeEngine } from "../../thinNativeEngine.pure";
 
@@ -117,11 +118,7 @@ export function RegisterNativeEngineCubeTexture(): void {
                     onInternalError
                 );
             }
-        } else {
-            if (!files || files.length !== 6) {
-                throw new Error("Cannot load cubemap because 6 files were not defined");
-            }
-
+        } else if (files && files.length === 6) {
             // Reorder from [+X, +Y, +Z, -X, -Y, -Z] to [+X, -X, +Y, -Y, +Z, -Z].
             const reorderedFiles = [files[0], files[3], files[1], files[4], files[2], files[5]];
             // eslint-disable-next-line github/no-then
@@ -129,7 +126,7 @@ export function RegisterNativeEngineCubeTexture(): void {
                 // eslint-disable-next-line github/no-then
                 .then(async (data) => {
                     return await new Promise<void>((resolve, reject) => {
-                        this._engine.loadCubeTexture(texture._hardwareTexture!.underlyingResource, data, !noMipmap, true, texture._useSRGBBuffer, resolve, reject);
+                        this._engine.loadCubeTexture(texture._hardwareTexture!.underlyingResource, data, !noMipmap, true, texture._useSRGBBuffer, () => resolve(), reject);
                     });
                 })
                 // eslint-disable-next-line github/no-then
@@ -142,10 +139,64 @@ export function RegisterNativeEngineCubeTexture(): void {
                     },
                     (error) => {
                         if (onError) {
-                            onError(`Failed to load cubemap: ${error.message}`, error);
+                            onError(`Failed to load cubemap: ${error?.message}`, error);
                         }
                     }
                 );
+        } else if (!files || files.length <= 1) {
+            // Self-contained single-file cubemap container (.dds / .ktx / .ktx2) that already holds
+            // all six faces (and their prefiltered mip chain). Load the single buffer and hand it to
+            // the native engine, which parses the container directly and returns the diffuse spherical
+            // harmonics (as a 27-float SphericalPolynomial) so PBR irradiance matches the web engines.
+            const singleUrl = files && files.length > 0 ? files[0] : rootUrl;
+            // eslint-disable-next-line github/no-then
+            this._loadFileAsync(singleUrl, undefined, true)
+                // eslint-disable-next-line github/no-then
+                .then(async (data) => {
+                    const buffer = new Uint8Array(data, 0, data.byteLength);
+                    return await new Promise<void>((resolve, reject) => {
+                        this._engine.loadCubeTexture(
+                            texture._hardwareTexture!.underlyingResource,
+                            [buffer],
+                            !noMipmap,
+                            false,
+                            texture._useSRGBBuffer,
+                            (sphericalPolynomial?: ArrayLike<number>) => {
+                                if (createPolynomials && sphericalPolynomial && sphericalPolynomial.length >= 27) {
+                                    const sp = new SphericalPolynomial();
+                                    sp.x.copyFromFloats(sphericalPolynomial[0], sphericalPolynomial[1], sphericalPolynomial[2]);
+                                    sp.y.copyFromFloats(sphericalPolynomial[3], sphericalPolynomial[4], sphericalPolynomial[5]);
+                                    sp.z.copyFromFloats(sphericalPolynomial[6], sphericalPolynomial[7], sphericalPolynomial[8]);
+                                    sp.xx.copyFromFloats(sphericalPolynomial[9], sphericalPolynomial[10], sphericalPolynomial[11]);
+                                    sp.yy.copyFromFloats(sphericalPolynomial[12], sphericalPolynomial[13], sphericalPolynomial[14]);
+                                    sp.zz.copyFromFloats(sphericalPolynomial[15], sphericalPolynomial[16], sphericalPolynomial[17]);
+                                    sp.yz.copyFromFloats(sphericalPolynomial[18], sphericalPolynomial[19], sphericalPolynomial[20]);
+                                    sp.zx.copyFromFloats(sphericalPolynomial[21], sphericalPolynomial[22], sphericalPolynomial[23]);
+                                    sp.xy.copyFromFloats(sphericalPolynomial[24], sphericalPolynomial[25], sphericalPolynomial[26]);
+                                    texture._sphericalPolynomial = sp;
+                                }
+                                resolve();
+                            },
+                            reject
+                        );
+                    });
+                })
+                // eslint-disable-next-line github/no-then
+                .then(
+                    () => {
+                        texture.isReady = true;
+                        if (onLoad) {
+                            onLoad();
+                        }
+                    },
+                    (error) => {
+                        if (onError) {
+                            onError(`Failed to load cubemap: ${error?.message}`, error);
+                        }
+                    }
+                );
+        } else {
+            throw new Error("Cannot load cubemap because 6 files were not defined");
         }
 
         this._internalTexturesCache.push(texture);

--- a/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
+++ b/packages/dev/core/src/Engines/Native/nativeInterfaces.ts
@@ -95,7 +95,15 @@ export interface INativeEngine {
         generateMipMaps: boolean,
         invertY: boolean
     ): void;
-    loadCubeTexture(texture: NativeTexture, data: Array<ArrayBufferView>, generateMips: boolean, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
+    loadCubeTexture(
+        texture: NativeTexture,
+        data: Array<ArrayBufferView>,
+        generateMips: boolean,
+        invertY: boolean,
+        srgb: boolean,
+        onSuccess: (sphericalPolynomial?: ArrayLike<number>) => void,
+        onError: () => void
+    ): void;
     loadCubeTextureWithMips(texture: NativeTexture, data: Array<Array<ArrayBufferView>>, invertY: boolean, srgb: boolean, onSuccess: () => void, onError: () => void): void;
     getTextureWidth(texture: NativeTexture): number;
     getTextureHeight(texture: NativeTexture): number;

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -240,6 +240,9 @@ export class ThinNativeEngine extends ThinEngine {
     private _stencilOpStencilDepthPass: number;
     private _zOffset: number;
     private _zOffsetUnits: number;
+    private _cachedCulling: boolean;
+    private _cachedReverseSide: boolean;
+    private _cachedCullBackFaces: boolean;
     private _depthWrite: boolean;
     // warning for non supported fill mode has already been displayed
     private _fillModeWarningDisplayed: boolean;
@@ -282,6 +285,9 @@ export class ThinNativeEngine extends ThinEngine {
         this._stencilOpStencilDepthPass = Constants.REPLACE;
         this._zOffset = 0;
         this._zOffsetUnits = 0;
+        this._cachedCulling = true;
+        this._cachedReverseSide = false;
+        this._cachedCullBackFaces = true;
         this._depthWrite = true;
         // warning for non supported fill mode has already been displayed
         this._fillModeWarningDisplayed = false;
@@ -1016,8 +1022,22 @@ export class ThinNativeEngine extends ThinEngine {
         this._commandBufferEncoder.finishEncodingCommand();
     }
 
-    public override setStateCullFaceType(_cullBackFaces?: boolean, _force?: boolean): void {
-        throw new Error("setStateCullFaceType: Not Implemented");
+    public override setStateCullFaceType(cullBackFaces?: boolean, force?: boolean): void {
+        const cullBack = this.cullBackFaces ?? cullBackFaces ?? true;
+        if (this._cachedCullBackFaces === cullBack && !force) {
+            return;
+        }
+        this._cachedCullBackFaces = cullBack;
+
+        // Native uses an immediate command-buffer state model (no lazy _depthCullingState),
+        // so re-issue the full render state preserving the cached culling/zOffset/reverseSide.
+        this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_SETSTATE);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(this._cachedCulling ? 1 : 0);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(this._zOffset);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(this._zOffsetUnits);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(cullBack ? 1 : 0);
+        this._commandBufferEncoder.encodeCommandArgAsUInt32(this._cachedReverseSide ? 1 : 0);
+        this._commandBufferEncoder.finishEncodingCommand();
     }
 
     public override setState(
@@ -1042,6 +1062,11 @@ export class ThinNativeEngine extends ThinEngine {
         this._commandBufferEncoder.encodeCommandArgAsUInt32((this.cullBackFaces ?? cullBackFaces ?? true) ? 1 : 0);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(reverseSide ? 1 : 0);
         this._commandBufferEncoder.finishEncodingCommand();
+
+        // Cache the resolved state so setStateCullFaceType() can re-issue it with a new cull face.
+        this._cachedCulling = culling;
+        this._cachedReverseSide = reverseSide;
+        this._cachedCullBackFaces = this.cullBackFaces ?? cullBackFaces ?? true;
     }
 
     /**

--- a/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
+++ b/packages/dev/core/src/Engines/thinNativeEngine.pure.ts
@@ -243,6 +243,8 @@ export class ThinNativeEngine extends ThinEngine {
     private _cachedCulling: boolean;
     private _cachedReverseSide: boolean;
     private _cachedCullBackFaces: boolean;
+    private _cachedZOffset: number;
+    private _cachedZOffsetUnits: number;
     private _depthWrite: boolean;
     // warning for non supported fill mode has already been displayed
     private _fillModeWarningDisplayed: boolean;
@@ -288,6 +290,8 @@ export class ThinNativeEngine extends ThinEngine {
         this._cachedCulling = true;
         this._cachedReverseSide = false;
         this._cachedCullBackFaces = true;
+        this._cachedZOffset = 0;
+        this._cachedZOffsetUnits = 0;
         this._depthWrite = true;
         // warning for non supported fill mode has already been displayed
         this._fillModeWarningDisplayed = false;
@@ -1029,12 +1033,15 @@ export class ThinNativeEngine extends ThinEngine {
         }
         this._cachedCullBackFaces = cullBack;
 
-        // Native uses an immediate command-buffer state model (no lazy _depthCullingState),
-        // so re-issue the full render state preserving the cached culling/zOffset/reverseSide.
+        // Native uses an immediate command-buffer state model (no lazy _depthCullingState), so
+        // re-issue the last COMMAND_SETSTATE payload with only the cull face changed. The zOffset
+        // values are the ones that command actually encoded rather than the live _zOffset fields,
+        // which setZOffset()/setZOffsetUnits() can update independently (and encode with the
+        // opposite sign under a reverse depth buffer).
         this._commandBufferEncoder.startEncodingCommand(_native.Engine.COMMAND_SETSTATE);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(this._cachedCulling ? 1 : 0);
-        this._commandBufferEncoder.encodeCommandArgAsFloat32(this._zOffset);
-        this._commandBufferEncoder.encodeCommandArgAsFloat32(this._zOffsetUnits);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(this._cachedZOffset);
+        this._commandBufferEncoder.encodeCommandArgAsFloat32(this._cachedZOffsetUnits);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(cullBack ? 1 : 0);
         this._commandBufferEncoder.encodeCommandArgAsUInt32(this._cachedReverseSide ? 1 : 0);
         this._commandBufferEncoder.finishEncodingCommand();
@@ -1067,6 +1074,8 @@ export class ThinNativeEngine extends ThinEngine {
         this._cachedCulling = culling;
         this._cachedReverseSide = reverseSide;
         this._cachedCullBackFaces = this.cullBackFaces ?? cullBackFaces ?? true;
+        this._cachedZOffset = zOffset;
+        this._cachedZOffsetUnits = zOffsetUnits;
     }
 
     /**


### PR DESCRIPTION
Two small `NativeEngine` fixes, both replacing paths that currently throw. Pure JavaScript, and both native counterparts already exist in Babylon Native `master`, so no companion change is required.

### 1. Load single-file prefiltered cube containers

`createCubeTexture` handled only `.env` and 6-file cubemaps. A self-contained container that already holds all six faces and their prefiltered mip chain — `CubeTexture.CreateFromPrefilteredData("…​.dds")` — fell through to:

```
Error: Cannot load cubemap because 6 files were not defined
```

The new branch loads the single buffer and hands it to the native engine, which parses the container directly and returns the diffuse spherical harmonics as 27 floats; those are rebuilt into `texture._sphericalPolynomial` when `createPolynomials` is set, so PBR irradiance matches the web engines. Babylon Native `master` already implements this end to end — `NativeEngine::LoadCubeTexture` takes the single-buffer path when `data.Length() == 1`, calls `ComputeCubeSphericalPolynomial` before the upload hands the container's memory to bgfx, and passes the result to `onSuccess`.

The change is strictly additive with respect to anything that worked before:

- the `.env` branch is untouched;
- the 6-file branch keeps identical behaviour — `resolve` becomes `() => resolve()` only because `onSuccess` now carries an optional argument, which would otherwise be adopted as the promise's resolution value;
- every remaining case previously threw unconditionally. Now 0 or 1 file takes the container path, and 2-5 files still raise the original error rather than silently treating the first file as a container.

### 2. Implement `setStateCullFaceType`

It was `throw new Error("setStateCullFaceType: Not Implemented")`, so anything toggling cull-face direction outside a full `setState` failed. Native uses an immediate command-buffer state model rather than WebGL's lazy `_depthCullingState`, so the override re-issues `COMMAND_SETSTATE` with the new cull face while preserving the cached culling / zOffset / reverseSide, and `setState` now records those values for it to reuse. The `this.cullBackFaces ?? cullBackFaces ?? true` precedence and the `force` semantics match `ThinEngine.setStateCullFaceType` exactly, and `COMMAND_SETSTATE` is already used by the adjacent `setState`.

## Testing

- `tsc --noEmit` on `packages/dev/core`: identical to the `master` baseline (the same 4 pre-existing `fsr1*` generated-module errors).
- `eslint` on all three changed files: **0 errors**, and 128 warnings — byte-identical to the count on `master` for the same files.
- `vitest run --project=unit` (4607 tests): no regressions. The tree-shaking suite is the one that could plausibly react to the new `SphericalPolynomial` import, and it is unchanged at 16 failed / 14 passed / 30 skipped on both this branch and `master`.
