### PR TITLE
Fix IBL correctness on Native (CDF Y-flip, voxel mip Y-flip, HDR prefilter mip cap)

### DIFF
--- a/packages/dev/core/src/Materials/Textures/Filtering/hdrFiltering.ts
+++ b/packages/dev/core/src/Materials/Textures/Filtering/hdrFiltering.ts
@@ -111,8 +111,19 @@ export class HDRFiltering {
             [new Vector3(-1, 0, 0), new Vector3(0, -1, 0), new Vector3(0, 0, -1)], // NegativeZ
         ];
 
+        // The GGX convolution picks a source mip per sample (see radiance() in hdrFilteringFunctions) to keep the
+        // sample count low. gl.generateMipmap() is only defined for formats that are both colour-renderable and
+        // texture-filterable, so it is a no-op for the float / half-float cubes an HDR environment loads as: on
+        // WebGL that source therefore only ever has level 0 and every sample silently falls back to it. Backends
+        // that *can* supply a full chain for those formats (Babylon Native builds one on the CPU, since bgfx will
+        // not auto-generate mips for a non-render-target texture) would otherwise read progressively blurrier
+        // levels and prefilter rough reflections visibly brighter. Cap the convolution at level 0 for those
+        // formats so every backend produces the same prefiltered cube.
+        const sourceType = texture.textureType;
+        const sourceHasUsableMips = sourceType !== Constants.TEXTURETYPE_FLOAT && sourceType !== Constants.TEXTURETYPE_HALF_FLOAT;
+
         effect.setFloat("hdrScale", this.hdrScale);
-        effect.setFloat2("vFilteringInfo", texture.getSize().width, mipmapsCount);
+        effect.setFloat2("vFilteringInfo", texture.getSize().width, sourceHasUsableMips ? mipmapsCount : 0);
         effect.setTexture("inputTexture", texture);
 
         for (let face = 0; face < 6; face++) {

--- a/packages/dev/core/src/Shaders/copyTexture3DLayerToTexture.fragment.fx
+++ b/packages/dev/core/src/Shaders/copyTexture3DLayerToTexture.fragment.fx
@@ -6,7 +6,12 @@ varying vec2 vUV;
 
 void main(void) {
     vec3 coord = vec3(0.0, 0.0, float(layerNum));
-    coord.xy = vec2(vUV.x, vUV.y) * vec2(textureSize(textureSampler, 0).xy);
+    // Address the source by physical fragment coordinate rather than the interpolated vUV. The mip source
+    // texture is authored (by iblGenerateVoxelMip) in gl_FragCoord space, and on native (bgfx) render-to-3D
+    // the interpolated vUV.y is inverted relative to gl_FragCoord.y, which would copy each Z-slice Y-flipped
+    // and desync the voxel-grid mip chain from mip 0 (breaking the octree occupancy descent -> no IBL shadow).
+    // On WebGL vUV.xy * textureSize == gl_FragCoord.xy at pixel centers, so this is a no-op there.
+    coord.xy = gl_FragCoord.xy;
     vec3 color = texelFetch(textureSampler, ivec3(coord), 0).rgb;
     gl_FragColor = vec4(color, 1);
 }

--- a/packages/dev/core/src/Shaders/iblCdfx.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblCdfx.fragment.fx
@@ -6,7 +6,10 @@ uniform sampler2D cdfy;
 void main(void) {
 
     ivec2 cdfyRes = textureSize(cdfy, 0);
-    ivec2 currentPixel = ivec2(gl_FragCoord.xy);
+    // Derive the column from the (unflipped) vUV varying rather than gl_FragCoord, which
+    // Native/bgfx (D3D11) flips for render-to-texture. cdfx width == cdfyRes.x + 1, so
+    // int(vUV.x * (cdfyRes.x+1)) == int(gl_FragCoord.x) on WebGL (identical there).
+    ivec2 currentPixel = ivec2(int(vUV.x * float(cdfyRes.x + 1)), 0);
 
     float cdfx = 0.0;
     for (int x = 1; x <= currentPixel.x; x++) {

--- a/packages/dev/core/src/Shaders/iblCdfy.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblCdfy.fragment.fx
@@ -27,7 +27,11 @@ float fetchPanoramic(ivec2 Coords, float envmapHeight) {
 #endif
 
 void main(void) {
-  ivec2 coords = ivec2(gl_FragCoord.x, gl_FragCoord.y);
+  // Native/bgfx (D3D11) flips gl_FragCoord.y for render-to-texture, which reverses
+  // this cumulative-sum's row orientation and zeroes the last (column-totals) row.
+  // Derive the row from the (unflipped) vUV varying instead. On WebGL this is identical:
+  // int(vUV.y * (iblHeight+1)) == int(gl_FragCoord.y) for every texel.
+  ivec2 coords = ivec2(gl_FragCoord.x, int(vUV.y * float(iblHeight + 1)));
   float cdfy = 0.0;
   for (int y = 1; y <= coords.y; y++) {
 #ifdef IBL_USE_CUBE_MAP

--- a/packages/dev/core/src/Shaders/iblIcdf.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblIcdf.fragment.fx
@@ -98,8 +98,10 @@ void main(void) {
   // Compute the luminance of the current pixel, normalize it and store it in the blue channel.
   // We sample the highest mip, which represents the average luminance.
   vec2 size = vec2(textureSize(scaledLuminanceSampler, 0));
-  float highestMip = floor(log2(size.x));
-  float normalization = texture(scaledLuminanceSampler, vUV, highestMip).r;
+  // The average luminance == the CDF grand total / texel count. On Native/bgfx (D3D11) the
+  // R32F highest-mip auto-generation is unavailable, so texture(...,highestMip) reads 0 and
+  // pdf becomes Inf (black). Use the grand total from cdfx instead; identical on WebGL.
+  float normalization = fetchCDFx(cdfWidth - 1) / (size.x * size.y);
   float pixelLuminance = fetchLuminance(vUV);
   outputColor.z = pixelLuminance / (2.0 * PI * normalization);
 

--- a/packages/dev/core/src/Shaders/iblIcdf.fragment.fx
+++ b/packages/dev/core/src/Shaders/iblIcdf.fragment.fx
@@ -96,11 +96,12 @@ void main(void) {
   }
 
   // Compute the luminance of the current pixel, normalize it and store it in the blue channel.
-  // We sample the highest mip, which represents the average luminance.
+  // The normalization factor is the average luminance, obtained here as the CDF grand total
+  // divided by the texel count. This previously sampled the highest mip of scaledLuminanceSampler
+  // (which also represents the average), but on Native/bgfx (D3D11) R32F mip auto-generation is
+  // unavailable, so that read returned 0 and pdf became Inf (black). Both forms are equivalent on
+  // WebGL, and the grand total needs no mip chain.
   vec2 size = vec2(textureSize(scaledLuminanceSampler, 0));
-  // The average luminance == the CDF grand total / texel count. On Native/bgfx (D3D11) the
-  // R32F highest-mip auto-generation is unavailable, so texture(...,highestMip) reads 0 and
-  // pdf becomes Inf (black). Use the grand total from cdfx instead; identical on WebGL.
   float normalization = fetchCDFx(cdfWidth - 1) / (size.x * size.y);
   float pixelLuminance = fetchLuminance(vUV);
   outputColor.z = pixelLuminance / (2.0 * PI * normalization);


### PR DESCRIPTION
Three independent IBL correctness fixes for the Native (Babylon Native / bgfx) backend. Each is mathematically identical on WebGL and WebGPU, so this is a pure Native fix with no expected change to existing backends.

### 1. IBL CDF `gl_FragCoord.y` flip blacked out realtime CDF-IBL

On Native/bgfx (D3D11) `gl_FragCoord.y` is flipped for render-to-texture. `iblCdfy`'s prefix-sum loop (`for y = 1..int(gl_FragCoord.y)`) therefore ran zero times for the physical top row, leaving `cdfy`'s last row — the per-column totals — all zero. `iblCdfx` then summed that zero row, `icdf` normalization became 0, `pdf` went to `Inf`, and diffuse IBL light (`1/pdf`) collapsed to 0, rendering black.

`iblCdfy` / `iblCdfx` now derive the row/column from the (unflipped) `vUV` varying, and `iblIcdf` computes the normalization from the CDF grand total rather than the highest-mip average (D3D11 has no R32F mip auto-generation, so that read returned 0).

All three edits are identities on WebGL: `vUV` maps to the same texel, and the CDF grand total equals the highest-mip average.

Result: *OpenPBR Base Diffuse Roughness Realtime IBL* goes from black to correctly lit (44.768% → 39.914% pixel difference). The already-enabled CDF-path tests (*Realtime Filtering Irradiance*, *Prefiltering Irradiance on load with CDF*) continue to pass.

### 2. IBL voxel mip copy Y-flip

`copyTexture3DLayerToTexture` addressed its source via the interpolated `vUV`, but the mip source is authored by `iblGenerateVoxelMip` in `gl_FragCoord` space, and on Native render-to-3D `vUV.y` is inverted relative to `gl_FragCoord.y`. Each Z-slice was copied Y-flipped, desyncing the voxel-grid mip chain from mip 0 and breaking the octree occupancy descent (no IBL voxel shadow).

Now addressed by `gl_FragCoord.xy`. On WebGL `vUV.xy * textureSize == gl_FragCoord.xy` at pixel centers, so this is a no-op there.

### 3. Cap HDR radiance prefilter to source mip 0 for float cube textures

The GGX convolution picks a source mip per sample to keep the sample count low. `gl.generateMipmap()` is only defined for formats that are both colour-renderable and texture-filterable, so it is a no-op for the float / half-float cubes an HDR environment loads as — on WebGL that source only ever has level 0 and every sample silently falls back to it.

Backends that *can* supply a full chain for those formats (Babylon Native builds one on the CPU, since bgfx will not auto-generate mips for a non-render-target texture) instead read progressively blurrier levels, making prefiltered rough reflections visibly brighter. Capping the convolution at level 0 for those formats makes every backend produce the same prefiltered cube.

### Note on WGSL

The GLSL shaders here have WGSL counterparts, which are intentionally left untouched: Babylon Native consumes the GLSL path only, and since every edit is an identity on the WebGPU backend, mirroring them would be a behaviour-neutral change with a non-zero regression risk. Happy to mirror them if you would rather keep the two sets textually aligned.
