### PR TITLE
Fix shared material alpha mode state after parsing

### DIFF
--- a/packages/dev/core/src/Materials/material.pure.ts
+++ b/packages/dev/core/src/Materials/material.pure.ts
@@ -2143,9 +2143,9 @@ export class Material implements IAnimatable, IClipPlanesHolder {
      */
     public static ParseAlphaMode(parsedMaterial: any, material: Material) {
         if (parsedMaterial._alphaMode !== undefined) {
-            material._alphaMode = Array.isArray(parsedMaterial._alphaMode) ? parsedMaterial._alphaMode : [parsedMaterial._alphaMode];
+            material._alphaMode = Array.isArray(parsedMaterial._alphaMode) ? [...parsedMaterial._alphaMode] : [parsedMaterial._alphaMode];
         } else if (parsedMaterial.alphaMode !== undefined) {
-            material._alphaMode = Array.isArray(parsedMaterial.alphaMode) ? parsedMaterial.alphaMode : [parsedMaterial.alphaMode];
+            material._alphaMode = Array.isArray(parsedMaterial.alphaMode) ? [...parsedMaterial.alphaMode] : [parsedMaterial.alphaMode];
         } else {
             material._alphaMode = [Constants.ALPHA_COMBINE];
         }

--- a/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts
@@ -78,6 +78,41 @@ describe("Babylon NodeMaterial image processing observer lifecycle", () => {
     });
 });
 
+describe("Babylon NodeMaterial alpha mode parsing", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it.each(["_alphaMode", "alphaMode"] as const)("does not share serialized %s state between parsed materials", (propertyName) => {
+        const serialized = {
+            blocks: [],
+            outputNodes: [],
+            [propertyName]: [2],
+        };
+
+        const transparent = new NodeMaterial("transparent", scene);
+        transparent.parseSerializedObject(serialized);
+        transparent.alphaMode = 7;
+
+        const opaque = new NodeMaterial("opaque", scene);
+        opaque.parseSerializedObject(serialized);
+        opaque.alphaMode = 0;
+
+        expect(serialized[propertyName]).toEqual([2]);
+        expect(transparent.alphaMode).toBe(7);
+        expect(opaque.alphaMode).toBe(0);
+    });
+});
+
 describe("Babylon NodeMaterial image processing configuration parsing", () => {
     let engine: NullEngine;
     let scene: Scene;


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Clone parsed `_alphaMode` arrays before assigning them to a material.
- Apply the same ownership boundary to the legacy `alphaMode` array format.
- Add regression coverage for repeated Node Material parsing from one serialized object.

## Motivation

`Material.ParseAlphaMode` retained the serialized array by reference. Because material alpha mode setters mutate that array in place, parsing the same object into multiple materials allowed one material to mutate the source data and another material's state.

Repro: https://playground.babylonjs.com/#IEVLH2#2

## Testing

- `npm run format:check`
- `npm run lint:check`
- `npm run test:unit -- --maxWorkers=1`
- `npx vitest run --project=unit packages/dev/core/test/unit/Materials/Node/babylon.nodeMaterials.parse.test.ts`
