### PR TITLE
Suspend rendering in the Lite Viewer while offscreen

### DIFF
--- a/packages/tools/viewer/src/full/viewerFactory.ts
+++ b/packages/tools/viewer/src/full/viewerFactory.ts
@@ -1,8 +1,9 @@
-import { type AbstractEngine, type AbstractEngineOptions, type EngineOptions, type IDisposable, type Nullable, type WebGPUEngineOptions } from "core/index";
+import { type AbstractEngine, type AbstractEngineOptions, type EngineOptions, type WebGPUEngineOptions } from "core/index";
 import { type ViewerDetails, type ViewerOptions, Viewer } from "./viewer";
 
 import { Deferred } from "core/Misc/deferred";
 import { Logger } from "core/Misc/logger";
+import { SuspendRenderingWhenOffscreen } from "../offscreenRenderingSuspension";
 
 /**
  * Options for creating a Viewer instance that is bound to an HTML canvas.
@@ -144,19 +145,7 @@ export async function CreateViewerForCanvas(
         disposeActions.push(() => beforeRenderObserver.remove());
 
         // If the canvas is not visible, suspend rendering.
-        let offscreenRenderingSuspension: Nullable<IDisposable> = null;
-        const intersectionObserver = new IntersectionObserver((entries) => {
-            if (entries.length > 0) {
-                if (entries[entries.length - 1].isIntersecting) {
-                    offscreenRenderingSuspension?.dispose();
-                    offscreenRenderingSuspension = null;
-                } else {
-                    offscreenRenderingSuspension = details.suspendRendering();
-                }
-            }
-        });
-        intersectionObserver.observe(canvas);
-        disposeActions.push(() => intersectionObserver.disconnect());
+        disposeActions.push(SuspendRenderingWhenOffscreen(canvas, () => details.suspendRendering()).dispose);
     }
 
     disposeActions.push(viewer.dispose.bind(viewer));

--- a/packages/tools/viewer/src/lite/viewer.ts
+++ b/packages/tools/viewer/src/lite/viewer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { type Nullable } from "core/index";
+import { type IDisposable, type Nullable } from "core/index";
 import { AsyncLock } from "core/Misc/asyncLock";
 import { AbortError } from "core/Misc/error";
 import { Logger } from "core/Misc/logger";
@@ -87,6 +87,7 @@ import {
     throwIfAborted,
     observePromise,
 } from "../viewerBase";
+import { SuspendRenderingWhenOffscreen } from "../offscreenRenderingSuspension";
 
 /**
  * The options for the Lite Viewer.
@@ -162,6 +163,10 @@ function toneMappingToLiteToneMapping(mode: ToneMapping): LiteToneMapping | unde
  * Babylon Lite is a WebGPU-only engine that provides a subset of the full Babylon.js feature set.
  * Features that are not available in Lite (SSAO, "high" shadow quality, hot spots, File/ArrayBufferView model sources)
  * will log warnings and fall back gracefully.
+ *
+ * The `autoSuspendRendering` option is silently ignored: Lite has no scene-mutation tracking, so it cannot
+ * detect when a scene is idle. Rendering is still suspended while the canvas is offscreen (see
+ * {@link CreateViewerForCanvas}), which is the case that dominates cost on pages with multiple viewers.
  */
 export class Viewer extends ViewerBase implements IViewer {
     // ── Private State ──
@@ -170,7 +175,28 @@ export class Viewer extends ViewerBase implements IViewer {
     private readonly _camera: ArcRotateCamera;
     private readonly _deviceLostRecovery: DeviceLostRecoveryHandle;
     private _detachControl: (() => void) | null = null;
+    /** True while the engine's requestAnimationFrame loop is running. False while suspended or disposed. */
     private _renderLoopRunning = false;
+    /**
+     * True once the scene has been registered with the engine (deferred builders run, renderables bucketed).
+     * Distinct from {@link _renderLoopRunning}: suspending rendering stops the rAF loop but leaves the scene
+     * registered, so code that needs to know "has the scene been built" must consult this instead.
+     */
+    private _sceneRegistered = false;
+    /** Number of live suspension handles returned by {@link _suspendRendering}. Rendering runs only at zero. */
+    private _suspendRenderCount = 0;
+    /**
+     * Serializes every engine start/stop and scene (un)registration, so a suspend/resume triggered by the
+     * offscreen observer can never interleave with {@link _beginRendering}'s stop, unregister, register,
+     * start sequence (which is itself re-entered from model loads, environment loads, and construction).
+     */
+    private readonly _renderLoopLock = new AsyncLock();
+    /**
+     * Resolves the pending `startEngine` await when the render loop is stopped before its first frame.
+     * Lite's `startEngine` promise only settles from inside the rAF callback, so stopping the loop first
+     * (by suspension or disposal) would otherwise leave the await pending forever.
+     */
+    private _renderLoopStopped: Nullable<() => void> = null;
 
     // Auto-orbit
     private _autoOrbitIdleTime = 0;
@@ -789,8 +815,10 @@ export class Viewer extends ViewerBase implements IViewer {
 
             // Re-register the scene so that the env loader's deferred builders are processed
             // and the new skybox/ground renderables land in the draw buckets. Lite only fills
-            // `_opaqueRenderables` etc. at registerScene() time.
-            if (this._renderLoopRunning) {
+            // `_opaqueRenderables` etc. at registerScene() time. Gated on `_sceneRegistered` (not the
+            // rAF-loop state) so an environment loaded while rendering is suspended still re-registers;
+            // otherwise the skybox would never appear, even after rendering resumes.
+            if (this._sceneRegistered) {
                 await this._beginRendering();
             }
 
@@ -802,7 +830,7 @@ export class Viewer extends ViewerBase implements IViewer {
             // environment explicitly added to an already-displayed model — the model keeps its previous
             // (often absent) IBL and renders unlit/black while the skybox looks correct. Force a PBR rebuild
             // so the model picks up the new lighting. No-op when no model is loaded.
-            if (this._renderLoopRunning && this._container) {
+            if (this._sceneRegistered && this._container) {
                 await this._rebuildModelPbrForEnvironment();
             }
 
@@ -1205,7 +1233,7 @@ export class Viewer extends ViewerBase implements IViewer {
             //   `_renderableVersion` so the frame graph re-buckets them. Re-registering here would be wrong:
             //   `buildScene` clears the material-swap queue before the loop can drain it, dropping the model.
             //
-            // So only (re-)register when the render loop isn't running yet or the model's material group
+            // So only (re-)register when the scene isn't registered yet or the model's material group
             // has not been built before; otherwise let the running loop drain the swap queue.
             //
             // `this._scene` is created once in the constructor and never recreated (it is disposed only in
@@ -1221,7 +1249,11 @@ export class Viewer extends ViewerBase implements IViewer {
             // task is rebuilt against the new light/ground instead of going stale. Shadow quality is fixed at
             // construction (see `_updateShadowsImpl`), so this only affects the rarely-used shadow + model-swap
             // combination.
-            if (!this._renderLoopRunning || this._shadowQuality !== "none" || !this._modelMaterialGroupBuilt) {
+            //
+            // The condition tests `_sceneRegistered` rather than the rAF-loop state so that a model loaded
+            // while rendering is suspended still registers its renderables; the swap queue it may instead
+            // enqueue into is drained by the first frame after rendering resumes.
+            if (!this._sceneRegistered || this._shadowQuality !== "none" || !this._modelMaterialGroupBuilt) {
                 await this._beginRendering();
             }
             this._modelMaterialGroupBuilt = true;
@@ -1850,25 +1882,90 @@ export class Viewer extends ViewerBase implements IViewer {
     /**
      * Registers the scene with the engine and starts the render loop.
      * Safe to call multiple times — stops and re-registers if already running.
+     * @remarks
+     * Serialized against suspend/resume via {@link _renderLoopLock} so a scroll-driven suspension can never
+     * land in the middle of the stop, unregister, register, start sequence below.
      */
     private async _beginRendering(): Promise<void> {
-        if (this._isDisposed) {
+        await this._renderLoopLock.lockAsync(async () => {
+            if (this._isDisposed) {
+                return;
+            }
+            this._stopRenderLoop();
+            if (this._sceneRegistered) {
+                unregisterScene(this._scene);
+                this._sceneRegistered = false;
+            }
+            // Install the scene-owned frame-graph shadow task only when shadows are enabled, so the
+            // shadow-task bundle is tree-shaken out for viewers that never render shadows.
+            if (this._shadowQuality === "none") {
+                await registerScene(this._scene);
+            } else {
+                await registerSceneWithShadowSupport(this._scene);
+            }
+            if (this._isDisposed) {
+                return;
+            }
+            this._sceneRegistered = true;
+            await this._startRenderLoop();
+        });
+    }
+
+    /**
+     * Starts the engine's render loop, unless rendering is suspended (or the viewer is disposed), and waits
+     * for the first frame.
+     * @remarks
+     * Lite's `startEngine` promise resolves from inside the rAF callback, so it never settles if the loop is
+     * stopped before that first frame. {@link _renderLoopStopped} races against it so a suspension or a
+     * disposal arriving in that window can't leave this await (and any model load awaiting it) pending forever.
+     */
+    private async _startRenderLoop(): Promise<void> {
+        if (this._renderLoopRunning || this._isDisposed || this._suspendRenderCount > 0) {
             return;
         }
+        this._renderLoopRunning = true;
+        const firstFrame = startEngine(this._engine);
+        const stopped = new Promise<void>((resolve) => (this._renderLoopStopped = resolve));
+        await Promise.race([firstFrame, stopped]);
+        this._renderLoopStopped = null;
+    }
+
+    /** Stops the engine's render loop (if running) and releases anyone awaiting its first frame. */
+    private _stopRenderLoop(): void {
         if (this._renderLoopRunning) {
             stopEngine(this._engine);
-            unregisterScene(this._scene);
             this._renderLoopRunning = false;
         }
-        // Install the scene-owned frame-graph shadow task only when shadows are enabled, so the
-        // shadow-task bundle is tree-shaken out for viewers that never render shadows.
-        if (this._shadowQuality === "none") {
-            await registerScene(this._scene);
-        } else {
-            await registerSceneWithShadowSupport(this._scene);
+        this._renderLoopStopped?.();
+        this._renderLoopStopped = null;
+    }
+
+    /**
+     * Suspends rendering until the returned disposable is disposed.
+     * @remarks
+     * Reference counted, mirroring the full Viewer: rendering only resumes once every suspension handle has
+     * been disposed. The scene stays registered while suspended, so resuming does not rebuild anything.
+     * @returns A disposable that resumes rendering (when no other suspensions are outstanding).
+     * @internal
+     */
+    public _suspendRendering(): IDisposable {
+        if (this._suspendRenderCount++ === 0) {
+            observePromise(this._renderLoopLock.lockAsync(() => this._stopRenderLoop()));
         }
-        await startEngine(this._engine);
-        this._renderLoopRunning = true;
+
+        let disposed = false;
+        return {
+            dispose: () => {
+                if (!disposed) {
+                    disposed = true;
+                    if (--this._suspendRenderCount === 0) {
+                        // Not awaited: resuming must not block the caller (typically an IntersectionObserver
+                        // callback) on the first rendered frame.
+                        observePromise(this._renderLoopLock.lockAsync(async () => await this._startRenderLoop()));
+                    }
+                }
+            },
+        };
     }
 
     public override dispose(): void {
@@ -1905,8 +2002,9 @@ export class Viewer extends ViewerBase implements IViewer {
         this._unloadCurrentModel();
 
         // Stop and dispose engine/scene
-        stopEngine(this._engine);
+        this._stopRenderLoop();
         unregisterScene(this._scene);
+        this._sceneRegistered = false;
         disposeScene(this._scene);
         disposeEngine(this._engine);
 
@@ -2022,5 +2120,19 @@ export class Viewer extends ViewerBase implements IViewer {
  */
 export async function CreateViewerForCanvas(canvas: HTMLCanvasElement, options?: CanvasViewerOptions): Promise<Viewer> {
     const engine = await createEngine(canvas, { alphaMode: "premultiplied" });
-    return new Viewer(engine, options);
+    const viewer = new Viewer(engine, options);
+
+    // If the canvas is not visible, suspend rendering. Matches the full Viewer, where this is unconditional
+    // (the `autoSuspendRendering` option gates idle suspension, not offscreen suspension).
+    const offscreenSuspensionObserver = SuspendRenderingWhenOffscreen(canvas, () => viewer._suspendRendering());
+
+    // Override the Viewer's dispose method to add in additional cleanup. Matches the full Viewer's factory:
+    // only the observer needs disconnecting — any live suspension handle is dropped along with the Viewer.
+    const disposeViewer = viewer.dispose.bind(viewer);
+    viewer.dispose = () => {
+        offscreenSuspensionObserver.dispose();
+        disposeViewer();
+    };
+
+    return viewer;
 }

--- a/packages/tools/viewer/src/offscreenRenderingSuspension.ts
+++ b/packages/tools/viewer/src/offscreenRenderingSuspension.ts
@@ -1,0 +1,32 @@
+import { type IDisposable, type Nullable } from "core/index";
+
+/**
+ * Suspends rendering while a canvas is scrolled out of the viewport.
+ * @remarks
+ * Shared by the full and Lite Viewer canvas factories. The two flavors implement suspension very differently
+ * (full disposes a render loop controller synchronously, Lite stops the engine's rAF loop under an async
+ * lock), but the observer wiring and the pairing of suspend/resume against intersection changes are identical,
+ * so only the `suspendRendering` callback differs.
+ * @param canvas The canvas whose visibility should drive rendering.
+ * @param suspendRendering Called when the canvas leaves the viewport; the returned disposable is disposed when it comes back.
+ * @returns A disposable that stops observing the canvas. Must be disposed along with the Viewer.
+ */
+export function SuspendRenderingWhenOffscreen(canvas: HTMLCanvasElement, suspendRendering: () => IDisposable): IDisposable {
+    let offscreenRenderingSuspension: Nullable<IDisposable> = null;
+
+    const intersectionObserver = new IntersectionObserver((entries) => {
+        if (entries.length > 0) {
+            if (entries[entries.length - 1].isIntersecting) {
+                offscreenRenderingSuspension?.dispose();
+                offscreenRenderingSuspension = null;
+            } else {
+                // `??=` rather than `=`: repeated non-intersecting records must not acquire a second
+                // suspension, which would leak a reference and leave rendering suspended forever.
+                offscreenRenderingSuspension ??= suspendRendering();
+            }
+        }
+    });
+    intersectionObserver.observe(canvas);
+
+    return { dispose: () => intersectionObserver.disconnect() };
+}

--- a/packages/tools/viewer/src/viewerBase.ts
+++ b/packages/tools/viewer/src/viewerBase.ts
@@ -339,6 +339,9 @@ export type ViewerBaseOptions = Partial<{
      * When enabled, rendering will be suspended when no scene state driven by the Viewer has changed.
      * This can reduce resource CPU/GPU pressure when the scene is static.
      * Enabled by default.
+     * @remarks
+     * Only honored by the full Viewer; the Lite Viewer has no scene-mutation tracking and ignores this
+     * option. Both flavors suspend rendering while the canvas is offscreen regardless of this setting.
      */
     autoSuspendRendering: boolean;
 

--- a/packages/tools/viewer/test/viewer.lite.test.ts
+++ b/packages/tools/viewer/test/viewer.lite.test.ts
@@ -104,10 +104,11 @@ async function waitForCameraSettled(page: Page) {
 }
 
 async function expectScreenshotMatch(page: Page, name: string, maxDiffPixelRatio = 0.011) {
-    // Lite renders continuously (no autoSuspend/isIdle yet), so "settled" is approximated by: no load in
-    // flight, no camera interpolation in flight, then a fixed burst of rendered frames to let deferred GPU
-    // work (skybox/ground builders, shadow map, material swaps) drain into a stable image. This
-    // intentionally does NOT require a model (environment-only and model-cleared scenes have none).
+    // Lite renders continuously while visible (offscreen suspension aside, there is no idle suspension), so
+    // "settled" is approximated by: no load in flight, no camera interpolation in flight, then a fixed burst
+    // of rendered frames to let deferred GPU work (skybox/ground builders, shadow map, material swaps) drain
+    // into a stable image. This intentionally does NOT require a model (environment-only and model-cleared
+    // scenes have none).
     await waitForLoadingComplete(page);
     await waitForCameraSettled(page);
     const before = await waitForFrameCount(page, 1);
@@ -1170,4 +1171,186 @@ test("reset() restores initial state", async ({ page }) => {
 
     // Wait for reset to complete and the scene to settle.
     await expectScreenshotMatch(page, "viewer-reset.png");
+});
+
+// ============================================================
+// Offscreen Render Suspension
+// ============================================================
+
+/**
+ * Makes the document scrollable by appending a tall spacer below the viewer, so the viewer can be scrolled
+ * out of the viewport. `test-lite.html` sizes `html`/`body` to 100% with no scrollable content; the spacer
+ * overflows the body, which propagates to the viewport and creates the scroll range. The viewer element is
+ * deliberately left at its inherited (viewport) size so screenshots still match the shared reference images.
+ */
+async function makeViewerScrollable(page: Page) {
+    await page.evaluate(() => {
+        const spacer = document.createElement("div");
+        spacer.style.height = "5000px";
+        document.body.appendChild(spacer);
+    });
+}
+
+/** Scrolls the viewer completely out of the viewport (requires {@link makeViewerScrollable}). */
+async function scrollViewerOffscreen(page: Page) {
+    await page.evaluate(() => window.scrollTo(0, 4000));
+}
+
+/** Scrolls the viewer back into the viewport. */
+async function scrollViewerOnscreen(page: Page) {
+    await page.evaluate(() => window.scrollTo(0, 0));
+}
+
+/**
+ * Waits until the viewer's render loop reaches the expected running state. The `IntersectionObserver` that
+ * drives suspension fires asynchronously after layout, so polling the loop state is more deterministic than
+ * waiting a fixed interval.
+ */
+async function waitForRenderLoopRunning(page: Page, expected: boolean) {
+    await page.waitForFunction((expected) => {
+        const viewer = (document.querySelector("babylon-viewer") as ViewerElement | null)?.viewer as unknown as { _renderLoopRunning: boolean } | undefined;
+        return viewer != null && viewer._renderLoopRunning === expected;
+    }, expected);
+}
+
+/** Reads the current rendered-frame count without waiting for it to advance. */
+async function getFrameCount(page: Page): Promise<number> {
+    return await page.evaluate(() => (window as unknown as { __liteFrameCount?: number }).__liteFrameCount ?? 0);
+}
+
+test("rendering is suspended while the viewer is offscreen", async ({ page }) => {
+    await attachViewerElement(
+        page,
+        `
+        <babylon-viewer
+            source="https://assets.babylonjs.com/meshes/boombox.glb"
+        >
+        </babylon-viewer>
+        `
+    );
+
+    await waitForModelLoaded(page);
+    await makeViewerScrollable(page);
+
+    // Attach the frame counter and confirm frames are advancing while the viewer is visible.
+    const visibleBefore = await waitForFrameCount(page, 1);
+    await waitForFrameCount(page, visibleBefore + 5);
+
+    await scrollViewerOffscreen(page);
+    await waitForRenderLoopRunning(page, false);
+
+    // Sample after a short settle (an in-flight frame may still land as the loop stops), then confirm the
+    // count is genuinely frozen rather than merely slowed.
+    await page.waitForTimeout(200);
+    const suspended = await getFrameCount(page);
+    await page.waitForTimeout(500);
+    expect(await getFrameCount(page), "Frames rendered while offscreen").toBe(suspended);
+
+    // Restore visibility so the shared afterEach frame-count assertion can be satisfied.
+    await scrollViewerOnscreen(page);
+    await waitForRenderLoopRunning(page, true);
+});
+
+test("rendering resumes when the viewer is scrolled back into view", async ({ page }) => {
+    await attachViewerElement(
+        page,
+        `
+        <babylon-viewer
+            source="https://assets.babylonjs.com/meshes/boombox.glb"
+        >
+        </babylon-viewer>
+        `
+    );
+
+    await waitForModelLoaded(page);
+    await makeViewerScrollable(page);
+
+    await scrollViewerOffscreen(page);
+    await waitForRenderLoopRunning(page, false);
+
+    await scrollViewerOnscreen(page);
+    await waitForRenderLoopRunning(page, true);
+
+    // Frames advance again, and the scene still renders correctly after the pause. Validates against the
+    // same reference image as the plain "load model from url" test — suspending and resuming must be
+    // visually transparent.
+    await expectScreenshotMatch(page, "viewer-load-model-url.png");
+});
+
+test("model and environment loaded while offscreen render correctly on resume", async ({ page }) => {
+    // Regression test for the render-loop/scene-registration split: an environment or model loaded while
+    // rendering is suspended must still register its renderables, otherwise the skybox (or the model) would
+    // never appear even after rendering resumes. The viewer is created *below the fold* so it is suspended
+    // essentially from birth — this also covers a viewer that must reach a correct first render on resume.
+    await page.goto(viewerUrl, { waitUntil: "load" });
+
+    await page.evaluate(() => {
+        // Spacer first, so the viewer element lands below the viewport and starts out offscreen.
+        const spacer = document.createElement("div");
+        spacer.style.height = "5000px";
+        document.body.appendChild(spacer);
+
+        const container = document.createElement("div");
+        container.innerHTML = `
+            <babylon-viewer
+                source="https://assets.babylonjs.com/meshes/boombox.glb"
+                environment-skybox="https://assets.babylonjs.com/environments/environmentSpecular.env"
+            >
+            </babylon-viewer>
+            `;
+        document.body.appendChild(container);
+    });
+
+    await page.locator("babylon-viewer").waitFor();
+    await waitForRenderLoopRunning(page, false);
+
+    // The model and environment must load to completion even though no frame is ever rendered.
+    await waitForLoadingComplete(page);
+    expect(await getFrameCount(page), "Frames rendered while offscreen").toBe(0);
+
+    // Bring the viewer into view: the spacer plus the viewport-sized viewer means max scroll lands the
+    // viewer exactly in the viewport.
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await waitForRenderLoopRunning(page, true);
+    await waitForModelLoaded(page);
+
+    // Same reference image as the `environment-skybox` test: the model and skybox must both be present.
+    await expectScreenshotMatch(page, "viewer-env-skybox.png");
+});
+
+test("disposing a viewer while it is offscreen", async ({ page }) => {
+    const viewerElementHandle = await attachViewerElement(
+        page,
+        `
+        <babylon-viewer
+            source="https://assets.babylonjs.com/meshes/boombox.glb"
+        >
+        </babylon-viewer>
+        `
+    );
+
+    await waitForModelLoaded(page);
+    await makeViewerScrollable(page);
+
+    await scrollViewerOffscreen(page);
+    await waitForRenderLoopRunning(page, false);
+
+    // Dispose the suspended viewer. This must tear down cleanly: the suspension holds the render loop
+    // stopped, so anything still awaiting the loop's first frame has to be released by disposal.
+    await page.evaluate((viewerElement) => {
+        viewerElement.remove();
+    }, viewerElementHandle);
+    await page.waitForTimeout(500);
+
+    // Re-add a visible viewer so the shared afterEach frame-count assertion has something to observe. This
+    // test deliberately never attaches the frame counter before the removal, so it binds to this new viewer.
+    await scrollViewerOnscreen(page);
+    await page.evaluate(() => {
+        const container = document.createElement("div");
+        container.innerHTML = "<babylon-viewer></babylon-viewer>";
+        document.body.prepend(container);
+    });
+
+    await waitForLoadingComplete(page);
+    await waitForRenderLoopRunning(page, true);
 });

--- a/packages/tools/viewer/test/viewer.lite.test.ts
+++ b/packages/tools/viewer/test/viewer.lite.test.ts
@@ -47,12 +47,17 @@ test.afterEach(async ({ page }) => {
     }
 });
 
-async function waitForFrameCount(page: Page, minFrameCount: number): Promise<number> {
-    // Install a frame counter on the viewer (idempotent) and wait until it reaches the target.
-    const frameCountHandle = await page.waitForFunction((minFrameCount) => {
+/**
+ * Installs the rendered-frame counter on the viewer (idempotent), waiting for the viewer to exist first.
+ * Call this explicitly before asserting that frames are *not* advancing: until the counter is installed
+ * {@link getFrameCount} reports 0 regardless of what the viewer is doing, which would make such an
+ * assertion pass vacuously.
+ */
+async function attachFrameCounter(page: Page) {
+    await page.waitForFunction(() => {
         const viewer = (document.querySelector("babylon-viewer") as ViewerElement)?.viewer;
         if (!viewer) {
-            return null;
+            return false;
         }
         const w = window as unknown as { __liteFrameCount?: number; __liteFrameObserverAttached?: boolean };
         if (!w.__liteFrameObserverAttached) {
@@ -62,6 +67,15 @@ async function waitForFrameCount(page: Page, minFrameCount: number): Promise<num
             });
             w.__liteFrameObserverAttached = true;
         }
+        return true;
+    });
+}
+
+async function waitForFrameCount(page: Page, minFrameCount: number): Promise<number> {
+    await attachFrameCounter(page);
+
+    const frameCountHandle = await page.waitForFunction((minFrameCount) => {
+        const w = window as unknown as { __liteFrameCount?: number };
         return (w.__liteFrameCount ?? 0) >= minFrameCount ? w.__liteFrameCount : null;
     }, minFrameCount);
 
@@ -1302,11 +1316,20 @@ test("model and environment loaded while offscreen render correctly on resume", 
     });
 
     await page.locator("babylon-viewer").waitFor();
+
+    // Install the frame counter as early as possible, before anything could render, so the assertions below
+    // observe the real absence of rendering rather than an uninitialized counter.
+    await attachFrameCounter(page);
+
+    // The model and environment must load to completion even though the viewer is suspended. The
+    // `IntersectionObserver` fires asynchronously after layout, so a frame or two can land before suspension
+    // engages; the invariant that matters is that rendering does not *continue* while offscreen.
+    await waitForLoadingComplete(page);
     await waitForRenderLoopRunning(page, false);
 
-    // The model and environment must load to completion even though no frame is ever rendered.
-    await waitForLoadingComplete(page);
-    expect(await getFrameCount(page), "Frames rendered while offscreen").toBe(0);
+    const suspended = await getFrameCount(page);
+    await page.waitForTimeout(500);
+    expect(await getFrameCount(page), "Frames rendered while offscreen").toBe(suspended);
 
     // Bring the viewer into view: the spacer plus the viewport-sized viewer means max scroll lands the
     // viewer exactly in the viewport.


### PR DESCRIPTION
The full Viewer suspends rendering for canvases scrolled out of the viewport. Lite did not, so every `<babylon-viewer>` on a page rendered continuously regardless of scroll position.

**Motivation:** the Babylon.js Website `/viewer/` page stacks four `<babylon-viewer>` elements with camera auto-orbit. It currently sets `forceFullViewer: true` on that page *specifically* because Lite lacked offscreen suspension — Lite paid for all four viewers forever (main-thread CPU plus four live WebGPU devices doing continuous GPU work). This change is what makes that fallback droppable once published.

## Results

Frames rendered per viewer over 3s — 4 stacked viewers, boombox + `environment="auto"` + `camera-auto-orbit`, viewport 1400×800:

| scroll position | visible | before | after |
|---|---|---|---|
| top | `[Y,n,n,n]` | `[181,181,181,181]` | `[181,0,0,0]` |
| 650px | `[Y,Y,n,n]` | `[181,181,181,181]` | `[181,181,0,0]` |
| bottom | `[n,n,n,n]` | `[180,180,180,180]` | `[0,0,0,0]` |

Main-thread CPU (% of one core, CDP `Performance.getMetrics`, 10s samples):

| visible | lite before | lite after | full (reference) |
|---|---|---|---|
| 1 of 4 | 5.5% | 3.6% | 4.5% |
| 2 of 4 | 5.2% | 4.2% | 5.4% |
| 0 of 4 | 5.4% | **0.0%** | 0.0% |

Lite was flat; it now scales with visible-viewer count in the same shape as full, and is cheaper than full at every position. (Absolute numbers are lower than the Website's because this repro scene is much lighter — the *shape* is what reproduces.)

## Approach

`stopEngine`/`startEngine` **without** touching scene registration is a safe, cheap pause. Verified against the Lite engine source rather than assumed:

- `stopEngine` cancels the rAF, nulls `_renderFn`, and flushes GPU resource retirements. It never touches `surface._renderingContexts`, so scene registration survives a pause.
- `startEngine` builds a fresh closure with `firstRafFrame = true` / `lastTime = 0`, so the first frame after resume gets `delta = 0` — no delta spike, and auto-orbit does not jump after a long offscreen period.
- `_renderFn` calls `resizeEngine` every frame, so a resize during suspension is picked up on the first resumed frame. This is why Lite doesn't need full's `ResizeObserver`.

`_beginRendering()`'s `unregisterScene`/`registerScene` pair exists only to re-run deferred builders and re-wire the shadow frame-graph task — incidental to pausing, not inherent to it.

Self-driving the loop via the exposed `renderFrame` was evaluated and rejected: it would mean reimplementing per-frame `resizeEngine`, first-frame/delta bookkeeping, and retirement flushing, and bypassing `engine._renderFn`, which `disposeEngine` and device-lost recovery reason about. More bytes, more divergence, no benefit for offscreen-only suspension. It stays in reserve as the enabler for a future shared-rAF-across-viewers or true idle suspension.

## Two things reviewers won't infer from the diff

**1. The `_renderLoopRunning` → `_renderLoopRunning` + `_sceneRegistered` split is required, not cleanup.**

Three sites read `_renderLoopRunning` as *"has the scene been registered/built"*, not *"is the rAF loop running"*. If suspension flipped that flag false, an environment loaded **while offscreen** would skip its re-registration and the skybox would never appear — even after the viewer scrolled back into view. Hence the split: `_renderLoopRunning` now means only rAF-loop state, and the three scene-lifetime sites moved to `_sceneRegistered`. There is a dedicated test for exactly this case.

**2. This also fixes a pre-existing `dispose()` hang.**

`startEngine`'s promise only settles from inside the rAF callback. If the loop was stopped before its first frame, `await startEngine(...)` never settled — stranding `_beginRendering()` and `_loadModelImpl`'s `finally { loadOperation.dispose() }`. That bug predates this PR (reachable via `dispose()` during startup) but suspension would have made it frequent. Fixed by racing `startEngine` against a `_renderLoopStopped` signal.

## Race safety

`_suspendRendering()` increments the refcount **synchronously** but queues the actual `stopEngine` on the same `AsyncLock` that now serializes all of `_beginRendering()`. Because `lockAsync` always defers at least a microtask, a suspend requested while `_beginRendering()` holds the lock is already visible to that call's `_startRenderLoop()`, which declines — the queued stop is then a harmless no-op. The reverse ordering works symmetrically. `_startRenderLoop` is only ever called under the lock, so the stop signal can't be clobbered. `_isDisposed` is re-checked after every await.

## Shared code

The `IntersectionObserver` wiring was near-identical in both flavors, so it moved to `src/offscreenRenderingSuspension.ts` and full's inline copy is deleted. Full also inherits Lite's `??=` guard, which keeps repeated non-intersecting records from acquiring a second suspension and pinning the viewer suspended forever. (Unlikely with `threshold: [0]`, so this is correctness-by-construction rather than a fix for a confirmed live bug.)

It's a new module rather than `viewerBase.ts` because `viewerBase.ts` is deliberately DOM-free.

The **refcount** was deliberately *not* shared. Full's stop is synchronous (`_renderLoopController?.dispose()`), Lite's is async and lock-serialized; full's `_beginRendering()` is sync/void, Lite's is `async`; full stops unconditionally per call, Lite gates on the 0→1 transition; full is `protected` (reached via `ViewerDetails`), Lite's must be `public @internal`. Bridging sync-vs-async semantics to dedupe ~6 lines would *add* bytes to a budgeted bundle.

## `autoSuspendRendering`

Lite silently ignores the shared `autoSuspendRendering` option (idle suspension). This PR documents that divergence on the option and on Lite's `Viewer` class rather than implementing it — real idle support is follow-up work. Note it wouldn't have helped the Website case regardless, since auto-orbit mutates the camera every frame.

A runtime warning isn't viable: the element's options Proxy always returns a concrete boolean, so the Viewer can't distinguish "user set it" from "default" and would warn for everyone.

Offscreen suspension is intentionally **not** gated on `autoSuspendRendering`, matching full, where the observer is unconditional.

## Bundle size

Measured two ways:

- **Bundled** (esbuild over `src/lite/index.ts` — what consumers actually pay): 195,461 → 196,605 minified (**+1,144 B**, +0.59%); 106,485 → 106,781 gzipped (**+296 B**, +0.28%).
- Per-file minified `lite/viewer.js` for the pre-extraction shape: **+1,094 B min / +288 B gzip**.

Sharing the observer costs Lite ~50 B min / ~8 B gz versus keeping it inline, while full sheds ~350 B of duplicate — net repo win. Viewers that never scroll offscreen pay nothing at runtime beyond one `IntersectionObserver`.

## Testing

- `viewer-lite`: **40/40 passing** (36 existing + 4 new), two consecutive clean runs
- `viewer` (full): **45/45 passing** — full's factory is exercised against the extracted helper
- The 4 new tests under `--repeat-each=4`: **16/16**, no flakes
- `tsc -b`, `prettier --check`, `eslint` (0 errors) all clean

New tests:
- rendering is suspended while the viewer is offscreen
- rendering resumes when the viewer is scrolled back into view
- model and environment loaded while offscreen render correctly on resume — the viewer is created below the fold, so it is suspended from birth; this covers both the `_sceneRegistered` hazard above and "a viewer suspended before its first frame must still reach a correct first render"
- disposing a viewer while it is offscreen

The resume tests reuse existing reference images rather than adding new baselines.