### PR TITLE
Fix atmosphere GLSL shaders under WebGPU by inlining sampler-taking functions

### DIFF
--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereFunctions.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/atmosphereFunctions.fx
@@ -140,6 +140,7 @@ void getSkyViewUVFromParameters(
 
 #if USE_SKY_VIEW_LUT && SAMPLE_SKY_VIEW_LUT
 
+#define inline
 vec4 sampleSkyViewLut(
     sampler2D skyViewLut,
     float positionRadius,
@@ -296,6 +297,7 @@ vec2 getTransmittanceUV(float radius, float cosAngleLightToZenith, out float dis
 }
 
 // Gets the transmittance of an external light through the atmosphere to a point described by its radius (from the center of the planet) and the angle of incoming light.
+#define inline
 vec4 sampleTransmittanceLut(sampler2D transmittanceLut, float positionRadius, float cosAngleLightToZenith) {
 
     float distanceToHorizon;
@@ -312,6 +314,7 @@ vec4 sampleTransmittanceLut(sampler2D transmittanceLut, float positionRadius, fl
 #ifndef EXCLUDE_RAY_MARCHING_FUNCTIONS
 
 #ifndef COMPUTE_MULTI_SCATTERING
+#define inline
 vec3 sampleMultiScatteringLut(sampler2D multiScatteringLut, float radius, float cosAngleLightToZenith) {
 
     vec2 unit = vec2(0.5 + 0.5 * cosAngleLightToZenith, (radius - planetRadius) / atmosphereThickness);
@@ -328,6 +331,7 @@ vec3 sampleMultiScatteringLut(sampler2D multiScatteringLut, float radius, float 
 const float uniformPhase = RECIPROCAL_PI4;
 
 // Utilizes the transmittance LUT and multiple scattering LUT to compute the radiance and transmittance for a given ray.
+#define inline
 vec3 integrateScatteredRadiance(
     bool isAerialPerspectiveLut,
     float lightIntensity,
@@ -599,6 +603,7 @@ vec3 getSphereSample(float azimuth, float inclination, out float sinInclination)
     return vec3(sinInclination * sin(azimuth), cos(inclination), sinInclination * cos(azimuth));
 }
 
+#define inline
 vec4 renderMultiScattering(vec2 uv, sampler2D transmittanceLut) {
     float MultiScatteringAzimuthIterationAngle = TWO_PI / multiScatteringAzimuthSampleCount;
     float MultiScatteringInclinationIterationAngle = PI / multiScatteringInclinationSampleCount;
@@ -697,6 +702,7 @@ void getSkyViewParametersFromUV(
 
 }
 
+#define inline
 vec4 renderSkyView(vec2 uv, sampler2D transmittanceLut, sampler2D multiScatteringLut) {
 
     float cosAngleBetweenViewAndZenith;
@@ -748,6 +754,7 @@ vec4 renderSkyView(vec2 uv, sampler2D transmittanceLut, sampler2D multiScatterin
 
 #if RENDER_CAMERA_VOLUME
 
+#define inline
 vec4 renderCameraVolume(
     vec3 positionOnNearPlane,
     float layerIdx,

--- a/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/depthFunctions.fx
+++ b/packages/dev/addons/src/atmosphere/Shaders/ShadersInclude/depthFunctions.fx
@@ -7,6 +7,7 @@ float reconstructDistanceFromCameraPlane(float depth, float cameraNearPlane) {
 }
 
 // If depth is at far plane, returns 0.
+#define inline
 float sampleDistanceFromCameraPlane(sampler2D depthTexture, vec2 uv, float cameraNearPlane) {
     float depth = textureLod(depthTexture, uv, 0.).r;
     return depth >= 1. ? 0. : reconstructDistanceFromCameraPlane(depth, cameraNearPlane);
@@ -19,6 +20,7 @@ float reconstructDistanceFromCamera(float depth, vec3 cameraRayDirection, vec3 c
 }
 
 // If depth is at far plane, returns 0.
+#define inline
 float reconstructDistanceFromCamera(
     sampler2D depthTexture,
     vec2 uv,


### PR DESCRIPTION
## Problem

WebGPU has no combined-sampler type, so Babylon's WebGPU GLSL processor rewrites every `sampler2D` into a separate `texture2D` + `sampler` pair. A function that takes a `sampler2D` **parameter** cannot survive that rewrite, so the convention across core is to mark such functions `#define inline` and let the shader inliner remove them before glslang runs — see `shadowsFragmentFunctions.fx`, `clusteredLightingFunctions.fx`, `bonesDeclaration.fx`, `hdrFilteringFunctions.fx`, and others.

The atmosphere shader includes carry no inline markers, so on WebGPU + GLSL every atmosphere effect fails to compile:

```
Parse failed
ERROR: 0:957: '' :  syntax error, unexpected SAMPLER2D, expecting RIGHT_PAREN
ERROR: 1 compilation errors.  No code generated.
```

The material never finishes compiling, so the scene never becomes ready and the atmosphere silently never renders.

This is reachable from public API: on WebGPU, `PBRBaseMaterial.ForceGLSL = true` (or `EffectWrapper.ForceGLSL`) selects the GLSL path. The "Test code inlining" playground ([#YG3BBF#51](https://playground.babylonjs.com/#YG3BBF#51)) sets exactly that. It is not hit by default because WebGPU normally takes the WGSL variants, which are unaffected by this change.

## Fix

Add `#define inline` to the eight atmosphere functions that take a sampler parameter:

| File | Functions |
| --- | --- |
| `atmosphereFunctions.fx` | `sampleSkyViewLut`, `sampleTransmittanceLut`, `sampleMultiScatteringLut`, `integrateScatteredRadiance`, `renderMultiScattering`, `renderSkyView`, `renderCameraVolume` |
| `depthFunctions.fx` | `sampleDistanceFromCameraPlane`, `reconstructDistanceFromCamera` |

GLSL-only; the WGSL shaders are untouched and WGSL handles texture parameters natively.

## Verification

On a WebGPU (Dawn) backend with `ForceGLSL` enabled, running the "Test code inlining" playground followed by the eight Atmosphere visual tests:

- **Before:** all eight fail to compile and never become ready (each burns the full scene-ready timeout).
- **After:** `ran=9 passed=9 failed=0`, every Atmosphere scene pixel-matching its reference image.

## Follow-up (not in this PR)

An audit of `packages/dev` found the same missing-`#define inline` pattern at ~18 other sites, mostly in `core` (`lightsFragmentFunctions.fx`, `ltcHelperFunctions.fx`, `openpbrVolumeFunctions.fx`, `textureRepetitionFunctions.fx`, `pbrDirectLighting*.fx`, `standard.fragment.fx`) and the GUI MRDL/Fluent materials. Those are left alone here since I have not reproduced a failure for them, but they look like the same latent issue on the WebGPU GLSL path.