### PR TITLE
CI: bound and isolate Nx pipeline caches

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -73,8 +73,9 @@ variables:
       value: $(Pipeline.Workspace)/.npm
     - name: NX_CACHE_DIRECTORY
       value: $(Pipeline.Workspace)/.nxcache
-    # Cache@2 creates an uncompressed tar alongside the Nx cache when saving it.
-    # Keep enough disk headroom for both the cache and that temporary archive.
+    # Nx 22.7.8 reads NX_MAX_CACHE_SIZE and accepts B/KB/MB/GB values. Cache@2
+    # creates an uncompressed tar alongside the cache, so cap the source
+    # directory to leave enough disk headroom for that temporary archive.
     - name: NX_MAX_CACHE_SIZE
       value: 4GB
     - name: PLAYWRIGHT_BROWSERS_PATH

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -73,6 +73,10 @@ variables:
       value: $(Pipeline.Workspace)/.npm
     - name: NX_CACHE_DIRECTORY
       value: $(Pipeline.Workspace)/.nxcache
+    # Cache@2 creates an uncompressed tar alongside the Nx cache when saving it.
+    # Keep enough disk headroom for both the cache and that temporary archive.
+    - name: NX_MAX_CACHE_SIZE
+      value: 4GB
     - name: PLAYWRIGHT_BROWSERS_PATH
       value: $(Pipeline.Workspace)/.playwright
     # Cache location for the pinned Khronos KHR_interactivity conformance assets.
@@ -184,6 +188,7 @@ jobs:
           - template: templates/cache-steps.yml
             parameters:
                 nx: true
+                nxCacheKey: build
 
           - script: npm install
             displayName: "npm install"
@@ -316,6 +321,7 @@ jobs:
           - template: templates/cache-steps.yml
             parameters:
                 nx: true
+                nxCacheKey: es6
 
           - script: npm install
             displayName: "npm install"
@@ -396,6 +402,7 @@ jobs:
           - template: templates/cache-steps.yml
             parameters:
                 nx: true
+                nxCacheKey: es6-tools
 
           - script: npm install
             displayName: "npm install"

--- a/.azure-pipelines/templates/cache-steps.yml
+++ b/.azure-pipelines/templates/cache-steps.yml
@@ -5,11 +5,12 @@
 # `npm install` step so the npm download cache is restored first, and (when
 # enabled) the Nx computation cache is available for the later build target.
 #
-# Requires these pipeline-level variables to be defined (see ci-monorepo.yml):
+# Uses these pipeline-level cache path variables (see ci-monorepo.yml):
 #   - npm_config_cache          e.g. $(Pipeline.Workspace)/.npm
 #   - NX_CACHE_DIRECTORY        e.g. $(Pipeline.Workspace)/.nxcache
-#   - NX_MAX_CACHE_SIZE         e.g. 4GB
 #   - PLAYWRIGHT_BROWSERS_PATH  e.g. $(Pipeline.Workspace)/.playwright
+# The consuming job controls Nx's local cache size; this template only persists
+# the resulting directory.
 #
 # Cache keys:
 #   - npm:        keyed on package-lock.json (hits until dependencies change).

--- a/.azure-pipelines/templates/cache-steps.yml
+++ b/.azure-pipelines/templates/cache-steps.yml
@@ -8,14 +8,15 @@
 # Requires these pipeline-level variables to be defined (see ci-monorepo.yml):
 #   - npm_config_cache          e.g. $(Pipeline.Workspace)/.npm
 #   - NX_CACHE_DIRECTORY        e.g. $(Pipeline.Workspace)/.nxcache
+#   - NX_MAX_CACHE_SIZE         e.g. 4GB
 #   - PLAYWRIGHT_BROWSERS_PATH  e.g. $(Pipeline.Workspace)/.playwright
 #
 # Cache keys:
 #   - npm:        keyed on package-lock.json (hits until dependencies change).
 #   - nx:         keyed per-job on the commit, with restoreKeys falling back to
-#                 the most recent prior cache. Nx validates each task by its own
-#                 input hash, so unchanged packages are restored as cache hits —
-#                 this is what makes re-pushes (e.g. fixing one comment) fast.
+#                 that job's most recent cache. Nx validates each task by its
+#                 own input hash, so unchanged packages are restored as cache
+#                 hits — this is what makes re-pushes fast.
 #   - playwright: keyed on package-lock.json (browser version is pinned there).
 # =============================================================================
 
@@ -23,6 +24,9 @@ parameters:
     - name: nx
       type: boolean
       default: false
+    - name: nxCacheKey
+      type: string
+      default: default
     - name: playwright
       type: boolean
       default: false
@@ -46,11 +50,11 @@ steps:
     - ${{ if eq(parameters.nx, true) }}:
           - task: Cache@2
             displayName: "Cache Nx computation"
+            continueOnError: true
             inputs:
-                key: 'nx | "$(Agent.OS)" | "$(System.JobName)" | $(Build.SourceVersion)'
+                key: 'nx | "$(Agent.OS)" | "${{ parameters.nxCacheKey }}" | $(Build.SourceVersion)'
                 restoreKeys: |
-                    nx | "$(Agent.OS)" | "$(System.JobName)"
-                    nx | "$(Agent.OS)"
+                    nx | "$(Agent.OS)" | "${{ parameters.nxCacheKey }}"
                 path: $(NX_CACHE_DIRECTORY)
 
     - ${{ if eq(parameters.playwright, true) }}:


### PR DESCRIPTION
## Problem

[Monorepo CI build 58065](https://dev.azure.com/babylonjs/ContinousIntegration/_build/results?buildId=58065&view=logs&j=f705d504-441b-52d2-897b-4ba4ae53dc56) restored the same 19.3 GB Nx cache into the Build, ES6, and ES6Tools jobs. Although the hosted-agent cleanup freed 42 GB, each post-job `Cache@2` save then created an additional uncompressed tar and exhausted the 72 GB OS disk.

The cache key used `$(System.JobName)`, which resolved to `__default` in all three jobs, and the broad fallback allowed every job to restore the same oversized cache.

## Fix

- Give Build, ES6, and ES6Tools explicit, isolated Nx cache keys.
- Remove the broad cross-job fallback so the legacy 19.3 GB cache is not restored.
- Set `NX_MAX_CACHE_SIZE=4GB`, supported by the pinned Nx 22.7.8, leaving headroom for the `Cache@2` save tar.
- Mark Nx cache persistence non-blocking because cache upload is an optimization and should not fail an otherwise successful build.