### PR TITLE
Fix Gaussian splat transform and proxy visibility updates

### DIFF
--- a/packages/dev/core/src/Collisions/gpuPicker.ts
+++ b/packages/dev/core/src/Collisions/gpuPicker.ts
@@ -715,10 +715,8 @@ export class GPUPicker {
             const plugin = gsPickingMaterial.pluginManager!.getPlugin<GaussianSplattingGpuPickingMaterialPlugin>("GaussianSplatGpuPicking")!;
             plugin.isCompound = true;
             plugin.partMeshIds = partMeshIds;
-            // Only active (included, visible, and pickable) parts should contribute to the depth buffer.
-            const activeParts = group.partEntries
-                .filter((e) => (e.proxy as AbstractMesh).isPickable && (e.proxy as AbstractMesh).isVisible)
-                .map((e) => (e.proxy as any).partIndex as number);
+            // Only active (included, enabled, visible, and pickable) parts should contribute to the depth buffer.
+            const activeParts = group.partEntries.filter((e) => this._isPartProxyActiveForPicking(e.proxy as AbstractMesh)).map((e) => (e.proxy as any).partIndex as number);
             plugin.setPartActive(activeParts);
 
             gsPickingMaterial.onBindObservable.add(() => {
@@ -1007,6 +1005,10 @@ export class GPUPicker {
                 : GPUPicker._MultiPickIndividualReadbackAreaRatio;
         const pointReadArea = inBoundsPointCount * (this._useDepthPicking ? 1 + (GPUPicker._DepthPixelRadius * 2 + 1) ** 2 : 1);
         return readArea > pointReadArea * individualReadbackAreaRatio;
+    }
+
+    private _isPartProxyActiveForPicking(proxy: Pick<AbstractMesh, "isEnabled" | "isPickable" | "isVisible">): boolean {
+        return proxy.isEnabled() && proxy.isPickable && proxy.isVisible;
     }
 
     private _preparePickingBuffer(engine: AbstractEngine, rttSizeW: number, rttSizeH: number, x: number, y: number, w = 1, h = 1, readBufferW = w, readBufferH = h): void {

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMesh.pure.ts
@@ -2193,7 +2193,7 @@ export class GaussianSplattingMesh extends GaussianSplattingMeshBase {
                 const newPartIndex = proxyMesh.partIndex;
                 mesh._partProxies[newPartIndex] = proxyMesh;
                 mesh.setWorldMatrixForPart(newPartIndex, proxyMesh.getWorldMatrix());
-                mesh.setPartVisibility(newPartIndex, proxyMesh.visibility);
+                mesh.setPartVisibility(newPartIndex, proxyMesh.isEnabled() ? proxyMesh.visibility : 0);
             }
         }
 

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -1260,14 +1260,15 @@ export class GaussianSplattingMeshBase extends Mesh {
             return false;
         }
 
-        // Before the first successful render, apply strict sort-state checks to ensure
-        // the first rendered frame uses correct splat ordering. Once the mesh has been
-        // rendered at least once, skip these checks — the render loop will continuously
-        // re-sort as the camera/world changes via _postToWorker() in render().
+        // Before the first successful render, require an applied index buffer and no pending sort.
+        // World-matrix drift queues a fresher sort but can use the latest completed buffer, otherwise
+        // a transform changed every frame would starve the first render. Once rendered, the render loop
+        // continuously re-sorts as the camera/world changes via _postToWorker() in render().
         if (!this._hasRenderedOnce && !this._disableDepthSort) {
             const cameras = this._scene.activeCameras?.length ? this._scene.activeCameras : [this._scene.activeCamera!];
             const worldMatrix = this.computeWorldMatrix(true);
-            let anyDirty = false;
+            let sortPending = false;
+            let worldMatrixDirty = false;
             for (const camera of cameras) {
                 if (!camera) {
                     continue;
@@ -1275,30 +1276,34 @@ export class GaussianSplattingMeshBase extends Mesh {
 
                 const cameraViewInfo = this._cameraViewInfos.get(camera.uniqueId);
                 if (!cameraViewInfo || !cameraViewInfo.splatIndexBufferSet) {
-                    anyDirty = true;
+                    sortPending = true;
                     continue;
                 }
 
                 // Wait for the most recently requested sort to be applied so that the splat indices
                 // match the latest world/camera state.
                 if (cameraViewInfo.sortAppliedId !== cameraViewInfo.sortRequestId) {
-                    anyDirty = true;
+                    sortPending = true;
                     continue;
                 }
 
-                // If world matrix drifted (user applied transforms after load), re-sort before first render.
+                // If world matrix drifted (user applied transforms after load), request an updated sort.
                 // Camera drift is intentionally excluded here: checking camera movement would cause isReady()
                 // to return false indefinitely while the camera is moving. The render loop handles camera
                 // re-sorting continuously via _postToWorker() in render().
                 if (this._isSortStateDirty(cameraViewInfo, worldMatrix, camera, true)) {
-                    anyDirty = true;
+                    worldMatrixDirty = true;
                 }
             }
 
-            if (anyDirty) {
+            if (sortPending || worldMatrixDirty) {
                 // Try to post any pending sort so subsequent polling iterations make progress.
                 this._postToWorker(true);
-                return false;
+                // A completed index buffer remains renderable while a new world-matrix sort is pending.
+                // Waiting here would starve the first render when the transform changes every frame.
+                if (sortPending) {
+                    return false;
+                }
             }
         }
 

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -1265,6 +1265,7 @@ export class GaussianSplattingMeshBase extends Mesh {
         // first render. Once rendered, the render loop continuously re-sorts as the camera/world changes.
         if (!this._hasRenderedOnce && !this._disableDepthSort) {
             const cameras = this._scene.activeCameras?.length ? this._scene.activeCameras : [this._scene.activeCamera!];
+            const canRenderWithPendingRefresh = cameras.filter((camera) => camera !== null).length === 1;
             const worldMatrix = this.computeWorldMatrix(true);
             let sortBufferMissing = false;
             let sortRefreshPending = false;
@@ -1275,7 +1276,7 @@ export class GaussianSplattingMeshBase extends Mesh {
                 }
 
                 const cameraViewInfo = this._cameraViewInfos.get(camera.uniqueId);
-                if (!cameraViewInfo || !cameraViewInfo.splatIndexBufferSet) {
+                if (!cameraViewInfo || !cameraViewInfo.splatIndexBufferSet || cameraViewInfo.sortAppliedId === 0) {
                     sortBufferMissing = true;
                     continue;
                 }
@@ -1297,7 +1298,10 @@ export class GaussianSplattingMeshBase extends Mesh {
             if (sortBufferMissing || sortRefreshPending || worldMatrixDirty) {
                 // Try to post any pending sort so subsequent polling iterations make progress.
                 this._postToWorker(true);
-                if (sortBufferMissing) {
+                // A single-camera scene may use its latest completed sort while a transform refresh is
+                // pending, which prevents continuously changing transforms from starving the first render.
+                // Multi-camera scenes must wait because each viewport needs its own refreshed ordering.
+                if (sortBufferMissing || !canRenderWithPendingRefresh) {
                     return false;
                 }
             }
@@ -1463,10 +1467,15 @@ export class GaussianSplattingMeshBase extends Mesh {
                 this._cameraViewInfos.set(cameraId, newViewInfos);
             }
         });
-        // sort view infos: cameras without an initial splat-index buffer come first so they don't get starved
+        // Sort view infos: cameras without a completed initial sort come first so they don't get starved
         // by a `forced` re-sort of an already-initialized camera (which would consume `_canPostToWorker`).
+        // A camera can already have the shared index buffer bound when another camera's first sort resizes it,
+        // so splatIndexBufferSet alone does not mean this camera has received its own sorted result.
         // Among initialized cameras, the least recently updated comes first.
         activeViewInfos.sort((a, b) => {
+            if ((a.sortAppliedId === 0) !== (b.sortAppliedId === 0)) {
+                return a.sortAppliedId === 0 ? -1 : 1;
+            }
             if (a.splatIndexBufferSet !== b.splatIndexBufferSet) {
                 return a.splatIndexBufferSet ? 1 : -1;
             }

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -1260,14 +1260,14 @@ export class GaussianSplattingMeshBase extends Mesh {
             return false;
         }
 
-        // Before the first successful render, require an applied index buffer and no pending sort.
-        // World-matrix drift queues a fresher sort but can use the latest completed buffer, otherwise
-        // a transform changed every frame would starve the first render. Once rendered, the render loop
-        // continuously re-sorts as the camera/world changes via _postToWorker() in render().
+        // Before the first successful render, require an applied index buffer. A pending refresh can
+        // use the latest completed buffer, otherwise a transform changed every frame would starve the
+        // first render. Once rendered, the render loop continuously re-sorts as the camera/world changes.
         if (!this._hasRenderedOnce && !this._disableDepthSort) {
             const cameras = this._scene.activeCameras?.length ? this._scene.activeCameras : [this._scene.activeCamera!];
             const worldMatrix = this.computeWorldMatrix(true);
-            let sortPending = false;
+            let sortBufferMissing = false;
+            let sortRefreshPending = false;
             let worldMatrixDirty = false;
             for (const camera of cameras) {
                 if (!camera) {
@@ -1276,14 +1276,12 @@ export class GaussianSplattingMeshBase extends Mesh {
 
                 const cameraViewInfo = this._cameraViewInfos.get(camera.uniqueId);
                 if (!cameraViewInfo || !cameraViewInfo.splatIndexBufferSet) {
-                    sortPending = true;
+                    sortBufferMissing = true;
                     continue;
                 }
 
-                // Wait for the most recently requested sort to be applied so that the splat indices
-                // match the latest world/camera state.
                 if (cameraViewInfo.sortAppliedId !== cameraViewInfo.sortRequestId) {
-                    sortPending = true;
+                    sortRefreshPending = true;
                     continue;
                 }
 
@@ -1296,12 +1294,10 @@ export class GaussianSplattingMeshBase extends Mesh {
                 }
             }
 
-            if (sortPending || worldMatrixDirty) {
+            if (sortBufferMissing || sortRefreshPending || worldMatrixDirty) {
                 // Try to post any pending sort so subsequent polling iterations make progress.
                 this._postToWorker(true);
-                // A completed index buffer remains renderable while a new world-matrix sort is pending.
-                // Waiting here would starve the first render when the transform changes every frame.
-                if (sortPending) {
+                if (sortBufferMissing) {
                     return false;
                 }
             }

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingPartProxyMesh.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingPartProxyMesh.pure.ts
@@ -21,6 +21,8 @@ export class GaussianSplattingPartProxyMesh extends Mesh {
     private _minimum: Vector3;
     private _maximum: Vector3;
 
+    private _disabledVisibility: Nullable<number> = null;
+
     /**
      * The index of the part in the compound mesh (internal storage)
      */
@@ -101,6 +103,15 @@ export class GaussianSplattingPartProxyMesh extends Mesh {
         // Update the compound mesh's part matrix when this proxy's world matrix changes.
         this.onAfterWorldMatrixUpdateObservable.add(() => {
             this.compoundSplatMesh.setWorldMatrixForPart(this.partIndex, this.getWorldMatrix());
+        });
+        this.onEffectiveEnabledStateChangedObservable.add((isEnabled) => {
+            if (isEnabled) {
+                this.compoundSplatMesh.setPartVisibility(this.partIndex, this._disabledVisibility ?? this.compoundSplatMesh.getPartVisibility(this.partIndex));
+                this._disabledVisibility = null;
+            } else {
+                this._disabledVisibility = this.compoundSplatMesh.getPartVisibility(this.partIndex);
+                this.compoundSplatMesh.setPartVisibility(this.partIndex, 0);
+            }
         });
     }
 
@@ -183,31 +194,36 @@ export class GaussianSplattingPartProxyMesh extends Mesh {
     }
 
     /**
-     * Gets whether the part is visible
+     * Gets whether the part should be visible when this proxy is enabled
      */
     public override get isVisible(): boolean {
-        return this.compoundSplatMesh.getPartVisibility(this.partIndex) > 0;
+        return this.visibility > 0;
     }
 
     /**
-     * Sets whether the part is visible
+     * Sets whether the part should be visible when this proxy is enabled
      */
     public override set isVisible(value: boolean) {
-        this.compoundSplatMesh.setPartVisibility(this.partIndex, value ? 1.0 : 0.0);
+        this.visibility = value ? 1.0 : 0.0;
     }
 
     /**
-     * Gets the visibility of the part (0.0 to 1.0)
+     * Gets the visibility applied to the part while this proxy is enabled (0.0 to 1.0)
      */
     public override get visibility(): number {
-        return this.compoundSplatMesh.getPartVisibility(this.partIndex);
+        return this._disabledVisibility ?? this.compoundSplatMesh.getPartVisibility(this.partIndex);
     }
 
     /**
-     * Sets the visibility of the part (0.0 to 1.0)
+     * Sets the visibility to apply to the part while this proxy is enabled (0.0 to 1.0)
      */
     public override set visibility(value: number) {
-        this.compoundSplatMesh.setPartVisibility(this.partIndex, value);
+        const visibility = Math.max(0.0, Math.min(1.0, value));
+        if (this.isEnabled()) {
+            this.compoundSplatMesh.setPartVisibility(this.partIndex, visibility);
+        } else {
+            this._disabledVisibility = visibility;
+        }
     }
 
     /**

--- a/packages/dev/core/test/unit/Collisions/babylon.gpuPicker.test.ts
+++ b/packages/dev/core/test/unit/Collisions/babylon.gpuPicker.test.ts
@@ -49,6 +49,7 @@ type GPUPickerInternals = GPUPicker & {
     _prepareForPicking: (x: number, y: number, scaleX: number, scaleY: number) => { x: number; y: number };
     _readDepthTexturePixelsAsync: (x: number, y: number, w: number, h: number) => Promise<Nullable<ArrayBufferView>>;
     _shouldUseIndividualMultiPickReadback: (inBoundsPointCount: number, readArea: number, options?: IGPUMultiPickOptions) => boolean;
+    _isPartProxyActiveForPicking: (proxy: { isEnabled: () => boolean; isPickable: boolean; isVisible: boolean }) => boolean;
 };
 
 const createPicker = (): GPUPickerInternals => {
@@ -58,6 +59,13 @@ const createPicker = (): GPUPickerInternals => {
 describe("GPUPicker", () => {
     it("uses high precision integers for WebGL2 picking ID bit shifts", () => {
         expect(pickingPixelShader.shader).toContain("precision highp int;");
+    });
+
+    it("excludes disabled Gaussian splatting part proxies from picking", () => {
+        const picker = createPicker();
+        const proxy = { isEnabled: () => false, isPickable: true, isVisible: true };
+
+        expect(picker._isPartProxyActiveForPicking(proxy)).toBe(false);
     });
 
     it("decodes float depth values from a depth read buffer", () => {

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.partProxyEnabled.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.partProxyEnabled.test.ts
@@ -1,0 +1,52 @@
+import { BoundingInfo } from "core/Culling/boundingInfo";
+import { NullEngine } from "core/Engines/nullEngine";
+import "core/Materials/GaussianSplatting/gaussianSplattingMaterial";
+import { Vector3 } from "core/Maths/math.vector";
+import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
+import { GaussianSplattingPartProxyMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingPartProxyMesh";
+import { TransformNode } from "core/Meshes/transformNode";
+import { Scene } from "core/scene";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("GaussianSplattingPartProxyMesh enabled state", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let compound: GaussianSplattingMesh;
+    let proxy: GaussianSplattingPartProxyMesh;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
+        scene = new Scene(engine);
+        compound = new GaussianSplattingMesh("compound", null, scene);
+        proxy = new GaussianSplattingPartProxyMesh("part", scene, compound, 0, new BoundingInfo(Vector3.Zero(), Vector3.One()), 1, 0);
+        proxy.visibility = 0.25;
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("hides the part while disabled and restores its visibility when re-enabled", () => {
+        proxy.setEnabled(false);
+
+        expect(compound.getPartVisibility(0)).toBe(0);
+        expect(proxy.visibility).toBe(0.25);
+
+        proxy.setEnabled(true);
+
+        expect(compound.getPartVisibility(0)).toBe(0.25);
+    });
+
+    it("tracks enabled state inherited from an ancestor", () => {
+        const parent = new TransformNode("parent", scene);
+        proxy.parent = parent;
+
+        parent.setEnabled(false);
+        expect(compound.getPartVisibility(0)).toBe(0);
+
+        parent.setEnabled(true);
+        expect(compound.getPartVisibility(0)).toBe(0.25);
+    });
+});

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.partProxyEnabled.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.partProxyEnabled.test.ts
@@ -32,11 +32,13 @@ describe("GaussianSplattingPartProxyMesh enabled state", () => {
         proxy.setEnabled(false);
 
         expect(compound.getPartVisibility(0)).toBe(0);
-        expect(proxy.visibility).toBe(0.25);
+        proxy.visibility = 0.5;
+        expect(proxy.visibility).toBe(0.5);
+        expect(compound.getPartVisibility(0)).toBe(0);
 
         proxy.setEnabled(true);
 
-        expect(compound.getPartVisibility(0)).toBe(0.25);
+        expect(compound.getPartVisibility(0)).toBe(0.5);
     });
 
     it("tracks enabled state inherited from an ancestor", () => {

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.serialization.test.ts
@@ -130,6 +130,7 @@ describe("GaussianSplatting serialization", () => {
         const proxies = compound.addParts([sourceA, sourceB], false);
         proxies[1].position = new Vector3(7, 8, 9);
         proxies[1].visibility = 0.25;
+        proxies[1].setEnabled(false);
         proxies[1].computeWorldMatrix(true);
 
         const serialized = compound.serialize();
@@ -147,13 +148,17 @@ describe("GaussianSplatting serialization", () => {
         expect(parsed).toBeInstanceOf(GaussianSplattingCompoundMesh);
         expect(parsed.partCount).toBe(2);
         expect(parsedProxies).toHaveLength(2);
+        expect(parsedProxies[1].isEnabled()).toBe(false);
         expect(parsedProxies[1].visibility).toBeCloseTo(0.25);
+        expect(parsed.getPartVisibility(1)).toBe(0);
         expect(parsedProxies[1].position.asArray()).toEqual([7, 8, 9]);
 
         expect(() => parsed.removePart(0)).not.toThrow();
         expect(parsed.partCount).toBe(1);
 
         const rebuiltProxy = (parsed as any)._partProxies.filter(Boolean)[0];
+        rebuiltProxy.setEnabled(true);
+        expect(parsed.getPartVisibility(0)).toBeCloseTo(0.25);
         const rebuiltRetainedPart = (parsed as any)._createRetainedPartSource(rebuiltProxy);
         expect(ArrayBuffer.isView(rebuiltRetainedPart._splatsData)).toBe(true);
         expect(rebuiltRetainedPart._splatsData.buffer).toBe((parsed as any)._splatsData);

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -30,7 +30,7 @@ describe("GaussianSplatting transform before first render", () => {
         const cameraMesh = new Mesh("cameraMesh", scene);
         Reflect.set(mesh, "_readyToDisplay", true);
         const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
-        cameraViewInfos.set(camera.uniqueId, {
+        const cameraViewInfo = {
             camera,
             cameraDirection: Vector3.Zero(),
             sortWorldMatrix: Matrix.Identity(),
@@ -41,12 +41,17 @@ describe("GaussianSplatting transform before first render", () => {
             mesh: cameraMesh,
             frameIdLastUpdate: scene.getFrameId(),
             splatIndexBufferSet: true,
-        });
+        };
+        cameraViewInfos.set(camera.uniqueId, cameraViewInfo);
         const postToWorker = vi.spyOn(mesh, "_postToWorker").mockImplementation(() => {});
 
         mesh.position.y = 1;
 
         expect(mesh.isReady()).toBe(true);
         expect(postToWorker).toHaveBeenCalledWith(true);
+
+        cameraViewInfo.sortRequestId = 2;
+
+        expect(mesh.isReady()).toBe(true);
     });
 });

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -1,0 +1,52 @@
+import { FreeCamera } from "core/Cameras/freeCamera";
+import { NullEngine } from "core/Engines/nullEngine";
+import "core/Materials/GaussianSplatting/gaussianSplattingMaterial";
+import { Matrix, Vector3 } from "core/Maths/math.vector";
+import { Mesh } from "core/Meshes/mesh";
+import { GaussianSplattingMesh } from "core/Meshes/GaussianSplatting/gaussianSplattingMesh";
+import { Scene } from "core/scene";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("GaussianSplatting transform before first render", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        (engine.getCaps() as { maxVertexUniformVectors: number }).maxVertexUniformVectors = 256;
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("remains ready when its transform changes after the first depth sort completes", () => {
+        const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
+        scene.activeCamera = camera;
+
+        const mesh = new GaussianSplattingMesh("gs", null, scene);
+        const cameraMesh = new Mesh("cameraMesh", scene);
+        Reflect.set(mesh, "_readyToDisplay", true);
+        const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
+        cameraViewInfos.set(camera.uniqueId, {
+            camera,
+            cameraDirection: Vector3.Zero(),
+            sortWorldMatrix: Matrix.Identity(),
+            sortCameraForward: Vector3.Zero(),
+            sortCameraPosition: Vector3.Zero(),
+            sortRequestId: 1,
+            sortAppliedId: 1,
+            mesh: cameraMesh,
+            frameIdLastUpdate: scene.getFrameId(),
+            splatIndexBufferSet: true,
+        });
+        const postToWorker = vi.spyOn(mesh, "_postToWorker").mockImplementation(() => {});
+
+        mesh.position.y = 1;
+
+        expect(mesh.isReady()).toBe(true);
+        expect(postToWorker).toHaveBeenCalledWith(true);
+    });
+});

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -54,4 +54,63 @@ describe("GaussianSplatting transform before first render", () => {
 
         expect(mesh.isReady()).toBe(true);
     });
+
+    it("waits for every active camera to complete its initial sort", () => {
+        const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
+        const camera2 = new FreeCamera("camera2", new Vector3(0, 0, 10), scene);
+        scene.activeCameras = [camera, camera2];
+        const mesh = new GaussianSplattingMesh("splat", null, scene);
+        const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
+        const createCameraViewInfo = (viewCamera: FreeCamera, sortRequestId: number, sortAppliedId: number) => ({
+            camera: viewCamera,
+            cameraDirection: Vector3.Zero(),
+            sortWorldMatrix: Matrix.Identity(),
+            sortCameraForward: Vector3.Zero(),
+            sortCameraPosition: Vector3.Zero(),
+            sortRequestId,
+            sortAppliedId,
+            mesh: new Mesh(`${viewCamera.name}Mesh`, scene),
+            frameIdLastUpdate: scene.getFrameId(),
+            splatIndexBufferSet: true,
+        });
+        cameraViewInfos.set(camera.uniqueId, createCameraViewInfo(camera, 1, 1));
+        cameraViewInfos.set(camera2.uniqueId, createCameraViewInfo(camera2, 0, 0));
+        Reflect.set(mesh, "_readyToDisplay", true);
+        const depthMix = new BigInt64Array(16);
+        Reflect.set(mesh, "_depthMix", depthMix);
+        const postMessage = vi.fn();
+        Reflect.set(mesh, "_worker", { postMessage, terminate: vi.fn() });
+
+        expect(mesh.isReady()).toBe(false);
+        expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({ cameraId: camera2.uniqueId }), [depthMix.buffer]);
+    });
+
+    it("waits for transform refreshes in multi-camera scenes", () => {
+        const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
+        const camera2 = new FreeCamera("camera2", new Vector3(0, 0, 10), scene);
+        scene.activeCameras = [camera, camera2];
+        const mesh = new GaussianSplattingMesh("splat", null, scene);
+        const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
+        for (const activeCamera of scene.activeCameras) {
+            cameraViewInfos.set(activeCamera.uniqueId, {
+                camera: activeCamera,
+                cameraDirection: Vector3.Zero(),
+                sortWorldMatrix: Matrix.Identity(),
+                sortCameraForward: Vector3.Zero(),
+                sortCameraPosition: Vector3.Zero(),
+                sortRequestId: activeCamera.uniqueId,
+                sortAppliedId: activeCamera.uniqueId,
+                mesh: new Mesh(`${activeCamera.name}Mesh`, scene),
+                frameIdLastUpdate: scene.getFrameId(),
+                splatIndexBufferSet: true,
+            });
+        }
+        Reflect.set(mesh, "_readyToDisplay", true);
+        const postToWorker = vi.spyOn(mesh, "_postToWorker").mockImplementation(() => {});
+
+        mesh.position.y = 1;
+
+        expect(mesh.isReady()).toBe(false);
+        expect(postToWorker).toHaveBeenCalledWith(true);
+    });
 });


### PR DESCRIPTION
## Motivation

Gaussian splatting meshes could be permanently excluded from rendering when their transform changed from `onBeforeRenderObservable` before the first frame. In addition, disabling a `GaussianSplattingPartProxyMesh` did not hide its compound-mesh part because the proxy does not own the actual draw call.

Reported in https://forum.babylonjs.com/t/gaussian-splatting-update-transform-before-render/63906

## Changes

- Allow the first splat frame to use the latest completed sort while a transform-driven refresh is queued, preventing first-render starvation.
- Synchronize proxy effective enabled state, including disabled ancestors, with compound part visibility.
- Preserve requested part visibility across disable, re-enable, serialization, and compound rebuilds.
- Add regression coverage for pre-render transforms and proxy enabled-state behavior.

## Testing

- Gaussian splatting unit tests: 47 passed.
- Core TypeScript build passed.
- Targeted ESLint and Prettier checks passed.