### PR TITLE
Add WebXR composition and media layer support

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -871,7 +871,7 @@ interface XRMediaLayerInit {
 
 interface XRCylinderLayerInit extends XRLayerInit {
     textureType?: XRTextureType | undefined;
-    transform: XRRigidTransform;
+    transform?: XRRigidTransform | undefined;
     radius?: number | undefined;
     centralAngle?: number | undefined;
     aspectRatio?: number | undefined;

--- a/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
@@ -40,6 +40,9 @@ export class WebXRCompositionLayerWrapper<
         public override getHeight: () => number,
         public override readonly layer: LayerT,
         public override readonly layerType: LayerTypeT,
+        /**
+         * Whether the layer renders both views into a texture array.
+         */
         public readonly isMultiview: boolean,
         public createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider<LayerTypeT>,
         public _originalInternalTexture: Nullable<InternalTexture> = null,

--- a/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
@@ -2,27 +2,293 @@ import { type InternalTexture } from "core/Materials/Textures/internalTexture";
 import { type RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 import { type Viewport } from "core/Maths/math.viewport";
 import { Observable } from "core/Misc/observable";
-import { type WebXRLayerType, WebXRLayerWrapper } from "core/XR/webXRLayerWrapper";
-import { type WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
+import { type WebXRLayerType, WebXRLayerWrapper, type WebXRSpatialLayerType, type WebXRSupportedLayerType } from "core/XR/webXRLayerWrapper";
+import { WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
 import { WebXRWebGLRenderTargetTextureProvider } from "core/XR/webXRWebGLRenderTargetTextureProvider";
 import { type WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { type Nullable } from "core/types";
+import { Quaternion, Vector3 } from "core/Maths/math.vector.pure";
+import { type TransformNode } from "core/Meshes/transformNode.pure";
 
 /**
- * Wraps xr composition layers.
- * @internal
+ * The non-projection composition layers that can be positioned in an XR space.
  */
-export class WebXRCompositionLayerWrapper extends WebXRLayerWrapper {
+export type WebXRSpatialLayer = XRQuadLayer | XRCylinderLayer | XREquirectLayer | XRCubeLayer;
+
+export type { WebXRSpatialLayerType } from "core/XR/webXRLayerWrapper";
+
+/**
+ * Wraps an XR composition layer and creates its Babylon render target provider.
+ * @typeParam LayerT the concrete WebXR composition layer type
+ */
+export class WebXRCompositionLayerWrapper<
+    LayerT extends XRCompositionLayer = XRCompositionLayer,
+    LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType,
+> extends WebXRLayerWrapper<LayerTypeT> {
+    /**
+     * Whether this layer receives its content directly from an HTML media element.
+     */
+    public readonly isMediaLayer: boolean = false;
+
+    /**
+     * Whether Babylon should acquire subimages and expose render target textures for this layer.
+     */
+    public readonly usesRenderTargetProvider: boolean = true;
+
     constructor(
         public override getWidth: () => number,
         public override getHeight: () => number,
-        public override readonly layer: XRCompositionLayer,
-        public override readonly layerType: WebXRLayerType,
+        public override readonly layer: LayerT,
+        public override readonly layerType: LayerTypeT,
         public readonly isMultiview: boolean,
-        public createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider,
-        public _originalInternalTexture: Nullable<InternalTexture> = null
+        public createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider<LayerTypeT>,
+        public _originalInternalTexture: Nullable<InternalTexture> = null,
+        private readonly _destroyLayerOnDispose = false,
+        /**
+         * Whether the layer can only be rendered when its native `needsRedraw` flag is set.
+         */
+        public readonly isStatic = false
     ) {
         super(getWidth, getHeight, layer, layerType, createRTTProvider);
+    }
+
+    /**
+     * Disposes the Babylon render-target resources and destroys the native layer when this wrapper owns it.
+     */
+    public override dispose(): void {
+        super.dispose();
+        if (this._destroyLayerOnDispose) {
+            this.layer.destroy();
+        }
+    }
+}
+
+/**
+ * Wraps a positionable XR composition layer and synchronizes it with a Babylon transform node.
+ * The node's scaling does not affect the physical dimensions of the layer.
+ * @typeParam LayerT the concrete positionable WebXR layer type
+ */
+export class WebXRSpatialLayerWrapper<
+    LayerT extends WebXRSpatialLayer = WebXRSpatialLayer,
+    LayerTypeT extends WebXRSpatialLayerType = WebXRSpatialLayerType,
+> extends WebXRCompositionLayerWrapper<LayerT, LayerTypeT> {
+    private readonly _currentPosition = new Vector3();
+    private readonly _currentRotation = new Quaternion();
+    private readonly _lastPosition = new Vector3(Number.NaN, Number.NaN, Number.NaN);
+    private readonly _lastRotation = new Quaternion(Number.NaN, Number.NaN, Number.NaN, Number.NaN);
+
+    constructor(
+        getWidth: () => number,
+        getHeight: () => number,
+        layer: LayerT,
+        layerType: LayerTypeT,
+        isMultiview: boolean,
+        isStatic: boolean,
+        /**
+         * Whether the layer should follow changes to the session manager's reference space.
+         */
+        public readonly usesSessionReferenceSpace: boolean,
+        createRTTProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider<LayerTypeT>,
+        /**
+         * The Babylon node whose world position and rotation are applied to the native layer.
+         */
+        public readonly transformNode: TransformNode,
+        private readonly _ownsTransformNode: boolean
+    ) {
+        super(getWidth, getHeight, layer, layerType, isMultiview, createRTTProvider, null, true, isStatic);
+    }
+
+    /**
+     * Synchronizes the native layer with the current world transform of the Babylon node.
+     * @param useRightHandedSystem whether the Babylon scene uses right-handed coordinates
+     * @param worldScalingFactor the number of Babylon scene units represented by one meter
+     */
+    public updateFromTransformNode(useRightHandedSystem: boolean, worldScalingFactor: number): void {
+        this.transformNode.computeWorldMatrix(true).decompose(undefined, this._currentRotation, this._currentPosition);
+        this._currentPosition.scaleInPlace(1 / worldScalingFactor);
+
+        if (!useRightHandedSystem) {
+            this._currentPosition.z *= -1;
+            this._currentRotation.z *= -1;
+            this._currentRotation.w *= -1;
+        }
+
+        if (this._currentPosition.equals(this._lastPosition) && this._currentRotation.equals(this._lastRotation)) {
+            return;
+        }
+
+        this._lastPosition.copyFrom(this._currentPosition);
+        this._lastRotation.copyFrom(this._currentRotation);
+
+        const orientation = {
+            x: this._currentRotation.x,
+            y: this._currentRotation.y,
+            z: this._currentRotation.z,
+            w: this._currentRotation.w,
+        };
+        if (this.layerType === "XRCubeLayer") {
+            (this.layer as XRCubeLayer).orientation =
+                typeof DOMPointReadOnly === "undefined" ? (orientation as DOMPointReadOnly) : new DOMPointReadOnly(orientation.x, orientation.y, orientation.z, orientation.w);
+        } else {
+            (this.layer as XRQuadLayer | XRCylinderLayer | XREquirectLayer).transform = new XRRigidTransform(
+                {
+                    x: this._currentPosition.x,
+                    y: this._currentPosition.y,
+                    z: this._currentPosition.z,
+                },
+                orientation
+            );
+        }
+    }
+
+    /**
+     * Disposes the native layer wrapper and its Babylon transform node when the node was created by Babylon.
+     */
+    public override dispose(): void {
+        super.dispose();
+        if (this._ownsTransformNode) {
+            this.transformNode.dispose();
+        }
+    }
+}
+
+/**
+ * Wraps an XRMediaBinding layer.
+ * @typeParam LayerT the concrete media layer type
+ */
+export class WebXRMediaLayerWrapper<
+    LayerT extends Exclude<WebXRSpatialLayer, XRCubeLayer> = Exclude<WebXRSpatialLayer, XRCubeLayer>,
+    LayerTypeT extends Exclude<WebXRSpatialLayerType, "XRCubeLayer"> = Exclude<WebXRSpatialLayerType, "XRCubeLayer">,
+> extends WebXRSpatialLayerWrapper<LayerT, LayerTypeT> {
+    /**
+     * Media layers receive their contents directly from the user agent.
+     */
+    public override readonly isMediaLayer: boolean = true;
+    /**
+     * Media layers are populated directly by the user agent.
+     */
+    public override readonly usesRenderTargetProvider: boolean = false;
+
+    /**
+     * Creates a wrapper for a media-backed spatial layer.
+     * @param getWidth returns the current video width
+     * @param getHeight returns the current video height
+     * @param layer the native media composition layer
+     * @param layerType the concrete spatial layer type
+     * @param transformNode the Babylon transform synchronized with the native layer
+     * @param ownsTransformNode whether the wrapper should dispose the transform node
+     * @param usesSessionReferenceSpace whether the layer should follow session reference-space changes
+     */
+    constructor(
+        getWidth: () => number,
+        getHeight: () => number,
+        layer: LayerT,
+        layerType: LayerTypeT,
+        transformNode: TransformNode,
+        ownsTransformNode: boolean,
+        usesSessionReferenceSpace: boolean
+    ) {
+        super(
+            getWidth,
+            getHeight,
+            layer,
+            layerType,
+            false,
+            false,
+            usesSessionReferenceSpace,
+            (sessionManager) => new WebXRNoRenderTargetTextureProvider(sessionManager, this),
+            transformNode,
+            ownsTransformNode
+        );
+    }
+}
+
+/**
+ * Wraps a native cube layer and exposes its raw subimage.
+ * Cube layers require six face uploads or render passes and therefore do not use Babylon's 2D composition-layer render target provider.
+ */
+export class WebXRCubeLayerWrapper extends WebXRSpatialLayerWrapper<XRCubeLayer, "XRCubeLayer"> {
+    /**
+     * Cube layers are populated through raw cubemap or array-layer access.
+     */
+    public override readonly usesRenderTargetProvider: boolean = false;
+
+    constructor(
+        getWidth: () => number,
+        getHeight: () => number,
+        layer: XRCubeLayer,
+        isStatic: boolean,
+        usesSessionReferenceSpace: boolean,
+        private readonly _binding: XRWebGLBinding | XRGPUBinding,
+        transformNode: TransformNode,
+        ownsTransformNode: boolean
+    ) {
+        super(
+            getWidth,
+            getHeight,
+            layer,
+            "XRCubeLayer",
+            false,
+            isStatic,
+            usesSessionReferenceSpace,
+            (sessionManager) => new WebXRNoRenderTargetTextureProvider(sessionManager, this),
+            transformNode,
+            ownsTransformNode
+        );
+    }
+
+    /**
+     * Gets the compositor-owned cube subimage for the current frame.
+     * WebGL callers must populate all six cubemap faces. WebGPU callers must render to six consecutive array layers beginning at the descriptor's base array layer.
+     * @param frame the current XR frame
+     * @param eye the eye to retrieve for stereo cube layers
+     * @returns the raw WebGL or WebGPU cube subimage
+     */
+    public getSubImage(frame: XRFrame, eye?: XREye): XRWebGLSubImage | XRGPUSubImage {
+        return this._binding.getSubImage(this.layer, frame, eye);
+    }
+}
+
+/**
+ * Composition layers that are populated outside Babylon do not expose render targets.
+ * @internal
+ */
+class WebXRNoRenderTargetTextureProvider<LayerTypeT extends WebXRSupportedLayerType> extends WebXRLayerRenderTargetTextureProvider<LayerTypeT> {
+    /**
+     * Creates a no-render-target provider.
+     * @param sessionManager the current XR session manager
+     * @param layerWrapper the composition layer wrapper
+     */
+    constructor(sessionManager: WebXRSessionManager, layerWrapper: WebXRCompositionLayerWrapper<XRCompositionLayer, LayerTypeT>) {
+        super(sessionManager.scene, layerWrapper);
+    }
+
+    /**
+     * Media layers do not expose a viewport.
+     * @param _viewport unused viewport
+     * @param _view unused XR view
+     * @returns always `false`
+     */
+    public trySetViewportForView(_viewport: Viewport, _view: XRView): boolean {
+        return false;
+    }
+
+    /**
+     * Media layers do not expose render target textures.
+     * @param _eye unused XR eye
+     * @returns always `null`
+     */
+    public getRenderTargetTextureForEye(_eye: XREye): Nullable<RenderTargetTexture> {
+        return null;
+    }
+
+    /**
+     * Media layers do not expose render target textures.
+     * @param _view unused XR view
+     * @returns always `null`
+     */
+    public getRenderTargetTextureForView(_view: XRView): Nullable<RenderTargetTexture> {
+        return null;
     }
 }
 
@@ -30,7 +296,9 @@ export class WebXRCompositionLayerWrapper extends WebXRLayerWrapper {
  * Provides render target textures and other important rendering information for a given XRCompositionLayer.
  * @internal
  */
-export class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRWebGLRenderTargetTextureProvider {
+export class WebXRCompositionLayerRenderTargetTextureProvider<
+    LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType,
+> extends WebXRWebGLRenderTargetTextureProvider<LayerTypeT> {
     protected _lastSubImages = new Map<XREye, XRWebGLSubImage>();
     private _compositionLayer: XRCompositionLayer;
     /**
@@ -41,7 +309,7 @@ export class WebXRCompositionLayerRenderTargetTextureProvider extends WebXRWebGL
     constructor(
         protected readonly _xrSessionManager: WebXRSessionManager,
         protected readonly _xrWebGLBinding: XRWebGLBinding,
-        public override readonly layerWrapper: WebXRCompositionLayerWrapper
+        public override readonly layerWrapper: WebXRCompositionLayerWrapper<XRCompositionLayer, LayerTypeT>
     ) {
         super(_xrSessionManager.scene, layerWrapper);
         this._compositionLayer = layerWrapper.layer;

--- a/packages/dev/core/src/XR/features/Layers/WebXRFallbackLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRFallbackLayer.ts
@@ -173,7 +173,11 @@ export class WebXRFallbackLayerWrapper {
      */
     public updateFromTransformNode(worldScalingFactor = 1): void {
         this.transformNode.computeWorldMatrix(true).decompose(undefined, this._currentRotation, this._currentPosition);
-        this.mesh.position.copyFrom(this._currentPosition);
+        if (this.layerType === "XRCubeLayer") {
+            this.mesh.position.setAll(0);
+        } else {
+            this.mesh.position.copyFrom(this._currentPosition);
+        }
         this._currentRotation.multiplyToRef(this._meshRotationOffset, this.mesh.rotationQuaternion!);
         this.mesh.scaling.setAll(worldScalingFactor);
     }

--- a/packages/dev/core/src/XR/features/Layers/WebXRFallbackLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRFallbackLayer.ts
@@ -1,0 +1,194 @@
+import { type BaseTexture } from "core/Materials/Textures/baseTexture";
+import { StandardMaterial } from "core/Materials/standardMaterial.pure";
+import { Quaternion, Vector3 } from "core/Maths/math.vector.pure";
+import { Color3 } from "core/Maths/math.color.pure";
+import { Mesh } from "core/Meshes/mesh.pure";
+import { CreateBox } from "core/Meshes/Builders/boxBuilder.pure";
+import { CreateCylinder } from "core/Meshes/Builders/cylinderBuilder.pure";
+import { CreatePlane } from "core/Meshes/Builders/planeBuilder.pure";
+import { CreateSphere } from "core/Meshes/Builders/sphereBuilder.pure";
+import { type TransformNode } from "core/Meshes/transformNode.pure";
+import { type Scene } from "core/scene";
+import { Constants } from "core/Engines/constants";
+import { type WebXRSpatialLayerType } from "./WebXRCompositionLayer";
+
+/**
+ * Physical dimensions used to approximate a native composition layer with a Babylon mesh.
+ */
+export interface IWebXRFallbackLayerDimensions {
+    /** The quad width in meters. */
+    width?: number;
+    /** The quad height in meters. */
+    height?: number;
+    /** The cylinder or sphere radius in meters. */
+    radius?: number;
+    /** The cylinder central angle in radians. */
+    centralAngle?: number;
+    /** The cylinder width-to-height aspect ratio. */
+    aspectRatio?: number;
+    /** The equirectangular horizontal angle in radians. */
+    centralHorizontalAngle?: number;
+    /** The equirectangular upper vertical angle in radians. */
+    upperVerticalAngle?: number;
+    /** The equirectangular lower vertical angle in radians. */
+    lowerVerticalAngle?: number;
+}
+
+/**
+ * Wraps a mesh used when a requested native WebXR composition layer is unavailable.
+ */
+export class WebXRFallbackLayerWrapper {
+    private readonly _currentPosition = new Vector3();
+    private readonly _currentRotation = new Quaternion();
+    private readonly _meshRotationOffset = new Quaternion();
+    private readonly _material: StandardMaterial;
+    private readonly _ownsTexture: boolean;
+
+    /**
+     * The native layer is always `null` for a fallback wrapper.
+     */
+    public readonly layer = null;
+
+    /**
+     * Whether this wrapper is backed by a native WebXR composition layer.
+     */
+    public readonly isNative = false;
+
+    /**
+     * The Babylon mesh that approximates the requested composition layer.
+     */
+    public readonly mesh: Mesh;
+
+    /**
+     * The texture displayed by the fallback mesh.
+     */
+    public readonly texture: BaseTexture;
+
+    constructor(
+        scene: Scene,
+        /**
+         * The requested WebXR composition layer type.
+         */
+        public readonly layerType: WebXRSpatialLayerType,
+        /**
+         * The texture displayed by the fallback mesh.
+         */
+        texture: BaseTexture,
+        /**
+         * The Babylon node whose world position and rotation control the fallback mesh.
+         */
+        public readonly transformNode: TransformNode,
+        private readonly _ownsTransformNode: boolean,
+        ownsTexture: boolean,
+        dimensions: IWebXRFallbackLayerDimensions,
+        worldScalingFactor: number
+    ) {
+        if (layerType === "XRCubeLayer") {
+            const clonedTexture = texture.clone();
+            if (clonedTexture) {
+                texture = clonedTexture;
+                texture.coordinatesMode = Constants.TEXTURE_SKYBOX_MODE;
+                ownsTexture = true;
+            }
+        }
+        this.texture = texture;
+        this._ownsTexture = ownsTexture;
+        this.mesh = this._createMesh(scene, dimensions);
+        this.mesh.isPickable = false;
+        this.mesh.rotationQuaternion = new Quaternion();
+        this._material = new StandardMaterial(`WebXR ${layerType} fallback material`, scene);
+        this._material.disableLighting = true;
+        this._material.emissiveColor = Color3.Black();
+        this._material.backFaceCulling = layerType === "XRQuadLayer";
+        if (layerType === "XRCubeLayer" && this.texture.isCube) {
+            this._material.reflectionTexture = this.texture;
+        } else {
+            this._material.emissiveTexture = this.texture;
+            this._material.opacityTexture = this.texture;
+        }
+        this.mesh.material = this._material;
+        this.updateFromTransformNode(worldScalingFactor);
+    }
+
+    private _createMesh(scene: Scene, dimensions: IWebXRFallbackLayerDimensions): Mesh {
+        switch (this.layerType) {
+            case "XRQuadLayer":
+                return CreatePlane(
+                    `WebXR ${this.layerType} fallback`,
+                    {
+                        width: dimensions.width ?? 1,
+                        height: dimensions.height ?? 1,
+                    },
+                    scene
+                );
+            case "XRCylinderLayer": {
+                const radius = dimensions.radius ?? 2;
+                const centralAngle = dimensions.centralAngle ?? Math.PI / 4;
+                const aspectRatio = dimensions.aspectRatio ?? 2;
+                Quaternion.RotationAxisToRef(Vector3.UpReadOnly, (Math.PI - centralAngle) / 2, this._meshRotationOffset);
+                return CreateCylinder(
+                    `WebXR ${this.layerType} fallback`,
+                    {
+                        diameter: radius * 2,
+                        height: (radius * centralAngle) / aspectRatio,
+                        arc: centralAngle / (Math.PI * 2),
+                        cap: Mesh.NO_CAP,
+                        sideOrientation: Mesh.BACKSIDE,
+                    },
+                    scene
+                );
+            }
+            case "XREquirectLayer": {
+                const radius = dimensions.radius && Number.isFinite(dimensions.radius) ? dimensions.radius : 1000;
+                const centralHorizontalAngle = dimensions.centralHorizontalAngle ?? Math.PI * 2;
+                const upperVerticalAngle = dimensions.upperVerticalAngle ?? Math.PI / 2;
+                const lowerVerticalAngle = dimensions.lowerVerticalAngle ?? -Math.PI / 2;
+                Quaternion.RotationYawPitchRollToRef((Math.PI - centralHorizontalAngle) / 2, upperVerticalAngle - Math.PI / 2, 0, this._meshRotationOffset);
+                return CreateSphere(
+                    `WebXR ${this.layerType} fallback`,
+                    {
+                        diameter: radius * 2,
+                        arc: centralHorizontalAngle / (Math.PI * 2),
+                        slice: (upperVerticalAngle - lowerVerticalAngle) / Math.PI,
+                        sideOrientation: Mesh.BACKSIDE,
+                    },
+                    scene
+                );
+            }
+            case "XRCubeLayer":
+                return CreateBox(
+                    `WebXR ${this.layerType} fallback`,
+                    {
+                        size: 1000,
+                        sideOrientation: Mesh.BACKSIDE,
+                    },
+                    scene
+                );
+        }
+    }
+
+    /**
+     * Copies the transform node's world position and rotation to the fallback mesh without applying the node's scaling.
+     * @param worldScalingFactor the number of Babylon scene units represented by one meter
+     */
+    public updateFromTransformNode(worldScalingFactor = 1): void {
+        this.transformNode.computeWorldMatrix(true).decompose(undefined, this._currentRotation, this._currentPosition);
+        this.mesh.position.copyFrom(this._currentPosition);
+        this._currentRotation.multiplyToRef(this._meshRotationOffset, this.mesh.rotationQuaternion!);
+        this.mesh.scaling.setAll(worldScalingFactor);
+    }
+
+    /**
+     * Disposes the fallback mesh, material, and any resources owned by this wrapper.
+     */
+    public dispose(): void {
+        this.mesh.dispose(false, false);
+        this._material.dispose();
+        if (this._ownsTexture) {
+            this.texture.dispose();
+        }
+        if (this._ownsTransformNode) {
+            this.transformNode.dispose();
+        }
+    }
+}

--- a/packages/dev/core/src/XR/features/Layers/WebXRWebGPUCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRWebGPUCompositionLayer.ts
@@ -2,7 +2,7 @@ import { type RenderTargetTexture } from "core/Materials/Textures/renderTargetTe
 import { type Viewport } from "core/Maths/math.viewport";
 import { Observable } from "core/Misc/observable";
 import { type WebXRLayerRenderTargetTexture } from "core/XR/webXRLayerRenderTargetTexture";
-import { type WebXRLayerType } from "core/XR/webXRLayerWrapper";
+import { type WebXRLayerType, type WebXRSupportedLayerType } from "core/XR/webXRLayerWrapper";
 import { type WebXRLayerRenderTargetTextureProvider } from "core/XR/webXRRenderTargetTextureProvider";
 import { WebXRWebGPURenderTargetTextureProvider } from "core/XR/webXRWebGPURenderTargetTextureProvider";
 import { type WebXRSessionManager } from "core/XR/webXRSessionManager";
@@ -33,7 +33,9 @@ export class WebXRWebGPUCompositionLayerWrapper extends WebXRCompositionLayerWra
  * {@link XRGPUSubImage} GPUTextures instead of WebGL textures.
  * @internal
  */
-export class WebXRWebGPUCompositionLayerRenderTargetTextureProvider extends WebXRWebGPURenderTargetTextureProvider {
+export class WebXRWebGPUCompositionLayerRenderTargetTextureProvider<
+    LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType,
+> extends WebXRWebGPURenderTargetTextureProvider<LayerTypeT> {
     protected _lastSubImages = new Map<XREye, XRGPUSubImage>();
     /**
      * Per-eye render targets, indexed by eye (0 = left/none, 1 = right). Kept separate from the base
@@ -52,7 +54,7 @@ export class WebXRWebGPUCompositionLayerRenderTargetTextureProvider extends WebX
     constructor(
         _xrSessionManager: WebXRSessionManager,
         protected readonly _xrGPUBinding: XRGPUBinding,
-        public override readonly layerWrapper: WebXRWebGPUCompositionLayerWrapper,
+        public override readonly layerWrapper: WebXRCompositionLayerWrapper<XRCompositionLayer, LayerTypeT>,
         protected readonly _depthStencilFormat?: GPUTextureFormat
     ) {
         super(_xrSessionManager, layerWrapper);

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -20,11 +20,14 @@ import { WebXRWebGPUProjectionLayerWrapper, CreateDefaultXRGPUProjectionLayerIni
 import { WebXRWebGPUCompositionLayerRenderTargetTextureProvider } from "./Layers/WebXRWebGPUCompositionLayer";
 import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 import { type ThinTexture } from "../../Materials/Textures/thinTexture";
+import { type RenderTargetTexture } from "../../Materials/Textures/renderTargetTexture.pure";
 import { type DynamicTexture } from "../../Materials/Textures/dynamicTexture.pure";
 import { Color4 } from "../../Maths/math.color.pure";
 import { type LensFlareSystem } from "../../LensFlares/lensFlareSystem";
 import { Logger } from "../../Misc/logger";
 import { type Nullable } from "../../types";
+import { type Observer } from "../../Misc/observable.pure";
+import { type Scene } from "../../scene.pure";
 import { TransformNode } from "../../Meshes/transformNode.pure";
 import { Quaternion } from "../../Maths/math.vector.pure";
 import { type BaseTexture } from "../../Materials/Textures/baseTexture";
@@ -186,6 +189,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
 
     private _compositionLayerTextureMapping: WeakMap<XRCompositionLayer, ThinTexture> = new WeakMap();
     private _layerToRTTProviderMapping: WeakMap<XRCompositionLayer, WebXRLayerRenderTargetTextureProvider<WebXRSupportedLayerType>> = new WeakMap();
+    private _layerCleanupFunctions = new WeakMap<WebXRLayerWrapper<WebXRSupportedLayerType>, () => void>();
 
     constructor(
         _xrSessionManager: WebXRSessionManager,
@@ -248,6 +252,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
             return false;
         }
         for (const layer of this._existingLayers) {
+            this._layerCleanupFunctions.get(layer)?.();
             layer.dispose();
         }
         this._existingLayers.length = 0;
@@ -399,15 +404,20 @@ export class WebXRLayers extends WebXRAbstractFeature {
         }
 
         const dimensions = this._getProjectionLayerDimensions();
+        const defaultViewPixelWidth = layerType === "XRCubeLayer" ? Math.min(dimensions.width, dimensions.height) : dimensions.width;
+        const defaultViewPixelHeight = layerType === "XRCubeLayer" ? defaultViewPixelWidth : dimensions.height;
         const populatedParams = {
             space: this._xrSessionManager.referenceSpace,
-            viewPixelWidth: dimensions.width,
-            viewPixelHeight: dimensions.height,
+            viewPixelWidth: defaultViewPixelWidth,
+            viewPixelHeight: defaultViewPixelHeight,
             clearOnAccess: true,
             textureType: "texture",
             layout: "mono",
             ...options.layerInit,
         } as TWebGLInit;
+        if (layerType === "XRCubeLayer" && populatedParams.viewPixelWidth !== populatedParams.viewPixelHeight) {
+            throw new Error("WebXR cube layer faces must have equal pixel width and height.");
+        }
         this._validateLayerInit(populatedParams, false, layerType === "XRCubeLayer");
 
         let layer: LayerT;
@@ -875,25 +885,45 @@ export class WebXRLayers extends WebXRAbstractFeature {
         if (!babylonLayer) {
             throw new Error("Could not find the babylon layer for the texture");
         }
-        rttProvider.onRenderTargetTextureCreatedObservable.add((data) => {
+        const renderTargetTextures = new Set<RenderTargetTexture>();
+        const beforeRenderObservers: Observer<Scene>[] = [];
+        const previousRenderOnlyInRenderTargetTextures = babylonLayer.renderOnlyInRenderTargetTextures;
+        let cleanedUp = false;
+        const renderTargetCreatedObserver = rttProvider.onRenderTargetTextureCreatedObservable.add((data) => {
             if (data.eye && data.eye === "right") {
                 return;
             }
             data.texture.clearColor = new Color4(0, 0, 0, 0);
             babylonLayer.renderTargetTextures.push(data.texture);
+            renderTargetTextures.add(data.texture);
             babylonLayer.renderOnlyInRenderTargetTextures = true;
             // for stereo (not for gui) it should be onBeforeCameraRenderObservable
-            this._xrSessionManager.scene.onBeforeRenderObservable.add(() => {
-                data.texture.render();
-            });
-            babylonLayer.renderTargetTextures.push(data.texture);
-            babylonLayer.renderOnlyInRenderTargetTextures = true;
-            // add it back when the session ends
-            this._xrSessionManager.onXRSessionEnded.addOnce(() => {
-                babylonLayer.renderTargetTextures.splice(babylonLayer.renderTargetTextures.indexOf(data.texture), 1);
-                babylonLayer.renderOnlyInRenderTargetTextures = false;
-            });
+            beforeRenderObservers.push(
+                this._xrSessionManager.scene.onBeforeRenderObservable.add(() => {
+                    data.texture.render();
+                })
+            );
         });
+        const cleanup = () => {
+            if (cleanedUp) {
+                return;
+            }
+            cleanedUp = true;
+            rttProvider.onRenderTargetTextureCreatedObservable.remove(renderTargetCreatedObserver);
+            for (const observer of beforeRenderObservers) {
+                this._xrSessionManager.scene.onBeforeRenderObservable.remove(observer);
+            }
+            for (const renderTargetTexture of renderTargetTextures) {
+                const index = babylonLayer.renderTargetTextures.indexOf(renderTargetTexture);
+                if (index !== -1) {
+                    babylonLayer.renderTargetTextures.splice(index, 1);
+                }
+            }
+            babylonLayer.renderOnlyInRenderTargetTextures = previousRenderOnlyInRenderTargetTextures;
+            this._layerCleanupFunctions.delete(wrapper);
+        };
+        this._layerCleanupFunctions.set(wrapper, cleanup);
+        this._xrSessionManager.onXRSessionEnded.addOnce(cleanup);
         return wrapper;
     }
 
@@ -982,6 +1012,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
         }
 
         this._existingLayers.splice(index, 1);
+        this._layerCleanupFunctions.get(wrappedLayer)?.();
         if (wrappedLayer instanceof WebXRCompositionLayerWrapper) {
             this._layerToRTTProviderMapping.delete(wrappedLayer.layer);
             this._compositionLayerTextureMapping.delete(wrappedLayer.layer);

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -437,6 +437,9 @@ export class WebXRLayers extends WebXRAbstractFeature {
             } as TWebGPUInit;
             copyWebGPUSpecificInit(populatedParams, gpuParams);
             Object.assign(gpuParams, options.gpuLayerInit);
+            if (layerType === "XRCubeLayer" && gpuParams.viewPixelWidth !== gpuParams.viewPixelHeight) {
+                throw new Error("WebXR cube layer faces must have equal pixel width and height.");
+            }
             effectiveParams = gpuParams;
             depthStencilFormat = gpuParams.depthStencilFormat;
             layer = createWebGPULayer(binding, gpuParams);

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -730,6 +730,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
 
     /**
      * Creates a video-backed quad layer and adds it to the current XR session.
+     * @see https://playground.babylonjs.com/#D35HOL#0
      * @param video the video element presented by the XR compositor
      * @param options initialization and transform-node options for the layer
      * @returns the created media layer wrapper, or `null` when XRMediaBinding is unavailable

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -3,12 +3,21 @@
 import { WebXRFeatureName, WebXRFeaturesManager } from "../webXRFeaturesManager";
 import { type WebXRSessionManager } from "../webXRSessionManager";
 import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
-import { type WebXRLayerWrapper } from "../webXRLayerWrapper";
+import { type WebXRLayerWrapper, type WebXRSupportedLayerType } from "../webXRLayerWrapper";
+import { type WebXRLayerRenderTargetTextureProvider } from "../webXRRenderTargetTextureProvider";
 import { WebXRWebGLLayerWrapper } from "../webXRWebGLLayer";
 import { WebXRProjectionLayerWrapper, DefaultXRProjectionLayerInit } from "./Layers/WebXRProjectionLayer";
-import { WebXRCompositionLayerRenderTargetTextureProvider, WebXRCompositionLayerWrapper } from "./Layers/WebXRCompositionLayer";
+import {
+    WebXRCompositionLayerRenderTargetTextureProvider,
+    WebXRCompositionLayerWrapper,
+    WebXRCubeLayerWrapper,
+    WebXRMediaLayerWrapper,
+    WebXRSpatialLayerWrapper,
+    type WebXRSpatialLayer,
+    type WebXRSpatialLayerType,
+} from "./Layers/WebXRCompositionLayer";
 import { WebXRWebGPUProjectionLayerWrapper, CreateDefaultXRGPUProjectionLayerInit } from "./Layers/WebXRWebGPUProjectionLayer";
-import { WebXRWebGPUCompositionLayerRenderTargetTextureProvider, WebXRWebGPUCompositionLayerWrapper } from "./Layers/WebXRWebGPUCompositionLayer";
+import { WebXRWebGPUCompositionLayerRenderTargetTextureProvider } from "./Layers/WebXRWebGPUCompositionLayer";
 import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 import { type ThinTexture } from "../../Materials/Textures/thinTexture";
 import { type DynamicTexture } from "../../Materials/Textures/dynamicTexture.pure";
@@ -16,12 +25,23 @@ import { Color4 } from "../../Maths/math.color.pure";
 import { type LensFlareSystem } from "../../LensFlares/lensFlareSystem";
 import { Logger } from "../../Misc/logger";
 import { type Nullable } from "../../types";
+import { TransformNode } from "../../Meshes/transformNode.pure";
+import { Quaternion } from "../../Maths/math.vector.pure";
+import { type BaseTexture } from "../../Materials/Textures/baseTexture";
+import { type WebXRFallbackLayerWrapper, type IWebXRFallbackLayerDimensions } from "./Layers/WebXRFallbackLayer";
+
+export { WebXRCompositionLayerWrapper, WebXRCubeLayerWrapper, WebXRMediaLayerWrapper, WebXRSpatialLayerWrapper } from "./Layers/WebXRCompositionLayer";
+export type { WebXRSpatialLayer, WebXRSpatialLayerType } from "./Layers/WebXRCompositionLayer";
+export type { IWebXRFallbackLayerDimensions, WebXRFallbackLayerWrapper } from "./Layers/WebXRFallbackLayer";
 
 const DefaultXRWebGLLayerInit: XRWebGLLayerInit = {};
 const WebGPUQuadLayerCreateWarning =
     "WebGPU XR quad layers are unavailable because XRGPUBinding.createQuadLayer is not supported; the requested quad layer was skipped and projection rendering remains active.";
 const WebGPUQuadLayerSubImageWarning =
     "WebGPU XR quad layers are unavailable because XRGPUBinding.getSubImage is not supported; the requested quad layer was skipped and projection rendering remains active.";
+
+type WebXRGraphicsLayerInit = XRLayerInit & { textureType?: XRTextureType };
+type WebXRGPUGraphicsLayerInit = XRGPULayerInit;
 
 /**
  * Configuration options of the layers feature
@@ -37,6 +57,103 @@ export interface IWebXRLayersOptions {
      * Optional configuration for the base projection layer.
      */
     projectionLayerInit?: Partial<XRProjectionLayerInit>;
+}
+
+/**
+ * Common options for creating a graphics-backed WebXR composition layer.
+ * @typeParam TWebGLInit the WebGL layer initialization dictionary
+ * @typeParam TWebGPUInit the WebGPU layer initialization dictionary
+ */
+export interface IWebXRCompositionLayerCreationOptions<TWebGLInit, TWebGPUInit> {
+    /**
+     * Initialization values shared with the WebGL Layers API.
+     * Babylon supplies the current reference space and projection-layer pixel dimensions when omitted.
+     */
+    layerInit?: Partial<TWebGLInit>;
+    /**
+     * WebGPU-specific initialization overrides.
+     * Shared spatial and layout values are copied from `layerInit` before these overrides are applied.
+     */
+    gpuLayerInit?: Partial<TWebGPUInit>;
+    /**
+     * A Babylon node whose world position and rotation will be synchronized with the layer.
+     * Babylon creates and owns a node when this is omitted.
+     */
+    transformNode?: TransformNode;
+    /**
+     * Uses a Babylon mesh when the requested native layer factory is unavailable.
+     * Import `@babylonjs/core/XR/features/WebXRLayersFallback` to enable this optional fallback.
+     * Fallback is disabled by default.
+     */
+    fallbackMode?: "none" | "mesh";
+    /**
+     * A texture to display on the fallback mesh.
+     * Required when `fallbackMode` is `"mesh"`.
+     */
+    fallbackTexture?: BaseTexture;
+}
+
+/**
+ * Common options for creating an XRMediaBinding layer.
+ * @typeParam InitT the media layer initialization dictionary
+ */
+export interface IWebXRMediaLayerCreationOptions<InitT> {
+    /**
+     * Initialization values for the media layer.
+     * Babylon supplies the current reference space when omitted.
+     */
+    layerInit?: Partial<InitT>;
+    /**
+     * A Babylon node whose world position and rotation will be synchronized with the layer.
+     * Babylon creates and owns a node when this is omitted.
+     */
+    transformNode?: TransformNode;
+    /**
+     * Uses a Babylon mesh and VideoTexture when XRMediaBinding is unavailable.
+     * Import `@babylonjs/core/XR/features/WebXRLayersFallback` to enable this optional fallback.
+     * Fallback is disabled by default.
+     */
+    fallbackMode?: "none" | "mesh";
+}
+
+/**
+ * Selects whether a layer is created from a graphics binding or directly from a media element.
+ */
+export type WebXRLayerSource = "graphics" | "media";
+
+/**
+ * The result of creating a spatial WebXR layer.
+ * Native wrappers expose an XR composition layer, while fallback wrappers expose a Babylon mesh.
+ * @typeParam LayerT the native layer type
+ */
+export type WebXRLayerCreationResult<LayerT extends WebXRSpatialLayer, LayerTypeT extends WebXRSpatialLayerType = WebXRSpatialLayerType> =
+    WebXRSpatialLayerWrapper<LayerT, LayerTypeT> | WebXRFallbackLayerWrapper;
+
+/**
+ * Data supplied to an optional WebXR mesh-fallback implementation.
+ * @internal
+ */
+export interface IWebXRFallbackLayerCreationContext {
+    scene: WebXRSessionManager["scene"];
+    isWebGPU: boolean;
+    layerType: WebXRSpatialLayerType;
+    transformNode: TransformNode;
+    ownsTransformNode: boolean;
+    dimensions: IWebXRFallbackLayerDimensions;
+    worldScalingFactor: number;
+    texture?: BaseTexture;
+    video?: HTMLVideoElement;
+}
+
+let _FallbackLayerFactory: Nullable<(context: IWebXRFallbackLayerCreationContext) => Nullable<WebXRFallbackLayerWrapper>> = null;
+
+/**
+ * Registers the optional mesh-fallback implementation without making its rendering dependencies part of projection-only bundles.
+ * @param factory creates a fallback wrapper
+ * @internal
+ */
+export function _RegisterWebXRFallbackLayerFactory(factory: (context: IWebXRFallbackLayerCreationContext) => Nullable<WebXRFallbackLayerWrapper>): void {
+    _FallbackLayerFactory = factory;
 }
 
 /**
@@ -56,18 +173,19 @@ export class WebXRLayers extends WebXRAbstractFeature {
     /**
      * Already-created layers
      */
-    private _existingLayers: WebXRLayerWrapper[] = [];
+    private _existingLayers: WebXRLayerWrapper<WebXRSupportedLayerType>[] = [];
+    private _fallbackLayers: WebXRFallbackLayerWrapper[] = [];
 
     private _glContext: WebGLRenderingContext | WebGL2RenderingContext;
     private _xrWebGLBinding: XRWebGLBinding;
     private _isWebGPU = false;
     private _xrGPUBinding?: XRGPUBinding;
+    private _xrMediaBinding?: XRMediaBinding;
     private _isMultiviewEnabled = false;
     private _projectionLayerInitialized = false;
 
     private _compositionLayerTextureMapping: WeakMap<XRCompositionLayer, ThinTexture> = new WeakMap();
-    private _layerToRTTProviderMapping: WeakMap<XRCompositionLayer, WebXRCompositionLayerRenderTargetTextureProvider | WebXRWebGPUCompositionLayerRenderTargetTextureProvider> =
-        new WeakMap();
+    private _layerToRTTProviderMapping: WeakMap<XRCompositionLayer, WebXRLayerRenderTargetTextureProvider<WebXRSupportedLayerType>> = new WeakMap();
 
     constructor(
         _xrSessionManager: WebXRSessionManager,
@@ -114,6 +232,13 @@ export class WebXRLayers extends WebXRAbstractFeature {
             this.createProjectionLayer(projectionLayerInit /*, projectionLayerMultiview*/);
         }
         this._projectionLayerInitialized = true;
+        this._addNewAttachObserver(this._xrSessionManager.onXRReferenceSpaceChanged, (referenceSpace) => {
+            for (const layer of this._existingLayers) {
+                if (layer instanceof WebXRSpatialLayerWrapper && layer.usesSessionReferenceSpace) {
+                    layer.layer.space = referenceSpace;
+                }
+            }
+        });
 
         return true;
     }
@@ -126,6 +251,11 @@ export class WebXRLayers extends WebXRAbstractFeature {
             layer.dispose();
         }
         this._existingLayers.length = 0;
+        for (const layer of this._fallbackLayers) {
+            layer.dispose();
+        }
+        this._fallbackLayers.length = 0;
+        this._xrMediaBinding = undefined;
         this._projectionLayerInitialized = false;
         return true;
     }
@@ -140,7 +270,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
         return new WebXRWebGLLayerWrapper(layer);
     }
 
-    private _validateLayerInit(params: XRProjectionLayerInit | XRQuadLayerInit, multiview = this._isMultiviewEnabled): void {
+    private _validateLayerInit(params: XRProjectionLayerInit | WebXRGraphicsLayerInit, multiview = this._isMultiviewEnabled, allowTextureArrayWithoutMultiview = false): void {
         // check if we are in session
         if (!this._xrSessionManager.inXRSession) {
             throw new Error("Cannot create a layer outside of a WebXR session. Make sure the session has started before creating layers.");
@@ -150,16 +280,263 @@ export class WebXRLayers extends WebXRAbstractFeature {
         }
 
         // TODO (rgerd): Support RTT's that are bound to sub-images in the texture array.
-        if (!multiview && params.textureType === "texture-array") {
+        if (!multiview && params.textureType === "texture-array" && !allowTextureArrayWithoutMultiview) {
             throw new Error("We currently only support multiview rendering when the textureType parameter is set to 'texture-array'.");
         }
     }
 
-    private _extendXRLayerInit(params: XRProjectionLayerInit | XRQuadLayerInit, multiview = this._isMultiviewEnabled): XRProjectionLayerInit | XRQuadLayerInit {
+    private _extendXRLayerInit<T extends XRProjectionLayerInit | WebXRGraphicsLayerInit>(params: T, multiview = this._isMultiviewEnabled): T {
         if (multiview) {
             params.textureType = "texture-array";
         }
         return params;
+    }
+
+    private _getProjectionLayerDimensions(): { width: number; height: number } {
+        const projectionLayer = this._existingLayers.find((layer) => layer.layerType === "XRProjectionLayer");
+        if (!projectionLayer) {
+            throw new Error("A projection layer must be created before adding WebXR composition layers.");
+        }
+        return {
+            width: projectionLayer.getWidth(),
+            height: projectionLayer.getHeight(),
+        };
+    }
+
+    private _createTransformNode(
+        layerType: WebXRSpatialLayerType,
+        transformNode: TransformNode | undefined,
+        transform?: XRRigidTransform,
+        orientation?: DOMPointReadOnly
+    ): { node: TransformNode; ownsNode: boolean } {
+        if (transformNode) {
+            return { node: transformNode, ownsNode: false };
+        }
+
+        const node = new TransformNode(`WebXR ${layerType}`, this._xrSessionManager.scene);
+        node.rotationQuaternion = new Quaternion();
+        const sourcePosition = transform?.position;
+        const sourceOrientation = transform?.orientation ?? orientation;
+        if (sourcePosition) {
+            const worldScalingFactor = this._xrSessionManager.worldScalingFactor;
+            node.position.set(sourcePosition.x * worldScalingFactor, sourcePosition.y * worldScalingFactor, sourcePosition.z * worldScalingFactor);
+        }
+        if (sourceOrientation) {
+            node.rotationQuaternion.set(sourceOrientation.x, sourceOrientation.y, sourceOrientation.z, sourceOrientation.w);
+        }
+        if (!this._xrSessionManager.scene.useRightHandedSystem) {
+            node.position.z *= -1;
+            node.rotationQuaternion.z *= -1;
+            node.rotationQuaternion.w *= -1;
+        }
+        return { node, ownsNode: true };
+    }
+
+    private _createFallbackLayer(
+        layerType: WebXRSpatialLayerType,
+        transformNode: TransformNode | undefined,
+        transform: XRRigidTransform | undefined,
+        orientation: DOMPointReadOnly | undefined,
+        dimensions: IWebXRFallbackLayerDimensions,
+        texture?: BaseTexture,
+        video?: HTMLVideoElement
+    ): Nullable<WebXRFallbackLayerWrapper> {
+        if (!_FallbackLayerFactory) {
+            Logger.Warn("WebXR mesh fallbacks require importing `@babylonjs/core/XR/features/WebXRLayersFallback`.");
+            return null;
+        }
+
+        const transformInfo = this._createTransformNode(layerType, transformNode, transform, orientation);
+        const wrapper = _FallbackLayerFactory({
+            scene: this._xrSessionManager.scene,
+            isWebGPU: this._isWebGPU,
+            layerType,
+            transformNode: transformInfo.node,
+            ownsTransformNode: transformInfo.ownsNode,
+            dimensions,
+            worldScalingFactor: this._xrSessionManager.worldScalingFactor,
+            texture,
+            video,
+        });
+        if (wrapper) {
+            this._fallbackLayers.push(wrapper);
+        } else if (transformInfo.ownsNode) {
+            transformInfo.node.dispose();
+        }
+        return wrapper;
+    }
+
+    private _createGraphicsLayer<
+        LayerT extends WebXRSpatialLayer,
+        LayerTypeT extends WebXRSpatialLayerType,
+        TWebGLInit extends WebXRGraphicsLayerInit,
+        TWebGPUInit extends WebXRGPUGraphicsLayerInit,
+    >(
+        layerType: LayerTypeT,
+        factoryName: string,
+        factorySupported: boolean,
+        options: IWebXRCompositionLayerCreationOptions<TWebGLInit, TWebGPUInit>,
+        createWebGLLayer: (binding: XRWebGLBinding, init: TWebGLInit) => LayerT,
+        createWebGPULayer: (binding: XRGPUBinding, init: TWebGPUInit) => LayerT,
+        copyWebGPUSpecificInit: (webGLInit: TWebGLInit, webGPUInit: TWebGPUInit) => void
+    ): Nullable<WebXRSpatialLayerWrapper<LayerT, LayerTypeT>> {
+        if (!this._xrSessionManager.inXRSession) {
+            throw new Error("Cannot create a layer outside of a WebXR session. Make sure the session has started before creating layers.");
+        }
+        if (!factorySupported) {
+            if (options.fallbackMode !== "mesh") {
+                Logger.Warn(`${layerType} is unavailable because ${factoryName} is not supported; the requested layer was skipped and projection rendering remains active.`);
+            }
+            return null;
+        }
+        if (this._isWebGPU && typeof this._xrGPUBinding?.getSubImage !== "function") {
+            if (options.fallbackMode !== "mesh") {
+                Logger.Warn(
+                    `${layerType} is unavailable because XRGPUBinding.getSubImage is not supported; the requested layer was skipped and projection rendering remains active.`
+                );
+            }
+            return null;
+        }
+
+        const dimensions = this._getProjectionLayerDimensions();
+        const populatedParams = {
+            space: this._xrSessionManager.referenceSpace,
+            viewPixelWidth: dimensions.width,
+            viewPixelHeight: dimensions.height,
+            clearOnAccess: true,
+            textureType: "texture",
+            layout: "mono",
+            ...options.layerInit,
+        } as TWebGLInit;
+        this._validateLayerInit(populatedParams, false, layerType === "XRCubeLayer");
+
+        let layer: LayerT;
+        let effectiveParams: TWebGLInit | TWebGPUInit = populatedParams;
+        let depthStencilFormat: GPUTextureFormat | undefined;
+        if (this._isWebGPU) {
+            const binding = this._xrGPUBinding!;
+            const gpuParams = {
+                colorFormat: binding.getPreferredColorFormat(),
+                textureUsage: 0x10,
+                space: populatedParams.space,
+                viewPixelWidth: populatedParams.viewPixelWidth,
+                viewPixelHeight: populatedParams.viewPixelHeight,
+                layout: populatedParams.layout,
+                mipLevels: populatedParams.mipLevels,
+                isStatic: populatedParams.isStatic,
+            } as TWebGPUInit;
+            copyWebGPUSpecificInit(populatedParams, gpuParams);
+            Object.assign(gpuParams, options.gpuLayerInit);
+            effectiveParams = gpuParams;
+            depthStencilFormat = gpuParams.depthStencilFormat;
+            layer = createWebGPULayer(binding, gpuParams);
+        } else {
+            layer = createWebGLLayer(this._xrWebGLBinding, populatedParams);
+        }
+
+        const transform = "transform" in effectiveParams ? (effectiveParams.transform as XRRigidTransform | undefined) : undefined;
+        const orientation = "orientation" in effectiveParams ? (effectiveParams.orientation as DOMPointReadOnly | undefined) : undefined;
+        const usesSessionReferenceSpace = options.layerInit?.space === undefined && (!this._isWebGPU || options.gpuLayerInit?.space === undefined);
+        const transformInfo = this._createTransformNode(layerType, options.transformNode, transform, orientation);
+        let wrapper: WebXRSpatialLayerWrapper<LayerT, LayerTypeT>;
+        if (layerType === "XRCubeLayer") {
+            wrapper = new WebXRCubeLayerWrapper(
+                () => effectiveParams.viewPixelWidth,
+                () => effectiveParams.viewPixelHeight,
+                layer as XRCubeLayer,
+                !!effectiveParams.isStatic,
+                usesSessionReferenceSpace,
+                this._isWebGPU ? this._xrGPUBinding! : this._xrWebGLBinding,
+                transformInfo.node,
+                transformInfo.ownsNode
+            ) as unknown as WebXRSpatialLayerWrapper<LayerT, LayerTypeT>;
+        } else if (this._isWebGPU) {
+            const binding = this._xrGPUBinding!;
+            wrapper = new WebXRSpatialLayerWrapper(
+                () => effectiveParams.viewPixelWidth,
+                () => effectiveParams.viewPixelHeight,
+                layer,
+                layerType,
+                false,
+                !!effectiveParams.isStatic,
+                usesSessionReferenceSpace,
+                (sessionManager) => new WebXRWebGPUCompositionLayerRenderTargetTextureProvider(sessionManager, binding, wrapper, depthStencilFormat),
+                transformInfo.node,
+                transformInfo.ownsNode
+            );
+        } else {
+            wrapper = new WebXRSpatialLayerWrapper(
+                () => effectiveParams.viewPixelWidth,
+                () => effectiveParams.viewPixelHeight,
+                layer,
+                layerType,
+                false,
+                !!effectiveParams.isStatic,
+                usesSessionReferenceSpace,
+                (sessionManager) => new WebXRCompositionLayerRenderTargetTextureProvider(sessionManager, this._xrWebGLBinding, wrapper),
+                transformInfo.node,
+                transformInfo.ownsNode
+            );
+        }
+
+        if (wrapper.usesRenderTargetProvider) {
+            const rttProvider = wrapper.createRenderTargetTextureProvider(this._xrSessionManager);
+            this._layerToRTTProviderMapping.set(layer, rttProvider);
+        }
+        this.addXRSessionLayer(wrapper);
+        return wrapper;
+    }
+
+    private _createMediaLayer<
+        LayerT extends XRQuadLayer | XRCylinderLayer | XREquirectLayer,
+        LayerTypeT extends Exclude<WebXRSpatialLayerType, "XRCubeLayer">,
+        InitT extends XRMediaLayerInit & { transform?: XRRigidTransform },
+    >(
+        layerType: LayerTypeT,
+        factoryName: string,
+        video: HTMLVideoElement,
+        options: IWebXRMediaLayerCreationOptions<InitT>,
+        createLayer: (binding: XRMediaBinding, video: HTMLVideoElement, init: InitT) => LayerT
+    ): Nullable<WebXRMediaLayerWrapper<LayerT, LayerTypeT>> {
+        if (!this._xrSessionManager.inXRSession) {
+            throw new Error("Cannot create a layer outside of a WebXR session. Make sure the session has started before creating layers.");
+        }
+        if (typeof XRMediaBinding === "undefined") {
+            if (options.fallbackMode !== "mesh") {
+                Logger.Warn(`${layerType} media layers are unavailable because XRMediaBinding is not supported; the requested layer was skipped.`);
+            }
+            return null;
+        }
+
+        this._xrMediaBinding ??= new XRMediaBinding(this._xrSessionManager.session);
+        const mediaBinding = this._xrMediaBinding;
+        const factory = mediaBinding[factoryName as "createQuadLayer" | "createCylinderLayer" | "createEquirectLayer"];
+        if (typeof factory !== "function") {
+            if (options.fallbackMode !== "mesh") {
+                Logger.Warn(`${layerType} media layers are unavailable because XRMediaBinding.${factoryName} is not supported; the requested layer was skipped.`);
+            }
+            return null;
+        }
+
+        const populatedParams = {
+            space: this._xrSessionManager.referenceSpace,
+            layout: "mono",
+            ...options.layerInit,
+        } as InitT;
+        const layer = createLayer(mediaBinding, video, populatedParams);
+        const transform = "transform" in populatedParams ? populatedParams.transform : undefined;
+        const transformInfo = this._createTransformNode(layerType, options.transformNode, transform);
+        const wrapper = new WebXRMediaLayerWrapper(
+            () => video.videoWidth,
+            () => video.videoHeight,
+            layer,
+            layerType,
+            transformInfo.node,
+            transformInfo.ownsNode,
+            options.layerInit?.space === undefined
+        );
+        this.addXRSessionLayer(wrapper);
+        return wrapper;
     }
 
     /**
@@ -169,10 +546,10 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * @returns the projection layer
      */
     public createProjectionLayer(params = DefaultXRProjectionLayerInit, multiview = this._isMultiviewEnabled): WebXRProjectionLayerWrapper {
-        this._extendXRLayerInit(params, multiview);
-        this._validateLayerInit(params, multiview);
+        const extendedParams = this._extendXRLayerInit(params, multiview);
+        this._validateLayerInit(extendedParams, multiview);
 
-        const projLayer = this._xrWebGLBinding.createProjectionLayer(params);
+        const projLayer = this._xrWebGLBinding.createProjectionLayer(extendedParams);
         const layer = new WebXRProjectionLayerWrapper(projLayer, multiview, this._xrWebGLBinding);
         this.addXRSessionLayer(layer);
         return layer;
@@ -196,26 +573,239 @@ export class WebXRLayers extends WebXRAbstractFeature {
     }
 
     /**
-     * Note about making it private - this function will be exposed once I decide on a proper API to support all of the XR layers' options
-     * @param options an object providing configuration options for the new XRQuadLayer.
-     * @param babylonTexture the texture to display in the layer
-     * @returns the quad layer, or null when the WebGPU binding lacks quad-layer support
+     * Creates a graphics-backed quad layer and adds it to the current XR session.
+     * @param options initialization and transform-node options for the layer
+     * @returns the created layer wrapper, or `null` when the active graphics binding does not support quad layers
      */
-    private _createQuadLayer(options: { params: Partial<XRQuadLayerInit> } = { params: {} }, babylonTexture?: ThinTexture): Nullable<WebXRCompositionLayerWrapper> {
-        this._extendXRLayerInit(options.params, false);
-        const width = (this._existingLayers[0].layer as XRProjectionLayer).textureWidth;
-        const height = (this._existingLayers[0].layer as XRProjectionLayer).textureHeight;
-        const populatedParams: XRQuadLayerInit = {
-            space: this._xrSessionManager.referenceSpace,
-            viewPixelWidth: width,
-            viewPixelHeight: height,
-            clearOnAccess: true,
-            ...options.params,
-        };
-        this._validateLayerInit(populatedParams, false);
-        let quadLayer: XRQuadLayer;
-        let wrapper: WebXRCompositionLayerWrapper;
+    public createQuadLayer(
+        options: IWebXRCompositionLayerCreationOptions<XRQuadLayerInit, XRGPUQuadLayerInit> = {}
+    ): Nullable<WebXRLayerCreationResult<XRQuadLayer, "XRQuadLayer">> {
+        const factorySupported = this._isWebGPU ? typeof this._xrGPUBinding?.createQuadLayer === "function" : typeof this._xrWebGLBinding.createQuadLayer === "function";
+        const factoryName = this._isWebGPU ? "XRGPUBinding.createQuadLayer" : "XRWebGLBinding.createQuadLayer";
+        const nativeLayer = this._createGraphicsLayer(
+            "XRQuadLayer",
+            factoryName,
+            factorySupported,
+            options,
+            (binding, init) => binding.createQuadLayer(init),
+            (binding, init) => binding.createQuadLayer(init),
+            (webGLInit, webGPUInit) => {
+                webGPUInit.transform = webGLInit.transform;
+                webGPUInit.width = webGLInit.width;
+                webGPUInit.height = webGLInit.height;
+            }
+        );
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer(
+            "XRQuadLayer",
+            options.transformNode,
+            options.layerInit?.transform,
+            undefined,
+            { width: options.layerInit?.width, height: options.layerInit?.height },
+            options.fallbackTexture
+        );
+    }
 
+    /**
+     * Creates a graphics-backed cylinder layer and adds it to the current XR session.
+     * @param options initialization and transform-node options for the layer
+     * @returns the created layer wrapper, or `null` when the active graphics binding does not support cylinder layers
+     */
+    public createCylinderLayer(
+        options: IWebXRCompositionLayerCreationOptions<XRCylinderLayerInit, XRGPUCylinderLayerInit> = {}
+    ): Nullable<WebXRLayerCreationResult<XRCylinderLayer, "XRCylinderLayer">> {
+        const factorySupported = this._isWebGPU ? typeof this._xrGPUBinding?.createCylinderLayer === "function" : typeof this._xrWebGLBinding.createCylinderLayer === "function";
+        const factoryName = this._isWebGPU ? "XRGPUBinding.createCylinderLayer" : "XRWebGLBinding.createCylinderLayer";
+        const nativeLayer = this._createGraphicsLayer(
+            "XRCylinderLayer",
+            factoryName,
+            factorySupported,
+            options,
+            (binding, init) => binding.createCylinderLayer(init),
+            (binding, init) => binding.createCylinderLayer(init),
+            (webGLInit, webGPUInit) => {
+                webGPUInit.transform = webGLInit.transform;
+                webGPUInit.radius = webGLInit.radius;
+                webGPUInit.centralAngle = webGLInit.centralAngle;
+                webGPUInit.aspectRatio = webGLInit.aspectRatio;
+            }
+        );
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer(
+            "XRCylinderLayer",
+            options.transformNode,
+            options.layerInit?.transform,
+            undefined,
+            {
+                radius: options.layerInit?.radius,
+                centralAngle: options.layerInit?.centralAngle,
+                aspectRatio: options.layerInit?.aspectRatio,
+            },
+            options.fallbackTexture
+        );
+    }
+
+    /**
+     * Creates a graphics-backed equirectangular layer and adds it to the current XR session.
+     * @param options initialization and transform-node options for the layer
+     * @returns the created layer wrapper, or `null` when the active graphics binding does not support equirectangular layers
+     */
+    public createEquirectLayer(
+        options: IWebXRCompositionLayerCreationOptions<XREquirectLayerInit, XRGPUEquirectLayerInit> = {}
+    ): Nullable<WebXRLayerCreationResult<XREquirectLayer, "XREquirectLayer">> {
+        const factorySupported = this._isWebGPU ? typeof this._xrGPUBinding?.createEquirectLayer === "function" : typeof this._xrWebGLBinding.createEquirectLayer === "function";
+        const factoryName = this._isWebGPU ? "XRGPUBinding.createEquirectLayer" : "XRWebGLBinding.createEquirectLayer";
+        const nativeLayer = this._createGraphicsLayer(
+            "XREquirectLayer",
+            factoryName,
+            factorySupported,
+            options,
+            (binding, init) => binding.createEquirectLayer(init),
+            (binding, init) => binding.createEquirectLayer(init),
+            (webGLInit, webGPUInit) => {
+                webGPUInit.transform = webGLInit.transform;
+                webGPUInit.radius = webGLInit.radius;
+                webGPUInit.centralHorizontalAngle = webGLInit.centralHorizontalAngle;
+                webGPUInit.upperVerticalAngle = webGLInit.upperVerticalAngle;
+                webGPUInit.lowerVerticalAngle = webGLInit.lowerVerticalAngle;
+            }
+        );
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer(
+            "XREquirectLayer",
+            options.transformNode,
+            options.layerInit?.transform,
+            undefined,
+            {
+                radius: options.layerInit?.radius,
+                centralHorizontalAngle: options.layerInit?.centralHorizontalAngle,
+                upperVerticalAngle: options.layerInit?.upperVerticalAngle,
+                lowerVerticalAngle: options.layerInit?.lowerVerticalAngle,
+            },
+            options.fallbackTexture
+        );
+    }
+
+    /**
+     * Creates a graphics-backed cube layer and adds it to the current XR session.
+     * Cube layers synchronize only the rotation of their transform node because the WebXR API does not support cube-layer translation.
+     * @param options initialization and transform-node options for the layer
+     * @returns the created layer wrapper, or `null` when the active graphics binding does not support cube layers
+     */
+    public createCubeLayer(options: IWebXRCompositionLayerCreationOptions<XRCubeLayerInit, XRGPUCubeLayerInit> = {}): Nullable<WebXRCubeLayerWrapper | WebXRFallbackLayerWrapper> {
+        const factorySupported = this._isWebGPU ? typeof this._xrGPUBinding?.createCubeLayer === "function" : typeof this._xrWebGLBinding.createCubeLayer === "function";
+        const factoryName = this._isWebGPU ? "XRGPUBinding.createCubeLayer" : "XRWebGLBinding.createCubeLayer";
+        const nativeLayer = this._createGraphicsLayer(
+            "XRCubeLayer",
+            factoryName,
+            factorySupported,
+            options,
+            (binding, init) => binding.createCubeLayer(init),
+            (binding, init) => binding.createCubeLayer(init),
+            (webGLInit, webGPUInit) => {
+                webGPUInit.orientation = webGLInit.orientation;
+            }
+        ) as Nullable<WebXRCubeLayerWrapper>;
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer("XRCubeLayer", options.transformNode, undefined, options.layerInit?.orientation, {}, options.fallbackTexture);
+    }
+
+    /**
+     * Creates a video-backed quad layer and adds it to the current XR session.
+     * @param video the video element presented by the XR compositor
+     * @param options initialization and transform-node options for the layer
+     * @returns the created media layer wrapper, or `null` when XRMediaBinding is unavailable
+     */
+    public createMediaQuadLayer(
+        video: HTMLVideoElement,
+        options: IWebXRMediaLayerCreationOptions<XRMediaQuadLayerInit> = {}
+    ): Nullable<WebXRLayerCreationResult<XRQuadLayer, "XRQuadLayer">> {
+        const nativeLayer = this._createMediaLayer("XRQuadLayer", "createQuadLayer", video, options, (binding, media, init) => binding.createQuadLayer(media, init));
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer(
+            "XRQuadLayer",
+            options.transformNode,
+            options.layerInit?.transform,
+            undefined,
+            { width: options.layerInit?.width, height: options.layerInit?.height },
+            undefined,
+            video
+        );
+    }
+
+    /**
+     * Creates a video-backed cylinder layer and adds it to the current XR session.
+     * @param video the video element presented by the XR compositor
+     * @param options initialization and transform-node options for the layer
+     * @returns the created media layer wrapper, or `null` when XRMediaBinding is unavailable
+     */
+    public createMediaCylinderLayer(
+        video: HTMLVideoElement,
+        options: IWebXRMediaLayerCreationOptions<XRMediaCylinderLayerInit> = {}
+    ): Nullable<WebXRLayerCreationResult<XRCylinderLayer, "XRCylinderLayer">> {
+        const nativeLayer = this._createMediaLayer("XRCylinderLayer", "createCylinderLayer", video, options, (binding, media, init) => binding.createCylinderLayer(media, init));
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer(
+            "XRCylinderLayer",
+            options.transformNode,
+            options.layerInit?.transform,
+            undefined,
+            {
+                radius: options.layerInit?.radius,
+                centralAngle: options.layerInit?.centralAngle,
+                aspectRatio: options.layerInit?.aspectRatio,
+            },
+            undefined,
+            video
+        );
+    }
+
+    /**
+     * Creates a video-backed equirectangular layer and adds it to the current XR session.
+     * @param video the video element presented by the XR compositor
+     * @param options initialization and transform-node options for the layer
+     * @returns the created media layer wrapper, or `null` when XRMediaBinding is unavailable
+     */
+    public createMediaEquirectLayer(
+        video: HTMLVideoElement,
+        options: IWebXRMediaLayerCreationOptions<XRMediaEquirectLayerInit> = {}
+    ): Nullable<WebXRLayerCreationResult<XREquirectLayer, "XREquirectLayer">> {
+        const nativeLayer = this._createMediaLayer("XREquirectLayer", "createEquirectLayer", video, options, (binding, media, init) => binding.createEquirectLayer(media, init));
+        if (nativeLayer || options.fallbackMode !== "mesh") {
+            return nativeLayer;
+        }
+        return this._createFallbackLayer(
+            "XREquirectLayer",
+            options.transformNode,
+            options.layerInit?.transform,
+            undefined,
+            {
+                radius: options.layerInit?.radius,
+                centralHorizontalAngle: options.layerInit?.centralHorizontalAngle,
+                upperVerticalAngle: options.layerInit?.upperVerticalAngle,
+                lowerVerticalAngle: options.layerInit?.lowerVerticalAngle,
+            },
+            undefined,
+            video
+        );
+    }
+
+    private _createQuadLayer(
+        options: { params: Partial<XRQuadLayerInit> } = { params: {} },
+        babylonTexture?: ThinTexture
+    ): Nullable<WebXRSpatialLayerWrapper<XRQuadLayer, "XRQuadLayer">> {
         if (this._isWebGPU) {
             const binding = this._xrGPUBinding!;
             if (typeof binding.createQuadLayer !== "function") {
@@ -226,65 +816,19 @@ export class WebXRLayers extends WebXRAbstractFeature {
                 Logger.Warn(WebGPUQuadLayerSubImageWarning);
                 return null;
             }
-
-            const gpuParams: XRGPUQuadLayerInit = {
-                colorFormat: binding.getPreferredColorFormat(),
-                // GPUTextureUsage.RENDER_ATTACHMENT (0x10) is requested explicitly. The usage of a
-                // compositor-owned sub-image texture is not a valid source for layer creation flags.
-                textureUsage: 0x10,
-                space: populatedParams.space,
-                viewPixelWidth: populatedParams.viewPixelWidth,
-                viewPixelHeight: populatedParams.viewPixelHeight,
-            };
-            if (populatedParams.layout !== undefined) {
-                gpuParams.layout = populatedParams.layout;
-            }
-            if (populatedParams.mipLevels !== undefined) {
-                gpuParams.mipLevels = populatedParams.mipLevels;
-            }
-            if (populatedParams.isStatic !== undefined) {
-                gpuParams.isStatic = populatedParams.isStatic;
-            }
-            if (populatedParams.transform !== undefined) {
-                gpuParams.transform = populatedParams.transform;
-            }
-            if (populatedParams.width !== undefined) {
-                gpuParams.width = populatedParams.width;
-            }
-            if (populatedParams.height !== undefined) {
-                gpuParams.height = populatedParams.height;
-            }
-            quadLayer = binding.createQuadLayer(gpuParams);
-            wrapper = new WebXRWebGPUCompositionLayerWrapper(
-                () => quadLayer.width,
-                () => quadLayer.height,
-                quadLayer,
-                "XRQuadLayer",
-                false,
-                (sessionManager) => new WebXRWebGPUCompositionLayerRenderTargetTextureProvider(sessionManager, binding, wrapper)
-            );
-        } else {
-            quadLayer = this._xrWebGLBinding.createQuadLayer(populatedParams);
-            wrapper = new WebXRCompositionLayerWrapper(
-                () => quadLayer.width,
-                () => quadLayer.height,
-                quadLayer,
-                "XRQuadLayer",
-                false,
-                (sessionManager) => new WebXRCompositionLayerRenderTargetTextureProvider(sessionManager, this._xrWebGLBinding, wrapper)
-            );
         }
 
+        const wrapper = this.createQuadLayer({ layerInit: options.params });
+        if (!wrapper || wrapper.layer === null) {
+            return null;
+        }
+        const quadLayer = wrapper.layer;
         quadLayer.width = this._isMultiviewEnabled ? 1 : 2;
         quadLayer.height = 1;
 
         if (babylonTexture) {
             this._compositionLayerTextureMapping.set(quadLayer, babylonTexture);
         }
-        const rtt = wrapper.createRenderTargetTextureProvider(this._xrSessionManager) as
-            WebXRCompositionLayerRenderTargetTextureProvider | WebXRWebGPUCompositionLayerRenderTargetTextureProvider;
-        this._layerToRTTProviderMapping.set(quadLayer, rtt);
-        this.addXRSessionLayer(wrapper);
         return wrapper;
     }
 
@@ -314,14 +858,15 @@ export class WebXRLayers extends WebXRAbstractFeature {
             return null;
         }
 
-        const layer = wrapper.layer as XRQuadLayer;
         const distance = Math.max(0.1, options.distanceFromHeadset);
-        const pos = { x: 0, y: 0, z: -distance };
-        const orient = { x: 0, y: 0, z: 0, w: 1 };
-        layer.transform = new XRRigidTransform(pos, orient);
+        const z = this._xrSessionManager.scene.useRightHandedSystem ? -distance : distance;
+        wrapper.transformNode.position.set(0, 0, z * this._xrSessionManager.worldScalingFactor);
 
-        const rttProvider = this._layerToRTTProviderMapping.get(layer);
-        if (!rttProvider) {
+        const rttProvider = this._layerToRTTProviderMapping.get(wrapper.layer);
+        if (
+            !rttProvider ||
+            (!(rttProvider instanceof WebXRCompositionLayerRenderTargetTextureProvider) && !(rttProvider instanceof WebXRWebGPUCompositionLayerRenderTargetTextureProvider))
+        ) {
             throw new Error("Could not find the RTT provider for the layer");
         }
         const babylonLayer = this._xrSessionManager.scene.layers.find((babylonLayer) => {
@@ -372,17 +917,19 @@ export class WebXRLayers extends WebXRAbstractFeature {
             return null;
         }
 
-        const layer = wrapper.layer as XRQuadLayer;
+        const layer = wrapper.layer;
         layer.width = 2;
         layer.height = 1;
         const distance = 10;
-        const pos = { x: 0, y: 0, z: -distance };
-        const orient = { x: 0, y: 0, z: 0, w: 1 };
-        layer.transform = new XRRigidTransform(pos, orient);
+        const z = this._xrSessionManager.scene.useRightHandedSystem ? -distance : distance;
+        wrapper.transformNode.position.set(0, 0, z * this._xrSessionManager.worldScalingFactor);
 
         // get the rtt wrapper
         const rttProvider = this._layerToRTTProviderMapping.get(layer);
-        if (!rttProvider) {
+        if (
+            !rttProvider ||
+            (!(rttProvider instanceof WebXRCompositionLayerRenderTargetTextureProvider) && !(rttProvider instanceof WebXRWebGPUCompositionLayerRenderTargetTextureProvider))
+        ) {
             throw new Error("Could not find the RTT provider for the layer");
         }
         // render the flare system to the rtt
@@ -413,9 +960,58 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * Add a new layer to the already-existing list of layers
      * @param wrappedLayer the new layer to add to the existing ones
      */
-    public addXRSessionLayer(wrappedLayer: WebXRLayerWrapper) {
+    public addXRSessionLayer(wrappedLayer: WebXRLayerWrapper<WebXRSupportedLayerType>) {
         this._existingLayers.push(wrappedLayer);
         this.setXRSessionLayers(this._existingLayers);
+    }
+
+    /**
+     * Removes a non-projection layer from the current XR session.
+     * @param wrappedLayer the layer wrapper to remove
+     * @param dispose whether to dispose the wrapper and destroy its native composition layer
+     * @returns whether the layer was present and removed
+     */
+    public removeXRSessionLayer(wrappedLayer: WebXRLayerWrapper<WebXRSupportedLayerType>, dispose = true): boolean {
+        const index = this._existingLayers.indexOf(wrappedLayer);
+        if (index === -1) {
+            return false;
+        }
+        if (wrappedLayer.layerType === "XRProjectionLayer") {
+            Logger.Warn("The active projection layer cannot be removed from WebXRLayers.");
+            return false;
+        }
+
+        this._existingLayers.splice(index, 1);
+        if (wrappedLayer instanceof WebXRCompositionLayerWrapper) {
+            this._layerToRTTProviderMapping.delete(wrappedLayer.layer);
+            this._compositionLayerTextureMapping.delete(wrappedLayer.layer);
+        }
+        this.setXRSessionLayers(this._existingLayers);
+        if (dispose) {
+            wrappedLayer.dispose();
+        }
+        return true;
+    }
+
+    /**
+     * Removes either a native spatial layer or a fallback layer created by this feature.
+     * @param wrappedLayer the native or fallback layer wrapper to remove
+     * @param dispose whether to dispose resources owned by the wrapper
+     * @returns whether the wrapper was present and removed
+     */
+    public removeLayer(wrappedLayer: WebXRLayerCreationResult<WebXRSpatialLayer>, dispose = true): boolean {
+        if (wrappedLayer.layer === null) {
+            const index = this._fallbackLayers.indexOf(wrappedLayer);
+            if (index === -1) {
+                return false;
+            }
+            this._fallbackLayers.splice(index, 1);
+            if (dispose) {
+                wrappedLayer.dispose();
+            }
+            return true;
+        }
+        return this.removeXRSessionLayer(wrappedLayer, dispose);
     }
 
     /**
@@ -427,7 +1023,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * as the first layer in the array, which feeds the WebXR camera(s) attached to the session.
      * @param wrappedLayers An array of WebXRLayerWrapper, usually returned from the WebXRLayers createLayer functions.
      */
-    public setXRSessionLayers(wrappedLayers: Array<WebXRLayerWrapper> = this._existingLayers): void {
+    public setXRSessionLayers(wrappedLayers: Array<WebXRLayerWrapper<WebXRSupportedLayerType>> = this._existingLayers): void {
         // this._existingLayers = wrappedLayers;
         const renderStateInit: XRRenderStateInit = { ...this._xrSessionManager.session.renderState };
         // Clear out the layer-related fields.
@@ -435,7 +1031,64 @@ export class WebXRLayers extends WebXRAbstractFeature {
         renderStateInit.layers = wrappedLayers.map((wrappedLayer) => wrappedLayer.layer);
         this._xrSessionManager.updateRenderState(renderStateInit);
         if (!this._projectionLayerInitialized) {
-            this._xrSessionManager._setBaseLayerWrapper(wrappedLayers.length > 0 ? wrappedLayers.at(0)! : null);
+            this._xrSessionManager._setBaseLayerWrapper(wrappedLayers.length > 0 ? (wrappedLayers.at(0)! as WebXRLayerWrapper) : null);
+        }
+    }
+
+    /**
+     * Checks whether the active runtime exposes the factory needed for a layer type.
+     * This is a capability check only; creation can still fail when an initialization dictionary is invalid.
+     * @param layerType the concrete WebXR layer type
+     * @param source whether to check a graphics-backed or media-backed layer
+     * @returns whether the requested factory is available
+     */
+    public isLayerTypeSupported(layerType: WebXRSpatialLayerType | "XRProjectionLayer", source: WebXRLayerSource = "graphics"): boolean {
+        if (source === "media") {
+            if (layerType === "XRProjectionLayer" || layerType === "XRCubeLayer" || typeof XRMediaBinding === "undefined") {
+                return false;
+            }
+            switch (layerType) {
+                case "XRQuadLayer":
+                    return typeof XRMediaBinding.prototype.createQuadLayer === "function";
+                case "XRCylinderLayer":
+                    return typeof XRMediaBinding.prototype.createCylinderLayer === "function";
+                case "XREquirectLayer":
+                    return typeof XRMediaBinding.prototype.createEquirectLayer === "function";
+            }
+        }
+
+        if (this._xrSessionManager.scene.getEngine().isWebGPU) {
+            if (typeof XRGPUBinding === "undefined") {
+                return false;
+            }
+            switch (layerType) {
+                case "XRProjectionLayer":
+                    return typeof XRGPUBinding.prototype.createProjectionLayer === "function";
+                case "XRQuadLayer":
+                    return typeof XRGPUBinding.prototype.createQuadLayer === "function";
+                case "XRCylinderLayer":
+                    return typeof XRGPUBinding.prototype.createCylinderLayer === "function";
+                case "XREquirectLayer":
+                    return typeof XRGPUBinding.prototype.createEquirectLayer === "function";
+                case "XRCubeLayer":
+                    return typeof XRGPUBinding.prototype.createCubeLayer === "function";
+            }
+        }
+
+        if (typeof XRWebGLBinding === "undefined") {
+            return false;
+        }
+        switch (layerType) {
+            case "XRProjectionLayer":
+                return typeof XRWebGLBinding.prototype.createProjectionLayer === "function";
+            case "XRQuadLayer":
+                return typeof XRWebGLBinding.prototype.createQuadLayer === "function";
+            case "XRCylinderLayer":
+                return typeof XRWebGLBinding.prototype.createCylinderLayer === "function";
+            case "XREquirectLayer":
+                return typeof XRWebGLBinding.prototype.createEquirectLayer === "function";
+            case "XRCubeLayer":
+                return typeof XRWebGLBinding.prototype.createCubeLayer === "function";
         }
     }
 
@@ -458,29 +1111,36 @@ export class WebXRLayers extends WebXRAbstractFeature {
     }
 
     protected _onXRFrame(_xrFrame: XRFrame): void {
-        // Replace once the mapped internal texture of each available composition layer, apart from the last one, which is the projection layer that needs an RTT
+        for (let i = 0; i < this._fallbackLayers.length; ++i) {
+            this._fallbackLayers[i].updateFromTransformNode(this._xrSessionManager.worldScalingFactor);
+        }
+
         const layers = this._existingLayers;
         for (let i = 0; i < layers.length; ++i) {
             const layer = layers[i];
-            if (layer.layerType !== "XRProjectionLayer") {
-                // get the rtt provider
-                const rttProvider = this._layerToRTTProviderMapping.get(layer.layer as XRCompositionLayer);
-                if (!rttProvider) {
-                    continue;
-                }
+            if (layer instanceof WebXRSpatialLayerWrapper) {
+                layer.updateFromTransformNode(this._xrSessionManager.scene.useRightHandedSystem, this._xrSessionManager.worldScalingFactor);
+            }
+            if (layer.layerType === "XRProjectionLayer" || !(layer instanceof WebXRCompositionLayerWrapper) || !layer.usesRenderTargetProvider) {
+                continue;
+            }
+            if (layer.isStatic && !layer.layer.needsRedraw) {
+                continue;
+            }
 
-                if (rttProvider.layerWrapper.isMultiview) {
-                    // get the views, if we are in multiview
-                    const pose = _xrFrame.getViewerPose(this._xrSessionManager.referenceSpace);
-                    if (pose) {
-                        const views = pose.views;
-                        for (let j = 0; j < views.length; ++j) {
-                            const view = views[j];
-                            rttProvider.getRenderTargetTextureForView(view);
-                        }
+            const rttProvider = this._layerToRTTProviderMapping.get(layer.layer);
+            if (!rttProvider) {
+                continue;
+            }
+            if (layer.layer.layout === "mono") {
+                rttProvider.getRenderTargetTextureForEye("none");
+            } else {
+                const pose = _xrFrame.getViewerPose(this._xrSessionManager.referenceSpace);
+                if (pose) {
+                    const views = pose.views;
+                    for (let j = 0; j < views.length; ++j) {
+                        rttProvider.getRenderTargetTextureForView(views[j]);
                     }
-                } else {
-                    rttProvider.getRenderTargetTextureForView();
                 }
             }
         }

--- a/packages/dev/core/src/XR/features/WebXRLayersFallback.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayersFallback.pure.ts
@@ -1,0 +1,57 @@
+/** This file must only contain pure code and pure imports */
+
+export * from "./Layers/WebXRFallbackLayer";
+
+import { RegisterEnginesExtensionsEngineVideoTexture } from "../../Engines/Extensions/engine.videoTexture.pure";
+import { RegisterEnginesWebGPUExtensionsEngineVideoTexture } from "../../Engines/WebGPU/Extensions/engine.videoTexture.pure";
+import { VideoTexture } from "../../Materials/Textures/videoTexture.pure";
+import { Logger } from "../../Misc/logger";
+import { WebXRFallbackLayerWrapper } from "./Layers/WebXRFallbackLayer";
+import { _RegisterWebXRFallbackLayerFactory } from "./WebXRLayers.pure";
+
+let _Registered = false;
+
+/**
+ * Registers the optional WebXR mesh-fallback implementation.
+ */
+export function RegisterWebXRLayersFallback(): void {
+    if (_Registered) {
+        return;
+    }
+    _Registered = true;
+
+    _RegisterWebXRFallbackLayerFactory((context) => {
+        let texture = context.texture;
+        let ownsTexture = false;
+        if (context.video) {
+            if (context.isWebGPU) {
+                RegisterEnginesWebGPUExtensionsEngineVideoTexture();
+            } else {
+                RegisterEnginesExtensionsEngineVideoTexture();
+            }
+            texture = new VideoTexture(`WebXR ${context.layerType} fallback video`, context.video, context.scene, false, false, undefined, {
+                independentVideoSource: true,
+            });
+            ownsTexture = true;
+        } else if (!texture) {
+            Logger.Warn(`fallbackTexture must be provided to emulate an ${context.layerType} graphics layer with a mesh.`);
+            return null;
+        }
+
+        if (context.layerType === "XRCubeLayer" && !texture.isCube) {
+            Logger.Warn("fallbackTexture must be a cube texture to emulate an XRCubeLayer.");
+            return null;
+        }
+
+        return new WebXRFallbackLayerWrapper(
+            context.scene,
+            context.layerType,
+            texture,
+            context.transformNode,
+            context.ownsTransformNode,
+            ownsTexture,
+            context.dimensions,
+            context.worldScalingFactor
+        );
+    });
+}

--- a/packages/dev/core/src/XR/features/WebXRLayersFallback.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayersFallback.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-exports the pure implementation and registers optional WebXR mesh fallbacks.
+ * Import WebXRLayersFallback.pure for side-effect-free usage.
+ */
+export * from "./WebXRLayersFallback.pure";
+
+import { RegisterWebXRLayersFallback } from "./WebXRLayersFallback.pure";
+RegisterWebXRLayersFallback();

--- a/packages/dev/core/src/XR/features/pure.ts
+++ b/packages/dev/core/src/XR/features/pure.ts
@@ -23,3 +23,4 @@ export * from "./WebXRDepthSensing.pure";
 export * from "./WebXRSpaceWarp.pure";
 export * from "./WebXRRawCameraAccess.pure";
 export * from "./WebXRBodyTracking.pure";
+export * from "./WebXRLayersFallback.pure";

--- a/packages/dev/core/src/XR/webXRLayerWrapper.ts
+++ b/packages/dev/core/src/XR/webXRLayerWrapper.ts
@@ -3,19 +3,35 @@ import { type WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetT
 import { type WebXRSessionManager } from "./webXRSessionManager";
 
 /** Covers all supported subclasses of WebXR's XRCompositionLayer */
-// TODO (rgerd): Extend for all other subclasses of XRCompositionLayer.
 export type WebXRCompositionLayerType = "XRProjectionLayer";
+
+/**
+ * The quad-layer type name.
+ */
 export type WebXRQuadLayerType = "XRQuadLayer";
 
 /** Covers all supported subclasses of WebXR's XRLayer */
 export type WebXRLayerType = "XRWebGLLayer" | WebXRCompositionLayerType | WebXRQuadLayerType;
 
+/** Covers the spatial composition-layer types supported by WebXRLayers. */
+export type WebXRSpatialLayerType = WebXRQuadLayerType | "XRCylinderLayer" | "XREquirectLayer" | "XRCubeLayer";
+
+/** Covers every native layer type supported by Babylon.js. */
+export type WebXRSupportedLayerType = WebXRLayerType | WebXRSpatialLayerType;
+
 /**
  * Wrapper over subclasses of XRLayer.
  * @internal
  */
-export class WebXRLayerWrapper {
-    private _rttWrapper: Nullable<WebXRLayerRenderTargetTextureProvider> = null;
+export class WebXRLayerWrapper<LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType> {
+    private _rttWrapper: Nullable<WebXRLayerRenderTargetTextureProvider<LayerTypeT>> = null;
+
+    /**
+     * The render target provider created for this layer, or `null` until one is created.
+     */
+    public get renderTargetTextureProvider(): Nullable<WebXRLayerRenderTargetTextureProvider<LayerTypeT>> {
+        return this._rttWrapper;
+    }
     /**
      * Check if fixed foveation is supported on this device
      */
@@ -50,11 +66,14 @@ export class WebXRLayerWrapper {
      * @param xrSessionManager The XR Session Manager
      * @returns A new render target texture provider for the wrapped layer.
      */
-    public createRenderTargetTextureProvider(xrSessionManager: WebXRSessionManager): WebXRLayerRenderTargetTextureProvider {
+    public createRenderTargetTextureProvider(xrSessionManager: WebXRSessionManager): WebXRLayerRenderTargetTextureProvider<LayerTypeT> {
         this._rttWrapper = this._createRenderTargetTextureProvider(xrSessionManager);
         return this._rttWrapper;
     }
 
+    /**
+     * Disposes the render target provider created for this layer.
+     */
     public dispose(): void {
         if (this._rttWrapper) {
             this._rttWrapper.dispose();
@@ -70,8 +89,8 @@ export class WebXRLayerWrapper {
         /** The XR layer that this WebXRLayerWrapper wraps. */
         public readonly layer: XRLayer,
         /** The type of XR layer that is being wrapped. */
-        public readonly layerType: WebXRLayerType,
+        public readonly layerType: LayerTypeT,
         /** Create a render target provider for the wrapped layer. */
-        private _createRenderTargetTextureProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider
+        private _createRenderTargetTextureProvider: (xrSessionManager: WebXRSessionManager) => WebXRLayerRenderTargetTextureProvider<LayerTypeT>
     ) {}
 }

--- a/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRRenderTargetTextureProvider.ts
@@ -5,7 +5,7 @@ import { RenderTargetTexture } from "../Materials/Textures/renderTargetTexture.p
 import { type Viewport } from "../Maths/math.viewport";
 import { type IDisposable, type Scene } from "../scene";
 import { type Nullable } from "../types";
-import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
+import { type WebXRLayerType, type WebXRLayerWrapper, type WebXRSupportedLayerType } from "./webXRLayerWrapper";
 
 /**
  * An interface for objects that provide render target textures for XR rendering.
@@ -37,7 +37,7 @@ export interface IWebXRRenderTargetTextureProvider extends IDisposable {
  * Provides render target textures and other important rendering information for a given XRLayer.
  * @internal
  */
-export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRenderTargetTextureProvider {
+export abstract class WebXRLayerRenderTargetTextureProvider<LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType> implements IWebXRRenderTargetTextureProvider {
     public abstract trySetViewportForView(viewport: Viewport, view: XRView): boolean;
     public abstract getRenderTargetTextureForEye(eye: XREye): Nullable<RenderTargetTexture>;
     public abstract getRenderTargetTextureForView(view: XRView): Nullable<RenderTargetTexture>;
@@ -49,7 +49,7 @@ export abstract class WebXRLayerRenderTargetTextureProvider implements IWebXRRen
 
     constructor(
         protected readonly _scene: Scene,
-        public readonly layerWrapper: WebXRLayerWrapper
+        public readonly layerWrapper: WebXRLayerWrapper<LayerTypeT>
     ) {
         this._engine = _scene.getEngine();
     }

--- a/packages/dev/core/src/XR/webXRWebGLRenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRWebGLRenderTargetTextureProvider.ts
@@ -5,13 +5,14 @@ import { InternalTexture, InternalTextureSource } from "../Materials/Textures/in
 import { type RenderTargetTexture } from "../Materials/Textures/renderTargetTexture.pure";
 import { type Nullable } from "../types";
 import { WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetTextureProvider";
+import { type WebXRLayerType, type WebXRSupportedLayerType } from "./webXRLayerWrapper";
 
 /**
  * Provides render target textures for WebGL-backed XR layers. Owns all WebGL-specific
  * framebuffer/texture wiring so the base provider can stay graphics-API-agnostic.
  * @internal
  */
-export abstract class WebXRWebGLRenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+export abstract class WebXRWebGLRenderTargetTextureProvider<LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType> extends WebXRLayerRenderTargetTextureProvider<LayerTypeT> {
     private _createInternalTexture(textureSize: { width: number; height: number }, texture: WebGLTexture): InternalTexture {
         const gl = (this._engine as ThinEngine)._gl;
         if (!gl) {

--- a/packages/dev/core/src/XR/webXRWebGPURenderTargetTextureProvider.ts
+++ b/packages/dev/core/src/XR/webXRWebGPURenderTargetTextureProvider.ts
@@ -6,7 +6,7 @@ import { type RenderTargetTexture } from "../Materials/Textures/renderTargetText
 import { Color4 } from "../Maths/math.color.pure";
 import { type Nullable } from "../types";
 import { WebXRLayerRenderTargetTexture } from "./webXRLayerRenderTargetTexture";
-import { type WebXRLayerWrapper } from "./webXRLayerWrapper";
+import { type WebXRLayerType, type WebXRLayerWrapper, type WebXRSupportedLayerType } from "./webXRLayerWrapper";
 import { WebXRLayerRenderTargetTextureProvider } from "./webXRRenderTargetTextureProvider";
 import { type WebXRSessionManager } from "./webXRSessionManager";
 
@@ -46,12 +46,14 @@ function GetBabylonDepthFormat(format: GPUTextureFormat): number {
  * WebGPU (XRGPUBinding) backend.
  * @internal
  */
-export abstract class WebXRWebGPURenderTargetTextureProvider extends WebXRLayerRenderTargetTextureProvider {
+export abstract class WebXRWebGPURenderTargetTextureProvider<
+    LayerTypeT extends WebXRSupportedLayerType = WebXRLayerType,
+> extends WebXRLayerRenderTargetTextureProvider<LayerTypeT> {
     private readonly _transparentClearColor = new Color4(0, 0, 0, 0);
 
     constructor(
         protected readonly _xrSessionManager: WebXRSessionManager,
-        layerWrapper: WebXRLayerWrapper
+        layerWrapper: WebXRLayerWrapper<LayerTypeT>
     ) {
         super(_xrSessionManager.scene, layerWrapper);
     }

--- a/packages/dev/core/test/unit/XR/webXRLayers.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayers.test.ts
@@ -3,23 +3,40 @@
  */
 
 import { NullEngine } from "core/Engines/nullEngine";
+import { DynamicTexture } from "core/Materials/Textures/dynamicTexture";
+import { type StandardMaterial } from "core/Materials/standardMaterial.pure";
 import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
-import { WebXRCompositionLayerWrapper } from "core/XR/features/Layers/WebXRCompositionLayer";
+import { WebXRCompositionLayerWrapper, WebXRCubeLayerWrapper, WebXRMediaLayerWrapper, WebXRSpatialLayerWrapper } from "core/XR/features/Layers/WebXRCompositionLayer";
+import { WebXRFallbackLayerWrapper } from "core/XR/features/WebXRLayersFallback";
 import { WebXRWebGPUCompositionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUCompositionLayer";
 import { WebXRLayers } from "core/XR/features/WebXRLayers";
 import { WebXRSessionManager } from "core/XR/webXRSessionManager";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-interface ProjectionLayerBindingConstructor {
+interface LayerBindingConstructor {
     prototype: {
         createProjectionLayer?: () => void;
+        createQuadLayer?: () => void;
+        createCylinderLayer?: () => void;
+        createEquirectLayer?: () => void;
+        createCubeLayer?: () => void;
+        getSubImage?: () => void;
+    };
+}
+
+interface MediaBindingConstructor {
+    prototype: {
+        createQuadLayer?: () => void;
+        createCylinderLayer?: () => void;
+        createEquirectLayer?: () => void;
     };
 }
 
 type TestGlobals = typeof globalThis & {
-    XRGPUBinding?: ProjectionLayerBindingConstructor;
-    XRWebGLBinding?: ProjectionLayerBindingConstructor;
+    XRGPUBinding?: LayerBindingConstructor;
+    XRWebGLBinding?: LayerBindingConstructor;
+    XRMediaBinding?: MediaBindingConstructor;
     XRRigidTransform?: typeof XRRigidTransform;
 };
 
@@ -33,8 +50,9 @@ describe("WebXRLayers", () => {
     let scene: Scene;
     let sessionManager: WebXRSessionManager;
     const testGlobals = globalThis as TestGlobals;
-    let originalGPUBinding: ProjectionLayerBindingConstructor | undefined;
-    let originalWebGLBinding: ProjectionLayerBindingConstructor | undefined;
+    let originalGPUBinding: LayerBindingConstructor | undefined;
+    let originalWebGLBinding: LayerBindingConstructor | undefined;
+    let originalMediaBinding: MediaBindingConstructor | undefined;
     let originalRigidTransform: typeof XRRigidTransform | undefined;
 
     beforeEach(() => {
@@ -50,8 +68,16 @@ describe("WebXRLayers", () => {
         (sessionManager as any)._xrNavigator = { xr: { native: false } };
         originalGPUBinding = testGlobals.XRGPUBinding;
         originalWebGLBinding = testGlobals.XRWebGLBinding;
+        originalMediaBinding = testGlobals.XRMediaBinding;
         originalRigidTransform = testGlobals.XRRigidTransform;
-        testGlobals.XRRigidTransform = vi.fn(function () {}) as unknown as typeof XRRigidTransform;
+        testGlobals.XRRigidTransform = vi.fn(function (
+            this: { position: DOMPointReadOnly; orientation: DOMPointReadOnly },
+            position: { x?: number; y?: number; z?: number; w?: number } = {},
+            orientation: { x?: number; y?: number; z?: number; w?: number } = {}
+        ) {
+            this.position = position as DOMPointReadOnly;
+            this.orientation = orientation as DOMPointReadOnly;
+        }) as unknown as typeof XRRigidTransform;
     });
 
     afterEach(() => {
@@ -64,6 +90,11 @@ describe("WebXRLayers", () => {
             testGlobals.XRWebGLBinding = originalWebGLBinding;
         } else {
             delete testGlobals.XRWebGLBinding;
+        }
+        if (originalMediaBinding) {
+            testGlobals.XRMediaBinding = originalMediaBinding;
+        } else {
+            delete testGlobals.XRMediaBinding;
         }
         if (originalRigidTransform) {
             testGlobals.XRRigidTransform = originalRigidTransform;
@@ -81,13 +112,13 @@ describe("WebXRLayers", () => {
     }
 
     function installGPUBinding(): void {
-        const binding = vi.fn() as unknown as ProjectionLayerBindingConstructor;
+        const binding = vi.fn() as unknown as LayerBindingConstructor;
         binding.prototype.createProjectionLayer = vi.fn();
         testGlobals.XRGPUBinding = binding;
     }
 
     function installWebGLBinding(): void {
-        const binding = vi.fn() as unknown as ProjectionLayerBindingConstructor;
+        const binding = vi.fn() as unknown as LayerBindingConstructor;
         binding.prototype.createProjectionLayer = vi.fn();
         testGlobals.XRWebGLBinding = binding;
     }
@@ -161,10 +192,11 @@ describe("WebXRLayers", () => {
             const xrWebGLBinding = vi.fn().mockImplementation(function () {
                 return nativeBinding;
             });
-            testGlobals.XRWebGLBinding = xrWebGLBinding as unknown as ProjectionLayerBindingConstructor;
+            testGlobals.XRWebGLBinding = xrWebGLBinding as unknown as LayerBindingConstructor;
             const glContext = {} as WebGLRenderingContext;
             (engine as any)._gl = glContext;
             initializeSession();
+            sessionManager.worldScalingFactor = 2;
             const feature = new WebXRLayers(sessionManager, { projectionLayerInit: { scaleFactor: 0.75 } });
 
             expect(feature.attach()).toBe(true);
@@ -195,6 +227,7 @@ describe("WebXRLayers", () => {
             });
             expect(quadLayer.width).toBe(2);
             expect(quadLayer.height).toBe(1);
+            expect(wrapper!.transformNode.position.z).toBe(3);
         });
 
         it("uses native WebGPU quad creation with explicit render-attachment usage", () => {
@@ -210,7 +243,7 @@ describe("WebXRLayers", () => {
             };
             testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
                 return nativeBinding;
-            }) as unknown as ProjectionLayerBindingConstructor;
+            }) as unknown as LayerBindingConstructor;
             (engine as any)._isWebGPU = true;
             (engine as any)._device = {};
             initializeSession();
@@ -222,7 +255,7 @@ describe("WebXRLayers", () => {
             addBabylonLayer(texture);
             const wrapper = feature.addFullscreenAdvancedDynamicTexture(texture as any);
 
-            expect(wrapper).toBeInstanceOf(WebXRWebGPUCompositionLayerWrapper);
+            expect(wrapper).toBeInstanceOf(WebXRSpatialLayerWrapper);
             expect(wrapper).toBeInstanceOf(WebXRCompositionLayerWrapper);
             expect(createQuadLayer).toHaveBeenCalledExactlyOnceWith({
                 colorFormat: "rgba8unorm",
@@ -245,7 +278,7 @@ describe("WebXRLayers", () => {
             };
             testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
                 return nativeBinding;
-            }) as unknown as ProjectionLayerBindingConstructor;
+            }) as unknown as LayerBindingConstructor;
             (engine as any)._isWebGPU = true;
             (engine as any)._device = {};
             const updateRenderState = initializeSession();
@@ -270,7 +303,7 @@ describe("WebXRLayers", () => {
             };
             testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
                 return nativeBinding;
-            }) as unknown as ProjectionLayerBindingConstructor;
+            }) as unknown as LayerBindingConstructor;
             (engine as any)._isWebGPU = true;
             (engine as any)._device = {};
             const updateRenderState = initializeSession();
@@ -284,6 +317,276 @@ describe("WebXRLayers", () => {
             expect(warnSpy).toHaveBeenCalledExactlyOnceWith(WebGPUQuadLayerSubImageWarning);
             expect(updateRenderState).toHaveBeenCalledTimes(1);
             expect(updateRenderState.mock.calls[0][0].layers).toEqual([projectionLayer]);
+        });
+    });
+
+    describe("spatial layer factories", () => {
+        it("creates every graphics-backed spatial layer through the shared WebGL path", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { layout: "mono", width: 1, height: 1, needsRedraw: true, destroy: vi.fn() };
+            const cylinderLayer = { layout: "mono", radius: 2, centralAngle: Math.PI / 2, aspectRatio: 2, needsRedraw: true, destroy: vi.fn() };
+            const equirectLayer = { layout: "mono", radius: 0, needsRedraw: true, destroy: vi.fn() };
+            const cubeLayer = { layout: "mono", orientation: {}, needsRedraw: true, destroy: vi.fn() };
+            const cubeSubImage = { colorTexture: {} };
+            const binding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer: vi.fn(() => quadLayer),
+                createCylinderLayer: vi.fn(() => cylinderLayer),
+                createEquirectLayer: vi.fn(() => equirectLayer),
+                createCubeLayer: vi.fn(() => cubeLayer),
+                getSubImage: vi.fn(() => cubeSubImage),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return binding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._gl = {};
+            const updateRenderState = initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+
+            expect(feature.attach()).toBe(true);
+            const quad = feature.createQuadLayer({ layerInit: { width: 1.5, height: 0.75 } });
+            const cylinder = feature.createCylinderLayer({ layerInit: { radius: 3, centralAngle: 1, aspectRatio: 1.5 } });
+            const equirect = feature.createEquirectLayer({ layerInit: { centralHorizontalAngle: Math.PI } });
+            const cube = feature.createCubeLayer({ layerInit: { textureType: "texture-array" } });
+
+            expect(quad).toBeInstanceOf(WebXRSpatialLayerWrapper);
+            expect(cylinder).toBeInstanceOf(WebXRSpatialLayerWrapper);
+            expect(equirect).toBeInstanceOf(WebXRSpatialLayerWrapper);
+            expect(cube).toBeInstanceOf(WebXRCubeLayerWrapper);
+            expect((cube as WebXRCubeLayerWrapper).renderTargetTextureProvider).toBeNull();
+            const frame = {} as XRFrame;
+            expect((cube as WebXRCubeLayerWrapper).getSubImage(frame)).toBe(cubeSubImage);
+            expect(binding.getSubImage).toHaveBeenCalledWith(cubeLayer, frame, undefined);
+            expect(binding.createQuadLayer).toHaveBeenCalledWith(expect.objectContaining({ width: 1.5, height: 0.75, viewPixelWidth: 1024, viewPixelHeight: 512 }));
+            expect(binding.createCylinderLayer).toHaveBeenCalledWith(expect.objectContaining({ radius: 3, centralAngle: 1, aspectRatio: 1.5 }));
+            expect(binding.createEquirectLayer).toHaveBeenCalledWith(expect.objectContaining({ centralHorizontalAngle: Math.PI }));
+            expect(binding.createCubeLayer).toHaveBeenCalledWith(expect.objectContaining({ space: sessionManager.referenceSpace, textureType: "texture-array" }));
+            expect(updateRenderState.mock.lastCall?.[0].layers).toEqual([projectionLayer, quadLayer, cylinderLayer, equirectLayer, cubeLayer]);
+        });
+
+        it("translates shared initialization values for WebGPU cylinder, equirect, and cube layers", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const gpuSpace = { name: "gpu-space" } as unknown as XRReferenceSpace;
+            const cylinderLayer = { layout: "mono", radius: 2, centralAngle: 1, aspectRatio: 2, space: gpuSpace, needsRedraw: true, destroy: vi.fn() };
+            const equirectLayer = { layout: "mono", radius: 0, needsRedraw: true, destroy: vi.fn() };
+            const cubeLayer = { layout: "mono", orientation: {}, needsRedraw: true, destroy: vi.fn() };
+            const binding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createCylinderLayer: vi.fn(() => cylinderLayer),
+                createEquirectLayer: vi.fn(() => equirectLayer),
+                createCubeLayer: vi.fn(() => cubeLayer),
+                getSubImage: vi.fn(),
+                getPreferredColorFormat: vi.fn(() => "rgba8unorm"),
+            };
+            testGlobals.XRGPUBinding = vi.fn().mockImplementation(function () {
+                return binding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._isWebGPU = true;
+            (engine as any)._device = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+
+            const cylinder = feature.createCylinderLayer({
+                layerInit: { radius: 3, centralAngle: 1.25, aspectRatio: 1.5, isStatic: true },
+                gpuLayerInit: { depthStencilFormat: "depth24plus", space: gpuSpace, viewPixelWidth: 256 },
+            });
+            feature.createEquirectLayer({ layerInit: { radius: 4, centralHorizontalAngle: Math.PI } });
+            feature.createCubeLayer();
+
+            expect(binding.createCylinderLayer).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    colorFormat: "rgba8unorm",
+                    depthStencilFormat: "depth24plus",
+                    textureUsage: 0x10,
+                    space: gpuSpace,
+                    viewPixelWidth: 256,
+                    radius: 3,
+                    centralAngle: 1.25,
+                    aspectRatio: 1.5,
+                    isStatic: true,
+                })
+            );
+            expect(cylinder!.getWidth()).toBe(256);
+            sessionManager.onXRReferenceSpaceChanged.notifyObservers({ name: "recentered" } as unknown as XRReferenceSpace);
+            expect(cylinderLayer.space).toBe(gpuSpace);
+            expect(binding.createEquirectLayer).toHaveBeenCalledWith(expect.objectContaining({ radius: 4, centralHorizontalAngle: Math.PI }));
+            expect(binding.createCubeLayer).toHaveBeenCalledWith(expect.objectContaining({ colorFormat: "rgba8unorm", space: sessionManager.referenceSpace }));
+        });
+
+        it("updates only layers that use the session manager's default reference space", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const defaultSpaceLayer = { layout: "mono", width: 1, height: 1, space: sessionManager.referenceSpace, needsRedraw: true, destroy: vi.fn() };
+            const explicitSpace = { name: "explicit" } as unknown as XRReferenceSpace;
+            const explicitSpaceLayer = { layout: "mono", width: 1, height: 1, space: explicitSpace, needsRedraw: true, destroy: vi.fn() };
+            const binding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer: vi.fn().mockReturnValueOnce(defaultSpaceLayer).mockReturnValueOnce(explicitSpaceLayer),
+                getSubImage: vi.fn(),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return binding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._gl = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+            feature.createQuadLayer();
+            feature.createQuadLayer({ layerInit: { space: explicitSpace } });
+
+            const newReferenceSpace = { name: "recentered" } as unknown as XRReferenceSpace;
+            sessionManager.onXRReferenceSpaceChanged.notifyObservers(newReferenceSpace);
+
+            expect(defaultSpaceLayer.space).toBe(newReferenceSpace);
+            expect(explicitSpaceLayer.space).toBe(explicitSpace);
+        });
+
+        it("removes and disposes native spatial layers without disturbing projection rendering", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { layout: "mono", width: 1, height: 1, needsRedraw: true, destroy: vi.fn() };
+            const binding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer: vi.fn(() => quadLayer),
+                getSubImage: vi.fn(),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return binding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._gl = {};
+            const updateRenderState = initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+            const wrapper = feature.createQuadLayer() as WebXRSpatialLayerWrapper;
+            const ownedTransformNode = wrapper.transformNode;
+
+            expect(feature.removeLayer(wrapper)).toBe(true);
+
+            expect(updateRenderState.mock.lastCall?.[0].layers).toEqual([projectionLayer]);
+            expect(quadLayer.destroy).toHaveBeenCalledOnce();
+            expect(ownedTransformNode.isDisposed()).toBe(true);
+            expect(feature.removeLayer(wrapper)).toBe(false);
+        });
+
+        it("synchronizes transform-node world transforms into native layer coordinates", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { layout: "mono", width: 1, height: 1, needsRedraw: true, destroy: vi.fn() };
+            const binding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer: vi.fn(() => quadLayer),
+                getSubImage: vi.fn(),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return binding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._gl = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+            const wrapper = feature.createQuadLayer();
+            expect(wrapper).toBeInstanceOf(WebXRSpatialLayerWrapper);
+            const nativeWrapper = wrapper as WebXRSpatialLayerWrapper;
+
+            nativeWrapper.transformNode.position.set(1, 2, 3);
+            sessionManager.onXRFrameObservable.notifyObservers({ getViewerPose: vi.fn() } as unknown as XRFrame);
+
+            expect(quadLayer).toHaveProperty("transform");
+            const transform = (quadLayer as typeof quadLayer & { transform: XRRigidTransform }).transform;
+            expect(transform.position).toMatchObject({ x: 1, y: 2, z: -3 });
+            expect(transform.orientation.x).toBeCloseTo(0);
+            expect(transform.orientation.y).toBeCloseTo(0);
+            expect(transform.orientation.z).toBeCloseTo(0);
+            expect(transform.orientation.w).toBeCloseTo(-1);
+        });
+
+        it("creates media layers without allocating a render target provider", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { layout: "mono", width: 1, height: 1, needsRedraw: true, destroy: vi.fn() };
+            const cylinderLayer = { layout: "mono", radius: 2, centralAngle: 1, aspectRatio: 2, needsRedraw: true, destroy: vi.fn() };
+            const equirectLayer = { layout: "mono", radius: 0, needsRedraw: true, destroy: vi.fn() };
+            const graphicsBinding = { createProjectionLayer: vi.fn(() => projectionLayer) };
+            const createQuadLayer = vi.fn(() => quadLayer);
+            const createCylinderLayer = vi.fn(() => cylinderLayer);
+            const createEquirectLayer = vi.fn(() => equirectLayer);
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return graphicsBinding;
+            }) as unknown as LayerBindingConstructor;
+            testGlobals.XRMediaBinding = vi.fn().mockImplementation(function () {
+                return { createQuadLayer, createCylinderLayer, createEquirectLayer };
+            }) as unknown as MediaBindingConstructor;
+            (engine as any)._gl = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+            const video = document.createElement("video");
+
+            const quad = feature.createMediaQuadLayer(video, { layerInit: { width: 2, height: 1 } });
+            const cylinder = feature.createMediaCylinderLayer(video, { layerInit: { radius: 3, centralAngle: 1.5 } });
+            const equirect = feature.createMediaEquirectLayer(video, { layerInit: { centralHorizontalAngle: Math.PI } });
+
+            expect(quad).toBeInstanceOf(WebXRMediaLayerWrapper);
+            expect(cylinder).toBeInstanceOf(WebXRMediaLayerWrapper);
+            expect(equirect).toBeInstanceOf(WebXRMediaLayerWrapper);
+            expect((quad as WebXRMediaLayerWrapper).renderTargetTextureProvider).toBeNull();
+            expect(createQuadLayer).toHaveBeenCalledWith(video, expect.objectContaining({ width: 2, height: 1, space: sessionManager.referenceSpace }));
+            expect(createCylinderLayer).toHaveBeenCalledWith(video, expect.objectContaining({ radius: 3, centralAngle: 1.5 }));
+            expect(createEquirectLayer).toHaveBeenCalledWith(video, expect.objectContaining({ centralHorizontalAngle: Math.PI }));
+        });
+
+        it("uses an opt-in mesh fallback without changing the XR render-state layers", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const graphicsBinding = { createProjectionLayer: vi.fn(() => projectionLayer) };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return graphicsBinding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._gl = {};
+            const updateRenderState = initializeSession();
+            sessionManager.worldScalingFactor = 2;
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+
+            const fallbackTexture = new DynamicTexture("fallback", { width: 1, height: 1 }, scene);
+            const disposeTexture = vi.spyOn(fallbackTexture, "dispose");
+            const wrapper = feature.createCylinderLayer({
+                fallbackMode: "mesh",
+                fallbackTexture,
+                layerInit: { radius: 2, centralAngle: Math.PI, aspectRatio: 2 },
+            });
+
+            expect(wrapper).toBeInstanceOf(WebXRFallbackLayerWrapper);
+            expect((wrapper as WebXRFallbackLayerWrapper).layer).toBeNull();
+            expect((wrapper as WebXRFallbackLayerWrapper).mesh.scaling.asArray()).toEqual([2, 2, 2]);
+            expect(((wrapper as WebXRFallbackLayerWrapper).mesh.material as StandardMaterial).emissiveColor.asArray()).toEqual([0, 0, 0]);
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+            expect(feature.removeLayer(wrapper!)).toBe(true);
+            expect((wrapper as WebXRFallbackLayerWrapper).mesh.isDisposed()).toBe(true);
+            expect(disposeTexture).not.toHaveBeenCalled();
+            fallbackTexture.dispose();
+        });
+
+        it("uses a Babylon VideoTexture for media fallbacks without taking control of playback", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const graphicsBinding = { createProjectionLayer: vi.fn(() => projectionLayer) };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return graphicsBinding;
+            }) as unknown as LayerBindingConstructor;
+            delete testGlobals.XRMediaBinding;
+            (engine as any)._gl = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+            const video = document.createElement("video");
+            Object.defineProperties(video, {
+                readyState: { value: video.HAVE_CURRENT_DATA },
+                videoWidth: { value: 2 },
+                videoHeight: { value: 2 },
+            });
+            const playSpy = vi.spyOn(video, "play");
+
+            const wrapper = feature.createMediaQuadLayer(video, { fallbackMode: "mesh" });
+
+            expect(wrapper).toBeInstanceOf(WebXRFallbackLayerWrapper);
+            expect((wrapper as WebXRFallbackLayerWrapper).texture.getClassName()).toBe("VideoTexture");
+            expect(playSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/dev/core/test/unit/XR/webXRLayers.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayers.test.ts
@@ -4,10 +4,17 @@
 
 import { NullEngine } from "core/Engines/nullEngine";
 import { DynamicTexture } from "core/Materials/Textures/dynamicTexture";
+import { RenderTargetTexture } from "core/Materials/Textures/renderTargetTexture";
 import { type StandardMaterial } from "core/Materials/standardMaterial.pure";
 import { Logger } from "core/Misc/logger";
 import { Scene } from "core/scene";
-import { WebXRCompositionLayerWrapper, WebXRCubeLayerWrapper, WebXRMediaLayerWrapper, WebXRSpatialLayerWrapper } from "core/XR/features/Layers/WebXRCompositionLayer";
+import {
+    WebXRCompositionLayerRenderTargetTextureProvider,
+    WebXRCompositionLayerWrapper,
+    WebXRCubeLayerWrapper,
+    WebXRMediaLayerWrapper,
+    WebXRSpatialLayerWrapper,
+} from "core/XR/features/Layers/WebXRCompositionLayer";
 import { WebXRFallbackLayerWrapper } from "core/XR/features/WebXRLayersFallback";
 import { WebXRWebGPUCompositionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUCompositionLayer";
 import { WebXRLayers } from "core/XR/features/WebXRLayers";
@@ -360,8 +367,18 @@ describe("WebXRLayers", () => {
             expect(binding.createQuadLayer).toHaveBeenCalledWith(expect.objectContaining({ width: 1.5, height: 0.75, viewPixelWidth: 1024, viewPixelHeight: 512 }));
             expect(binding.createCylinderLayer).toHaveBeenCalledWith(expect.objectContaining({ radius: 3, centralAngle: 1, aspectRatio: 1.5 }));
             expect(binding.createEquirectLayer).toHaveBeenCalledWith(expect.objectContaining({ centralHorizontalAngle: Math.PI }));
-            expect(binding.createCubeLayer).toHaveBeenCalledWith(expect.objectContaining({ space: sessionManager.referenceSpace, textureType: "texture-array" }));
+            expect(binding.createCubeLayer).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    space: sessionManager.referenceSpace,
+                    textureType: "texture-array",
+                    viewPixelWidth: 512,
+                    viewPixelHeight: 512,
+                })
+            );
             expect(updateRenderState.mock.lastCall?.[0].layers).toEqual([projectionLayer, quadLayer, cylinderLayer, equirectLayer, cubeLayer]);
+            expect(() => feature.createCubeLayer({ layerInit: { viewPixelWidth: 256, viewPixelHeight: 128 } })).toThrow(
+                "WebXR cube layer faces must have equal pixel width and height."
+            );
         });
 
         it("translates shared initialization values for WebGPU cylinder, equirect, and cube layers", () => {
@@ -560,7 +577,58 @@ describe("WebXRLayers", () => {
             expect(feature.removeLayer(wrapper!)).toBe(true);
             expect((wrapper as WebXRFallbackLayerWrapper).mesh.isDisposed()).toBe(true);
             expect(disposeTexture).not.toHaveBeenCalled();
+
+            fallbackTexture.getInternalTexture()!.isCube = true;
+            vi.spyOn(fallbackTexture, "clone").mockReturnValue(null);
+            const cubeWrapper = feature.createCubeLayer({
+                fallbackMode: "mesh",
+                fallbackTexture,
+            }) as WebXRFallbackLayerWrapper;
+            cubeWrapper.transformNode.position.set(1, 2, 3);
+            sessionManager.onXRFrameObservable.notifyObservers({ getViewerPose: vi.fn() } as unknown as XRFrame);
+
+            expect(cubeWrapper.mesh.position.asArray()).toEqual([0, 0, 0]);
+            expect(feature.removeLayer(cubeWrapper)).toBe(true);
             fallbackTexture.dispose();
+        });
+
+        it("removes fullscreen ADT render callbacks and render-target references with the layer", () => {
+            const projectionLayer = { textureWidth: 1024, textureHeight: 512 };
+            const quadLayer = { layout: "mono", width: 0, height: 0, needsRedraw: true, destroy: vi.fn() };
+            const binding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer: vi.fn(() => quadLayer),
+                getSubImage: vi.fn(),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return binding;
+            }) as unknown as LayerBindingConstructor;
+            (engine as any)._gl = {};
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            feature.attach();
+            const texture = {};
+            addBabylonLayer(texture);
+            const wrapper = feature.addFullscreenAdvancedDynamicTexture(texture as any)!;
+            const provider = wrapper.renderTargetTextureProvider as WebXRCompositionLayerRenderTargetTextureProvider;
+            const renderTargetTexture = new RenderTargetTexture("fullscreen ADT test", 1, scene);
+            const render = vi.spyOn(renderTargetTexture, "render").mockImplementation(() => {});
+
+            provider.onRenderTargetTextureCreatedObservable.notifyObservers({ texture: renderTargetTexture, eye: "none" });
+            scene.onBeforeRenderObservable.notifyObservers(scene);
+
+            const babylonLayer = scene.layers[0];
+            expect(babylonLayer.renderTargetTextures).toEqual([renderTargetTexture]);
+            expect(babylonLayer.renderOnlyInRenderTargetTextures).toBe(true);
+            expect(render).toHaveBeenCalledOnce();
+
+            expect(feature.removeXRSessionLayer(wrapper)).toBe(true);
+            scene.onBeforeRenderObservable.notifyObservers(scene);
+
+            expect(babylonLayer.renderTargetTextures).toEqual([]);
+            expect(babylonLayer.renderOnlyInRenderTargetTextures).toBe(false);
+            expect(render).toHaveBeenCalledOnce();
+            renderTargetTexture.dispose();
         });
 
         it("uses a Babylon VideoTexture for media fallbacks without taking control of playback", () => {

--- a/packages/dev/core/test/unit/XR/webXRLayers.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayers.test.ts
@@ -429,6 +429,10 @@ describe("WebXRLayers", () => {
             expect(cylinderLayer.space).toBe(gpuSpace);
             expect(binding.createEquirectLayer).toHaveBeenCalledWith(expect.objectContaining({ radius: 4, centralHorizontalAngle: Math.PI }));
             expect(binding.createCubeLayer).toHaveBeenCalledWith(expect.objectContaining({ colorFormat: "rgba8unorm", space: sessionManager.referenceSpace }));
+            expect(() => feature.createCubeLayer({ gpuLayerInit: { viewPixelWidth: 256, viewPixelHeight: 128 } })).toThrow(
+                "WebXR cube layer faces must have equal pixel width and height."
+            );
+            expect(binding.createCubeLayer).toHaveBeenCalledTimes(1);
         });
 
         it("updates only layers that use the session manager's default reference space", () => {

--- a/packages/public/@babylonjs/core/package.json
+++ b/packages/public/@babylonjs/core/package.json
@@ -702,6 +702,7 @@
         "XR/features/WebXRHitTest.js",
         "XR/features/WebXRImageTracking.js",
         "XR/features/WebXRLayers.js",
+        "XR/features/WebXRLayersFallback.js",
         "XR/features/WebXRLightEstimation.js",
         "XR/features/WebXRMeshDetector.js",
         "XR/features/WebXRNearInteraction.js",

--- a/scripts/treeshaking/side-effects-manifest/core/XR.json
+++ b/scripts/treeshaking/side-effects-manifest/core/XR.json
@@ -16,6 +16,7 @@
         "XR/features/WebXRHitTest.ts": ["top-level-call"],
         "XR/features/WebXRImageTracking.ts": ["top-level-call"],
         "XR/features/WebXRLayers.ts": ["top-level-call"],
+        "XR/features/WebXRLayersFallback.ts": ["top-level-call"],
         "XR/features/WebXRLightEstimation.ts": ["top-level-call"],
         "XR/features/WebXRMeshDetector.ts": ["top-level-call"],
         "XR/features/WebXRNearInteraction.ts": ["top-level-call"],


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- add shared WebGL and WebGPU creation paths for quad, cylinder, equirectangular, and cube composition layers
- add `XRMediaBinding` factories for video-backed quad, cylinder, and equirectangular layers
- synchronize native layer transforms with Babylon `TransformNode`s, including handedness, world scaling, recentering, static-layer redraws, ordering, removal, and disposal
- expose raw cube subimages for six-face uploads
- add optional mesh fallbacks that reuse Babylon meshes, materials, textures, and `VideoTexture`
- keep fallback rendering in the explicit `WebXRLayersFallback` opt-in module so projection-only users do not load its rendering dependencies

## Compatibility

WebXR Layers remains opt-in and disabled by default. Existing projection-layer behavior and the legacy public layer-type unions are preserved. Users who do not enable the feature do not enter any new runtime paths.

## Playground

[Compare a Babylon `VideoTexture` with a native WebXR media quad layer using this PR's snapshot](https://playground.babylonjs.com/?snapshot=refs/pull/18832/merge#D35HOL#0). Both videos play side by side before entering XR; in XR, the right preview is replaced by the compositor layer.

## Validation

- core TypeScript compilation
- 18 focused WebXR Layers unit tests
- 336 XR unit tests
- formatting and lint checks
- all 16 tree-shaking checks
- Quest 3 comparison of a Babylon `VideoTexture` mesh and a compositor media layer

The full unit suite completed 4,659 passing tests plus one expected failure; two unrelated timeout flakes passed when rerun in isolation.