### PR TITLE
Harden public Playwright report uploads

### DIFF
--- a/.azure-pipelines/scripts/validate-public-report.mjs
+++ b/.azure-pipelines/scripts/validate-public-report.mjs
@@ -6,8 +6,20 @@ if (!reportDirectory) {
     throw new Error("Usage: node validate-public-report.mjs <report-directory>");
 }
 
-const allowedExtensions = new Set([".css", ".gif", ".html", ".ico", ".jpeg", ".jpg", ".js", ".mjs", ".png", ".svg", ".ttf", ".txt", ".webp", ".woff", ".woff2"]);
-const blockedMarkers = ["browserstack.accesskey", "%22browserstack.accesskey%22", "cdp.browserstack.com/playwright?caps=", "data:application/zip;base64"];
+const allowedExtensions = new Set([".css", ".gif", ".html", ".ico", ".jpeg", ".jpg", ".png", ".svg", ".ttf", ".txt", ".webp", ".woff", ".woff2"]);
+const blockedMarkers = [
+    "browserstack.accesskey",
+    "%22browserstack.accesskey%22",
+    "cdp.browserstack.com/playwright?caps=",
+    "data:application/gzip;base64",
+    "data:application/zip;base64",
+];
+const blockedFileSignatures = [
+    ["Gzip archive", Buffer.from([0x1f, 0x8b])],
+    ["ZIP archive", Buffer.from([0x50, 0x4b, 0x03, 0x04])],
+    ["ZIP archive", Buffer.from([0x50, 0x4b, 0x05, 0x06])],
+    ["ZIP archive", Buffer.from([0x50, 0x4b, 0x07, 0x08])],
+];
 const configuredSecrets = [
     ["BrowserStack access key", process.env.BROWSERSTACK_ACCESS_KEY],
     ["BrowserStack username", process.env.BROWSERSTACK_USERNAME],
@@ -51,6 +63,12 @@ const scanDirectory = async (directory) => {
 
         const contents = await readFile(path);
         const searchableContents = contents.toString("latin1").toLowerCase();
+        for (const [name, signature] of blockedFileSignatures) {
+            if (contents.subarray(0, signature.length).equals(signature)) {
+                violations.push(`${displayPath}: contains ${name} data`);
+                break;
+            }
+        }
         for (const marker of blockedMarkers) {
             if (searchableContents.includes(marker)) {
                 violations.push(`${displayPath}: contains blocked marker "${marker}"`);

--- a/.azure-pipelines/scripts/validate-public-report.mjs
+++ b/.azure-pipelines/scripts/validate-public-report.mjs
@@ -1,0 +1,83 @@
+import { lstat, readdir, readFile } from "node:fs/promises";
+import { extname, join, relative, resolve } from "node:path";
+
+const reportDirectory = process.argv[2];
+if (!reportDirectory) {
+    throw new Error("Usage: node validate-public-report.mjs <report-directory>");
+}
+
+const allowedExtensions = new Set([".css", ".gif", ".html", ".ico", ".jpeg", ".jpg", ".js", ".mjs", ".png", ".svg", ".ttf", ".txt", ".webp", ".woff", ".woff2"]);
+const blockedMarkers = ["browserstack.accesskey", "%22browserstack.accesskey%22", "cdp.browserstack.com/playwright?caps=", "data:application/zip;base64"];
+const configuredSecrets = [
+    ["BrowserStack access key", process.env.BROWSERSTACK_ACCESS_KEY],
+    ["BrowserStack username", process.env.BROWSERSTACK_USERNAME],
+];
+const violations = [];
+const root = resolve(reportDirectory);
+
+const isConfiguredSecret = (value) => {
+    return value && value.length >= 8 && !value.startsWith("$(");
+};
+
+const getSecretVariants = (value) => {
+    return [value, encodeURIComponent(value), Buffer.from(value).toString("base64"), Buffer.from(value).toString("base64url")];
+};
+
+const scanDirectory = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+        const path = join(directory, entry.name);
+        const displayPath = relative(root, path);
+        const stats = await lstat(path);
+
+        if (stats.isSymbolicLink()) {
+            violations.push(`${displayPath}: symbolic links are not allowed`);
+            continue;
+        }
+        if (stats.isDirectory()) {
+            await scanDirectory(path);
+            continue;
+        }
+        if (!stats.isFile()) {
+            violations.push(`${displayPath}: special files are not allowed`);
+            continue;
+        }
+
+        const extension = extname(entry.name).toLowerCase();
+        if (!allowedExtensions.has(extension)) {
+            violations.push(`${displayPath}: file type "${extension || "(none)"}" is not allowed`);
+            continue;
+        }
+
+        const contents = await readFile(path);
+        const searchableContents = contents.toString("latin1").toLowerCase();
+        for (const marker of blockedMarkers) {
+            if (searchableContents.includes(marker)) {
+                violations.push(`${displayPath}: contains blocked marker "${marker}"`);
+            }
+        }
+        for (const [name, value] of configuredSecrets) {
+            if (!isConfiguredSecret(value)) {
+                continue;
+            }
+            for (const variant of getSecretVariants(value)) {
+                if (contents.includes(Buffer.from(variant))) {
+                    violations.push(`${displayPath}: contains ${name}`);
+                    break;
+                }
+            }
+        }
+    }
+};
+
+await scanDirectory(root);
+
+if (violations.length > 0) {
+    process.stderr.write("Public report validation failed:\n");
+    for (const violation of violations) {
+        process.stderr.write(`- ${violation}\n`);
+    }
+    process.exitCode = 1;
+} else {
+    process.stdout.write("Public report validation passed.\n");
+}

--- a/.azure-pipelines/templates/upload-test-results.yml
+++ b/.azure-pipelines/templates/upload-test-results.yml
@@ -1,9 +1,9 @@
 # =============================================================================
 # Template: Upload Playwright test results to the deployment server
 #
-# Looks for a playwright-report directory, zips it, and uploads to the
-# deployment server. Supports a fallback directory for cases where the
-# report may be in a different location.
+# Looks for a sanitized public report directory, validates its contents, zips
+# it, and uploads it to the deployment server. Supports a fallback directory
+# for cases where the report may be in a different location.
 # =============================================================================
 
 parameters:
@@ -30,29 +30,37 @@ parameters:
 
 steps:
     - script: |
+          set -euo pipefail
+
           REPORT_DIR="${{ parameters.reportDir }}"
           FALLBACK_DIR="${{ parameters.fallbackReportDir }}"
 
           if test -d "$REPORT_DIR"; then
-            cd "$REPORT_DIR"
+            SELECTED_REPORT_DIR="$REPORT_DIR"
           elif [ -n "$FALLBACK_DIR" ] && test -d "$FALLBACK_DIR"; then
-            cd "$FALLBACK_DIR"
+            SELECTED_REPORT_DIR="$FALLBACK_DIR"
           else
             echo "No report directory found, skipping upload"
             exit 0
           fi
 
-          zip -r $(Build.SourcesDirectory)/_test_report.zip *
-          cd $(Build.SourcesDirectory)
+          node "$(Build.SourcesDirectory)/.azure-pipelines/scripts/validate-public-report.mjs" "$SELECTED_REPORT_DIR"
 
-          curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+          REPORT_ARCHIVE="$(Build.SourcesDirectory)/_test_report.zip"
+          trap 'rm -f "$REPORT_ARCHIVE"' EXIT
+          cd "$SELECTED_REPORT_DIR"
+          zip -q -r "$REPORT_ARCHIVE" .
+          cd "$(Build.SourcesDirectory)"
+
+          curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD)" -X POST \
             -H "Content-Type: multipart/form-data" \
             -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
             -F "path=${{ parameters.deployPath }}" \
             -F "storageAccount=${{ parameters.storageAccount }}" \
-            -F "zip=@_test_report.zip"
-
-          rm -f _test_report.zip
+            -F "zip=@$REPORT_ARCHIVE"
       displayName: "${{ parameters.displayName }}"
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
+      env:
+          BROWSERSTACK_USERNAME: $(BROWSERSTACK_USERNAME)
+          BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)

--- a/packages/tools/tests/publicReportReporter.ts
+++ b/packages/tools/tests/publicReportReporter.ts
@@ -1,0 +1,85 @@
+import type { FullResult, Reporter, TestCase, TestResult } from "@playwright/test/reporter";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+type PublicReportReporterOptions = {
+    outputFolder?: string;
+};
+
+type PublicTestResult = {
+    duration: number;
+    retry: number;
+    status: TestResult["status"];
+    title: string;
+};
+
+const escapeHtml = (value: string): string => {
+    return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+};
+
+class PublicReportReporter implements Reporter {
+    private readonly _outputFolder: string;
+    private readonly _results = new Map<string, PublicTestResult>();
+
+    public constructor(options: PublicReportReporterOptions = {}) {
+        this._outputFolder = options.outputFolder ?? "playwright-report";
+    }
+
+    public onTestEnd(test: TestCase, result: TestResult): void {
+        this._results.set(test.id, {
+            duration: result.duration,
+            retry: result.retry,
+            status: result.status,
+            title: test.titlePath().join(" > "),
+        });
+    }
+
+    public onEnd(result: FullResult): void {
+        const results = [...this._results.values()].sort((left, right) => left.title.localeCompare(right.title));
+        const totals = new Map<string, number>();
+        for (const testResult of results) {
+            totals.set(testResult.status, (totals.get(testResult.status) ?? 0) + 1);
+        }
+
+        const summary = [...totals.entries()]
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([status, count]) => `<li><strong>${escapeHtml(status)}</strong>: ${count}</li>`)
+            .join("");
+        const rows = results
+            .map(
+                (testResult) =>
+                    `<tr><td>${escapeHtml(testResult.title)}</td><td>${escapeHtml(testResult.status)}</td><td>${testResult.retry + 1}</td><td>${testResult.duration} ms</td></tr>`
+            )
+            .join("");
+        const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Playwright test report</title>
+<style>
+body { color: #24292f; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #d0d7de; padding: 0.5rem; text-align: left; }
+th { background: #f6f8fa; }
+</style>
+</head>
+<body>
+<h1>Playwright test report</h1>
+<p>Overall status: <strong>${escapeHtml(result.status)}</strong></p>
+<ul>${summary}</ul>
+<p>This public report intentionally omits errors, output, attachments, traces, and configuration.</p>
+<table>
+<thead><tr><th>Test</th><th>Status</th><th>Attempts</th><th>Duration</th></tr></thead>
+<tbody>${rows}</tbody>
+</table>
+</body>
+</html>
+`;
+
+        mkdirSync(this._outputFolder, { recursive: true });
+        writeFileSync(join(this._outputFolder, "index.html"), html, "utf8");
+    }
+}
+
+export default PublicReportReporter;

--- a/playwright.browserstack.config.ts
+++ b/playwright.browserstack.config.ts
@@ -74,17 +74,15 @@ const caps = {
     ...(usesBrowserStackLocal && browserStackLocalIdentifier ? { "browserstack.localIdentifier": browserStackLocalIdentifier } : {}),
 };
 
-// SECURITY NOTE: The wsEndpoint embeds BROWSERSTACK_ACCESS_KEY. Playwright may
-// log this URL on connection failure, and trace files (trace: "on-first-retry")
-// may include it. Ensure BROWSERSTACK_ACCESS_KEY is marked **secret** in the
-// Azure DevOps variable group, and do NOT publish playwright-report/ or
-// trace-*.zip as public CI artifacts.
+// The endpoint contains the BrowserStack access key. BrowserStack runs must not
+// record traces or use reporters that serialize errors, output, attachments, or
+// configuration into the public report.
 const wsEndpoint = `wss://cdp.browserstack.com/playwright?caps=${encodeURIComponent(JSON.stringify(caps))}`;
 
 // ---------------------------------------------------------------------------
 // Reporters
 // ---------------------------------------------------------------------------
-const baseReporters: any[] = [["line"], ["junit", { outputFile: "junit.xml" }], ["html", { open: "never" }]];
+const baseReporters: any[] = [["line"], ["junit", { outputFile: "junit.xml" }], ["./packages/tools/tests/publicReportReporter.ts", { outputFolder: "playwright-report" }]];
 if (isPerformanceRun) {
     baseReporters.push(["./packages/tools/tests/performanceSummaryReporter.ts"]);
 }
@@ -113,7 +111,7 @@ export default defineConfig({
     testMatch: activeConfig.testMatch,
     use: {
         connectOptions: { wsEndpoint },
-        trace: "on-first-retry",
+        trace: "off",
         ignoreHTTPSErrors: true,
         ...(activeConfig.local ? { baseURL: "http://localhost:1340" } : {}),
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ populateEnvironment();
 
 const isCI = !!process.env.CI;
 const browserType = process.env.BROWSER || (isCI ? "Firefox" : "Chrome");
+const isBrowserStackRun = browserType === "BrowserStack";
 const numberOfWorkers = process.env.CIWORKERS ? +process.env.CIWORKERS : process.env.CI ? 1 : browserType === "BrowserStack" ? 1 : 4;
 
 // Include the performance summary reporter only when running performance tests
@@ -18,7 +19,9 @@ const isPerformanceRun = (() => {
     }
     return false;
 })();
-const baseReporters: any[] = isCI ? [["line"], ["junit", { outputFile: "junit.xml" }], ["html", { open: "never" }]] : [["list"], ["html"]];
+const baseReporters: any[] = isCI
+    ? [["line"], ["junit", { outputFile: "junit.xml" }], ["./packages/tools/tests/publicReportReporter.ts", { outputFolder: "playwright-report" }]]
+    : [["list"], ["html"]];
 if (isPerformanceRun) {
     baseReporters.push(["./packages/tools/tests/performanceSummaryReporter.ts"]);
 }
@@ -38,12 +41,12 @@ export default defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-        trace: "on-first-retry",
+        trace: isBrowserStackRun ? "off" : "on-first-retry",
         ignoreHTTPSErrors: true,
     },
 
-    globalSetup: browserType === "BrowserStack" ? require.resolve("./packages/tools/tests/globalSetup.ts") : undefined,
-    globalTeardown: browserType === "BrowserStack" ? require.resolve("./packages/tools/tests/globalTeardown.ts") : undefined,
+    globalSetup: isBrowserStackRun ? require.resolve("./packages/tools/tests/globalSetup.ts") : undefined,
+    globalTeardown: isBrowserStackRun ? require.resolve("./packages/tools/tests/globalTeardown.ts") : undefined,
 
     /* Project configuration */
     projects: getBabylonServerTestsList(),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ populateEnvironment();
 const isCI = !!process.env.CI;
 const browserType = process.env.BROWSER || (isCI ? "Firefox" : "Chrome");
 const isBrowserStackRun = browserType === "BrowserStack";
-const numberOfWorkers = process.env.CIWORKERS ? +process.env.CIWORKERS : process.env.CI ? 1 : browserType === "BrowserStack" ? 1 : 4;
+const numberOfWorkers = process.env.CIWORKERS ? +process.env.CIWORKERS : process.env.CI ? 1 : isBrowserStackRun ? 1 : 4;
 
 // Include the performance summary reporter only when running performance tests
 const isPerformanceRun = (() => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- disable tracing for BrowserStack CDP sessions so credential-bearing endpoints cannot enter retry traces
- replace CI HTML reports with a minimal public reporter that omits errors, output, attachments, traces, and configuration
- validate report contents before CDN upload, rejecting archives, embedded report bundles, unsafe file types, and raw or encoded BrowserStack credentials
- make report uploads fail closed while preserving the existing deployment authorization flow

## Validation
- `npm run format:check`
- `npm run lint:check`
- BrowserStack Playwright config loading and sanitized report generation (815 tests discovered)
- artifact validator rejection coverage for raw, URL-encoded, base64, archived, and embedded-report credentials
