### PR TITLE
Fix Gaussian splat readiness regression

### DIFF
--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -1265,7 +1265,7 @@ export class GaussianSplattingMeshBase extends Mesh {
         // first render. Once rendered, the render loop continuously re-sorts as the camera/world changes.
         if (!this._hasRenderedOnce && !this._disableDepthSort) {
             const cameras = this._scene.activeCameras?.length ? this._scene.activeCameras : [this._scene.activeCamera!];
-            const canRenderWithPendingRefresh = this._scene._isInActiveMeshEvaluation() && cameras.filter((camera) => camera !== null).length === 1;
+            const canRenderWithPendingRefresh = this._scene._isInRenderingMeshEvaluation() && cameras.filter((camera) => camera !== null).length === 1;
             const worldMatrix = this.computeWorldMatrix(true);
             let sortBufferMissing = false;
             let sortRefreshPending = false;

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -1265,7 +1265,7 @@ export class GaussianSplattingMeshBase extends Mesh {
         // first render. Once rendered, the render loop continuously re-sorts as the camera/world changes.
         if (!this._hasRenderedOnce && !this._disableDepthSort) {
             const cameras = this._scene.activeCameras?.length ? this._scene.activeCameras : [this._scene.activeCamera!];
-            const canRenderWithPendingRefresh = this._scene._isInRenderingFrame() && cameras.filter((camera) => camera !== null).length === 1;
+            const canRenderWithPendingRefresh = this._scene._isInActiveMeshEvaluation() && cameras.filter((camera) => camera !== null).length === 1;
             const worldMatrix = this.computeWorldMatrix(true);
             let sortBufferMissing = false;
             let sortRefreshPending = false;

--- a/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
+++ b/packages/dev/core/src/Meshes/GaussianSplatting/gaussianSplattingMeshBase.pure.ts
@@ -1265,7 +1265,7 @@ export class GaussianSplattingMeshBase extends Mesh {
         // first render. Once rendered, the render loop continuously re-sorts as the camera/world changes.
         if (!this._hasRenderedOnce && !this._disableDepthSort) {
             const cameras = this._scene.activeCameras?.length ? this._scene.activeCameras : [this._scene.activeCamera!];
-            const canRenderWithPendingRefresh = cameras.filter((camera) => camera !== null).length === 1;
+            const canRenderWithPendingRefresh = this._scene._isInRenderingFrame() && cameras.filter((camera) => camera !== null).length === 1;
             const worldMatrix = this.computeWorldMatrix(true);
             let sortBufferMissing = false;
             let sortRefreshPending = false;

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -5644,6 +5644,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         if (this.customRenderFunction) {
             this._renderId++;
             this._engine.currentRenderPassId = Constants.RENDERPASS_MAIN;
+            this._renderingMeshEvaluationDepth++;
 
             this.customRenderFunction(updateCameras, ignoreAnimations);
         } else {

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -1744,7 +1744,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
     private _renderId = 0;
     private _frameId = 0;
-    private _renderingFrameDepth = 0;
+    private _activeMeshesEvaluationDepth = 0;
     private _executeWhenReadyTimeoutId: Nullable<ReturnType<typeof setTimeout>> = null;
     /** @internal */
     public _intermediateRendering = false;
@@ -4570,8 +4570,8 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     }
 
     /** @internal */
-    public _isInRenderingFrame(): boolean {
-        return this._renderingFrameDepth > 0;
+    public _isInActiveMeshEvaluation(): boolean {
+        return this._activeMeshesEvaluationDepth > 0;
     }
 
     /**
@@ -5062,7 +5062,12 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         this._engine.currentRenderPassId = camera.outputRenderTarget?.renderPassId ?? camera.renderPassId ?? Constants.RENDERPASS_MAIN;
 
         // Meshes
-        this._evaluateActiveMeshes();
+        this._activeMeshesEvaluationDepth++;
+        try {
+            this._evaluateActiveMeshes();
+        } finally {
+            this._activeMeshesEvaluationDepth--;
+        }
 
         // Software skinning
         for (let softwareSkinnedMeshIndex = 0; softwareSkinnedMeshIndex < this._softwareSkinnedMeshes.length; softwareSkinnedMeshIndex++) {
@@ -5555,15 +5560,6 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             return;
         }
 
-        this._renderingFrameDepth++;
-        try {
-            this._renderFrame(updateCameras, ignoreAnimations);
-        } finally {
-            this._renderingFrameDepth--;
-        }
-    }
-
-    private _renderFrame(updateCameras: boolean, ignoreAnimations: boolean): void {
         if (this.onReadyObservable.hasObservers() && this._executeWhenReadyTimeoutId === null) {
             this._checkIsReady();
         }

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -1744,7 +1744,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
     private _renderId = 0;
     private _frameId = 0;
-    private _activeMeshesEvaluationDepth = 0;
+    private _renderingMeshEvaluationDepth = 0;
     private _executeWhenReadyTimeoutId: Nullable<ReturnType<typeof setTimeout>> = null;
     /** @internal */
     public _intermediateRendering = false;
@@ -4570,8 +4570,8 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
     }
 
     /** @internal */
-    public _isInActiveMeshEvaluation(): boolean {
-        return this._activeMeshesEvaluationDepth > 0;
+    public _isInRenderingMeshEvaluation(): boolean {
+        return this._renderingMeshEvaluationDepth > 0;
     }
 
     /**
@@ -5062,12 +5062,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         this._engine.currentRenderPassId = camera.outputRenderTarget?.renderPassId ?? camera.renderPassId ?? Constants.RENDERPASS_MAIN;
 
         // Meshes
-        this._activeMeshesEvaluationDepth++;
-        try {
-            this._evaluateActiveMeshes();
-        } finally {
-            this._activeMeshesEvaluationDepth--;
-        }
+        this._evaluateActiveMeshes();
 
         // Software skinning
         for (let softwareSkinnedMeshIndex = 0; softwareSkinnedMeshIndex < this._softwareSkinnedMeshes.length; softwareSkinnedMeshIndex++) {
@@ -5413,6 +5408,15 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
         this.onBeforeRenderObservable.notifyObservers(this);
 
+        this._renderingMeshEvaluationDepth++;
+        try {
+            this._renderWithFrameGraphAfterBeforeRender(forceUpdateWorldMatrix);
+        } finally {
+            this._renderingMeshEvaluationDepth--;
+        }
+    }
+
+    private _renderWithFrameGraphAfterBeforeRender(forceUpdateWorldMatrix: boolean): void {
         // Customs render targets
         this.onBeforeRenderTargetsRenderObservable.notifyObservers(this);
 
@@ -5560,6 +5564,15 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             return;
         }
 
+        const renderingMeshEvaluationDepth = this._renderingMeshEvaluationDepth;
+        try {
+            this._renderFrame(updateCameras, ignoreAnimations);
+        } finally {
+            this._renderingMeshEvaluationDepth = renderingMeshEvaluationDepth;
+        }
+    }
+
+    private _renderFrame(updateCameras: boolean, ignoreAnimations: boolean): void {
         if (this.onReadyObservable.hasObservers() && this._executeWhenReadyTimeoutId === null) {
             this._checkIsReady();
         }
@@ -5636,6 +5649,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         } else {
             // Before render
             this.onBeforeRenderObservable.notifyObservers(this);
+            this._renderingMeshEvaluationDepth++;
 
             // Customs render targets
             this.onBeforeRenderTargetsRenderObservable.notifyObservers(this);

--- a/packages/dev/core/src/scene.pure.ts
+++ b/packages/dev/core/src/scene.pure.ts
@@ -1744,6 +1744,7 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
 
     private _renderId = 0;
     private _frameId = 0;
+    private _renderingFrameDepth = 0;
     private _executeWhenReadyTimeoutId: Nullable<ReturnType<typeof setTimeout>> = null;
     /** @internal */
     public _intermediateRendering = false;
@@ -4568,6 +4569,11 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
         return this._intermediateRendering;
     }
 
+    /** @internal */
+    public _isInRenderingFrame(): boolean {
+        return this._renderingFrameDepth > 0;
+    }
+
     /**
      * Lambda returning the list of potentially active meshes.
      */
@@ -5549,6 +5555,15 @@ export class Scene implements IAnimatable, IClipPlanesHolder, IAssetContainer {
             return;
         }
 
+        this._renderingFrameDepth++;
+        try {
+            this._renderFrame(updateCameras, ignoreAnimations);
+        } finally {
+            this._renderingFrameDepth--;
+        }
+    }
+
+    private _renderFrame(updateCameras: boolean, ignoreAnimations: boolean): void {
         if (this.onReadyObservable.hasObservers() && this._executeWhenReadyTimeoutId === null) {
             this._checkIsReady();
         }

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -55,6 +55,18 @@ describe("GaussianSplatting transform before first render", () => {
         expect(scene._isInRenderingMeshEvaluation()).toBe(false);
     });
 
+    it("tracks mesh evaluation during custom rendering", () => {
+        const customRenderFunction = vi.fn(() => {
+            expect(scene._isInRenderingMeshEvaluation()).toBe(true);
+        });
+        scene.customRenderFunction = customRenderFunction;
+
+        scene.render();
+
+        expect(customRenderFunction).toHaveBeenCalled();
+        expect(scene._isInRenderingMeshEvaluation()).toBe(false);
+    });
+
     it.each([
         { title: "waits for a transform refresh outside rendering mesh evaluation", renderingMeshEvaluationDepth: 0, expectedReady: false },
         { title: "remains ready when its transform changes during rendering mesh evaluation", renderingMeshEvaluationDepth: 1, expectedReady: true },

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -22,13 +22,17 @@ describe("GaussianSplatting transform before first render", () => {
         engine.dispose();
     });
 
-    it("remains ready when its transform changes after the first depth sort completes", () => {
+    it.each([
+        { title: "waits for a transform refresh outside a render frame", renderingFrameDepth: 0, expectedReady: false },
+        { title: "remains ready when its transform changes during a render frame", renderingFrameDepth: 1, expectedReady: true },
+    ])("$title", ({ renderingFrameDepth, expectedReady }) => {
         const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
         scene.activeCamera = camera;
 
         const mesh = new GaussianSplattingMesh("gs", null, scene);
         const cameraMesh = new Mesh("cameraMesh", scene);
         Reflect.set(mesh, "_readyToDisplay", true);
+        Reflect.set(scene, "_renderingFrameDepth", renderingFrameDepth);
         const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
         const cameraViewInfo = {
             camera,
@@ -47,12 +51,12 @@ describe("GaussianSplatting transform before first render", () => {
 
         mesh.position.y = 1;
 
-        expect(mesh.isReady()).toBe(true);
+        expect(mesh.isReady()).toBe(expectedReady);
         expect(postToWorker).toHaveBeenCalledWith(true);
 
         cameraViewInfo.sortRequestId = 2;
 
-        expect(mesh.isReady()).toBe(true);
+        expect(mesh.isReady()).toBe(expectedReady);
     });
 
     it("waits for every active camera to complete its initial sort", () => {

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -22,33 +22,50 @@ describe("GaussianSplatting transform before first render", () => {
         engine.dispose();
     });
 
-    it("tracks active mesh evaluation during scene rendering", () => {
+    it("tracks mesh evaluation during scene rendering", () => {
         const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
         scene.activeCamera = camera;
         const mesh = new Mesh("mesh", scene);
+        scene.onBeforeRenderObservable.add(() => {
+            expect(scene._isInRenderingMeshEvaluation()).toBe(false);
+        });
         const isReady = vi.spyOn(mesh, "isReady").mockImplementation(() => {
-            expect(scene._isInActiveMeshEvaluation()).toBe(true);
+            expect(scene._isInRenderingMeshEvaluation()).toBe(true);
             return false;
         });
 
-        expect(scene._isInActiveMeshEvaluation()).toBe(false);
+        expect(scene._isInRenderingMeshEvaluation()).toBe(false);
         scene.render();
 
         expect(isReady).toHaveBeenCalled();
-        expect(scene._isInActiveMeshEvaluation()).toBe(false);
+        expect(scene._isInRenderingMeshEvaluation()).toBe(false);
+    });
+
+    it("tracks mesh evaluation during frame graph rendering", () => {
+        const mesh = new Mesh("mesh", scene);
+        const isReady = vi.spyOn(mesh, "isReady").mockImplementation(() => {
+            expect(scene._isInRenderingMeshEvaluation()).toBe(true);
+            return false;
+        });
+        const renderWithFrameGraph = Reflect.get(scene, "_renderWithFrameGraph") as (updateCameras: boolean, ignoreAnimations: boolean) => void;
+
+        renderWithFrameGraph.call(scene, false, false);
+
+        expect(isReady).toHaveBeenCalled();
+        expect(scene._isInRenderingMeshEvaluation()).toBe(false);
     });
 
     it.each([
-        { title: "waits for a transform refresh outside active mesh evaluation", activeMeshesEvaluationDepth: 0, expectedReady: false },
-        { title: "remains ready when its transform changes during active mesh evaluation", activeMeshesEvaluationDepth: 1, expectedReady: true },
-    ])("$title", ({ activeMeshesEvaluationDepth, expectedReady }) => {
+        { title: "waits for a transform refresh outside rendering mesh evaluation", renderingMeshEvaluationDepth: 0, expectedReady: false },
+        { title: "remains ready when its transform changes during rendering mesh evaluation", renderingMeshEvaluationDepth: 1, expectedReady: true },
+    ])("$title", ({ renderingMeshEvaluationDepth, expectedReady }) => {
         const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
         scene.activeCamera = camera;
 
         const mesh = new GaussianSplattingMesh("gs", null, scene);
         const cameraMesh = new Mesh("cameraMesh", scene);
         Reflect.set(mesh, "_readyToDisplay", true);
-        Reflect.set(scene, "_activeMeshesEvaluationDepth", activeMeshesEvaluationDepth);
+        Reflect.set(scene, "_renderingMeshEvaluationDepth", renderingMeshEvaluationDepth);
         const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
         const cameraViewInfo = {
             camera,

--- a/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
+++ b/packages/dev/core/test/unit/Meshes/babylon.gaussianSplatting.transformBeforeRender.test.ts
@@ -22,17 +22,33 @@ describe("GaussianSplatting transform before first render", () => {
         engine.dispose();
     });
 
+    it("tracks active mesh evaluation during scene rendering", () => {
+        const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
+        scene.activeCamera = camera;
+        const mesh = new Mesh("mesh", scene);
+        const isReady = vi.spyOn(mesh, "isReady").mockImplementation(() => {
+            expect(scene._isInActiveMeshEvaluation()).toBe(true);
+            return false;
+        });
+
+        expect(scene._isInActiveMeshEvaluation()).toBe(false);
+        scene.render();
+
+        expect(isReady).toHaveBeenCalled();
+        expect(scene._isInActiveMeshEvaluation()).toBe(false);
+    });
+
     it.each([
-        { title: "waits for a transform refresh outside a render frame", renderingFrameDepth: 0, expectedReady: false },
-        { title: "remains ready when its transform changes during a render frame", renderingFrameDepth: 1, expectedReady: true },
-    ])("$title", ({ renderingFrameDepth, expectedReady }) => {
+        { title: "waits for a transform refresh outside active mesh evaluation", activeMeshesEvaluationDepth: 0, expectedReady: false },
+        { title: "remains ready when its transform changes during active mesh evaluation", activeMeshesEvaluationDepth: 1, expectedReady: true },
+    ])("$title", ({ activeMeshesEvaluationDepth, expectedReady }) => {
         const camera = new FreeCamera("camera", new Vector3(0, 0, -10), scene);
         scene.activeCamera = camera;
 
         const mesh = new GaussianSplattingMesh("gs", null, scene);
         const cameraMesh = new Mesh("cameraMesh", scene);
         Reflect.set(mesh, "_readyToDisplay", true);
-        Reflect.set(scene, "_renderingFrameDepth", renderingFrameDepth);
+        Reflect.set(scene, "_activeMeshesEvaluationDepth", activeMeshesEvaluationDepth);
         const cameraViewInfos = Reflect.get(mesh, "_cameraViewInfos") as Map<number, object>;
         const cameraViewInfo = {
             camera,


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

> 🤖 *This PR was created by the create-pr skill.*

## Context

[Babylon.js #18831](https://github.com/BabylonJS/Babylon.js/pull/18831) fixed transforms applied during the first render, but external readiness waits could then finish before a one-time transformed splat sort. This regressed one-shot rendering and surfaced as deterministic SOGS visualization failures in [#18829](https://github.com/BabylonJS/Babylon.js/pull/18829).

## Validation

- The unchanged `SOGS with SH` test at `renderCount: 1` passed 10/10 in WebGL2 and 10/10 in WebGPU.