### PR TITLE
Preserve WebXR light estimation on WebGPU

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRLightEstimation.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLightEstimation.pure.ts
@@ -17,6 +17,10 @@ import { SphericalHarmonics, SphericalPolynomial } from "../../Maths/sphericalPo
 import { LightConstants } from "../../Lights/lightConstants";
 import { HDRFiltering } from "core/Materials/Textures/Filtering/hdrFiltering";
 import { type ThinEngine } from "core/Engines";
+import { WebXRGraphicsBindingType, type WebXRWebGLGraphicsBinding } from "../webXRGraphicsBinding";
+
+const WebGPUReflectionWarning =
+    "WebXR Light Estimation reflection cube maps are unavailable with WebGPU XR because they are exposed only by XRWebGLBinding; light direction, intensity, and spherical harmonics remain enabled.";
 
 /**
  * Options for Light Estimation feature
@@ -99,11 +103,11 @@ export interface IWebXRLightEstimation {
  * @since 5.0.0
  */
 export class WebXRLightEstimation extends WebXRAbstractFeature {
-    private _canvasContext: Nullable<WebGLRenderingContext | WebGL2RenderingContext> = null;
     private _reflectionCubeMap: Nullable<BaseTexture> = null;
     private _xrLightEstimate: Nullable<XRLightEstimate> = null;
     private _xrLightProbe: Nullable<XRLightProbe> = null;
-    private _xrWebGLBinding: Nullable<XRWebGLBinding> = null;
+    private _reflectionCubeMapEnabled = false;
+    private _webGPUReflectionWarningEmitted = false;
     private _lightDirection: Vector3 = Vector3.Up().negateInPlace();
     private _lightColor: Color3 = Color3.White();
     private _intensity: number = 1;
@@ -203,19 +207,12 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
         return this._xrLightEstimate;
     }
 
-    private _getCanvasContext(): WebGLRenderingContext | WebGL2RenderingContext {
-        if (this._canvasContext === null) {
-            this._canvasContext = (this._xrSessionManager.scene.getEngine() as ThinEngine)._gl;
+    private _getXRWebGLBinding(): WebXRWebGLGraphicsBinding {
+        const graphicsBinding = this._xrSessionManager._getGraphicsBinding();
+        if (graphicsBinding.bindingType !== WebXRGraphicsBindingType.WebGL) {
+            throw new Error("Expected a WebGL graphics binding for WebXR Light Estimation reflections.");
         }
-        return this._canvasContext;
-    }
-
-    private _getXRGLBinding(): XRWebGLBinding {
-        if (this._xrWebGLBinding === null) {
-            const context = this._getCanvasContext();
-            this._xrWebGLBinding = new XRWebGLBinding(this._xrSessionManager.session, context);
-        }
-        return this._xrWebGLBinding;
+        return graphicsBinding;
     }
 
     /**
@@ -233,7 +230,8 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
             }
             this._cubeMapPollTime = now;
         }
-        const lp = this._getXRGLBinding().getReflectionCubeMap(this._xrLightProbe);
+        const graphicsBinding = this._getXRWebGLBinding();
+        const lp = graphicsBinding.binding.getReflectionCubeMap(this._xrLightProbe);
         if (lp && this._reflectionCubeMap) {
             if (!this._reflectionCubeMap._texture) {
                 const internalTexture = new InternalTexture(this._xrSessionManager.scene.getEngine(), InternalTextureSource.Unknown);
@@ -248,7 +246,7 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
                 internalTexture.height = this._reflectionCubeMapTextureSize;
                 internalTexture._cachedWrapU = Constants.TEXTURE_WRAP_ADDRESSMODE;
                 internalTexture._cachedWrapV = Constants.TEXTURE_WRAP_ADDRESSMODE;
-                internalTexture._hardwareTexture = new WebGLHardwareTexture(lp, this._getCanvasContext() as WebGLRenderingContext);
+                internalTexture._hardwareTexture = new WebGLHardwareTexture(lp, graphicsBinding.context);
                 this._reflectionCubeMap._texture = internalTexture;
             } else {
                 this._reflectionCubeMap._texture._hardwareTexture?.set(lp);
@@ -282,6 +280,13 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
             return false;
         }
 
+        const isWebGPU = this._xrSessionManager.scene.getEngine().isWebGPU;
+        this._reflectionCubeMapEnabled = !this.options.disableCubeMapReflection && !isWebGPU;
+        if (!this.options.disableCubeMapReflection && isWebGPU && !this._webGPUReflectionWarningEmitted) {
+            Logger.Warn(WebGPUReflectionWarning);
+            this._webGPUReflectionWarningEmitted = true;
+        }
+
         const reflectionFormat = this.options.reflectionFormat ?? (this._xrSessionManager.session.preferredReflectionFormat || "srgba8");
         this.options.reflectionFormat = reflectionFormat;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -292,7 +297,7 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
             // eslint-disable-next-line github/no-then
             .then((xrLightProbe: XRLightProbe) => {
                 this._xrLightProbe = xrLightProbe;
-                if (!this.options.disableCubeMapReflection) {
+                if (this._reflectionCubeMapEnabled) {
                     if (!this._reflectionCubeMap) {
                         this._reflectionCubeMap = new BaseTexture(this._xrSessionManager.scene);
                         this._reflectionCubeMap._isCube = true;
@@ -317,15 +322,12 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
     public override detach(): boolean {
         const detached = super.detach();
 
-        if (this._xrLightProbe !== null && !this.options.disableCubeMapReflection) {
+        if (this._xrLightProbe !== null && this._reflectionCubeMapEnabled) {
             this._xrLightProbe.removeEventListener("reflectionchange", this._updateReflectionCubeMap);
             this._xrLightProbe = null;
         }
 
-        this._canvasContext = null;
         this._xrLightEstimate = null;
-        // When the session ends (on detach) we must clear our XRWebGLBinging instance, which references the ended session.
-        this._xrWebGLBinding = null;
 
         return detached;
     }

--- a/packages/dev/core/src/XR/features/WebXRLightEstimation.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLightEstimation.pure.ts
@@ -322,8 +322,10 @@ export class WebXRLightEstimation extends WebXRAbstractFeature {
     public override detach(): boolean {
         const detached = super.detach();
 
-        if (this._xrLightProbe !== null && this._reflectionCubeMapEnabled) {
-            this._xrLightProbe.removeEventListener("reflectionchange", this._updateReflectionCubeMap);
+        if (this._xrLightProbe !== null) {
+            if (this._reflectionCubeMapEnabled) {
+                this._xrLightProbe.removeEventListener("reflectionchange", this._updateReflectionCubeMap);
+            }
             this._xrLightProbe = null;
         }
 

--- a/packages/dev/core/test/unit/XR/webXRLightEstimation.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLightEstimation.test.ts
@@ -138,6 +138,7 @@ describe("WebXRLightEstimation", () => {
         expect(warnSpy.mock.calls.filter(([warning]) => warning === WebGPUReflectionWarning)).toHaveLength(1);
 
         expect(feature.detach()).toBe(true);
+        expect((feature as any)._xrLightProbe).toBeNull();
         expect(feature.attach()).toBe(true);
         await Promise.resolve();
         expect(requestLightProbe).toHaveBeenCalledTimes(2);
@@ -172,6 +173,8 @@ describe("WebXRLightEstimation", () => {
         expect(feature.xrLightingEstimate?.sphericalHarmonics.l00.asArray()).toEqual([30, 31, 32]);
         expect(feature.reflectionCubeMapTexture).toBeNull();
 
+        expect(feature.detach()).toBe(true);
+        expect((feature as any)._xrLightProbe).toBeNull();
         feature.dispose();
     });
 

--- a/packages/dev/core/test/unit/XR/webXRLightEstimation.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLightEstimation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { WebGLHardwareTexture } from "core/Engines/WebGL/webGLHardwareTexture";
+import { Logger } from "core/Misc/logger";
+import { Scene } from "core/scene";
+import { WebXRLightEstimation } from "core/XR/features/WebXRLightEstimation";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WebGPUReflectionWarning =
+    "WebXR Light Estimation reflection cube maps are unavailable with WebGPU XR because they are exposed only by XRWebGLBinding; light direction, intensity, and spherical harmonics remain enabled.";
+
+type ReflectionListener = ((event: Event) => void) | { handleEvent(event: Event): void };
+
+function createLightProbe() {
+    const reflectionListeners = new Set<ReflectionListener>();
+    const lightProbe = {
+        addEventListener: vi.fn((type: string, listener: ReflectionListener) => {
+            if (type === "reflectionchange") {
+                reflectionListeners.add(listener);
+            }
+        }),
+        removeEventListener: vi.fn((type: string, listener: ReflectionListener) => {
+            if (type === "reflectionchange") {
+                reflectionListeners.delete(listener);
+            }
+        }),
+    } as unknown as XRLightProbe;
+
+    return {
+        lightProbe,
+        dispatchReflectionChange: () => {
+            for (const listener of reflectionListeners) {
+                if (typeof listener === "function") {
+                    listener(new Event("reflectionchange"));
+                } else {
+                    listener.handleEvent(new Event("reflectionchange"));
+                }
+            }
+        },
+    };
+}
+
+function createLightEstimate(direction: [number, number, number], intensity: [number, number, number], sphericalHarmonicsStart: number): XRLightEstimate {
+    return {
+        primaryLightDirection: { x: direction[0], y: direction[1], z: direction[2] } as DOMPointReadOnly,
+        primaryLightIntensity: { x: intensity[0], y: intensity[1], z: intensity[2] } as DOMPointReadOnly,
+        sphericalHarmonicsCoefficients: Float32Array.from({ length: 27 }, (_, index) => sphericalHarmonicsStart + index),
+    };
+}
+
+describe("WebXRLightEstimation", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let originalWebGLBinding: unknown;
+    let originalGPUBinding: unknown;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        (sessionManager as any)._xrNavigator = { xr: { native: false } };
+        originalWebGLBinding = (globalThis as any).XRWebGLBinding;
+        originalGPUBinding = (globalThis as any).XRGPUBinding;
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        (globalThis as any).XRWebGLBinding = originalWebGLBinding;
+        (globalThis as any).XRGPUBinding = originalGPUBinding;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("keeps changing frame estimates active while disabling requested reflection on WebGPU", async () => {
+        const { lightProbe } = createLightProbe();
+        const requestLightProbe = vi.fn(async () => lightProbe);
+        const xrWebGLBinding = vi.fn();
+        const xrGPUBinding = vi.fn();
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (globalThis as any).XRGPUBinding = xrGPUBinding;
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            enabledFeatures: ["light-estimation"],
+            preferredReflectionFormat: "rgba16f",
+            requestLightProbe,
+        } as unknown as XRSession;
+        const getGraphicsBindingSpy = vi.spyOn(sessionManager, "_getGraphicsBinding");
+        const webGLTextureSetSpy = vi.spyOn(WebGLHardwareTexture.prototype, "set");
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        const feature = new WebXRLightEstimation(sessionManager, {});
+
+        expect(feature.attach()).toBe(true);
+        await Promise.resolve();
+
+        expect(requestLightProbe).toHaveBeenCalledExactlyOnceWith({ reflectionFormat: "rgba16f" });
+        expect(lightProbe.addEventListener).not.toHaveBeenCalled();
+        expect(warnSpy.mock.calls.filter(([warning]) => warning === WebGPUReflectionWarning)).toHaveLength(1);
+
+        const firstEstimate = createLightEstimate([1, 2, 3], [2, 4, 1], 10);
+        const secondEstimate = createLightEstimate([-2, 1, -4], [6, 3, 1.5], 20);
+        const getLightEstimate = vi.fn().mockReturnValueOnce(firstEstimate).mockReturnValueOnce(secondEstimate);
+        const xrFrame = { getLightEstimate } as unknown as XRFrame;
+
+        sessionManager.onXRFrameObservable.notifyObservers(xrFrame);
+        const firstResult = feature.xrLightingEstimate!;
+        expect(firstResult.lightDirection.asArray()).toEqual([-1, -2, 3]);
+        expect(firstResult.lightIntensity).toBe(4);
+        expect(firstResult.lightColor.asArray()).toEqual([0.5, 1, 0.25]);
+        expect(firstResult.sphericalHarmonics.l00.asArray()).toEqual([10, 11, 12]);
+
+        sessionManager.onXRFrameObservable.notifyObservers(xrFrame);
+        const secondResult = feature.xrLightingEstimate!;
+        expect(secondResult.lightDirection.asArray()).toEqual([2, -1, -4]);
+        expect(secondResult.lightIntensity).toBe(6);
+        expect(secondResult.lightColor.asArray()).toEqual([1, 0.5, 0.25]);
+        expect(secondResult.sphericalHarmonics.l00.asArray()).toEqual([20, 21, 22]);
+        expect(getLightEstimate).toHaveBeenCalledTimes(2);
+        expect(getLightEstimate).toHaveBeenNthCalledWith(1, lightProbe);
+        expect(getLightEstimate).toHaveBeenNthCalledWith(2, lightProbe);
+        expect(feature.reflectionCubeMapTexture).toBeNull();
+        expect(getGraphicsBindingSpy).not.toHaveBeenCalled();
+        expect(webGLTextureSetSpy).not.toHaveBeenCalled();
+        expect(xrGPUBinding).not.toHaveBeenCalled();
+        expect(xrWebGLBinding).not.toHaveBeenCalled();
+        expect(warnSpy.mock.calls.filter(([warning]) => warning === WebGPUReflectionWarning)).toHaveLength(1);
+
+        expect(feature.detach()).toBe(true);
+        expect(feature.attach()).toBe(true);
+        await Promise.resolve();
+        expect(requestLightProbe).toHaveBeenCalledTimes(2);
+        expect(warnSpy.mock.calls.filter(([warning]) => warning === WebGPUReflectionWarning)).toHaveLength(1);
+
+        feature.dispose();
+    });
+
+    it("does not emit the WebGPU reflection warning when reflection was disabled by the caller", async () => {
+        const { lightProbe } = createLightProbe();
+        const requestLightProbe = vi.fn(async () => lightProbe);
+        (engine as any)._isWebGPU = true;
+        (engine as any)._device = {};
+        (sessionManager as any).session = {
+            enabledFeatures: ["light-estimation"],
+            requestLightProbe,
+        } as unknown as XRSession;
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        const feature = new WebXRLightEstimation(sessionManager, { disableCubeMapReflection: true });
+
+        expect(feature.attach()).toBe(true);
+        await Promise.resolve();
+
+        expect(requestLightProbe).toHaveBeenCalledExactlyOnceWith({ reflectionFormat: "srgba8" });
+        expect(lightProbe.addEventListener).not.toHaveBeenCalled();
+        expect(warnSpy.mock.calls.filter(([warning]) => warning === WebGPUReflectionWarning)).toHaveLength(0);
+
+        const getLightEstimate = vi.fn(() => createLightEstimate([0, 1, 0], [1, 2, 1], 30));
+        sessionManager.onXRFrameObservable.notifyObservers({ getLightEstimate } as unknown as XRFrame);
+
+        expect(feature.xrLightingEstimate?.lightIntensity).toBe(2);
+        expect(feature.xrLightingEstimate?.sphericalHarmonics.l00.asArray()).toEqual([30, 31, 32]);
+        expect(feature.reflectionCubeMapTexture).toBeNull();
+
+        feature.dispose();
+    });
+
+    it("preserves WebGL reflection options, polling, lifecycle, wrapping, and cached binding reuse", async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000);
+        const { lightProbe, dispatchReflectionChange } = createLightProbe();
+        const requestLightProbe = vi.fn(async () => lightProbe);
+        const firstWebGLTexture = {} as WebGLTexture;
+        const secondWebGLTexture = {} as WebGLTexture;
+        const getReflectionCubeMap = vi.fn().mockReturnValueOnce(firstWebGLTexture).mockReturnValueOnce(secondWebGLTexture);
+        const nativeBinding = { getReflectionCubeMap };
+        const xrWebGLBinding = vi.fn().mockImplementation(function () {
+            return nativeBinding;
+        });
+        const glContext = {
+            deleteRenderbuffer: vi.fn(),
+            deleteTexture: vi.fn(),
+        } as unknown as WebGLRenderingContext;
+        (globalThis as any).XRWebGLBinding = xrWebGLBinding;
+        (engine as any)._gl = glContext;
+        (sessionManager as any).session = {
+            enabledFeatures: ["light-estimation"],
+            preferredReflectionFormat: "rgba16f",
+            requestLightProbe,
+        } as unknown as XRSession;
+        const resetTextureCacheSpy = vi.spyOn(engine, "resetTextureCache");
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        const feature = new WebXRLightEstimation(sessionManager, {
+            cubeMapPollInterval: 1_000,
+            disablePreFiltering: true,
+            reflectionFormat: "srgba8",
+            setSceneEnvironmentTexture: true,
+        });
+
+        expect(feature.attach()).toBe(true);
+        await Promise.resolve();
+
+        expect(requestLightProbe).toHaveBeenCalledExactlyOnceWith({ reflectionFormat: "srgba8" });
+        expect(warnSpy.mock.calls.filter(([warning]) => warning === WebGPUReflectionWarning)).toHaveLength(0);
+        expect(lightProbe.addEventListener).toHaveBeenCalledExactlyOnceWith("reflectionchange", expect.any(Function));
+        expect(scene.environmentTexture).toBe(feature.reflectionCubeMapTexture);
+
+        dispatchReflectionChange();
+        vi.advanceTimersByTime(999);
+        dispatchReflectionChange();
+        expect(getReflectionCubeMap).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(1);
+        dispatchReflectionChange();
+        expect(getReflectionCubeMap).toHaveBeenCalledExactlyOnceWith(lightProbe);
+        expect(xrWebGLBinding).toHaveBeenCalledExactlyOnceWith(sessionManager.session, glContext);
+        expect(sessionManager._getGraphicsBinding().binding).toBe(nativeBinding);
+        expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
+        expect(feature.reflectionCubeMapTexture?._texture?._hardwareTexture?.underlyingResource).toBe(firstWebGLTexture);
+        expect(feature.reflectionCubeMapTexture?._texture?._useSRGBBuffer).toBe(true);
+
+        vi.advanceTimersByTime(1_000);
+        dispatchReflectionChange();
+        expect(getReflectionCubeMap).toHaveBeenCalledTimes(2);
+        expect(feature.reflectionCubeMapTexture?._texture?._hardwareTexture?.underlyingResource).toBe(secondWebGLTexture);
+        expect(resetTextureCacheSpy).toHaveBeenCalledTimes(1);
+        expect(xrWebGLBinding).toHaveBeenCalledTimes(1);
+
+        expect(feature.detach()).toBe(true);
+        expect(lightProbe.removeEventListener).toHaveBeenCalledExactlyOnceWith("reflectionchange", expect.any(Function));
+
+        feature.dispose();
+        expect(feature.reflectionCubeMapTexture).toBeNull();
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Preserve graphics-neutral WebXR light direction, intensity, and spherical harmonics estimates on WebGPU.
- Disable only XRWebGLBinding reflection cube maps on WebGPU, with one specific warning when reflection was requested.
- Reuse the cached Phase 4A WebGL graphics binding while preserving existing reflection options and lifecycle behavior.
- Add deterministic WebGPU and WebGL regression coverage.

## Validation

- Core XR unit tests: 22 files, 341 tests passed.
- Core TypeScript compilation passed.
- Targeted formatting and lint passed with no errors.
- Tree-shaking and side-effect synchronization checks passed.

The Quest runtime used for manual validation did not expose Light Estimation in either WebGPU or WebGL2, so device validation was inconclusive rather than failed. XR entry itself succeeded.

Closes #18770
