### PR TITLE
Add WebXR persistent anchor lifecycle support

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -560,10 +560,17 @@ type XRAnchorSet = Set<XRAnchor>;
 
 interface XRAnchor {
     anchorSpace: XRSpace;
+    requestPersistentHandle?: () => Promise<string>;
     delete(): void;
 }
 
 declare abstract class XRAnchor implements XRAnchor {}
+
+interface XRSession {
+    readonly persistentAnchors?: ReadonlyArray<string>;
+    restorePersistentAnchor?: (uuid: string) => Promise<XRAnchor>;
+    deletePersistentAnchor?: (uuid: string) => Promise<void>;
+}
 
 interface XRFrame {
     trackedAnchors?: XRAnchorSet | undefined;

--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.pure.ts
@@ -47,6 +47,11 @@ export interface IWebXRAnchor {
     xrAnchor: XRAnchor;
 
     /**
+     * The persistent handle associated with this anchor, if one was requested or the anchor was restored from one
+     */
+    persistentHandle?: string;
+
+    /**
      * if defined, this object will be constantly updated by the anchor's position and rotation
      */
     attachedNode?: TransformNode;
@@ -85,11 +90,15 @@ interface IWebXRFutureAnchor {
     /**
      * A reject function
      */
-    reject: (msg?: string) => void;
+    reject: (reason?: unknown) => void;
     /**
      * The XR Transformation of the future anchor
      */
-    xrTransformation: XRRigidTransform;
+    xrTransformation?: XRRigidTransform;
+    /**
+     * The persistent handle used to restore this anchor
+     */
+    persistentHandle?: string;
 }
 
 let AnchorIdProvider = 0;
@@ -154,6 +163,7 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
 
         if (this._options.clearAnchorsOnSessionInit) {
             this._xrSessionManager.onXRSessionInit.add(() => {
+                this._rejectPendingPersistentAnchors("Persistent anchor restoration was interrupted before tracking began");
                 this._trackedAnchors.length = 0;
                 this._futureAnchors.length = 0;
                 this._lastFrameDetected.clear();
@@ -271,6 +281,122 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
     }
 
     /**
+     * Whether the current XR session exposes all session-level persistent anchor APIs
+     * @returns Whether all session-level persistent anchor APIs are supported
+     */
+    public get isPersistentAnchorSupported(): boolean {
+        const session = this._xrSessionManager.session;
+        return (
+            !!session && session.persistentAnchors !== undefined && typeof session.restorePersistentAnchor === "function" && typeof session.deletePersistentAnchor === "function"
+        );
+    }
+
+    /**
+     * Get the persistent anchor handles known to the current XR session
+     * @returns The persistent anchor handles
+     * @throws If persistent anchor enumeration is not supported by the current session
+     */
+    public get persistentAnchors(): ReadonlyArray<string> {
+        const persistentAnchors = this._xrSessionManager.session?.persistentAnchors;
+        if (persistentAnchors === undefined) {
+            throw new Error("Persistent anchor enumeration is not supported in this environment/browser");
+        }
+        return persistentAnchors;
+    }
+
+    /**
+     * Request a persistent handle for a tracked anchor
+     * @param anchor The Babylon anchor to persist
+     * @returns A promise that resolves with the persistent handle
+     * @throws If requesting persistent handles is not supported by the native anchor
+     */
+    public async requestPersistentHandleAsync(anchor: IWebXRAnchor): Promise<string> {
+        const requestPersistentHandle = anchor.xrAnchor.requestPersistentHandle;
+        if (!requestPersistentHandle) {
+            throw new Error("Requesting persistent anchor handles is not supported in this environment/browser");
+        }
+        const handle = await requestPersistentHandle.call(anchor.xrAnchor);
+        this._setPersistentHandle(anchor, handle);
+        return handle;
+    }
+
+    /**
+     * Restore a persistent anchor into the Babylon anchor lifecycle
+     * @param handle The persistent anchor handle to restore
+     * @returns A promise that resolves after the restored anchor is tracked by an XR frame
+     * @throws If restoring persistent anchors is not supported by the current session
+     */
+    public async restorePersistentAnchorAsync(handle: string): Promise<IWebXRAnchor> {
+        if (!this.attached) {
+            throw new Error("Restoring persistent anchors requires the anchor system to be attached");
+        }
+
+        const session = this._xrSessionManager.session;
+        const restorePersistentAnchor = session?.restorePersistentAnchor;
+        if (!restorePersistentAnchor) {
+            throw new Error("Restoring persistent anchors is not supported in this environment/browser");
+        }
+
+        const nativeAnchor = await restorePersistentAnchor.call(session, handle);
+        if (!this.attached || this._xrSessionManager.session !== session) {
+            nativeAnchor.delete();
+            throw new Error("Persistent anchor restoration was interrupted before tracking began");
+        }
+        const existingAnchorIndex = this._findIndexInAnchorArray(nativeAnchor);
+        if (existingAnchorIndex !== -1) {
+            const existingAnchor = this._trackedAnchors[existingAnchorIndex];
+            existingAnchor.persistentHandle = handle;
+            return existingAnchor;
+        }
+
+        return await new Promise<IWebXRAnchor>((resolve, reject) => {
+            this._futureAnchors.push({
+                nativeAnchor,
+                resolved: false,
+                submitted: true,
+                persistentHandle: handle,
+                resolve,
+                reject,
+            });
+        });
+    }
+
+    /**
+     * Restore all persistent anchors known to the current XR session
+     * @returns A promise that resolves after all restored anchors are tracked by an XR frame
+     * @throws If persistent anchor enumeration or restoration is not supported by the current session
+     */
+    public async restorePersistentAnchorsAsync(): Promise<IWebXRAnchor[]> {
+        return await Promise.all(this.persistentAnchors.map(async (handle) => await this.restorePersistentAnchorAsync(handle)));
+    }
+
+    /**
+     * Delete a persistent anchor from native storage
+     * @param handle The persistent anchor handle to delete
+     * @returns A promise that resolves after native persistent storage is deleted
+     * @throws If deleting persistent anchors is not supported by the current session
+     */
+    public async deletePersistentAnchorAsync(handle: string): Promise<void> {
+        const deletePersistentAnchor = this._xrSessionManager.session?.deletePersistentAnchor;
+        if (!deletePersistentAnchor) {
+            throw new Error("Deleting persistent anchors is not supported in this environment/browser");
+        }
+
+        await deletePersistentAnchor.call(this._xrSessionManager.session, handle);
+        for (const anchor of this._trackedAnchors) {
+            if (anchor.persistentHandle === handle) {
+                anchor._removed = true;
+            }
+        }
+        for (const futureAnchor of this._futureAnchors) {
+            if (!futureAnchor.resolved && futureAnchor.persistentHandle === handle) {
+                futureAnchor.resolved = true;
+                futureAnchor.reject(new Error("The persistent anchor was deleted before tracking began"));
+            }
+        }
+    }
+
+    /**
      * detach this feature.
      * Will usually be called by the features manager
      *
@@ -280,6 +406,8 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
         if (!super.detach()) {
             return false;
         }
+
+        this._rejectPendingPersistentAnchors("Persistent anchor restoration was interrupted before tracking began");
 
         if (!this._options.doNotRemoveAnchorsOnSessionEnded) {
             while (this._trackedAnchors.length) {
@@ -300,8 +428,8 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
      * Dispose this feature and all of the resources attached
      */
     public override dispose(): void {
-        this._futureAnchors.length = 0;
         super.dispose();
+        this._futureAnchors.length = 0;
         this.onAnchorAddedObservable.clear();
         this.onAnchorRemovedObservable.clear();
         this.onAnchorUpdatedObservable.clear();
@@ -325,30 +453,34 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
             }
             // now check for new ones
             trackedAnchors.forEach((xrAnchor) => {
-                if (!this._lastFrameDetected.has(xrAnchor)) {
-                    const newAnchor: Partial<IWebXRAnchor> = {
+                const trackedAnchorIndex = this._findIndexInAnchorArray(xrAnchor);
+                const futureAnchor = this._findFutureAnchor(xrAnchor);
+                if (!this._lastFrameDetected.has(xrAnchor) || (trackedAnchorIndex === -1 && futureAnchor !== undefined)) {
+                    const anchor: IWebXRAnchor = {
+                        _removed: false,
                         id: AnchorIdProvider++,
                         xrAnchor: xrAnchor,
+                        transformationMatrix: new Matrix(),
+                        persistentHandle: futureAnchor?.persistentHandle,
                         remove: () => {
-                            newAnchor._removed = true;
+                            anchor._removed = true;
                         },
                     };
-                    const anchor = this._updateAnchorWithXRFrame(xrAnchor, newAnchor, frame);
+                    this._updateAnchorWithXRFrame(xrAnchor, anchor, frame);
                     this._trackedAnchors.push(anchor);
                     this.onAnchorAddedObservable.notifyObservers(anchor);
                     // search for the future anchor promise that matches this
-                    const results = this._futureAnchors.filter((futureAnchor) => futureAnchor.nativeAnchor === xrAnchor);
-                    const result = results[0];
-                    if (result) {
-                        result.resolve(anchor);
-                        result.resolved = true;
+                    for (const pendingAnchor of this._futureAnchors) {
+                        if (pendingAnchor.nativeAnchor === xrAnchor && !pendingAnchor.resolved) {
+                            pendingAnchor.resolve(anchor);
+                            pendingAnchor.resolved = true;
+                        }
                     }
                 } else {
-                    const index = this._findIndexInAnchorArray(xrAnchor);
-                    if (index < 0) {
+                    if (trackedAnchorIndex < 0) {
                         return;
                     }
-                    const anchor = this._trackedAnchors[index];
+                    const anchor = this._trackedAnchors[trackedAnchorIndex];
                     this._updateAnchorWithXRFrame(xrAnchor, anchor, frame);
                     if (anchor.attachedNode) {
                         anchor.attachedNode.rotationQuaternion = anchor.attachedNode.rotationQuaternion || new Quaternion();
@@ -363,6 +495,11 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
         // process future anchors
         for (const futureAnchor of this._futureAnchors) {
             if (!futureAnchor.resolved && !futureAnchor.submitted) {
+                if (!futureAnchor.xrTransformation) {
+                    futureAnchor.resolved = true;
+                    futureAnchor.reject(new Error("Anchor creation requires an XR transformation"));
+                    continue;
+                }
                 // eslint-disable-next-line github/no-then
                 this._createAnchorAtTransformationAsync(futureAnchor.xrTransformation, frame).then(
                     (nativeAnchor) => {
@@ -374,6 +511,11 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
                     }
                 );
                 futureAnchor.submitted = true;
+            }
+        }
+        for (let i = this._futureAnchors.length - 1; i >= 0; --i) {
+            if (this._futureAnchors[i].resolved) {
+                this._futureAnchors.splice(i, 1);
             }
         }
     }
@@ -390,6 +532,28 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
             }
         }
         return -1;
+    }
+
+    private _findFutureAnchor(xrAnchor: XRAnchor): IWebXRFutureAnchor | undefined {
+        for (const futureAnchor of this._futureAnchors) {
+            if (futureAnchor.nativeAnchor === xrAnchor && !futureAnchor.resolved) {
+                return futureAnchor;
+            }
+        }
+        return undefined;
+    }
+
+    private _setPersistentHandle(anchor: IWebXRAnchor, handle: string): void {
+        anchor.persistentHandle = handle;
+    }
+
+    private _rejectPendingPersistentAnchors(message: string): void {
+        for (const futureAnchor of this._futureAnchors) {
+            if (!futureAnchor.resolved && futureAnchor.persistentHandle !== undefined) {
+                futureAnchor.resolved = true;
+                futureAnchor.reject(new Error(message));
+            }
+        }
     }
 
     private _updateAnchorWithXRFrame(xrAnchor: XRAnchor, anchor: Partial<IWebXRAnchor>, xrFrame: XRFrame): IWebXRAnchor {

--- a/packages/dev/core/src/XR/features/WebXRAnchorSystem.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRAnchorSystem.pure.ts
@@ -377,12 +377,13 @@ export class WebXRAnchorSystem extends WebXRAbstractFeature {
      * @throws If deleting persistent anchors is not supported by the current session
      */
     public async deletePersistentAnchorAsync(handle: string): Promise<void> {
-        const deletePersistentAnchor = this._xrSessionManager.session?.deletePersistentAnchor;
+        const session = this._xrSessionManager.session;
+        const deletePersistentAnchor = session?.deletePersistentAnchor;
         if (!deletePersistentAnchor) {
             throw new Error("Deleting persistent anchors is not supported in this environment/browser");
         }
 
-        await deletePersistentAnchor.call(this._xrSessionManager.session, handle);
+        await deletePersistentAnchor.call(session, handle);
         for (const anchor of this._trackedAnchors) {
             if (anchor.persistentHandle === handle) {
                 anchor._removed = true;

--- a/packages/dev/core/test/unit/XR/webXRAnchorSystem.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRAnchorSystem.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Matrix } from "core/Maths/math.vector";
+import { Scene } from "core/scene";
+import { type IWebXRAnchor, WebXRAnchorSystem } from "core/XR/features/WebXRAnchorSystem";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function createNativeAnchor(requestPersistentHandle?: () => Promise<string>) {
+    return {
+        anchorSpace: {} as XRSpace,
+        delete: vi.fn(),
+        requestPersistentHandle,
+    } as XRAnchor;
+}
+
+function createFrame(trackedAnchors: XRAnchor[]) {
+    return {
+        getPose: vi.fn(() => {
+            return {
+                transform: {
+                    matrix: Float32Array.from(Matrix.Identity().asArray()),
+                },
+            } as XRPose;
+        }),
+        trackedAnchors: new Set(trackedAnchors),
+    } as unknown as XRFrame;
+}
+
+describe("WebXRAnchorSystem", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let feature: WebXRAnchorSystem;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        Object.defineProperty(sessionManager, "_xrNavigator", {
+            configurable: true,
+            value: { xr: { native: false } },
+        });
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+    });
+
+    afterEach(() => {
+        feature?.dispose();
+        scene.dispose();
+        engine.dispose();
+        vi.restoreAllMocks();
+    });
+
+    function initializeFeature(session: Partial<XRSession>) {
+        sessionManager.session = {
+            enabledFeatures: ["anchors"],
+            ...session,
+        } as XRSession;
+        feature = new WebXRAnchorSystem(sessionManager);
+        expect(feature.attach()).toBe(true);
+    }
+
+    async function trackAnchor(nativeAnchor: XRAnchor) {
+        const added = vi.fn();
+        feature.onAnchorAddedObservable.add(added);
+        sessionManager.onXRFrameObservable.notifyObservers(createFrame([nativeAnchor]));
+        expect(added).toHaveBeenCalledTimes(1);
+        return added.mock.calls[0][0] as IWebXRAnchor;
+    }
+
+    it("detects and enumerates persistent anchor support on the current session", () => {
+        const handles = ["first", "second"];
+        initializeFeature({
+            deletePersistentAnchor: vi.fn(),
+            persistentAnchors: handles,
+            restorePersistentAnchor: vi.fn(),
+        });
+
+        expect(feature.isPersistentAnchorSupported).toBe(true);
+        expect(feature.persistentAnchors).toBe(handles);
+    });
+
+    it("requests and stores a persistent handle on a tracked anchor", async () => {
+        initializeFeature({});
+        const requestPersistentHandle = vi.fn(async () => "persistent-handle");
+        const anchor = await trackAnchor(createNativeAnchor(requestPersistentHandle));
+
+        await expect(feature.requestPersistentHandleAsync(anchor)).resolves.toBe("persistent-handle");
+        expect(requestPersistentHandle).toHaveBeenCalledOnce();
+        expect(anchor.persistentHandle).toBe("persistent-handle");
+    });
+
+    it("restores an anchor through the existing collection and observable lifecycle", async () => {
+        const nativeAnchor = createNativeAnchor();
+        const restorePersistentAnchor = vi.fn(async () => nativeAnchor);
+        initializeFeature({
+            persistentAnchors: ["restored-handle"],
+            restorePersistentAnchor,
+        });
+        const added = vi.fn();
+        feature.onAnchorAddedObservable.add(added);
+
+        const restoredAnchorPromise = feature.restorePersistentAnchorAsync("restored-handle");
+        await Promise.resolve();
+        sessionManager.onXRFrameObservable.notifyObservers(createFrame([nativeAnchor]));
+        const restoredAnchor = await restoredAnchorPromise;
+
+        expect(restorePersistentAnchor).toHaveBeenCalledExactlyOnceWith("restored-handle");
+        expect(restoredAnchor.persistentHandle).toBe("restored-handle");
+        expect(feature.anchors).toEqual([restoredAnchor]);
+        expect(added).toHaveBeenCalledExactlyOnceWith(restoredAnchor, expect.anything());
+    });
+
+    it("restores all persistent anchors", async () => {
+        const firstAnchor = createNativeAnchor();
+        const secondAnchor = createNativeAnchor();
+        const anchorsByHandle = new Map([
+            ["first", firstAnchor],
+            ["second", secondAnchor],
+        ]);
+        const restorePersistentAnchor = vi.fn(async (handle: string) => anchorsByHandle.get(handle)!);
+        initializeFeature({
+            persistentAnchors: ["first", "second"],
+            restorePersistentAnchor,
+        });
+
+        const restoredAnchorsPromise = feature.restorePersistentAnchorsAsync();
+        await Promise.resolve();
+        sessionManager.onXRFrameObservable.notifyObservers(createFrame([firstAnchor, secondAnchor]));
+        const restoredAnchors = await restoredAnchorsPromise;
+
+        expect(restorePersistentAnchor).toHaveBeenCalledTimes(2);
+        expect(restoredAnchors.map((anchor) => anchor.persistentHandle)).toEqual(["first", "second"]);
+        expect(feature.anchors).toEqual(restoredAnchors);
+    });
+
+    it("deletes persistent storage and removes a tracked anchor through the existing lifecycle", async () => {
+        const deletePersistentAnchor = vi.fn(async () => {});
+        initializeFeature({ deletePersistentAnchor });
+        const anchor = await trackAnchor(createNativeAnchor(async () => "persistent-handle"));
+        await feature.requestPersistentHandleAsync(anchor);
+        const removed = vi.fn();
+        feature.onAnchorRemovedObservable.add(removed);
+
+        await feature.deletePersistentAnchorAsync("persistent-handle");
+        sessionManager.onXRFrameObservable.notifyObservers(createFrame([]));
+
+        expect(deletePersistentAnchor).toHaveBeenCalledExactlyOnceWith("persistent-handle");
+        expect(feature.anchors).toHaveLength(0);
+        expect(removed).toHaveBeenCalledExactlyOnceWith(anchor, expect.anything());
+    });
+
+    it("rejects a native restore that completes after the feature detaches", async () => {
+        const nativeAnchor = createNativeAnchor();
+        let resolveRestore!: (anchor: XRAnchor) => void;
+        const nativeRestorePromise = new Promise<XRAnchor>((resolve) => {
+            resolveRestore = resolve;
+        });
+        initializeFeature({
+            restorePersistentAnchor: vi.fn(async () => await nativeRestorePromise),
+        });
+
+        const restoredAnchorPromise = feature.restorePersistentAnchorAsync("pending-handle");
+        feature.detach();
+        resolveRestore(nativeAnchor);
+
+        await expect(restoredAnchorPromise).rejects.toThrow("Persistent anchor restoration was interrupted");
+        expect(nativeAnchor.delete).toHaveBeenCalledOnce();
+    });
+
+    it("rejects a queued persistent restore when the feature is disposed", async () => {
+        const nativeAnchor = createNativeAnchor();
+        initializeFeature({
+            restorePersistentAnchor: vi.fn(async () => nativeAnchor),
+        });
+
+        const restoredAnchorPromise = feature.restorePersistentAnchorAsync("pending-handle");
+        await Promise.resolve();
+        feature.dispose();
+
+        await expect(restoredAnchorPromise).rejects.toThrow("Persistent anchor restoration was interrupted");
+    });
+
+    it("rejects a queued persistent restore when session initialization clears anchors", async () => {
+        const nativeAnchor = createNativeAnchor();
+        sessionManager.session = {
+            enabledFeatures: ["anchors"],
+            restorePersistentAnchor: vi.fn(async () => nativeAnchor),
+        } as XRSession;
+        feature = new WebXRAnchorSystem(sessionManager, { clearAnchorsOnSessionInit: true });
+        expect(feature.attach()).toBe(true);
+
+        const restoredAnchorPromise = feature.restorePersistentAnchorAsync("pending-handle");
+        await Promise.resolve();
+        sessionManager.onXRSessionInit.notifyObservers(sessionManager.session);
+
+        await expect(restoredAnchorPromise).rejects.toThrow("Persistent anchor restoration was interrupted");
+    });
+
+    it("feature-detects each unsupported persistence operation", async () => {
+        initializeFeature({});
+        const anchor = await trackAnchor(createNativeAnchor());
+
+        expect(feature.isPersistentAnchorSupported).toBe(false);
+        expect(() => feature.persistentAnchors).toThrow("Persistent anchor enumeration is not supported");
+        await expect(feature.requestPersistentHandleAsync(anchor)).rejects.toThrow("Requesting persistent anchor handles is not supported");
+        await expect(feature.restorePersistentAnchorAsync("missing")).rejects.toThrow("Restoring persistent anchors is not supported");
+        await expect(feature.deletePersistentAnchorAsync("missing")).rejects.toThrow("Deleting persistent anchors is not supported");
+    });
+
+    it("preserves ordinary non-persistent anchor behavior", async () => {
+        initializeFeature({});
+        const nativeAnchor = createNativeAnchor();
+        const anchor = await trackAnchor(nativeAnchor);
+        const removed = vi.fn();
+        feature.onAnchorRemovedObservable.add(removed);
+
+        expect(anchor.persistentHandle).toBeUndefined();
+        anchor.remove();
+        sessionManager.onXRFrameObservable.notifyObservers(createFrame([]));
+
+        expect(nativeAnchor.delete).toHaveBeenCalledOnce();
+        expect(feature.anchors).toHaveLength(0);
+        expect(removed).toHaveBeenCalledExactlyOnceWith(anchor, expect.anything());
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRAnchorSystem.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRAnchorSystem.test.ts
@@ -138,17 +138,33 @@ describe("WebXRAnchorSystem", () => {
     });
 
     it("deletes persistent storage and removes a tracked anchor through the existing lifecycle", async () => {
-        const deletePersistentAnchor = vi.fn(async () => {});
+        let calledSession: XRSession | undefined;
+        const deletePersistentAnchor = vi.fn(async function (this: XRSession) {
+            calledSession = this;
+        });
         initializeFeature({ deletePersistentAnchor });
+        const activeSession = sessionManager.session;
+        const replacementSession = {} as XRSession;
         const anchor = await trackAnchor(createNativeAnchor(async () => "persistent-handle"));
         await feature.requestPersistentHandleAsync(anchor);
         const removed = vi.fn();
         feature.onAnchorRemovedObservable.add(removed);
+        let sessionReadCount = 0;
+        Object.defineProperty(sessionManager, "session", {
+            configurable: true,
+            get: () => (sessionReadCount++ === 0 ? activeSession : replacementSession),
+        });
 
         await feature.deletePersistentAnchorAsync("persistent-handle");
+        Object.defineProperty(sessionManager, "session", {
+            configurable: true,
+            value: activeSession,
+            writable: true,
+        });
         sessionManager.onXRFrameObservable.notifyObservers(createFrame([]));
 
         expect(deletePersistentAnchor).toHaveBeenCalledExactlyOnceWith("persistent-handle");
+        expect(calledSession).toBe(activeSession);
         expect(feature.anchors).toHaveLength(0);
         expect(removed).toHaveBeenCalledExactlyOnceWith(anchor, expect.anything());
     });


### PR DESCRIPTION
## Summary
- expose typed persistent-anchor support detection, handle enumeration, persistence, restore/restore-all, and deletion on `WebXRAnchorSystem`
- route restored native anchors through the existing Babylon anchor collection and observables
- add the experimental WebXR anchor/session declarations with per-operation feature detection and lifecycle-safe errors

## Compatibility
Browsers without the experimental persistence APIs retain existing ordinary-anchor behavior. Unsupported persistence operations reject with clear errors rather than disabling the anchor feature.

## Validation
- targeted WebXR anchor unit tests (10 tests)
- `@dev/core` source compilation
- targeted ESLint and repository format check
- core tree-shaking and side-effects checks

The full repository unit/lint runs also surfaced unrelated existing environment/generated-artifact failures outside these three files.