### PR TITLE
Add WebXR room capture support

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRPlaneDetector.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRPlaneDetector.pure.ts
@@ -153,18 +153,21 @@ export class WebXRPlaneDetector extends WebXRAbstractFeature {
     }
 
     /**
-     * Enable room capture mode.
-     * When enabled and supported by the system,
-     * the detectedPlanes array will be populated with the detected room boundaries
-     * @see https://immersive-web.github.io/real-world-geometry/plane-detection.html#dom-xrsession-initiateroomcapture
-     * @returns true if plane detection is enabled and supported. Will reject if not supported.
+     * Requests that the active XR session capture or refresh the current room layout.
+     * Detected room planes are reported through the existing plane observables.
+     * @see https://immersive-web.github.io/plane-detection/#dom-xrsession-initiateroomcapture
+     * @returns A promise that resolves when the native room capture request completes.
      */
     // eslint-disable-next-line @typescript-eslint/naming-convention
     public async initiateRoomCapture(): Promise<void> {
-        if (this._xrSessionManager.session.initiateRoomCapture) {
-            return await this._xrSessionManager.session.initiateRoomCapture();
+        const session = this._xrSessionManager.session;
+        if (!this._xrSessionManager.inXRSession || !session) {
+            throw new Error("WebXR room capture requires an active XR session.");
         }
-        throw "initiateRoomCapture is not supported on this session";
+        if (typeof session.initiateRoomCapture !== "function") {
+            throw new Error("XRSession.initiateRoomCapture is not supported by this XR runtime.");
+        }
+        return await session.initiateRoomCapture();
     }
 
     protected _onXRFrame(frame: XRFrame) {

--- a/packages/dev/core/test/unit/XR/webXRPlaneDetector.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRPlaneDetector.test.ts
@@ -12,6 +12,7 @@ describe("WebXRPlaneDetector", () => {
     let engine: NullEngine;
     let scene: Scene;
     let sessionManager: WebXRSessionManager;
+    const originalXRDescriptor = Object.getOwnPropertyDescriptor(navigator, "xr");
 
     const setActiveSession = (initiateRoomCapture?: () => Promise<void>) => {
         const session = {
@@ -43,8 +44,14 @@ describe("WebXRPlaneDetector", () => {
 
     afterEach(() => {
         sessionManager.inXRSession = false;
+        sessionManager.dispose();
         scene.dispose();
         engine.dispose();
+        if (originalXRDescriptor) {
+            Object.defineProperty(navigator, "xr", originalXRDescriptor);
+        } else {
+            Reflect.deleteProperty(navigator, "xr");
+        }
     });
 
     it("delegates room capture and follows native promise settlement", async () => {

--- a/packages/dev/core/test/unit/XR/webXRPlaneDetector.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRPlaneDetector.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { WebXRPlaneDetector } from "core/XR/features/WebXRPlaneDetector";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("WebXRPlaneDetector", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+
+    const setActiveSession = (initiateRoomCapture?: () => Promise<void>) => {
+        const session = {
+            enabledFeatures: ["plane-detection"],
+            initiateRoomCapture,
+        } as XRSession;
+        sessionManager.session = session;
+        sessionManager.inXRSession = true;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        return session;
+    };
+
+    beforeEach(async () => {
+        Object.defineProperty(navigator, "xr", {
+            configurable: true,
+            value: { native: false },
+        });
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        await sessionManager.initializeAsync();
+    });
+
+    afterEach(() => {
+        sessionManager.inXRSession = false;
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("delegates room capture and follows native promise settlement", async () => {
+        let resolveNativePromise = () => {};
+        const nativePromise = new Promise<void>((resolve) => {
+            resolveNativePromise = resolve;
+        });
+        const initiateRoomCapture = vi.fn(() => nativePromise);
+        const session = setActiveSession(initiateRoomCapture);
+        const feature = new WebXRPlaneDetector(sessionManager);
+        let settled = false;
+
+        const result = feature.initiateRoomCapture();
+        void result.then(() => {
+            settled = true;
+        });
+
+        expect(initiateRoomCapture).toHaveBeenCalledExactlyOnceWith();
+        expect(initiateRoomCapture.mock.instances[0]).toBe(session);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        resolveNativePromise();
+        await result;
+        expect(settled).toBe(true);
+    });
+
+    it("propagates native room capture rejections", async () => {
+        const nativeError = new Error("Room capture failed");
+        const nativePromise = Promise.reject(nativeError);
+        setActiveSession(() => nativePromise);
+        const feature = new WebXRPlaneDetector(sessionManager);
+
+        const result = feature.initiateRoomCapture();
+
+        await expect(result).rejects.toBe(nativeError);
+    });
+
+    it("rejects when the active session does not support room capture", async () => {
+        setActiveSession();
+        const feature = new WebXRPlaneDetector(sessionManager);
+
+        await expect(feature.initiateRoomCapture()).rejects.toThrow("XRSession.initiateRoomCapture is not supported by this XR runtime.");
+    });
+
+    it("rejects when there is no active XR session", async () => {
+        const feature = new WebXRPlaneDetector(sessionManager);
+
+        await expect(feature.initiateRoomCapture()).rejects.toThrow("WebXR room capture requires an active XR session.");
+    });
+
+    it("continues reporting detected planes after room capture", async () => {
+        setActiveSession(() => Promise.resolve());
+        const feature = new WebXRPlaneDetector(sessionManager);
+        const onPlaneAdded = vi.fn();
+        feature.onPlaneAddedObservable.add(onPlaneAdded);
+        const xrPlane = {
+            lastChangedTime: 0,
+            planeSpace: {},
+            polygon: [{ x: 1, y: 2, z: 3 }],
+        };
+        const xrFrame = {
+            detectedPlanes: new Set([xrPlane]),
+            getPose: vi.fn(() => ({
+                transform: {
+                    matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+                },
+            })),
+        } as unknown as XRFrame;
+
+        expect(feature.attach()).toBe(true);
+        await feature.initiateRoomCapture();
+        sessionManager.onXRFrameObservable.notifyObservers(xrFrame);
+
+        expect(onPlaneAdded).toHaveBeenCalledTimes(1);
+        expect(onPlaneAdded.mock.calls[0][0].xrPlane).toBe(xrPlane);
+        expect(onPlaneAdded.mock.calls[0][0].polygonDefinition[0].asArray()).toEqual([1, 2, -3]);
+    });
+});


### PR DESCRIPTION
## Summary
- add deterministic active-session and capability checks to `WebXRPlaneDetector.initiateRoomCapture()`
- delegate to the native `XRSession.initiateRoomCapture()` promise without adding feature state
- cover delegation, native rejection propagation, unsupported and inactive sessions, and plane detection after capture

## Validation
- `npm run format:check`
- `npm run lint:check`
- `npx vitest run --project=unit --maxWorkers=1 --testTimeout=30000` (4,640 passed)