### PR TITLE
Add WebXR depth sensing lifecycle controls

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -534,6 +534,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
     /**
      * Whether depth sensing is currently active for the XR session.
      * Returns false when there is no active session or the runtime does not expose the active state.
+     * @see https://immersive-web.github.io/depth-sensing/
      * @see https://playground.babylonjs.com/#SU7NUW#0
      */
     public get isDepthSensingActive(): boolean {
@@ -545,6 +546,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
      * Pauses depth sensing for the active XR session.
      * @returns A promise that resolves when the native pause operation completes.
      * @throws If there is no active XR session or pausing depth sensing is not supported by the runtime.
+     * @see https://immersive-web.github.io/depth-sensing/
      */
     public async pauseDepthSensingAsync(): Promise<void> {
         const session: IWebXRDepthSensingSession | undefined = this._xrSessionManager.session;
@@ -561,6 +563,7 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
      * Resumes depth sensing for the active XR session.
      * @returns A promise that resolves when the native resume operation completes.
      * @throws If there is no active XR session or resuming depth sensing is not supported by the runtime.
+     * @see https://immersive-web.github.io/depth-sensing/
      */
     public async resumeDepthSensingAsync(): Promise<void> {
         const session: IWebXRDepthSensingSession | undefined = this._xrSessionManager.session;

--- a/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRDepthSensing.pure.ts
@@ -29,6 +29,12 @@ import { WebXRGraphicsBindingType } from "../webXRGraphicsBinding";
 export type WebXRDepthUsage = "cpu" | "gpu";
 export type WebXRDepthDataFormat = "ushort" | "float" | "luminance-alpha";
 
+interface IWebXRDepthSensingSession extends XRSession {
+    readonly depthActive?: boolean;
+    pauseDepthSensing?: () => Promise<void>;
+    resumeDepthSensing?: () => Promise<void>;
+}
+
 /**
  * Options for Depth Sensing feature
  */
@@ -523,6 +529,48 @@ export class WebXRDepthSensing extends WebXRAbstractFeature {
             case "unsigned-short":
                 return "ushort";
         }
+    }
+
+    /**
+     * Whether depth sensing is currently active for the XR session.
+     * Returns false when there is no active session or the runtime does not expose the active state.
+     * @see https://playground.babylonjs.com/#SU7NUW#0
+     */
+    public get isDepthSensingActive(): boolean {
+        const session: IWebXRDepthSensingSession | undefined = this._xrSessionManager.session;
+        return this._xrSessionManager.inXRSession && session?.depthActive === true;
+    }
+
+    /**
+     * Pauses depth sensing for the active XR session.
+     * @returns A promise that resolves when the native pause operation completes.
+     * @throws If there is no active XR session or pausing depth sensing is not supported by the runtime.
+     */
+    public async pauseDepthSensingAsync(): Promise<void> {
+        const session: IWebXRDepthSensingSession | undefined = this._xrSessionManager.session;
+        if (!this._xrSessionManager.inXRSession || !session) {
+            throw new Error("Pausing WebXR depth sensing requires an active XR session.");
+        }
+        if (typeof session.pauseDepthSensing !== "function") {
+            throw new Error("XRSession.pauseDepthSensing is not supported by this XR runtime.");
+        }
+        return await session.pauseDepthSensing();
+    }
+
+    /**
+     * Resumes depth sensing for the active XR session.
+     * @returns A promise that resolves when the native resume operation completes.
+     * @throws If there is no active XR session or resuming depth sensing is not supported by the runtime.
+     */
+    public async resumeDepthSensingAsync(): Promise<void> {
+        const session: IWebXRDepthSensingSession | undefined = this._xrSessionManager.session;
+        if (!this._xrSessionManager.inXRSession || !session) {
+            throw new Error("Resuming WebXR depth sensing requires an active XR session.");
+        }
+        if (typeof session.resumeDepthSensing !== "function") {
+            throw new Error("XRSession.resumeDepthSensing is not supported by this XR runtime.");
+        }
+        return await session.resumeDepthSensing();
     }
 
     /**

--- a/packages/dev/core/test/unit/XR/webXRDepthSensing.lifecycle.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRDepthSensing.lifecycle.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Logger } from "core/Misc/logger";
+import { Scene } from "core/scene";
+import { WebXRDepthSensing } from "core/XR/features/WebXRDepthSensing";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface IDepthLifecycleSession {
+    depthActive?: boolean;
+    pauseDepthSensing?: () => Promise<void>;
+    resumeDepthSensing?: () => Promise<void>;
+}
+
+describe("WebXRDepthSensing lifecycle controls", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let feature: WebXRDepthSensing;
+    const originalXRDescriptor = Object.getOwnPropertyDescriptor(navigator, "xr");
+
+    const setActiveSession = (members: IDepthLifecycleSession = {}) => {
+        const session = {
+            depthDataFormat: "float32",
+            depthUsage: "cpu-optimized",
+            enabledFeatures: ["depth-sensing"],
+            ...members,
+        } as XRSession & IDepthLifecycleSession;
+        sessionManager.session = session;
+        sessionManager.inXRSession = true;
+        return session;
+    };
+
+    beforeEach(async () => {
+        Object.defineProperty(navigator, "xr", {
+            configurable: true,
+            value: { native: false },
+        });
+        engine = new NullEngine();
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        await sessionManager.initializeAsync();
+        vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+        feature = new WebXRDepthSensing(sessionManager, {
+            dataFormatPreference: ["float"],
+            usagePreference: ["cpu"],
+        });
+    });
+
+    afterEach(() => {
+        sessionManager.inXRSession = false;
+        feature.dispose();
+        sessionManager.dispose();
+        scene.dispose();
+        engine.dispose();
+        vi.restoreAllMocks();
+        if (originalXRDescriptor) {
+            Object.defineProperty(navigator, "xr", originalXRDescriptor);
+        } else {
+            Reflect.deleteProperty(navigator, "xr");
+        }
+    });
+
+    it("reports the native active state without caching it", () => {
+        expect(feature.isDepthSensingActive).toBe(false);
+        const session = setActiveSession({ depthActive: true });
+
+        expect(feature.isDepthSensingActive).toBe(true);
+
+        session.depthActive = false;
+        expect(feature.isDepthSensingActive).toBe(false);
+
+        delete session.depthActive;
+        expect(feature.isDepthSensingActive).toBe(false);
+    });
+
+    it("delegates pause and follows native promise settlement", async () => {
+        let resolveNativePromise = () => {};
+        const nativePromise = new Promise<void>((resolve) => {
+            resolveNativePromise = resolve;
+        });
+        const pauseDepthSensing = vi.fn(() => nativePromise);
+        const session = setActiveSession({ pauseDepthSensing });
+        let settled = false;
+
+        const result = feature.pauseDepthSensingAsync();
+        void result.then(() => {
+            settled = true;
+        });
+
+        expect(pauseDepthSensing).toHaveBeenCalledExactlyOnceWith();
+        expect(pauseDepthSensing.mock.instances[0]).toBe(session);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        resolveNativePromise();
+        await result;
+        expect(settled).toBe(true);
+    });
+
+    it("delegates resume and follows native promise settlement", async () => {
+        let resolveNativePromise = () => {};
+        const nativePromise = new Promise<void>((resolve) => {
+            resolveNativePromise = resolve;
+        });
+        const resumeDepthSensing = vi.fn(() => nativePromise);
+        const session = setActiveSession({ resumeDepthSensing });
+        let settled = false;
+
+        const result = feature.resumeDepthSensingAsync();
+        void result.then(() => {
+            settled = true;
+        });
+
+        expect(resumeDepthSensing).toHaveBeenCalledExactlyOnceWith();
+        expect(resumeDepthSensing.mock.instances[0]).toBe(session);
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        resolveNativePromise();
+        await result;
+        expect(settled).toBe(true);
+    });
+
+    it("propagates native pause and resume rejections", async () => {
+        const pauseError = new Error("Pause failed");
+        const resumeError = new Error("Resume failed");
+        setActiveSession({
+            pauseDepthSensing: () => Promise.reject(pauseError),
+            resumeDepthSensing: () => Promise.reject(resumeError),
+        });
+
+        await expect(feature.pauseDepthSensingAsync()).rejects.toBe(pauseError);
+        await expect(feature.resumeDepthSensingAsync()).rejects.toBe(resumeError);
+    });
+
+    it("detects pause and resume support independently", async () => {
+        const resumeDepthSensing = vi.fn(() => Promise.resolve());
+        setActiveSession({ resumeDepthSensing });
+
+        await expect(feature.pauseDepthSensingAsync()).rejects.toThrow("XRSession.pauseDepthSensing is not supported by this XR runtime.");
+        await expect(feature.resumeDepthSensingAsync()).resolves.toBeUndefined();
+        expect(resumeDepthSensing).toHaveBeenCalledExactlyOnceWith();
+
+        const pauseDepthSensing = vi.fn(() => Promise.resolve());
+        setActiveSession({ pauseDepthSensing });
+
+        await expect(feature.pauseDepthSensingAsync()).resolves.toBeUndefined();
+        await expect(feature.resumeDepthSensingAsync()).rejects.toThrow("XRSession.resumeDepthSensing is not supported by this XR runtime.");
+        expect(pauseDepthSensing).toHaveBeenCalledExactlyOnceWith();
+    });
+
+    it("rejects lifecycle operations without an active XR session", async () => {
+        await expect(feature.pauseDepthSensingAsync()).rejects.toThrow("Pausing WebXR depth sensing requires an active XR session.");
+        await expect(feature.resumeDepthSensingAsync()).rejects.toThrow("Resuming WebXR depth sensing requires an active XR session.");
+
+        setActiveSession({
+            pauseDepthSensing: () => Promise.resolve(),
+            resumeDepthSensing: () => Promise.resolve(),
+        });
+        sessionManager.inXRSession = false;
+
+        await expect(feature.pauseDepthSensingAsync()).rejects.toThrow("Pausing WebXR depth sensing requires an active XR session.");
+        await expect(feature.resumeDepthSensingAsync()).rejects.toThrow("Resuming WebXR depth sensing requires an active XR session.");
+    });
+
+    it("preserves existing attach and detach behavior", async () => {
+        Object.defineProperty(engine, "isWebGPU", { configurable: true, value: true });
+        const pauseDepthSensing = vi.fn(() => Promise.resolve());
+        const resumeDepthSensing = vi.fn(() => Promise.resolve());
+        setActiveSession({ depthActive: true, pauseDepthSensing, resumeDepthSensing });
+
+        expect(feature.attach()).toBe(true);
+        expect(feature.attached).toBe(true);
+        await feature.pauseDepthSensingAsync();
+        expect(feature.detach()).toBe(true);
+        expect(feature.attached).toBe(false);
+        await feature.resumeDepthSensingAsync();
+
+        expect(pauseDepthSensing).toHaveBeenCalledExactlyOnceWith();
+        expect(resumeDepthSensing).toHaveBeenCalledExactlyOnceWith();
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- expose `WebXRDepthSensing.isDepthSensingActive` as a live view of `XRSession.depthActive`
- add `pauseDepthSensingAsync()` and `resumeDepthSensingAsync()` with active-session checks, independent native capability detection, and direct promise propagation
- preserve the existing depth acquisition, material occlusion, attach, and detach paths
- add focused lifecycle coverage without expanding the global WebXR declarations

## Compatibility

These controls wrap the experimental [WebXR Depth Sensing Module](https://immersive-web.github.io/depth-sensing/) APIs currently documented for Chromium 139+ and Meta Quest Browser 33.3+. Runtimes without `depthActive` report the Babylon active state as `false`; unsupported pause and resume operations reject with explicit errors. Native promise resolution and rejection are preserved.

## Playground

[WebXR Depth Sensing Lifecycle Controls — #SU7NUW#0](https://playground.babylonjs.com/#SU7NUW#0)

The snippet enters immersive AR with depth sensing requested, reports the live active state, and provides pause/resume controls with unsupported and error messaging. The public CDN does not contain this Babylon API until the PR ships, so the saved snippet is future-compatible; its saved source was round-trip verified and syntax checked, while the API itself was validated against the local branch build.

## Validation

- `npx vitest run --project=unit packages/dev/core/test/unit/XR/webXRDepthSensing.lifecycle.test.ts packages/dev/core/test/unit/XR/webXRDepthSensing.test.ts packages/dev/core/test/unit/XR/webXRDepthSensing.shaders.test.ts` — 23 passed
- `npx tsc -b packages/dev/core/tsconfig.build.json --pretty false`
- `npm run build:dev`
- `npm run format:check`
- `npm run lint:check`
- `npm run check:treeshaking && npm run check:side-effects-sync && npm run test:treeshaking`
- full `npm run test:unit` — 4,721 passed; one unrelated `KHR_materials_transmission` assertion failed during the full run and passed immediately when rerun in isolation
