### PR TITLE
Add advanced WebXR controller haptics

### DIFF
--- a/packages/dev/core/src/XR/motionController/webXRAbstractMotionController.ts
+++ b/packages/dev/core/src/XR/motionController/webXRAbstractMotionController.ts
@@ -24,6 +24,28 @@ export type MotionControllerComponentType = "trigger" | "squeeze" | "touchpad" |
 export type MotionControllerComponentStateType = "default" | "touched" | "pressed";
 
 /**
+ * The haptic capabilities exposed by a WebXR motion controller actuator.
+ */
+export interface IWebXRControllerHapticActuator {
+    /**
+     * The haptic effects reported as supported by this actuator.
+     */
+    readonly effects?: ReadonlyArray<GamepadHapticEffectType>;
+    /**
+     * Plays a haptic effect, when advanced haptic playback is supported.
+     */
+    playEffect?: GamepadHapticActuator["playEffect"];
+    /**
+     * Stops the active haptic effect, when reset is supported.
+     */
+    reset?: GamepadHapticActuator["reset"];
+    /**
+     * Plays a legacy haptic pulse.
+     */
+    pulse: (value: number, duration: number) => Promise<boolean>;
+}
+
+/**
  * The schema of motion controller layout.
  * No object will be initialized using this interface
  * This is used just to define the profile.
@@ -218,9 +240,7 @@ export interface IMinimalMotionControllerObject {
     /**
      * EXPERIMENTAL haptic support.
      */
-    hapticActuators?: Array<{
-        pulse: (value: number, duration: number) => Promise<boolean>;
-    }>;
+    hapticActuators?: IWebXRControllerHapticActuator[];
 }
 
 /**
@@ -463,6 +483,58 @@ export abstract class WebXRAbstractMotionController implements IDisposable {
     }
 
     /**
+     * Gets the haptic effects reported as supported by an actuator.
+     * See https://playground.babylonjs.com/#556G65#0 for an interactive example.
+     *
+     * @param hapticActuatorIndex index of the actuator (usually 0)
+     * @returns the effects reported by the actuator, or an empty array when effect discovery is unavailable
+     * @throws a RangeError when the actuator index is invalid
+     */
+    public getHapticEffects(hapticActuatorIndex: number = 0): ReadonlyArray<GamepadHapticEffectType> {
+        return this._getHapticActuator(hapticActuatorIndex).effects ?? [];
+    }
+
+    /**
+     * Plays an advanced haptic effect on this controller.
+     *
+     * @param effectType the standard Gamepad haptic effect to play
+     * @param parameters effect duration, delay, and motor magnitudes
+     * @param hapticActuatorIndex index of the actuator (usually 0)
+     * @returns the native completion result from the actuator
+     * @throws an Error when the actuator or requested effect is unsupported, or a RangeError when the actuator index is invalid
+     */
+    public async playHapticEffectAsync(effectType: GamepadHapticEffectType, parameters?: GamepadEffectParameters, hapticActuatorIndex: number = 0): Promise<GamepadHapticsResult> {
+        const actuator = this._getHapticActuator(hapticActuatorIndex);
+        if (!actuator.effects) {
+            throw new Error(`Haptic actuator ${hapticActuatorIndex} does not support effect discovery.`);
+        }
+        if (actuator.effects.indexOf(effectType) === -1) {
+            throw new Error(`Haptic effect "${effectType}" is not supported by actuator ${hapticActuatorIndex}.`);
+        }
+        if (!actuator.playEffect) {
+            throw new Error(`Haptic actuator ${hapticActuatorIndex} does not support advanced effect playback.`);
+        }
+
+        return await actuator.playEffect(effectType, parameters);
+    }
+
+    /**
+     * Stops the active haptic effect on an actuator.
+     *
+     * @param hapticActuatorIndex index of the actuator (usually 0)
+     * @returns the native completion result from the actuator
+     * @throws an Error when reset is unsupported, or a RangeError when the actuator index is invalid
+     */
+    public async resetHapticActuatorAsync(hapticActuatorIndex: number = 0): Promise<GamepadHapticsResult> {
+        const actuator = this._getHapticActuator(hapticActuatorIndex);
+        if (!actuator.reset) {
+            throw new Error(`Haptic actuator ${hapticActuatorIndex} does not support reset.`);
+        }
+
+        return await actuator.reset();
+    }
+
+    /**
      * Pulse (vibrate) this controller
      * If the controller does not support pulses, this function will fail silently and return Promise<false> directly after called
      * Consecutive calls to this function will cancel the last pulse call
@@ -479,6 +551,15 @@ export abstract class WebXRAbstractMotionController implements IDisposable {
         } else {
             return false;
         }
+    }
+
+    private _getHapticActuator(hapticActuatorIndex: number): IWebXRControllerHapticActuator {
+        const actuators = this.gamepadObject.hapticActuators;
+        if (!Number.isInteger(hapticActuatorIndex) || hapticActuatorIndex < 0 || !actuators || hapticActuatorIndex >= actuators.length) {
+            throw new RangeError(`Haptic actuator index ${hapticActuatorIndex} is out of range.`);
+        }
+
+        return actuators[hapticActuatorIndex];
     }
 
     // Look through all children recursively. This will return null if no mesh exists with the given name.

--- a/packages/dev/core/src/XR/motionController/webXRAbstractMotionController.ts
+++ b/packages/dev/core/src/XR/motionController/webXRAbstractMotionController.ts
@@ -39,10 +39,6 @@ export interface IWebXRControllerHapticActuator {
      * Stops the active haptic effect, when reset is supported.
      */
     reset?: GamepadHapticActuator["reset"];
-    /**
-     * Plays a legacy haptic pulse.
-     */
-    pulse: (value: number, duration: number) => Promise<boolean>;
 }
 
 /**
@@ -240,7 +236,19 @@ export interface IMinimalMotionControllerObject {
     /**
      * EXPERIMENTAL haptic support.
      */
-    hapticActuators?: IWebXRControllerHapticActuator[];
+    hapticActuators?: Array<
+        IWebXRControllerHapticActuator & {
+            /**
+             * Plays a legacy haptic pulse.
+             */
+            pulse: (value: number, duration: number) => Promise<boolean>;
+        }
+    >;
+
+    /**
+     * The primary Gamepad vibration actuator used for advanced haptic effects.
+     */
+    vibrationActuator?: IWebXRControllerHapticActuator;
 }
 
 /**
@@ -484,7 +492,7 @@ export abstract class WebXRAbstractMotionController implements IDisposable {
 
     /**
      * Gets the haptic effects reported as supported by an actuator.
-     * See https://playground.babylonjs.com/#556G65#0 for an interactive example.
+     * See https://playground.babylonjs.com/#ULVR1X#0 for an interactive example.
      *
      * @param hapticActuatorIndex index of the actuator (usually 0)
      * @returns the effects reported by the actuator, or an empty array when effect discovery is unavailable
@@ -554,12 +562,21 @@ export abstract class WebXRAbstractMotionController implements IDisposable {
     }
 
     private _getHapticActuator(hapticActuatorIndex: number): IWebXRControllerHapticActuator {
-        const actuators = this.gamepadObject.hapticActuators;
-        if (!Number.isInteger(hapticActuatorIndex) || hapticActuatorIndex < 0 || !actuators || hapticActuatorIndex >= actuators.length) {
+        if (!Number.isInteger(hapticActuatorIndex) || hapticActuatorIndex < 0) {
             throw new RangeError(`Haptic actuator index ${hapticActuatorIndex} is out of range.`);
         }
 
-        return actuators[hapticActuatorIndex];
+        if (hapticActuatorIndex === 0 && this.gamepadObject.vibrationActuator) {
+            return this.gamepadObject.vibrationActuator;
+        }
+
+        const actuators = this.gamepadObject.hapticActuators;
+        const actuator = actuators?.[hapticActuatorIndex];
+        if (!actuator) {
+            throw new RangeError(`Haptic actuator index ${hapticActuatorIndex} is out of range.`);
+        }
+
+        return actuator;
     }
 
     // Look through all children recursively. This will return null if no mesh exists with the given name.

--- a/packages/dev/core/test/unit/XR/webXRControllerHaptics.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRControllerHaptics.test.ts
@@ -8,18 +8,31 @@ import { type IMinimalMotionControllerObject, type IWebXRControllerHapticActuato
 import { WebXRGenericTriggerMotionController } from "core/XR/motionController/webXRGenericMotionController";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-function createActuator(overrides: Partial<IWebXRControllerHapticActuator> = {}): IWebXRControllerHapticActuator {
+type LegacyHapticActuator = NonNullable<IMinimalMotionControllerObject["hapticActuators"]>[number];
+
+function createAdvancedActuator(overrides: Partial<IWebXRControllerHapticActuator> = {}): IWebXRControllerHapticActuator {
+    return {
+        ...overrides,
+    };
+}
+
+function createLegacyActuator(overrides: Partial<LegacyHapticActuator> = {}): LegacyHapticActuator {
     return {
         pulse: vi.fn(async () => true),
         ...overrides,
     };
 }
 
-function createGamepad(hapticActuators?: IWebXRControllerHapticActuator[]): IMinimalMotionControllerObject {
+function createGamepad(
+    options: {
+        hapticActuators?: LegacyHapticActuator[];
+        vibrationActuator?: IWebXRControllerHapticActuator;
+    } = {}
+): IMinimalMotionControllerObject {
     return {
         axes: [],
         buttons: [{ value: 0, touched: false, pressed: false }],
-        hapticActuators,
+        ...options,
     };
 }
 
@@ -37,10 +50,31 @@ describe("WebXR motion controller haptics", () => {
         engine.dispose();
     });
 
-    it("enumerates only the effects reported by the selected actuator", () => {
+    it("uses the browser vibration actuator for effect discovery", () => {
         const controller = new WebXRGenericTriggerMotionController(
             scene,
-            createGamepad([createActuator({ effects: ["dual-rumble"] }), createActuator({ effects: ["trigger-rumble"] })]),
+            createGamepad({
+                hapticActuators: [createLegacyActuator()],
+                vibrationActuator: createAdvancedActuator({ effects: ["dual-rumble"] }),
+            }),
+            "right"
+        );
+
+        expect(controller.getHapticEffects()).toEqual(["dual-rumble"]);
+    });
+
+    it("supports explicitly advanced haptic actuator array entries as a fallback", () => {
+        const controller = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad({
+                hapticActuators: [
+                    createLegacyActuator(),
+                    createLegacyActuator({
+                        effects: ["trigger-rumble"],
+                    }),
+                ],
+                vibrationActuator: createAdvancedActuator({ effects: ["dual-rumble"] }),
+            }),
             "right"
         );
 
@@ -49,7 +83,7 @@ describe("WebXR motion controller haptics", () => {
     });
 
     it("returns no effects when the actuator does not expose discovery", () => {
-        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator()]), "right");
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad({ vibrationActuator: createAdvancedActuator() }), "right");
 
         expect(controller.getHapticEffects()).toEqual([]);
     });
@@ -69,7 +103,19 @@ describe("WebXR motion controller haptics", () => {
         };
         const controller = new WebXRGenericTriggerMotionController(
             scene,
-            createGamepad([createActuator({ effects: ["dual-rumble"], playEffect }), createActuator({ effects: ["trigger-rumble"], playEffect })]),
+            createGamepad({
+                hapticActuators: [
+                    createLegacyActuator(),
+                    createLegacyActuator({
+                        effects: ["trigger-rumble"],
+                        playEffect,
+                    }),
+                ],
+                vibrationActuator: createAdvancedActuator({
+                    effects: ["dual-rumble"],
+                    playEffect,
+                }),
+            }),
             "right"
         );
 
@@ -82,18 +128,30 @@ describe("WebXR motion controller haptics", () => {
     it("resets the selected actuator and returns its native result", async () => {
         const firstReset: NonNullable<IWebXRControllerHapticActuator["reset"]> = vi.fn(async () => "complete");
         const secondReset: NonNullable<IWebXRControllerHapticActuator["reset"]> = vi.fn(async () => "preempted");
-        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ reset: firstReset }), createActuator({ reset: secondReset })]), "left");
+        const controller = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad({
+                hapticActuators: [createLegacyActuator(), createLegacyActuator({ reset: secondReset })],
+                vibrationActuator: createAdvancedActuator({ reset: firstReset }),
+            }),
+            "left"
+        );
 
+        await expect(controller.resetHapticActuatorAsync()).resolves.toBe("complete");
         await expect(controller.resetHapticActuatorAsync(1)).resolves.toBe("preempted");
-        expect(firstReset).not.toHaveBeenCalled();
+        expect(firstReset).toHaveBeenCalledOnce();
         expect(secondReset).toHaveBeenCalledOnce();
     });
 
     it("rejects advanced playback when required capabilities are unavailable", async () => {
         const playEffect: NonNullable<IWebXRControllerHapticActuator["playEffect"]> = vi.fn(async () => "complete");
-        const withoutDiscovery = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ playEffect })]), "right");
-        const withoutPlayback = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ effects: ["dual-rumble"] })]), "right");
-        const withoutRequestedEffect = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ effects: ["dual-rumble"], playEffect })]), "right");
+        const withoutDiscovery = new WebXRGenericTriggerMotionController(scene, createGamepad({ vibrationActuator: createAdvancedActuator({ playEffect }) }), "right");
+        const withoutPlayback = new WebXRGenericTriggerMotionController(scene, createGamepad({ vibrationActuator: createAdvancedActuator({ effects: ["dual-rumble"] }) }), "right");
+        const withoutRequestedEffect = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad({ vibrationActuator: createAdvancedActuator({ effects: ["dual-rumble"], playEffect }) }),
+            "right"
+        );
 
         await expect(withoutDiscovery.playHapticEffectAsync("dual-rumble")).rejects.toThrow("does not support effect discovery");
         await expect(withoutPlayback.playHapticEffectAsync("dual-rumble")).rejects.toThrow("does not support advanced effect playback");
@@ -101,13 +159,13 @@ describe("WebXR motion controller haptics", () => {
     });
 
     it("rejects reset when the selected actuator does not expose it", async () => {
-        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator()]), "right");
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad({ vibrationActuator: createAdvancedActuator() }), "right");
 
         await expect(controller.resetHapticActuatorAsync()).rejects.toThrow("does not support reset");
     });
 
     it("rejects invalid actuator indices deterministically", async () => {
-        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator()]), "right");
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad({ vibrationActuator: createAdvancedActuator() }), "right");
 
         expect(() => controller.getHapticEffects(-1)).toThrow(RangeError);
         expect(() => controller.getHapticEffects(0.5)).toThrow(RangeError);
@@ -120,8 +178,8 @@ describe("WebXR motion controller haptics", () => {
         const resetError = new Error("native reset failure");
         const controller = new WebXRGenericTriggerMotionController(
             scene,
-            createGamepad([
-                createActuator({
+            createGamepad({
+                vibrationActuator: createAdvancedActuator({
                     effects: ["dual-rumble"],
                     playEffect: vi.fn(async () => {
                         throw playError;
@@ -130,7 +188,7 @@ describe("WebXR motion controller haptics", () => {
                         throw resetError;
                     }),
                 }),
-            ]),
+            }),
             "right"
         );
 
@@ -140,7 +198,14 @@ describe("WebXR motion controller haptics", () => {
 
     it("preserves legacy pulse behavior", async () => {
         const pulse = vi.fn(async () => true);
-        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator(), createActuator({ pulse })]), "right");
+        const controller = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad({
+                hapticActuators: [createLegacyActuator(), createLegacyActuator({ pulse })],
+                vibrationActuator: createAdvancedActuator({ effects: ["dual-rumble"] }),
+            }),
+            "right"
+        );
         const unsupportedController = new WebXRGenericTriggerMotionController(scene, createGamepad(), "right");
 
         await expect(controller.pulse(0.7, 50, 1)).resolves.toBe(true);

--- a/packages/dev/core/test/unit/XR/webXRControllerHaptics.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRControllerHaptics.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { type IMinimalMotionControllerObject, type IWebXRControllerHapticActuator } from "core/XR/motionController/webXRAbstractMotionController";
+import { WebXRGenericTriggerMotionController } from "core/XR/motionController/webXRGenericMotionController";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function createActuator(overrides: Partial<IWebXRControllerHapticActuator> = {}): IWebXRControllerHapticActuator {
+    return {
+        pulse: vi.fn(async () => true),
+        ...overrides,
+    };
+}
+
+function createGamepad(hapticActuators?: IWebXRControllerHapticActuator[]): IMinimalMotionControllerObject {
+    return {
+        axes: [],
+        buttons: [{ value: 0, touched: false, pressed: false }],
+        hapticActuators,
+    };
+}
+
+describe("WebXR motion controller haptics", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("enumerates only the effects reported by the selected actuator", () => {
+        const controller = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad([createActuator({ effects: ["dual-rumble"] }), createActuator({ effects: ["trigger-rumble"] })]),
+            "right"
+        );
+
+        expect(controller.getHapticEffects()).toEqual(["dual-rumble"]);
+        expect(controller.getHapticEffects(1)).toEqual(["trigger-rumble"]);
+    });
+
+    it("returns no effects when the actuator does not expose discovery", () => {
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator()]), "right");
+
+        expect(controller.getHapticEffects()).toEqual([]);
+    });
+
+    it("delegates dual-rumble and trigger-rumble effects with their parameters", async () => {
+        const playEffect: NonNullable<IWebXRControllerHapticActuator["playEffect"]> = vi.fn(async () => "complete");
+        const parameters = {
+            duration: 120,
+            startDelay: 5,
+            strongMagnitude: 0.8,
+            weakMagnitude: 0.4,
+        };
+        const triggerParameters = {
+            duration: 80,
+            leftTrigger: 0.6,
+            rightTrigger: 0.3,
+        };
+        const controller = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad([createActuator({ effects: ["dual-rumble"], playEffect }), createActuator({ effects: ["trigger-rumble"], playEffect })]),
+            "right"
+        );
+
+        await expect(controller.playHapticEffectAsync("dual-rumble", parameters)).resolves.toBe("complete");
+        await expect(controller.playHapticEffectAsync("trigger-rumble", triggerParameters, 1)).resolves.toBe("complete");
+        expect(playEffect).toHaveBeenNthCalledWith(1, "dual-rumble", parameters);
+        expect(playEffect).toHaveBeenNthCalledWith(2, "trigger-rumble", triggerParameters);
+    });
+
+    it("resets the selected actuator and returns its native result", async () => {
+        const firstReset: NonNullable<IWebXRControllerHapticActuator["reset"]> = vi.fn(async () => "complete");
+        const secondReset: NonNullable<IWebXRControllerHapticActuator["reset"]> = vi.fn(async () => "preempted");
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ reset: firstReset }), createActuator({ reset: secondReset })]), "left");
+
+        await expect(controller.resetHapticActuatorAsync(1)).resolves.toBe("preempted");
+        expect(firstReset).not.toHaveBeenCalled();
+        expect(secondReset).toHaveBeenCalledOnce();
+    });
+
+    it("rejects advanced playback when required capabilities are unavailable", async () => {
+        const playEffect: NonNullable<IWebXRControllerHapticActuator["playEffect"]> = vi.fn(async () => "complete");
+        const withoutDiscovery = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ playEffect })]), "right");
+        const withoutPlayback = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ effects: ["dual-rumble"] })]), "right");
+        const withoutRequestedEffect = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator({ effects: ["dual-rumble"], playEffect })]), "right");
+
+        await expect(withoutDiscovery.playHapticEffectAsync("dual-rumble")).rejects.toThrow("does not support effect discovery");
+        await expect(withoutPlayback.playHapticEffectAsync("dual-rumble")).rejects.toThrow("does not support advanced effect playback");
+        await expect(withoutRequestedEffect.playHapticEffectAsync("trigger-rumble")).rejects.toThrow('Haptic effect "trigger-rumble" is not supported');
+    });
+
+    it("rejects reset when the selected actuator does not expose it", async () => {
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator()]), "right");
+
+        await expect(controller.resetHapticActuatorAsync()).rejects.toThrow("does not support reset");
+    });
+
+    it("rejects invalid actuator indices deterministically", async () => {
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator()]), "right");
+
+        expect(() => controller.getHapticEffects(-1)).toThrow(RangeError);
+        expect(() => controller.getHapticEffects(0.5)).toThrow(RangeError);
+        await expect(controller.playHapticEffectAsync("dual-rumble", undefined, 1)).rejects.toThrow("Haptic actuator index 1 is out of range");
+        await expect(controller.resetHapticActuatorAsync(1)).rejects.toThrow("Haptic actuator index 1 is out of range");
+    });
+
+    it("propagates native play and reset rejections", async () => {
+        const playError = new Error("native play failure");
+        const resetError = new Error("native reset failure");
+        const controller = new WebXRGenericTriggerMotionController(
+            scene,
+            createGamepad([
+                createActuator({
+                    effects: ["dual-rumble"],
+                    playEffect: vi.fn(async () => {
+                        throw playError;
+                    }),
+                    reset: vi.fn(async () => {
+                        throw resetError;
+                    }),
+                }),
+            ]),
+            "right"
+        );
+
+        await expect(controller.playHapticEffectAsync("dual-rumble")).rejects.toBe(playError);
+        await expect(controller.resetHapticActuatorAsync()).rejects.toBe(resetError);
+    });
+
+    it("preserves legacy pulse behavior", async () => {
+        const pulse = vi.fn(async () => true);
+        const controller = new WebXRGenericTriggerMotionController(scene, createGamepad([createActuator(), createActuator({ pulse })]), "right");
+        const unsupportedController = new WebXRGenericTriggerMotionController(scene, createGamepad(), "right");
+
+        await expect(controller.pulse(0.7, 50, 1)).resolves.toBe(true);
+        expect(pulse).toHaveBeenCalledWith(0.7, 50);
+        await expect(controller.pulse(0.7, 50, 2)).resolves.toBe(false);
+        await expect(unsupportedController.pulse(0.7, 50)).resolves.toBe(false);
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- expose each XR controller haptic actuator's reported standard effects without claiming unreported capabilities
- add typed advanced effect playback and reset APIs using the standard Gamepad haptics effect, parameter, and result types
- preserve the existing `pulse()` API and its silent `false` behavior for unavailable actuators
- cover multiple actuators, dual/trigger rumble, unsupported capabilities, invalid indices, native rejections, reset, and legacy pulse behavior

## API

- `IWebXRControllerHapticActuator`
- `WebXRAbstractMotionController.getHapticEffects(hapticActuatorIndex?)`
- `WebXRAbstractMotionController.playHapticEffectAsync(effectType, parameters?, hapticActuatorIndex?)`
- `WebXRAbstractMotionController.resetHapticActuatorAsync(hapticActuatorIndex?)`

Advanced playback only delegates effects listed by the selected actuator. Missing advanced members and invalid indices reject with deterministic errors, while native promise results and rejections are propagated unchanged.

## Compatibility

This is additive. Existing `IMinimalMotionControllerObject` haptic actuator definitions remain compatible because `pulse` is unchanged and the new advanced members are optional. Existing `pulse()` runtime behavior is unchanged.

## Playground

https://playground.babylonjs.com/#ULVR1X#0

The Playground safely handles browsers without immersive VR or connected controllers, lists reported effects per controller actuator, and provides explicit short dual-rumble, trigger-rumble, and reset controls. The current public CDN does not yet contain these convenience methods, so advanced controls require a local branch build or a post-merge Babylon.js version.

## Validation

- `npx vitest run --project=unit packages/dev/core/test/unit/XR/webXRControllerHaptics.test.ts` — 10 passed
- `npx tsc -b packages/dev/core/tsconfig.build.json --pretty false`
- `npm run format:check`
- `npm run lint:check`
- `npm run test:treeshaking`
- `npm run test:unit` — 4,721 passed; three unrelated tests hit the shared 5-second timeout under full parallel load and passed together on immediate rerun (25/25)
