### PR TITLE
Add WebXR tracked sources support

### DIFF
--- a/packages/dev/core/src/XR/features/WebXRTrackedSources.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRTrackedSources.pure.ts
@@ -146,6 +146,11 @@ export class WebXRTrackedSources extends WebXRAbstractFeature {
                 this.onTrackedSourceAddedObservable.notifyObservers(trackedSource);
             }
         }
+
+        let index = 0;
+        for (const trackedSource of session.trackedSources) {
+            this._trackedSources[index++] = trackedSource;
+        }
     }
 
     private _clearTrackedSources(): void {

--- a/packages/dev/core/src/XR/features/WebXRTrackedSources.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRTrackedSources.pure.ts
@@ -1,0 +1,181 @@
+/** This file must only contain pure code and pure imports */
+
+import { Observable } from "../../Misc/observable.pure";
+import { WebXRFeatureName, WebXRFeaturesManager } from "../webXRFeaturesManager";
+import { type WebXRSessionManager } from "../webXRSessionManager";
+import { WebXRAbstractFeature } from "./WebXRAbstractFeature";
+
+interface IWebXRTrackedSourcesSession extends XRSession {
+    readonly trackedSources: XRInputSourceArray;
+}
+
+function IsTrackedSourcesSession(session: XRSession): session is IWebXRTrackedSourcesSession {
+    return "trackedSources" in session;
+}
+
+/**
+ * Exposes input sources that the XR runtime continues tracking while they are not active input sources.
+ *
+ * Tracked sources are intentionally kept separate from `XRSession.inputSources` and Babylon's normal
+ * WebXR input/controller pipeline.
+ * @see https://immersive-web.github.io/webxr/#dom-xrsession-trackedsources
+ * @see https://playground.babylonjs.com/#JRBQVL#0
+ */
+export class WebXRTrackedSources extends WebXRAbstractFeature {
+    private readonly _trackedSources: XRInputSource[] = [];
+    private _trackedSourcesSession: IWebXRTrackedSourcesSession | null = null;
+
+    /**
+     * The module's name.
+     */
+    public static readonly Name = WebXRFeatureName.TRACKED_SOURCES;
+
+    /**
+     * The Babylon version of this module.
+     *
+     * This number does not correspond to the WebXR specification version.
+     */
+    public static readonly Version = 1;
+
+    /**
+     * Notifies observers when a source enters the feature's current tracked source set.
+     */
+    public readonly onTrackedSourceAddedObservable: Observable<XRInputSource> = new Observable();
+
+    /**
+     * Notifies observers when a source leaves the feature's current tracked source set, including on detach.
+     */
+    public readonly onTrackedSourceRemovedObservable: Observable<XRInputSource> = new Observable();
+
+    /**
+     * Creates a WebXR tracked sources feature.
+     * @param _xrSessionManager The WebXR session manager.
+     */
+    constructor(_xrSessionManager: WebXRSessionManager) {
+        super(_xrSessionManager);
+        this.xrNativeFeatureName = "tracked-sources";
+    }
+
+    /**
+     * Gets a copy of the sources currently reported by `XRSession.trackedSources`.
+     *
+     * These sources are not added to `XRSession.inputSources` or Babylon's controller collection.
+     */
+    public get trackedSources(): ReadonlyArray<XRInputSource> {
+        return this._trackedSources.slice();
+    }
+
+    /**
+     * Attaches the feature to the active XR session.
+     * @param force Whether to reattach when the feature is already attached.
+     * @returns `true` when attachment succeeds; otherwise `false`.
+     */
+    public override attach(force?: boolean): boolean {
+        const session = this._xrSessionManager.session;
+        if (!session || !IsTrackedSourcesSession(session)) {
+            return this._disableAutoAttach("XRSession.trackedSources is not supported by this XR runtime.");
+        }
+
+        if (!super.attach(force)) {
+            return false;
+        }
+
+        this._trackedSourcesSession = session;
+        session.addEventListener("trackedsourceschange", this._onTrackedSourcesChanged);
+        this._synchronizeTrackedSources();
+        return true;
+    }
+
+    /**
+     * Detaches the feature and clears its tracked source state.
+     * @returns `true` when detachment succeeds; otherwise `false`.
+     */
+    public override detach(): boolean {
+        if (!super.detach()) {
+            return false;
+        }
+
+        this._trackedSourcesSession?.removeEventListener("trackedsourceschange", this._onTrackedSourcesChanged);
+        this._trackedSourcesSession = null;
+        this._clearTrackedSources();
+        return true;
+    }
+
+    /**
+     * Disposes the feature and clears its observables.
+     */
+    public override dispose(): void {
+        super.dispose();
+        this.onTrackedSourceAddedObservable.clear();
+        this.onTrackedSourceRemovedObservable.clear();
+    }
+
+    protected override _onXRFrame(): void {}
+
+    private _onTrackedSourcesChanged = (): void => {
+        this._synchronizeTrackedSources();
+    };
+
+    private _synchronizeTrackedSources(): void {
+        const session = this._trackedSourcesSession;
+        if (!this.attached || !session) {
+            return;
+        }
+
+        for (let index = 0; index < this._trackedSources.length;) {
+            const trackedSource = this._trackedSources[index];
+            let isStillTracked = false;
+            for (const nativeTrackedSource of session.trackedSources) {
+                if (nativeTrackedSource === trackedSource) {
+                    isStillTracked = true;
+                    break;
+                }
+            }
+
+            if (isStillTracked) {
+                index++;
+            } else {
+                this._trackedSources.splice(index, 1);
+                this.onTrackedSourceRemovedObservable.notifyObservers(trackedSource);
+            }
+        }
+
+        for (const trackedSource of session.trackedSources) {
+            if (this._trackedSources.indexOf(trackedSource) === -1) {
+                this._trackedSources.push(trackedSource);
+                this.onTrackedSourceAddedObservable.notifyObservers(trackedSource);
+            }
+        }
+    }
+
+    private _clearTrackedSources(): void {
+        while (this._trackedSources.length > 0) {
+            const trackedSource = this._trackedSources.shift();
+            if (trackedSource) {
+                this.onTrackedSourceRemovedObservable.notifyObservers(trackedSource);
+            }
+        }
+    }
+}
+
+let _Registered = false;
+
+/**
+ * Registers the WebXR tracked sources feature.
+ *
+ * Safe to call multiple times; only the first call has an effect.
+ */
+export function RegisterWebXRTrackedSources(): void {
+    if (_Registered) {
+        return;
+    }
+    _Registered = true;
+
+    WebXRFeaturesManager.AddWebXRFeature(
+        WebXRTrackedSources.Name,
+        (xrSessionManager) => {
+            return () => new WebXRTrackedSources(xrSessionManager);
+        },
+        WebXRTrackedSources.Version
+    );
+}

--- a/packages/dev/core/src/XR/features/WebXRTrackedSources.ts
+++ b/packages/dev/core/src/XR/features/WebXRTrackedSources.ts
@@ -1,0 +1,8 @@
+/**
+ * Re-exports the pure implementation and applies runtime side effects.
+ * Import WebXRTrackedSources.pure for tree-shakeable, side-effect-free usage.
+ */
+export * from "./WebXRTrackedSources.pure";
+
+import { RegisterWebXRTrackedSources } from "./WebXRTrackedSources.pure";
+RegisterWebXRTrackedSources();

--- a/packages/dev/core/src/XR/features/index.ts
+++ b/packages/dev/core/src/XR/features/index.ts
@@ -22,3 +22,4 @@ export * from "./WebXRDepthSensing";
 export * from "./WebXRSpaceWarp";
 export * from "./WebXRRawCameraAccess";
 export * from "./WebXRBodyTracking";
+export * from "./WebXRTrackedSources";

--- a/packages/dev/core/src/XR/features/pure.ts
+++ b/packages/dev/core/src/XR/features/pure.ts
@@ -23,4 +23,5 @@ export * from "./WebXRDepthSensing.pure";
 export * from "./WebXRSpaceWarp.pure";
 export * from "./WebXRRawCameraAccess.pure";
 export * from "./WebXRBodyTracking.pure";
+export * from "./WebXRTrackedSources.pure";
 export * from "./WebXRLayersFallback.pure";

--- a/packages/dev/core/src/XR/webXRFeaturesManager.ts
+++ b/packages/dev/core/src/XR/webXRFeaturesManager.ts
@@ -22,6 +22,7 @@ import { type IWebXRNearInteractionOptions, type WebXRNearInteraction } from "./
 import { type IWebXRPlaneDetectorOptions, type WebXRPlaneDetector } from "./features/WebXRPlaneDetector";
 import { type IWebXRRawCameraAccessOptions, type WebXRRawCameraAccess } from "./features/WebXRRawCameraAccess";
 import { type WebXRSpaceWarp } from "./features/WebXRSpaceWarp";
+import { type WebXRTrackedSources } from "./features/WebXRTrackedSources";
 import { type IWebXRWalkingLocomotionOptions, type WebXRWalkingLocomotion } from "./features/WebXRWalkingLocomotion";
 import { _ConsumeWebXRFeatureSpecificDisableWarning } from "./webXRFeatureWarningRegistry";
 import { type WebXRSessionManager } from "./webXRSessionManager";
@@ -190,6 +191,10 @@ export class WebXRFeatureName {
      * The name of the body tracking feature
      */
     public static readonly BODY_TRACKING = "xr-body-tracking" as const;
+    /**
+     * The name of the tracked sources feature
+     */
+    public static readonly TRACKED_SOURCES = "xr-tracked-sources" as const;
 }
 
 export type WebXRFeatureNameType = (typeof WebXRFeatureName)[Exclude<keyof typeof WebXRFeatureName, "prototype">];
@@ -242,6 +247,8 @@ export interface IWebXRFeatureNameTypeMap {
     [WebXRFeatureName.WALKING_LOCOMOTION]: WebXRWalkingLocomotion;
     /** Body tracking feature implementation. */
     [WebXRFeatureName.BODY_TRACKING]: WebXRBodyTracking;
+    /** Tracked sources feature implementation. */
+    [WebXRFeatureName.TRACKED_SOURCES]: WebXRTrackedSources;
 }
 
 /**
@@ -292,6 +299,8 @@ export interface IWebXRFeatureNameOptionsMap {
     [WebXRFeatureName.WALKING_LOCOMOTION]: IWebXRWalkingLocomotionOptions;
     /** Body tracking feature options. */
     [WebXRFeatureName.BODY_TRACKING]: IWebXRBodyTrackingOptions;
+    /** Tracked sources feature options. */
+    [WebXRFeatureName.TRACKED_SOURCES]: undefined;
 }
 
 /**

--- a/packages/dev/core/test/unit/XR/webXRTrackedSources.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRTrackedSources.test.ts
@@ -1,0 +1,218 @@
+/*
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Logger } from "core/Misc/logger";
+import { Scene } from "core/scene";
+import { WebXRTrackedSources, RegisterWebXRTrackedSources } from "core/XR/features/WebXRTrackedSources.pure";
+import { WebXRFeatureName, WebXRFeaturesManager } from "core/XR/webXRFeaturesManager";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MockXRInputSource implements XRInputSource {
+    public readonly targetRayMode = "tracked-pointer";
+    public readonly targetRaySpace!: XRSpace;
+
+    constructor(
+        public readonly handedness: XRInputSource["handedness"],
+        public readonly profiles: string[]
+    ) {}
+}
+
+class MockTrackedSourcesSession extends EventTarget {
+    public readonly enabledFeatures = ["tracked-sources"];
+    public readonly inputSources: XRInputSource[] = [];
+    public readonly trackedSources: XRInputSource[] = [];
+}
+
+class MockUnsupportedSession extends EventTarget {
+    public readonly enabledFeatures = ["tracked-sources"];
+    public readonly inputSources: XRInputSource[] = [];
+}
+
+describe("WebXRTrackedSources", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+    let session: MockTrackedSourcesSession;
+    let feature: WebXRTrackedSources;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+        Reflect.set(sessionManager, "_xrNavigator", { xr: { native: false } });
+        session = new MockTrackedSourcesSession();
+        Reflect.set(sessionManager, "session", session);
+        feature = new WebXRTrackedSources(sessionManager);
+    });
+
+    afterEach(() => {
+        if (!feature.isDisposed) {
+            feature.dispose();
+        }
+        scene.dispose();
+        engine.dispose();
+    });
+
+    it("requests the tracked-sources native feature through the features manager", async () => {
+        RegisterWebXRTrackedSources();
+        const featuresManager = new WebXRFeaturesManager(sessionManager);
+        const enabledFeature = featuresManager.enableFeature(WebXRFeatureName.TRACKED_SOURCES, 1, undefined, false);
+
+        const sessionInit = await featuresManager._extendXRSessionInitObject({});
+
+        expect(enabledFeature).toBeInstanceOf(WebXRTrackedSources);
+        expect(enabledFeature.xrNativeFeatureName).toBe("tracked-sources");
+        expect(sessionInit.requiredFeatures).toEqual(["tracked-sources"]);
+        featuresManager.dispose();
+    });
+
+    it("publishes the initial tracked sources in native order while preserving identity", () => {
+        const left = new MockXRInputSource("left", ["tracked-left"]);
+        const right = new MockXRInputSource("right", ["tracked-right"]);
+        session.trackedSources.push(left, right);
+        const added: XRInputSource[] = [];
+        feature.onTrackedSourceAddedObservable.add((source) => added.push(source));
+
+        expect(feature.attach()).toBe(true);
+
+        expect(feature.trackedSources).toEqual([left, right]);
+        expect(added).toEqual([left, right]);
+        expect(feature.trackedSources).not.toBe(feature.trackedSources);
+    });
+
+    it("reports deterministic removals and additions from trackedsourceschange", () => {
+        const first = new MockXRInputSource("left", ["first"]);
+        const second = new MockXRInputSource("right", ["second"]);
+        const third = new MockXRInputSource("none", ["third"]);
+        session.trackedSources.push(first, second);
+        feature.attach();
+        const added: XRInputSource[] = [];
+        const removed: XRInputSource[] = [];
+        feature.onTrackedSourceAddedObservable.add((source) => added.push(source));
+        feature.onTrackedSourceRemovedObservable.add((source) => removed.push(source));
+
+        session.trackedSources.splice(0, 2, second, third);
+        session.dispatchEvent(new Event("trackedsourceschange"));
+
+        expect(feature.trackedSources).toEqual([second, third]);
+        expect(removed).toEqual([first]);
+        expect(added).toEqual([third]);
+    });
+
+    it("does not poll or notify when events and XR frames leave the tracked source set unchanged", () => {
+        session.trackedSources.push(new MockXRInputSource("left", ["tracked"]));
+        feature.attach();
+        const added = vi.fn();
+        const removed = vi.fn();
+        feature.onTrackedSourceAddedObservable.add(added);
+        feature.onTrackedSourceRemovedObservable.add(removed);
+
+        session.dispatchEvent(new Event("trackedsourceschange"));
+        Reflect.set(sessionManager, "currentFrame", {});
+        sessionManager.onXRFrameObservable.notifyObservers(sessionManager.currentFrame!);
+
+        expect(added).not.toHaveBeenCalled();
+        expect(removed).not.toHaveBeenCalled();
+    });
+
+    it("cleans up native listeners and state on detach", () => {
+        const initial = new MockXRInputSource("left", ["initial"]);
+        const later = new MockXRInputSource("right", ["later"]);
+        session.trackedSources.push(initial);
+        feature.attach();
+        const added = vi.fn();
+        const removed: XRInputSource[] = [];
+        feature.onTrackedSourceAddedObservable.add(added);
+        feature.onTrackedSourceRemovedObservable.add((source) => removed.push(source));
+
+        expect(feature.detach()).toBe(true);
+        session.trackedSources.push(later);
+        session.dispatchEvent(new Event("trackedsourceschange"));
+
+        expect(feature.trackedSources).toEqual([]);
+        expect(removed).toEqual([initial]);
+        expect(added).not.toHaveBeenCalled();
+    });
+
+    it("reattaches to a new session without retaining sources or listeners from the old session", () => {
+        const oldSource = new MockXRInputSource("left", ["old"]);
+        const newSource = new MockXRInputSource("right", ["new"]);
+        session.trackedSources.push(oldSource);
+        feature.attach();
+        feature.detach();
+
+        const newSession = new MockTrackedSourcesSession();
+        newSession.trackedSources.push(newSource);
+        Reflect.set(sessionManager, "session", newSession);
+        expect(feature.attach()).toBe(true);
+
+        session.trackedSources.push(new MockXRInputSource("none", ["stale"]));
+        session.dispatchEvent(new Event("trackedsourceschange"));
+        expect(feature.trackedSources).toEqual([newSource]);
+    });
+
+    it("clears observables and native listeners on dispose", () => {
+        session.trackedSources.push(new MockXRInputSource("left", ["initial"]));
+        feature.attach();
+        const added = vi.fn();
+        feature.onTrackedSourceAddedObservable.add(added);
+
+        feature.dispose();
+        session.trackedSources.push(new MockXRInputSource("right", ["later"]));
+        session.dispatchEvent(new Event("trackedsourceschange"));
+
+        expect(feature.trackedSources).toEqual([]);
+        expect(feature.onTrackedSourceAddedObservable.hasObservers()).toBe(false);
+        expect(feature.onTrackedSourceRemovedObservable.hasObservers()).toBe(false);
+        expect(added).not.toHaveBeenCalled();
+    });
+
+    it("rejects attachment when XRSession.trackedSources is unavailable", () => {
+        Reflect.set(sessionManager, "session", new MockUnsupportedSession());
+        const warning = "XRSession.trackedSources is not supported by this XR runtime.";
+        const warnSpy = vi.spyOn(Logger, "Warn").mockImplementation(() => {});
+
+        expect(feature.attach()).toBe(false);
+
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(true);
+        expect(warnSpy).toHaveBeenCalledExactlyOnceWith(warning);
+        warnSpy.mockRestore();
+    });
+
+    it("does not attach when the session did not grant the tracked-sources feature", () => {
+        const trackedSource = new MockXRInputSource("left", ["tracked"]);
+        session.enabledFeatures.length = 0;
+        session.trackedSources.push(trackedSource);
+
+        expect(feature.attach()).toBe(false);
+        session.dispatchEvent(new Event("trackedsourceschange"));
+
+        expect(feature.attached).toBe(false);
+        expect(feature.disableAutoAttach).toBe(false);
+        expect(feature.trackedSources).toEqual([]);
+    });
+
+    it("does not add tracked sources to the active input source collection", () => {
+        const activeSource = new MockXRInputSource("left", ["active"]);
+        const trackedSource = new MockXRInputSource("right", ["tracked"]);
+        session.inputSources.push(activeSource);
+        session.trackedSources.push(trackedSource);
+
+        feature.attach();
+        session.dispatchEvent(new Event("trackedsourceschange"));
+
+        expect(session.inputSources).toEqual([activeSource]);
+        expect(session.inputSources).not.toContain(trackedSource);
+        expect(feature.trackedSources).toEqual([trackedSource]);
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRTrackedSources.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRTrackedSources.test.ts
@@ -124,6 +124,24 @@ describe("WebXRTrackedSources", () => {
         expect(removed).not.toHaveBeenCalled();
     });
 
+    it("updates native ordering without reporting additions or removals", () => {
+        const first = new MockXRInputSource("left", ["first"]);
+        const second = new MockXRInputSource("right", ["second"]);
+        session.trackedSources.push(first, second);
+        feature.attach();
+        const added = vi.fn();
+        const removed = vi.fn();
+        feature.onTrackedSourceAddedObservable.add(added);
+        feature.onTrackedSourceRemovedObservable.add(removed);
+
+        session.trackedSources.reverse();
+        session.dispatchEvent(new Event("trackedsourceschange"));
+
+        expect(feature.trackedSources).toEqual([second, first]);
+        expect(added).not.toHaveBeenCalled();
+        expect(removed).not.toHaveBeenCalled();
+    });
+
     it("cleans up native listeners and state on detach", () => {
         const initial = new MockXRInputSource("left", ["initial"]);
         const later = new MockXRInputSource("right", ["later"]);

--- a/packages/public/@babylonjs/core/package.json
+++ b/packages/public/@babylonjs/core/package.json
@@ -710,6 +710,7 @@
         "XR/features/WebXRPlaneDetector.js",
         "XR/features/WebXRRawCameraAccess.js",
         "XR/features/WebXRSpaceWarp.js",
+        "XR/features/WebXRTrackedSources.js",
         "XR/features/WebXRWalkingLocomotion.js",
         "XR/motionController/webXRGenericHandController.js",
         "XR/motionController/webXRHTCViveMotionController.js",

--- a/scripts/treeshaking/side-effects-manifest/core/XR.json
+++ b/scripts/treeshaking/side-effects-manifest/core/XR.json
@@ -24,6 +24,7 @@
         "XR/features/WebXRPlaneDetector.ts": ["top-level-call"],
         "XR/features/WebXRRawCameraAccess.ts": ["top-level-call"],
         "XR/features/WebXRSpaceWarp.ts": ["bare-import", "top-level-call"],
+        "XR/features/WebXRTrackedSources.ts": ["top-level-call"],
         "XR/features/WebXRWalkingLocomotion.ts": ["top-level-call"],
         "XR/motionController/webXRGenericHandController.ts": ["top-level-call"],
         "XR/motionController/webXRHTCViveMotionController.ts": ["top-level-call"],


### PR DESCRIPTION
## Summary

- add the managed `WebXRTrackedSources` feature and `WebXRFeatureName.TRACKED_SOURCES`
- request the native `tracked-sources` session feature and observe the specification's `trackedsourceschange` event
- expose copied read-only current state plus deterministic add/remove observables while preserving native `XRInputSource` identity
- keep tracked sources isolated from `XRSession.inputSources`, `WebXRInput`, and Babylon's controller pipeline
- use a feature-local structural session interface, avoiding a shared `webxr.d.ts` change

## Specification and browser status

The current [WebXR Device API editor's draft](https://immersive-web.github.io/webxr/#dom-xrsession-trackedsources) defines `XRSession.trackedSources`, the `trackedsourceschange` event, and the opt-in `tracked-sources` feature descriptor. The opt-in requirement was merged on March 16, 2026 in [immersive-web/webxr#1432](https://github.com/immersive-web/webxr/pull/1432), following the working-group decision tracked in [issue #1430](https://github.com/immersive-web/webxr/issues/1430).

Meta Quest Browser 34.1+ is the known shipping implementation. The Babylon feature still uses normal feature negotiation and runtime capability detection, so unsupported browsers do not attach the feature or alter active input behavior.

## Public API

- `WebXRFeatureName.TRACKED_SOURCES`
- `WebXRTrackedSources`
- `WebXRTrackedSources.trackedSources`
- `WebXRTrackedSources.onTrackedSourceAddedObservable`
- `WebXRTrackedSources.onTrackedSourceRemovedObservable`
- `RegisterWebXRTrackedSources()` for the side-effect-free import path

## Playground

https://playground.babylonjs.com/#JRBQVL#0

The public CDN currently serves Babylon.js 9.23.0 and does not yet contain this new API. The saved snippet detects that state and reports it on screen without throwing. Its saved payload was verified byte-for-byte, and the live Playground was validated against the current CDN; once this API ships, the same snippet enables it as optional and displays active `inputSources` separately from tracked sources.

## Validation

- `npx vitest run --project=unit packages/dev/core/test/unit/XR/webXRTrackedSources.test.ts` — 10 passed
- `npx tsc -b packages/dev/core/tsconfig.build.json --pretty false`
- `npm run format:check`
- `npm run lint:check`
- `npm run check:treeshaking`
- `npm run check:side-effects-sync`
- `npm run test:treeshaking`
- `npx vitest run --project=unit --maxWorkers=1 --testTimeout=30000` — 314 files passed; 4,725 tests passed, 1 expected failure, 30 skipped

The default parallel `npm run test:unit` completed 4,723 tests before the existing NME MCP environment-teardown race affected two `nmeParse.test.ts` cases. The complete serial run above passed.
