### PR TITLE
Harden build and release pipelines

### DIFF
--- a/.azure-pipelines/cd-publish.yml
+++ b/.azure-pipelines/cd-publish.yml
@@ -56,8 +56,8 @@ jobs:
                 git checkout $(Build.SourceBranchName)
             displayName: "prepare git"
 
-          - bash: npm install
-            displayName: "npm install"
+          - bash: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -150,7 +150,7 @@ jobs:
                 zip -r ../snapshot.zip *
                 cd ..
 
-                curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+                curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
                   -H "Content-Type: multipart/form-data" \
                   -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
                   -F "path=cdn/master/v$(PackageVersion)" \
@@ -177,7 +177,7 @@ jobs:
                 zip ../../../../fileSize.zip fileSizes.json
                 cd ../../../..
 
-                curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+                curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
                   -H "Content-Type: multipart/form-data" \
                   -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
                   -F "path=cdn/master/v$(PackageVersion)" \

--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -59,10 +59,11 @@ jobs:
                 version: "24.x"
 
           - task: Npm@1
-            displayName: "npm install"
+            displayName: "npm ci"
             retryCountOnTaskFailure: 2
             inputs:
-                command: install
+                command: custom
+                customCommand: "ci"
 
           # DISABLED in classic pipeline:
           # - task: Npm@1

--- a/.azure-pipelines/ci-browser-testing.yml
+++ b/.azure-pipelines/ci-browser-testing.yml
@@ -63,8 +63,8 @@ jobs:
             inputs:
                 version: "24.x"
 
-          - script: npm install
-            displayName: "NPM install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -89,7 +89,7 @@ jobs:
           # Only upload reports when the run failed. Path is stable so the
           # previous nightly's report is overwritten and the URL never changes.
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/webkitplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/webkitplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete previous nightly Webkit report"
             condition: failed()
             continueOnError: true
@@ -130,8 +130,8 @@ jobs:
             inputs:
                 version: "24.x"
 
-          - script: npm install
-            displayName: "NPM install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -156,7 +156,7 @@ jobs:
           # Only upload reports when the run failed. Path is stable so the
           # previous nightly's report is overwritten and the URL never changes.
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/firefoxplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/firefoxplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete previous nightly Firefox report"
             condition: failed()
             continueOnError: true
@@ -201,8 +201,8 @@ jobs:
             inputs:
                 version: "24.x"
 
-          - script: npm install
-            displayName: "NPM install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -223,7 +223,7 @@ jobs:
           # Only upload reports when the run failed. The path is stable so the
           # previous nightly's report is overwritten and the URL never changes.
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/webgl2playwright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/webgl2playwright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete previous nightly WebGL2 report"
             condition: failed()
             continueOnError: true
@@ -269,8 +269,8 @@ jobs:
             inputs:
                 version: "24.x"
 
-          - script: npm install
-            displayName: "NPM install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -292,7 +292,7 @@ jobs:
           # Only upload reports when the run failed. The path is stable so the
           # previous nightly's report is overwritten and the URL never changes.
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/webgpuplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/webgpuplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete previous nightly WebGPU report"
             condition: failed()
             continueOnError: true
@@ -344,9 +344,9 @@ jobs:
                 jdkSourceOption: PreInstalled
 
           - script: |
-                npm install
-                npm i google-closure-compiler
-            displayName: "NPM install"
+                npm ci
+                npm install --no-save --package-lock=false google-closure-compiler
+            displayName: "npm ci and install Closure Compiler"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -429,8 +429,8 @@ jobs:
             inputs:
                 version: "24.x"
 
-          - script: npm install
-            displayName: "NPM install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -466,7 +466,7 @@ jobs:
           # Upload reports only when the perf run failed. Path is stable so the
           # previous weekly's report is overwritten and the URL never changes.
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/perfplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(NightlyReportRoot)/perfplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete previous weekly perf report"
             condition: eq(variables['PerfTestsFailed'], 'true')
             continueOnError: true

--- a/.azure-pipelines/ci-graph-tools.yml
+++ b/.azure-pipelines/ci-graph-tools.yml
@@ -51,9 +51,10 @@ jobs:
                 version: "24.x"
 
           - task: Npm@1
-            displayName: "npm install"
+            displayName: "npm ci"
             inputs:
-                command: install
+                command: custom
+                customCommand: "ci"
 
           - task: Npm@1
             displayName: "npm build:dev"

--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -137,7 +137,7 @@ jobs:
                 snapshotPath: "$(BuildName)"
 
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Clear snapshot"
             condition: and(succeeded(), eq(variables['SNAPSHOTEXISTS'], 'true'), not(eq(variables['Build.SourceBranchName'], 'master')))
 
@@ -191,8 +191,8 @@ jobs:
                 nx: true
                 nxCacheKey: build
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -226,7 +226,6 @@ jobs:
 
           - task: Npm@1
             displayName: "Test es version of UMD packages"
-            continueOnError: true
             inputs:
                 command: custom
                 customCommand: "run test:escheck"
@@ -248,7 +247,7 @@ jobs:
                 zip -r ../snapshot.zip *
                 cd ..
 
-                curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+                curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
                   -H "Content-Type: multipart/form-data" \
                   -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
                   -F "path=$(BuildName)" \
@@ -324,8 +323,8 @@ jobs:
                 nx: true
                 nxCacheKey: es6
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -353,7 +352,7 @@ jobs:
                 BROWSERSTACK_ACCESS_KEY: $(BROWSERSTACK_ACCESS_KEY)
 
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/es6visplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/es6visplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete ES6 visualization test results"
             continueOnError: true
             condition: eq(variables['SNAPSHOTEXISTS'], 'true')
@@ -405,8 +404,8 @@ jobs:
                 nx: true
                 nxCacheKey: es6-tools
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -420,7 +419,6 @@ jobs:
           - bash: |
                 npx nx run-many --target=prepublishOnly --all
             displayName: "Make sure es6 packages are ready"
-            continueOnError: true
 
           - task: Npm@1
             displayName: "Test ES6 packages"
@@ -445,7 +443,7 @@ jobs:
                 zip ../../../../snapshot.zip fileSizes.json
                 cd ../../../..
 
-                curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+                curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
                   -H "Content-Type: multipart/form-data" \
                   -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
                   -F "path=$(BuildName)" \
@@ -472,8 +470,8 @@ jobs:
 
           - template: templates/cache-steps.yml
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
                 PUPPETEER_SKIP_DOWNLOAD: "true"
@@ -511,8 +509,8 @@ jobs:
 
           - template: templates/cache-steps.yml
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -563,10 +561,11 @@ jobs:
           - template: templates/cache-steps.yml
 
           - task: Npm@1
-            displayName: "npm install"
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             inputs:
-                command: install
+                command: custom
+                customCommand: "ci"
 
           - script: npm run test:unit
             displayName: "unit tests"
@@ -635,9 +634,9 @@ jobs:
                 playwright: true
 
           - script: |
-                npm install
+                npm ci
                 npx playwright install --with-deps
-            displayName: "npm install && playwright install"
+            displayName: "npm ci && playwright install"
             retryCountOnTaskFailure: 1
 
           - script: npm run test:interactions
@@ -650,7 +649,7 @@ jobs:
                 CI: "true"
 
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/interactionplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/interactionplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete test results"
             continueOnError: true
             condition: eq(variables['SNAPSHOTEXISTS'], 'true')
@@ -737,9 +736,9 @@ jobs:
                 path: $(KHR_ASSETS_CACHE)
 
           - script: |
-                npm install
+                npm ci
                 npx playwright install --with-deps chromium
-            displayName: "npm install && playwright install"
+            displayName: "npm ci && playwright install"
             retryCountOnTaskFailure: 1
 
           - script: node ./scripts/runKHRInteractivityAssetTests.mjs
@@ -802,8 +801,8 @@ jobs:
           - template: templates/cache-steps.yml
 
           - script: |
-                npm install
-            displayName: "npm install"
+                npm ci
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -828,7 +827,7 @@ jobs:
                 AFFECTED_TAGS: $(AFFECTED_TAGS)
 
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/webgl2playwright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/webgl2playwright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete test results"
             continueOnError: true
             condition: eq(variables['SNAPSHOTEXISTS'], 'true')
@@ -887,8 +886,8 @@ jobs:
           - template: templates/cache-steps.yml
 
           - script: |
-                npm install
-            displayName: "npm install"
+                npm ci
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -914,7 +913,7 @@ jobs:
                 AFFECTED_TAGS: $(AFFECTED_TAGS)
 
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/webgpuplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_DELETE)?path=$(BuildName)/testResults/webgpuplaywright" -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Delete test results"
             continueOnError: true
             condition: eq(variables['SNAPSHOTEXISTS'], 'true')
@@ -980,7 +979,8 @@ jobs:
             displayName: "Disable JIT Debugging for Script"
 
           - script: |
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_SNAPSHOT_CHECK)?buildNumber=$(BuildName)&fileTocheck=cdnSnapshot.zip" -o ./tmp.json -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_SNAPSHOT_CHECK)?buildNumber=$(BuildName)&fileTocheck=cdnSnapshot.zip" -o ./tmp.json -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                if errorlevel 1 exit /b %errorlevel%
                 findstr "true" .\tmp.json >nul 2>&1
                 if %errorlevel% equ 0 (
                    echo snapshot exists
@@ -988,7 +988,7 @@ jobs:
                     echo snapshot does not exist
                 )
 
-                curl "$(SNAPSHOT_CDN_URL)/$(BuildName)/cdnSnapshot.zip" -o snapshot.zip
+                curl --fail-with-body --silent --show-error "$(SNAPSHOT_CDN_URL)/$(BuildName)/cdnSnapshot.zip" -o snapshot.zip
                 if errorlevel 1 exit /b %errorlevel%
 
                 setlocal EnableDelayedExpansion
@@ -1083,8 +1083,8 @@ jobs:
 
           - template: templates/cache-steps.yml
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             env:
                 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
@@ -1192,10 +1192,11 @@ jobs:
                 playwright: true
 
           - task: Npm@1
-            displayName: "npm install"
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
             inputs:
-                command: install
+                command: custom
+                customCommand: "ci"
 
           - task: Npm@1
             displayName: "npm build"
@@ -1254,20 +1255,22 @@ jobs:
             displayName: "Prepare download directory"
 
           - script: |
-                curl "$(SNAPSHOT_CDN_URL)/$(BuildName)/cdnSnapshot.zip" -o snapshot.zip
+                set -euo pipefail
 
-                curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+                curl --fail-with-body --silent --show-error "$(SNAPSHOT_CDN_URL)/$(BuildName)/cdnSnapshot.zip" -o snapshot.zip
+
+                curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
                   -H "Content-Type: multipart/form-data" \
                   -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
                   -F "path=cdn/$(Build.SourceBranchName)" \
                   -F "storageAccount=$(SNAPSHOTS_STORAGE_ACCOUNT)" \
                   -F "zip=@snapshot.zip"
 
-                curl "$(SNAPSHOT_CDN_URL)/$(BuildName)/fileSizes.json" -o fileSizes.json
+                curl --fail-with-body --silent --show-error "$(SNAPSHOT_CDN_URL)/$(BuildName)/fileSizes.json" -o fileSizes.json
 
                 zip ./fileSize.zip fileSizes.json
 
-                curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+                curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
                   -H "Content-Type: multipart/form-data" \
                   -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
                   -F "path=cdn/$(Build.SourceBranchName)" \
@@ -1276,8 +1279,10 @@ jobs:
             displayName: "Update CDN"
 
           - script: |
-                # Async purge: don't block CI on the CDN purge completing.
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                set -euo pipefail
 
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_PREVIEW_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                # Async purge: don't block CI on the CDN purge completing.
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_PREVIEW_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Purge CDN"

--- a/.azure-pipelines/ci-playground-sandbox.yml
+++ b/.azure-pipelines/ci-playground-sandbox.yml
@@ -51,9 +51,10 @@ jobs:
                 version: "24.x"
 
           - task: Npm@1
-            displayName: "npm install"
+            displayName: "npm ci"
             inputs:
-                command: install
+                command: custom
+                customCommand: "ci"
 
           - template: templates/check-snapshot-exists.yml
             parameters:
@@ -151,9 +152,10 @@ jobs:
                 version: "24.x"
 
           - task: Npm@1
-            displayName: "npm install"
+            displayName: "npm ci"
             inputs:
-                command: install
+                command: custom
+                customCommand: "ci"
 
           - template: templates/check-snapshot-exists.yml
             parameters:

--- a/.azure-pipelines/templates/cache-steps.yml
+++ b/.azure-pipelines/templates/cache-steps.yml
@@ -2,7 +2,7 @@
 # Template: Pipeline caches (npm / Nx / Playwright)
 #
 # Emits Cache@2 restore+save steps. Insert this immediately BEFORE the job's
-# `npm install` step so the npm download cache is restored first, and (when
+# `npm ci` step so the npm download cache is restored first, and (when
 # enabled) the Nx computation cache is available for the later build target.
 #
 # Uses these pipeline-level cache path variables (see ci-monorepo.yml):

--- a/.azure-pipelines/templates/check-snapshot-exists.yml
+++ b/.azure-pipelines/templates/check-snapshot-exists.yml
@@ -17,7 +17,9 @@ parameters:
 
 steps:
     - script: |
-          curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_SNAPSHOT_CHECK)?buildNumber=${{ parameters.snapshotPath }}" -o ./tmp.json -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+          set -euo pipefail
+
+          curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_SNAPSHOT_CHECK)?buildNumber=${{ parameters.snapshotPath }}" -o ./tmp.json -H "Authorization: Bearer $(DEPLOY_TOKEN)"
           if grep "true" ./tmp.json
           then
              echo "##vso[task.setvariable variable=${{ parameters.variableName }}]true"

--- a/.azure-pipelines/templates/check-snapshot-exists.yml
+++ b/.azure-pipelines/templates/check-snapshot-exists.yml
@@ -19,7 +19,22 @@ steps:
     - script: |
           set -euo pipefail
 
-          curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_SNAPSHOT_CHECK)?buildNumber=${{ parameters.snapshotPath }}" -o ./tmp.json -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+          HTTP_STATUS=$(curl --silent --show-error \
+            --output ./tmp.json \
+            --write-out "%{http_code}" \
+            "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_SNAPSHOT_CHECK)?buildNumber=${{ parameters.snapshotPath }}" \
+            -H "Authorization: Bearer $(DEPLOY_TOKEN)")
+
+          if [ "$HTTP_STATUS" = "404" ]; then
+             echo "##vso[task.setvariable variable=${{ parameters.variableName }}]false"
+             exit 0
+          fi
+
+          if [ "$HTTP_STATUS" != "200" ]; then
+             echo "Snapshot check failed with HTTP status $HTTP_STATUS"
+             exit 1
+          fi
+
           if grep "true" ./tmp.json
           then
              echo "##vso[task.setvariable variable=${{ parameters.variableName }}]true"

--- a/.azure-pipelines/templates/deploy-tool.yml
+++ b/.azure-pipelines/templates/deploy-tool.yml
@@ -25,6 +25,8 @@ parameters:
 
 steps:
     - script: |
+          set -euo pipefail
+
           cd ${{ parameters.toolPackageDir }}/dist
           zip -r $(Build.SourcesDirectory)/_deploy_dist.zip *
           cd $(Build.SourcesDirectory)
@@ -33,14 +35,14 @@ steps:
           zip -r $(Build.SourcesDirectory)/_deploy_public.zip *
           cd $(Build.SourcesDirectory)
 
-          curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+          curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
             -H "Content-Type: multipart/form-data" \
             -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
             -F "path=${{ parameters.deployPath }}" \
             -F "storageAccount=${{ parameters.storageAccount }}" \
             -F "zip=@_deploy_dist.zip"
 
-          curl $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
+          curl --fail-with-body --silent --show-error $(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_UPLOAD) -i -X POST \
             -H "Content-Type: multipart/form-data" \
             -H "Authorization: Bearer $(DEPLOY_TOKEN)" \
             -F "path=${{ parameters.deployPath }}" \
@@ -55,5 +57,5 @@ steps:
                 # Async purge: don't wait for the CDN to finish purging.
                 # The deployment server has a much shorter timeout than Azure's
                 # purge operation, so blocking on it always times out in CI.
-                curl "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Purge CDN (${{ parameters.purgeEndpoint }})"

--- a/.azure-pipelines/templates/free-disk-space.yml
+++ b/.azure-pipelines/templates/free-disk-space.yml
@@ -14,7 +14,7 @@
 # image layout can never fail the job. Node itself
 # (/opt/hostedtoolcache/node, installed by UseNode@1) is deliberately kept.
 #
-# Include this immediately BEFORE the cache/restore + npm install steps.
+# Include this immediately BEFORE the cache/restore + npm ci steps.
 # =============================================================================
 
 steps:

--- a/.azure-pipelines/templates/memory-leak-job.yml
+++ b/.azure-pipelines/templates/memory-leak-job.yml
@@ -53,8 +53,8 @@ jobs:
 
           - template: cache-steps.yml
 
-          - script: npm install
-            displayName: "npm install"
+          - script: npm ci
+            displayName: "npm ci"
             retryCountOnTaskFailure: 1
 
           - script: npm run ${{ parameters.npmScript }} -- --no-fail-fast

--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,7 @@
         }
     },
     "affected": {
-        "defaultBase": "main"
+        "defaultBase": "master"
     },
     "analytics": false
 }

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "check:treeshaking": "node ./scripts/treeshaking/verifyTreeShaking.mjs --all-packages",
         "check:treeshaking-all": "npm run check:treeshaking && npm run check:side-effects-sync && npm run test:treeshaking",
         "catalog:static-helpers": "node ./scripts/treeshaking/catalogStaticHelpers.mjs",
-        "prepare": "npm run build:tools && node ./packages/dev/buildTools/dist/index.js -c pa --global && npm run build:test-tools && node scripts/setupGitHooks.mjs",
+        "prepare": "npm run build:tools && npm rebuild @dev/build-tools && npm run build:assets && npm run build:test-tools && node scripts/setupGitHooks.mjs",
         "clean": "npx nx run-many --outputStyle=static --target=clean --all --exclude=@babylonjs/root && npm run build:tools",
         "format": "npm run format:check && npm run format:fix",
         "format:check": "prettier --check \"packages/**/src/**/*.{ts,tsx,js,json,scss,css}\"",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "check:treeshaking": "node ./scripts/treeshaking/verifyTreeShaking.mjs --all-packages",
         "check:treeshaking-all": "npm run check:treeshaking && npm run check:side-effects-sync && npm run test:treeshaking",
         "catalog:static-helpers": "node ./scripts/treeshaking/catalogStaticHelpers.mjs",
-        "prepare": "npm run build:tools && npm i @dev/build-tools -D && npm run build:assets && npm run build:test-tools && node scripts/setupGitHooks.mjs",
+        "prepare": "npm run build:tools && node ./packages/dev/buildTools/dist/index.js -c pa --global && npm run build:test-tools && node scripts/setupGitHooks.mjs",
         "clean": "npx nx run-many --outputStyle=static --target=clean --all --exclude=@babylonjs/root && npm run build:tools",
         "format": "npm run format:check && npm run format:fix",
         "format:check": "prettier --check \"packages/**/src/**/*.{ts,tsx,js,json,scss,css}\"",

--- a/packages/public/umd/babylonjs-gui/package.json
+++ b/packages/public/umd/babylonjs-gui/package.json
@@ -7,7 +7,7 @@
         "*"
     ],
     "scripts": {
-        "build": "npm run clean & npm run build:prod && npm run build:declaration",
+        "build": "npm run clean && npm run build:prod && npm run build:declaration",
         "build:dev": "rollup -c rollup.config.umd.mjs",
         "build:dev:fast": "rollup -c rollup.config.umd.mjs --environment ROLLUP_DEVMODE:true",
         "build:prod": "rollup -c rollup.config.umd.mjs --environment ROLLUP_MODE:production",

--- a/scripts/updateVersion.js
+++ b/scripts/updateVersion.js
@@ -31,25 +31,23 @@ const updateCdnVersion = (version) => {
     const toolsData = fs.readFileSync(toolsFile, "utf-8");
     const newToolsData = toolsData.replace(/static _CdnVersion = "(.*)"/, `static _CdnVersion = "${version}"`);
     if (newToolsData === toolsData) {
-        console.warn("Warning: Could not find Tools._CdnVersion to update");
-    } else {
-        fs.writeFileSync(toolsFile, newToolsData);
-        console.log(`Updated Tools._CdnVersion to "${version}"`);
+        throw new Error("Could not find Tools._CdnVersion to update");
     }
+    fs.writeFileSync(toolsFile, newToolsData);
+    console.log(`Updated Tools._CdnVersion to "${version}"`);
 
     // Update Transcoder.CdnVersion in ktx2Decoder so CDN URLs are versioned at runtime
     const transcoderFile = path.join(baseDirectory, "packages", "tools", "ktx2Decoder", "src", "transcoder.ts");
     const transcoderData = fs.readFileSync(transcoderFile, "utf-8");
     const newTranscoderData = transcoderData.replace(/static CdnVersion = "(.*)"/, `static CdnVersion = "${version}"`);
     if (newTranscoderData === transcoderData) {
-        console.warn("Warning: Could not find Transcoder.CdnVersion to update");
-    } else {
-        fs.writeFileSync(transcoderFile, newTranscoderData);
-        console.log(`Updated Transcoder.CdnVersion to "${version}"`);
+        throw new Error("Could not find Transcoder.CdnVersion to update");
     }
+    fs.writeFileSync(transcoderFile, newTranscoderData);
+    console.log(`Updated Transcoder.CdnVersion to "${version}"`);
 };
 
-const updateSinceTag = (version) => {
+const updateSinceTag = async (version) => {
     // get all typescript files in the dev folder
     const files = glob.globSync(path.join(baseDirectory, "packages", "dev", "**", "*.ts").replace(/\\/g, "/"));
     files.forEach((file) => {
@@ -69,11 +67,11 @@ const updateSinceTag = (version) => {
                 fs.writeFileSync(file, newData);
             }
         } catch (e) {
-            console.log("updateSinceTag error", e);
+            throw new Error(`Could not update @since tags in ${file}`, { cause: e });
         }
     });
     // run formatter to make sure the package.json files are formatted
-    runCommand("npx prettier --write packages/public/**/package.json");
+    await runCommand("npx prettier --write packages/public/**/package.json");
 };
 
 // Babylon-scoped packages that are versioned independently from the monorepo and must NOT be bumped
@@ -137,7 +135,7 @@ const updatePeerDependencies = (version) => {
                 fs.writeFileSync(file, JSON.stringify(packageJson, null, 4));
             }
         } catch (e) {
-            console.log("updatePeerDependencies error", e);
+            throw new Error(`Could not update peer dependencies in ${file}`, { cause: e });
         }
     });
 };
@@ -168,7 +166,7 @@ const updatePackages = (version) => {
             // write file
             fs.writeFileSync(file, JSON.stringify(packageJson, null, 4));
         } catch (e) {
-            console.log("updatePackages error", e);
+            throw new Error(`Could not update package metadata in ${file}`, { cause: e });
         }
     });
 };
@@ -207,7 +205,7 @@ async function main() {
         console.log("Release notes written to .build/release-notes.md");
     }
     // update since tags
-    updateSinceTag(version);
+    await updateSinceTag(version);
     // if major, update peer dependencies
     if (config.versionDefinition === "major") {
         updatePeerDependencies(`^${version}`);
@@ -217,5 +215,8 @@ if (!branchName) {
     console.log("Please provide a branch name");
     process.exit(1);
 } else {
-    main();
+    main().catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });
 }


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Hardens Babylon.js build, CI, and release infrastructure so failures are surfaced immediately and dependency restoration is reproducible.

- uses `npm ci` for pipeline dependency restoration while preserving the intentional release lockfile update
- invokes the freshly built local build-tools CLI directly during the root `prepare` lifecycle
- makes deployment, snapshot, and purge requests fail on HTTP errors
- makes UMD ES compatibility and package prepublish validation blocking
- aborts release version updates on partial package/CDN updates and awaits formatting
- fixes the UMD GUI clean/build race and sets Nx's default base to `master`

## Motivation

Several pipeline paths could report success after failed HTTP deployments, silently continue after partial version updates, or repair lockfile drift during CI. The GUI UMD build could also race cleanup against Rollup, and default Nx affected commands targeted the repository's nonexistent `main` branch.

## Validation

- clean `npm ci`
- targeted `babylonjs-gui` UMD build and ES compatibility check
- repository lint, tree-shaking, and side-effect synchronization checks
- YAML, JavaScript, JSON, and formatting validation
- Nx affected-project resolution against `master`

The reviewed fork-PR secret workflow is intentionally unchanged.