### PR TITLE
Add WebXR composition layer controls and limits

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -438,6 +438,7 @@ interface XRSession extends EventTarget {
     readonly visibilityState: XRVisibilityState;
     readonly frameRate?: number | undefined;
     readonly supportedFrameRates?: Float32Array | undefined;
+    readonly maxRenderLayers?: number | undefined;
 
     /**
      * Removes a callback from the animation frame painting callback from
@@ -814,8 +815,11 @@ interface XRCompositionLayer extends XRLayer {
     readonly layout: XRLayerLayout;
     blendTextureSourceAlpha: boolean;
     chromaticAberrationCorrection?: boolean | undefined;
+    forceMonoPresentation?: boolean | undefined;
+    opacity?: number | undefined;
     readonly mipLevels: number;
     readonly needsRedraw: boolean;
+    quality?: XRLayerQuality | undefined;
     destroy(): void;
 
     space: XRSpace;
@@ -841,6 +845,8 @@ type XRTextureType = "texture" | "texture-array";
 
 type XRLayerLayout = "default" | "mono" | "stereo" | "stereo-left-right" | "stereo-top-bottom";
 
+type XRLayerQuality = "default" | "text-optimized" | "graphics-optimized";
+
 interface XRProjectionLayerInit {
     scaleFactor?: number | undefined;
     textureType?: XRTextureType | undefined;
@@ -854,7 +860,7 @@ interface XRProjectionLayer extends XRCompositionLayer {
     readonly textureHeight: number;
     readonly textureArrayLength: number;
     readonly ignoreDepthValues: number;
-    fixedFoveation: number;
+    fixedFoveation?: number | null | undefined;
 }
 
 declare abstract class XRProjectionLayer implements XRProjectionLayer {}

--- a/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
+++ b/packages/dev/core/src/XR/features/Layers/WebXRCompositionLayer.ts
@@ -20,6 +20,7 @@ export type { WebXRSpatialLayerType } from "core/XR/webXRLayerWrapper";
 /**
  * Wraps an XR composition layer and creates its Babylon render target provider.
  * @typeParam LayerT the concrete WebXR composition layer type
+ * @see https://playground.babylonjs.com/#TODARD#0
  */
 export class WebXRCompositionLayerWrapper<
     LayerT extends XRCompositionLayer = XRCompositionLayer,
@@ -34,6 +35,89 @@ export class WebXRCompositionLayerWrapper<
      * Whether Babylon should acquire subimages and expose render target textures for this layer.
      */
     public readonly usesRenderTargetProvider: boolean = true;
+
+    /**
+     * Whether the native layer exposes compositor opacity control.
+     */
+    public get isOpacitySupported(): boolean {
+        return "opacity" in this.layer;
+    }
+
+    /**
+     * Gets the compositor opacity applied to this layer.
+     * @returns The native opacity in the range 0 to 1.
+     * @throws If opacity is not supported by the active XR runtime.
+     */
+    public get opacity(): number {
+        this._assertControlSupported("opacity");
+        return this.layer.opacity!;
+    }
+
+    /**
+     * Sets the compositor opacity applied to this layer.
+     * The native runtime clamps the value to the range 0 to 1.
+     * @param value The desired opacity.
+     * @throws If opacity is not supported by the active XR runtime.
+     */
+    public set opacity(value: number) {
+        this._assertControlSupported("opacity");
+        this.layer.opacity = value;
+    }
+
+    /**
+     * Whether the native layer exposes compositor quality hints.
+     */
+    public get isQualitySupported(): boolean {
+        return "quality" in this.layer;
+    }
+
+    /**
+     * Gets the compositor quality hint applied to this layer.
+     * @returns The current native layer quality hint.
+     * @throws If quality hints are not supported by the active XR runtime.
+     */
+    public get quality(): XRLayerQuality {
+        this._assertControlSupported("quality");
+        return this.layer.quality!;
+    }
+
+    /**
+     * Sets the compositor quality hint applied to this layer.
+     * @param value The desired quality hint.
+     * @throws If quality hints are not supported by the active XR runtime, or the native runtime rejects the value.
+     */
+    public set quality(value: XRLayerQuality) {
+        this._assertControlSupported("quality");
+        this.layer.quality = value;
+    }
+
+    /**
+     * Whether the native layer exposes mono-presentation control.
+     */
+    public get isForceMonoPresentationSupported(): boolean {
+        return "forceMonoPresentation" in this.layer;
+    }
+
+    /**
+     * Gets whether the compositor presents the left-eye layer configuration to both eyes.
+     * @returns Whether mono presentation is forced.
+     * @throws If mono presentation control is not supported by the active XR runtime.
+     */
+    public get forceMonoPresentation(): boolean {
+        this._assertControlSupported("forceMonoPresentation");
+        return this.layer.forceMonoPresentation!;
+    }
+
+    /**
+     * Sets whether the compositor presents the left-eye layer configuration to both eyes.
+     * Applications should continue rendering both eyes when this is enabled.
+     * @param value Whether to force mono presentation.
+     * @throws If mono presentation control is not supported by the active XR runtime.
+     */
+    public set forceMonoPresentation(value: boolean) {
+        this._assertControlSupported("forceMonoPresentation");
+        this.layer.forceMonoPresentation = value;
+    }
 
     constructor(
         public override getWidth: () => number,
@@ -53,6 +137,12 @@ export class WebXRCompositionLayerWrapper<
         public readonly isStatic = false
     ) {
         super(getWidth, getHeight, layer, layerType, createRTTProvider);
+    }
+
+    private _assertControlSupported(control: "opacity" | "quality" | "forceMonoPresentation"): void {
+        if (!(control in this.layer)) {
+            throw new Error(`XRCompositionLayer.${control} is not supported by this XR runtime.`);
+        }
     }
 
     /**

--- a/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
+++ b/packages/dev/core/src/XR/features/WebXRLayers.pure.ts
@@ -200,6 +200,24 @@ export class WebXRLayers extends WebXRAbstractFeature {
     }
 
     /**
+     * Whether the active XR session exposes its compositor layer limit.
+     */
+    public get isMaxRenderLayersSupported(): boolean {
+        return this.maxRenderLayers !== null;
+    }
+
+    /**
+     * Gets the maximum number of native layers accepted in the active session's render-state `layers` array.
+     * The projection layer counts toward this limit. Fallback mesh layers do not.
+     * @returns The native layer limit, or `null` when the runtime does not expose it.
+     * @see https://playground.babylonjs.com/#TODARD#0
+     */
+    public get maxRenderLayers(): Nullable<number> {
+        const maxRenderLayers = this._xrSessionManager.session?.maxRenderLayers;
+        return typeof maxRenderLayers === "number" ? maxRenderLayers : null;
+    }
+
+    /**
      * Attach this feature.
      * Will usually be called by the features manager.
      *
@@ -403,6 +421,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
             return null;
         }
 
+        this._validateLayerCount(this._existingLayers.length + 1);
         const dimensions = this._getProjectionLayerDimensions();
         const defaultViewPixelWidth = layerType === "XRCubeLayer" ? Math.min(dimensions.width, dimensions.height) : dimensions.width;
         const defaultViewPixelHeight = layerType === "XRCubeLayer" ? defaultViewPixelWidth : dimensions.height;
@@ -531,6 +550,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
             return null;
         }
 
+        this._validateLayerCount(this._existingLayers.length + 1);
         const populatedParams = {
             space: this._xrSessionManager.referenceSpace,
             layout: "mono",
@@ -561,6 +581,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
     public createProjectionLayer(params = DefaultXRProjectionLayerInit, multiview = this._isMultiviewEnabled): WebXRProjectionLayerWrapper {
         const extendedParams = this._extendXRLayerInit(params, multiview);
         this._validateLayerInit(extendedParams, multiview);
+        this._validateLayerCount(this._existingLayers.length + 1);
 
         const projLayer = this._xrWebGLBinding.createProjectionLayer(extendedParams);
         const layer = new WebXRProjectionLayerWrapper(projLayer, multiview, this._xrWebGLBinding);
@@ -577,6 +598,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
         if (!this._xrSessionManager.inXRSession) {
             throw new Error("Cannot create a layer outside of a WebXR session. Make sure the session has started before creating layers.");
         }
+        this._validateLayerCount(this._existingLayers.length + 1);
         const binding = this._xrGPUBinding!;
         const init = CreateDefaultXRGPUProjectionLayerInit(binding.getPreferredColorFormat());
         const projLayer = binding.createProjectionLayer(init);
@@ -995,6 +1017,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * @param wrappedLayer the new layer to add to the existing ones
      */
     public addXRSessionLayer(wrappedLayer: WebXRLayerWrapper<WebXRSupportedLayerType>) {
+        this._validateLayerCount(this._existingLayers.length + 1);
         this._existingLayers.push(wrappedLayer);
         this.setXRSessionLayers(this._existingLayers);
     }
@@ -1059,6 +1082,7 @@ export class WebXRLayers extends WebXRAbstractFeature {
      * @param wrappedLayers An array of WebXRLayerWrapper, usually returned from the WebXRLayers createLayer functions.
      */
     public setXRSessionLayers(wrappedLayers: Array<WebXRLayerWrapper<WebXRSupportedLayerType>> = this._existingLayers): void {
+        this._validateLayerCount(wrappedLayers.length);
         // this._existingLayers = wrappedLayers;
         const renderStateInit: XRRenderStateInit = { ...this._xrSessionManager.session.renderState };
         // Clear out the layer-related fields.
@@ -1067,6 +1091,14 @@ export class WebXRLayers extends WebXRAbstractFeature {
         this._xrSessionManager.updateRenderState(renderStateInit);
         if (!this._projectionLayerInitialized) {
             this._xrSessionManager._setBaseLayerWrapper(wrappedLayers.length > 0 ? (wrappedLayers.at(0)! as WebXRLayerWrapper) : null);
+        }
+    }
+
+    private _validateLayerCount(layerCount: number): void {
+        const maxRenderLayers = this.maxRenderLayers;
+        if (maxRenderLayers !== null && layerCount > maxRenderLayers) {
+            const layerLabel = maxRenderLayers === 1 ? "layer" : "layers";
+            throw new Error(`The XR session supports at most ${maxRenderLayers} render ${layerLabel}, but ${layerCount} were provided.`);
         }
     }
 

--- a/packages/dev/core/src/XR/webXRLayerWrapper.ts
+++ b/packages/dev/core/src/XR/webXRLayerWrapper.ts
@@ -33,31 +33,34 @@ export class WebXRLayerWrapper<LayerTypeT extends WebXRSupportedLayerType = WebX
         return this._rttWrapper;
     }
     /**
-     * Check if fixed foveation is supported on this device
+     * Check if fixed foveation is supported by the wrapped XRWebGLLayer or XRProjectionLayer.
      */
     public get isFixedFoveationSupported(): boolean {
-        return this.layerType == "XRWebGLLayer" && typeof (this.layer as XRWebGLLayer).fixedFoveation == "number";
+        const isFoveationLayer = this.layerType === "XRWebGLLayer" || this.layerType === "XRProjectionLayer";
+        return isFoveationLayer && typeof (this.layer as XRWebGLLayer | XRProjectionLayer).fixedFoveation === "number";
     }
 
     /**
-     * Get the fixed foveation currently set, as specified by the webxr specs
-     * If this returns null, then fixed foveation is not supported
+     * Gets the fixed foveation currently set, as specified by the WebXR specs.
+     * @returns The fixed foveation level, or `null` when fixed foveation is not supported.
      */
     public get fixedFoveation(): Nullable<number> {
         if (this.isFixedFoveationSupported) {
-            return (this.layer as XRWebGLLayer).fixedFoveation!;
+            return (this.layer as XRWebGLLayer | XRProjectionLayer).fixedFoveation ?? null;
         }
         return null;
     }
 
     /**
-     * Set the fixed foveation to the specified value, as specified by the webxr specs
-     * This value will be normalized to be between 0 and 1, 1 being max foveation, 0 being no foveation
+     * Sets the fixed foveation level, as specified by the WebXR specs.
+     * The value is normalized between 0 and 1, where 1 is maximum foveation and 0 is no foveation.
+     * Unsupported native layers ignore the assignment, matching the WebXR fixed-foveation contract.
+     * @param value The fixed foveation level, or `null` to use no foveation.
      */
     public set fixedFoveation(value: Nullable<number>) {
         if (this.isFixedFoveationSupported) {
             const val = Math.max(0, Math.min(1, value || 0));
-            (this.layer as XRWebGLLayer).fixedFoveation = val;
+            (this.layer as XRWebGLLayer | XRProjectionLayer).fixedFoveation = val;
         }
     }
 

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -556,7 +556,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
      * If this returns null, then fixed foveation is not supported
      */
     public get fixedFoveation(): Nullable<number> {
-        return this._baseLayerWrapper?.fixedFoveation || null;
+        return this._baseLayerWrapper?.fixedFoveation ?? null;
     }
 
     /**

--- a/packages/dev/core/test/unit/XR/webXRLayerControls.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayerControls.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { WebXRCompositionLayerWrapper } from "core/XR/features/Layers/WebXRCompositionLayer";
+import { WebXRProjectionLayerWrapper } from "core/XR/features/Layers/WebXRProjectionLayer";
+import { WebXRWebGPUCompositionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUCompositionLayer";
+import { WebXRWebGPUProjectionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUProjectionLayer";
+import { WebXRWebGLLayerWrapper } from "core/XR/webXRWebGLLayer";
+import { describe, expect, it, vi } from "vitest";
+
+type CompositionLayer = ConstructorParameters<typeof WebXRCompositionLayerWrapper>[2];
+type ProjectionLayer = ConstructorParameters<typeof WebXRProjectionLayerWrapper>[0];
+type GPUBinding = ConstructorParameters<typeof WebXRWebGPUProjectionLayerWrapper>[2];
+type LayerQuality = NonNullable<CompositionLayer["quality"]>;
+
+const unusedProvider = () => {
+    throw new Error("The render target provider is not used by these tests.");
+};
+
+function createCompositionWrapper(layer: CompositionLayer): WebXRCompositionLayerWrapper {
+    return new WebXRCompositionLayerWrapper(
+        () => 1,
+        () => 1,
+        layer,
+        "XRQuadLayer",
+        false,
+        unusedProvider
+    );
+}
+
+function createWebGPUCompositionWrapper(layer: CompositionLayer): WebXRWebGPUCompositionLayerWrapper {
+    return new WebXRWebGPUCompositionLayerWrapper(
+        () => 1,
+        () => 1,
+        layer,
+        "XRQuadLayer",
+        false,
+        unusedProvider
+    );
+}
+
+function createProjectionLayer(fixedFoveation: number | null): ProjectionLayer {
+    return {
+        fixedFoveation,
+        textureHeight: 512,
+        textureWidth: 1024,
+    } as ProjectionLayer;
+}
+
+describe("WebXR composition layer controls", () => {
+    it.each([
+        ["WebGL", createCompositionWrapper],
+        ["WebGPU", createWebGPUCompositionWrapper],
+    ])("exposes supported controls through the %s wrapper", (_backend, createWrapper) => {
+        const layer = {
+            forceMonoPresentation: false,
+            opacity: 0.75,
+            quality: "default",
+        } as CompositionLayer;
+        const wrapper = createWrapper(layer);
+
+        expect(wrapper.isOpacitySupported).toBe(true);
+        expect(wrapper.opacity).toBe(0.75);
+        wrapper.opacity = 0.5;
+        expect(layer.opacity).toBe(0.5);
+
+        expect(wrapper.isQualitySupported).toBe(true);
+        expect(wrapper.quality).toBe("default");
+        wrapper.quality = "text-optimized";
+        expect(layer.quality).toBe("text-optimized");
+
+        expect(wrapper.isForceMonoPresentationSupported).toBe(true);
+        expect(wrapper.forceMonoPresentation).toBe(false);
+        wrapper.forceMonoPresentation = true;
+        expect(layer.forceMonoPresentation).toBe(true);
+    });
+
+    it("detects every unsupported control independently and rejects unsupported access", () => {
+        const unsupportedWrapper = createCompositionWrapper({} as CompositionLayer);
+        const opacityOnlyLayer = { opacity: 1 } as CompositionLayer;
+        const wrapper = createCompositionWrapper(opacityOnlyLayer);
+
+        expect(unsupportedWrapper.isOpacitySupported).toBe(false);
+        expect(() => unsupportedWrapper.opacity).toThrow("XRCompositionLayer.opacity is not supported by this XR runtime.");
+        expect(() => {
+            unsupportedWrapper.opacity = 0.5;
+        }).toThrow("XRCompositionLayer.opacity is not supported by this XR runtime.");
+        expect(wrapper.isOpacitySupported).toBe(true);
+        expect(wrapper.isQualitySupported).toBe(false);
+        expect(wrapper.isForceMonoPresentationSupported).toBe(false);
+        expect(() => wrapper.quality).toThrow("XRCompositionLayer.quality is not supported by this XR runtime.");
+        expect(() => {
+            wrapper.quality = "graphics-optimized";
+        }).toThrow("XRCompositionLayer.quality is not supported by this XR runtime.");
+        expect(() => wrapper.forceMonoPresentation).toThrow("XRCompositionLayer.forceMonoPresentation is not supported by this XR runtime.");
+        expect(() => {
+            wrapper.forceMonoPresentation = true;
+        }).toThrow("XRCompositionLayer.forceMonoPresentation is not supported by this XR runtime.");
+    });
+
+    it("forwards native getters, values, and setter errors without replacing native validation", () => {
+        const nativeError = new TypeError("native quality rejection");
+        const getOpacity = vi.fn(() => 0.25);
+        const setOpacity = vi.fn();
+        const getQuality = vi.fn((): LayerQuality => "default");
+        const setQuality = vi.fn(() => {
+            throw nativeError;
+        });
+        const getForceMonoPresentation = vi.fn(() => false);
+        const setForceMonoPresentation = vi.fn();
+        const layer = Object.defineProperties(
+            {},
+            {
+                opacity: { configurable: true, get: getOpacity, set: setOpacity },
+                quality: { configurable: true, get: getQuality, set: setQuality },
+                forceMonoPresentation: { configurable: true, get: getForceMonoPresentation, set: setForceMonoPresentation },
+            }
+        ) as CompositionLayer;
+        const wrapper = createCompositionWrapper(layer);
+
+        expect(wrapper.opacity).toBe(0.25);
+        wrapper.opacity = 2;
+        expect(getOpacity).toHaveBeenCalledOnce();
+        expect(setOpacity).toHaveBeenCalledExactlyOnceWith(2);
+
+        expect(wrapper.quality).toBe("default");
+        expect(() => {
+            wrapper.quality = "text-optimized";
+        }).toThrow(nativeError);
+        expect(getQuality).toHaveBeenCalledOnce();
+        expect(setQuality).toHaveBeenCalledExactlyOnceWith("text-optimized");
+
+        expect(wrapper.forceMonoPresentation).toBe(false);
+        wrapper.forceMonoPresentation = true;
+        expect(getForceMonoPresentation).toHaveBeenCalledOnce();
+        expect(setForceMonoPresentation).toHaveBeenCalledExactlyOnceWith(true);
+    });
+});
+
+describe("WebXR projection layer fixed foveation", () => {
+    it("preserves XRWebGLLayer fixed-foveation behavior", () => {
+        const layer = {
+            fixedFoveation: 0.25,
+            framebufferHeight: 512,
+            framebufferWidth: 1024,
+        } as XRWebGLLayer;
+        const wrapper = new WebXRWebGLLayerWrapper(layer);
+
+        expect(wrapper.isFixedFoveationSupported).toBe(true);
+        expect(wrapper.fixedFoveation).toBe(0.25);
+        wrapper.fixedFoveation = 2;
+        expect(layer.fixedFoveation).toBe(1);
+    });
+
+    it.each(["WebGL", "WebGPU"])("supports fixed foveation on %s projection wrappers", (backend) => {
+        const layer = createProjectionLayer(0.25);
+        const wrapper =
+            backend === "WebGL" ? new WebXRProjectionLayerWrapper(layer, false, {} as XRWebGLBinding) : new WebXRWebGPUProjectionLayerWrapper(layer, false, {} as GPUBinding);
+
+        expect(wrapper.isFixedFoveationSupported).toBe(true);
+        expect(wrapper.fixedFoveation).toBe(0.25);
+        wrapper.fixedFoveation = -1;
+        expect(layer.fixedFoveation).toBe(0);
+    });
+
+    it("reports nullable native projection foveation as unsupported and preserves the native no-op", () => {
+        const layer = createProjectionLayer(null);
+        const wrapper = new WebXRProjectionLayerWrapper(layer, false, {} as XRWebGLBinding);
+
+        expect(wrapper.isFixedFoveationSupported).toBe(false);
+        expect(wrapper.fixedFoveation).toBeNull();
+        wrapper.fixedFoveation = 0.5;
+        expect(layer.fixedFoveation).toBeNull();
+    });
+});

--- a/packages/dev/core/test/unit/XR/webXRLayers.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRLayers.test.ts
@@ -15,6 +15,7 @@ import {
     WebXRMediaLayerWrapper,
     WebXRSpatialLayerWrapper,
 } from "core/XR/features/Layers/WebXRCompositionLayer";
+import { WebXRProjectionLayerWrapper } from "core/XR/features/Layers/WebXRProjectionLayer";
 import { WebXRFallbackLayerWrapper } from "core/XR/features/WebXRLayersFallback";
 import { WebXRWebGPUCompositionLayerWrapper } from "core/XR/features/Layers/WebXRWebGPUCompositionLayer";
 import { WebXRLayers } from "core/XR/features/WebXRLayers";
@@ -186,6 +187,98 @@ describe("WebXRLayers", () => {
             installWebGLBinding();
 
             expect(new WebXRLayers(sessionManager).isCompatible()).toBe(true);
+        });
+    });
+
+    describe("maxRenderLayers", () => {
+        function createProjectionLayer(): WebXRProjectionLayerWrapper {
+            const layer = { textureHeight: 512, textureWidth: 1024 } as ConstructorParameters<typeof WebXRProjectionLayerWrapper>[0];
+            return new WebXRProjectionLayerWrapper(layer, false, {} as XRWebGLBinding);
+        }
+
+        function createWrappedLayer(): WebXRCompositionLayerWrapper {
+            const layer = {} as ConstructorParameters<typeof WebXRCompositionLayerWrapper>[2];
+            return new WebXRCompositionLayerWrapper(
+                () => 1,
+                () => 1,
+                layer,
+                "XRQuadLayer",
+                false,
+                () => {
+                    throw new Error("Only the projection layer creates a render target provider in these tests.");
+                }
+            );
+        }
+
+        it("exposes the active session limit and rejects arrays that exceed it", () => {
+            const updateRenderState = initializeSession();
+            Object.defineProperty(sessionManager.session, "maxRenderLayers", { configurable: true, value: 2 });
+            const feature = new WebXRLayers(sessionManager);
+            const layers = [createProjectionLayer(), createWrappedLayer(), createWrappedLayer()];
+
+            expect(feature.isMaxRenderLayersSupported).toBe(true);
+            expect(feature.maxRenderLayers).toBe(2);
+            feature.setXRSessionLayers(layers.slice(0, 2));
+            expect(updateRenderState.mock.lastCall?.[0].layers).toEqual(layers.slice(0, 2).map((wrapper) => wrapper.layer));
+
+            expect(() => feature.setXRSessionLayers(layers)).toThrow("The XR session supports at most 2 render layers, but 3 were provided.");
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+        });
+
+        it("remains unsupported-aware and delegates layer limits when the native member is absent", () => {
+            const updateRenderState = initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+            const layers = [createProjectionLayer(), createWrappedLayer(), createWrappedLayer()];
+
+            expect(feature.isMaxRenderLayersSupported).toBe(false);
+            expect(feature.maxRenderLayers).toBeNull();
+            expect(() => feature.setXRSessionLayers(layers)).not.toThrow();
+            expect(updateRenderState.mock.lastCall?.[0].layers).toEqual(layers.map((wrapper) => wrapper.layer));
+        });
+
+        it("checks the active limit before creating another native layer", () => {
+            const projectionLayer = { textureHeight: 512, textureWidth: 1024 };
+            const createQuadLayer = vi.fn();
+            const nativeBinding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+                createQuadLayer,
+                getSubImage: vi.fn(),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return nativeBinding;
+            }) as unknown as LayerBindingConstructor;
+            Object.defineProperty(engine, "_gl", { configurable: true, value: {} });
+            const updateRenderState = initializeSession();
+            Object.defineProperty(sessionManager.session, "maxRenderLayers", { configurable: true, value: 1 });
+            const feature = new WebXRLayers(sessionManager);
+
+            expect(feature.attach()).toBe(true);
+            expect(() => feature.createQuadLayer()).toThrow("The XR session supports at most 1 render layer, but 2 were provided.");
+            expect(createQuadLayer).not.toHaveBeenCalled();
+            expect(updateRenderState).toHaveBeenCalledTimes(1);
+            expect(updateRenderState.mock.lastCall?.[0].layers).toEqual([projectionLayer]);
+        });
+    });
+
+    describe("projection fixed foveation", () => {
+        it("exposes XRProjectionLayer fixed foveation through the session manager convenience API", () => {
+            const projectionLayer = { fixedFoveation: 0, textureHeight: 512, textureWidth: 1024 };
+            const nativeBinding = {
+                createProjectionLayer: vi.fn(() => projectionLayer),
+            };
+            testGlobals.XRWebGLBinding = vi.fn().mockImplementation(function () {
+                return nativeBinding;
+            }) as unknown as LayerBindingConstructor;
+            Object.defineProperty(engine, "_gl", { configurable: true, value: {} });
+            initializeSession();
+            const feature = new WebXRLayers(sessionManager);
+
+            expect(feature.attach()).toBe(true);
+            expect(sessionManager.isFixedFoveationSupported).toBe(true);
+            expect(sessionManager.fixedFoveation).toBe(0);
+
+            sessionManager.fixedFoveation = 0.5;
+            expect(projectionLayer.fixedFoveation).toBe(0.5);
         });
     });
 


### PR DESCRIPTION
## Summary

- exposes `opacity`, `quality`, and `forceMonoPresentation` on `WebXRCompositionLayerWrapper`, with independent `is*Supported` capability checks and native getter/setter propagation
- extends `WebXRLayerWrapper.fixedFoveation` and `WebXRSessionManager.fixedFoveation` to `XRProjectionLayer` for both WebGL and WebGPU while preserving `XRWebGLLayer` behavior
- exposes `WebXRLayers.maxRenderLayers` and `isMaxRenderLayersSupported`
- validates native `layers[]` counts before render-state updates and before Babylon convenience factories allocate a layer; the projection layer counts, mesh fallbacks do not, and arrays are never truncated
- keeps `wrapper.layer` available for raw native access

## API

| API | Type / behavior |
| --- | --- |
| `WebXRCompositionLayerWrapper.isOpacitySupported` | `boolean` |
| `WebXRCompositionLayerWrapper.opacity` | `number`; native `[0, 1]` clamping |
| `WebXRCompositionLayerWrapper.isQualitySupported` | `boolean` |
| `WebXRCompositionLayerWrapper.quality` | `"default" \| "text-optimized" \| "graphics-optimized"` |
| `WebXRCompositionLayerWrapper.isForceMonoPresentationSupported` | `boolean` |
| `WebXRCompositionLayerWrapper.forceMonoPresentation` | `boolean` |
| `WebXRLayerWrapper.isFixedFoveationSupported` / `fixedFoveation` | now recognizes `XRProjectionLayer` as well as `XRWebGLLayer` |
| `WebXRLayers.isMaxRenderLayersSupported` | `boolean` |
| `WebXRLayers.maxRenderLayers` | `number \| null` |

Unsupported composition-control access throws a deterministic error rather than creating an expando property that pretends the native runtime accepted the setting. Supported setters write directly to the native layer, so WebIDL clamping and validation errors are preserved.

## Compatibility and spec notes

The API follows the [WebXR Layers Level 1 editor's draft](https://immersive-web.github.io/layers/): all three compositor controls are inherited by every `XRCompositionLayer` subtype; `XRLayerQuality` is the draft's closed WebIDL enum; projection `fixedFoveation` is nullable; and `maxRenderLayers` is the hard maximum length of `XRRenderStateInit.layers`.

Current browser-compat-data reports Chrome/Edge 147 for opacity, mono presentation, projection fixed foveation, and maxRenderLayers. Quality remains unavailable in Chromium and is currently reported for Meta Quest Browser 31.2; Quest Browser support for projection fixed foveation begins at 16.1. Ambient members remain optional so older runtimes can be feature-detected independently.

## Playground

https://playground.babylonjs.com/#TODARD#0

The public CDN does not contain these Babylon wrapper conveniences until this change is released. The snippet prefers the new wrapper/session APIs when present and uses raw native layer access as a pre-release fallback, while reporting every unsupported property explicitly.

## Validation

- focused WebXR layer unit suite: 54 passed across composition controls, WebGL/WebGPU projection layers, and layer-limit behavior
- full unit suite (serialized): 317 files passed; 4,755 passed, 1 expected failure, 30 skipped
- core TypeScript build
- repository `format:check`
- repository `lint:check`
- `check:treeshaking`
- `check:side-effects-sync`
- `test:treeshaking`