### PR TITLE
Respect XRInputSource skipRendering

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -247,6 +247,8 @@ interface XRInputSource {
     readonly gamepad?: Gamepad | undefined;
     readonly profiles: string[];
     readonly hand?: XRHand;
+    /** Indicates that the user agent recommends omitting the application's input source representation. */
+    readonly skipRendering?: boolean;
 }
 
 declare abstract class XRInputSource implements XRInputSource {}

--- a/packages/dev/core/src/XR/webXRInputSource.ts
+++ b/packages/dev/core/src/XR/webXRInputSource.ts
@@ -115,7 +115,7 @@ export class WebXRInputSource {
                     this.motionController = motionController;
                     this.onMotionControllerInitObservable.notifyObservers(motionController);
                     // should the model be loaded?
-                    if (!this._options.doNotLoadControllerMesh && !this.motionController._doNotLoadControllerMesh) {
+                    if (!this._options.doNotLoadControllerMesh && !this.inputSource.skipRendering && !this.motionController._doNotLoadControllerMesh) {
                         // eslint-disable-next-line @typescript-eslint/no-floating-promises, github/no-then
                         this.motionController.loadModel().then((success) => {
                             if (success && this.motionController && this.motionController.rootMesh) {

--- a/packages/dev/core/test/unit/XR/webXRInput.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRInput.test.ts
@@ -77,11 +77,11 @@ describe("WebXRInput", () => {
     });
 
     describe("controller management via session events", () => {
-        it("adds a controller when inputsourceschange fires with added sources", () => {
+        it("adds a skipRendering controller when inputsourceschange fires with added sources", () => {
             const addedCallback = vi.fn();
             xrInput.onControllerAddedObservable.add(addedCallback);
 
-            const mockInputSource = createMockInputSource();
+            const mockInputSource = createMockInputSource({ skipRendering: true });
 
             // Simulate session init so the event listener is registered
             const mockSession = {
@@ -100,14 +100,15 @@ describe("WebXRInput", () => {
             handler({ added: [mockInputSource], removed: [] });
 
             expect(xrInput.controllers.length).toBe(1);
+            expect(xrInput.controllers[0].inputSource).toBe(mockInputSource);
             expect(addedCallback).toHaveBeenCalledTimes(1);
         });
 
-        it("removes a controller when inputsourceschange fires with removed sources", () => {
+        it("removes a skipRendering controller when inputsourceschange fires with removed sources", () => {
             const removedCallback = vi.fn();
             xrInput.onControllerRemovedObservable.add(removedCallback);
 
-            const mockInputSource = createMockInputSource();
+            const mockInputSource = createMockInputSource({ skipRendering: true });
 
             const mockSession = {
                 addEventListener: vi.fn(),

--- a/packages/dev/core/test/unit/XR/webXRInputSource.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRInputSource.test.ts
@@ -6,6 +6,8 @@ import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { WebXRInputSource } from "core/XR/webXRInputSource";
 import { Quaternion } from "core/Maths/math.vector";
+import { WebXRGenericTriggerMotionController } from "core/XR/motionController/webXRGenericMotionController";
+import { WebXRMotionControllerManager } from "core/XR/motionController/webXRMotionControllerManager";
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
 
 /**
@@ -21,6 +23,19 @@ function createMockInputSource(overrides: Partial<XRInputSource> = {}): XRInputS
         gamepad: null,
         ...overrides,
     } as XRInputSource;
+}
+
+function createMockGamepad(): Gamepad {
+    return {
+        axes: [],
+        buttons: [{ value: 0, touched: false, pressed: false }],
+        connected: true,
+        id: "test-gamepad",
+        index: 0,
+        mapping: "xr-standard",
+        timestamp: 0,
+        vibrationActuator: null,
+    };
 }
 
 describe("WebXRInputSource", () => {
@@ -39,9 +54,31 @@ describe("WebXRInputSource", () => {
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         scene.dispose();
         engine.dispose();
     });
+
+    async function createTrackedInputSource(skipRendering: boolean | undefined, doNotLoadControllerMesh = false) {
+        const gamepad = createMockGamepad();
+        const motionController = new WebXRGenericTriggerMotionController(scene, gamepad, "right");
+        const loadModel = vi.spyOn(motionController, "loadModel").mockResolvedValue(true);
+        vi.spyOn(WebXRMotionControllerManager, "GetMotionControllerWithXRInput").mockResolvedValue(motionController);
+
+        const source = new WebXRInputSource(
+            scene,
+            createMockInputSource({
+                gamepad,
+                skipRendering,
+            }),
+            { doNotLoadControllerMesh }
+        );
+        const motionControllerInitialized = vi.fn();
+        source.onMotionControllerInitObservable.add(motionControllerInitialized);
+        await vi.waitFor(() => expect(source.motionController).toBe(motionController));
+
+        return { source, motionController, loadModel, motionControllerInitialized };
+    }
 
     describe("construction", () => {
         it("creates with a unique id", () => {
@@ -120,6 +157,64 @@ describe("WebXRInputSource", () => {
         it("has onMotionControllerInitObservable", () => {
             const source = new WebXRInputSource(scene, createMockInputSource(), { doNotLoadControllerMesh: true });
             expect(source.onMotionControllerInitObservable).toBeDefined();
+            source.dispose();
+        });
+    });
+
+    describe("skipRendering", () => {
+        it("keeps the motion controller lifecycle active without loading its default model", async () => {
+            const { source, motionController, loadModel, motionControllerInitialized } = await createTrackedInputSource(true);
+            const disposeCallback = vi.fn();
+            const disposeMotionController = vi.spyOn(motionController, "dispose");
+            source.onDisposeObservable.add(disposeCallback);
+
+            expect(source.pointer).toBeDefined();
+            expect(source.grip).toBeDefined();
+            expect(source.motionController).toBe(motionController);
+            expect(motionControllerInitialized).toHaveBeenCalledOnce();
+            expect(motionControllerInitialized.mock.calls[0][0]).toBe(motionController);
+            expect(loadModel).not.toHaveBeenCalled();
+            expect(motionController.rootMesh).toBeFalsy();
+
+            source.dispose();
+
+            expect(disposeMotionController).toHaveBeenCalledOnce();
+            expect(disposeCallback).toHaveBeenCalledOnce();
+            expect(disposeCallback.mock.calls[0][0]).toBe(source);
+        });
+
+        it.each([undefined, false])("loads the default model when skipRendering is %s", async (skipRendering) => {
+            const { source, loadModel } = await createTrackedInputSource(skipRendering);
+
+            expect(loadModel).toHaveBeenCalledOnce();
+
+            source.dispose();
+        });
+
+        it("preserves explicit controller mesh suppression", async () => {
+            const { source, loadModel } = await createTrackedInputSource(false, true);
+
+            expect(loadModel).not.toHaveBeenCalled();
+
+            source.dispose();
+        });
+
+        it.each(["gaze", "screen"] as const)("does not change %s input source handling", async (targetRayMode) => {
+            const getMotionController = vi.spyOn(WebXRMotionControllerManager, "GetMotionControllerWithXRInput");
+            const source = new WebXRInputSource(
+                scene,
+                createMockInputSource({
+                    gamepad: createMockGamepad(),
+                    skipRendering: true,
+                    targetRayMode,
+                })
+            );
+            await Promise.resolve();
+
+            expect(source.pointer).toBeDefined();
+            expect(source.motionController).toBeUndefined();
+            expect(getMotionController).not.toHaveBeenCalled();
+
             source.dispose();
         });
     });


### PR DESCRIPTION
## Summary

- honor the browser-provided `XRInputSource.skipRendering` hint when deciding whether to load Babylon's default motion-controller model
- keep the Babylon input source, pointer/grip tracking nodes, motion-controller data, poses, lifecycle observables, and input interactions active
- add the missing optional WebXR declaration and focused regression coverage

## Spec and browser notes

The WebXR Device API defines `skipRendering` as a read-only hint that the input source is already visible to the user and the application may omit its device representation. For tracked pointers, the user agent must ensure a representation remains visible, and applications should continue rendering pick rays/cursors.

The value is intended to remain stable for an `XRInputSource`; WebXR replaces the source when immutable characteristics change. The current normative input-source change algorithm does not explicitly list `skipRendering`, so this implementation evaluates the hint for each newly created source and does not speculate about runtime mutation.

Meta Quest Browser 40.0+ is the confirmed shipping implementation in MDN browser-compatibility data. Mainstream Chrome, Firefox, and Safari currently do not expose the property. An absent or `false` value preserves Babylon's existing behavior.

Spec: https://immersive-web.github.io/webxr/#dom-xrinputsource-skiprendering

## Playground

https://playground.babylonjs.com/#2HDOVT#0

The Playground enters immersive VR, lists active source handedness/profiles/target-ray mode/native `skipRendering` state, and reports live poses plus select/squeeze and controller lifecycle events. The public CDN does not contain this PR yet, so automatic model suppression in the snippet depends on a Babylon version that includes this change.

## Validation

- targeted WebXR input tests: 32 passed
- all core XR unit tests passed
- core TypeScript compilation passed
- repository formatting and lint checks passed
- tree-shaking and side-effect synchronization checks passed
- full unit suite: 4,749 passed, 1 expected failure, 30 skipped
- saved Playground snippet round-trip verified with the official scripts
- no XR interaction/integration test files exist for this input-source path
