### PR TITLE
Add dynamic WebXR viewport scaling

### DIFF
--- a/packages/dev/core/src/LibDeclarations/webxr.d.ts
+++ b/packages/dev/core/src/LibDeclarations/webxr.d.ts
@@ -533,8 +533,8 @@ interface XRView {
     readonly eye: XREye;
     readonly projectionMatrix: Float32Array;
     readonly transform: XRRigidTransform;
-    readonly recommendedViewportScale?: number | undefined;
-    requestViewportScale(scale: number): void;
+    readonly recommendedViewportScale?: number | null | undefined;
+    requestViewportScale(scale: number | null): void;
 }
 
 declare abstract class XRView implements XRView {}

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -224,6 +224,74 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
     }
 
     /**
+     * Checks whether the current XR view exposes the dynamic viewport scaling API.
+     * API availability does not guarantee that the active XR device will change the viewport dimensions.
+     * This method must be called during an active XR frame.
+     * @param viewIndex the index of the view in the current viewer pose
+     * @returns whether dynamic viewport scaling is exposed for the view
+     * @see https://playground.babylonjs.com/#BAGIIM#0
+     */
+    public isViewportScaleSupported(viewIndex: number): boolean {
+        const view = this._getCurrentXRView(viewIndex);
+        return "recommendedViewportScale" in view && typeof view.requestViewportScale === "function";
+    }
+
+    /**
+     * Gets the runtime-recommended viewport scale for the current XR view.
+     * A number is returned when the runtime has a recommendation, `null` when the API is supported but
+     * the runtime has no recommendation, and `undefined` when the API is not supported.
+     * This method must be called during an active XR frame.
+     * @param viewIndex the index of the view in the current viewer pose
+     * @returns the recommended viewport scale, `null` when no recommendation is available, or `undefined` when unsupported
+     * @see https://playground.babylonjs.com/#BAGIIM#0
+     */
+    public getRecommendedViewportScale(viewIndex: number): Nullable<number> | undefined {
+        const view = this._getCurrentXRView(viewIndex);
+        if (!("recommendedViewportScale" in view) || typeof view.requestViewportScale !== "function") {
+            return undefined;
+        }
+        return view.recommendedViewportScale ?? null;
+    }
+
+    /**
+     * Requests a viewport scale for the current XR view.
+     * The request is a hint to the runtime. Babylon uses the native viewport returned on subsequent frames
+     * and does not derive viewport dimensions from this value. Pass `1` to restore the full viewport scale;
+     * `null` follows the native no-op behavior. Native ignored-value, clamping, and exception behavior is preserved.
+     * Requests made from an application observer of `onXRFrameObservable` apply to a future frame because
+     * Babylon's camera acquires the current frame's viewport before notifying application observers.
+     * This method must be called during an active XR frame.
+     * @param viewIndex the index of the view in the current viewer pose
+     * @param scale the viewport scale requested from the runtime
+     * @see https://playground.babylonjs.com/#BAGIIM#0
+     */
+    public requestViewportScale(viewIndex: number, scale: Nullable<number>): void {
+        const view = this._getCurrentXRView(viewIndex);
+        if (!("recommendedViewportScale" in view) || typeof view.requestViewportScale !== "function") {
+            throw new Error(`Dynamic viewport scaling is not supported for XR view ${viewIndex}.`);
+        }
+        view.requestViewportScale(scale);
+    }
+
+    private _getCurrentXRView(viewIndex: number): XRView {
+        if (!this.inXRSession || !this.session) {
+            throw new Error("Dynamic viewport scaling requires an active XR session.");
+        }
+        if (!this.inXRFrameLoop || !this.currentFrame) {
+            throw new Error("Dynamic viewport scaling must be used during an active XR frame.");
+        }
+        if (!Number.isInteger(viewIndex) || viewIndex < 0) {
+            throw new RangeError("The XR view index must be a non-negative integer.");
+        }
+
+        const pose = this.currentFrame.getViewerPose(this.referenceSpace);
+        if (!pose || viewIndex >= pose.views.length) {
+            throw new RangeError(`XR view ${viewIndex} is not available in the current viewer pose.`);
+        }
+        return pose.views[viewIndex];
+    }
+
+    /**
      * Obtains the XR graphics binding for the current session, creating it lazily.
      * This is the API-agnostic seam used by WebGL and WebGPU XR features to share a binding.
      * @returns the XR graphics binding for the current session

--- a/packages/dev/core/src/XR/webXRSessionManager.ts
+++ b/packages/dev/core/src/XR/webXRSessionManager.ts
@@ -26,6 +26,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
     private _xrNavigator: any;
     private _sessionMode: XRSessionMode;
     private _onEngineDisposedObserver: Nullable<Observer<AbstractEngine>>;
+    private _referenceSpaceInitialized = false;
 
     /**
      * The base reference space from which the session started. good if you want to reset your
@@ -148,6 +149,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
      */
     public set referenceSpace(newReferenceSpace: XRReferenceSpace) {
         this._referenceSpace = newReferenceSpace;
+        this._referenceSpaceInitialized = true;
         this.onXRReferenceSpaceChanged.notifyObservers(this._referenceSpace);
     }
 
@@ -280,6 +282,9 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
         if (!this.inXRFrameLoop || !this.currentFrame) {
             throw new Error("Dynamic viewport scaling must be used during an active XR frame.");
         }
+        if (!this._referenceSpaceInitialized) {
+            throw new Error("Dynamic viewport scaling requires an initialized XR reference space.");
+        }
         if (!Number.isInteger(viewIndex) || viewIndex < 0) {
             throw new RangeError("The XR view index must be a non-negative integer.");
         }
@@ -364,6 +369,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
         const session = await this._xrNavigator.xr.requestSession(xrSessionMode, xrSessionInit);
 
         this.session = session;
+        this._referenceSpaceInitialized = false;
         this._sessionMode = xrSessionMode;
         this.inXRSession = true;
         this.onXRSessionInit.notifyObservers(session);
@@ -373,6 +379,7 @@ export class WebXRSessionManager implements IDisposable, IWebXRRenderTargetTextu
             "end",
             () => {
                 this.inXRSession = false;
+                this._referenceSpaceInitialized = false;
 
                 // Cache the value of engine in case it is disposed during onXRSessionEnded callbacks
                 const engine = this._engine;

--- a/packages/dev/core/test/unit/XR/webXRViewportScaling.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRViewportScaling.test.ts
@@ -170,6 +170,17 @@ describe("WebXR viewport scaling", () => {
         expect(() => sessionManager.requestViewportScale(0, 0.5)).toThrow("XR view 0 is not available in the current viewer pose.");
     });
 
+    it("rejects calls before the XR reference space is initialized", () => {
+        const getViewerPose = vi.fn();
+        sessionManager.session = { end: vi.fn().mockResolvedValue(undefined) } as unknown as XRSession;
+        sessionManager.currentFrame = { getViewerPose } as unknown as XRFrame;
+        sessionManager.inXRSession = true;
+        sessionManager.inXRFrameLoop = true;
+
+        expect(() => sessionManager.isViewportScaleSupported(0)).toThrow("Dynamic viewport scaling requires an initialized XR reference space.");
+        expect(getViewerPose).not.toHaveBeenCalled();
+    });
+
     it("refreshes every rig viewport from the native dimensions on each frame", () => {
         const camera = new WebXRCamera("xr", scene, sessionManager);
         const views = [createView({ eye: "left" }), createView({ eye: "right" })];

--- a/packages/dev/core/test/unit/XR/webXRViewportScaling.test.ts
+++ b/packages/dev/core/test/unit/XR/webXRViewportScaling.test.ts
@@ -1,0 +1,225 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { NullEngine } from "core/Engines/nullEngine";
+import { Matrix } from "core/Maths/math.vector";
+import { Viewport } from "core/Maths/math.viewport";
+import { Scene } from "core/scene";
+import { WebXRCamera } from "core/XR/webXRCamera";
+import { WebXRSessionManager } from "core/XR/webXRSessionManager";
+import { WebXRWebGLLayerWrapper } from "core/XR/webXRWebGLLayer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface IMockXRViewOptions {
+    eye?: "none" | "left" | "right";
+    recommendation?: number | null;
+    requestViewportScale?: (scale: number | null) => void;
+    unsupported?: boolean;
+}
+
+function createView(options: IMockXRViewOptions = {}): XRView {
+    const view = {
+        eye: options.eye ?? "none",
+        projectionMatrix: Float32Array.from(Matrix.Identity().asArray()),
+        transform: {
+            position: { x: 0, y: 0, z: 0, w: 1 },
+            orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        recommendedViewportScale: options.recommendation ?? null,
+        requestViewportScale: options.requestViewportScale ?? vi.fn(),
+    };
+
+    if (options.unsupported) {
+        delete (view as Partial<typeof view>).recommendedViewportScale;
+        delete (view as Partial<typeof view>).requestViewportScale;
+    }
+
+    return view as unknown as XRView;
+}
+
+function createPose(views: XRView[]): XRViewerPose {
+    return {
+        emulatedPosition: false,
+        transform: {
+            position: { x: 0, y: 0, z: 0, w: 1 },
+            orientation: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        views,
+    } as unknown as XRViewerPose;
+}
+
+describe("WebXR viewport scaling", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+    let sessionManager: WebXRSessionManager;
+
+    beforeEach(() => {
+        engine = new NullEngine({
+            renderHeight: 256,
+            renderWidth: 256,
+            textureSize: 256,
+            deterministicLockstep: false,
+            lockstepMaxSteps: 1,
+        });
+        scene = new Scene(engine);
+        sessionManager = new WebXRSessionManager(scene);
+    });
+
+    afterEach(() => {
+        scene.dispose();
+        engine.dispose();
+    });
+
+    function setCurrentPose(pose: XRViewerPose): void {
+        sessionManager.session = { updateRenderState: vi.fn(), end: vi.fn().mockResolvedValue(undefined) } as unknown as XRSession;
+        sessionManager.referenceSpace = {} as XRReferenceSpace;
+        sessionManager.currentFrame = {
+            getViewerPose: vi.fn(() => pose),
+        } as unknown as XRFrame;
+        sessionManager.inXRSession = true;
+        sessionManager.inXRFrameLoop = true;
+    }
+
+    it("detects API support and preserves numeric and null recommendations", () => {
+        setCurrentPose(createPose([createView({ recommendation: 0.7 }), createView({ eye: "right", recommendation: null }), createView({ unsupported: true })]));
+
+        expect(sessionManager.isViewportScaleSupported(0)).toBe(true);
+        expect(sessionManager.getRecommendedViewportScale(0)).toBe(0.7);
+        expect(sessionManager.isViewportScaleSupported(1)).toBe(true);
+        expect(sessionManager.getRecommendedViewportScale(1)).toBeNull();
+        expect(sessionManager.isViewportScaleSupported(2)).toBe(false);
+        expect(sessionManager.getRecommendedViewportScale(2)).toBeUndefined();
+    });
+
+    it("delegates requests independently to every current view", () => {
+        const leftRequest = vi.fn();
+        const rightRequest = vi.fn();
+        setCurrentPose(
+            createPose([
+                createView({ eye: "left", requestViewportScale: leftRequest }),
+                createView({ eye: "right", requestViewportScale: rightRequest }),
+                createView({ eye: "none", requestViewportScale: vi.fn() }),
+            ])
+        );
+
+        expect(sessionManager.requestViewportScale(0, 0.75)).toBeUndefined();
+        expect(sessionManager.requestViewportScale(1, 0.5)).toBeUndefined();
+
+        expect(leftRequest).toHaveBeenCalledExactlyOnceWith(0.75);
+        expect(rightRequest).toHaveBeenCalledExactlyOnceWith(0.5);
+    });
+
+    it("preserves native ignored-value, clamping, and reset semantics", () => {
+        let appliedScale = 0.5;
+        const nativeRequest = vi.fn((scale: number | null) => {
+            if (scale !== null && scale > 0) {
+                appliedScale = Math.min(scale, 1);
+            }
+        });
+        setCurrentPose(createPose([createView({ requestViewportScale: nativeRequest })]));
+
+        sessionManager.requestViewportScale(0, -1);
+        expect(appliedScale).toBe(0.5);
+        sessionManager.requestViewportScale(0, null);
+        expect(appliedScale).toBe(0.5);
+        sessionManager.requestViewportScale(0, 2);
+        expect(appliedScale).toBe(1);
+        sessionManager.requestViewportScale(0, 0.5);
+        sessionManager.requestViewportScale(0, 1);
+        expect(appliedScale).toBe(1);
+
+        expect(nativeRequest.mock.calls).toEqual([[-1], [null], [2], [0.5], [1]]);
+    });
+
+    it("propagates native exceptions", () => {
+        const nativeError = new TypeError("Native viewport scale conversion failed.");
+        setCurrentPose(
+            createPose([
+                createView({
+                    requestViewportScale: () => {
+                        throw nativeError;
+                    },
+                }),
+            ])
+        );
+
+        expect(() => sessionManager.requestViewportScale(0, Number.NaN)).toThrow(nativeError);
+    });
+
+    it("fails clearly for an unsupported view", () => {
+        setCurrentPose(createPose([createView({ unsupported: true })]));
+
+        expect(() => sessionManager.requestViewportScale(0, 0.5)).toThrow("Dynamic viewport scaling is not supported for XR view 0.");
+    });
+
+    it("rejects calls outside a current XR frame and invalid view indices", () => {
+        expect(() => sessionManager.isViewportScaleSupported(0)).toThrow("Dynamic viewport scaling requires an active XR session.");
+
+        setCurrentPose(createPose([createView()]));
+        sessionManager.inXRFrameLoop = false;
+        expect(() => sessionManager.getRecommendedViewportScale(0)).toThrow("Dynamic viewport scaling must be used during an active XR frame.");
+
+        sessionManager.inXRFrameLoop = true;
+        expect(() => sessionManager.requestViewportScale(-1, 0.5)).toThrow("The XR view index must be a non-negative integer.");
+        expect(() => sessionManager.requestViewportScale(1, 0.5)).toThrow("XR view 1 is not available in the current viewer pose.");
+
+        sessionManager.currentFrame = {
+            getViewerPose: vi.fn(() => null),
+        } as unknown as XRFrame;
+        expect(() => sessionManager.requestViewportScale(0, 0.5)).toThrow("XR view 0 is not available in the current viewer pose.");
+    });
+
+    it("refreshes every rig viewport from the native dimensions on each frame", () => {
+        const camera = new WebXRCamera("xr", scene, sessionManager);
+        const views = [createView({ eye: "left" }), createView({ eye: "right" })];
+        const pose = createPose(views);
+        setCurrentPose(pose);
+
+        const nativeViewports = [
+            { x: 0, y: 0, width: 0.5, height: 1 },
+            { x: 0.5, y: 0, width: 0.5, height: 1 },
+        ];
+        vi.spyOn(sessionManager, "getRenderTargetTextureForView").mockReturnValue(null);
+        vi.spyOn(sessionManager, "trySetViewportForView").mockImplementation((viewport, view) => {
+            const nativeViewport = nativeViewports[view.eye === "right" ? 1 : 0];
+            viewport.x = nativeViewport.x;
+            viewport.y = nativeViewport.y;
+            viewport.width = nativeViewport.width;
+            viewport.height = nativeViewport.height;
+            return true;
+        });
+
+        sessionManager.onXRFrameObservable.notifyObservers(sessionManager.currentFrame!);
+        expect(camera.rigCameras[0].viewport.width).toBe(0.5);
+        expect(camera.rigCameras[1].viewport.width).toBe(0.5);
+
+        nativeViewports[0] = { x: 0, y: 0, width: 0.3, height: 0.6 };
+        nativeViewports[1] = { x: 0.5, y: 0, width: 0.25, height: 0.5 };
+        sessionManager.onXRFrameObservable.notifyObservers(sessionManager.currentFrame!);
+
+        expect(camera.rigCameras[0].viewport).toEqual(new Viewport(0, 0, 0.3, 0.6));
+        expect(camera.rigCameras[1].viewport).toEqual(new Viewport(0.5, 0, 0.25, 0.5));
+    });
+
+    it("keeps the full render target size while consuming the scaled native WebGL viewport", () => {
+        const getViewport = vi.fn(() => ({ x: 50, y: 25, width: 400, height: 200 }));
+        const layer = {
+            framebufferWidth: 1000,
+            framebufferHeight: 500,
+            framebuffer: null,
+            getViewport,
+        } as unknown as XRWebGLLayer;
+        const wrapper = new WebXRWebGLLayerWrapper(layer);
+        const provider = wrapper.createRenderTargetTextureProvider(sessionManager);
+        const view = createView({ eye: "left" });
+
+        const renderTarget = provider.getRenderTargetTextureForView(view);
+        const viewport = new Viewport(0, 0, 1, 1);
+        expect(provider.trySetViewportForView(viewport, view)).toBe(true);
+
+        expect(renderTarget?.getRenderWidth()).toBe(1000);
+        expect(renderTarget?.getRenderHeight()).toBe(500);
+        expect(viewport).toEqual(new Viewport(0.05, 0.05, 0.4, 0.4));
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- exposes dynamic viewport scaling for every view in the current WebXR viewer pose
- keeps ephemeral `XRView` objects internal and resolves them by current-frame view index
- preserves native request, clamping, no-op, and exception semantics
- continues using the authoritative native `getViewport()` / `getViewSubImage()` dimensions for Babylon rig-camera viewports and render targets
- corrects Babylon's WebXR declarations for the nullable recommendation and request argument

## Public API

```ts
WebXRSessionManager.isViewportScaleSupported(viewIndex: number): boolean;
WebXRSessionManager.getRecommendedViewportScale(viewIndex: number): number | null | undefined;
WebXRSessionManager.requestViewportScale(viewIndex: number, scale: number | null): void;
```

All three methods require an active XR frame. Invalid session/frame state and unavailable view indices fail with clear errors. `getRecommendedViewportScale` distinguishes:

- `number`: the runtime has a recommendation
- `null`: the API is exposed but the runtime has no recommendation
- `undefined`: the API is not exposed for that view

## WebXR semantics and browser caveats

- Requests are native hints, not exact pixel-size contracts. Babylon does not compute viewport dimensions from the requested scale.
- Pass `1` to restore the full dynamic viewport scale. Per the specification, `null` is a no-op.
- The WebXR specification ignores non-positive finite values and clamps values above `1`; current Chromium instead clamps finite requests to `[0.125, 1]`. Babylon forwards values unchanged so runtime behavior and exceptions are preserved.
- Babylon's camera acquires its viewport before application `onXRFrameObservable` observers run, so requests from an application observer take effect on a future frame.
- Dynamic scaling is normative for `XRWebGLLayer.getViewport()`. WebXR Layers does not currently require it for `XRWebGLBinding.getViewSubImage()`, though Chromium applies it there. Babylon consumes whichever viewport the runtime returns on both paths.
- MDN browser-compat data records API exposure in Chrome 90+ and Chromium-derived browsers. Firefox and Safari do not expose it. API exposure also does not guarantee that the active XR runtime honors scaling requests.

Specification: https://immersive-web.github.io/webxr/#dom-xrview-requestviewportscale

## Playground

https://playground.babylonjs.com/#BAGIIM#0

The snippet selects immersive VR or AR based on hardware support, displays per-view recommendation/request/viewport data, and provides explicit 75%, recommended, and full-scale controls. Until the convenience API reaches the public CDN, the snippet reports that limitation instead of falling back unsafely.

## Validation

- core production TypeScript build
- focused WebXR viewport, session manager, camera, layers, WebGL, and WebGPU unit suites
- full unit suite: 317 files, 4,751 passed, 1 expected failure, 30 skipped
- repository format and lint checks
- tree-shaking, side-effect synchronization, and bundle smoke checks
- `npm run build:dev`

The local devhost browser smoke was blocked by an unrelated current-master Vite parse error in `dracoDecoder.ts` (`DracoDecoderModule` is reported as already declared). Temporary devhost changes and the alternate-port server were removed.
