### PR TITLE
Allow URL preprocessing to handle parent-relative glTF resources

### DIFF
--- a/packages/dev/loaders/src/glTF/2.0/glTFLoader.pure.ts
+++ b/packages/dev/loaders/src/glTF/2.0/glTFLoader.pure.ts
@@ -2770,7 +2770,7 @@ export class GLTFLoader implements IGLTFLoader {
             return extensionPromise;
         }
 
-        if (!GLTFLoader._ValidateUri(uri)) {
+        if (!this._parent._isPreprocessUrlAsyncSet && !GLTFLoader._ValidateUri(uri)) {
             throw new Error(`${context}: '${uri}' is invalid`);
         }
 
@@ -2782,7 +2782,7 @@ export class GLTFLoader implements IGLTFLoader {
 
         this.log(`${context}: Loading ${uri}`);
 
-        return this._parent.preprocessUrlAsync(this._rootUrl + uri).then((url) => {
+        return this._parent.preprocessUrlAsync(this._rootUrl + uri, this._rootUrl ?? undefined).then((url) => {
             return new Promise((resolve, reject) => {
                 this._parent._loadFile(
                     this._babylonScene,

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.pure.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.pure.ts
@@ -455,7 +455,7 @@ abstract class GLTFLoaderOptions extends GLTFLoaderBaseOptions {
      * Setting this function allows parent-relative asset URIs and makes the callback responsible for URI safety.
      * @param url The URL referenced by the asset
      * @param rootUrl The root URL of the asset, if available
-     * @returns The URL to load
+     * @returns A promise that resolves to the URL to load
      */
     public preprocessUrlAsync: (url: string, rootUrl?: string) => Promise<string> = DefaultPreprocessUrlAsync;
 }

--- a/packages/dev/loaders/src/glTF/glTFFileLoader.pure.ts
+++ b/packages/dev/loaders/src/glTF/glTFFileLoader.pure.ts
@@ -184,6 +184,8 @@ type DefaultExtensionOptions<BaseExtensionOptions> = {
     enabled?: boolean;
 } & BaseExtensionOptions;
 
+const DefaultPreprocessUrlAsync = (url: string) => Promise.resolve(url);
+
 /**
  * This class contains all the concrete (not abstract) glTF options, excluding callbacks.
  * The purpose of this class is to make it easy to provide a way to mutate the default
@@ -449,11 +451,13 @@ abstract class GLTFLoaderOptions extends GLTFLoaderBaseOptions {
     public abstract onValidated?: (results: GLTF2.IGLTFValidationResults) => void;
 
     /**
-     * Function called before loading a url referenced by the asset.
-     * @param url url referenced by the asset
-     * @returns Async url to load
+     * Function called before loading a URL referenced by the asset.
+     * Setting this function allows parent-relative asset URIs and makes the callback responsible for URI safety.
+     * @param url The URL referenced by the asset
+     * @param rootUrl The root URL of the asset, if available
+     * @returns The URL to load
      */
-    public preprocessUrlAsync = (url: string) => Promise.resolve(url);
+    public preprocessUrlAsync: (url: string, rootUrl?: string) => Promise<string> = DefaultPreprocessUrlAsync;
 }
 
 /**
@@ -473,6 +477,11 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
     public constructor(options?: Partial<Readonly<GLTFLoaderOptions>>) {
         super();
         this.copyFrom(Object.assign({ ...GLTFLoaderDefaultOptions }, options));
+    }
+
+    /** @internal */
+    public get _isPreprocessUrlAsyncSet(): boolean {
+        return this.preprocessUrlAsync !== DefaultPreprocessUrlAsync;
     }
 
     // --------------------
@@ -790,7 +799,7 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
 
         delete this._progressCallback;
 
-        this.preprocessUrlAsync = (url) => Promise.resolve(url);
+        this.preprocessUrlAsync = DefaultPreprocessUrlAsync;
 
         this.onMeshLoadedObservable.clear();
         this.onSkinLoadedObservable.clear();
@@ -1177,7 +1186,7 @@ export class GLTFFileLoader extends GLTFLoaderOptions implements IDisposable, IS
 
         this._startPerformanceCounter("Validate JSON");
         GLTFValidation.ValidateAsync(data, rootUrl, fileName, (uri) => {
-            return this.preprocessUrlAsync(rootUrl + uri).then((url) => {
+            return this.preprocessUrlAsync(rootUrl + uri, rootUrl).then((url) => {
                 return scene._loadFileAsync(url, undefined, true, true).then((data) => {
                     return new Uint8Array(data, 0, data.byteLength);
                 });

--- a/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
+++ b/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
@@ -169,7 +169,6 @@ test.describe("Babylon Scene Loader", function () {
                     };
                 }, rootUrl);
                 expect(assertionData.defaultError).toContain("'../shared/mesh.bin' is invalid");
-                expect(assertionData.defaultError).toContain("'../shared/mesh.bin' is invalid");
                 expect(assertionData.hasTriangle).toBe(true);
                 expect(assertionData.preprocessCalls).toEqual([[`${rootUrl}../shared/mesh.bin`, rootUrl]]);
             } finally {

--- a/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
+++ b/packages/dev/loaders/test/integration/babylon.sceneLoader.test.ts
@@ -122,6 +122,61 @@ test.describe("Babylon Scene Loader", function () {
             expect(assertionData.lights).toBe(1);
         });
 
+        test("glTF URL preprocessing can resolve parent resource paths", async () => {
+            const routePattern = "**/gltf-parent-uri/**";
+            await page.route(routePattern, async (route) => {
+                await route.fulfill({
+                    body: Buffer.from(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]).buffer),
+                    contentType: "application/octet-stream",
+                });
+            });
+
+            try {
+                const rootUrl = `${getGlobalConfig().baseUrl}/gltf-parent-uri/models/nested/`;
+                const assertionData = await page.evaluate(async (rootUrl) => {
+                    const preprocessCalls = new Array<[string, string | undefined]>();
+                    const gltf = {
+                        asset: { version: "2.0" },
+                        scene: 0,
+                        scenes: [{ nodes: [0] }],
+                        nodes: [{ mesh: 0 }],
+                        meshes: [{ primitives: [{ attributes: { POSITION: 0 } }] }],
+                        accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: "VEC3", max: [1, 1, 0], min: [0, 0, 0] }],
+                        bufferViews: [{ buffer: 0, byteLength: 36 }],
+                        buffers: [{ byteLength: 36, uri: "../shared/mesh.bin" }],
+                    };
+                    let defaultError: string | undefined;
+                    try {
+                        await BABYLON.ImportMeshAsync(`data:${JSON.stringify(gltf)}`, window.scene!, { rootUrl });
+                    } catch (error) {
+                        defaultError = error instanceof Error ? error.message : String(error);
+                    }
+
+                    const gltfOptions = {
+                        preprocessUrlAsync: (url: string, assetRootUrl?: string) => {
+                            preprocessCalls.push([url, assetRootUrl]);
+                            return Promise.resolve(url);
+                        },
+                    } satisfies GLTFOptions;
+                    const result = await BABYLON.ImportMeshAsync(`data:${JSON.stringify(gltf)}`, window.scene!, {
+                        rootUrl,
+                        pluginOptions: { gltf: gltfOptions },
+                    });
+                    return {
+                        defaultError,
+                        hasTriangle: result.meshes.some((mesh) => mesh.getTotalVertices() === 3),
+                        preprocessCalls,
+                    };
+                }, rootUrl);
+                expect(assertionData.defaultError).toContain("'../shared/mesh.bin' is invalid");
+                expect(assertionData.defaultError).toContain("'../shared/mesh.bin' is invalid");
+                expect(assertionData.hasTriangle).toBe(true);
+                expect(assertionData.preprocessCalls).toEqual([[`${rootUrl}../shared/mesh.bin`, rootUrl]]);
+            } finally {
+                await page.unroute(routePattern);
+            }
+        });
+
         test("Load BoomBox with ImportMesh", async () => {
             const assertionData = await page.evaluate(() => {
                 return BABYLON.SceneLoader.ImportMeshAsync(null, "https://playground.babylonjs.com/scenes/BoomBox/", "BoomBox.gltf", window.scene).then((result) => {


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

[Created by Copilot on behalf of @bghgary]

## Context

The glTF 2.0 loader rejects parent-relative resource URIs before applications can preprocess them. This prevents standards-valid assets such as 3D Tiles content with resources shared above individual tile directories from loading without modifying the asset.

Forum request: https://forum.babylonjs.com/t/add-allowparenturis-option-to-gltffileloader-to-allow-rfc-3986-spec-compliant-relative-paths/63618

## Behavior

The default rejection remains unchanged. Configuring `preprocessUrlAsync` is now an explicit opt-in to own URI safety, and its optional `rootUrl` argument lets the callback resolve or preserve parent-relative paths. Existing one-argument callbacks remain compatible.
