### PR TITLE
Fix late notifications for Observable<void>

### DIFF
--- a/packages/dev/core/src/Misc/observable.pure.ts
+++ b/packages/dev/core/src/Misc/observable.pure.ts
@@ -273,9 +273,7 @@ export class Observable<T> implements IReadonlyObservable<T> {
 
         // If the observable was already triggered and the observable is set to notify if triggered, notify the new observer
         if (this._hasNotified && this.notifyIfTriggered) {
-            if (this._lastNotifiedValue !== undefined) {
-                this.notifyObserver(observer, this._lastNotifiedValue);
-            }
+            this.notifyObserver(observer, this._lastNotifiedValue as T);
         }
 
         // attach the remove function to the observer

--- a/packages/dev/core/test/unit/Misc/observable.test.ts
+++ b/packages/dev/core/test/unit/Misc/observable.test.ts
@@ -19,9 +19,12 @@ describe("Observable", () => {
 
         observable.notifyObservers();
         observable.addOnce(callback);
-        observable.notifyObservers();
 
         expect(callback).toHaveBeenCalledOnce();
         expect(observable.hasObservers()).toBe(false);
+
+        observable.notifyObservers();
+
+        expect(callback).toHaveBeenCalledOnce();
     });
 });

--- a/packages/dev/core/test/unit/Misc/observable.test.ts
+++ b/packages/dev/core/test/unit/Misc/observable.test.ts
@@ -1,0 +1,27 @@
+import { Observable } from "core/Misc/observable";
+import { describe, expect, it, vi } from "vitest";
+
+describe("Observable", () => {
+    it("notifies late observers after being triggered without event data", () => {
+        const observable = new Observable<void>(undefined, true);
+        const callback = vi.fn();
+
+        observable.notifyObservers();
+        observable.add(callback);
+
+        expect(callback).toHaveBeenCalledOnce();
+        expect(callback.mock.calls[0][0]).toBeUndefined();
+    });
+
+    it("unregisters a late addOnce observer after notifying it without event data", () => {
+        const observable = new Observable<void>(undefined, true);
+        const callback = vi.fn();
+
+        observable.notifyObservers();
+        observable.addOnce(callback);
+        observable.notifyObservers();
+
+        expect(callback).toHaveBeenCalledOnce();
+        expect(observable.hasObservers()).toBe(false);
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary
- Notify late observers when a `notifyIfTriggered` observable was triggered with an `undefined` payload.
- Add regression coverage for late `add` and `addOnce` subscriptions on `Observable<void>`.

## Motivation
`Observable.add()` used the last payload as a notification sentinel, conflating a valid `undefined` payload with an observable that had never fired. This prevented late subscribers from running and could leave lens flares without initialized draw wrappers.

## Behavioral change
`Observable<void>` and `Observable<T | undefined>` now honor `notifyIfTriggered` consistently with observables carrying defined payloads.

Fixes #18853
