### PR TITLE
Avoid blocking CDN purge requests

### DIFF
--- a/.azure-pipelines/ci-monorepo.yml
+++ b/.azure-pipelines/ci-monorepo.yml
@@ -1281,8 +1281,8 @@ jobs:
           - script: |
                 set -euo pipefail
 
-                # Async purge: don't block CI on the CDN purge completing.
-                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                # Omitting wait selects the deployment server's non-blocking path.
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_CDN)&profileName=$(CDN_PROFILE_CDN)" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
 
-                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_PREVIEW_CDN)&profileName=$(CDN_PROFILE_CDN)&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=$(CDN_ENDPOINT_PREVIEW_CDN)&profileName=$(CDN_PROFILE_CDN)" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Purge CDN"

--- a/.azure-pipelines/templates/deploy-tool.yml
+++ b/.azure-pipelines/templates/deploy-tool.yml
@@ -54,8 +54,6 @@ steps:
 
     - ${{ if ne(parameters.purgeEndpoint, '') }}:
           - script: |
-                # Async purge: don't wait for the CDN to finish purging.
-                # The deployment server has a much shorter timeout than Azure's
-                # purge operation, so blocking on it always times out in CI.
-                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}&wait=false" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
+                # Omitting wait selects the deployment server's non-blocking path.
+                curl --fail-with-body --silent --show-error "$(DEPLOYMENT_SERVER)/$(DEPLOY_ENDPOINT_PURGE)?endpoint=${{ parameters.purgeEndpoint }}&profileName=${{ parameters.purgeProfile }}" -i -X POST -H "Authorization: Bearer $(DEPLOY_TOKEN)"
             displayName: "Purge CDN (${{ parameters.purgeEndpoint }})"


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- omits the `wait` query parameter from tools CD purge requests
- applies the same fix to the monorepo CDN and preview CDN purges

## Motivation

The deployment server uses `req.query.wait || false`, so the query string `wait=false` is a non-empty, truthy string and selects `beginPurgeContentAndWait`. Purges then block until the gateway returns HTTP 499 after four minutes. Omitting the parameter selects the intended non-blocking purge path.

## Validation

- targeted Prettier check for both changed YAML files
- confirmed build 58776 compiled and sent `wait=false`, and the deployment server interprets that value as truthy