### PR TITLE
Use NPM publish variable group

### DIFF
--- a/.azure-pipelines/VARIABLE-GROUPS.md
+++ b/.azure-pipelines/VARIABLE-GROUPS.md
@@ -114,6 +114,16 @@ deploy tools.
 
 Linked by: ci-monorepo, ci-playground-sandbox, ci-graph-tools, cd-publish, cd-tools.
 
+## Variable Group: `NPM_Publish`
+
+npm registry credentials used to publish packages.
+
+| Variable    | Description                            |
+| ----------- | -------------------------------------- |
+| `NPM_TOKEN` | npm registry auth token for publishing |
+
+Linked by: cd-publish.
+
 ### Secret Variables (per-pipeline)
 
 These must be configured as **secret variables** on each pipeline (not in the
@@ -122,7 +132,6 @@ variable group) because they contain credentials:
 | Variable     | Used By          | Description                                                   |
 | ------------ | ---------------- | ------------------------------------------------------------- |
 | `GitHubPAT`  | cd-publish       | GitHub Personal Access Token for git push and version scripts |
-| `NPM_TOKEN`  | cd-publish       | npm registry auth token for publishing                        |
 | `SEARCH_KEY` | ci-documentation | Search API key for documentation builds                       |
 
 ### Manual YAML Configuration
@@ -150,8 +159,9 @@ variables:
 ```
 
 After creating a new YAML pipeline, go to **Pipeline → Edit → Variables →
-Variable groups** and link `BabylonJS-CI-Infrastructure`. The pipeline must be
-authorized to access the group.
+Variable groups** and link every variable group referenced by its YAML. The
+pipeline must be authorized to access each group. In particular, `cd-publish`
+must link and authorize `NPM_Publish`.
 
 > **Note:** The `GITHUB_SERVICE_CONNECTION` variable is used in `GitHubComment@0`
 > and `GitHubRelease@1` task inputs. After linking the variable group, you may

--- a/.azure-pipelines/cd-publish.yml
+++ b/.azure-pipelines/cd-publish.yml
@@ -9,10 +9,10 @@
 # Variable groups:
 #   - BabylonJS-CI-Infrastructure
 #   - BabylonJS-Deployment (DEPLOY_TOKEN, DEPLOYMENT_SERVER)
+#   - NPM_Publish (NPM_TOKEN)
 #
 # Secret variables (configure in pipeline UI):
 #   - GitHubPAT
-#   - NPM_TOKEN
 # =============================================================================
 
 trigger:
@@ -29,6 +29,7 @@ pr: none
 variables:
     - group: BabylonJS-CI-Infrastructure
     - group: BabylonJS-Deployment
+    - group: NPM_Publish
 
 pool:
     vmImage: ubuntu-latest


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## What

Adds the `NPM_Publish` variable group to the publish pipeline so the existing npm authentication step receives `NPM_TOKEN` from the new group.

Updates the pipeline header documentation to reflect where the token is configured.