### PR TITLE
Enable SFE production deployment

### DIFF
--- a/.azure-pipelines/VARIABLE-GROUPS.md
+++ b/.azure-pipelines/VARIABLE-GROUPS.md
@@ -48,6 +48,7 @@ These are Azure Front Door endpoint names used in CDN cache purge calls.
 | `CDN_ENDPOINT_GUIEDITOR`   | GUI Editor endpoint               |
 | `CDN_ENDPOINT_NPE`         | Node Particle Editor endpoint     |
 | `CDN_ENDPOINT_FGE`         | Flow Graph Editor endpoint        |
+| `CDN_ENDPOINT_SFE`         | Smart Filters Editor endpoint     |
 | `CDN_ENDPOINT_DOCS`        | Documentation site endpoint       |
 
 ### CDN Purge Profiles

--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -65,12 +65,11 @@ jobs:
                 command: custom
                 customCommand: "ci"
 
-          # DISABLED in classic pipeline:
-          # - task: Npm@1
-          #   displayName: 'npm update-version (for smart filters)'
-          #   inputs:
-          #     command: custom
-          #     customCommand: 'run update-version -w @dev/smart-filters'
+          - task: Npm@1
+            displayName: "update smart filters version"
+            inputs:
+                command: custom
+                customCommand: "run update-version -w @dev/smart-filters"
 
           - task: Npm@1
             displayName: "build dev"

--- a/.azure-pipelines/cd-tools.yml
+++ b/.azure-pipelines/cd-tools.yml
@@ -3,7 +3,7 @@
 # Converted from Azure DevOps Classic Pipeline
 #
 # Builds and deploys all tools (Playground, Sandbox, NME, NGE, NRGE,
-# GUI Editor, NPE, FGE) to production storage after a successful publish.
+# GUI Editor, NPE, FGE, SFE) to production storage after a successful publish.
 #
 # Triggers:
 #   - Schedule: midnight PST on Tue/Wed/Fri/Sat (daysToBuild: 22)
@@ -78,12 +78,11 @@ jobs:
                 command: custom
                 customCommand: "run build:dev"
 
-          # DISABLED in classic pipeline:
-          # - task: Npm@1
-          #   displayName: 'build smart filters core'
-          #   inputs:
-          #     command: custom
-          #     customCommand: 'run build:source:smart-filters'
+          - task: Npm@1
+            displayName: "build smart filters"
+            inputs:
+                command: custom
+                customCommand: "run build:source:smart-filters"
 
           - task: Npm@1
             displayName: "build playground"
@@ -133,12 +132,11 @@ jobs:
                 command: custom
                 customCommand: "run build:deployment -w @tools/flow-graph-editor"
 
-          # DISABLED in classic pipeline:
-          # - task: Npm@1
-          #   displayName: 'build smart filters editor'
-          #   inputs:
-          #     command: custom
-          #     customCommand: 'run build:deployment -w @tools/smart-filters-editor'
+          - task: Npm@1
+            displayName: "build smart filters editor"
+            inputs:
+                command: custom
+                customCommand: "run build:deployment -w @tools/smart-filters-editor"
 
           - template: templates/deploy-tool.yml
             parameters:
@@ -212,7 +210,16 @@ jobs:
                 purgeEndpoint: "$(CDN_ENDPOINT_FGE)"
                 purgeProfile: "$(CDN_PROFILE_TOOLS)"
 
-          # DISABLED in classic pipeline:
+          - template: templates/deploy-tool.yml
+            parameters:
+                toolPackageDir: "packages/tools/smartFiltersEditor"
+                deployPath: "smartFiltersEditor"
+                storageAccount: "$(TOOLS_STORAGE_ACCOUNT)"
+                displayName: "SFE deployment"
+                purgeEndpoint: "$(CDN_ENDPOINT_SFE)"
+                purgeProfile: "$(CDN_PROFILE_TOOLS)"
+
+          # Legacy classic pipeline deployment (superseded by the template above):
           # - script: |
           #     # sfe
           #     cd packages/tools/smartFiltersEditor/dist


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Record the current Smart Filters version during the production tools build.
- Build Smart Filters and the Smart Filters Editor in the production tools pipeline.
- Deploy SFE to the production tools storage and purge its CDN endpoint.
- Document the `CDN_ENDPOINT_SFE` infrastructure variable.

## Motivation

SFE was included in graph-tools snapshot deployments, but its production version update, build, and deployment remained disabled after the classic pipeline migration.
