### PR TITLE
Fix: IBL Shadows silent failure on Adreno mobile GPUs

### DIFF
--- a/packages/dev/core/src/Rendering/iblCdfGenerator.ts
+++ b/packages/dev/core/src/Rendering/iblCdfGenerator.ts
@@ -316,8 +316,9 @@ export class IblCdfGenerator {
             "iblScaledLuminance",
             this._scene,
             // This texture is trilinear-filtered and mip-mapped, so it must use a filterable format.
-            // r32float (used by the other CDF textures) is only filterable when the optional WebGPU
-            // `float32-filterable` feature is present; r16float is filterable everywhere.
+            // r16float is filterable everywhere (no optional feature required) and is sufficient here:
+            // the value only ever feeds a ratio (pixelLuminance / normalization) used as an
+            // importance-sampling weight, well within r16float's range and precision.
             { ...cdfOptions, type: Constants.TEXTURETYPE_HALF_FLOAT, samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE, generateMipMaps: true },
             true,
             false

--- a/packages/dev/core/src/Rendering/iblCdfGenerator.ts
+++ b/packages/dev/core/src/Rendering/iblCdfGenerator.ts
@@ -315,7 +315,10 @@ export class IblCdfGenerator {
             { width: size.width, height: size.height },
             "iblScaledLuminance",
             this._scene,
-            { ...cdfOptions, samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE, generateMipMaps: true },
+            // This texture is trilinear-filtered and mip-mapped, so it must use a filterable format.
+            // r32float (used by the other CDF textures) is only filterable when the optional WebGPU
+            // `float32-filterable` feature is present; r16float is filterable everywhere.
+            { ...cdfOptions, type: Constants.TEXTURETYPE_HALF_FLOAT, samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE, generateMipMaps: true },
             true,
             false
         );

--- a/packages/dev/core/src/Rendering/iblCdfGenerator.ts
+++ b/packages/dev/core/src/Rendering/iblCdfGenerator.ts
@@ -261,6 +261,13 @@ export class IblCdfGenerator {
         }
 
         const isWebGPU = this._engine.isWebGPU;
+        // r32float mip generation requires filtered sampling. On WebGPU this hard-fails bind group
+        // validation (and drops the whole command buffer) when the optional `float32-filterable` adapter
+        // feature is absent, so fall back to r16float there. WebGL2/Native are not gated here even though
+        // they also depend on an extension (OES_texture_float_linear) for float32 filtering: when it's
+        // missing they silently degrade to nearest sampling instead of hard-failing, which is pre-existing,
+        // unrelated behavior this fix doesn't need to change.
+        const scaledLuminanceType = isWebGPU && !this._engine.getCaps().textureFloatLinearFiltering ? Constants.TEXTURETYPE_HALF_FLOAT : Constants.TEXTURETYPE_FLOAT;
         // Create CDF maps (Cumulative Distribution Function) to assist in importance sampling
         const cdfOptions: IProceduralTextureCreationOptions = {
             generateDepthBuffer: false,
@@ -315,11 +322,9 @@ export class IblCdfGenerator {
             { width: size.width, height: size.height },
             "iblScaledLuminance",
             this._scene,
-            // This texture is trilinear-filtered and mip-mapped, so it must use a filterable format.
-            // r16float is filterable everywhere (no optional feature required) and is sufficient here:
-            // the value only ever feeds a ratio (pixelLuminance / normalization) used as an
-            // importance-sampling weight, well within r16float's range and precision.
-            { ...cdfOptions, type: Constants.TEXTURETYPE_HALF_FLOAT, samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE, generateMipMaps: true },
+            // This texture is trilinear-filtered and mip-mapped, so it must use a filterable format;
+            // see scaledLuminanceType above for why r16float is only used as a WebGPU fallback.
+            { ...cdfOptions, type: scaledLuminanceType, samplingMode: Constants.TEXTURE_TRILINEAR_SAMPLINGMODE, generateMipMaps: true },
             true,
             false
         );

--- a/packages/dev/core/src/Rendering/iblCdfGenerator.ts
+++ b/packages/dev/core/src/Rendering/iblCdfGenerator.ts
@@ -263,10 +263,9 @@ export class IblCdfGenerator {
         const isWebGPU = this._engine.isWebGPU;
         // r32float mip generation requires filtered sampling. On WebGPU this hard-fails bind group
         // validation (and drops the whole command buffer) when the optional `float32-filterable` adapter
-        // feature is absent, so fall back to r16float there. WebGL2/Native are not gated here even though
-        // they also depend on an extension (OES_texture_float_linear) for float32 filtering: when it's
-        // missing they silently degrade to nearest sampling instead of hard-failing, which is pre-existing,
-        // unrelated behavior this fix doesn't need to change.
+        // feature is absent, so fall back to r16float there. WebGL2/Native also depend on an extension
+        // (OES_texture_float_linear) for float32 filtering, but when it's missing they silently degrade
+        // to nearest sampling instead of hard-failing, so no fallback is needed there.
         const scaledLuminanceType = isWebGPU && !this._engine.getCaps().textureFloatLinearFiltering ? Constants.TEXTURETYPE_HALF_FLOAT : Constants.TEXTURETYPE_FLOAT;
         // Create CDF maps (Cumulative Distribution Function) to assist in importance sampling
         const cdfOptions: IProceduralTextureCreationOptions = {

--- a/packages/dev/core/src/Shaders/ShadersInclude/hdrFilteringFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/hdrFilteringFunctions.fx
@@ -2,9 +2,13 @@
     #if NUM_SAMPLES > 0
 
     #if defined(WEBGL2) || defined(WEBGPU) || defined(NATIVE)
+        // Some drivers (e.g. certain Android/Adreno implementations) default fragment-shader int/uint
+        // precision to mediump, which silently corrupts the 32-bit bit manipulation below.
+        precision highp int;
+
         // https://learnopengl.com/PBR/IBL/Specular-IBL
         // Hammersley
-        float radicalInverse_VdC(uint bits) 
+        float radicalInverse_VdC(uint bits)
         {
             bits = (bits << 16u) | (bits >> 16u);
             bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);

--- a/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/helperFunctions.fx
@@ -251,7 +251,11 @@ float avg(vec3 value) {
     return dot(value, vec3(0.333333333));
 }
 
-#if defined(WEBGL2) || defined(WEBGPU) || defined(NATIVE) 
+#if defined(WEBGL2) || defined(WEBGPU) || defined(NATIVE)
+// Some drivers (e.g. certain Android/Adreno implementations) default fragment-shader int/uint
+// precision to mediump, which silently corrupts the 32-bit bit manipulation below.
+precision highp int;
+
 uint extractBits(uint value, int offset, int width) {
     return (value >> offset) & ((1u << width) - 1u);
 }

--- a/packages/dev/core/test/unit/Rendering/iblCdfGenerator.test.ts
+++ b/packages/dev/core/test/unit/Rendering/iblCdfGenerator.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { Constants } from "core/Engines/constants";
+import { IblCdfGenerator } from "core/Rendering/iblCdfGenerator";
+
+// Regression coverage for the scaled-luminance texture format: r32float mip generation requires
+// filtered sampling, which on WebGPU hard-fails bind group validation (dropping the whole command
+// buffer) when the optional `float32-filterable` adapter feature is absent. r16float is filterable
+// everywhere but loses range/precision that the CDF importance-sampling ratio does NOT cancel out
+// (see iblIcdf.fragment: it divides a fresh full-precision iblSource sample by the mip-averaged
+// scaled-luminance value, which are independently sampled). So the r16float fallback must only
+// apply to the WebGPU adapters that actually need it.
+describe("IblCdfGenerator scaled-luminance texture format", () => {
+    function createScaledLuminanceType(configureEngine: (engine: NullEngine) => void): number | undefined {
+        const engine = new NullEngine();
+        engine.getCaps().texelFetch = true; // required by IblCdfGenerator.isSupported
+        configureEngine(engine);
+        const scene = new Scene(engine);
+
+        const generator = new IblCdfGenerator(scene);
+        (generator as any)._createTextures();
+        const type = (generator as any)._scaledLuminancePT.getInternalTexture()?.type;
+
+        scene.dispose();
+        engine.dispose();
+        return type;
+    }
+
+    it("uses r32float when float32 linear filtering is supported", () => {
+        const type = createScaledLuminanceType((engine) => {
+            engine.getCaps().textureFloatLinearFiltering = true;
+        });
+        expect(type).toBe(Constants.TEXTURETYPE_FLOAT);
+    });
+
+    it("falls back to r16float on WebGPU adapters lacking float32-filterable", () => {
+        const type = createScaledLuminanceType((engine) => {
+            (engine as any)._isWebGPU = true;
+            engine.getCaps().textureFloatLinearFiltering = false;
+        });
+        expect(type).toBe(Constants.TEXTURETYPE_HALF_FLOAT);
+    });
+
+    it("keeps r32float on non-WebGPU engines even without float32 linear filtering", () => {
+        const type = createScaledLuminanceType((engine) => {
+            engine.getCaps().textureFloatLinearFiltering = false;
+        });
+        expect(type).toBe(Constants.TEXTURETYPE_FLOAT);
+    });
+});


### PR DESCRIPTION
This PR fixed two issues preventing the correct IBL shadow rendering on Adreno mobile GPUs:

- `iblScaledLuminance` unnecessarily used a mip-mapped, trilinear-filtered `r32float` texture. 32-bit float filtering requires the optional `float32-filterable` adapter feature, absent on this device class. Bind-group validation failed, and the frame's command buffer was dropped.

- `plasticSequence()`/`uint2float()` and `radicalInverse_VdC()`/`hammersley()` do raw 32-bit `uint` bit manipulation without declaring `precision highp int;`. On drivers that enforce GLSL ES's `mediump` int/uint default, these hash functions collapsed to a constant output, causing every tracing ray sampled the same direction, hit empty voxels, and shadows silently never appeared.

## Fixes

- `iblCdfGenerator.ts`: `iblScaledLuminance` → `TEXTURETYPE_HALF_FLOAT` (`r16float`, filterable everywhere; precision loss is negligible since the value only feeds a normalized ratio). 
- `helperFunctions.fx`, `hdrFilteringFunctions.fx`: added `precision highp int;` at the 32-bit bit-manipulation functions.

## Verification

Confirmed on-device (a Samsung Galaxy Flip Z 5 with Adreno 740) via the Babylon.js playground example (#DAID4Q#2), visually.