### PR TITLE
build: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1740,9 +1740,9 @@
             "link": true
         },
         "node_modules/@babylonjs/havok": {
-            "version": "1.3.13",
-            "resolved": "https://registry.npmjs.org/@babylonjs/havok/-/havok-1.3.13.tgz",
-            "integrity": "sha512-DDrPHbNdeanogdE261r4sfgKgtZb11ccaDjNEbhEcrcWz1XgYHTIJzz5QwO+J4XhOQJLXfn9Lv20cI2REIZiwg==",
+            "version": "1.3.14",
+            "resolved": "https://registry.npmjs.org/@babylonjs/havok/-/havok-1.3.14.tgz",
+            "integrity": "sha512-+j2FDwLtkh5Gb//KizE8Ks3GIB/3vH8Yx9cQsMvZQpsKkH5gn089wIlJ9Yt8dJxbwBmWKGpMTIXxZE7YdOHUnQ==",
             "license": "MIT",
             "dependencies": {
                 "@types/emscripten": "^1.39.6"
@@ -3017,9 +3017,9 @@
             }
         },
         "node_modules/@fluentui/keyboard-keys": {
-            "version": "9.0.8",
-            "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
-            "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.9.tgz",
+            "integrity": "sha512-DjX4z+dDCB49rsmyDuOwtD28Zbe9CUf86JKi8aUEvO5/TetsiuGPokgJiFIR0S9SGeFbquj5CUmAslk1RpgMzw==",
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.1"
@@ -3904,16 +3904,16 @@
             }
         },
         "node_modules/@fluentui/react-positioning": {
-            "version": "9.22.3",
-            "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.22.3.tgz",
-            "integrity": "sha512-2j2k87k7yVX8LYd9q3SniXYVGqED6JFRdTNeyamDf4DTk9/ECxTl2nKTmKedkDodddR5RRXpAtJXv874Mi9eyw==",
+            "version": "9.23.1",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.23.1.tgz",
+            "integrity": "sha512-QtnF1gOc0pQx5ks0DADpl5Jxh8mh4R82ddtaYu9XdyqBIfRz/SdYOPD6eB99qc7ynZnywuHsNH144W77jO+vdQ==",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/devtools": "^0.2.3",
                 "@floating-ui/dom": "^1.6.12",
-                "@fluentui/react-shared-contexts": "^9.26.2",
-                "@fluentui/react-theme": "^9.2.1",
-                "@fluentui/react-utilities": "^9.26.5",
+                "@fluentui/react-shared-contexts": "^9.26.3",
+                "@fluentui/react-theme": "^9.2.2",
+                "@fluentui/react-utilities": "^9.26.6",
                 "@griffel/react": "^1.5.32",
                 "@swc/helpers": "^0.5.1",
                 "use-sync-external-store": "^1.2.0"
@@ -4060,12 +4060,12 @@
             }
         },
         "node_modules/@fluentui/react-shared-contexts": {
-            "version": "9.26.2",
-            "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
-            "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+            "version": "9.26.3",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.3.tgz",
+            "integrity": "sha512-+FvkVJqX9yuZaZ//FWtNA4O0V33UA8Q82/5shp2fCox6HItENn87E5QecUobsodeYJ6xCAbTHccMh+LRiZhHJA==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/react-theme": "^9.2.1",
+                "@fluentui/react-theme": "^9.2.2",
                 "@swc/helpers": "^0.5.1"
             },
             "peerDependencies": {
@@ -4403,12 +4403,12 @@
             }
         },
         "node_modules/@fluentui/react-theme": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
-            "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.2.tgz",
+            "integrity": "sha512-yUQMQkMLGvo6+Q/RITxpLh00STvI299gnk1IV/QHc2DW5EKiCcmIp9xma7+lJzfLACfDkwJDy5hZSl+7MIYf9w==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/tokens": "1.0.0-alpha.23",
+                "@fluentui/tokens": "1.0.0-alpha.24",
                 "@swc/helpers": "^0.5.1"
             }
         },
@@ -4520,13 +4520,13 @@
             }
         },
         "node_modules/@fluentui/react-utilities": {
-            "version": "9.26.5",
-            "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.5.tgz",
-            "integrity": "sha512-lLWhnfMVEu+cWx3o9uTA5sDwo4U9PnpDJGVtheZ1bOCdh1YiQsJxeFM7n6nLE72UK2w+ATkGZQPYZA4QW1JLPQ==",
+            "version": "9.26.6",
+            "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.6.tgz",
+            "integrity": "sha512-a14Iihg2MmRSq1fxqr/4ffMl8VO0gYWRHAYKENz2PoL+oWnCtkMz4PDglIY8rVa7RADwXYI65XOjui0BjIFMvQ==",
             "license": "MIT",
             "dependencies": {
-                "@fluentui/keyboard-keys": "^9.0.8",
-                "@fluentui/react-shared-contexts": "^9.26.2",
+                "@fluentui/keyboard-keys": "^9.0.9",
+                "@fluentui/react-shared-contexts": "^9.26.3",
                 "@swc/helpers": "^0.5.1"
             },
             "peerDependencies": {
@@ -4554,9 +4554,9 @@
             }
         },
         "node_modules/@fluentui/tokens": {
-            "version": "1.0.0-alpha.23",
-            "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
-            "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+            "version": "1.0.0-alpha.24",
+            "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.24.tgz",
+            "integrity": "sha512-YrjGQfnxBR+9o8wXyTflON3Ohsv7OrZWYLVRU+7RaiFO1gcu36iDm3WjudlVmYuWRLDO0Gmxotm6RQNhbZuEQQ==",
             "license": "MIT",
             "dependencies": {
                 "@swc/helpers": "^0.5.1"
@@ -4748,9 +4748,9 @@
             }
         },
         "node_modules/@img/sharp-darwin-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-            "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+            "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
             "cpu": [
                 "arm64"
             ],
@@ -4767,13 +4767,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-arm64": "1.3.2"
+                "@img/sharp-libvips-darwin-arm64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-darwin-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-            "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+            "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
             "cpu": [
                 "x64"
             ],
@@ -4790,13 +4790,13 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-darwin-x64": "1.3.2"
+                "@img/sharp-libvips-darwin-x64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-freebsd-wasm32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-            "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+            "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
@@ -4804,7 +4804,7 @@
                 "freebsd"
             ],
             "dependencies": {
-                "@img/sharp-wasm32": "0.35.3"
+                "@img/sharp-wasm32": "0.35.4"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -4814,9 +4814,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-arm64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-            "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+            "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
             "cpu": [
                 "arm64"
             ],
@@ -4831,9 +4831,9 @@
             }
         },
         "node_modules/@img/sharp-libvips-darwin-x64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-            "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+            "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
             "cpu": [
                 "x64"
             ],
@@ -4848,13 +4848,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-            "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+            "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4865,13 +4868,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-arm64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-            "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+            "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4882,13 +4888,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-ppc64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-            "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+            "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4899,13 +4908,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-riscv64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-            "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+            "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4916,13 +4928,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-s390x": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-            "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+            "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4933,13 +4948,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linux-x64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-            "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+            "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4950,13 +4968,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-            "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+            "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4967,13 +4988,16 @@
             }
         },
         "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-            "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+            "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -4984,13 +5008,16 @@
             }
         },
         "node_modules/@img/sharp-linux-arm": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-            "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+            "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5003,17 +5030,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm": "1.3.2"
+                "@img/sharp-libvips-linux-arm": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-            "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+            "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5026,17 +5056,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-arm64": "1.3.2"
+                "@img/sharp-libvips-linux-arm64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-ppc64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-            "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+            "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5049,17 +5082,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-ppc64": "1.3.2"
+                "@img/sharp-libvips-linux-ppc64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-riscv64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-            "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+            "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5072,17 +5108,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-riscv64": "1.3.2"
+                "@img/sharp-libvips-linux-riscv64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-s390x": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-            "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+            "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5095,17 +5134,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-s390x": "1.3.2"
+                "@img/sharp-libvips-linux-s390x": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linux-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-            "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+            "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5118,17 +5160,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linux-x64": "1.3.2"
+                "@img/sharp-libvips-linux-x64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linuxmusl-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-            "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+            "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5141,17 +5186,20 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-linuxmusl-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-            "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+            "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -5164,18 +5212,18 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
             }
         },
         "node_modules/@img/sharp-wasm32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-            "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+            "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
             "dev": true,
             "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/runtime": "^1.11.1"
+                "@emnapi/runtime": "^1.11.3"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -5184,10 +5232,21 @@
                 "url": "https://opencollective.com/libvips"
             }
         },
+        "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@img/sharp-webcontainers-wasm32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-            "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+            "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
             "cpu": [
                 "wasm32"
             ],
@@ -5195,7 +5254,7 @@
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@img/sharp-wasm32": "0.35.3"
+                "@img/sharp-wasm32": "0.35.4"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -5205,9 +5264,9 @@
             }
         },
         "node_modules/@img/sharp-win32-arm64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-            "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+            "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
             "cpu": [
                 "arm64"
             ],
@@ -5225,9 +5284,9 @@
             }
         },
         "node_modules/@img/sharp-win32-ia32": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-            "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+            "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
             "cpu": [
                 "ia32"
             ],
@@ -5245,9 +5304,9 @@
             }
         },
         "node_modules/@img/sharp-win32-x64": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-            "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+            "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
             "cpu": [
                 "x64"
             ],
@@ -8278,9 +8337,9 @@
             }
         },
         "node_modules/@vitejs/plugin-react": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
-            "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
+            "integrity": "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8292,6 +8351,7 @@
             "peerDependencies": {
                 "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
                 "babel-plugin-react-compiler": "^1.0.0",
+                "oxc-transform-react": "^0.145.0",
                 "vite": "^8.0.0"
             },
             "peerDependenciesMeta": {
@@ -8299,6 +8359,9 @@
                     "optional": true
                 },
                 "babel-plugin-react-compiler": {
+                    "optional": true
+                },
+                "oxc-transform-react": {
                     "optional": true
                 }
             }
@@ -8735,19 +8798,6 @@
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-phases": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "peerDependencies": {
-                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -9557,9 +9607,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.31",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
-            "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+            "version": "2.11.19",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+            "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -9822,9 +9872,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+            "version": "4.28.8",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+            "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
             "dev": true,
             "funding": [
                 {
@@ -9842,11 +9892,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
+                "baseline-browser-mapping": "^2.11.12",
+                "caniuse-lite": "^1.0.30001809",
+                "electron-to-chromium": "^1.5.402",
+                "node-releases": "^2.0.53",
+                "update-browserslist-db": "^1.3.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -10081,9 +10131,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001793",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+            "version": "1.0.30001810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+            "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
             "dev": true,
             "funding": [
                 {
@@ -11451,9 +11501,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.357",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
-            "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
+            "version": "1.5.415",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+            "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
             "dev": true,
             "license": "ISC"
         },
@@ -11514,9 +11564,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-            "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15405,20 +15455,6 @@
                 "@types/trusted-types": "^2.0.2"
             }
         },
-        "node_modules/loader-runner": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-            "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.11.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            }
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -16356,11 +16392,14 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.36",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-            "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+            "version": "2.0.53",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+            "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -18333,9 +18372,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-            "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+            "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19974,9 +20013,9 @@
             "license": "ISC"
         },
         "node_modules/sharp": {
-            "version": "0.35.3",
-            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-            "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+            "version": "0.35.4",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+            "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -19991,31 +20030,31 @@
                 "url": "https://opencollective.com/libvips"
             },
             "optionalDependencies": {
-                "@img/sharp-darwin-arm64": "0.35.3",
-                "@img/sharp-darwin-x64": "0.35.3",
-                "@img/sharp-freebsd-wasm32": "0.35.3",
-                "@img/sharp-libvips-darwin-arm64": "1.3.2",
-                "@img/sharp-libvips-darwin-x64": "1.3.2",
-                "@img/sharp-libvips-linux-arm": "1.3.2",
-                "@img/sharp-libvips-linux-arm64": "1.3.2",
-                "@img/sharp-libvips-linux-ppc64": "1.3.2",
-                "@img/sharp-libvips-linux-riscv64": "1.3.2",
-                "@img/sharp-libvips-linux-s390x": "1.3.2",
-                "@img/sharp-libvips-linux-x64": "1.3.2",
-                "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-                "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-                "@img/sharp-linux-arm": "0.35.3",
-                "@img/sharp-linux-arm64": "0.35.3",
-                "@img/sharp-linux-ppc64": "0.35.3",
-                "@img/sharp-linux-riscv64": "0.35.3",
-                "@img/sharp-linux-s390x": "0.35.3",
-                "@img/sharp-linux-x64": "0.35.3",
-                "@img/sharp-linuxmusl-arm64": "0.35.3",
-                "@img/sharp-linuxmusl-x64": "0.35.3",
-                "@img/sharp-webcontainers-wasm32": "0.35.3",
-                "@img/sharp-win32-arm64": "0.35.3",
-                "@img/sharp-win32-ia32": "0.35.3",
-                "@img/sharp-win32-x64": "0.35.3"
+                "@img/sharp-darwin-arm64": "0.35.4",
+                "@img/sharp-darwin-x64": "0.35.4",
+                "@img/sharp-freebsd-wasm32": "0.35.4",
+                "@img/sharp-libvips-darwin-arm64": "1.3.3",
+                "@img/sharp-libvips-darwin-x64": "1.3.3",
+                "@img/sharp-libvips-linux-arm": "1.3.3",
+                "@img/sharp-libvips-linux-arm64": "1.3.3",
+                "@img/sharp-libvips-linux-ppc64": "1.3.3",
+                "@img/sharp-libvips-linux-riscv64": "1.3.3",
+                "@img/sharp-libvips-linux-s390x": "1.3.3",
+                "@img/sharp-libvips-linux-x64": "1.3.3",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+                "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+                "@img/sharp-linux-arm": "0.35.4",
+                "@img/sharp-linux-arm64": "0.35.4",
+                "@img/sharp-linux-ppc64": "0.35.4",
+                "@img/sharp-linux-riscv64": "0.35.4",
+                "@img/sharp-linux-s390x": "0.35.4",
+                "@img/sharp-linux-x64": "0.35.4",
+                "@img/sharp-linuxmusl-arm64": "0.35.4",
+                "@img/sharp-linuxmusl-x64": "0.35.4",
+                "@img/sharp-webcontainers-wasm32": "0.35.4",
+                "@img/sharp-win32-arm64": "0.35.4",
+                "@img/sharp-win32-ia32": "0.35.4",
+                "@img/sharp-win32-x64": "0.35.4"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
@@ -21697,9 +21736,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+            "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
             "dev": true,
             "funding": [
                 {
@@ -22057,9 +22096,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.108.4",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
-            "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
+            "version": "5.109.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+            "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -22069,22 +22108,20 @@
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
                 "acorn": "^8.16.0",
-                "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.22.2",
+                "enhanced-resolve": "^5.24.4",
                 "es-module-lexer": "^2.1.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "graceful-fs": "^4.2.11",
-                "loader-runner": "^4.3.2",
                 "mime-db": "^1.54.0",
                 "minimizer-webpack-plugin": "^5.6.1",
                 "neo-async": "^2.6.2",
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
                 "watchpack": "^2.5.2",
-                "webpack-sources": "^3.5.0"
+                "webpack-sources": "^3.5.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- Refresh in-range workspace dependencies, including Babylon Havok, Fluent UI positioning, Vite React tooling, Sharp, and webpack.
- Update related transitive packages such as Browserslist, caniuse-lite, enhanced-resolve, and PostCSS selector parser.
- Apply non-breaking npm audit fixes, reducing findings from 12 to 10 and removing the low-severity finding.

## Deferred updates

- React, React DOM, and their type packages remain on React 18 because permissive peer ranges in published workspaces otherwise make npm resolve React 19 against packages that explicitly require React 18.
- ESLint remains at 10.7.0 because `eslint-plugin-jsx-a11y` currently declares support only through ESLint 9.
- The remaining 10 high-severity audit findings originate from MemLab's Puppeteer/extract-zip dependency chain. npm's proposed fix is a breaking downgrade to MemLab 1.1.40.

## Validation

- Clean install with npm 11.18.0
- Formatting check
- Lint and tree-shaking checks
- Unit suite: 322 files and 4,786 tests passed
