### PR TITLE
Fix wgsl output for PowBlock and TriPlanarBlock

### DIFF
--- a/packages/dev/core/src/Materials/Node/Blocks/powBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/powBlock.pure.ts
@@ -58,8 +58,9 @@ export class PowBlock extends NodeMaterialBlock {
         super._buildBlock(state);
 
         const output = this._outputs[0];
+        const zero = `${state._getShaderType(output.type)}(0.)`;
 
-        state.compilationString += state._declareOutput(output) + ` = pow(max(${this.value.associatedVariableName}, 0.), ${this.power.associatedVariableName});\n`;
+        state.compilationString += state._declareOutput(output) + ` = pow(max(${this.value.associatedVariableName}, ${zero}), ${this.power.associatedVariableName});\n`;
 
         return this;
     }

--- a/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.pure.ts
@@ -448,28 +448,30 @@ export class TriPlanarBlock extends NodeMaterialBlock {
         }
 
         const suffix = state.fSuffix;
+        const uniformPrefix = state.shaderLanguage === ShaderLanguage.WGSL ? "uniforms." : "";
+        const mat2 = state.shaderLanguage === ShaderLanguage.WGSL ? "mat2x2f" : "mat2";
 
         state.compilationString += `
             // apply rotation
             {
-            float cosAngle = cos(${this._textureInfoName}.y);
-            float sinAngle = sin(${this._textureInfoName}.y);
-            ${uvx} = mat2${suffix}(cosAngle, -sinAngle, sinAngle, cosAngle) * ${uvx};
-            cosAngle = cos(${this._textureInfoName}.z);
-            sinAngle = sin(${this._textureInfoName}.z);
-            ${uvy} = mat2${suffix}(cosAngle, sinAngle, -sinAngle, cosAngle) * ${uvy};
-            cosAngle = cos(${this._textureInfoName}.w);
-            sinAngle = sin(${this._textureInfoName}.w);
-            ${uvz} = mat2${suffix}(cosAngle, -sinAngle, sinAngle, cosAngle) * ${uvz};
+            ${state._declareLocalVar("cosAngle", NodeMaterialBlockConnectionPointTypes.Float)} = cos(${uniformPrefix}${this._textureInfoName}.y);
+            ${state._declareLocalVar("sinAngle", NodeMaterialBlockConnectionPointTypes.Float)} = sin(${uniformPrefix}${this._textureInfoName}.y);
+            ${uvx} = ${mat2}(cosAngle, -sinAngle, sinAngle, cosAngle) * ${uvx};
+            cosAngle = cos(${uniformPrefix}${this._textureInfoName}.z);
+            sinAngle = sin(${uniformPrefix}${this._textureInfoName}.z);
+            ${uvy} = ${mat2}(cosAngle, sinAngle, -sinAngle, cosAngle) * ${uvy};
+            cosAngle = cos(${uniformPrefix}${this._textureInfoName}.w);
+            sinAngle = sin(${uniformPrefix}${this._textureInfoName}.w);
+            ${uvz} = ${mat2}(cosAngle, -sinAngle, sinAngle, cosAngle) * ${uvz};
 
             // apply scaling
-            vec2${suffix} uvScale = vec2${suffix}(${this._textureInfoName2}.z, ${this._textureInfoName2}.w);
+            ${state._declareLocalVar("uvScale", NodeMaterialBlockConnectionPointTypes.Vector2)} = vec2${suffix}(${uniformPrefix}${this._textureInfoName2}.z, ${uniformPrefix}${this._textureInfoName2}.w);
             ${uvx} = ${uvx} * uvScale;
             ${uvy} = ${uvy} * uvScale;
             ${uvz} = ${uvz} * uvScale;
 
             // apply offset
-            vec2${suffix} offset = vec2${suffix}(${this._textureInfoName2}.x, ${this._textureInfoName2}.y);
+            ${state._declareLocalVar("offset", NodeMaterialBlockConnectionPointTypes.Vector2)} = vec2${suffix}(${uniformPrefix}${this._textureInfoName2}.x, ${uniformPrefix}${this._textureInfoName2}.y);
             ${uvx} = ${uvx} + offset;
             ${uvy} = ${uvy} + offset;
             ${uvz} = ${uvz} + offset;

--- a/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.pure.ts
+++ b/packages/dev/core/src/Materials/Node/Blocks/triPlanarBlock.pure.ts
@@ -86,7 +86,7 @@ export class TriPlanarBlock extends NodeMaterialBlock {
      */
     public get textureZ(): Nullable<Texture> {
         if (this.sourceZ?.isConnected) {
-            return (this.sourceY.connectedPoint?.ownerBlock as ImageSourceBlock).texture;
+            return (this.sourceZ.connectedPoint?.ownerBlock as ImageSourceBlock).texture;
         }
         return null;
     }

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/mathBlocks.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/mathBlocks.test.ts
@@ -1,6 +1,67 @@
-import { InputBlock, MultiplyBlock, NodeMaterialBlockConnectionPointTypes, NodeMaterialBlockTargets } from "core/Materials";
+import { InputBlock, MultiplyBlock, NodeMaterialBlockConnectionPointTypes, NodeMaterialBlockTargets, PowBlock } from "core/Materials";
+import { type NodeMaterial } from "core/Materials/Node/nodeMaterial";
+import { NodeMaterialBuildState } from "core/Materials/Node/nodeMaterialBuildState";
+import { NodeMaterialBuildStateSharedData } from "core/Materials/Node/nodeMaterialBuildStateSharedData";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
+
+class TestablePowBlock extends PowBlock {
+    public build(state: NodeMaterialBuildState) {
+        return this._buildBlock(state);
+    }
+}
+
+function createBuildState(shaderLanguage: ShaderLanguage): NodeMaterialBuildState {
+    const state = new NodeMaterialBuildState();
+    state.sharedData = new NodeMaterialBuildStateSharedData();
+    state.sharedData.nodeMaterial = { shaderLanguage } as NodeMaterial;
+    return state;
+}
 
 describe("NME Math Blocks", () => {
+    describe("PowBlock", () => {
+        it.each([
+            [NodeMaterialBlockConnectionPointTypes.Float, "f32"],
+            [NodeMaterialBlockConnectionPointTypes.Vector2, "vec2f"],
+            [NodeMaterialBlockConnectionPointTypes.Vector3, "vec3f"],
+            [NodeMaterialBlockConnectionPointTypes.Vector4, "vec4f"],
+        ])("emits a typed WGSL zero for %s inputs", (type, shaderType) => {
+            const value = new InputBlock("value", NodeMaterialBlockTargets.Fragment, type);
+            const power = new InputBlock("power", NodeMaterialBlockTargets.Fragment, type);
+            const pow = new TestablePowBlock("pow");
+            value.output.connectTo(pow.value);
+            power.output.connectTo(pow.power);
+            value.associatedVariableName = "value";
+            power.associatedVariableName = "power";
+            pow.output.associatedVariableName = "output";
+
+            const state = createBuildState(ShaderLanguage.WGSL);
+            pow.build(state);
+
+            expect(state.compilationString).toBe(`var output: ${shaderType} = pow(max(value, ${shaderType}(0.)), power);\n`);
+        });
+
+        it.each([
+            [NodeMaterialBlockConnectionPointTypes.Float, "float"],
+            [NodeMaterialBlockConnectionPointTypes.Vector2, "vec2"],
+            [NodeMaterialBlockConnectionPointTypes.Vector3, "vec3"],
+            [NodeMaterialBlockConnectionPointTypes.Vector4, "vec4"],
+        ])("preserves valid GLSL generation for %s inputs", (type, shaderType) => {
+            const value = new InputBlock("value", NodeMaterialBlockTargets.Fragment, type);
+            const power = new InputBlock("power", NodeMaterialBlockTargets.Fragment, type);
+            const pow = new TestablePowBlock("pow");
+            value.output.connectTo(pow.value);
+            power.output.connectTo(pow.power);
+            value.associatedVariableName = "value";
+            power.associatedVariableName = "power";
+            pow.output.associatedVariableName = "output";
+
+            const state = createBuildState(ShaderLanguage.GLSL);
+            pow.build(state);
+
+            expect(state.compilationString).toBe(`${shaderType} output = pow(max(value, ${shaderType}(0.)), power);\n`);
+        });
+    });
+
     describe("Dynamic Updates", () => {
         it("invalid input type combinations throw", async () => {
             const validatePair = (leftType: NodeMaterialBlockConnectionPointTypes, rightType: NodeMaterialBlockConnectionPointTypes) => {

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/triPlanarBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/triPlanarBlock.test.ts
@@ -1,8 +1,10 @@
 import { type NodeMaterial } from "core/Materials/Node/nodeMaterial";
 import { NodeMaterialBuildState } from "core/Materials/Node/nodeMaterialBuildState";
 import { NodeMaterialBuildStateSharedData } from "core/Materials/Node/nodeMaterialBuildStateSharedData";
+import { ImageSourceBlock } from "core/Materials/Node/Blocks/Dual/imageSourceBlock";
 import { TriPlanarBlock } from "core/Materials/Node/Blocks/triPlanarBlock";
 import { ShaderLanguage } from "core/Materials/shaderLanguage";
+import { type Texture } from "core/Materials/Textures/texture";
 
 class TestableTriPlanarBlock extends TriPlanarBlock {
     public generateTextureLookup(state: NodeMaterialBuildState): void {
@@ -29,6 +31,31 @@ function generateTextureLookup(shaderLanguage: ShaderLanguage): string {
 }
 
 describe("TriPlanarBlock", () => {
+    it("returns the texture connected to sourceZ instead of the sourceY texture", () => {
+        const block = new TriPlanarBlock("triPlanar");
+        const sourceY = new ImageSourceBlock("sourceY");
+        const sourceZ = new ImageSourceBlock("sourceZ");
+        const textureY = { getScene: () => null } as Texture;
+        const textureZ = { getScene: () => null } as Texture;
+        sourceY.texture = textureY;
+        sourceZ.texture = textureZ;
+        sourceY.source.connectTo(block.sourceY);
+        sourceZ.source.connectTo(block.sourceZ!);
+
+        expect(block.textureY).toBe(textureY);
+        expect(block.textureZ).toBe(textureZ);
+    });
+
+    it("returns the sourceZ texture when sourceY is not connected", () => {
+        const block = new TriPlanarBlock("triPlanar");
+        const sourceZ = new ImageSourceBlock("sourceZ");
+        const textureZ = { getScene: () => null } as Texture;
+        sourceZ.texture = textureZ;
+        sourceZ.source.connectTo(block.sourceZ!);
+
+        expect(block.textureZ).toBe(textureZ);
+    });
+
     it("generates native WGSL declarations, uniform references, and matrix constructors", () => {
         const shader = generateTextureLookup(ShaderLanguage.WGSL);
 

--- a/packages/dev/core/test/unit/Materials/Node/Blocks/triPlanarBlock.test.ts
+++ b/packages/dev/core/test/unit/Materials/Node/Blocks/triPlanarBlock.test.ts
@@ -1,0 +1,57 @@
+import { type NodeMaterial } from "core/Materials/Node/nodeMaterial";
+import { NodeMaterialBuildState } from "core/Materials/Node/nodeMaterialBuildState";
+import { NodeMaterialBuildStateSharedData } from "core/Materials/Node/nodeMaterialBuildStateSharedData";
+import { TriPlanarBlock } from "core/Materials/Node/Blocks/triPlanarBlock";
+import { ShaderLanguage } from "core/Materials/shaderLanguage";
+
+class TestableTriPlanarBlock extends TriPlanarBlock {
+    public generateTextureLookup(state: NodeMaterialBuildState): void {
+        this._generateTextureLookup(state);
+    }
+}
+
+function generateTextureLookup(shaderLanguage: ShaderLanguage): string {
+    const state = new NodeMaterialBuildState();
+    state.sharedData = new NodeMaterialBuildStateSharedData();
+    state.sharedData.nodeMaterial = { shaderLanguage } as NodeMaterial;
+
+    const block = new TestableTriPlanarBlock("triPlanar");
+    block.position.associatedVariableName = "position";
+    block.normal.associatedVariableName = "normal";
+    Object.assign(block, {
+        _samplerName: "triPlanarSampler",
+        _textureInfoName: "textureInfo",
+        _textureInfoName2: "textureInfo2",
+    });
+
+    block.generateTextureLookup(state);
+    return state.compilationString;
+}
+
+describe("TriPlanarBlock", () => {
+    it("generates native WGSL declarations, uniform references, and matrix constructors", () => {
+        const shader = generateTextureLookup(ShaderLanguage.WGSL);
+
+        expect(shader).toContain("var cosAngle: f32 = cos(uniforms.textureInfo.y);");
+        expect(shader).toContain("var sinAngle: f32 = sin(uniforms.textureInfo.y);");
+        expect(shader).toContain("var uvScale: vec2f = vec2f(uniforms.textureInfo2.z, uniforms.textureInfo2.w);");
+        expect(shader).toContain("var offset: vec2f = vec2f(uniforms.textureInfo2.x, uniforms.textureInfo2.y);");
+        expect(shader.match(/mat2x2f\(/g)).toHaveLength(3);
+        expect(shader.match(/uniforms\.textureInfo\.[yzw]/g)).toHaveLength(6);
+        expect(shader.match(/uniforms\.textureInfo2\.[xyzw]/g)).toHaveLength(4);
+        expect(shader).not.toContain("mat2f(");
+        expect(shader).not.toMatch(/\bfloat (?:cosAngle|sinAngle)\b/);
+    });
+
+    it("preserves GLSL declarations, uniform references, and matrix constructors", () => {
+        const shader = generateTextureLookup(ShaderLanguage.GLSL);
+
+        expect(shader).toContain("float cosAngle = cos(textureInfo.y);");
+        expect(shader).toContain("float sinAngle = sin(textureInfo.y);");
+        expect(shader).toContain("vec2 uvScale = vec2(textureInfo2.z, textureInfo2.w);");
+        expect(shader).toContain("vec2 offset = vec2(textureInfo2.x, textureInfo2.y);");
+        expect(shader.match(/mat2\(/g)).toHaveLength(3);
+        expect(shader).not.toContain("uniforms.textureInfo");
+        expect(shader).not.toContain("mat2x2f(");
+    });
+});


### PR DESCRIPTION
Hey there, I recently ran into some issues when using `PowBlock`  and `TriPlanarBlock` inside a WebGPU setup. 

I used an agent to help investigate them, and identified three issues:

- `PowBlock` outputs WGSL with a type mismatch when the input is not a float
- `TriPlanarBlock` outputs GLSL inside its WGSL
- `TriPlanarBlock` suspiciously connects `textureZ` to `sourceY` 

This PR fixes all 3, let me know if that works for you!