### PR TITLE
WebGPU: key the leftover uniform buffer slots on the draw context, not on draw order

### DIFF
--- a/packages/dev/core/src/Engines/IDrawContext.ts
+++ b/packages/dev/core/src/Engines/IDrawContext.ts
@@ -31,6 +31,8 @@ export interface IDrawContext {
      * Resets the draw context to its initial state.
      */
     reset(): void;
+    /** Releases effect-specific uniform-buffer reservations. @internal */
+    _releaseUniformBufferSlots?(): void;
     /**
      * Disposes the draw context and its resources.
      */

--- a/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
@@ -5,6 +5,7 @@ import { type Nullable } from "../../types";
 import { type IDrawContext } from "../IDrawContext";
 import { type WebGPUBufferManager } from "./webgpuBufferManager";
 import { type WebGPUPipelineContext } from "./webgpuPipelineContext";
+import { type UniformBuffer } from "../../Materials/uniformBuffer";
 import * as WebGPUConstants from "./webgpuConstants";
 
 /**
@@ -47,6 +48,12 @@ export class WebGPUDrawContext implements IDrawContext {
     private _isDirty: boolean;
     private _enableIndirectDraw: boolean;
     private _vertexPullingEnabled: boolean;
+
+    /**
+     * Uniform buffers in which this context owns a slot (see UniformBuffer.update). Filled by the buffers themselves.
+     * @internal
+     */
+    public _uniformBuffersWithOwnedSlot?: UniformBuffer[];
 
     /**
      * Checks if the draw context is dirty.
@@ -237,5 +244,11 @@ export class WebGPUDrawContext implements IDrawContext {
         this.bindGroups = undefined;
         this.buffers = undefined as any;
         this._enableIndirectDraw = false;
+        if (this._uniformBuffersWithOwnedSlot) {
+            for (const uniformBuffer of this._uniformBuffersWithOwnedSlot) {
+                uniformBuffer._releaseOwnerSlot(this);
+            }
+            this._uniformBuffersWithOwnedSlot = undefined;
+        }
     }
 }

--- a/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
+++ b/packages/dev/core/src/Engines/WebGPU/webgpuDrawContext.ts
@@ -50,7 +50,7 @@ export class WebGPUDrawContext implements IDrawContext {
     private _vertexPullingEnabled: boolean;
 
     /**
-     * Uniform buffers in which this context owns a slot (see UniformBuffer.update). Filled by the buffers themselves.
+     * Uniform buffers in which this context owns a slot. Filled by the buffers themselves.
      * @internal
      */
     public _uniformBuffersWithOwnedSlot?: UniformBuffer[];
@@ -142,6 +142,7 @@ export class WebGPUDrawContext implements IDrawContext {
     }
 
     public reset(): void {
+        this._releaseUniformBufferSlots();
         this.buffers = {};
         this._isDirty = true;
         this._materialContextUpdateId = 0;
@@ -235,6 +236,7 @@ export class WebGPUDrawContext implements IDrawContext {
     }
 
     public dispose(): void {
+        this._releaseUniformBufferSlots();
         if (this.indirectDrawBuffer) {
             this._bufferManager.releaseBuffer(this.indirectDrawBuffer);
             this.indirectDrawBuffer = undefined;
@@ -244,11 +246,19 @@ export class WebGPUDrawContext implements IDrawContext {
         this.bindGroups = undefined;
         this.buffers = undefined as any;
         this._enableIndirectDraw = false;
-        if (this._uniformBuffersWithOwnedSlot) {
-            for (const uniformBuffer of this._uniformBuffersWithOwnedSlot) {
-                uniformBuffer._releaseOwnerSlot(this);
-            }
-            this._uniformBuffersWithOwnedSlot = undefined;
+    }
+
+    /** @internal */
+    public _releaseUniformBufferSlots(): void {
+        const buffers = this._uniformBuffersWithOwnedSlot;
+        if (!buffers) {
+            return;
         }
+        // _releaseOwnerSlot removes its reciprocal entry; pop first to avoid skipping
+        // entries when several buffers were registered on this context.
+        while (buffers.length) {
+            buffers.pop()!._releaseOwnerSlot(this);
+        }
+        this._uniformBuffersWithOwnedSlot = undefined;
     }
 }

--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -481,6 +481,15 @@ export class WebGPUEngine extends ThinWebGPUEngine {
     }
 
     /**
+     * When true (default), the "leftover" uniform buffer of an effect (the buffer that holds the uniforms not declared in a named
+     * uniform block) keeps one GPU buffer per draw context, so a given draw call always binds the same buffer for a given effect.
+     * When false, the GPU buffers are assigned in draw order: the buffer bound by a draw call then changes with the order in which
+     * meshes are drawn, and every new (draw context, buffer) pair is a new entry in the bind group cache.
+     * Change it before rendering the first frame. You should set it to false only for testing purpose!
+     */
+    public useOwnerKeyedUniformBufferSlots = true;
+
+    /**
      * Sets this to true to disable the cache for the bind groups. You should do it only for testing purpose!
      */
     public get disableCacheBindGroups(): boolean {
@@ -3777,7 +3786,7 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         );
 
         if (webgpuPipelineContext.uniformBuffer) {
-            webgpuPipelineContext.uniformBuffer.update();
+            webgpuPipelineContext.uniformBuffer.update(this.useOwnerKeyedUniformBufferSlots ? this._currentDrawContext : undefined);
             this.bindUniformBufferBase(webgpuPipelineContext.uniformBuffer.getBuffer()!, 0, WebGPUShaderProcessor.LeftOvertUBOName);
         }
 

--- a/packages/dev/core/src/Engines/webgpuEngine.pure.ts
+++ b/packages/dev/core/src/Engines/webgpuEngine.pure.ts
@@ -486,8 +486,9 @@ export class WebGPUEngine extends ThinWebGPUEngine {
      * When false, the GPU buffers are assigned in draw order: the buffer bound by a draw call then changes with the order in which
      * meshes are drawn, and every new (draw context, buffer) pair is a new entry in the bind group cache.
      * Change it before rendering the first frame. You should set it to false only for testing purpose!
+     * @internal
      */
-    public useOwnerKeyedUniformBufferSlots = true;
+    public _useOwnerKeyedUniformBufferSlots = true;
 
     /**
      * Sets this to true to disable the cache for the bind groups. You should do it only for testing purpose!
@@ -3786,7 +3787,11 @@ export class WebGPUEngine extends ThinWebGPUEngine {
         );
 
         if (webgpuPipelineContext.uniformBuffer) {
-            webgpuPipelineContext.uniformBuffer.update(this.useOwnerKeyedUniformBufferSlots ? this._currentDrawContext : undefined);
+            if (this._useOwnerKeyedUniformBufferSlots) {
+                webgpuPipelineContext.uniformBuffer._updateOwnerKeyed(this._currentDrawContext);
+            } else {
+                webgpuPipelineContext.uniformBuffer.update();
+            }
             this.bindUniformBufferBase(webgpuPipelineContext.uniformBuffer.getBuffer()!, 0, WebGPUShaderProcessor.LeftOvertUBOName);
         }
 

--- a/packages/dev/core/src/Materials/drawWrapper.ts
+++ b/packages/dev/core/src/Materials/drawWrapper.ts
@@ -78,6 +78,9 @@ export class DrawWrapper {
      * @param resetContext If true, resets the draw context (default is true).
      */
     public setEffect(effect: Nullable<Effect>, defines?: Nullable<string | MaterialDefines>, resetContext = true): void {
+        if (!resetContext && this.effect !== effect) {
+            this.drawContext?._releaseUniformBufferSlots?.();
+        }
         this.effect = effect;
         if (defines !== undefined) {
             this.defines = defines;

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -7,6 +7,16 @@ import { type DataBuffer } from "../Buffers/dataBuffer";
 import { type InternalTexture } from "./Textures/internalTexture";
 import { Tools } from "../Misc/tools.pure";
 import { type AbstractEngine } from "core/Engines/abstractEngine";
+import { type IDrawContext } from "../Engines/IDrawContext";
+
+/**
+ * A draw context that owns a slot in one or more tracked uniform buffers (see UniformBuffer.update).
+ * A buffer registers itself here when it assigns a slot to the context, so that the slot can be released when the context is disposed.
+ */
+export interface IUniformBufferSlotOwner extends IDrawContext {
+    /** @internal */
+    _uniformBuffersWithOwnedSlot?: UniformBuffer[];
+}
 
 /**
  * Uniform buffer objects.
@@ -40,6 +50,12 @@ export class UniformBuffer {
     private _name: string;
     private _currentFrameId: number;
     private _trackUBOsInFrame: boolean;
+    // Owner-keyed slots (trackUBOsInFrame only): draw context -> index in _buffers, last frame each slot was flushed in,
+    // number of live owners, and slots no longer owned (released by a disposed context, or created for a same-frame overflow)
+    private _slotByOwner: WeakMap<IUniformBufferSlotOwner, number>;
+    private _slotFrameId: number[];
+    private _ownerCount: number;
+    private _freeSlots: number[];
 
     // Pool for avoiding memory leaks
     private static _MAX_UNIFORM_SIZE = 256;
@@ -260,6 +276,7 @@ export class UniformBuffer {
             this._createBufferOnWrite = false;
             this._currentFrameId = 0;
             this._trackUBOsInFrame = true;
+            this._resetOwnerSlots();
         }
 
         if (this._noUBO) {
@@ -615,8 +632,16 @@ export class UniformBuffer {
         if (this._trackUBOsInFrame) {
             this._buffers = [];
             this._currentFrameId = 0;
+            this._resetOwnerSlots();
         }
         this._rebuild();
+    }
+
+    private _resetOwnerSlots(): void {
+        this._slotByOwner = new WeakMap();
+        this._slotFrameId = [];
+        this._ownerCount = 0;
+        this._freeSlots = [];
     }
 
     /** @internal */
@@ -662,9 +687,17 @@ export class UniformBuffer {
      * Updates the WebGL Uniform Buffer on the GPU.
      * If the `dynamic` flag is set to true, no cache comparison is done.
      * Otherwise, the buffer will be updated only if the cache differs.
+     * @param owner When the buffer tracks its GPU buffers per frame (WebGPU), the draw context on behalf of which the update is done.
+     * The context then always flushes to the same GPU buffer (its slot), instead of the next unused buffer in draw order, so the buffer
+     * bound by a given draw call does not change when the draw order changes and the bind group cache stays bounded.
      */
-    public update(): void {
+    public update(owner?: IUniformBufferSlotOwner): void {
         if (this._noUBO) {
+            return;
+        }
+
+        if (owner && this._trackUBOsInFrame) {
+            this._updateOwnerKeyed(owner);
             return;
         }
 
@@ -696,6 +729,98 @@ export class UniformBuffer {
 
         this._needSync = false;
         this._createBufferOnWrite = this._trackUBOsInFrame;
+    }
+
+    /**
+     * Flushes the current uniform values into the GPU buffer owned by the draw context.
+     * Invariant: `_buffers[i][1]` (the CPU shadow) always holds what the GPU buffer of slot i contains.
+     * @param owner the draw context on behalf of which the update is done
+     */
+    private _updateOwnerKeyed(owner: IUniformBufferSlotOwner): void {
+        if (!this._buffer) {
+            this.create(); // _rebuild pushes slot 0, created from _bufferData, with a shadow copy of it
+        }
+
+        this._checkNewFrame();
+
+        let idx = this._slotByOwner.get(owner);
+        if (idx === undefined) {
+            if (this._ownerCount === 0 && this._buffers.length === 1) {
+                idx = 0; // the slot create() made: hand it to the first owner instead of leaving it unused
+            } else {
+                idx = this._takeFreeSlot(true);
+            }
+            this._slotByOwner.set(owner, idx);
+            this._ownerCount++;
+            if (!owner._uniformBuffersWithOwnedSlot) {
+                owner._uniformBuffersWithOwnedSlot = [];
+            }
+            owner._uniformBuffersWithOwnedSlot.push(this);
+        }
+
+        const owned = this._buffers[idx][1];
+        if (this._slotFrameId[idx] === this._currentFrameId && owned && !this._buffersEqual(this._bufferData, owned)) {
+            // The same context flushes a second time in the same frame with different values: the GPU has not consumed the
+            // first values yet, so they must not be overwritten. Use a slot nobody owns for this flush.
+            idx = this._takeFreeSlot(false);
+        }
+
+        this._bufferIndex = idx;
+        this._buffer = this._buffers[idx][0];
+        this.bindUniformBuffer();
+
+        const shadow = this._buffers[idx][1];
+        if (!shadow || !this._buffersEqual(this._bufferData, shadow)) {
+            if (shadow) {
+                this._copyBuffer(this._bufferData, shadow);
+            }
+            this._bufferUpdatedLastFrame = true;
+            this._engine.updateUniformBuffer(this._buffer, this._bufferData);
+        }
+
+        this._slotFrameId[idx] = this._currentFrameId;
+        this._needSync = false;
+        this._createBufferOnWrite = false; // slots are keyed on the owner, the updateXXX methods must never switch buffer
+    }
+
+    /**
+     * Gets a slot that is not owned by any draw context and has not been flushed in the current frame, creating one if needed.
+     * @param takeOwnership true to remove the slot from the free list (it is going to be owned by a context)
+     * @returns the slot index
+     */
+    private _takeFreeSlot(takeOwnership: boolean): number {
+        for (let i = 0; i < this._freeSlots.length; ++i) {
+            const idx = this._freeSlots[i];
+            if (this._slotFrameId[idx] !== this._currentFrameId) {
+                if (takeOwnership) {
+                    this._freeSlots[i] = this._freeSlots[this._freeSlots.length - 1];
+                    this._freeSlots.pop();
+                }
+                return idx;
+            }
+        }
+
+        this._rebuild();
+        const idx = this._buffers.length - 1;
+        if (!takeOwnership) {
+            this._freeSlots.push(idx);
+        }
+        return idx;
+    }
+
+    /**
+     * Releases the slot owned by a draw context (called when the context is disposed), so that another context can reuse it.
+     * @param owner the draw context
+     * @internal
+     */
+    public _releaseOwnerSlot(owner: IUniformBufferSlotOwner): void {
+        const idx = this._slotByOwner?.get(owner);
+        if (idx === undefined) {
+            return;
+        }
+        this._slotByOwner.delete(owner);
+        this._ownerCount--;
+        this._freeSlots.push(idx);
     }
 
     private _createNewBuffer() {

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -745,8 +745,10 @@ export class UniformBuffer {
 
         let idx = this._slotByOwner.get(owner);
         if (idx === undefined) {
-            if (this._ownerCount === 0 && this._buffers.length === 1) {
-                idx = 0; // the slot create() made: hand it to the first owner instead of leaving it unused
+            if (this._ownerCount === 0 && this._buffers.length === 1 && this._freeSlots.length === 0) {
+                // the slot create() made and nobody has owned yet: hand it to the first owner instead of leaving it unused.
+                // (Once an owner has released it, it is in _freeSlots and must be taken from there, or two owners could share it.)
+                idx = 0;
             } else {
                 idx = this._takeFreeSlot(true);
             }

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -56,6 +56,11 @@ export class UniformBuffer {
     private _slotFrameId: number[];
     private _ownerCount: number;
     private _freeSlots: number[];
+    // Generation of the staging data (_bufferData): bumped on every write that changes it. Each owner-keyed slot
+    // remembers the generation it was last flushed with, so a draw whose values did not change since that flush
+    // costs one integer compare instead of a full compare of the block against the slot's shadow.
+    private _dataGeneration: number;
+    private _slotGeneration: number[];
 
     // Pool for avoiding memory leaks
     private static _MAX_UNIFORM_SIZE = 256;
@@ -267,6 +272,7 @@ export class UniformBuffer {
         this._uniformArraySizes = {};
         this._uniformLocationPointer = 0;
         this._needSync = false;
+        this._dataGeneration = 0;
         this._trackUBOsInFrame = false;
 
         if ((trackUBOsInFrame === undefined && this._engine._features.trackUbosInFrame) || trackUBOsInFrame === true) {
@@ -586,6 +592,7 @@ export class UniformBuffer {
         // See spec, alignment must be filled as a vec4
         this._fillAlignment(4);
         this._bufferData = new Float32Array(this._data);
+        this._dataGeneration++;
 
         this._rebuild();
 
@@ -642,6 +649,7 @@ export class UniformBuffer {
         this._slotFrameId = [];
         this._ownerCount = 0;
         this._freeSlots = [];
+        this._slotGeneration = [];
     }
 
     /** @internal */
@@ -760,6 +768,18 @@ export class UniformBuffer {
             owner._uniformBuffersWithOwnedSlot.push(this);
         }
 
+        if (this._slotGeneration[idx] === this._dataGeneration) {
+            // The slot was last flushed with exactly the current data and nothing has been written since: nothing to
+            // compare, nothing to upload, and no same-frame conflict is possible either (same bytes).
+            this._bufferIndex = idx;
+            this._buffer = this._buffers[idx][0];
+            this.bindUniformBuffer();
+            this._slotFrameId[idx] = this._currentFrameId;
+            this._needSync = false;
+            this._createBufferOnWrite = false;
+            return;
+        }
+
         const owned = this._buffers[idx][1];
         if (this._slotFrameId[idx] === this._currentFrameId && owned && !this._buffersEqual(this._bufferData, owned)) {
             // The same context flushes a second time in the same frame with different values: the GPU has not consumed the
@@ -781,6 +801,7 @@ export class UniformBuffer {
         }
 
         this._slotFrameId[idx] = this._currentFrameId;
+        this._slotGeneration[idx] = this._dataGeneration;
         this._needSync = false;
         this._createBufferOnWrite = false; // slots are keyed on the owner, the updateXXX methods must never switch buffer
     }
@@ -895,11 +916,15 @@ export class UniformBuffer {
             }
 
             this._needSync = this._needSync || changed;
+            if (changed) {
+                this._dataGeneration++;
+            }
         } else {
             // No cache for dynamic
             for (let i = 0; i < size; i++) {
                 this._bufferData[location + i] = data[i];
             }
+            this._dataGeneration++;
         }
     }
 
@@ -948,11 +973,15 @@ export class UniformBuffer {
             }
 
             this._needSync = this._needSync || changed;
+            if (changed) {
+                this._dataGeneration++;
+            }
         } else {
             // No cache for dynamic
             for (let i = 0; i < size; i++) {
                 this._bufferData[location + i] = data[i];
             }
+            this._dataGeneration++;
         }
     }
 
@@ -1339,6 +1368,7 @@ export class UniformBuffer {
                 // Note that if _buffers.length == 1, we don't copy _bufferData into _buffers[_bufferIndex][1] (see the update() method), and _bufferData already contains the right data
                 if (this._buffers.length > 1 && this._buffers[b][1]) {
                     this._bufferData.set(this._buffers[b][1]!);
+                    this._dataGeneration++;
                 }
                 this._valueCache = {};
                 // The following line prevents the current buffer (_buffer / _bufferIndex) from being updated during subsequent calls to updateXXX() due to a call to _checkNewFrame()

--- a/packages/dev/core/src/Materials/uniformBuffer.ts
+++ b/packages/dev/core/src/Materials/uniformBuffer.ts
@@ -7,16 +7,7 @@ import { type DataBuffer } from "../Buffers/dataBuffer";
 import { type InternalTexture } from "./Textures/internalTexture";
 import { Tools } from "../Misc/tools.pure";
 import { type AbstractEngine } from "core/Engines/abstractEngine";
-import { type IDrawContext } from "../Engines/IDrawContext";
-
-/**
- * A draw context that owns a slot in one or more tracked uniform buffers (see UniformBuffer.update).
- * A buffer registers itself here when it assigns a slot to the context, so that the slot can be released when the context is disposed.
- */
-export interface IUniformBufferSlotOwner extends IDrawContext {
-    /** @internal */
-    _uniformBuffersWithOwnedSlot?: UniformBuffer[];
-}
+import { type WebGPUDrawContext } from "../Engines/WebGPU/webgpuDrawContext";
 
 /**
  * Uniform buffer objects.
@@ -52,7 +43,10 @@ export class UniformBuffer {
     private _trackUBOsInFrame: boolean;
     // Owner-keyed slots (trackUBOsInFrame only): draw context -> index in _buffers, last frame each slot was flushed in,
     // number of live owners, and slots no longer owned (released by a disposed context, or created for a same-frame overflow)
-    private _slotByOwner: WeakMap<IUniformBufferSlotOwner, number>;
+    private _slotByOwner: WeakMap<WebGPUDrawContext, number>;
+    // Reverse registrations hold the backlink arrays, not their draw contexts. This allows
+    // eager reciprocal teardown without making the weak owner keys strongly reachable.
+    private _ownerListsBySlot: Map<number, UniformBuffer[]>;
     private _slotFrameId: number[];
     private _ownerCount: number;
     private _freeSlots: number[];
@@ -645,6 +639,12 @@ export class UniformBuffer {
     }
 
     private _resetOwnerSlots(): void {
+        if (this._ownerListsBySlot) {
+            for (const list of this._ownerListsBySlot.values()) {
+                this._removeOwnerBacklink(list);
+            }
+        }
+        this._ownerListsBySlot = new Map();
         this._slotByOwner = new WeakMap();
         this._slotFrameId = [];
         this._ownerCount = 0;
@@ -695,17 +695,9 @@ export class UniformBuffer {
      * Updates the WebGL Uniform Buffer on the GPU.
      * If the `dynamic` flag is set to true, no cache comparison is done.
      * Otherwise, the buffer will be updated only if the cache differs.
-     * @param owner When the buffer tracks its GPU buffers per frame (WebGPU), the draw context on behalf of which the update is done.
-     * The context then always flushes to the same GPU buffer (its slot), instead of the next unused buffer in draw order, so the buffer
-     * bound by a given draw call does not change when the draw order changes and the bind group cache stays bounded.
      */
-    public update(owner?: IUniformBufferSlotOwner): void {
+    public update(): void {
         if (this._noUBO) {
-            return;
-        }
-
-        if (owner && this._trackUBOsInFrame) {
-            this._updateOwnerKeyed(owner);
             return;
         }
 
@@ -743,8 +735,13 @@ export class UniformBuffer {
      * Flushes the current uniform values into the GPU buffer owned by the draw context.
      * Invariant: `_buffers[i][1]` (the CPU shadow) always holds what the GPU buffer of slot i contains.
      * @param owner the draw context on behalf of which the update is done
+     * @internal
      */
-    private _updateOwnerKeyed(owner: IUniformBufferSlotOwner): void {
+    public _updateOwnerKeyed(owner: WebGPUDrawContext): void {
+        if (this._noUBO || !this._trackUBOsInFrame) {
+            this.update();
+            return;
+        }
         if (!this._buffer) {
             this.create(); // _rebuild pushes slot 0, created from _bufferData, with a shadow copy of it
         }
@@ -766,6 +763,7 @@ export class UniformBuffer {
                 owner._uniformBuffersWithOwnedSlot = [];
             }
             owner._uniformBuffersWithOwnedSlot.push(this);
+            this._ownerListsBySlot.set(idx, owner._uniformBuffersWithOwnedSlot);
         }
 
         if (this._slotGeneration[idx] === this._dataGeneration) {
@@ -836,14 +834,28 @@ export class UniformBuffer {
      * @param owner the draw context
      * @internal
      */
-    public _releaseOwnerSlot(owner: IUniformBufferSlotOwner): void {
+    public _releaseOwnerSlot(owner: WebGPUDrawContext): void {
         const idx = this._slotByOwner?.get(owner);
         if (idx === undefined) {
             return;
         }
         this._slotByOwner.delete(owner);
+        const list = this._ownerListsBySlot.get(idx);
+        if (list) {
+            this._removeOwnerBacklink(list);
+            this._ownerListsBySlot.delete(idx);
+        }
         this._ownerCount--;
+        // Keep _slotFrameId: a draw encoded earlier this frame may still need these bytes.
         this._freeSlots.push(idx);
+    }
+
+    private _removeOwnerBacklink(list: UniformBuffer[]): void {
+        const index = list.indexOf(this);
+        if (index !== -1) {
+            list[index] = list[list.length - 1];
+            list.pop();
+        }
     }
 
     private _createNewBuffer() {
@@ -1407,10 +1419,14 @@ export class UniformBuffer {
         }
 
         if (this._trackUBOsInFrame && this._buffers) {
+            this._resetOwnerSlots();
             for (let i = 0; i < this._buffers.length; ++i) {
                 const buffer = this._buffers[i][0];
                 this._engine._releaseBuffer(buffer);
             }
+            this._buffers = [];
+            this._buffer = null;
+            this._bufferIndex = -1;
         } else if (this._buffer && this._engine._releaseBuffer(this._buffer)) {
             this._buffer = null;
         }

--- a/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
+++ b/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
@@ -171,6 +171,34 @@ describe("UniformBuffer owner-keyed slots", () => {
         expect(ubo._numBuffers).toBe(3);
     });
 
+    it("never lets two live owners share a slot after the sole owner is released", () => {
+        // owner A is the only owner: it gets the slot create() made (slot 0)
+        engine.frameId = 1;
+        ubo.updateFloat4("color", 1, 1, 1, 1);
+        ubo.update(owners[0]);
+        const slot0 = ubo.getBuffer();
+        ubo._releaseOwnerSlot(owners[0]); // A's context is disposed; slot 0 is now in the free list
+
+        // B arrives: it must take slot 0 THROUGH the free list (so the entry is consumed), not via the first-owner shortcut
+        engine.frameId = 2;
+        ubo.updateFloat4("color", 2, 2, 2, 2);
+        ubo.update(owners[1]);
+        expect(ubo.getBuffer()).toBe(slot0);
+
+        // C arrives next frame: the free list must be empty, so C gets a NEW slot instead of B's
+        engine.frameId = 3;
+        ubo.updateFloat4("color", 3, 3, 3, 3);
+        ubo.update(owners[2]);
+        expect(ubo.getBuffer()).not.toBe(slot0);
+        expect(ubo._numBuffers).toBe(2);
+
+        // and B still reads back its own values from its own slot
+        ubo.updateFloat4("color", 2, 2, 2, 2);
+        ubo.update(owners[1]);
+        expect(ubo.getBuffer()).toBe(slot0);
+        expect((slot0 as unknown as MockGpuBuffer).gpu[0]).toBe(2);
+    });
+
     it("keeps the draw-order behavior when no owner is given", () => {
         const order = owners.map((_, i) => i);
         engine.frameId = 1;

--- a/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
+++ b/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { UniformBuffer, type IUniformBufferSlotOwner } from "core/Materials/uniformBuffer";
+
+/**
+ * A minimal engine that tracks its uniform buffers per frame the way WebGPUEngine does
+ * (trackUbosInFrame + checkUbosContentBeforeUpload), recording every GPU upload.
+ */
+interface MockGpuBuffer {
+    uniqueId: number;
+    gpu: Float32Array;
+}
+
+function createEngine() {
+    let nextId = 1;
+    const uploads: number[] = [];
+    const engine = {
+        supportsUniformBuffers: true,
+        frameId: 1,
+        _uniformBuffers: [] as UniformBuffer[],
+        _features: { trackUbosInFrame: true, checkUbosContentBeforeUpload: true, uniformBufferHardCheckMatrix: false },
+        createUniformBuffer(data: Float32Array): MockGpuBuffer {
+            return { uniqueId: nextId++, gpu: data.slice() };
+        },
+        createDynamicUniformBuffer(data: Float32Array): MockGpuBuffer {
+            return { uniqueId: nextId++, gpu: data.slice() };
+        },
+        updateUniformBuffer(buffer: MockGpuBuffer, data: Float32Array): void {
+            buffer.gpu = data.slice();
+            uploads.push(buffer.uniqueId);
+        },
+        _releaseBuffer(): boolean {
+            return true;
+        },
+        uploads,
+    };
+    return engine;
+}
+
+function createOwner(id: number): IUniformBufferSlotOwner {
+    return {
+        uniqueId: id,
+        useInstancing: false,
+        enableIndirectDraw: false,
+        setIndirectData: () => {},
+        reset: () => {},
+        dispose: () => {},
+    };
+}
+
+function shuffle<T>(array: T[]): T[] {
+    const result = array.slice();
+    for (let i = result.length - 1; i > 0; --i) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [result[i], result[j]] = [result[j], result[i]];
+    }
+    return result;
+}
+
+describe("UniformBuffer owner-keyed slots", () => {
+    let engine: ReturnType<typeof createEngine>;
+    let ubo: UniformBuffer;
+    let owners: IUniformBufferSlotOwner[];
+    const OWNERS = 40;
+
+    // Each owner writes its own values (as each material does into the effect's leftover UBO), then flushes on its own behalf.
+    function drawFrame(order: number[]): void {
+        for (const i of order) {
+            ubo.updateFloat4("color", i, i * 2, i * 3, 1);
+            ubo.updateFloat("scalar", i / 10);
+            ubo.update(owners[i]);
+            const gpu = (ubo.getBuffer() as unknown as MockGpuBuffer).gpu;
+            expect([gpu[0], gpu[1], gpu[2], gpu[4]]).toEqual([i, i * 2, i * 3, Math.fround(i / 10)]);
+        }
+    }
+
+    beforeEach(() => {
+        engine = createEngine();
+        ubo = new UniformBuffer(engine as any, undefined, false, "leftOver-test");
+        ubo.addUniform("color", 4);
+        ubo.addUniform("scalar", 1);
+        ubo.create();
+        owners = Array.from({ length: OWNERS }, (_, i) => createOwner(i));
+    });
+
+    it("keeps the pool at one GPU buffer per owner whatever the draw order, and every owner reads back its own values", () => {
+        const order = owners.map((_, i) => i);
+        for (let frame = 1; frame <= 200; ++frame) {
+            engine.frameId = frame;
+            drawFrame(shuffle(order));
+            expect(ubo._numBuffers).toBe(OWNERS);
+        }
+    });
+
+    it("uploads nothing once every owner's values are on the GPU, even when the draw order changes", () => {
+        const order = owners.map((_, i) => i);
+        engine.frameId = 1;
+        drawFrame(order);
+        const uploadsAfterFirstFrame = engine.uploads.length;
+        for (let frame = 2; frame <= 20; ++frame) {
+            engine.frameId = frame;
+            drawFrame(shuffle(order));
+        }
+        expect(engine.uploads.length).toBe(uploadsAfterFirstFrame);
+    });
+
+    it("binds the same GPU buffer for a given owner frame after frame", () => {
+        const order = owners.map((_, i) => i);
+        const bufferOf = new Map<number, unknown>();
+        engine.frameId = 1;
+        for (const i of order) {
+            ubo.updateFloat4("color", i, i * 2, i * 3, 1);
+            ubo.updateFloat("scalar", i / 10);
+            ubo.update(owners[i]);
+            bufferOf.set(i, ubo.getBuffer());
+        }
+        engine.frameId = 2;
+        for (const i of shuffle(order)) {
+            ubo.updateFloat4("color", i, i * 2, i * 3, 1);
+            ubo.updateFloat("scalar", i / 10);
+            ubo.update(owners[i]);
+            expect(ubo.getBuffer()).toBe(bufferOf.get(i));
+        }
+    });
+
+    it("does not overwrite a slot the GPU has not consumed yet when the same owner flushes twice in a frame with different values", () => {
+        engine.frameId = 1;
+        ubo.updateFloat4("color", 7, 7, 7, 7);
+        ubo.update(owners[3]);
+        const firstBuffer = ubo.getBuffer() as unknown as MockGpuBuffer;
+
+        ubo.updateFloat4("color", 8, 8, 8, 8);
+        ubo.update(owners[3]);
+        const secondBuffer = ubo.getBuffer() as unknown as MockGpuBuffer;
+
+        expect(secondBuffer).not.toBe(firstBuffer);
+        expect(firstBuffer.gpu[0]).toBe(7);
+        expect(secondBuffer.gpu[0]).toBe(8);
+
+        // next frame: the owner is back on its own slot, and the spill slot is reusable
+        engine.frameId = 2;
+        ubo.updateFloat4("color", 3, 3, 3, 3);
+        ubo.update(owners[3]);
+        expect(ubo.getBuffer()).toBe(firstBuffer);
+        ubo.updateFloat4("color", 9, 9, 9, 9);
+        ubo.update(owners[3]);
+        expect(ubo.getBuffer()).toBe(secondBuffer);
+        expect(ubo._numBuffers).toBe(2);
+    });
+
+    it("registers itself on the owner and gives a released slot to the next new owner", () => {
+        engine.frameId = 1;
+        for (let i = 0; i < 3; ++i) {
+            ubo.updateFloat4("color", i, i, i, i);
+            ubo.update(owners[i]);
+        }
+        expect(ubo._numBuffers).toBe(3);
+        expect(owners[1]._uniformBuffersWithOwnedSlot).toEqual([ubo]);
+        const releasedBuffer = (() => {
+            ubo.updateFloat4("color", 1, 1, 1, 1);
+            ubo.update(owners[1]);
+            return ubo.getBuffer();
+        })();
+
+        // the context is disposed (WebGPUDrawContext.dispose does exactly this)
+        ubo._releaseOwnerSlot(owners[1]);
+
+        engine.frameId = 2;
+        ubo.updateFloat4("color", 5, 5, 5, 5);
+        ubo.update(owners[10]);
+        expect(ubo.getBuffer()).toBe(releasedBuffer);
+        expect(ubo._numBuffers).toBe(3);
+    });
+
+    it("keeps the draw-order behavior when no owner is given", () => {
+        const order = owners.map((_, i) => i);
+        engine.frameId = 1;
+        for (const i of order) {
+            ubo.updateFloat4("color", i, i * 2, i * 3, 1);
+            ubo.update();
+        }
+        // one buffer per differing write in the frame, exactly as before
+        expect(ubo._numBuffers).toBe(OWNERS);
+    });
+});

--- a/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
+++ b/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { UniformBuffer, type IUniformBufferSlotOwner } from "core/Materials/uniformBuffer";
 
 /**
@@ -197,6 +197,36 @@ describe("UniformBuffer owner-keyed slots", () => {
         ubo.update(owners[1]);
         expect(ubo.getBuffer()).toBe(slot0);
         expect((slot0 as unknown as MockGpuBuffer).gpu[0]).toBe(2);
+    });
+
+    it("does not compare the block when the values have not changed since the slot was last flushed (many meshes, one material)", () => {
+        // Every owner writes the SAME values (the common case: many meshes sharing a material write identical
+        // leftover uniforms), so after the first frame nothing changes the staging data between flushes.
+        const order = owners.map((_, i) => i);
+        const drawSame = (o: number[]) => {
+            for (const i of o) {
+                ubo.updateFloat4("color", 0.5, 0.25, 0.125, 1);
+                ubo.updateFloat("scalar", 0.75);
+                ubo.update(owners[i]);
+            }
+        };
+        engine.frameId = 1;
+        drawSame(order); // first sight: each owner's slot is filled here
+        const spy = vi.spyOn(ubo as any, "_buffersEqual");
+        for (let frame = 2; frame <= 5; ++frame) {
+            engine.frameId = frame;
+            drawSame(shuffle(order));
+        }
+        expect(spy).not.toHaveBeenCalled(); // one integer compare per draw instead of a block compare
+        spy.mockRestore();
+
+        // a real change is still seen and reaches the GPU
+        const uploadsBefore = engine.uploads.length;
+        engine.frameId = 6;
+        ubo.updateFloat4("color", 100, 200, 300, 1);
+        ubo.update(owners[7]);
+        expect(engine.uploads.length).toBe(uploadsBefore + 1);
+        expect((ubo.getBuffer() as unknown as MockGpuBuffer).gpu[0]).toBe(100);
     });
 
     it("keeps the draw-order behavior when no owner is given", () => {

--- a/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
+++ b/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerKeyedSlots.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { UniformBuffer, type IUniformBufferSlotOwner } from "core/Materials/uniformBuffer";
+import { UniformBuffer } from "core/Materials/uniformBuffer";
+import { WebGPUDrawContext } from "core/Engines/WebGPU/webgpuDrawContext";
 
 /**
  * A minimal engine that tracks its uniform buffers per frame the way WebGPUEngine does
@@ -36,15 +37,8 @@ function createEngine() {
     return engine;
 }
 
-function createOwner(id: number): IUniformBufferSlotOwner {
-    return {
-        uniqueId: id,
-        useInstancing: false,
-        enableIndirectDraw: false,
-        setIndirectData: () => {},
-        reset: () => {},
-        dispose: () => {},
-    };
+function createOwner(_id: number): WebGPUDrawContext {
+    return new WebGPUDrawContext({} as any, {} as any);
 }
 
 function shuffle<T>(array: T[]): T[] {
@@ -59,7 +53,7 @@ function shuffle<T>(array: T[]): T[] {
 describe("UniformBuffer owner-keyed slots", () => {
     let engine: ReturnType<typeof createEngine>;
     let ubo: UniformBuffer;
-    let owners: IUniformBufferSlotOwner[];
+    let owners: WebGPUDrawContext[];
     const OWNERS = 40;
 
     // Each owner writes its own values (as each material does into the effect's leftover UBO), then flushes on its own behalf.
@@ -67,7 +61,7 @@ describe("UniformBuffer owner-keyed slots", () => {
         for (const i of order) {
             ubo.updateFloat4("color", i, i * 2, i * 3, 1);
             ubo.updateFloat("scalar", i / 10);
-            ubo.update(owners[i]);
+            ubo._updateOwnerKeyed(owners[i]);
             const gpu = (ubo.getBuffer() as unknown as MockGpuBuffer).gpu;
             expect([gpu[0], gpu[1], gpu[2], gpu[4]]).toEqual([i, i * 2, i * 3, Math.fround(i / 10)]);
         }
@@ -110,14 +104,14 @@ describe("UniformBuffer owner-keyed slots", () => {
         for (const i of order) {
             ubo.updateFloat4("color", i, i * 2, i * 3, 1);
             ubo.updateFloat("scalar", i / 10);
-            ubo.update(owners[i]);
+            ubo._updateOwnerKeyed(owners[i]);
             bufferOf.set(i, ubo.getBuffer());
         }
         engine.frameId = 2;
         for (const i of shuffle(order)) {
             ubo.updateFloat4("color", i, i * 2, i * 3, 1);
             ubo.updateFloat("scalar", i / 10);
-            ubo.update(owners[i]);
+            ubo._updateOwnerKeyed(owners[i]);
             expect(ubo.getBuffer()).toBe(bufferOf.get(i));
         }
     });
@@ -125,11 +119,11 @@ describe("UniformBuffer owner-keyed slots", () => {
     it("does not overwrite a slot the GPU has not consumed yet when the same owner flushes twice in a frame with different values", () => {
         engine.frameId = 1;
         ubo.updateFloat4("color", 7, 7, 7, 7);
-        ubo.update(owners[3]);
+        ubo._updateOwnerKeyed(owners[3]);
         const firstBuffer = ubo.getBuffer() as unknown as MockGpuBuffer;
 
         ubo.updateFloat4("color", 8, 8, 8, 8);
-        ubo.update(owners[3]);
+        ubo._updateOwnerKeyed(owners[3]);
         const secondBuffer = ubo.getBuffer() as unknown as MockGpuBuffer;
 
         expect(secondBuffer).not.toBe(firstBuffer);
@@ -139,10 +133,10 @@ describe("UniformBuffer owner-keyed slots", () => {
         // next frame: the owner is back on its own slot, and the spill slot is reusable
         engine.frameId = 2;
         ubo.updateFloat4("color", 3, 3, 3, 3);
-        ubo.update(owners[3]);
+        ubo._updateOwnerKeyed(owners[3]);
         expect(ubo.getBuffer()).toBe(firstBuffer);
         ubo.updateFloat4("color", 9, 9, 9, 9);
-        ubo.update(owners[3]);
+        ubo._updateOwnerKeyed(owners[3]);
         expect(ubo.getBuffer()).toBe(secondBuffer);
         expect(ubo._numBuffers).toBe(2);
     });
@@ -151,13 +145,13 @@ describe("UniformBuffer owner-keyed slots", () => {
         engine.frameId = 1;
         for (let i = 0; i < 3; ++i) {
             ubo.updateFloat4("color", i, i, i, i);
-            ubo.update(owners[i]);
+            ubo._updateOwnerKeyed(owners[i]);
         }
         expect(ubo._numBuffers).toBe(3);
         expect(owners[1]._uniformBuffersWithOwnedSlot).toEqual([ubo]);
         const releasedBuffer = (() => {
             ubo.updateFloat4("color", 1, 1, 1, 1);
-            ubo.update(owners[1]);
+            ubo._updateOwnerKeyed(owners[1]);
             return ubo.getBuffer();
         })();
 
@@ -166,7 +160,7 @@ describe("UniformBuffer owner-keyed slots", () => {
 
         engine.frameId = 2;
         ubo.updateFloat4("color", 5, 5, 5, 5);
-        ubo.update(owners[10]);
+        ubo._updateOwnerKeyed(owners[10]);
         expect(ubo.getBuffer()).toBe(releasedBuffer);
         expect(ubo._numBuffers).toBe(3);
     });
@@ -175,26 +169,26 @@ describe("UniformBuffer owner-keyed slots", () => {
         // owner A is the only owner: it gets the slot create() made (slot 0)
         engine.frameId = 1;
         ubo.updateFloat4("color", 1, 1, 1, 1);
-        ubo.update(owners[0]);
+        ubo._updateOwnerKeyed(owners[0]);
         const slot0 = ubo.getBuffer();
         ubo._releaseOwnerSlot(owners[0]); // A's context is disposed; slot 0 is now in the free list
 
         // B arrives: it must take slot 0 THROUGH the free list (so the entry is consumed), not via the first-owner shortcut
         engine.frameId = 2;
         ubo.updateFloat4("color", 2, 2, 2, 2);
-        ubo.update(owners[1]);
+        ubo._updateOwnerKeyed(owners[1]);
         expect(ubo.getBuffer()).toBe(slot0);
 
         // C arrives next frame: the free list must be empty, so C gets a NEW slot instead of B's
         engine.frameId = 3;
         ubo.updateFloat4("color", 3, 3, 3, 3);
-        ubo.update(owners[2]);
+        ubo._updateOwnerKeyed(owners[2]);
         expect(ubo.getBuffer()).not.toBe(slot0);
         expect(ubo._numBuffers).toBe(2);
 
         // and B still reads back its own values from its own slot
         ubo.updateFloat4("color", 2, 2, 2, 2);
-        ubo.update(owners[1]);
+        ubo._updateOwnerKeyed(owners[1]);
         expect(ubo.getBuffer()).toBe(slot0);
         expect((slot0 as unknown as MockGpuBuffer).gpu[0]).toBe(2);
     });
@@ -207,7 +201,7 @@ describe("UniformBuffer owner-keyed slots", () => {
             for (const i of o) {
                 ubo.updateFloat4("color", 0.5, 0.25, 0.125, 1);
                 ubo.updateFloat("scalar", 0.75);
-                ubo.update(owners[i]);
+                ubo._updateOwnerKeyed(owners[i]);
             }
         };
         engine.frameId = 1;
@@ -224,7 +218,7 @@ describe("UniformBuffer owner-keyed slots", () => {
         const uploadsBefore = engine.uploads.length;
         engine.frameId = 6;
         ubo.updateFloat4("color", 100, 200, 300, 1);
-        ubo.update(owners[7]);
+        ubo._updateOwnerKeyed(owners[7]);
         expect(engine.uploads.length).toBe(uploadsBefore + 1);
         expect((ubo.getBuffer() as unknown as MockGpuBuffer).gpu[0]).toBe(100);
     });

--- a/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerLifecycle.test.ts
+++ b/packages/dev/core/test/unit/Materials/babylon.uniformBuffer.ownerLifecycle.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { UniformBuffer } from "core/Materials/uniformBuffer";
+import { DrawWrapper } from "core/Materials/drawWrapper";
+import { WebGPUDrawContext } from "core/Engines/WebGPU/webgpuDrawContext";
+import { WebGPUPipelineContext } from "core/Engines/WebGPU/webgpuPipelineContext";
+
+function setup() {
+    let id = 0;
+    const live = new Set<any>();
+    const engine = {
+        supportsUniformBuffers: true,
+        frameId: 1,
+        _uniformBuffers: [] as UniformBuffer[],
+        _features: { trackUbosInFrame: true, checkUbosContentBeforeUpload: true },
+        createUniformBuffer(data: Float32Array) {
+            const buffer = { uniqueId: ++id, gpu: data.slice() };
+            live.add(buffer);
+            return buffer;
+        },
+        updateUniformBuffer(buffer: any, data: Float32Array) {
+            buffer.gpu.set(data);
+        },
+        _releaseBuffer(buffer: any) {
+            return live.delete(buffer);
+        },
+        createDrawContext() {
+            return new WebGPUDrawContext({} as any, {} as any);
+        },
+    };
+    const make = () => {
+        const buffer = new UniformBuffer(engine as any);
+        buffer.addUniform("value", 1);
+        buffer.create();
+        return buffer;
+    };
+    const draw = (buffer: UniformBuffer, owner: WebGPUDrawContext, value = 1) => {
+        buffer.updateFloat("value", value);
+        buffer._updateOwnerKeyed(owner);
+        return buffer.getBuffer() as any;
+    };
+    return { engine, live, make, draw };
+}
+
+describe("owner slot lifecycle through real draw/pipeline entry points", () => {
+    it.each([false, true])("bounds shared-effect/pass churn and accounts for retained capacity (distinct=%s)", (distinct) => {
+        const { engine, live, draw } = setup();
+        const buffers = Array.from({ length: 3 }, () => {
+            const buffer = new UniformBuffer(engine as any);
+            buffer.addUniform("value", 64); // 256-byte blocks
+            buffer.create();
+            return buffer;
+        });
+        for (let cycle = 0; cycle < 20; cycle++) {
+            engine.frameId++;
+            for (const buffer of buffers) {
+                // 40 objects, two pass-specific contexts each, sharing this effect.
+                const contexts = Array.from({ length: 80 }, () => engine.createDrawContext());
+                contexts.forEach((context, i) => draw(buffer, context, distinct ? i : 1));
+                contexts.forEach((context) => context.dispose());
+                expect((buffer as any)._ownerCount).toBe(0);
+                expect((buffer as any)._ownerListsBySlot.size).toBe(0);
+                expect(buffer._numBuffers).toBe(80); // Reusable high-water capacity, not live ownership.
+            }
+            expect(live.size).toBe(240);
+        }
+        expect([...live].reduce((sum, buffer) => sum + buffer.gpu.byteLength, 0)).toBe(61440);
+        expect(buffers.reduce((sum, buffer) => sum + (buffer as any)._buffers.reduce((n: number, slot: any) => n + slot[1].byteLength, 0), 0)).toBe(61440);
+        buffers.forEach((buffer) => buffer.dispose());
+        expect(live.size).toBe(0);
+        // These UBO objects are deliberately retained here: their slot arrays must still be empty.
+        buffers.forEach((buffer) => expect(buffer._numBuffers).toBe(0));
+    });
+
+    it.each([true, false])("releases the previous effect even with resetContext=%s", (resetContext) => {
+        const { engine, make, draw } = setup();
+        const wrapper = new DrawWrapper(engine as any, false);
+        const first = make();
+        const second = make();
+        const context = wrapper.drawContext as WebGPUDrawContext;
+        wrapper.setEffect({} as any);
+        draw(first, context);
+        wrapper.setEffect({} as any, undefined, resetContext);
+        expect((first as any)._ownerCount).toBe(0);
+        expect(context._uniformBuffersWithOwnedSlot).toBeUndefined();
+        draw(second, context);
+        expect(context._uniformBuffersWithOwnedSlot).toEqual([second]);
+    });
+
+    it("preserves a reservation when the same effect is set without resetting", () => {
+        const { engine, make, draw } = setup();
+        const wrapper = new DrawWrapper(engine as any, false);
+        const effect = {} as any;
+        wrapper.setEffect(effect);
+        const buffer = make();
+        draw(buffer, wrapper.drawContext as WebGPUDrawContext);
+        wrapper.setEffect(effect, undefined, false);
+        expect((buffer as any)._ownerCount).toBe(1);
+    });
+
+    it.each(["reset", "dispose"] as const)("%s releases every reciprocal registration exactly once", (method) => {
+        const { engine, make, draw } = setup();
+        const context = engine.createDrawContext();
+        const buffers = [make(), make(), make()];
+        buffers.forEach((buffer) => draw(buffer, context));
+        context[method]();
+        context[method]();
+        for (const buffer of buffers) {
+            expect((buffer as any)._ownerCount).toBe(0);
+            expect((buffer as any)._freeSlots).toEqual([0]);
+            expect((buffer as any)._ownerListsBySlot.size).toBe(0);
+        }
+        expect(context._uniformBuffersWithOwnedSlot).toBeUndefined();
+    });
+
+    it("UBO disposal detaches live owners and clears slot wrappers/shadows", () => {
+        const { engine, live, make, draw } = setup();
+        const buffer = make();
+        const other = make();
+        const contexts = [engine.createDrawContext(), engine.createDrawContext()];
+        contexts.forEach((context) => {
+            draw(buffer, context);
+            draw(other, context);
+        });
+        buffer.dispose();
+        buffer.dispose();
+        contexts.forEach((context) => expect(context._uniformBuffersWithOwnedSlot).toEqual([other]));
+        expect(buffer.getBuffer()).toBeNull();
+        expect(buffer._numBuffers).toBe(0);
+        expect((buffer as any)._ownerListsBySlot.size).toBe(0);
+        expect(live.size).toBe(2);
+        contexts.forEach((context) => context.dispose());
+        other.dispose();
+        expect(live.size).toBe(0);
+    });
+
+    it("context restoration detaches registrations before assigning new slots", () => {
+        const { engine, live, make, draw } = setup();
+        const buffer = make();
+        const context = engine.createDrawContext();
+        draw(buffer, context);
+        for (let i = 0; i < 20; i++) {
+            live.clear(); // Device loss invalidates old GPU allocations; do not emulate loss on a live device.
+            buffer._rebuildAfterContextLost();
+            expect(context._uniformBuffersWithOwnedSlot).toEqual([]);
+            engine.frameId++;
+            draw(buffer, context, i);
+            expect(context._uniformBuffersWithOwnedSlot).toEqual([buffer]);
+            expect((buffer as any)._ownerCount).toBe(1);
+            expect(live.size).toBe(1);
+        }
+    });
+
+    it("layout replacement and pipeline disposal detach their old UBO", () => {
+        const { engine, live, draw } = setup();
+        const pipeline = new WebGPUPipelineContext({ leftOverUniforms: [{ name: "value", type: "float" }] } as any, engine as any);
+        const context = engine.createDrawContext();
+        for (let i = 0; i < 20; i++) {
+            const old = pipeline.uniformBuffer;
+            pipeline.buildUniformLayout();
+            if (old) expect(old._numBuffers).toBe(0);
+            draw(pipeline.uniformBuffer!, context);
+            expect(context._uniformBuffersWithOwnedSlot).toEqual([pipeline.uniformBuffer]);
+            expect(live.size).toBe(1);
+        }
+        pipeline.dispose();
+        expect(context._uniformBuffersWithOwnedSlot).toEqual([]);
+        expect(live.size).toBe(0);
+    });
+
+    it("does not overwrite bytes used before an effect replacement in the same frame", () => {
+        const { engine, make, draw } = setup();
+        const wrapper = new DrawWrapper(engine as any, false);
+        const buffer = make();
+        const context = wrapper.drawContext as WebGPUDrawContext;
+        const first = draw(buffer, context, 7);
+        wrapper.setEffect({} as any);
+        const second = draw(buffer, engine.createDrawContext(), 9);
+        expect(second).not.toBe(first);
+        expect(first.gpu[0]).toBe(7);
+        expect(second.gpu[0]).toBe(9);
+        engine.frameId++;
+        expect(draw(buffer, context, 3)).toBe(first);
+        expect(buffer._numBuffers).toBe(2);
+    });
+
+    it("effect churn reuses capacity and leaves no departed owner reservations", () => {
+        const { engine, live, make, draw } = setup();
+        const buffer = make();
+        const wrappers: DrawWrapper[] = [];
+        for (let i = 0; i < 100; i++) {
+            engine.frameId++;
+            const wrapper = new DrawWrapper(engine as any, false);
+            wrappers.push(wrapper); // Keep departed contexts live to prove eager teardown.
+            draw(buffer, wrapper.drawContext as WebGPUDrawContext, i);
+            wrapper.setEffect({} as any);
+            expect((buffer as any)._ownerCount).toBe(0);
+            expect(buffer._numBuffers).toBe(1);
+        }
+        expect(wrappers).toHaveLength(100);
+        buffer.dispose();
+        expect(live.size).toBe(0);
+    });
+});


### PR DESCRIPTION
## Problem

WebGPU effect-level leftover uniform buffers select pooled GPU buffers by draw order. When visibility/order changes, a draw binds different buffer identities, producing more combinations in the non-evicting bind-group cache even in a static scene.

Original field evidence: a static 5,371-prim scene produced +27,701 bind groups in five seconds and eventually lost the D3D12 device around 240k bind groups. Stable owner-keyed slots stopped that growth in the original field test. Those field measurements predate the lifecycle revision below.

## Change

The internal WebGPU draw path assigns a stable slot per draw-context/UBO association, preserves same-frame spill safety, and skips block comparison when the slot already has the current data generation. Public `UniformBuffer.update()` keeps its original signature. Other callers retain their existing path. `_useOwnerKeyedUniformBufferSlots` is an internal A/B switch, configured only before rendering begins.

Reciprocal registrations are released on draw-context reset/disposal, effect replacement (including `resetContext=false`), UBO disposal, pipeline layout replacement, and context restoration. Reverse registrations hold backlink arrays without strongly retaining draw contexts. UBO teardown clears slot wrappers/shadows; same-frame released slots remain protected until reuse is safe.

## Memory contract

Capacity follows each UBO's historical peak reservation/spill demand and is reused; owner release does not shrink the pool to the current active count. UBO destruction detaches registrations and releases its buffers. This does not introduce bind-group cache eviction or claim that cumulative cache counts return to zero.

Identical uniform values can cost substantially more individual GPU buffers than stock: the recording-engine case with three effects and 400 contexts each uses 3 stock buffers versus 1,200 owner-keyed buffers. With distinct values, both use 1,200. Detailed payload/shadow accounting is in the revision comment; driver and JS object overhead remain to be characterized with the Playground and upstream gates.

## Validation

- 77 selected owner/WebGPU tests pass locally, including shuffled draw order, generation fast path, same-frame spill/reuse, real lifecycle entry points, and repeated three-effect/two-pass churn.
- Eight new lifecycle cases reproduce failures on the previously reviewed head.
- Full core TypeScript 6.0.2 check passes after shader generation.
- Original revision passed WebGPU visualization, memory and performance CI after the generation-counter fix. **The current lifecycle revision needs fresh upstream CI and WebGPU field validation.**
- A Playground comparison is being prepared for saved links/reports; its scene workflow passed a Playwright/WebGL smoke test. No WebGPU performance claim is made from that smoke test.
