### PR TITLE
fixes Bounty #9: Add FlexPanel and em/rem GUI units

### DIFF
--- a/packages/dev/gui/src/2D/controls/colorpicker.pure.ts
+++ b/packages/dev/gui/src/2D/controls/colorpicker.pure.ts
@@ -105,7 +105,7 @@ export class ColorPicker extends Control {
         }
 
         if (this._width.fromString(value)) {
-            if (this._width.getValue(this._host) === 0) {
+            if (this._getValueInPixel(this._width, 1) === 0) {
                 value = "1px";
                 this._width.fromString(value);
             }
@@ -130,7 +130,7 @@ export class ColorPicker extends Control {
         }
 
         if (this._height.fromString(value)) {
-            if (this._height.getValue(this._host) === 0) {
+            if (this._getValueInPixel(this._height, 1) === 0) {
                 value = "1px";
                 this._height.fromString(value);
             }

--- a/packages/dev/gui/src/2D/controls/container.pure.ts
+++ b/packages/dev/gui/src/2D/controls/container.pure.ts
@@ -453,15 +453,16 @@ export class Container extends Control {
             this._processMeasures(parentMeasure, context);
 
             if (!this._isClipped) {
+                this._beforeChildLayout();
                 for (const child of this._children) {
                     child._tempParentMeasure.copyFrom(this._measureForChildren);
 
                     if (child._layout(this._measureForChildren, context)) {
                         if (child.isVisible && !child.notRenderable) {
-                            if (this.adaptWidthToChildren && child._width.isPixel) {
+                            if (this.adaptWidthToChildren && !child._width.isPercentage) {
                                 computedWidth = Math.max(computedWidth, child._currentMeasure.width + child._paddingLeftInPixels + child._paddingRightInPixels);
                             }
-                            if (this.adaptHeightToChildren && child._height.isPixel) {
+                            if (this.adaptHeightToChildren && !child._height.isPercentage) {
                                 computedHeight = Math.max(computedHeight, child._currentMeasure.height + child._paddingTopInPixels + child._paddingBottomInPixels);
                             }
                         }
@@ -507,6 +508,19 @@ export class Container extends Control {
         }
 
         return true;
+    }
+
+    /** @internal */
+    protected _beforeChildLayout(): void {}
+
+    /**
+     * Gets an optional parent-controlled layout box, relative to the content origin.
+     * @param _child defines the child to lay out
+     * @returns the layout box, or null for the child's own layout
+     * @internal
+     */
+    public _getLayoutMeasureForChild(_child: Control): Nullable<Measure> {
+        return null;
     }
 
     protected override _postMeasure() {

--- a/packages/dev/gui/src/2D/controls/control.pure.ts
+++ b/packages/dev/gui/src/2D/controls/control.pure.ts
@@ -52,6 +52,7 @@ export class Control implements IAnimatable, IFocusableControl {
     private _fontFamily = "";
     private _fontStyle = "";
     private _fontWeight = "";
+    private static readonly _DefaultFontSize = /*#__PURE__*/ new ValueAndUnit(18);
     private _fontSize = new ValueAndUnit(18, ValueAndUnit.UNITMODE_PIXEL, false);
     private _font: string;
     /** @internal */
@@ -676,7 +677,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get widthInPixels(): number {
-        return this._width.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._width, this._cachedParentMeasure.width);
     }
 
     public set widthInPixels(value: number) {
@@ -713,7 +714,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get heightInPixels(): number {
-        return this._height.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        return this._getValueInPixel(this._height, this._cachedParentMeasure.height);
     }
 
     public set heightInPixels(value: number) {
@@ -803,11 +804,14 @@ export class Control implements IAnimatable, IFocusableControl {
     public get fontSizeInPixels(): number {
         const fontSizeToUse = this._style ? this._style._fontSize : this._fontSize;
 
-        if (fontSizeToUse.isPixel) {
-            return fontSizeToUse.getValue(this._host);
+        if (fontSizeToUse.unit !== ValueAndUnit.UNITMODE_EM && fontSizeToUse.unit !== ValueAndUnit.UNITMODE_REM) {
+            return fontSizeToUse.getValueInPixel(this._host, this._tempParentMeasure.height || this._cachedParentMeasure.height);
         }
-
-        return fontSizeToUse.getValueInPixel(this._host, this._tempParentMeasure.height || this._cachedParentMeasure.height);
+        const root: Control | undefined = this._host?.rootContainer;
+        const defaultSize = Control._DefaultFontSize.getValue(this._host);
+        const rootSize = root && root !== this ? root.fontSizeInPixels : defaultSize;
+        const parentSize = this.parent ? this.parent.fontSizeInPixels : defaultSize;
+        return fontSizeToUse.getValueInPixel(this._host, this._tempParentMeasure.height || this._cachedParentMeasure.height, parentSize, rootSize);
     }
 
     public set fontSizeInPixels(value: number) {
@@ -817,7 +821,11 @@ export class Control implements IAnimatable, IFocusableControl {
         this.fontSize = value + "px";
     }
 
-    /** Gets or sets font size */
+    /**
+     * Gets or sets the font size in px, percent of parent height, em, or rem.
+     * For font declarations, em uses the parent font and rem uses the GUI root font.
+     * Relative font sizes on the root use the default 18px font, including adaptive scaling.
+     */
     public get fontSize(): string | number {
         return this._fontSize.toString(this._host);
     }
@@ -963,7 +971,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get paddingLeftInPixels(): number {
-        return this._paddingLeft.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._paddingLeft, this._cachedParentMeasure.width);
     }
 
     public set paddingLeftInPixels(value: number) {
@@ -1002,7 +1010,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get paddingRightInPixels(): number {
-        return this._paddingRight.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._paddingRight, this._cachedParentMeasure.width);
     }
 
     public set paddingRightInPixels(value: number) {
@@ -1041,7 +1049,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get paddingTopInPixels(): number {
-        return this._paddingTop.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        return this._getValueInPixel(this._paddingTop, this._cachedParentMeasure.height);
     }
 
     public set paddingTopInPixels(value: number) {
@@ -1080,7 +1088,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get paddingBottomInPixels(): number {
-        return this._paddingBottom.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        return this._getValueInPixel(this._paddingBottom, this._cachedParentMeasure.height);
     }
 
     public set paddingBottomInPixels(value: number) {
@@ -1119,7 +1127,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get leftInPixels(): number {
-        return this._left.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._left, this._cachedParentMeasure.width);
     }
 
     public set leftInPixels(value: number) {
@@ -1149,7 +1157,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#position-and-size
      */
     public get topInPixels(): number {
-        return this._top.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        return this._getValueInPixel(this._top, this._cachedParentMeasure.height);
     }
 
     public set topInPixels(value: number) {
@@ -1179,7 +1187,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#tracking-positions
      */
     public get linkOffsetXInPixels(): number {
-        return this._linkOffsetX.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._linkOffsetX, this._cachedParentMeasure.width);
     }
 
     public set linkOffsetXInPixels(value: number) {
@@ -1209,7 +1217,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @see https://doc.babylonjs.com/features/featuresDeepDive/gui/gui#tracking-positions
      */
     public get linkOffsetYInPixels(): number {
-        return this._linkOffsetY.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        return this._getValueInPixel(this._linkOffsetY, this._cachedParentMeasure.height);
     }
 
     public set linkOffsetYInPixels(value: number) {
@@ -1398,6 +1406,46 @@ export class Control implements IAnimatable, IFocusableControl {
             this.onEnterPressedObservable.notifyObservers(this);
         }
         this.onKeyboardEventProcessedObservable.notifyObservers(evt, -1, this);
+    }
+
+    private _flexGrow = 0;
+
+    /**
+     * Gets or sets the nonnegative share of free main-axis space in a FlexPanel.
+     */
+    @serialize()
+    public get flexGrow(): number {
+        return this._flexGrow;
+    }
+
+    public set flexGrow(value: number) {
+        if (!Number.isFinite(value) || value < 0) {
+            throw new RangeError("flexGrow must be finite and nonnegative");
+        }
+        if (this._flexGrow !== value) {
+            this._flexGrow = value;
+            this._markAsDirty();
+        }
+    }
+
+    private _flexShrink = 1;
+
+    /**
+     * Gets or sets the nonnegative shrink factor in a FlexPanel, weighted by the declared main-axis size.
+     */
+    @serialize()
+    public get flexShrink(): number {
+        return this._flexShrink;
+    }
+
+    public set flexShrink(value: number) {
+        if (!Number.isFinite(value) || value < 0) {
+            throw new RangeError("flexShrink must be finite and nonnegative");
+        }
+        if (this._flexShrink !== value) {
+            this._flexShrink = value;
+            this._markAsDirty();
+        }
     }
 
     // Functions
@@ -1634,16 +1682,16 @@ export class Control implements IAnimatable, IFocusableControl {
      * @internal
      */
     public _moveToProjectedPosition(projectedPosition: Vector3): void {
-        const oldLeft = this._left.getValue(this._host);
-        const oldTop = this._top.getValue(this._host);
+        const oldLeft = this._getValueInPixel(this._left, 1);
+        const oldTop = this._getValueInPixel(this._top, 1);
 
         const parentMeasure = this.parent?._currentMeasure;
         if (parentMeasure) {
             this._processMeasures(parentMeasure, this._host.getContext());
         }
 
-        let newLeft = projectedPosition.x + this._linkOffsetX.getValue(this._host) - this._currentMeasure.width / 2;
-        let newTop = projectedPosition.y + this._linkOffsetY.getValue(this._host) - this._currentMeasure.height / 2;
+        let newLeft = projectedPosition.x + this._getValueInPixel(this._linkOffsetX, 1) - this._currentMeasure.width / 2;
+        let newTop = projectedPosition.y + this._getValueInPixel(this._linkOffsetY, 1) - this._currentMeasure.height / 2;
 
         if (this._left.ignoreAdaptiveScaling && this._top.ignoreAdaptiveScaling) {
             if (Math.abs(newLeft - oldLeft) < 0.5) {
@@ -1967,9 +2015,17 @@ export class Control implements IAnimatable, IFocusableControl {
 
         this._measure();
 
-        // Let children take some post-measurement actions
+        const flexMeasure = this.parent?._getLayoutMeasureForChild(this);
+        if (flexMeasure) {
+            this._currentMeasure.width = flexMeasure.width;
+            this._currentMeasure.height = flexMeasure.height;
+        }
+        // Text wrapping must use the allocated flex width rather than the declared basis.
         this._postMeasure(this._tempPaddingMeasure, context);
-
+        if (flexMeasure) {
+            this._currentMeasure.width = flexMeasure.width;
+            this._currentMeasure.height = flexMeasure.height;
+        }
         this._computeAlignment(this._tempPaddingMeasure, context);
 
         // Let children add more features
@@ -2016,20 +2072,24 @@ export class Control implements IAnimatable, IFocusableControl {
         this._isClipped = false;
     }
 
+    /**
+     * Resolves a GUI dimension using this control's computed font size.
+     * @param value defines the dimension to resolve
+     * @param reference defines the reference size for percentages
+     * @returns the dimension in pixels
+     * @internal
+     */
+    public _getValueInPixel(value: ValueAndUnit, reference: number): number {
+        if (value.unit === ValueAndUnit.UNITMODE_EM || value.unit === ValueAndUnit.UNITMODE_REM) {
+            return value.getValueInPixel(this._host, reference, this.fontSizeInPixels, this._host?.rootContainer.fontSizeInPixels);
+        }
+        return value.getValueInPixel(this._host, reference);
+    }
+
     /** @internal */
     public _measure(): void {
-        // Width / Height
-        if (this._width.isPixel) {
-            this._currentMeasure.width = this._width.getValue(this._host);
-        } else {
-            this._currentMeasure.width *= this._width.getValue(this._host);
-        }
-
-        if (this._height.isPixel) {
-            this._currentMeasure.height = this._height.getValue(this._host);
-        } else {
-            this._currentMeasure.height *= this._height.getValue(this._host);
-        }
+        this._currentMeasure.width = this._getValueInPixel(this._width, this._currentMeasure.width);
+        this._currentMeasure.height = this._getValueInPixel(this._height, this._currentMeasure.height);
 
         if (this._fixedRatio !== 0) {
             if (this._fixedRatioMasterIsWidth) {
@@ -2079,45 +2139,21 @@ export class Control implements IAnimatable, IFocusableControl {
         }
 
         if (!this.descendantsOnlyPadding) {
-            if (this._paddingLeft.isPixel) {
-                this._currentMeasure.left += this._paddingLeft.getValue(this._host);
-                this._currentMeasure.width -= this._paddingLeft.getValue(this._host);
-            } else {
-                this._currentMeasure.left += parentWidth * this._paddingLeft.getValue(this._host);
-                this._currentMeasure.width -= parentWidth * this._paddingLeft.getValue(this._host);
-            }
-
-            if (this._paddingRight.isPixel) {
-                this._currentMeasure.width -= this._paddingRight.getValue(this._host);
-            } else {
-                this._currentMeasure.width -= parentWidth * this._paddingRight.getValue(this._host);
-            }
-
-            if (this._paddingTop.isPixel) {
-                this._currentMeasure.top += this._paddingTop.getValue(this._host);
-                this._currentMeasure.height -= this._paddingTop.getValue(this._host);
-            } else {
-                this._currentMeasure.top += parentHeight * this._paddingTop.getValue(this._host);
-                this._currentMeasure.height -= parentHeight * this._paddingTop.getValue(this._host);
-            }
-
-            if (this._paddingBottom.isPixel) {
-                this._currentMeasure.height -= this._paddingBottom.getValue(this._host);
-            } else {
-                this._currentMeasure.height -= parentHeight * this._paddingBottom.getValue(this._host);
-            }
+            const left = this._getValueInPixel(this._paddingLeft, parentWidth);
+            const top = this._getValueInPixel(this._paddingTop, parentHeight);
+            this._currentMeasure.left += left;
+            this._currentMeasure.top += top;
+            this._currentMeasure.width -= left + this._getValueInPixel(this._paddingRight, parentWidth);
+            this._currentMeasure.height -= top + this._getValueInPixel(this._paddingBottom, parentHeight);
         }
 
-        if (this._left.isPixel) {
-            this._currentMeasure.left += this._left.getValue(this._host);
+        const flexMeasure = this.parent?._getLayoutMeasureForChild(this);
+        if (flexMeasure) {
+            x = flexMeasure.left;
+            y = flexMeasure.top;
         } else {
-            this._currentMeasure.left += parentWidth * this._left.getValue(this._host);
-        }
-
-        if (this._top.isPixel) {
-            this._currentMeasure.top += this._top.getValue(this._host);
-        } else {
-            this._currentMeasure.top += parentHeight * this._top.getValue(this._host);
+            this._currentMeasure.left += this._getValueInPixel(this._left, parentWidth);
+            this._currentMeasure.top += this._getValueInPixel(this._top, parentHeight);
         }
 
         this._currentMeasure.left += x;
@@ -2578,7 +2614,7 @@ export class Control implements IAnimatable, IFocusableControl {
      * @returns if the dimension is fully defined
      */
     public isDimensionFullyDefined(dim: "width" | "height"): boolean {
-        return this.getDimension(dim).isPixel;
+        return !this.getDimension(dim).isPercentage;
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/flexPanel.pure.ts
+++ b/packages/dev/gui/src/2D/controls/flexPanel.pure.ts
@@ -1,0 +1,294 @@
+import { Container } from "./container.pure";
+import { type Control } from "./control.pure";
+import { Measure } from "../measure";
+import { ValueAndUnit } from "../valueAndUnit";
+import { RegisterClass } from "core/Misc/typeStore";
+import { serialize } from "core/Misc/decorators";
+
+/**
+ * Main-axis direction and ordering of a FlexPanel.
+ */
+export type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
+/**
+ * Whether overflowing items form additional lines, and their cross-axis order.
+ */
+export type FlexWrap = "nowrap" | "wrap" | "wrap-reverse";
+/**
+ * Distribution of spare space along the main axis.
+ */
+export type FlexJustification = "flex-start" | "flex-end" | "center" | "space-between" | "space-around" | "space-evenly";
+/**
+ * Alignment of items within each line. Stretch fills the line's cross-axis size.
+ */
+export type FlexAlignment = "flex-start" | "flex-end" | "center" | "stretch";
+/**
+ * Distribution of lines along the cross axis.
+ */
+export type FlexContentAlignment = FlexJustification | "stretch";
+
+type FlexItem = { control: Control; basis: number; cross: number; size: number };
+type FlexLine = { start: number; end: number; basis: number; cross: number };
+
+/**
+ * Arranges controls in flexible rows or columns using their declared width/height as the basis.
+ * Supports wrapping, gaps, alignment and Control.flexGrow/flexShrink without rewriting child properties.
+ * The panel uses its declared size; intrinsic CSS sizing and baseline alignment are not supported.
+ */
+export class FlexPanel extends Container {
+    private _items: FlexItem[] = [];
+    private _lines: FlexLine[] = [];
+    private _boxes = new WeakMap<Control, Measure>();
+    private _gap = new ValueAndUnit(0, ValueAndUnit.UNITMODE_PIXEL, false);
+
+    private _flexDirection: FlexDirection = "row";
+    /**
+     * Gets or sets the main axis and item direction. Defaults to row.
+     */
+    @serialize()
+    public get flexDirection(): FlexDirection {
+        return this._flexDirection;
+    }
+    public set flexDirection(value: FlexDirection) {
+        if (this._flexDirection !== value) {
+            this._flexDirection = value;
+            this._markAsDirty();
+        }
+    }
+
+    private _flexWrap: FlexWrap = "nowrap";
+    /**
+     * Gets or sets line wrapping. Defaults to nowrap.
+     */
+    @serialize()
+    public get flexWrap(): FlexWrap {
+        return this._flexWrap;
+    }
+    public set flexWrap(value: FlexWrap) {
+        if (this._flexWrap !== value) {
+            this._flexWrap = value;
+            this._markAsDirty();
+        }
+    }
+
+    private _justifyContent: FlexJustification = "flex-start";
+    /**
+     * Gets or sets the distribution of remaining main-axis space after flexing.
+     */
+    @serialize()
+    public get justifyContent(): FlexJustification {
+        return this._justifyContent;
+    }
+    public set justifyContent(value: FlexJustification) {
+        if (this._justifyContent !== value) {
+            this._justifyContent = value;
+            this._markAsDirty();
+        }
+    }
+
+    private _alignItems: FlexAlignment = "flex-start";
+    /**
+     * Gets or sets cross-axis alignment within each line. Stretch fills the line.
+     */
+    @serialize()
+    public get alignItems(): FlexAlignment {
+        return this._alignItems;
+    }
+    public set alignItems(value: FlexAlignment) {
+        if (this._alignItems !== value) {
+            this._alignItems = value;
+            this._markAsDirty();
+        }
+    }
+
+    private _alignContent: FlexContentAlignment = "stretch";
+    /**
+     * Gets or sets cross-axis line distribution when wrapping is enabled.
+     */
+    @serialize()
+    public get alignContent(): FlexContentAlignment {
+        return this._alignContent;
+    }
+    public set alignContent(value: FlexContentAlignment) {
+        if (this._alignContent !== value) {
+            this._alignContent = value;
+            this._markAsDirty();
+        }
+    }
+
+    /**
+     * Gets or sets the gap between items and lines in px, em, rem, or percent of the main-axis size.
+     */
+    @serialize()
+    public get gap(): string | number {
+        return this._gap.toString(this._host);
+    }
+    public set gap(value: string | number) {
+        if (this._gap.fromString(value)) {
+            this._markAsDirty();
+        }
+    }
+
+    /**
+     * Creates a flex layout container.
+     * @param name defines the control name
+     */
+    constructor(name?: string) {
+        super(name);
+    }
+
+    protected override _getTypeName(): string {
+        return "FlexPanel";
+    }
+
+    /** @internal */
+    public override _getLayoutMeasureForChild(child: Control): Measure | null {
+        return this._boxes.get(child) ?? null;
+    }
+
+    private _spacing(alignment: FlexContentAlignment, free: number, count: number): number {
+        if (free <= 0) {
+            return 0;
+        }
+        switch (alignment) {
+            case "space-between":
+                return count > 1 ? free / (count - 1) : 0;
+            case "space-around":
+                return count > 0 ? free / count : 0;
+            case "space-evenly":
+                return free / (count + 1);
+            default:
+                return 0;
+        }
+    }
+
+    private _offset(alignment: FlexContentAlignment, free: number, spacing: number): number {
+        switch (alignment) {
+            case "flex-end":
+                return free;
+            case "center":
+                return free / 2;
+            case "space-around":
+                return spacing / 2;
+            case "space-evenly":
+                return spacing;
+            default:
+                return 0;
+        }
+    }
+
+    protected override _beforeChildLayout(): void {
+        const row = this._flexDirection === "row" || this._flexDirection === "row-reverse";
+        const reverse = this._flexDirection === "row-reverse" || this._flexDirection === "column-reverse";
+        const reverseLines = this._flexWrap === "wrap-reverse";
+        const width = Math.max(0, this._measureForChildren.width - (this.descendantsOnlyPadding ? this.paddingLeftInPixels + this.paddingRightInPixels : 0));
+        const height = Math.max(0, this._measureForChildren.height - (this.descendantsOnlyPadding ? this.paddingTopInPixels + this.paddingBottomInPixels : 0));
+        const main = row ? width : height;
+        const cross = row ? height : width;
+        const gap = this._getValueInPixel(this._gap, main);
+        let count = 0;
+        let lineCount = 0;
+        let line: FlexLine | undefined;
+        for (const child of this._children) {
+            if (!child.isVisible || child.notRenderable) {
+                continue;
+            }
+            child._tempParentMeasure.copyFrom(this._measureForChildren);
+            const basis = Math.max(0, child._getValueInPixel(child.getDimension(row ? "width" : "height"), main));
+            const crossSize = Math.max(0, child._getValueInPixel(child.getDimension(row ? "height" : "width"), cross));
+            if (!line || (this._flexWrap !== "nowrap" && count > line.start && line.basis + gap + basis > main)) {
+                line = this._lines[lineCount] ?? (this._lines[lineCount] = { start: 0, end: 0, basis: 0, cross: 0 });
+                line.start = count;
+                line.end = count;
+                line.basis = 0;
+                line.cross = 0;
+                lineCount++;
+            }
+            line.basis += basis + (count > line.start ? gap : 0);
+            line.cross = Math.max(line.cross, crossSize);
+            line.end++;
+            const entry = this._items[count];
+            if (!entry) {
+                this._items[count] = { control: child, basis, cross: crossSize, size: basis };
+            } else {
+                entry.control = child;
+                entry.basis = entry.size = basis;
+                entry.cross = crossSize;
+            }
+            count++;
+        }
+        this._items.length = count;
+        this._lines.length = lineCount;
+        let crossUsed = Math.max(0, lineCount - 1) * gap;
+        for (const current of this._lines) {
+            if (this._flexWrap === "nowrap") {
+                current.cross = cross;
+            }
+            crossUsed += current.cross;
+        }
+        const crossFree = cross - crossUsed;
+        const lineSpacing = this._spacing(this._alignContent, crossFree, lineCount);
+        const stretch = this._alignContent === "stretch" && crossFree > 0 && lineCount ? crossFree / lineCount : 0;
+        let crossPosition = this._flexWrap === "nowrap" ? 0 : this._offset(this._alignContent, crossFree, lineSpacing);
+        for (const current of this._lines) {
+            current.cross += stretch;
+            const free = main - current.basis;
+            let weight = 0;
+            let factorSum = 0;
+            for (let i = current.start; i < current.end; i++) {
+                const entry = this._items[i];
+                const factor = free >= 0 ? entry.control.flexGrow : entry.control.flexShrink;
+                weight += free >= 0 ? factor : factor * entry.basis;
+                factorSum += factor;
+            }
+            const distributable = free * Math.min(1, factorSum);
+            let used = Math.max(0, current.end - current.start - 1) * gap;
+            for (let i = current.start; i < current.end; i++) {
+                const entry = this._items[i];
+                const share = free >= 0 ? entry.control.flexGrow : entry.control.flexShrink * entry.basis;
+                entry.size = Math.max(0, entry.basis + (weight ? (distributable * share) / weight : 0));
+                used += entry.size;
+            }
+            const remaining = main - used;
+            const spacing = this._spacing(this._justifyContent, remaining, current.end - current.start);
+            let position = this._offset(this._justifyContent, remaining, spacing);
+            for (let i = current.start; i < current.end; i++) {
+                const entry = this._items[i];
+                const child = entry.control;
+                const childCross = this._alignItems === "stretch" ? current.cross : entry.cross;
+                const extra = current.cross - childCross;
+                let childCrossPosition = crossPosition + (this._alignItems === "center" ? extra / 2 : this._alignItems === "flex-end" ? extra : 0);
+                if (reverseLines) {
+                    childCrossPosition = cross - childCrossPosition - childCross;
+                }
+                const childMainPosition = reverse ? main - position - entry.size : position;
+                const left = row ? childMainPosition : childCrossPosition;
+                const top = row ? childCrossPosition : childMainPosition;
+                const childWidth = row ? entry.size : childCross;
+                const childHeight = row ? childCross : entry.size;
+                let box = this._boxes.get(child);
+                if (!box) {
+                    box = new Measure(left, top, childWidth, childHeight);
+                    this._boxes.set(child, box);
+                    child._markAsDirty();
+                } else if (box.left !== left || box.top !== top || box.width !== childWidth || box.height !== childHeight) {
+                    box.copyFromFloats(left, top, childWidth, childHeight);
+                    child._markAsDirty();
+                }
+                position += entry.size + gap + spacing;
+            }
+            crossPosition += current.cross + gap + lineSpacing;
+        }
+    }
+}
+
+let _Registered = false;
+/**
+ * Registers FlexPanel for serialization. Safe to call repeatedly.
+ */
+export function RegisterFlexPanel(): void {
+    if (_Registered) {
+        return;
+    }
+    _Registered = true;
+    RegisterClass("BABYLON.GUI.FlexPanel", FlexPanel);
+}

--- a/packages/dev/gui/src/2D/controls/flexPanel.pure.ts
+++ b/packages/dev/gui/src/2D/controls/flexPanel.pure.ts
@@ -26,7 +26,7 @@ export type FlexAlignment = "flex-start" | "flex-end" | "center" | "stretch";
  */
 export type FlexContentAlignment = FlexJustification | "stretch";
 
-type FlexItem = { control: Control; basis: number; cross: number; size: number };
+type FlexItem = { control: Control; basis: number; cross: number; size: number; frozen: boolean };
 type FlexLine = { start: number; end: number; basis: number; cross: number };
 
 /**
@@ -140,6 +140,19 @@ export class FlexPanel extends Container {
         return "FlexPanel";
     }
 
+    /**
+     * Removes a control and releases its cached layout data.
+     * @param control defines the control to remove
+     * @returns the current panel
+     */
+    public override removeControl(control: Control): FlexPanel {
+        this._boxes.delete(control);
+        this._items.length = 0;
+        this._lines.length = 0;
+        super.removeControl(control);
+        return this;
+    }
+
     /** @internal */
     public override _getLayoutMeasureForChild(child: Control): Measure | null {
         return this._boxes.get(child) ?? null;
@@ -176,6 +189,42 @@ export class FlexPanel extends Container {
         }
     }
 
+    private _resolveFlexibleLengths(line: FlexLine, main: number): void {
+        const free = main - line.basis;
+        let remaining = free;
+        let frozeItem: boolean;
+        do {
+            let weight = 0;
+            let factorSum = 0;
+            for (let i = line.start; i < line.end; i++) {
+                const entry = this._items[i];
+                if (entry.frozen) {
+                    continue;
+                }
+                const factor = free >= 0 ? entry.control.flexGrow : entry.control.flexShrink;
+                weight += free >= 0 ? factor : factor * entry.basis;
+                factorSum += factor;
+            }
+            // Fractional factors limit distribution using the initial free space, even after freezing.
+            const distributable = free >= 0 ? Math.min(remaining, free * factorSum) : Math.max(remaining, free * factorSum);
+            frozeItem = false;
+            for (let i = line.start; i < line.end; i++) {
+                const entry = this._items[i];
+                if (entry.frozen) {
+                    continue;
+                }
+                const share = free >= 0 ? entry.control.flexGrow : entry.control.flexShrink * entry.basis;
+                const size = entry.basis + (weight ? distributable * (share / weight) : 0);
+                entry.size = Math.max(0, size);
+                if (size < 0) {
+                    entry.frozen = true;
+                    remaining += entry.basis;
+                    frozeItem = true;
+                }
+            }
+        } while (frozeItem);
+    }
+
     protected override _beforeChildLayout(): void {
         const row = this._flexDirection === "row" || this._flexDirection === "row-reverse";
         const reverse = this._flexDirection === "row-reverse" || this._flexDirection === "column-reverse";
@@ -208,11 +257,12 @@ export class FlexPanel extends Container {
             line.end++;
             const entry = this._items[count];
             if (!entry) {
-                this._items[count] = { control: child, basis, cross: crossSize, size: basis };
+                this._items[count] = { control: child, basis, cross: crossSize, size: basis, frozen: false };
             } else {
                 entry.control = child;
                 entry.basis = entry.size = basis;
                 entry.cross = crossSize;
+                entry.frozen = false;
             }
             count++;
         }
@@ -231,22 +281,10 @@ export class FlexPanel extends Container {
         let crossPosition = this._flexWrap === "nowrap" ? 0 : this._offset(this._alignContent, crossFree, lineSpacing);
         for (const current of this._lines) {
             current.cross += stretch;
-            const free = main - current.basis;
-            let weight = 0;
-            let factorSum = 0;
-            for (let i = current.start; i < current.end; i++) {
-                const entry = this._items[i];
-                const factor = free >= 0 ? entry.control.flexGrow : entry.control.flexShrink;
-                weight += free >= 0 ? factor : factor * entry.basis;
-                factorSum += factor;
-            }
-            const distributable = free * Math.min(1, factorSum);
+            this._resolveFlexibleLengths(current, main);
             let used = Math.max(0, current.end - current.start - 1) * gap;
             for (let i = current.start; i < current.end; i++) {
-                const entry = this._items[i];
-                const share = free >= 0 ? entry.control.flexGrow : entry.control.flexShrink * entry.basis;
-                entry.size = Math.max(0, entry.basis + (weight ? (distributable * share) / weight : 0));
-                used += entry.size;
+                used += this._items[i].size;
             }
             const remaining = main - used;
             const spacing = this._spacing(this._justifyContent, remaining, current.end - current.start);

--- a/packages/dev/gui/src/2D/controls/flexPanel.ts
+++ b/packages/dev/gui/src/2D/controls/flexPanel.ts
@@ -1,0 +1,4 @@
+export * from "./flexPanel.pure";
+
+import { RegisterFlexPanel } from "./flexPanel.pure";
+RegisterFlexPanel();

--- a/packages/dev/gui/src/2D/controls/index.ts
+++ b/packages/dev/gui/src/2D/controls/index.ts
@@ -7,6 +7,7 @@ export * from "./ellipse";
 export * from "./focusableButton";
 export * from "./focusableControl";
 export * from "./grid";
+export * from "./flexPanel";
 export * from "./image";
 export * from "./inputText";
 export * from "./inputTextArea";

--- a/packages/dev/gui/src/2D/controls/inputText.pure.ts
+++ b/packages/dev/gui/src/2D/controls/inputText.pure.ts
@@ -112,7 +112,7 @@ export class InputText extends Control {
 
     /** Gets the maximum width allowed by the control in pixels */
     public get maxWidthInPixels(): number {
-        return this._maxWidth.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._maxWidth, this._cachedParentMeasure.width);
     }
 
     public set maxWidth(value: string | number) {
@@ -191,7 +191,7 @@ export class InputText extends Control {
 
     /** Gets control margin in pixels */
     public get marginInPixels(): number {
-        return this._margin.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._margin, this._cachedParentMeasure.width);
     }
 
     public set margin(value: string) {
@@ -929,7 +929,7 @@ export class InputText extends Control {
         }
 
         // Text
-        const clipTextLeft = this._currentMeasure.left + this._margin.getValueInPixel(this._host, this._tempParentMeasure.width);
+        const clipTextLeft = this._currentMeasure.left + this._getValueInPixel(this._margin, this._tempParentMeasure.width);
         if (this.color) {
             context.fillStyle = this.color;
         }
@@ -946,14 +946,15 @@ export class InputText extends Control {
         }
 
         this._textWidth = context.measureText(text.text).width;
-        const marginWidth = this._margin.getValueInPixel(this._host, this._tempParentMeasure.width) * 2;
+        const marginWidth = this._getValueInPixel(this._margin, this._tempParentMeasure.width) * 2;
         if (this._autoStretchWidth) {
-            this.width = Math.min(this._maxWidth.getValueInPixel(this._host, this._tempParentMeasure.width), this._textWidth + marginWidth) + "px";
+            this.width = Math.min(this._getValueInPixel(this._maxWidth, this._tempParentMeasure.width), this._textWidth + marginWidth) + "px";
             this._autoStretchWidth = true; // setting the width will have reset _autoStretchWidth to false!
         }
 
         const rootY = this._fontOffset.ascent + (this._currentMeasure.height - this._fontOffset.height) / 2;
-        const availableWidth = this._width.getValueInPixel(this._host, this._tempParentMeasure.width) - marginWidth;
+        const allocatedWidth = this.parent?._getLayoutMeasureForChild(this)?.width;
+        const availableWidth = (allocatedWidth ?? this._getValueInPixel(this._width, this._tempParentMeasure.width)) - marginWidth;
 
         context.save();
         context.beginPath();

--- a/packages/dev/gui/src/2D/controls/inputTextArea.pure.ts
+++ b/packages/dev/gui/src/2D/controls/inputTextArea.pure.ts
@@ -87,7 +87,7 @@ export class InputTextArea extends InputText {
 
     /** Gets the maximum width allowed by the control in pixels */
     public get maxHeightInPixels(): number {
-        return this._maxHeight.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        return this._getValueInPixel(this._maxHeight, this._cachedParentMeasure.height);
     }
 
     public set maxHeight(value: string | number) {
@@ -582,7 +582,7 @@ export class InputTextArea extends InputText {
         // measures the textlength -> this.measure.width
         this._textWidth = context.measureText(text).width;
         // we double up the margin width
-        const marginWidth = this._margin.getValueInPixel(this._host, parentMeasure.width) * 2;
+        const marginWidth = this._getValueInPixel(this._margin, parentMeasure.width) * 2;
 
         if (this._autoStretchWidth) {
             const tmpLines = text.split("\n");
@@ -593,12 +593,13 @@ export class InputTextArea extends InputText {
             }, "");
 
             const longerStringWidth = context.measureText(longerString).width;
-            this.width = Math.min(this._maxWidth.getValueInPixel(this._host, parentMeasure.width), longerStringWidth + marginWidth) + "px";
+            this.width = Math.min(this._getValueInPixel(this._maxWidth, parentMeasure.width), longerStringWidth + marginWidth) + "px";
 
             this.autoStretchWidth = true;
         }
 
-        this._availableWidth = this._width.getValueInPixel(this._host, parentMeasure.width) - marginWidth;
+        const allocatedMeasure = this.parent?._getLayoutMeasureForChild(this);
+        this._availableWidth = (allocatedMeasure?.width ?? this._getValueInPixel(this._width, parentMeasure.width)) - marginWidth;
 
         // Prepare lines
         this._lines = this._breakLines(this._availableWidth, context);
@@ -607,14 +608,14 @@ export class InputTextArea extends InputText {
 
         if (this._autoStretchHeight) {
             const textHeight = this._lines.length * this._fontOffset.height;
-            const totalHeight = textHeight + this._margin.getValueInPixel(this._host, parentMeasure.height) * 2;
-            this.height = Math.min(this._maxHeight.getValueInPixel(this._host, parentMeasure.height), totalHeight) + "px";
+            const totalHeight = textHeight + this._getValueInPixel(this._margin, parentMeasure.height) * 2;
+            this.height = Math.min(this._getValueInPixel(this._maxHeight, parentMeasure.height), totalHeight) + "px";
 
             this._autoStretchHeight = true;
         }
 
-        const marginHeight = this._margin.getValueInPixel(this._host, parentMeasure.height) * 2;
-        this._availableHeight = this._height.getValueInPixel(this._host, parentMeasure.height) - marginHeight;
+        const marginHeight = this._getValueInPixel(this._margin, parentMeasure.height) * 2;
+        this._availableHeight = (allocatedMeasure?.height ?? this._getValueInPixel(this._height, parentMeasure.height)) - marginHeight;
 
         if (this._isFocused) {
             this._cursorInfo.currentLineIndex = 0;
@@ -645,8 +646,8 @@ export class InputTextArea extends InputText {
     }
 
     private _computeScroll() {
-        this._clipTextLeft = this._currentMeasure.left + this._margin.getValueInPixel(this._host, this._cachedParentMeasure.width);
-        this._clipTextTop = this._currentMeasure.top + this._margin.getValueInPixel(this._host, this._cachedParentMeasure.height);
+        this._clipTextLeft = this._currentMeasure.left + this._getValueInPixel(this._margin, this._cachedParentMeasure.width);
+        this._clipTextTop = this._currentMeasure.top + this._getValueInPixel(this._margin, this._cachedParentMeasure.height);
 
         if (this._isFocused && this._lines[this._cursorInfo.currentLineIndex].width > this._availableWidth) {
             const textLeft = this._clipTextLeft - this._lines[this._cursorInfo.currentLineIndex].width + this._availableWidth;
@@ -849,10 +850,10 @@ export class InputTextArea extends InputText {
             const line = this._lines[i];
 
             if (i !== 0 && this._lineSpacing.internalValue !== 0) {
-                if (this._lineSpacing.isPixel) {
-                    rootY += this._lineSpacing.getValue(this._host);
+                if (!this._lineSpacing.isPercentage) {
+                    rootY += this._getValueInPixel(this._lineSpacing, 1);
                 } else {
-                    rootY = rootY + this._lineSpacing.getValue(this._host) * this._height.getValueInPixel(this._host, this._cachedParentMeasure.height);
+                    rootY = rootY + this._getValueInPixel(this._lineSpacing, 1) * this._getValueInPixel(this._height, this._cachedParentMeasure.height);
                 }
             }
 

--- a/packages/dev/gui/src/2D/controls/line.pure.ts
+++ b/packages/dev/gui/src/2D/controls/line.pure.ts
@@ -156,12 +156,12 @@ export class Line extends Control {
 
     /** @internal */
     public get _effectiveX2(): number {
-        return (this._connectedControl ? this._connectedControl.centerX - this._cachedParentMeasure.left : 0) + this._x2.getValue(this._host);
+        return (this._connectedControl ? this._connectedControl.centerX - this._cachedParentMeasure.left : 0) + this._getValueInPixel(this._x2, 1);
     }
 
     /** @internal */
     public get _effectiveY2(): number {
-        return (this._connectedControl ? this._connectedControl.centerY - this._cachedParentMeasure.top : 0) + this._y2.getValue(this._host);
+        return (this._connectedControl ? this._connectedControl.centerY - this._cachedParentMeasure.top : 0) + this._getValueInPixel(this._y2, 1);
     }
 
     /**
@@ -198,7 +198,7 @@ export class Line extends Control {
         context.setLineDash(this._dash);
 
         context.beginPath();
-        context.moveTo(this._cachedParentMeasure.left + this._x1.getValue(this._host), this._cachedParentMeasure.top + this._y1.getValue(this._host));
+        context.moveTo(this._cachedParentMeasure.left + this._getValueInPixel(this._x1, 1), this._cachedParentMeasure.top + this._getValueInPixel(this._y1, 1));
 
         context.lineTo(this._cachedParentMeasure.left + this._effectiveX2, this._cachedParentMeasure.top + this._effectiveY2);
         context.stroke();
@@ -208,8 +208,8 @@ export class Line extends Control {
 
     public override _measure(): void {
         // Width / Height
-        this._currentMeasure.width = Math.abs(this._x1.getValue(this._host) - this._effectiveX2) + this._lineWidth;
-        this._currentMeasure.height = Math.abs(this._y1.getValue(this._host) - this._effectiveY2) + this._lineWidth;
+        this._currentMeasure.width = Math.abs(this._getValueInPixel(this._x1, 1) - this._effectiveX2) + this._lineWidth;
+        this._currentMeasure.height = Math.abs(this._getValueInPixel(this._y1, 1) - this._effectiveY2) + this._lineWidth;
     }
 
     protected override _preMeasure(parentMeasure: Measure): void {
@@ -225,8 +225,8 @@ export class Line extends Control {
     }
 
     protected override _computeAlignment(parentMeasure: Measure): void {
-        this._currentMeasure.left = parentMeasure.left + Math.min(this._x1.getValue(this._host), this._effectiveX2) - this._lineWidth / 2;
-        this._currentMeasure.top = parentMeasure.top + Math.min(this._y1.getValue(this._host), this._effectiveY2) - this._lineWidth / 2;
+        this._currentMeasure.left = parentMeasure.left + Math.min(this._getValueInPixel(this._x1, 1), this._effectiveX2) - this._lineWidth / 2;
+        this._currentMeasure.top = parentMeasure.top + Math.min(this._getValueInPixel(this._y1, 1), this._effectiveY2) - this._lineWidth / 2;
     }
 
     /**
@@ -259,8 +259,8 @@ export class Line extends Control {
      * @param end (opt) Set to true to assign x2 and y2 coordinates of the line. Default assign to x1 and y1.
      */
     public override _moveToProjectedPosition(projectedPosition: Vector3, end: boolean = false): void {
-        const x: string = projectedPosition.x + this._linkOffsetX.getValue(this._host) + "px";
-        const y: string = projectedPosition.y + this._linkOffsetY.getValue(this._host) + "px";
+        const x: string = projectedPosition.x + this._getValueInPixel(this._linkOffsetX, 1) + "px";
+        const y: string = projectedPosition.y + this._getValueInPixel(this._linkOffsetY, 1) + "px";
 
         if (end) {
             this.x2 = x;

--- a/packages/dev/gui/src/2D/controls/pure.ts
+++ b/packages/dev/gui/src/2D/controls/pure.ts
@@ -8,6 +8,7 @@ export * from "./ellipse.pure";
 export * from "./focusableButton.pure";
 export * from "./focusableControl";
 export * from "./grid.pure";
+export * from "./flexPanel.pure";
 export * from "./image.pure";
 export * from "./inputText.pure";
 export * from "./inputTextArea.pure";

--- a/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/baseSlider.ts
@@ -74,7 +74,7 @@ export class BaseSlider extends Control {
 
     /** Gets main bar offset in pixels*/
     public get barOffsetInPixels(): number {
-        return this._barOffset.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._barOffset, this._cachedParentMeasure.width);
     }
 
     public set barOffset(value: string | number) {
@@ -95,7 +95,7 @@ export class BaseSlider extends Control {
 
     /** Gets thumb width in pixels */
     public get thumbWidthInPixels(): number {
-        return this._thumbWidth.getValueInPixel(this._host, this._cachedParentMeasure.width);
+        return this._getValueInPixel(this._thumbWidth, this._cachedParentMeasure.width);
     }
 
     public set thumbWidth(value: string | number) {
@@ -216,17 +216,17 @@ export class BaseSlider extends Control {
         let thumbThickness = 0;
         switch (type) {
             case "circle":
-                if (this._thumbWidth.isPixel) {
-                    thumbThickness = Math.max(this._thumbWidth.getValue(this._host), this._backgroundBoxThickness);
+                if (!this._thumbWidth.isPercentage) {
+                    thumbThickness = Math.max(this._getValueInPixel(this._thumbWidth, 1), this._backgroundBoxThickness);
                 } else {
-                    thumbThickness = this._backgroundBoxThickness * this._thumbWidth.getValue(this._host);
+                    thumbThickness = this._backgroundBoxThickness * this._getValueInPixel(this._thumbWidth, 1);
                 }
                 break;
             case "rectangle":
-                if (this._thumbWidth.isPixel) {
-                    thumbThickness = Math.min(this._thumbWidth.getValue(this._host), this._backgroundBoxThickness);
+                if (!this._thumbWidth.isPercentage) {
+                    thumbThickness = Math.min(this._getValueInPixel(this._thumbWidth, 1), this._backgroundBoxThickness);
                 } else {
-                    thumbThickness = this._backgroundBoxThickness * this._thumbWidth.getValue(this._host);
+                    thumbThickness = this._backgroundBoxThickness * this._getValueInPixel(this._thumbWidth, 1);
                 }
         }
         return thumbThickness;
@@ -252,10 +252,10 @@ export class BaseSlider extends Control {
             Logger.Error("Height should be greater than width");
             return;
         }
-        if (this._barOffset.isPixel) {
-            this._effectiveBarOffset = Math.min(this._barOffset.getValue(this._host), this._backgroundBoxThickness);
+        if (!this._barOffset.isPercentage) {
+            this._effectiveBarOffset = Math.min(this._getValueInPixel(this._barOffset, 1), this._backgroundBoxThickness);
         } else {
-            this._effectiveBarOffset = this._backgroundBoxThickness * this._barOffset.getValue(this._host);
+            this._effectiveBarOffset = this._backgroundBoxThickness * this._getValueInPixel(this._barOffset, 1);
         }
 
         this._backgroundBoxThickness -= this._effectiveBarOffset * 2;

--- a/packages/dev/gui/src/2D/controls/sliders/imageScrollBar.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/imageScrollBar.ts
@@ -184,10 +184,10 @@ export class ImageScrollBar extends BaseSlider {
 
     protected override _getThumbThickness(): number {
         let thumbThickness: number;
-        if (this._thumbWidth.isPixel) {
-            thumbThickness = this._thumbWidth.getValue(this._host);
+        if (!this._thumbWidth.isPercentage) {
+            thumbThickness = this._getValueInPixel(this._thumbWidth, 1);
         } else {
-            thumbThickness = this._backgroundBoxThickness * this._thumbWidth.getValue(this._host);
+            thumbThickness = this._backgroundBoxThickness * this._getValueInPixel(this._thumbWidth, 1);
         }
         return thumbThickness;
     }

--- a/packages/dev/gui/src/2D/controls/sliders/scrollBar.pure.ts
+++ b/packages/dev/gui/src/2D/controls/sliders/scrollBar.pure.ts
@@ -89,10 +89,10 @@ export class ScrollBar extends BaseSlider {
 
     protected override _getThumbThickness(): number {
         let thumbThickness: number;
-        if (this._thumbWidth.isPixel) {
-            thumbThickness = this._thumbWidth.getValue(this._host);
+        if (!this._thumbWidth.isPercentage) {
+            thumbThickness = this._getValueInPixel(this._thumbWidth, 1);
         } else {
-            thumbThickness = this._backgroundBoxThickness * this._thumbWidth.getValue(this._host);
+            thumbThickness = this._backgroundBoxThickness * this._getValueInPixel(this._thumbWidth, 1);
         }
         return thumbThickness;
     }

--- a/packages/dev/gui/src/2D/controls/stackPanel.pure.ts
+++ b/packages/dev/gui/src/2D/controls/stackPanel.pure.ts
@@ -247,7 +247,7 @@ export class StackPanel extends Container {
             return true;
         }
 
-        return this.getDimension(dim).isPixel || this._getAdaptDimTo(dim);
+        return !this.getDimension(dim).isPercentage || this._getAdaptDimTo(dim);
     }
 
     /**

--- a/packages/dev/gui/src/2D/controls/textBlock.pure.ts
+++ b/packages/dev/gui/src/2D/controls/textBlock.pure.ts
@@ -398,7 +398,7 @@ export class TextBlock extends Control {
         if (this._resizeToFit) {
             if (this._textWrapping === TextWrapping.Clip || this._forceResizeWidth) {
                 const newWidth = Math.ceil(this._paddingLeftInPixels) + Math.ceil(this._paddingRightInPixels) + Math.ceil(maxLineWidth);
-                if (newWidth !== this._width.getValueInPixel(this._host, this._tempParentMeasure.width)) {
+                if (newWidth !== this._getValueInPixel(this._width, this._tempParentMeasure.width)) {
                     this._width.updateInPlace(newWidth, ValueAndUnit.UNITMODE_PIXEL);
                     this._rebuildLayout = true;
                 }
@@ -407,10 +407,10 @@ export class TextBlock extends Control {
 
             if (this._lines.length > 0 && this._lineSpacing.internalValue !== 0) {
                 let lineSpacing: number;
-                if (this._lineSpacing.isPixel) {
-                    lineSpacing = this._lineSpacing.getValue(this._host);
+                if (!this._lineSpacing.isPercentage) {
+                    lineSpacing = this._getValueInPixel(this._lineSpacing, 1);
                 } else {
-                    lineSpacing = this._lineSpacing.getValue(this._host) * this._height.getValueInPixel(this._host, this._cachedParentMeasure.height);
+                    lineSpacing = this._getValueInPixel(this._lineSpacing, 1) * this._getValueInPixel(this._height, this._cachedParentMeasure.height);
                 }
 
                 newHeight += (this._lines.length - 1) * lineSpacing;
@@ -693,10 +693,10 @@ export class TextBlock extends Control {
             const line = this._lines[i];
 
             if (i !== 0 && this._lineSpacing.internalValue !== 0) {
-                if (this._lineSpacing.isPixel) {
-                    rootY += this._lineSpacing.getValue(this._host);
+                if (!this._lineSpacing.isPercentage) {
+                    rootY += this._getValueInPixel(this._lineSpacing, 1);
                 } else {
-                    rootY = rootY + this._lineSpacing.getValue(this._host) * this._height.getValueInPixel(this._host, this._cachedParentMeasure.height);
+                    rootY = rootY + this._getValueInPixel(this._lineSpacing, 1) * this._getValueInPixel(this._height, this._cachedParentMeasure.height);
                 }
             }
 
@@ -710,10 +710,10 @@ export class TextBlock extends Control {
 
         if (lineCount > 0 && this._lineSpacing.internalValue !== 0) {
             let lineSpacing: number;
-            if (this._lineSpacing.isPixel) {
-                lineSpacing = this._lineSpacing.getValue(this._host);
+            if (!this._lineSpacing.isPercentage) {
+                lineSpacing = this._getValueInPixel(this._lineSpacing, 1);
             } else {
-                lineSpacing = this._lineSpacing.getValue(this._host) * this._height.getValueInPixel(this._host, this._cachedParentMeasure.height);
+                lineSpacing = this._getValueInPixel(this._lineSpacing, 1) * this._getValueInPixel(this._height, this._cachedParentMeasure.height);
             }
 
             newHeight += (lineCount - 1) * lineSpacing;

--- a/packages/dev/gui/src/2D/multiLinePoint.ts
+++ b/packages/dev/gui/src/2D/multiLinePoint.ts
@@ -142,8 +142,8 @@ export class MultiLinePoint {
         } else {
             const host: any = this._multiLine._host as any;
 
-            const xValue: number = this._x.getValueInPixel(host, Number(host._canvas.width));
-            const yValue: number = this._y.getValueInPixel(host, Number(host._canvas.height));
+            const xValue: number = this._multiLine._getValueInPixel(this._x, Number(host._canvas.width));
+            const yValue: number = this._multiLine._getValueInPixel(this._y, Number(host._canvas.height));
 
             return new Vector3(xValue, yValue, 1 - Epsilon);
         }

--- a/packages/dev/gui/src/2D/valueAndUnit.ts
+++ b/packages/dev/gui/src/2D/valueAndUnit.ts
@@ -86,14 +86,12 @@ export class ValueAndUnit {
      * Gets value as pixel
      * @param host defines the root host
      * @param refValue defines the reference value for percentages
+     * @param fontSize defines the computed font size in pixels for em units
+     * @param rootFontSize defines the computed root font size in pixels for rem units
      * @returns the value as pixel
      */
-    public getValueInPixel(host: AdvancedDynamicTexture, refValue: number): number {
-        if (this.isPixel) {
-            return this.getValue(host);
-        }
-
-        return this.getValue(host) * refValue;
+    public getValueInPixel(host: AdvancedDynamicTexture, refValue: number, fontSize?: number, rootFontSize?: number): number {
+        return this.getValue(host, fontSize, rootFontSize) * (this.isPercentage ? refValue : 1);
     }
 
     /**
@@ -115,10 +113,16 @@ export class ValueAndUnit {
 
     /**
      * Gets the value accordingly to its unit
-     * @param host  defines the root host
+     * @param host defines the root host
+     * @param fontSize defines the computed font size in pixels for em units
+     * @param rootFontSize defines the computed root font size in pixels for rem units
      * @returns the value
      */
-    public getValue(host: AdvancedDynamicTexture): number {
+    public getValue(host: AdvancedDynamicTexture, fontSize?: number, rootFontSize?: number): number {
+        if (this._unit === ValueAndUnit.UNITMODE_EM || this._unit === ValueAndUnit.UNITMODE_REM) {
+            const rootSize = rootFontSize ?? host?.rootContainer.fontSizeInPixels ?? 18;
+            return this._value * (this._unit === ValueAndUnit.UNITMODE_EM ? (fontSize ?? rootSize) : rootSize);
+        }
         if (host && !this.ignoreAdaptiveScaling && this.unit !== ValueAndUnit.UNITMODE_PERCENTAGE) {
             let width: number = 0;
             let height: number = 0;
@@ -156,6 +160,9 @@ export class ValueAndUnit {
      */
     public toString(host: AdvancedDynamicTexture, decimals?: number): string {
         switch (this._unit) {
+            case ValueAndUnit.UNITMODE_EM:
+            case ValueAndUnit.UNITMODE_REM:
+                return (decimals === undefined ? this._value : this._value.toFixed(decimals)) + (this._unit === ValueAndUnit.UNITMODE_EM ? "em" : "rem");
             case ValueAndUnit.UNITMODE_PERCENTAGE: {
                 const percentage = this.getValue(host) * 100;
                 return (decimals ? percentage.toFixed(decimals) : percentage) + "%";
@@ -175,7 +182,7 @@ export class ValueAndUnit {
      * @returns true if the value was successfully parsed and updated
      */
     public fromString(source: string | number): boolean {
-        const match = ValueAndUnit._Regex.exec(source.toString());
+        const match = ValueAndUnit._Regex.exec(source.toString().trim());
 
         if (!match || match.length === 0) {
             return false;
@@ -183,6 +190,9 @@ export class ValueAndUnit {
 
         let sourceValue = parseFloat(match[1]);
         let sourceUnit = this._originalUnit;
+        if (!Number.isFinite(sourceValue)) {
+            return false;
+        }
 
         if (!this.negativeValueAllowed) {
             if (sourceValue < 0) {
@@ -190,8 +200,14 @@ export class ValueAndUnit {
             }
         }
 
-        if (match.length === 4) {
-            switch (match[3]) {
+        if (match.length === 3) {
+            switch (match[2]) {
+                case "em":
+                    sourceUnit = ValueAndUnit.UNITMODE_EM;
+                    break;
+                case "rem":
+                    sourceUnit = ValueAndUnit.UNITMODE_REM;
+                    break;
                 case "px":
                     sourceUnit = ValueAndUnit.UNITMODE_PIXEL;
                     break;
@@ -214,9 +230,19 @@ export class ValueAndUnit {
     }
 
     // Static
-    private static _Regex = /(^-?\d*(\.\d+)?)(%|px)?/;
+    private static _Regex = /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)(%|px|rem|em)?$/;
     private static _UNITMODE_PERCENTAGE = 0;
     private static _UNITMODE_PIXEL = 1;
+
+    /**
+     * Font-relative units, resolved against the control's computed font size.
+     */
+    public static readonly UNITMODE_EM = 2;
+
+    /**
+     * Root-relative units, resolved against the GUI root container's computed font size.
+     */
+    public static readonly UNITMODE_REM = 3;
 
     /** UNITMODE_PERCENTAGE */
     public static get UNITMODE_PERCENTAGE(): number {

--- a/packages/dev/gui/test/unit/flexPanel.test.ts
+++ b/packages/dev/gui/test/unit/flexPanel.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FlexPanel } from "../../src/2D/controls/flexPanel";
+import { Control } from "../../src/2D/controls/control";
+import { Container } from "../../src/2D/controls/container";
+import { Measure } from "../../src/2D/measure";
+import { InputText } from "../../src/2D/controls/inputText";
+import { InputTextArea } from "../../src/2D/controls/inputTextArea";
+import { MultiLine } from "../../src/2D/controls/multiLine";
+import { TextBlock } from "../../src/2D/controls/textBlock";
+import { StackPanel } from "../../src/2D/controls/stackPanel";
+import { ValueAndUnit } from "../../src/2D/valueAndUnit";
+import { type AdvancedDynamicTexture } from "../../src/2D/advancedDynamicTexture";
+import { type ICanvasRenderingContext } from "core/Engines/ICanvas";
+
+const context = {
+    save() {},
+    restore() {},
+    measureText(text: string) {
+        return { width: text.length * 10 };
+    },
+} as ICanvasRenderingContext;
+function setup(width = 300, height = 100) {
+    const root = new Container("root");
+    let id = 0;
+    const host = {
+        rootContainer: root,
+        _canvas: { width, height },
+        _linkedControls: [],
+        _cleanControlAfterRemoval() {},
+        idealRatio: 1,
+        idealWidth: 0,
+        idealHeight: 0,
+        getSize: () => ({ width, height }),
+        getScene: () => ({ getUniqueId: () => ++id, getEngine: () => undefined }),
+        markAsDirty() {},
+        _numLayoutCalls: 0,
+    } as unknown as AdvancedDynamicTexture;
+    root._link(host);
+    const panel = new FlexPanel("panel");
+    root.addControl(panel);
+    const layout = (w = width, h = height) => root._layout(new Measure(0, 0, w, h), context);
+    return { root, panel, host, layout };
+}
+function item(width: string | number = "100px", height: string | number = "20px") {
+    const child = new Control();
+    child.width = width;
+    child.height = height;
+    return child;
+}
+beforeEach(() => {
+    vi.spyOn(Control, "_GetFontOffset").mockReturnValue({ ascent: 14, height: 18, descent: 4 });
+});
+
+describe("FlexPanel", () => {
+    it("distributes free space without changing declared dimensions", () => {
+        const { panel, layout } = setup();
+        const a = item(),
+            b = item();
+        a.flexGrow = 1;
+        b.flexGrow = 2;
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.width).toBeCloseTo(400 / 3);
+        expect(b._currentMeasure.width).toBeCloseTo(500 / 3);
+        expect(b._currentMeasure.left).toBeCloseTo(400 / 3);
+        expect(a.width).toBe("100px");
+        layout(600);
+        expect(a._currentMeasure.width).toBeCloseTo(700 / 3);
+        expect(b._currentMeasure.width).toBeCloseTo(1100 / 3);
+    });
+    it("shrinks according to the declared basis and shrink factor", () => {
+        const { panel, layout } = setup(150);
+        const a = item("100px"),
+            b = item("200px");
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.width).toBeCloseTo(50);
+        expect(b._currentMeasure.width).toBeCloseTo(100);
+    });
+    it("wraps at the available width, with gaps and hidden children excluded", () => {
+        const { panel, layout } = setup(220, 100);
+        panel.flexWrap = "wrap";
+        panel.gap = "10px";
+        panel.alignContent = "flex-start";
+        const a = item(),
+            hidden = item(),
+            b = item(),
+            c = item();
+        hidden.isVisible = false;
+        panel.addControl(a).addControl(hidden).addControl(b).addControl(c);
+        layout();
+        expect(b._currentMeasure.left).toBe(110);
+        expect(c._currentMeasure.top).toBe(30);
+        layout(330);
+        expect(c._currentMeasure.top).toBe(0);
+        expect(c._currentMeasure.left).toBe(220);
+    });
+    it("supports reversed columns and cross-axis alignment", () => {
+        const { panel, layout } = setup(300, 100);
+        panel.flexDirection = "column-reverse";
+        panel.alignItems = "center";
+        panel.justifyContent = "space-between";
+        const a = item(),
+            b = item();
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.top).toBe(80);
+        expect(b._currentMeasure.top).toBe(0);
+        expect(a._currentMeasure.left).toBe(100);
+    });
+    it("reflows after a child changes and restores normal layout when reparented", () => {
+        const { root, panel, layout } = setup();
+        const a = item(),
+            b = item();
+        panel.addControl(a).addControl(b);
+        layout();
+        a.width = "150px";
+        layout();
+        expect(b._currentMeasure.left).toBe(150);
+        panel.removeControl(b);
+        root.addControl(b);
+        layout();
+        expect(b._currentMeasure.left).toBe(100);
+    });
+    it("lays out nested panels using allocated space", () => {
+        const { panel, layout } = setup(300, 100);
+        const nested = new FlexPanel();
+        nested.width = "100px";
+        nested.flexGrow = 1;
+        nested.alignItems = "stretch";
+        const a = item("50%"),
+            b = item("50%");
+        nested.addControl(a).addControl(b);
+        panel.addControl(item()).addControl(nested);
+        layout();
+        expect(nested._currentMeasure.width).toBe(200);
+        expect(a._currentMeasure.left).toBe(100);
+        expect(b._currentMeasure.left).toBe(200);
+        expect(a._currentMeasure.height).toBe(100);
+        layout(500);
+        expect(b._currentMeasure.left).toBe(300);
+    });
+    it("uses the allocated width when wrapping text", () => {
+        const { panel, layout } = setup(100);
+        const text = new TextBlock("text", "aaaa bbbb");
+        text.width = "200px";
+        text.height = "60px";
+        text.fontSize = "18px";
+        text.textWrapping = true;
+        panel.addControl(item("50px")).addControl(text);
+        layout();
+        expect(text._currentMeasure.width).toBeCloseTo(80);
+        expect(text.lines).toHaveLength(2);
+    });
+    it("uses allocated text-input dimensions for clipping and line wrapping", () => {
+        const { panel, layout } = setup(100, 80);
+        const area = new InputTextArea("area", "aaaa bbbb");
+        area.width = "200px";
+        area.height = "60px";
+        area.margin = "0px";
+        area.fontSize = "18px";
+        area.autoStretchHeight = false;
+        panel.addControl(item("50px")).addControl(area);
+        layout();
+        const areaInternals = area as unknown as { _availableWidth: number; _lines: unknown[] };
+        expect(areaInternals._availableWidth).toBeCloseTo(80);
+        expect(areaInternals._lines).toHaveLength(2);
+
+        panel.removeControl(area);
+        const input = new InputText("input", "hello");
+        input.width = "200px";
+        input.height = "30px";
+        input.margin = "0px";
+        input.fontSize = "18px";
+        panel.addControl(input);
+        layout();
+        const rect = vi.fn();
+        const drawContext = { ...context, rect, beginPath() {}, clip() {}, fillText() {}, fillRect() {}, strokeRect() {} } as unknown as ICanvasRenderingContext;
+        input._draw(drawContext);
+        expect(rect.mock.calls[0][2]).toBeCloseTo(82);
+    });
+    it("honors descendant padding without scaling allocated boxes twice", () => {
+        const { panel, layout } = setup(300, 100);
+        panel.descendantsOnlyPadding = true;
+        panel.paddingLeft = "10px";
+        panel.paddingRight = "20px";
+        panel.paddingTop = "5px";
+        const a = item("50%"),
+            b = item("50%");
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.left).toBe(10);
+        expect(a._currentMeasure.width).toBe(135);
+        expect(b._currentMeasure.left).toBe(145);
+        expect(b._currentMeasure.top).toBe(5);
+    });
+    it("supports reversed wrap lines and stretch", () => {
+        const { panel, layout } = setup(100, 100);
+        panel.flexWrap = "wrap-reverse";
+        panel.alignItems = "stretch";
+        const a = item(),
+            b = item();
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.top).toBe(50);
+        expect(b._currentMeasure.top).toBe(0);
+        expect(a._currentMeasure.height).toBe(50);
+    });
+    it("keeps overflow intentional when shrink is disabled", () => {
+        const { panel, layout } = setup(50);
+        const a = item();
+        a.flexShrink = 0;
+        panel.addControl(a);
+        layout();
+        expect(a._currentMeasure.width).toBe(100);
+        expect(() => {
+            a.flexGrow = NaN;
+        }).toThrow(RangeError);
+        expect(() => {
+            a.flexShrink = -1;
+        }).toThrow(RangeError);
+    });
+    it("handles an empty panel and single-item space distribution", () => {
+        const { panel, layout } = setup(300);
+        layout();
+        panel.justifyContent = "space-evenly";
+        const a = item();
+        panel.addControl(a);
+        layout();
+        expect(a._currentMeasure.left).toBe(100);
+    });
+    it("serializes layout settings and declared child sizes", () => {
+        const { panel, layout } = setup();
+        panel.flexDirection = "column";
+        panel.gap = "1rem";
+        const a = item("2em");
+        a.flexGrow = 1;
+        panel.addControl(a);
+        layout();
+        const json: any = {};
+        panel.serialize(json, false, false);
+        expect(json.className).toBe("FlexPanel");
+        expect(json.flexDirection).toBe("column");
+        expect(json.gap).toBe("1rem");
+        expect(json.children[0].width).toBe("2em");
+        expect(json.children[0].flexGrow).toBe(1);
+    });
+});
+
+describe("font-relative GUI units", () => {
+    it("resolves em from the control font and rem from the GUI root", () => {
+        const { root, panel, layout } = setup();
+        root.fontSize = "20px";
+        panel.fontSize = "1.5em";
+        const a = item("2em", "1rem");
+        a.fontSize = "2em";
+        panel.addControl(a);
+        layout();
+        expect(a.fontSizeInPixels).toBe(60);
+        expect(a._currentMeasure.width).toBe(120);
+        expect(a._currentMeasure.height).toBe(20);
+        root.fontSize = "30px";
+        layout();
+        expect(a._currentMeasure.width).toBe(180);
+        expect(a._currentMeasure.height).toBe(30);
+    });
+    it("scales relative units once with the ideal resolution", () => {
+        const { root, panel, host, layout } = setup();
+        host.idealWidth = 150;
+        root.fontSize = "20px";
+        const a = item("2rem", "1em");
+        a.fontSize = "10px";
+        panel.addControl(a);
+        layout();
+        expect(a._currentMeasure.width).toBe(80);
+        expect(a._currentMeasure.height).toBe(20);
+    });
+    it("resolves offsets and padding outside a flex panel", () => {
+        const { root, layout } = setup(300);
+        root.fontSize = "20px";
+        const a = item("5em", "3em");
+        a.fontSize = "10px";
+        a.horizontalAlignment = Control.HORIZONTAL_ALIGNMENT_LEFT;
+        a.verticalAlignment = Control.VERTICAL_ALIGNMENT_TOP;
+        a.left = "1rem";
+        a.top = "2em";
+        a.paddingLeft = "1em";
+        root.addControl(a);
+        layout();
+        expect(a._currentMeasure.left).toBe(30);
+        expect(a._currentMeasure.top).toBe(20);
+        expect(a._currentMeasure.width).toBe(40);
+    });
+    it("treats relative dimensions as defined when sizing a StackPanel", () => {
+        const { root, layout } = setup();
+        root.fontSize = "20px";
+        const stack = new StackPanel();
+        stack.addControl(item("2rem", "1rem"));
+        stack.addControl(item("2rem", "2rem"));
+        root.addControl(stack);
+        layout();
+        expect(stack._currentMeasure.height).toBe(60);
+    });
+    it("resolves em dimensions from percentage fonts on the current parent height", () => {
+        const { panel, layout } = setup(300, 100);
+        const child = item("2em", "1em");
+        child.fontSize = "10%";
+        panel.addControl(child);
+        layout();
+        expect(child._currentMeasure.width).toBe(20);
+        layout(300, 200);
+        expect(child._currentMeasure.width).toBe(40);
+        expect(child._currentMeasure.height).toBe(20);
+    });
+    it("uses the default font for root-relative font declarations without recursion", () => {
+        const { root } = setup();
+        root.fontSize = "2rem";
+        expect(root.fontSizeInPixels).toBe(36);
+    });
+    it("resolves multiline point em units against the multiline control", () => {
+        const { root } = setup();
+        const line = new MultiLine();
+        line.fontSize = "30px";
+        root.addControl(line);
+        const point = line.push({ x: "2em", y: "1rem" });
+        expect(point.translate().x).toBe(60);
+        expect(point.translate().y).toBe(18);
+    });
+    it("keeps pixel, percentage, decimal and scientific numeric inputs usable", () => {
+        const { host } = setup();
+        const value = new ValueAndUnit(0);
+        value.fromString("25%");
+        expect(value.getValueInPixel(host, 200)).toBe(50);
+        value.fromString(" 12px ");
+        expect(value.getValueInPixel(host, 200)).toBe(12);
+        value.fromString(1e-7);
+        expect(value.getValueInPixel(host, 200)).toBe(1e-7);
+        value.fromString(".5em");
+        expect(value.getValueInPixel(host, 200, 20, 18)).toBe(10);
+        expect(value.fromString(Infinity)).toBe(false);
+    });
+    it("parses, preserves and validates relative unit strings", () => {
+        const { host } = setup();
+        const value = new ValueAndUnit(0);
+        expect(value.fromString("1.5rem")).toBe(true);
+        expect(value.toString(host)).toBe("1.5rem");
+        expect(value.getValueInPixel(host, 100, 10, 20)).toBe(30);
+        expect(value.fromString("2emjunk")).toBe(false);
+        expect(value.fromString("rem")).toBe(false);
+        expect(value.toString(host)).toBe("1.5rem");
+    });
+});

--- a/packages/dev/gui/test/unit/flexPanel.test.ts
+++ b/packages/dev/gui/test/unit/flexPanel.test.ts
@@ -77,6 +77,63 @@ describe("FlexPanel", () => {
         expect(a._currentMeasure.width).toBeCloseTo(50);
         expect(b._currentMeasure.width).toBeCloseTo(100);
     });
+    it.each(["row", "column"] as const)("redistributes shrink after an item reaches zero in a %s", (direction) => {
+        const { panel, layout } = setup(50, 50);
+        panel.flexDirection = direction;
+        const a = item("10px", "10px");
+        const b = item("100px", "100px");
+        a.flexShrink = 10;
+        panel.addControl(a).addControl(b);
+        layout();
+        const dimension = direction === "row" ? "width" : "height";
+        expect(a._currentMeasure[dimension]).toBe(0);
+        expect(b._currentMeasure[dimension]).toBe(50);
+        layout(220, 220);
+        expect(a._currentMeasure[dimension]).toBe(10);
+        expect(b._currentMeasure[dimension]).toBe(100);
+    });
+    it("redistributes across successive zero-size freezes and preserves fixed items and gaps", () => {
+        const { panel, layout } = setup(80);
+        panel.gap = "10px";
+        const fixed = item("20px");
+        fixed.flexShrink = 0;
+        const a = item("10px");
+        a.flexShrink = 100;
+        const b = item("20px");
+        b.flexShrink = 10;
+        const c = item("100px");
+        panel.addControl(fixed).addControl(a).addControl(b).addControl(c);
+        layout();
+        expect([fixed, a, b, c].map((child) => child._currentMeasure.width)).toEqual([20, 0, 0, 30]);
+        expect(c._currentMeasure.left).toBe(50);
+    });
+    it("allows partial shrink when the remaining factors total less than one", () => {
+        const { panel, layout } = setup(100);
+        const a = item();
+        const b = item();
+        a.flexShrink = b.flexShrink = 0.2;
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.width).toBe(80);
+        expect(b._currentMeasure.width).toBe(80);
+
+        a.width = "10px";
+        a.flexShrink = 10;
+        layout(50);
+        expect(a._currentMeasure.width).toBe(0);
+        expect(b._currentMeasure.width).toBe(88);
+    });
+    it("finishes shrinking when only gaps can overflow", () => {
+        const { panel, layout } = setup(5);
+        panel.gap = "10px";
+        const a = item();
+        const b = item();
+        panel.addControl(a).addControl(b);
+        layout();
+        expect(a._currentMeasure.width).toBe(0);
+        expect(b._currentMeasure.width).toBe(0);
+        expect(b._currentMeasure.left).toBe(10);
+    });
     it("wraps at the available width, with gaps and hidden children excluded", () => {
         const { panel, layout } = setup(220, 100);
         panel.flexWrap = "wrap";
@@ -118,9 +175,25 @@ describe("FlexPanel", () => {
         layout();
         expect(b._currentMeasure.left).toBe(150);
         panel.removeControl(b);
+        expect(panel._getLayoutMeasureForChild(b)).toBeNull();
         root.addControl(b);
         layout();
         expect(b._currentMeasure.left).toBe(100);
+    });
+    it("releases allocated boxes when children are cleared or disposed", () => {
+        const { panel, layout } = setup();
+        const a = item();
+        const b = item();
+        panel.addControl(a).addControl(b);
+        layout();
+        a.dispose();
+        expect(panel._getLayoutMeasureForChild(a)).toBeNull();
+        panel.clearControls();
+        expect(panel._getLayoutMeasureForChild(b)).toBeNull();
+        b.width = "50px";
+        panel.addControl(b);
+        layout();
+        expect(b._currentMeasure.width).toBe(50);
     });
     it("lays out nested panels using allocated space", () => {
         const { panel, layout } = setup(300, 100);

--- a/packages/public/@babylonjs/gui/package.json
+++ b/packages/public/@babylonjs/gui/package.json
@@ -51,6 +51,7 @@
         "2D/controls/control.js",
         "2D/controls/displayGrid.js",
         "2D/controls/ellipse.js",
+        "2D/controls/flexPanel.js",
         "2D/controls/focusableButton.js",
         "2D/controls/gradient/LinearGradient.js",
         "2D/controls/gradient/RadialGradient.js",

--- a/packages/tools/gui-mcp-server/src/catalog.ts
+++ b/packages/tools/gui-mcp-server/src/catalog.ts
@@ -78,18 +78,20 @@ export interface IControlTypeInfo {
  */
 export const BaseControlProperties: Record<string, IPropertyInfo> = {
     // Size & position
-    width: { description: "Width as a string ('200px', '50%') or number", type: "string", defaultValue: "100%" },
-    height: { description: "Height as a string ('40px', '50%') or number", type: "string", defaultValue: "100%" },
-    left: { description: "Horizontal offset from alignment anchor", type: "string", defaultValue: "0px" },
-    top: { description: "Vertical offset from alignment anchor", type: "string", defaultValue: "0px" },
+    width: { description: "Width as a string ('200px', '50%', '10em', '10rem') or number; em uses the control font, rem the GUI root font", type: "string", defaultValue: "100%" },
+    height: { description: "Height as a string ('40px', '50%', '2em', '2rem') or number; em uses the control font, rem the GUI root font", type: "string", defaultValue: "100%" },
+    left: { description: "Horizontal offset from alignment anchor in px, %, em, or rem", type: "string", defaultValue: "0px" },
+    top: { description: "Vertical offset from alignment anchor in px, %, em, or rem", type: "string", defaultValue: "0px" },
     // Alignment
     horizontalAlignment: { description: "0 = LEFT, 1 = RIGHT, 2 = CENTER", type: "number", defaultValue: 2 },
     verticalAlignment: { description: "0 = TOP, 1 = BOTTOM, 2 = CENTER", type: "number", defaultValue: 2 },
+    flexGrow: { description: "Nonnegative share of extra main-axis space in a FlexPanel", type: "number", defaultValue: 0 },
+    flexShrink: { description: "Nonnegative shrink factor in a FlexPanel, weighted by the declared main-axis size; 0 disables shrinking", type: "number", defaultValue: 1 },
     // Padding
-    paddingLeft: { description: "Left padding (e.g. '10px')", type: "string", defaultValue: "0px" },
-    paddingRight: { description: "Right padding", type: "string", defaultValue: "0px" },
-    paddingTop: { description: "Top padding", type: "string", defaultValue: "0px" },
-    paddingBottom: { description: "Bottom padding", type: "string", defaultValue: "0px" },
+    paddingLeft: { description: "Left padding in px, %, em, or rem", type: "string", defaultValue: "0px" },
+    paddingRight: { description: "Right padding in px, %, em, or rem", type: "string", defaultValue: "0px" },
+    paddingTop: { description: "Top padding in px, %, em, or rem", type: "string", defaultValue: "0px" },
+    paddingBottom: { description: "Bottom padding in px, %, em, or rem", type: "string", defaultValue: "0px" },
     // Appearance
     color: { description: "Foreground / text color (CSS color string)", type: "string", defaultValue: "white" },
     alpha: { description: "Opacity (0 = transparent, 1 = opaque)", type: "number", defaultValue: 1 },
@@ -100,7 +102,7 @@ export const BaseControlProperties: Record<string, IPropertyInfo> = {
     scaleY: { description: "Vertical scale factor", type: "number", defaultValue: 1 },
     // Font
     fontFamily: { description: "CSS font family", type: "string" },
-    fontSize: { description: "Font size (e.g. '24px' or 24)", type: "string", defaultValue: "18px" },
+    fontSize: { description: "Font size ('24px', '1.5em', '1rem', or 24); em uses the parent font, rem the GUI root font", type: "string", defaultValue: "18px" },
     fontWeight: { description: "CSS font weight (normal, bold, 600, etc.)", type: "string" },
     fontStyle: { description: "CSS font style (normal, italic)", type: "string" },
     // Shadow
@@ -181,6 +183,34 @@ export const ControlRegistry: Record<string, IControlTypeInfo> = {
             spacing: { description: "Pixels of space between each child", type: "number", defaultValue: 0 },
             adaptWidthToChildren: { description: "Auto-resize width to fit children", type: "boolean", defaultValue: false },
             adaptHeightToChildren: { description: "Auto-resize height to fit children", type: "boolean", defaultValue: false },
+        },
+    },
+
+    FlexPanel: {
+        className: "FlexPanel",
+        category: "Layout",
+        description:
+            "Arranges children in flexible rows or columns with wrapping, gaps, alignment, growth, and weighted shrinking. " +
+            "Uses declared child dimensions as the basis and preserves them during layout. Keep panel adapt-to-children and child auto-size modes disabled on flex-controlled axes.",
+        isContainer: true,
+        properties: {
+            background: { description: "Background fill color", type: "string" },
+            flexDirection: { description: "Main-axis direction: row, row-reverse, column, or column-reverse", type: "string", defaultValue: "row" },
+            flexWrap: { description: "Line wrapping: nowrap, wrap, or wrap-reverse", type: "string", defaultValue: "nowrap" },
+            justifyContent: {
+                description: "Remaining main-axis space: flex-start, flex-end, center, space-between, space-around, or space-evenly",
+                type: "string",
+                defaultValue: "flex-start",
+            },
+            alignItems: { description: "Cross-axis item alignment: flex-start, flex-end, center, or stretch", type: "string", defaultValue: "flex-start" },
+            alignContent: {
+                description: "Wrapped-line distribution: flex-start, flex-end, center, space-between, space-around, space-evenly, or stretch",
+                type: "string",
+                defaultValue: "stretch",
+            },
+            gap: { description: "Space between items and lines in px, em, rem, or percent of the main-axis size", type: "string", defaultValue: "0px" },
+            adaptWidthToChildren: { description: "Keep disabled: panel width defines the available layout space", type: "boolean", defaultValue: false },
+            adaptHeightToChildren: { description: "Keep disabled: panel height defines the available layout space", type: "boolean", defaultValue: false },
         },
     },
 

--- a/packages/tools/gui-mcp-server/src/index.ts
+++ b/packages/tools/gui-mcp-server/src/index.ts
@@ -97,8 +97,8 @@ const server = new McpServer(
     {
         instructions: [
             "You build Babylon.js 2D GUI layouts (AdvancedDynamicTexture). Workflow: create_gui → add controls (containers first, then leaf controls inside them) → set properties → validate_gui → export_gui_json.",
-            "All controls must have a parent. The root container is created automatically. Use Grid for complex layouts, StackPanel for linear layouts.",
-            "Sizes accept '200px', '50%', or a number. Output JSON can be consumed by the Scene MCP via attach_gui.",
+            "All controls must have a parent. The root container is created automatically. Use Grid for complex layouts, StackPanel for linear layouts, and FlexPanel for flexible rows or columns.",
+            "Sizes accept '200px', '50%', '2em', '2rem', or a number. em uses the control font and rem the GUI root font. Output JSON can be consumed by the Scene MCP via attach_gui.",
         ].join(" "),
     }
 );
@@ -917,9 +917,10 @@ server.registerTool(
         }
 
         lines.push("\n### Base Properties (available on all controls):");
-        lines.push("  width, height, left, top, color, alpha, fontSize, fontFamily, fontWeight,");
-        lines.push("  horizontalAlignment, verticalAlignment, paddingLeft/Right/Top/Bottom,");
-        lines.push("  isVisible, isEnabled, zIndex, rotation, scaleX, scaleY, shadow*, clipChildren, clipContent");
+        for (const [k, v] of Object.entries(BaseControlProperties)) {
+            const def = v.defaultValue !== undefined ? ` [default: ${JSON.stringify(v.defaultValue)}]` : "";
+            lines.push(`  • ${k} (${v.type}): ${v.description}${def}`);
+        }
 
         return { content: [{ type: "text", text: lines.join("\n") }] };
     }

--- a/packages/tools/gui-mcp-server/test/unit/guiParse.test.ts
+++ b/packages/tools/gui-mcp-server/test/unit/guiParse.test.ts
@@ -60,6 +60,8 @@ if (typeof globalThis.OffscreenCanvas === "undefined") {
 import { NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { AdvancedDynamicTexture } from "gui/2D/advancedDynamicTexture";
+import { FlexPanel } from "gui/2D/controls/flexPanel";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 // Side-effect imports: register ALL GUI control types via RegisterClass
 import "gui/2D/controls/index";
@@ -156,6 +158,44 @@ describe("GUI MCP Server – Babylon.js Parse", () => {
         expect(label.name).toBe("label");
         expect(label.typeName).toBe("TextBlock");
 
+        adt.dispose();
+    });
+
+    it("creates and parses a FlexPanel with flex properties and relative units", () => {
+        const adt = buildAndParse("flex", (mgr) => {
+            getCtrlName(
+                mgr.addControl("flex", "FlexPanel", "panel", "root", {
+                    flexDirection: "column-reverse",
+                    flexWrap: "wrap-reverse",
+                    justifyContent: "space-evenly",
+                    alignItems: "center",
+                    alignContent: "flex-end",
+                    gap: "1rem",
+                    width: "20em",
+                    height: "10rem",
+                })
+            );
+            getCtrlName(mgr.addControl("flex", "TextBlock", "label", "panel", { text: "Flex", flexGrow: 2, flexShrink: 0.5, width: "4em", fontSize: "1rem" }));
+        });
+
+        const panel = adt.getControlByName("panel");
+        expect(panel).toBeInstanceOf(FlexPanel);
+        if (!(panel instanceof FlexPanel)) {
+            throw new Error("Expected a parsed FlexPanel");
+        }
+        expect(panel.flexDirection).toBe("column-reverse");
+        expect(panel.flexWrap).toBe("wrap-reverse");
+        expect(panel.justifyContent).toBe("space-evenly");
+        expect(panel.alignItems).toBe("center");
+        expect(panel.alignContent).toBe("flex-end");
+        expect(panel.gap).toBe("1rem");
+        expect(panel.width).toBe("20em");
+        expect(panel.height).toBe("10rem");
+        expect(panel.children).toHaveLength(1);
+        expect(panel.children[0].flexGrow).toBe(2);
+        expect(panel.children[0].flexShrink).toBe(0.5);
+        expect(panel.children[0].width).toBe("4em");
+        expect(panel.children[0].fontSize).toBe("1rem");
         adt.dispose();
     });
 

--- a/packages/tools/gui-mcp-server/test/unit/registryDrift.test.ts
+++ b/packages/tools/gui-mcp-server/test/unit/registryDrift.test.ts
@@ -14,6 +14,8 @@
  * out of sync with the real controls without anything catching it.
  */
 import { GetClass } from "core/Misc/typeStore";
+import { FlexPanel } from "gui/2D/controls/flexPanel";
+import { describe, expect, it } from "vitest";
 
 // Side-effect import: register ALL GUI control classes via RegisterClass
 import "gui/2D/index";
@@ -21,6 +23,22 @@ import "gui/2D/index";
 import { ControlRegistry, BaseControlProperties } from "../../src/catalog";
 
 describe("GUI MCP Server – Catalog Drift", () => {
+    it("includes FlexPanel and its serialized flex defaults in the catalog", () => {
+        const panel = new FlexPanel();
+        const serialized: Record<string, unknown> = {};
+        panel.serialize(serialized);
+        const info = ControlRegistry.FlexPanel;
+        expect(info?.className).toBe(panel.typeName);
+        expect(info?.isContainer).toBe(true);
+        for (const name of ["flexDirection", "flexWrap", "justifyContent", "alignItems", "alignContent", "gap"]) {
+            expect(info?.properties[name]?.defaultValue).toBe(serialized[name]);
+        }
+        for (const name of ["flexGrow", "flexShrink"]) {
+            expect(BaseControlProperties[name]?.defaultValue).toBe(serialized[name]);
+        }
+        panel.dispose();
+    });
+
     it("catalog control class names and property names match the real Babylon GUI controls", () => {
         const problems: string[] = [];
 

--- a/scripts/treeshaking/side-effects-manifest/gui/2D.json
+++ b/scripts/treeshaking/side-effects-manifest/gui/2D.json
@@ -9,6 +9,7 @@
         "2D/controls/control.ts": ["top-level-call"],
         "2D/controls/displayGrid.ts": ["top-level-call"],
         "2D/controls/ellipse.ts": ["top-level-call"],
+        "2D/controls/flexPanel.ts": ["top-level-call"],
         "2D/controls/focusableButton.ts": ["top-level-call"],
         "2D/controls/gradient/LinearGradient.ts": ["top-level-call"],
         "2D/controls/gradient/RadialGradient.ts": ["top-level-call"],

--- a/specs/gui-flex-layout/architecture.md
+++ b/specs/gui-flex-layout/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+ValueAndUnit represents `em` and `rem` as distinct units. Its resolver accepts optional computed font sizes. Control supplies font context to resolve dimensions, padding, offsets, text spacing, and widget-specific values. Font-size declarations resolve against the parent or root without recursion.
+
+Container calls `_beforeChildLayout` before measuring its children. The default implementation does nothing. FlexPanel uses the hook to calculate lines and layout boxes from current declarations and available space. Its item and line records are reused between layouts; boxes use a WeakMap keyed by child control.
+
+Container also exposes the internal `_getLayoutMeasureForChild` hook. The default returns null. FlexPanel returns the allocated box. Control applies allocated dimensions before post-measure work, so text wrapping uses the flex width, then uses the box's position during alignment. Child properties remain unchanged.
+
+Text inputs consult the allocated box when calculating clipping and wrapping widths. Pixel, percentage, and ordinary non-flex input behavior retains its prior path.
+
+Serialization uses the existing control decorators and RegisterClass mechanism. The ordinary entry point registers FlexPanel. The pure entry point exports its implementation and explicit idempotent registration function. Package side-effect metadata and pure barrels include the new module.
+
+Reference semantics: [CSS Flexible Box Layout](https://www.w3.org/TR/css-flexbox-1/) and [CSS Values and Units](https://www.w3.org/TR/css-values-4/). See requirements.md for the supported canvas-specific subset.

--- a/specs/gui-flex-layout/architecture.md
+++ b/specs/gui-flex-layout/architecture.md
@@ -2,12 +2,14 @@
 
 ValueAndUnit represents `em` and `rem` as distinct units. Its resolver accepts optional computed font sizes. Control supplies font context to resolve dimensions, padding, offsets, text spacing, and widget-specific values. Font-size declarations resolve against the parent or root without recursion.
 
-Container calls `_beforeChildLayout` before measuring its children. The default implementation does nothing. FlexPanel uses the hook to calculate lines and layout boxes from current declarations and available space. Its item and line records are reused between layouts; boxes use a WeakMap keyed by child control.
+Container calls `_beforeChildLayout` before measuring its children. The default implementation does nothing. FlexPanel uses the hook to calculate lines and layout boxes from current declarations and available space. Its item and line records are reused between layouts; boxes use a WeakMap keyed by child control. Removing a child deletes its box and clears the working records so the panel retains neither its measurement nor a reference to the removed control. Shrink resolution freezes items at zero and redistributes the deficit until no more items need clamping.
 
 Container also exposes the internal `_getLayoutMeasureForChild` hook. The default returns null. FlexPanel returns the allocated box. Control applies allocated dimensions before post-measure work, so text wrapping uses the flex width, then uses the box's position during alignment. Child properties remain unchanged.
 
 Text inputs consult the allocated box when calculating clipping and wrapping widths. Pixel, percentage, and ordinary non-flex input behavior retains its prior path.
 
 Serialization uses the existing control decorators and RegisterClass mechanism. The ordinary entry point registers FlexPanel. The pure entry point exports its implementation and explicit idempotent registration function. Package side-effect metadata and pure barrels include the new module.
+
+The GUI MCP catalog includes FlexPanel, its layout properties, the base flex factors, and font-relative sizing metadata. Parse tests create a panel through GuiManager and load its exported JSON into the real GUI runtime; catalog drift coverage checks its serialized defaults and property names.
 
 Reference semantics: [CSS Flexible Box Layout](https://www.w3.org/TR/css-flexbox-1/) and [CSS Values and Units](https://www.w3.org/TR/css-values-4/). See requirements.md for the supported canvas-specific subset.

--- a/specs/gui-flex-layout/requirements.md
+++ b/specs/gui-flex-layout/requirements.md
@@ -1,0 +1,56 @@
+# Responsive 2D GUI layout
+
+This implements the flex layout and relative-unit concepts requested in [Babylon.js #13059](https://github.com/BabylonJS/Babylon.js/issues/13059), now tracked on the [feature forum](https://forum.babylonjs.com/t/add-flexbox-behavior-and-responsive-units-rem-em-to-gui/52141).
+
+## Relative units
+
+- `em` dimensions use the control's computed font size.
+- `rem` dimensions use the AdvancedDynamicTexture root container's computed font size.
+- In a `fontSize` declaration, `em` uses the parent font size and `rem` uses the GUI root font size.
+- Root `fontSize` declarations in `em` or `rem` use Babylon's existing 18px default as the initial font size.
+- Font-relative dimensions use already-scaled computed font sizes. They do not apply ideal-resolution scaling a second time.
+- Percentages and pixels keep their existing meanings. Unsupported or non-finite strings do not change a ValueAndUnit.
+- Relative strings survive serialization. The GUI root is the unit reference, not the HTML document root; no DOM access is required.
+
+## FlexPanel
+
+The panel has a declared width and height, as other GUI containers do. It arranges visible, renderable children using these properties:
+
+| Property | Values / behavior | Default |
+| --- | --- | --- |
+| `flexDirection` | `row`, `row-reverse`, `column`, `column-reverse` | `row` |
+| `flexWrap` | `nowrap`, `wrap`, `wrap-reverse` | `nowrap` |
+| `justifyContent` | `flex-start`, `flex-end`, `center`, `space-between`, `space-around`, `space-evenly` | `flex-start` |
+| `alignItems` | `flex-start`, `flex-end`, `center`, `stretch` | `flex-start` |
+| `alignContent` | justification values plus `stretch`; distributes wrapped lines | `stretch` |
+| `gap` | px, em, rem, or percent of available main-axis size; separates items and lines | `0px` |
+| Child `flexGrow` | nonnegative share of extra main-axis space | `0` |
+| Child `flexShrink` | nonnegative shrink factor, weighted by the main-axis basis | `1` |
+
+The child's declared width (row) or height (column) supplies the flex basis. Cross-axis size comes from its other declared dimension. `alignItems = "stretch"` explicitly fills the line's cross-axis extent. The panel uses existing child order.
+
+This is a canvas GUI layout container, not a complete CSS formatting engine. It does not add CSS intrinsic/min-content sizing, baseline alignment, CSS margins, `order`, `alignSelf`, or a separate `flexBasis` property. Existing GUI padding semantics still apply. Give flex children explicit dimensions; avoid child auto-size modes such as `resizeToFit` or `autoStretchWidth` when the panel controls that dimension.
+
+FlexPanel controls child positions and final dimensions during layout. It preserves child width, height, left, top, and alignment properties. Removing a child restores its normal declared layout. The panel's `adaptWidthToChildren` / `adaptHeightToChildren` modes should remain disabled; panel size defines the available space.
+
+## Example
+
+```javascript
+const ui = BABYLON.GUI.AdvancedDynamicTexture.CreateFullscreenUI("ui");
+ui.rootContainer.fontSize = "18px";
+const panel = new BABYLON.GUI.FlexPanel("cards");
+panel.flexWrap = "wrap";
+panel.gap = "1rem";
+panel.alignContent = "flex-start";
+ui.addControl(panel);
+
+for (const name of ["Explore", "Build", "Test", "Ship"]) {
+    const card = new BABYLON.GUI.Rectangle(name);
+    card.width = "12rem";
+    card.height = "6rem";
+    card.flexGrow = 1;
+    panel.addControl(card);
+}
+```
+
+Resize the texture to change the number of columns. Change `ui.rootContainer.fontSize` to scale rem-based card dimensions and spacing.

--- a/specs/gui-flex-layout/requirements.md
+++ b/specs/gui-flex-layout/requirements.md
@@ -29,6 +29,8 @@ The panel has a declared width and height, as other GUI containers do. It arrang
 
 The child's declared width (row) or height (column) supplies the flex basis. Cross-axis size comes from its other declared dimension. `alignItems = "stretch"` explicitly fills the line's cross-axis extent. The panel uses existing child order.
 
+Shrinking freezes items that would become negative at zero, then redistributes the remaining deficit among the unfrozen items. As in [CSS flexible-length resolution](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths), flex factors totaling less than one request only that fraction of the initial free space. For example, two 100px children with `flexShrink = 0.2` in a 100px row each become 80px; their overflow is intentional.
+
 This is a canvas GUI layout container, not a complete CSS formatting engine. It does not add CSS intrinsic/min-content sizing, baseline alignment, CSS margins, `order`, `alignSelf`, or a separate `flexBasis` property. Existing GUI padding semantics still apply. Give flex children explicit dimensions; avoid child auto-size modes such as `resizeToFit` or `autoStretchWidth` when the panel controls that dimension.
 
 FlexPanel controls child positions and final dimensions during layout. It preserves child width, height, left, top, and alignment properties. Removing a child restores its normal declared layout. The panel's `adaptWidthToChildren` / `adaptHeightToChildren` modes should remain disabled; panel size defines the available space.


### PR DESCRIPTION
Adds a responsive layout container for the [GUI flexbox and relative-unit request](https://forum.babylonjs.com/t/add-flexbox-behavior-and-responsive-units-rem-em-to-gui/52141). Related sponsor listing: [BitReel bounty #9](https://github.com/BitReelCo/BJS-PR-Bounty-Pool/issues/9).

FlexPanel lays out visible controls in rows or columns, with reversal, wrapping, gaps, alignment, growth, and weighted shrinking. Allocated layout boxes preserve each child's declared dimensions and positions. Text wrapping and input clipping use the allocated size.

ValueAndUnit supports em and rem. Control supplies font context to dimensions, padding, offsets, text spacing, and widget values. Font declarations resolve against the parent or GUI root; already-scaled fonts prevent double adaptive scaling. Relative units and flex settings serialize through the existing GUI mechanism. Pure exports and side-effect metadata include the new control.

The supported canvas-specific subset and sample code are documented in specs/gui-flex-layout. This does not claim complete CSS conformance: intrinsic/min-content sizing, baseline alignment, order, alignSelf, and a separate flexBasis property are not included. Explicit child dimensions provide the basis. Child auto-size modes and panel adapt-to-children modes should remain disabled on flex-controlled axes.

Shrink resolution freezes items at zero and redistributes the remaining deficit. The 10px/100px example with shrink factors 10/1 in a 50px row now produces 0px/50px, including the column counterpart. Child removal deletes allocated boxes and clears cached working records immediately.

The GUI MCP catalog includes FlexPanel, its layout settings, base flexGrow/flexShrink properties, and em/rem metadata. The control-detail tool derives base-property descriptions from the catalog. Tests cover manager creation, runtime parsing, and serialized catalog defaults.

Fractional shrink behavior follows [CSS Flexbox §9.7](https://www.w3.org/TR/css-flexbox-1/#resolve-flexible-lengths): factors totaling less than one can intentionally leave overflow. Two 100px items with shrink factors 0.2/0.2 in a 100px row produce 80px/80px. Headless Chrome confirmed this behavior and the redistribution cases against native CSS.

Local validation on Node 24.19.0:

- npm run build:dev: passed, including TypeScript project builds.
- npm run build -w @babylonjs/mcp-servers: passed, rebuilding all bundled servers.
- npm exec -- tsc --noEmit -p packages/tools/gui-mcp-server/tsconfig.json: passed.
- npm run lint:check: passed, including all 16 tree-shaking checks and package metadata checks.
- npm run format:check: passed.
- npm run test:unit: 332 files passed; 4,845 tests passed, one expected failure, 30 skipped; exit 0.
- GUI and GUI MCP tests: 97 passed. Before the fixes, the regression run failed eight cases across layout, lifecycle, creation, and catalog coverage.
- Public GUI MCP bundle: stdio checks passed for control discovery, base-property descriptions, FlexPanel/child creation, and JSON export.
- Headless Chrome: existing responsive layouts at 360/640/960px, pointer clicks, and root-font changes passed. Five regression layouts matched native CSS; no page errors.

These are local results. Upstream Azure CI has not published its normal build/test checks for this PR; upstream merge readiness still requires those checks and maintainer review.
