### PR TITLE
Skip point-light shading outside the light range

### DIFF
--- a/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/Shaders/ShadersInclude/lightsFragmentFunctions.fx
@@ -20,6 +20,17 @@ lightingInfo computeLighting(vec3 viewDirectionW, vec3 vNormal, vec4 lightData, 
 		vec3 direction = lightData.xyz - vPositionW;
 
 		attenuation = max(0., 1.0 - length(direction) / range);
+#ifndef NDOTL
+		// Outside the point light's range both color terms are zero. Keep the
+		// full path when a caller also consumes the unattenuated N dot L.
+		if (attenuation == 0.) {
+			result.diffuse = vec3(0.);
+#ifdef SPECULARTERM
+			result.specular = vec3(0.);
+#endif
+			return result;
+		}
+#endif
 		lightVectorW = normalize(direction);
 	}
 	else

--- a/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
+++ b/packages/dev/core/src/ShadersWGSL/ShadersInclude/lightsFragmentFunctions.fx
@@ -20,6 +20,17 @@ fn computeLighting(viewDirectionW: vec3f, vNormal: vec3f, lightData: vec4f, diff
 		var direction: vec3f = lightData.xyz - fragmentInputs.vPositionW;
 
 		attenuation = max(0., 1.0 - length(direction) / range);
+#ifndef NDOTL
+		// Outside the point light's range both color terms are zero. Keep the
+		// full path when a caller also consumes the unattenuated N dot L.
+		if (attenuation == 0.) {
+			result.diffuse = vec3f(0.);
+#ifdef SPECULARTERM
+			result.specular = vec3f(0.);
+#endif
+			return result;
+		}
+#endif
 		lightVectorW = normalize(direction);
 	}
 	else


### PR DESCRIPTION
Skip standard point-light diffuse/specular work once the existing range attenuation reaches zero, preserving the `NDOTL` contract in GLSL and WGSL. Directional, spot and PBR lighting retain their existing paths.

**Quest measurements support an opt-in material define, not an unconditional change.** The current diff still applies the guard unconditionally when `NDOTL` is absent; the default-off gate and persistent regression coverage remain required before merge. A finite-range-only gate would not avoid the measured range-30 regression.

### Quest 1: native stereo WebXR

Oculus Browser 25.4 / Chromium 112, Adreno 540, Babylon 9.10.1; 2048×2263 per eye, two-layer multiview, measured 4× MSAA. The browser reported 60 Hz; physical compositor refresh was not independently logged for these arms. The fixture has 675 transparent thin-instanced cubes, seven point lights plus ambient, and specular enabled. A = existing shader, B = early return; each arm discards 45 rendered frames before a 4.5-second capture.

| Light range | A/B/B/A Render-stage medians (ms) | B versus A |
| --- | --- | --- |
| 2.7, sparse | 18.892 / 11.852 / 11.894 / 19.231 | −37.7% |
| 30 | 17.644 / 18.730 / 18.726 / 17.674 | +6.1% |
| Default unlimited | 19.351 / 20.331 / 20.121 / 19.047 | +5.4% |

These are Adreno **per-main-surface Render stages**, not whole stereo-frame times. Binning/color-store times were essentially unchanged. Range 30 used a later context with higher preemption; compare paired arms within each row. Global traffic per rendered frame decreased in the sparse control, but neither memory-bandwidth saturation nor tile spilling was established.

### Supporting backend controls

The same seven-light fixture at 1280×800 on M4 Max, warmed A/B/B/A. WebGL2 reports whole-frame GPU-query means; WebGPU reports main-pass timestamp means. These are separate scopes, not headset measurements. Mac power policy was not recorded for these older captures.

| Range | WebGL2 / ANGLE Metal A/B/B/A (ms) | WebGPU A/B/B/A (ms) |
| --- | --- | --- |
| 2.7 | 0.568 / 0.513 / 0.511 / 0.552 | 0.508 / 0.399 / 0.429 / 0.504 |
| 30 | 0.549 / 0.653 / 0.650 / 0.551 | 0.479 / 0.571 / 0.579 / 0.507 |
| Default | 0.561 / 0.655 / 0.650 / 0.548 | 0.518 / 0.582 / 0.582 / 0.929 |

WebGPU default-range repeats also drifted (0.508 / 1.077 / 0.577 / 0.500 ms); no stable aggregate is claimed. Each arm discarded 120 frames, then measured 240 frames, yielding 120 WebGL2 or 240 WebGPU timing samples.

### Reproduction and correctness

[Standalone Playground A/B](https://playground.babylonjs.com/#VAZXX2): synthetic geometry, distinct shader names, range controls and warmed A/B/B/A measurement. It has nine point lights; the controlled tables above use seven to fit the host WebGPU adapter's uniform-buffer limit. No application assets or private dependencies are needed.

All 12 Quest offscreen image cases (three ranges × low/original intensity × specular on/off) were bit-identical in RGBA32F and RGBA8. The 24 host cases across WebGL2/WebGPU passed with maximum float error 4.77e-7. Low-intensity RGB remained below 0.5, and removing one colored light changed every case. These 512×320 single-sample correctness targets are separate from the native stereo performance targets. Direct function checks also covered 112 GLSL/WGSL cases, including `NDOTL`.

[Filament's punctual-light loop](https://github.com/google/filament/blob/b073ca02937446d1cac77fd34c781708afde8500/shaders/src/surface_light_punctual.fs#L197-L209) provides prior art for skipping zero-contribution lighting under a material-semantics guard. Its clustered selection and different shading model do not establish branch profitability for Babylon; the Quest results justify retaining Babylon's ordinary path by default.

Persistent finite-range StandardMaterial tests on both backends and explicit CellMaterial/`NDOTL` coverage remain outstanding. Current CI passes build, unit, WebGPU visualization and generic performance checks; WebGL2 visualization failed and Native was canceled. Those failures have not been attributed to this patch or cleared.
