### PR TITLE
Add opt-out for iOS ringer switch audio workaround

### DIFF
--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -34,6 +34,11 @@ export interface IWebAudioEngineOptions extends IAudioEngineV2Options {
      */
     disableDefaultUI?: boolean;
     /**
+     * Set to `true` to disable the silent HTML audio element used to allow WebAudio playback when the iOS ringer switch is off.
+     * When this option is enabled, WebAudio may be muted by the ringer switch on iOS. Defaults to `false`.
+     */
+    disableIOSRingerSwitchWorkaround?: boolean;
+    /**
      * Set to `true` to automatically resume the audio context when the user interacts with the page. Defaults to `true`.
      */
     resumeOnInteraction: boolean;
@@ -75,6 +80,7 @@ const FormatMimeTypes: { [key: string]: string } = {
 export class _WebAudioEngine extends AudioEngineV2 {
     private _audioContextStarted = false;
     private _destinationNode: Nullable<AudioNode> = null;
+    private readonly _disableIOSRingerSwitchWorkaround: boolean;
     private _invalidFormats = new Set<string>();
     private _isUpdating = false;
     private _listener: Nullable<_SpatialAudioListener> = null;
@@ -122,6 +128,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
             this._listenerMinUpdateTime = options.listenerMinUpdateTime;
         }
 
+        this._disableIOSRingerSwitchWorkaround = options.disableIOSRingerSwitchWorkaround ?? false;
         this._volume = options.volume ?? 1;
 
         if (options.audioContext) {
@@ -505,7 +512,7 @@ export class _WebAudioEngine extends AudioEngineV2 {
         // The element is activated during a user gesture so it can be played/paused programmatically
         // later. It is immediately paused to avoid triggering iOS Safari's "now playing" detection,
         // which throttles the page to 30 FPS.
-        if (!this._silentHtmlAudio) {
+        if (!this._disableIOSRingerSwitchWorkaround && !this._silentHtmlAudio) {
             this._silentHtmlAudio = document.createElement("audio");
 
             const audio = this._silentHtmlAudio;

--- a/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
+++ b/packages/dev/core/src/AudioV2/webAudio/webAudioEngine.ts
@@ -35,7 +35,8 @@ export interface IWebAudioEngineOptions extends IAudioEngineV2Options {
     disableDefaultUI?: boolean;
     /**
      * Set to `true` to disable the silent HTML audio element used to allow WebAudio playback when the iOS ringer switch is off.
-     * When this option is enabled, WebAudio may be muted by the ringer switch on iOS. Defaults to `false`.
+     * This can avoid rendering performance degradation on affected iOS and iPadOS devices, but WebAudio may be muted when the ringer switch is off.
+     * Defaults to `false`.
      */
     disableIOSRingerSwitchWorkaround?: boolean;
     /**
@@ -451,8 +452,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
             // eslint-disable-next-line github/no-then
             void this._silentHtmlAudio.play().catch(() => {});
         } else if (!hasActiveSounds && !this._silentHtmlAudio.paused) {
-            // Pause silent audio when no sounds are playing to avoid triggering iOS Safari's
-            // audio playback detection, which causes FPS throttling and shows a blue audio icon.
+            // Pause silent audio when no sounds are playing to avoid keeping an iOS media
+            // playback session active, which can reduce rendering performance on affected devices.
             this._silentHtmlAudio.pause();
         }
     }
@@ -510,8 +511,8 @@ export class _WebAudioEngine extends AudioEngineV2 {
         // On iOS the ringer switch must be turned on for WebAudio to play.
         // This gets WebAudio to play with the ringer switch turned off by playing an HTMLAudioElement.
         // The element is activated during a user gesture so it can be played/paused programmatically
-        // later. It is immediately paused to avoid triggering iOS Safari's "now playing" detection,
-        // which throttles the page to 30 FPS.
+        // later. It is immediately paused so the iOS media playback session stays inactive until
+        // a Babylon sound starts.
         if (!this._disableIOSRingerSwitchWorkaround && !this._silentHtmlAudio) {
             this._silentHtmlAudio = document.createElement("audio");
 

--- a/packages/dev/core/test/unit/Audio/audioEngine.test.ts
+++ b/packages/dev/core/test/unit/Audio/audioEngine.test.ts
@@ -6,6 +6,7 @@ import { AudioEngine } from "core/Audio";
 import { AbstractEngine, NullEngine } from "core/Engines";
 import { Scene } from "core/scene";
 import { Sound } from "core/Audio/sound";
+import { _WebAudioEngine, type IWebAudioEngineOptions } from "../../../src/AudioV2/webAudio/webAudioEngine";
 
 import { type AudioContextMock, MockedAudioObjects } from "./helpers/mockedAudioObjects";
 
@@ -96,5 +97,31 @@ describe("AudioEngine", () => {
         AudioTestHelper.WaitForAudioContextSuspendedDoubleCheck();
 
         expect((audioEngine._v2 as any)._unmuteUI._button.style.display).toBe("none");
+    });
+
+    it("does not create silent HTML audio when the iOS ringer switch workaround is disabled", async () => {
+        const options: Partial<IWebAudioEngineOptions> = {
+            audioContext: new AudioContext(),
+            disableDefaultUI: true,
+            disableIOSRingerSwitchWorkaround: true,
+        };
+        const audioEngine = new _WebAudioEngine(options);
+        await audioEngine._initAsync(options);
+
+        const createElementSpy = vi.spyOn(document, "createElement");
+        const userGesturePromise = new Promise<void>((resolve) => {
+            audioEngine.userGestureObservable.addOnce(resolve);
+        });
+
+        try {
+            document.dispatchEvent(new MouseEvent("click"));
+            await userGesturePromise;
+
+            expect(createElementSpy).not.toHaveBeenCalledWith("audio");
+        } finally {
+            createElementSpy.mockRestore();
+            audioEngine.dispose();
+            createAudioEngine("running");
+        }
     });
 });


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Purpose

Adds an application-controlled policy for the iOS/iPadOS performance issue reported in [the Babylon.js forum](https://forum.babylonjs.com/t/audioenginev2-playing-staticsound-on-top-of-streamingsound-decreases-fps-in-ios-safari/64049?u=raananw).

AudioEngineV2 normally plays a looping silent `HTMLAudioElement` while Babylon sounds are active so Web Audio remains audible when the iOS ringer switch is off. Keeping that media playback session active can reduce rendering performance on affected Apple devices.

## Change

`IWebAudioEngineOptions` now accepts:

```ts
const audioEngine = await CreateAudioEngineAsync({
    disableIOSRingerSwitchWorkaround: true,
});
```

The default remains `false`, so existing applications retain the current behavior. When enabled, the engine does not create the silent media element.

## Confirmed device behavior

The forum reporter verified the expected A/B result on physical hardware:

- Enabling `disableIOSRingerSwitchWorkaround` restored FPS to normal.
- Audio became inaudible when the physical ringer switch was set to silent.
- The degradation also occurs on an iPad Pro 6th generation, but takes longer to appear.

See [the test result](https://forum.babylonjs.com/t/audioenginev2-playing-staticsound-on-top-of-streamingsound-decreases-fps-in-ios-safari/64049/5?u=raananw).

## Tradeoff

Applications can now choose between:

- **Current default:** audio ignores the iOS silent switch, with possible rendering degradation on affected devices.
- **Opt-out enabled:** normal rendering performance in the reported reproduction, while Web Audio obeys the silent switch.

There is not yet a verified way to provide both behaviors simultaneously. The Web Audio Audio Session API may be worth separate device testing, but it could activate the same iOS media-session behavior and is intentionally outside this PR.

## Coverage

- Adds unit coverage confirming a user gesture does not create the silent HTML audio element when the option is enabled.
- Verified in devhost that a real click creates zero audio elements with the option enabled.
- Confirmed by the reporter on affected iPhone and iPad hardware.