### PR TITLE
Support Smart Filters Lite in the debugger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24143,6 +24143,9 @@
             "name": "@tools/smart-filters-debugger",
             "version": "0.1.0",
             "license": "MIT",
+            "dependencies": {
+                "@babylonjs/smart-filters-lite": "1.26.0"
+            },
             "devDependencies": {
                 "@fortawesome/fontawesome-svg-core": "^7.3.1",
                 "@fortawesome/free-solid-svg-icons": "^7.3.1",

--- a/packages/tools/smartFiltersDebugger/package.json
+++ b/packages/tools/smartFiltersDebugger/package.json
@@ -18,6 +18,9 @@
         "compile": "rollup -c rollup.config.umd.mjs --environment ROLLUP_MODE:production",
         "watch": "rollup -c rollup.config.umd.mjs --watch"
     },
+    "dependencies": {
+        "@babylonjs/smart-filters-lite": "1.26.0"
+    },
     "devDependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.3.1",
         "@fortawesome/free-solid-svg-icons": "^7.3.1",

--- a/packages/tools/smartFiltersDebugger/readme.md
+++ b/packages/tools/smartFiltersDebugger/readme.md
@@ -26,8 +26,8 @@ This browser extension is intended to aid in the development of web applications
     - Click "Load Unpacked"
     - Browse to packages/tools/smartFiltersDebugger/dist
 1. Update the web application you are debugging to set these globals:
-    - window.currentSmartFilter to the current SmartFilter instance
-    - window.thinEngine to the ThinEngine instance used when creating your SmartFilter
+    - window.currentSmartFilter to the current full or Lite SmartFilter instance
+    - window.thinEngine to the ThinEngine or GLEngineContext used when creating your SmartFilter
 1. Browse to the web application you want to debug, and click the Smart Filter Debugger button in the Extensions menu (consider pinning it to make it easier to get to)
 1. A popup will appear with the Editor in it
 1. You can modify the values of input blocks and see the results in real time in your web application

--- a/packages/tools/smartFiltersDebugger/src/editorLauncher.ts
+++ b/packages/tools/smartFiltersDebugger/src/editorLauncher.ts
@@ -1,16 +1,13 @@
 /* eslint-disable no-console */
 import { SmartFilterEditorControl } from "smart-filters-editor-control";
+import { GetSmartFilterEditorOptions } from "./smartFilterCompatibility.js";
 
-const Filter = (window as any).currentSmartFilter;
-const Engine = (window as any).thinEngine;
+const Options = GetSmartFilterEditorOptions(window as Window & { currentSmartFilter?: unknown; thinEngine?: unknown });
 
-if (Filter) {
+if (Options) {
     console.log("A SmartFilter was found in the page, launching the editor");
     // Display the editor
-    SmartFilterEditorControl.Show({
-        engine: Engine,
-        filter: Filter,
-    });
+    SmartFilterEditorControl.Show(Options);
 } else {
     console.log("No SmartFilter was found in the page");
 }

--- a/packages/tools/smartFiltersDebugger/src/smartFilterCompatibility.ts
+++ b/packages/tools/smartFiltersDebugger/src/smartFilterCompatibility.ts
@@ -1,0 +1,61 @@
+import { type SmartFilterEditorOptions } from "smart-filters-editor-control";
+
+type SmartFilterHostWindow = {
+    currentSmartFilter?: unknown;
+    thinEngine?: unknown;
+};
+
+type CompatibleSmartFilter = NonNullable<SmartFilterEditorOptions["filter"]>;
+
+/**
+ * Whether a value exposes the graph capabilities required by the debugger.
+ * @param value - The value to inspect
+ * @returns Whether the value can be displayed as a Smart Filter
+ */
+export function IsCompatibleSmartFilter(value: unknown): value is CompatibleSmartFilter {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+
+    const smartFilter = value as {
+        name?: unknown;
+        attachedBlocks?: unknown;
+        output?: unknown;
+        outputBlock?: unknown;
+        getClassName?: unknown;
+    };
+
+    if (
+        typeof smartFilter.name !== "string" ||
+        !Array.isArray(smartFilter.attachedBlocks) ||
+        !smartFilter.output ||
+        typeof smartFilter.output !== "object" ||
+        !smartFilter.outputBlock ||
+        typeof smartFilter.outputBlock !== "object" ||
+        typeof smartFilter.getClassName !== "function"
+    ) {
+        return false;
+    }
+
+    try {
+        return smartFilter.getClassName() === "SmartFilter";
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Gets editor options for a compatible Smart Filter exposed by a host page.
+ * @param hostWindow - The host page globals
+ * @returns Editor options, or null when no compatible filter is available
+ */
+export function GetSmartFilterEditorOptions(hostWindow: SmartFilterHostWindow): SmartFilterEditorOptions | null {
+    if (!IsCompatibleSmartFilter(hostWindow.currentSmartFilter)) {
+        return null;
+    }
+
+    return {
+        filter: hostWindow.currentSmartFilter,
+        engine: hostWindow.thinEngine as SmartFilterEditorOptions["engine"],
+    };
+}

--- a/packages/tools/smartFiltersDebugger/test/unit/smartFilterCompatibility.test.ts
+++ b/packages/tools/smartFiltersDebugger/test/unit/smartFilterCompatibility.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { SmartFilter } from "@babylonjs/smart-filters-lite";
+import { GetSmartFilterEditorOptions, IsCompatibleSmartFilter } from "../../src/smartFilterCompatibility.js";
+
+type LiteEngineContext = Parameters<SmartFilter["createRuntimeAsync"]>[0];
+
+class ForeignBundleSmartFilter {
+    public readonly name = "Foreign filter";
+    public readonly attachedBlocks: unknown[] = [];
+    public readonly output = {};
+    public readonly outputBlock = {};
+
+    public getClassName(): string {
+        return "SmartFilter";
+    }
+}
+
+describe("Smart Filter debugger compatibility", () => {
+    it("accepts an actual Lite SmartFilter", () => {
+        expect(IsCompatibleSmartFilter(new SmartFilter("Lite filter"))).toBe(true);
+    });
+
+    it("accepts a structurally compatible filter from another bundle", () => {
+        expect(IsCompatibleSmartFilter(new ForeignBundleSmartFilter())).toBe(true);
+    });
+
+    it("passes a Lite engine context through without requiring ThinEngine capabilities", () => {
+        const filter = new SmartFilter("Lite filter");
+        const engineContext = {
+            canvas: {} as LiteEngineContext["canvas"],
+            gl: {} as LiteEngineContext["gl"],
+            caps: {
+                maxTextureSize: 4096,
+                maxTextureUnits: 16,
+                parallelShaderCompile: null,
+                textureFloatRender: true,
+                textureFloatLinearFiltering: true,
+                textureHalfFloatRender: true,
+                textureHalfFloatLinearFiltering: true,
+                needPOTTextures: false,
+            },
+        } satisfies LiteEngineContext;
+
+        const options = GetSmartFilterEditorOptions({ currentSmartFilter: filter, thinEngine: engineContext });
+
+        expect(options?.filter).toBe(filter);
+        expect(options?.engine).toBe(engineContext);
+    });
+
+    it("rejects unrelated page globals", () => {
+        expect(GetSmartFilterEditorOptions({ currentSmartFilter: { name: "Not a filter" } })).toBeNull();
+    });
+});

--- a/packages/tools/smartFiltersEditorControl/src/components/propertyTab/properties/imageSourcePropertyTabComponent.tsx
+++ b/packages/tools/smartFiltersEditorControl/src/components/propertyTab/properties/imageSourcePropertyTabComponent.tsx
@@ -9,7 +9,7 @@ import { type IInspectableOptions } from "core/Misc/iInspectable.js";
 import { CheckBoxLineComponent } from "../../../sharedComponents/checkBoxLineComponent.js";
 
 import { type Nullable } from "core/types.js";
-import { GetTextureInputBlockEditorData } from "../../../graphSystem/getEditorData.js";
+import { GetTextureInputBlockEditorData, GetTextureInputBlockUrl } from "../../../graphSystem/getEditorData.js";
 import { LazyTextInputLineComponent } from "../../../sharedComponents/lazyTextInputLineComponent.js";
 import { Debounce } from "../../../helpers/debounce.js";
 import { type StateManager } from "shared-ui-components/nodeGraphSystem/stateManager.js";
@@ -87,7 +87,7 @@ export class ImageSourcePropertyTabComponent extends react.Component<IImageSourc
                         if (editorData.url?.startsWith("data:")) {
                             return CustomImageOption;
                         }
-                        const url = editorData.url || this.props.inputBlock.runtimeValue.value?.getInternalTexture()?.url;
+                        const url = GetTextureInputBlockUrl(this.props.inputBlock);
                         if (!url) {
                             return CustomImageOption;
                         }

--- a/packages/tools/smartFiltersEditorControl/src/graphSystem/display/inputDisplayManager.ts
+++ b/packages/tools/smartFiltersEditorControl/src/graphSystem/display/inputDisplayManager.ts
@@ -5,7 +5,7 @@ import { type INodeData } from "shared-ui-components/nodeGraphSystem/interfaces/
 import * as styles from "../../assets/styles/graphSystem/display/inputDisplayManager.module.scss";
 import { ConnectionPointType, type AnyInputBlock } from "smart-filters";
 import { Color3, Color4 } from "core/Maths/math.color.js";
-import { GetTextureInputBlockEditorData } from "../getEditorData.js";
+import { GetTextureInputBlockEditorData, GetTextureInputBlockUrl } from "../getEditorData.js";
 
 export class InputDisplayManager implements IDisplayManager {
     public getHeaderClass(_nodeData: INodeData) {
@@ -67,7 +67,7 @@ export class InputDisplayManager implements IDisplayManager {
                     value = "Video";
                 } else {
                     const style = GetTextureInputBlockEditorData(inputBlock).flipY === false ? "transform: scaleY(-1); z-index: -1;" : "";
-                    const src = inputBlock.editorData?.url || inputBlock.runtimeValue.value?.getInternalTexture()?.url;
+                    const src = GetTextureInputBlockUrl(inputBlock);
                     value = src ? `<img src="${src}" style="${style}" class="texture-input-preview"/>` : "";
                 }
                 break;

--- a/packages/tools/smartFiltersEditorControl/src/graphSystem/getEditorData.ts
+++ b/packages/tools/smartFiltersEditorControl/src/graphSystem/getEditorData.ts
@@ -1,15 +1,33 @@
 import { type ConnectionPointType, type InputBlock, type InputBlockEditorData } from "smart-filters";
+import { type Nullable } from "core/types.js";
+
+type InternalTextureEditorMetadata = {
+    url?: Nullable<string>;
+    anisotropicFilteringLevel?: number;
+    invertY?: boolean;
+    _extension?: Nullable<string>;
+};
+
+type TextureWithInternalTexture = {
+    getInternalTexture: () => Nullable<InternalTextureEditorMetadata>;
+};
+
+function GetInternalTextureEditorMetadata(texture: unknown): Nullable<InternalTextureEditorMetadata> {
+    if (!texture || typeof (texture as Partial<TextureWithInternalTexture>).getInternalTexture !== "function") {
+        return null;
+    }
+
+    return (texture as TextureWithInternalTexture).getInternalTexture();
+}
 
 /**
- * Gets the InputBlockEditorData for a Texture InputBlock, and if it's missing,
- * reads the values from the actual texture, and falls back to defaults if necessary.
- * It sets the editor data on the input block for future use.
+ * Gets the metadata the editor can use for a texture input.
  * @param inputBlock - The input block to get the editor data for
  * @returns The editor data for the input block
  */
 export function GetTextureInputBlockEditorData(inputBlock: InputBlock<ConnectionPointType.Texture>): InputBlockEditorData<ConnectionPointType.Texture> {
-    if (inputBlock.editorData === null) {
-        const internalTexture = inputBlock.runtimeValue.value?.getInternalTexture();
+    if (inputBlock.editorData === null || inputBlock.editorData === undefined) {
+        const internalTexture = GetInternalTextureEditorMetadata(inputBlock.runtimeValue.value);
         inputBlock.editorData = {
             url: internalTexture?.url ?? null,
             urlTypeHint: null,
@@ -23,6 +41,15 @@ export function GetTextureInputBlockEditorData(inputBlock: InputBlock<Connection
     inputBlock.editorData.flipY = inputBlock.editorData.flipY ?? true;
 
     return inputBlock.editorData;
+}
+
+/**
+ * Gets the source URL available to the editor for a texture input.
+ * @param inputBlock - The texture input block
+ * @returns The source URL, if one is available
+ */
+export function GetTextureInputBlockUrl(inputBlock: InputBlock<ConnectionPointType.Texture>): Nullable<string> {
+    return inputBlock.editorData?.url || GetInternalTextureEditorMetadata(inputBlock.runtimeValue.value)?.url || null;
 }
 
 /**

--- a/packages/tools/smartFiltersEditorControl/src/smartFilterEditorControl.ts
+++ b/packages/tools/smartFiltersEditorControl/src/smartFilterEditorControl.ts
@@ -15,6 +15,19 @@ import { type LogEntry } from "./components/log/logComponent.js";
 import { type BlockEditorRegistration } from "./configuration/blockEditorRegistration.js";
 import { type ObservableProperty } from "./helpers/observableProperty.js";
 
+type DisposeObservable = {
+    addOnce(callback: () => void): unknown;
+};
+
+function GetDisposeObservable(engine: unknown): DisposeObservable | null {
+    if (!engine || typeof engine !== "object") {
+        return null;
+    }
+
+    const onDisposeObservable = (engine as { onDisposeObservable?: Partial<DisposeObservable> }).onDisposeObservable;
+    return typeof onDisposeObservable?.addOnce === "function" ? (onDisposeObservable as DisposeObservable) : null;
+}
+
 /**
  * Options to configure the Smart Filter Editor
  */
@@ -241,7 +254,7 @@ export class SmartFilterEditorControl {
 
         // Close the popup window when the page is refreshed or scene is disposed
         if (globalState.smartFilter && options.engine && this._PopupWindow) {
-            options.engine.onDisposeObservable.addOnce(() => {
+            GetDisposeObservable(options.engine)?.addOnce(() => {
                 if (this._PopupWindow) {
                     this._PopupWindow.close();
                 }

--- a/packages/tools/smartFiltersEditorControl/test/unit/getEditorData.test.ts
+++ b/packages/tools/smartFiltersEditorControl/test/unit/getEditorData.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    ConnectionPointType as LiteConnectionPointType,
+    type CreateImageTexture,
+    InputBlock as LiteInputBlock,
+    SmartFilter as LiteSmartFilter,
+} from "@babylonjs/smart-filters-lite";
+import { GetTextureInputBlockEditorData, GetTextureInputBlockUrl } from "../../src/graphSystem/getEditorData.js";
+
+type TextureInputBlock = Parameters<typeof GetTextureInputBlockEditorData>[0];
+type LiteTexture = ReturnType<typeof CreateImageTexture>;
+
+describe("texture editor compatibility", () => {
+    it("reads editor metadata from a full Smart Filter texture", () => {
+        const getInternalTexture = vi.fn(() => ({
+            url: "https://example.com/full.png",
+            anisotropicFilteringLevel: 8,
+            invertY: false,
+            _extension: ".png",
+        }));
+        const inputBlock = {
+            editorData: null,
+            runtimeValue: {
+                value: { getInternalTexture },
+            },
+        } as unknown as TextureInputBlock;
+
+        expect(GetTextureInputBlockEditorData(inputBlock)).toEqual({
+            url: "https://example.com/full.png",
+            urlTypeHint: null,
+            anisotropicFilteringLevel: 8,
+            flipY: false,
+            forcedExtension: ".png",
+        });
+        expect(getInternalTexture).toHaveBeenCalledOnce();
+    });
+
+    it("uses safe defaults for a Lite GLTexture", () => {
+        const texture = {
+            handle: {} as LiteTexture["handle"],
+            target: 3553,
+            width: 64,
+            height: 32,
+            isReady: true,
+        } satisfies LiteTexture;
+        const inputBlock = new LiteInputBlock(new LiteSmartFilter("Lite filter"), "Texture input", LiteConnectionPointType.Texture, texture);
+
+        expect(GetTextureInputBlockEditorData(inputBlock as unknown as TextureInputBlock)).toEqual({
+            url: null,
+            urlTypeHint: null,
+            anisotropicFilteringLevel: null,
+            flipY: true,
+            forcedExtension: null,
+        });
+        expect(GetTextureInputBlockUrl(inputBlock as unknown as TextureInputBlock)).toBeNull();
+    });
+
+    it("preserves the full texture URL fallback when editor metadata has no URL", () => {
+        const inputBlock = {
+            editorData: {
+                url: null,
+                urlTypeHint: null,
+                anisotropicFilteringLevel: null,
+                flipY: true,
+                forcedExtension: null,
+            },
+            runtimeValue: {
+                value: {
+                    getInternalTexture: () => ({ url: "https://example.com/fallback.png" }),
+                },
+            },
+        } as unknown as TextureInputBlock;
+
+        expect(GetTextureInputBlockUrl(inputBlock)).toBe("https://example.com/fallback.png");
+    });
+});


### PR DESCRIPTION
## Summary
- detect full and Lite Smart Filters structurally across bundle boundaries
- handle Babylon `ThinTexture` and Lite `GLTexture` inputs without unsafe texture API calls
- declare the Smart Filters Lite dependency and document the supported host globals

## Validation
- 7 focused Vitest tests
- Smart Filters Editor Control TypeScript build
- Smart Filters Debugger TypeScript and production Rollup builds
- targeted ESLint and Prettier checks
- real `@babylonjs/smart-filters-lite` 1.26.0 checkout linked temporarily for local validation

`@babylonjs/smart-filters-lite` is not published yet, so the lockfile records the workspace dependency without fabricated registry resolution data.

Refs https://github.com/AmoebaChant/pan-work/issues/142