### PR TITLE
OBJFileLoader: Fix AssetContainer handling and add opt-in texture loading waits

### DIFF
--- a/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
@@ -2,6 +2,8 @@ import { type Nullable } from "core/types";
 import { Color3 } from "core/Maths/math.color";
 import { Texture } from "core/Materials/Textures/texture";
 import { StandardMaterial } from "core/Materials/standardMaterial";
+import { Constants } from "core/Engines/constants";
+import { Deferred } from "core/Misc/deferred";
 
 import { type Scene } from "core/scene";
 import { type AssetContainer } from "core/assetContainer";
@@ -29,10 +31,23 @@ export class MTLFileLoader {
      * @param data defines the mtl data to parse
      * @param rootUrl defines the rooturl to use in order to load relative dependencies
      * @param assetContainer defines the asset container to store the material in (can be null)
+     * @param invertTextureY defines whether referenced textures are inverted on the Y axis
+     * @param materialNames defines which materials to load, or all materials if omitted
+     * @param textureLoadPromises collects texture loading promises and starts delayed textures when provided; null or undefined preserves delayed loading
+     * @returns a promise that waits for textureLoadPromises, or null when textureLoadPromises is null or undefined
      */
-    public parseMTL(scene: Scene, data: string | ArrayBuffer, rootUrl: string, assetContainer: Nullable<AssetContainer>): void {
+    public parseMTL(
+        scene: Scene,
+        data: string | ArrayBuffer,
+        rootUrl: string,
+        assetContainer: Nullable<AssetContainer>,
+        invertTextureY = MTLFileLoader.INVERT_TEXTURE_Y,
+        materialNames?: ReadonlySet<string>,
+        textureLoadPromises?: Nullable<Promise<void>[]>
+    ): Nullable<Promise<void>> {
         if (data instanceof ArrayBuffer) {
-            return;
+            // eslint-disable-next-line github/no-then
+            return textureLoadPromises ? Promise.all(textureLoadPromises).then(() => undefined) : null;
         }
 
         //Split the lines from the file
@@ -68,6 +83,10 @@ export class MTLFileLoader {
                 if (material) {
                     //Add the previous material in the material array.
                     this.materials.push(material);
+                }
+                if (materialNames && !materialNames.has(value)) {
+                    material = null;
+                    continue;
                 }
                 //Create a new material.
                 // value is the name of the material read in the mtl file
@@ -116,14 +135,14 @@ export class MTLFileLoader {
             } else if (key === "map_ka" && material) {
                 // ambient texture map with a loaded image
                 //We must first get the folder of the image
-                material.ambientTexture = MTLFileLoader._GetTexture(rootUrl, value, scene);
+                material.ambientTexture = MTLFileLoader._GetTexture(rootUrl, value, scene, assetContainer, invertTextureY, textureLoadPromises);
             } else if (key === "map_kd" && material) {
                 // Diffuse texture map with a loaded image
-                material.diffuseTexture = MTLFileLoader._GetTexture(rootUrl, value, scene);
+                material.diffuseTexture = MTLFileLoader._GetTexture(rootUrl, value, scene, assetContainer, invertTextureY, textureLoadPromises);
             } else if (key === "map_ks" && material) {
                 // Specular texture map with a loaded image
                 //We must first get the folder of the image
-                material.specularTexture = MTLFileLoader._GetTexture(rootUrl, value, scene);
+                material.specularTexture = MTLFileLoader._GetTexture(rootUrl, value, scene, assetContainer, invertTextureY, textureLoadPromises);
             } else if (key === "map_ns") {
                 //Specular
                 //Specular highlight component
@@ -143,13 +162,13 @@ export class MTLFileLoader {
                     values.splice(bumpMultiplierIndex, 2); // remove
                 }
 
-                material.bumpTexture = MTLFileLoader._GetTexture(rootUrl, values.join(" "), scene);
+                material.bumpTexture = MTLFileLoader._GetTexture(rootUrl, values.join(" "), scene, assetContainer, invertTextureY, textureLoadPromises);
                 if (material.bumpTexture && bumpMultiplier !== null) {
                     material.bumpTexture.level = parseFloat(bumpMultiplier);
                 }
             } else if (key === "map_d" && material) {
                 // The dissolve of the material
-                material.opacityTexture = MTLFileLoader._GetTexture(rootUrl, value, scene);
+                material.opacityTexture = MTLFileLoader._GetTexture(rootUrl, value, scene, assetContainer, invertTextureY, textureLoadPromises);
 
                 //Options for illumination
             } else if (key === "illum") {
@@ -185,6 +204,9 @@ export class MTLFileLoader {
         if (material) {
             this.materials.push(material);
         }
+
+        // eslint-disable-next-line github/no-then
+        return textureLoadPromises ? Promise.all(textureLoadPromises).then(() => undefined) : null;
     }
 
     /**
@@ -196,9 +218,19 @@ export class MTLFileLoader {
      * @param rootUrl The root url to load from
      * @param value The value stored in the mtl
      * @param scene
+     * @param assetContainer The asset container to store the texture in
+     * @param invertTextureY Whether to invert the texture on the Y axis
+     * @param textureLoadPromises The promises to wait for when loading asynchronously
      * @returns The Texture
      */
-    private static _GetTexture(rootUrl: string, value: string, scene: Scene): Nullable<Texture> {
+    private static _GetTexture(
+        rootUrl: string,
+        value: string,
+        scene: Scene,
+        assetContainer: Nullable<AssetContainer>,
+        invertTextureY: boolean,
+        textureLoadPromises?: Nullable<Promise<void>[]>
+    ): Nullable<Texture> {
         if (!value) {
             return null;
         }
@@ -222,6 +254,29 @@ export class MTLFileLoader {
             url += value;
         }
 
-        return new Texture(url, scene, false, MTLFileLoader.INVERT_TEXTURE_Y);
+        const deferred = textureLoadPromises ? new Deferred<void>() : null;
+        if (deferred) {
+            textureLoadPromises!.push(deferred.promise);
+        }
+
+        const blockEntityCollection = scene._blockEntityCollection;
+        scene._blockEntityCollection = !!assetContainer;
+        let texture: Texture;
+        try {
+            texture = new Texture(url, scene, {
+                invertY: invertTextureY,
+                onLoad: deferred?.resolve,
+                onError: deferred ? (message, exception) => deferred.reject(new Error(`${url}: ${exception?.message || message || "Failed to load texture"}`)) : undefined,
+            });
+            texture._parentContainer = assetContainer;
+        } finally {
+            scene._blockEntityCollection = blockEntityCollection;
+        }
+
+        // A container is not rendered yet, so delayed loading cannot wait for a material bind.
+        if (deferred && texture.delayLoadState === Constants.DELAYLOADSTATE_NOTLOADED) {
+            texture.delayLoad();
+        }
+        return texture;
     }
 }

--- a/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
+++ b/packages/dev/loaders/src/OBJ/mtlFileLoader.ts
@@ -33,8 +33,8 @@ export class MTLFileLoader {
      * @param assetContainer defines the asset container to store the material in (can be null)
      * @param invertTextureY defines whether referenced textures are inverted on the Y axis
      * @param materialNames defines which materials to load, or all materials if omitted
-     * @param textureLoadPromises collects texture loading promises and starts delayed textures when provided; null or undefined preserves delayed loading
-     * @returns a promise that waits for textureLoadPromises, or null when textureLoadPromises is null or undefined
+     * @param trackTextureLoading collects texture loading promises and starts delayed textures when true; defaults to false
+     * @returns the texture loading promises, or an empty array when trackTextureLoading is false
      */
     public parseMTL(
         scene: Scene,
@@ -43,11 +43,11 @@ export class MTLFileLoader {
         assetContainer: Nullable<AssetContainer>,
         invertTextureY = MTLFileLoader.INVERT_TEXTURE_Y,
         materialNames?: ReadonlySet<string>,
-        textureLoadPromises?: Nullable<Promise<void>[]>
-    ): Nullable<Promise<void>> {
+        trackTextureLoading = false
+    ): Promise<void>[] {
+        const textureLoadPromises: Nullable<Promise<void>[]> = trackTextureLoading ? [] : null;
         if (data instanceof ArrayBuffer) {
-            // eslint-disable-next-line github/no-then
-            return textureLoadPromises ? Promise.all(textureLoadPromises).then(() => undefined) : null;
+            return textureLoadPromises ?? [];
         }
 
         //Split the lines from the file
@@ -205,8 +205,7 @@ export class MTLFileLoader {
             this.materials.push(material);
         }
 
-        // eslint-disable-next-line github/no-then
-        return textureLoadPromises ? Promise.all(textureLoadPromises).then(() => undefined) : null;
+        return textureLoadPromises ?? [];
     }
 
     /**
@@ -256,6 +255,9 @@ export class MTLFileLoader {
 
         const deferred = textureLoadPromises ? new Deferred<void>() : null;
         if (deferred) {
+            // Parsing may throw before returning the array. Observe rejection without changing the original promise returned to the caller.
+            // eslint-disable-next-line github/no-then
+            void deferred.promise.catch(() => undefined);
             textureLoadPromises!.push(deferred.promise);
         }
 

--- a/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
@@ -354,7 +354,11 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
                                     }
                                 }
                                 if (this._loadingOptions.waitForTextures) {
-                                    await Promise.all(textureLoadPromises);
+                                    const results = await Promise.allSettled(textureLoadPromises);
+                                    const rejected = results.find((result) => result.status === "rejected");
+                                    if (rejected) {
+                                        throw rejected.reason;
+                                    }
                                 }
                                 resolve();
                             } catch (e) {

--- a/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
@@ -51,6 +51,12 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
     }
 
     /**
+     * Wait for referenced textures to finish loading before completing the OBJ load.
+     * Defaults to false for backwards compatibility.
+     */
+    public static WAIT_FOR_TEXTURES = false;
+
+    /**
      * Include in meshes the vertex colors available in some OBJ files.  This is not part of OBJ standard.
      */
     public static IMPORT_VERTEX_COLORS = false;
@@ -114,6 +120,7 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
             importVertexColors: OBJFileLoader.IMPORT_VERTEX_COLORS,
             invertY: OBJFileLoader.INVERT_Y,
             invertTextureY: OBJFileLoader.INVERT_TEXTURE_Y,
+            waitForTextures: OBJFileLoader.WAIT_FOR_TEXTURES,
             // eslint-disable-next-line @typescript-eslint/naming-convention
             UVScaling: OBJFileLoader.UV_SCALING,
             materialLoadingFailsSilently: OBJFileLoader.MATERIAL_LOADING_FAILS_SILENTLY,
@@ -315,7 +322,7 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         const mtlPromises: Array<Promise<void>> = [];
         // Check if we have a file to load
         if (fileToLoad !== "" && !this._loadingOptions.skipMaterials) {
-            // Load the MTL and wait for the textures used by the selected meshes.
+            // Load the MTL and optionally wait for the textures used by the selected meshes.
             mtlPromises.push(
                 new Promise((resolve, reject) => {
                     this._loadMTL(
@@ -331,7 +338,7 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
                                     this._assetContainer,
                                     this._loadingOptions.invertTextureY,
                                     new Set(materialToUse),
-                                    true
+                                    this._loadingOptions.waitForTextures
                                 );
                                 // Parsing creates the selected materials synchronously; only their textures are pending.
                                 for (let n = 0; n < materialsFromMTLFile.materials.length; ++n) {
@@ -346,7 +353,9 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
                                         }
                                     }
                                 }
-                                await Promise.all(textureLoadPromises);
+                                if (this._loadingOptions.waitForTextures) {
+                                    await Promise.all(textureLoadPromises);
+                                }
                                 resolve();
                             } catch (e) {
                                 Tools.Warn(`Error processing MTL file: '${fileToLoad}'`);

--- a/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
@@ -20,6 +20,7 @@ import { type OBJLoadingOptions } from "./objLoadingOptions";
 import { SolidParser } from "./solidParser";
 import { type Mesh } from "core/Meshes/mesh.pure";
 import { StandardMaterial } from "core/Materials/standardMaterial.pure";
+import { type Geometry } from "core/Meshes/geometry";
 
 /**
  * OBJ file type loader.
@@ -199,13 +200,20 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         //get the meshes from OBJ file
         // eslint-disable-next-line github/no-then
         return this._parseSolidAsync(meshesNames, scene, data, rootUrl).then((meshes) => {
+            const geometries: Geometry[] = [];
+            for (let i = 0; i < meshes.length; ++i) {
+                const geometry = (meshes[i] as Mesh).geometry;
+                if (geometry) {
+                    geometries.push(geometry);
+                }
+            }
             return {
                 meshes: meshes,
                 particleSystems: [],
                 skeletons: [],
                 animationGroups: [],
                 transformNodes: [],
-                geometries: [],
+                geometries: geometries,
                 lights: [],
                 spriteManagers: [],
             };
@@ -244,6 +252,7 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
             this.importMeshAsync(null, scene, data, rootUrl)
                 // eslint-disable-next-line github/no-then
                 .then((result) => {
+                    result.geometries.forEach((geometry) => container.geometries.push(geometry));
                     result.meshes.forEach((mesh) => container.meshes.push(mesh));
                     result.meshes.forEach((mesh) => {
                         const material = mesh.material;
@@ -306,48 +315,38 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
         const mtlPromises: Array<Promise<void>> = [];
         // Check if we have a file to load
         if (fileToLoad !== "" && !this._loadingOptions.skipMaterials) {
-            //Load the file synchronously
+            // Load the MTL and wait for the textures used by the selected meshes.
             mtlPromises.push(
                 new Promise((resolve, reject) => {
                     this._loadMTL(
                         fileToLoad,
                         rootUrl,
-                        (dataLoaded) => {
+                        async (dataLoaded) => {
                             try {
                                 //Create materials thanks MTLLoader function
-                                materialsFromMTLFile.parseMTL(scene, this._decode(dataLoaded), rootUrl, this._assetContainer);
-                                //Look at each material loaded in the mtl file
-                                for (let n = 0; n < materialsFromMTLFile.materials.length; n++) {
-                                    //Three variables to get all meshes with the same material
-                                    let startIndex = 0;
-                                    const _indices = [];
-                                    let _index;
+                                const materialLoadingPromise = materialsFromMTLFile.parseMTL(
+                                    scene,
+                                    this._decode(dataLoaded),
+                                    rootUrl,
+                                    this._assetContainer,
+                                    this._loadingOptions.invertTextureY,
+                                    new Set(materialToUse),
+                                    []
+                                );
+                                // Parsing creates the selected materials synchronously; only their textures are pending.
+                                for (let n = 0; n < materialsFromMTLFile.materials.length; ++n) {
+                                    const material = materialsFromMTLFile.materials[n];
+                                    for (let index = materialToUse.indexOf(material.name); index !== -1; index = materialToUse.indexOf(material.name, index + 1)) {
+                                        const mesh = babylonMeshesArray[index];
+                                        mesh.material = material;
 
-                                    //The material from MTL file is used in the meshes loaded
-                                    //Push the indice in an array
-                                    //Check if the material is not used for another mesh
-                                    while ((_index = materialToUse.indexOf(materialsFromMTLFile.materials[n].name, startIndex)) > -1) {
-                                        _indices.push(_index);
-                                        startIndex = _index + 1;
-                                    }
-                                    //If the material is not used dispose it
-                                    if (_index === -1 && _indices.length === 0) {
-                                        //If the material is not needed, remove it
-                                        materialsFromMTLFile.materials[n].dispose();
-                                    } else {
-                                        for (let o = 0; o < _indices.length; o++) {
-                                            //Apply the material to the Mesh for each mesh with the material
-                                            const mesh = babylonMeshesArray[_indices[o]];
-                                            const material = materialsFromMTLFile.materials[n];
-                                            mesh.material = material;
-
-                                            if (!mesh.getTotalIndices()) {
-                                                // No indices, we need to turn on point cloud
-                                                material.pointsCloud = true;
-                                            }
+                                        if (!mesh.getTotalIndices()) {
+                                            // No indices, we need to turn on point cloud
+                                            material.pointsCloud = true;
                                         }
                                     }
                                 }
+                                await materialLoadingPromise;
                                 resolve();
                             } catch (e) {
                                 Tools.Warn(`Error processing MTL file: '${fileToLoad}'`);
@@ -380,17 +379,53 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
             // Iterate over the mesh, determine if it is a line mesh, clone or modify the material to line rendering.
             babylonMeshesArray.forEach((mesh) => {
                 if (isLine(mesh)) {
-                    let mat = mesh.material ?? new StandardMaterial(mesh.name + "_line", scene);
+                    let mat = mesh.material;
+                    if (!mat) {
+                        const blockEntityCollection = scene._blockEntityCollection;
+                        scene._blockEntityCollection = !!this._assetContainer;
+                        mat = new StandardMaterial(mesh.name + "_line", scene);
+                        mat._parentContainer = this._assetContainer;
+                        scene._blockEntityCollection = blockEntityCollection;
+                    }
                     // If another mesh is using this material and it is not a line then we need to clone it.
                     const needClone = mat.getBindedMeshes().filter((e) => !isLine(e)).length > 0;
                     if (needClone) {
-                        mat = mat.clone(mat.name + "_line") ?? mat;
+                        // Clone only the material; keep the MTL texture objects shared.
+                        const sourceMaterial = mat as StandardMaterial;
+                        const { ambientTexture, diffuseTexture, specularTexture, bumpTexture, opacityTexture } = sourceMaterial;
+                        const blockEntityCollection = scene._blockEntityCollection;
+                        let lineMaterial: StandardMaterial;
+                        try {
+                            sourceMaterial.ambientTexture = null;
+                            sourceMaterial.diffuseTexture = null;
+                            sourceMaterial.specularTexture = null;
+                            sourceMaterial.bumpTexture = null;
+                            sourceMaterial.opacityTexture = null;
+                            scene._blockEntityCollection = !!this._assetContainer;
+                            lineMaterial = sourceMaterial.clone(sourceMaterial.name + "_line");
+                            lineMaterial._parentContainer = this._assetContainer;
+                        } finally {
+                            scene._blockEntityCollection = blockEntityCollection;
+                            sourceMaterial.ambientTexture = ambientTexture;
+                            sourceMaterial.diffuseTexture = diffuseTexture;
+                            sourceMaterial.specularTexture = specularTexture;
+                            sourceMaterial.bumpTexture = bumpTexture;
+                            sourceMaterial.opacityTexture = opacityTexture;
+                        }
+                        lineMaterial.ambientTexture = ambientTexture;
+                        lineMaterial.diffuseTexture = diffuseTexture;
+                        lineMaterial.specularTexture = specularTexture;
+                        lineMaterial.bumpTexture = bumpTexture;
+                        lineMaterial.opacityTexture = opacityTexture;
+                        mat = lineMaterial;
                     }
                     mat.wireframe = true;
                     mesh.material = mat;
-                    if (mesh._internalMetadata) {
-                        mesh._internalMetadata["_isLine"] = undefined;
-                    }
+                }
+            });
+            babylonMeshesArray.forEach((mesh) => {
+                if (mesh._internalMetadata) {
+                    mesh._internalMetadata["_isLine"] = undefined;
                 }
             });
 

--- a/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
+++ b/packages/dev/loaders/src/OBJ/objFileLoader.pure.ts
@@ -324,14 +324,14 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
                         async (dataLoaded) => {
                             try {
                                 //Create materials thanks MTLLoader function
-                                const materialLoadingPromise = materialsFromMTLFile.parseMTL(
+                                const textureLoadPromises = materialsFromMTLFile.parseMTL(
                                     scene,
                                     this._decode(dataLoaded),
                                     rootUrl,
                                     this._assetContainer,
                                     this._loadingOptions.invertTextureY,
                                     new Set(materialToUse),
-                                    []
+                                    true
                                 );
                                 // Parsing creates the selected materials synchronously; only their textures are pending.
                                 for (let n = 0; n < materialsFromMTLFile.materials.length; ++n) {
@@ -346,7 +346,7 @@ export class OBJFileLoader implements ISceneLoaderPluginAsync, ISceneLoaderPlugi
                                         }
                                     }
                                 }
-                                await materialLoadingPromise;
+                                await Promise.all(textureLoadPromises);
                                 resolve();
                             } catch (e) {
                                 Tools.Warn(`Error processing MTL file: '${fileToLoad}'`);

--- a/packages/dev/loaders/src/OBJ/objLoadingOptions.ts
+++ b/packages/dev/loaders/src/OBJ/objLoadingOptions.ts
@@ -28,6 +28,12 @@ export type OBJLoadingOptions = {
      */
     invertTextureY: boolean;
     /**
+     * Wait for referenced textures to finish loading before completing the OBJ load.
+     * When enabled, texture loading failures follow materialLoadingFailsSilently.
+     * Defaults to false for backwards compatibility.
+     */
+    waitForTextures?: boolean;
+    /**
      * Include in meshes the vertex colors available in some OBJ files.  This is not part of OBJ standard.
      */
     importVertexColors: boolean;

--- a/packages/dev/loaders/src/OBJ/solidParser.ts
+++ b/packages/dev/loaders/src/OBJ/solidParser.ts
@@ -921,7 +921,10 @@ export class SolidParser {
 
                 if (!this._materialNameFromObj) {
                     // Create a material with point cloud on
+                    scene._blockEntityCollection = !!assetContainer;
                     newMaterial = new StandardMaterial(Geometry.RandomId(), scene);
+                    newMaterial._parentContainer = assetContainer;
+                    scene._blockEntityCollection = false;
 
                     newMaterial.pointsCloud = true;
 
@@ -1019,7 +1022,14 @@ export class SolidParser {
                 vertexData.colors = this._handledMesh.colors;
             }
             //Set the data from the VertexBuffer to the current Mesh
-            vertexData.applyToMesh(babylonMesh);
+            const blockEntityCollection = scene._blockEntityCollection;
+            scene._blockEntityCollection = !!assetContainer;
+            try {
+                vertexData.applyToMesh(babylonMesh);
+                babylonMesh.geometry!._parentContainer = assetContainer;
+            } finally {
+                scene._blockEntityCollection = blockEntityCollection;
+            }
             if (this._loadingOptions.invertY) {
                 babylonMesh.scaling.y *= -1;
             }

--- a/packages/dev/loaders/test/unit/OBJ/assetContainer.test.ts
+++ b/packages/dev/loaders/test/unit/OBJ/assetContainer.test.ts
@@ -263,14 +263,20 @@ describe("OBJ asset containers and texture loading", () => {
         container.dispose();
     });
 
-    it("rejects texture failures when materialLoadingFailsSilently is false", async () => {
-        mockMTL();
+    it.each(["complete", "fail"] as const)("waits for remaining textures to %s before rejecting when materialLoadingFailsSilently is false", async (settle) => {
+        mockMTL(TexturedMaterial + "map_Ks specular.png\n");
         const pending = holdTextureRequests();
         const loading = new OBJFileLoader({ waitForTextures: true, materialLoadingFailsSilently: false }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
         const rejection = expect(loading).rejects.toThrow("/assets/color.png: 404 Not Found");
+        const onRejected = vi.fn();
+        void loading.catch(onRejected);
 
-        await vi.waitFor(() => expect(pending).toHaveLength(1));
+        await vi.waitFor(() => expect(pending).toHaveLength(2));
         pending[0].fail();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(onRejected).not.toHaveBeenCalled();
+        pending[1][settle]();
+
         await rejection;
         expect(scene._blockEntityCollection).toBe(false);
     });
@@ -284,6 +290,30 @@ describe("OBJ asset containers and texture loading", () => {
         pending[0].fail();
         const container = await loading;
         expect(container.textures[0].loadingError).toBe(true);
+        container.dispose();
+    });
+
+    it.each(["complete", "fail"] as const)("waits for remaining textures to %s after a silent texture failure", async (settle) => {
+        mockMTL(TexturedMaterial + "map_Ks specular.png\n");
+        const pending = holdTextureRequests();
+        let settled = false;
+        const loading = new OBJFileLoader({ waitForTextures: true }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/").then((container) => {
+            settled = true;
+            return container;
+        });
+
+        await vi.waitFor(() => expect(pending).toHaveLength(2));
+        pending[0].fail();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(settled).toBe(false);
+        pending[1][settle]();
+
+        const container = await loading;
+        expect(container.textures).toHaveLength(2);
+        const material = container.meshes[0].material as StandardMaterial;
+        expect(material.diffuseTexture!.loadingError).toBe(true);
+        expect(material.specularTexture!.isReady()).toBe(settle === "complete");
+        expect(material.specularTexture!.loadingError).toBe(settle === "fail");
         container.dispose();
     });
 

--- a/packages/dev/loaders/test/unit/OBJ/assetContainer.test.ts
+++ b/packages/dev/loaders/test/unit/OBJ/assetContainer.test.ts
@@ -1,0 +1,394 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NullEngine } from "core/Engines/nullEngine";
+import { Scene } from "core/scene";
+import { AssetContainer } from "core/assetContainer";
+import { Tools } from "core/Misc/tools";
+import { type InternalTexture } from "core/Materials/Textures/internalTexture";
+import { StandardMaterial } from "core/Materials/standardMaterial.pure";
+import { type Mesh } from "core/Meshes/mesh";
+import { Texture } from "core/Materials/Textures/texture";
+import { OBJFileLoader } from "loaders/OBJ/objFileLoader.pure";
+import { MTLFileLoader } from "loaders/OBJ/mtlFileLoader";
+
+const Triangle = "o triangle\nv 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n";
+const TexturedTriangle = "mtllib model.mtl\no triangle\nv 0 0 0\nv 1 0 0\nv 0 1 0\nusemtl Used\nf 1 2 3\n";
+const TexturedMaterial = "newmtl Used\nKd 1 1 1\nmap_Kd color.png\n";
+
+interface PendingTexture {
+    texture: InternalTexture;
+    complete(): void;
+    fail(): void;
+}
+
+describe("OBJ asset containers and texture loading", () => {
+    let engine: NullEngine;
+    let scene: Scene;
+
+    beforeEach(() => {
+        engine = new NullEngine();
+        scene = new Scene(engine);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        scene.dispose();
+        engine.dispose();
+    });
+
+    function mockMTL(data = TexturedMaterial): void {
+        vi.spyOn(Tools, "LoadFile").mockImplementation((_url, onSuccess) => {
+            queueMicrotask(() => onSuccess(data));
+            return { abort: vi.fn() } as unknown as ReturnType<typeof Tools.LoadFile>;
+        });
+    }
+
+    function holdTextureRequests(): PendingTexture[] {
+        const pending: PendingTexture[] = [];
+        const createTexture = engine.createTexture.bind(engine);
+        vi.spyOn(engine, "createTexture").mockImplementation((url, noMipmap, invertY, hostingScene, samplingMode, onLoad, onError, ...rest) => {
+            const texture = createTexture(url, noMipmap, invertY, hostingScene, samplingMode, null, null, ...rest);
+            texture.isReady = false;
+            pending.push({
+                texture,
+                complete: () => {
+                    texture.isReady = true;
+                    onLoad?.(texture);
+                    texture.onLoadedObservable.notifyObservers(texture);
+                },
+                fail: () => {
+                    const error = { message: "Texture request failed", exception: new Error("404 Not Found") };
+                    onError?.(error.message, error.exception);
+                    texture.onErrorObservable.notifyObservers(error);
+                },
+            });
+            return texture;
+        });
+        return pending;
+    }
+
+    it("returns geometries from normal mesh imports", async () => {
+        const result = await new OBJFileLoader().importMeshAsync(null, scene, Triangle, "");
+
+        expect(result.geometries).toHaveLength(1);
+        expect(result.geometries[0]).toBe((result.meshes[0] as Mesh).geometry);
+        expect(scene.getGeometries()).toEqual(result.geometries);
+        expect(result.geometries[0]._parentContainer).toBeNull();
+    });
+
+    it("keeps all model resources out of the scene until the container is added", async () => {
+        mockMTL();
+        const container = await new OBJFileLoader().loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        expect(container.meshes).toHaveLength(1);
+        expect(container.geometries).toHaveLength(1);
+        expect(container.materials).toHaveLength(1);
+        expect(container.textures).toHaveLength(1);
+        expect(container.meshes[0]._parentContainer).toBe(container);
+        expect(container.geometries[0]._parentContainer).toBe(container);
+        expect(container.materials[0]._parentContainer).toBe(container);
+        expect(container.textures[0]._parentContainer).toBe(container);
+        expect(container.textures[0].isReady()).toBe(true);
+        expect(scene.meshes).toHaveLength(0);
+        expect(scene.getGeometries()).toHaveLength(0);
+        expect(scene.materials).toHaveLength(0);
+        expect(scene.textures).toHaveLength(0);
+
+        container.addAllToScene();
+        expect(scene.meshes).toEqual(container.meshes);
+        expect(scene.getGeometries()).toEqual(container.geometries);
+        expect(scene.materials).toEqual(container.materials);
+        expect(scene.textures).toEqual(container.textures);
+
+        container.removeAllFromScene();
+        expect(scene.meshes).toHaveLength(0);
+        expect(scene.getGeometries()).toHaveLength(0);
+        expect(scene.materials).toHaveLength(0);
+        expect(scene.textures).toHaveLength(0);
+        container.dispose();
+    });
+
+    it("keeps generated point-cloud materials in the container", async () => {
+        const container = await new OBJFileLoader().loadAssetContainerAsync(scene, "v 0 0 0\nv 1 0 0\n", "");
+
+        expect(container.materials).toHaveLength(1);
+        expect(container.materials[0].pointsCloud).toBe(true);
+        expect(container.materials[0]._parentContainer).toBe(container);
+        expect(scene.materials).toHaveLength(0);
+        container.dispose();
+    });
+
+    it("keeps generated line materials in the container", async () => {
+        const container = await new OBJFileLoader().loadAssetContainerAsync(scene, "o line\nv 0 0 0\nv 1 0 0\nl 1 2\n", "");
+
+        expect(container.materials).toHaveLength(1);
+        expect(container.materials[0].wireframe).toBe(true);
+        expect(container.materials[0]._parentContainer).toBe(container);
+        expect(scene.materials).toHaveLength(0);
+        container.dispose();
+    });
+
+    it("clones line materials while sharing all MTL texture slots with the original", async () => {
+        mockMTL(TexturedMaterial + "map_Ka ambient.png\nmap_Ks specular.png\nmap_bump bump.png\nmap_d opacity.png\n");
+        const cloneTexture = vi.spyOn(Texture.prototype, "clone");
+        const data = TexturedTriangle + "o line\nusemtl Used\nl 1 2\n";
+        const container = await new OBJFileLoader().loadAssetContainerAsync(scene, data, "/assets/");
+
+        expect(container.materials).toHaveLength(2);
+        expect(container.textures).toHaveLength(5);
+        expect(cloneTexture).not.toHaveBeenCalled();
+        const original = container.meshes[0].material as StandardMaterial;
+        const line = container.meshes[1].material as StandardMaterial;
+        expect(line).not.toBe(original);
+        expect(original.wireframe).toBe(false);
+        expect(line.wireframe).toBe(true);
+        expect(line.ambientTexture).toBe(original.ambientTexture);
+        expect(line.diffuseTexture).toBe(original.diffuseTexture);
+        expect(line.specularTexture).toBe(original.specularTexture);
+        expect(line.bumpTexture).toBe(original.bumpTexture);
+        expect(line.opacityTexture).toBe(original.opacityTexture);
+        expect(line.diffuseColor).toEqual(original.diffuseColor);
+        expect(line.diffuseColor).not.toBe(original.diffuseColor);
+        for (let i = 0; i < container.materials.length; ++i) {
+            expect(container.materials[i]._parentContainer).toBe(container);
+        }
+        for (let i = 0; i < container.textures.length; ++i) {
+            expect(container.textures[i]._parentContainer).toBe(container);
+            expect(container.textures[i].isReady()).toBe(true);
+        }
+        expect(scene.materials).toHaveLength(0);
+        expect(scene.textures).toHaveLength(0);
+        container.dispose();
+    });
+
+    it("restores the original textures and scene collection when material cloning throws", async () => {
+        mockMTL(TexturedMaterial + "map_Ka ambient.png\nmap_Ks specular.png\nmap_bump bump.png\nmap_d opacity.png\n");
+        let sourceMaterial: StandardMaterial | undefined;
+        vi.spyOn(StandardMaterial.prototype, "clone").mockImplementation(function (this: StandardMaterial) {
+            sourceMaterial = this;
+            expect(this.ambientTexture).toBeNull();
+            expect(this.diffuseTexture).toBeNull();
+            expect(this.specularTexture).toBeNull();
+            expect(this.bumpTexture).toBeNull();
+            expect(this.opacityTexture).toBeNull();
+            throw new Error("Material clone failed");
+        });
+        const data = TexturedTriangle + "o line\nusemtl Used\nl 1 2\n";
+
+        await expect(new OBJFileLoader().loadAssetContainerAsync(scene, data, "/assets/")).rejects.toThrow("Material clone failed");
+        const material = sourceMaterial!;
+        expect(material.ambientTexture).not.toBeNull();
+        expect(material.diffuseTexture).not.toBeNull();
+        expect(material.specularTexture).not.toBeNull();
+        expect(material.bumpTexture).not.toBeNull();
+        expect(material.opacityTexture).not.toBeNull();
+        expect(scene._blockEntityCollection).toBe(false);
+        material.dispose(false, true);
+    });
+
+    it("does not create materials or request textures that the OBJ does not use", async () => {
+        mockMTL("newmtl Unused\nmap_Kd missing.png\n" + TexturedMaterial + "newmtl AlsoUnused\nmap_Kd missing2.png\n");
+        const createTexture = vi.spyOn(engine, "createTexture");
+        const container = await new OBJFileLoader().loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        expect(container.materials).toHaveLength(1);
+        expect(container.materials[0].name).toBe("Used");
+        expect(createTexture).toHaveBeenCalledTimes(1);
+        expect(createTexture.mock.calls[0][0]).toBe("/assets/color.png");
+        container.dispose();
+        expect(scene.textures).toHaveLength(0);
+    });
+
+    it.each([undefined, false])("returns before textures finish loading when waitForTextures is %s", async (waitForTextures) => {
+        mockMTL();
+        const pending = holdTextureRequests();
+        const loader = new OBJFileLoader(waitForTextures === undefined ? undefined : { waitForTextures });
+        const container = await loader.loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        expect(pending).toHaveLength(1);
+        expect(container.textures[0].isReady()).toBe(false);
+        pending[0].complete();
+        expect(container.textures[0].isReady()).toBe(true);
+        container.dispose();
+    });
+
+    it.each([undefined, false])("does not start delayed textures when waitForTextures is %s", async (waitForTextures) => {
+        scene.useDelayedTextureLoading = true;
+        mockMTL();
+        const delayLoad = vi.spyOn(Texture.prototype, "delayLoad");
+        const createTexture = vi.spyOn(engine, "createTexture");
+        const loader = new OBJFileLoader(waitForTextures === undefined ? undefined : { waitForTextures });
+        const container = await loader.loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        expect(container.textures).toHaveLength(1);
+        expect(container.textures[0].getInternalTexture()).toBeNull();
+        expect(delayLoad).not.toHaveBeenCalled();
+        expect(createTexture).not.toHaveBeenCalled();
+        container.dispose();
+    });
+
+    it("waits for every referenced texture without blocking scene registration while awaiting", async () => {
+        mockMTL(TexturedMaterial + "map_Ks specular.png\n");
+        const pending = holdTextureRequests();
+        let settled = false;
+        const loading = new OBJFileLoader({ waitForTextures: true }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/").then((container) => {
+            settled = true;
+            return container;
+        });
+
+        await vi.waitFor(() => expect(pending).toHaveLength(2));
+        expect(settled).toBe(false);
+        expect(scene._blockEntityCollection).toBe(false);
+        expect(scene.textures).toHaveLength(0);
+        pending[0].complete();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(settled).toBe(false);
+        pending[1].complete();
+
+        const container = await loading;
+        expect(container.textures[0].isReady()).toBe(true);
+        expect(container.textures[1].isReady()).toBe(true);
+        container.dispose();
+    });
+
+    it("waits for multiple texture wrappers sharing one pending internal texture", async () => {
+        mockMTL(TexturedMaterial + "map_Ks color.png\n");
+        const pending = holdTextureRequests();
+        const loading = new OBJFileLoader({ waitForTextures: true }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        await vi.waitFor(() => expect(pending).toHaveLength(1));
+        pending[0].complete();
+        const container = await loading;
+        expect(container.textures).toHaveLength(2);
+        expect(container.textures[0].getInternalTexture()).toBe(container.textures[1].getInternalTexture());
+        container.dispose();
+    });
+
+    it("rejects texture failures when materialLoadingFailsSilently is false", async () => {
+        mockMTL();
+        const pending = holdTextureRequests();
+        const loading = new OBJFileLoader({ waitForTextures: true, materialLoadingFailsSilently: false }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+        const rejection = expect(loading).rejects.toThrow("/assets/color.png: 404 Not Found");
+
+        await vi.waitFor(() => expect(pending).toHaveLength(1));
+        pending[0].fail();
+        await rejection;
+        expect(scene._blockEntityCollection).toBe(false);
+    });
+
+    it("preserves the default materialLoadingFailsSilently behavior when waiting for textures", async () => {
+        mockMTL();
+        const pending = holdTextureRequests();
+        const loading = new OBJFileLoader({ waitForTextures: true }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        await vi.waitFor(() => expect(pending).toHaveLength(1));
+        pending[0].fail();
+        const container = await loading;
+        expect(container.textures[0].loadingError).toBe(true);
+        container.dispose();
+    });
+
+    it("starts delayed textures without requiring the container to render", async () => {
+        scene.useDelayedTextureLoading = true;
+        mockMTL();
+        const container = await new OBJFileLoader({ waitForTextures: true }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        expect(container.textures[0].isReady()).toBe(true);
+        expect(scene.useDelayedTextureLoading).toBe(true);
+        expect(scene.textures).toHaveLength(0);
+        container.dispose();
+    });
+
+    it("uses the per-loader texture orientation without changing the static default", async () => {
+        mockMTL();
+        const defaultInvertY = MTLFileLoader.INVERT_TEXTURE_Y;
+        const container = await new OBJFileLoader({ invertTextureY: !defaultInvertY }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/");
+
+        expect((container.textures[0] as Texture).invertY).toBe(!defaultInvertY);
+        expect(MTLFileLoader.INVERT_TEXTURE_Y).toBe(defaultInvertY);
+        container.dispose();
+    });
+
+    it("returns an empty array without texture tracking and assigns texture container ownership synchronously", () => {
+        const loader = new MTLFileLoader();
+        const container = new AssetContainer(scene);
+        expect(loader.parseMTL(scene, TexturedMaterial, "/assets/", container)).toEqual([]);
+
+        expect(loader.materials).toHaveLength(1);
+        expect(loader.materials[0].diffuseTexture!._parentContainer).toBe(container);
+        expect(scene.materials).toHaveLength(0);
+        expect(scene.textures).toHaveLength(0);
+        loader.materials[0].dispose(false, true);
+        container.dispose();
+    });
+
+    it.each([undefined, false])("does not start delayed textures when trackTextureLoading is %s", (trackTextureLoading) => {
+        scene.useDelayedTextureLoading = true;
+        const loader = new MTLFileLoader();
+        const container = new AssetContainer(scene);
+        const delayLoad = vi.spyOn(Texture.prototype, "delayLoad");
+        const createTexture = vi.spyOn(engine, "createTexture");
+
+        expect(loader.parseMTL(scene, TexturedMaterial, "/assets/", container, undefined, undefined, trackTextureLoading)).toEqual([]);
+        expect(loader.materials).toHaveLength(1);
+        expect(loader.materials[0].diffuseTexture!._parentContainer).toBe(container);
+        expect(delayLoad).not.toHaveBeenCalled();
+        expect(createTexture).not.toHaveBeenCalled();
+        loader.materials[0].dispose(false, true);
+        container.dispose();
+    });
+
+    it("returns individual texture promises that the caller can await together", async () => {
+        scene.useDelayedTextureLoading = true;
+        const loader = new MTLFileLoader();
+        const container = new AssetContainer(scene);
+        const pending = holdTextureRequests();
+        const textureLoadPromises = loader.parseMTL(scene, TexturedMaterial + "map_Ks specular.png\n", "/assets/", container, undefined, undefined, true);
+        const loading = Promise.all(textureLoadPromises);
+
+        expect(loader.materials).toHaveLength(1);
+        expect(textureLoadPromises).toHaveLength(2);
+        expect(pending).toHaveLength(2);
+        let settled = false;
+        void loading.then(() => {
+            settled = true;
+        });
+        pending[0].complete();
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        pending[1].complete();
+        await expect(loading).resolves.toEqual([undefined, undefined]);
+        expect(loader.materials[0].diffuseTexture!.isReady()).toBe(true);
+        expect(loader.materials[0].specularTexture!.isReady()).toBe(true);
+        loader.materials[0].dispose(false, true);
+        container.dispose();
+    });
+
+    it.each([false, true])("restores scene collection when texture creation throws synchronously with waitForTextures = %s", async (waitForTextures) => {
+        mockMTL();
+        vi.spyOn(engine, "createTexture").mockImplementation(() => {
+            throw new Error("Texture allocation failed");
+        });
+
+        await expect(new OBJFileLoader({ waitForTextures, materialLoadingFailsSilently: false }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/")).rejects.toThrow(
+            "Texture allocation failed"
+        );
+        expect(scene._blockEntityCollection).toBe(false);
+    });
+
+    it("observes earlier texture rejections after parsing throws before returning its promises", async () => {
+        mockMTL(TexturedMaterial + "map_Ks specular.png\n");
+        const pending = holdTextureRequests();
+        const createTexture = vi.mocked(engine.createTexture);
+        createTexture.mockImplementationOnce(createTexture.getMockImplementation()!).mockImplementationOnce(() => {
+            throw new Error("Texture allocation failed");
+        });
+
+        await expect(
+            new OBJFileLoader({ waitForTextures: true, materialLoadingFailsSilently: false }).loadAssetContainerAsync(scene, TexturedTriangle, "/assets/")
+        ).rejects.toThrow("Texture allocation failed");
+        expect(pending).toHaveLength(1);
+        expect(scene._blockEntityCollection).toBe(false);
+        pending[0].fail();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+});


### PR DESCRIPTION
## Summary

  This PR fixes resource collection and ownership in the OBJ loader and adds an option to wait for referenced textures before completing a load.

  ## Changes

  - Return created geometries from `importMeshAsync` and include them in `AssetContainer.geometries`.
  - Prevent container-owned geometries, textures, and generated point/line materials from being registered in the scene prematurely, and assign their `_parentContainer`.
  - Skip unused MTL materials and their textures instead of creating and subsequently disposing unused materials.
  - Reuse existing textures when cloning materials for line rendering.
  - Preserve line markers until all line materials have been processed to avoid unnecessary material cloning.
  - Honor the per-load `invertTextureY` option.

  ## Optional texture loading waits

  Adds `OBJLoadingOptions.waitForTextures` defaulting to `false` to preserve the existing non-waiting behavior.

  When enabled:
  - Referenced texture loading promises are awaited.
  - Delayed textures are started without requiring the container to be rendered.
  - Texture loading failures follow `materialLoadingFailsSilently`.

  ```ts
  const container = await LoadAssetContainerAsync("model.obj", scene, {
      pluginOptions: {
          obj: {
              waitForTextures: true,
              materialLoadingFailsSilently: false,
          },
      },
  });
  ```

 ## Validation

  - 29 OBJ unit tests passed, covering resource ownership, shared textures, optional waiting, delayed loading, and error handling.

Note: The tests were AI-generated, but I have not reviewed their code quality.