### PR TITLE
Add Inspector v2 Explorer contribution APIs

### DIFF
--- a/packages/dev/inspector-v2/src/components/explorer/explorerModel.ts
+++ b/packages/dev/inspector-v2/src/components/explorer/explorerModel.ts
@@ -7,11 +7,13 @@ import { UniqueIdGenerator } from "core/Misc/uniqueIdGenerator";
 /**
  * The value used to uniquely identify a node within the Explorer tree (e.g. for expansion state).
  * This matches the Fluent `TreeItemValue` type.
+ * @experimental
  */
 export type ExplorerNodeValue = string | number;
 
 /**
  * Information about how to display a node in the Explorer tree.
+ * @experimental
  */
 export type ExplorerDisplayInfo = Partial<IDisposable> &
     Readonly<{
@@ -35,6 +37,7 @@ export type ExplorerDisplayInfo = Partial<IDisposable> &
 /**
  * Configuration for drag-and-drop behavior within a branch of the Explorer tree.
  * The configuration applies to the node it is specified on as well as all of its descendants.
+ * @experimental
  */
 export type ExplorerDragDropConfig<T> = Readonly<{
     /**
@@ -86,6 +89,7 @@ type ContextMenuCommand = {
 
 /**
  * The supported command modes (inline or context menu).
+ * @experimental
  */
 export type ExplorerCommandMode = NonNullable<(InlineCommand | ContextMenuCommand)["mode"]>;
 
@@ -109,11 +113,13 @@ type ToggleCommand = {
 
 /**
  * The supported command types (action or toggle).
+ * @experimental
  */
 export type ExplorerCommandType = (ActionCommand | ToggleCommand)["type"];
 
 /**
  * Describes a command that can be executed on a node in the Explorer.
+ * @experimental
  */
 export type ExplorerCommand<ModeT extends ExplorerCommandMode = ExplorerCommandMode, TypeT extends ExplorerCommandType = ExplorerCommandType> = Partial<IDisposable> &
     Readonly<{
@@ -143,6 +149,7 @@ export type ExplorerCommand<ModeT extends ExplorerCommandMode = ExplorerCommandM
 
 /**
  * Provides a command for a specific context (an entity or a group name) in the Explorer.
+ * @experimental
  */
 export type ExplorerCommandProvider<ContextT, ModeT extends ExplorerCommandMode = ExplorerCommandMode, TypeT extends ExplorerCommandType = ExplorerCommandType> = Readonly<{
     /**
@@ -167,6 +174,7 @@ export type ExplorerCommandProvider<ContextT, ModeT extends ExplorerCommandMode 
  * - "root": The single top level node representing the object being inspected (e.g. a Scene or an Engine).
  * - "group": A heading style node (e.g. "Nodes", "Materials", "Auxiliary Surfaces").
  * - "item": A standard node representing an entity within the tree (e.g. a mesh or a material).
+ * @experimental
  */
 export type ExplorerNodeKind = "root" | "group" | "item";
 
@@ -177,6 +185,7 @@ export type ExplorerNodeKind = "root" | "group" | "item";
  * presentation and enumerates its own children, which means an Explorer hierarchy can be arbitrarily
  * deep and fully heterogeneous (nodes of different kinds, backed by unrelated entity types, can be
  * freely nested within each other).
+ * @experimental
  */
 export type ExplorerNodeDescription = Readonly<{
     /**

--- a/packages/dev/inspector-v2/src/index.common.ts
+++ b/packages/dev/inspector-v2/src/index.common.ts
@@ -10,6 +10,8 @@ export type {
     ExplorerNodeKind,
     ExplorerNodeValue,
 } from "./components/explorer/explorerModel";
+export type { ExplorerNodeProvider, IExplorerService } from "./services/panes/explorer/explorerService";
+export { ExplorerServiceIdentity } from "./services/panes/explorer/explorerService";
 export * from "shared-ui-components/modularTool/components/errorBoundary";
 export * from "shared-ui-components/modularTool/components/extensibleAccordion";
 export { SidePaneContainer } from "shared-ui-components/modularTool/components/pane";

--- a/packages/dev/inspector-v2/src/lite/engineExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/engineExplorerService.tsx
@@ -1,17 +1,18 @@
 import { getRenderingContextKind, getRenderingContexts, type EngineContext, type RenderingContext, type SceneContext, type SurfaceContext } from "@babylonjs/lite";
 import { tokens } from "@fluentui/react-components";
 import { EngineRegular, GlobeRegular, PersonSquareRegular, TextFieldRegular, WindowRegular } from "@fluentui/react-icons";
-import { type FunctionComponent } from "react";
+import { createElement, type ComponentType, type FunctionComponent } from "react";
 
 import { type IDisposable } from "core/index";
 import { Observable } from "core/Misc/observable";
 
-import { type ExplorerNodeDescription } from "../components/explorer/explorerModel";
+import { type ExplorerDisplayInfo, type ExplorerNodeDescription } from "../components/explorer/explorerModel";
 import { type IService, type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
-import { ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
 import { type IShellService, ShellServiceIdentity } from "shared-ui-components/modularTool/services/shellService";
+import { ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
 
 import { CreateExplorerPaneRegistration } from "../services/panes/explorer/explorerPane";
+import { CreateExplorerService, type IExplorerService, ExplorerServiceIdentity } from "../services/panes/explorer/explorerService";
 import { type ISelectionService, SelectionServiceIdentity } from "../services/selectionService";
 import { type IWatcherService, WatcherServiceIdentity } from "../services/watcherService";
 import { type IEngineContext, EngineContextIdentity } from "./engineContext";
@@ -19,11 +20,13 @@ import { CreateWatchedNameDisplayInfo } from "./explorerDisplayInfo";
 
 /**
  * The unique identity symbol for the Babylon Lite engine explorer service.
+ * @experimental
  */
 export const EngineExplorerServiceIdentity = Symbol("EngineExplorer");
 
 /**
  * Contributes child nodes beneath a compatible Babylon Lite rendering context.
+ * @experimental
  */
 export type RenderingContextNodeProvider<T extends RenderingContext> = Readonly<{
     /** Controls this provider's position relative to other providers. */
@@ -37,13 +40,53 @@ export type RenderingContextNodeProvider<T extends RenderingContext> = Readonly<
 }>;
 
 /**
+ * Overrides presentation for a Babylon Lite rendering context node.
+ * @experimental
+ */
+export type RenderingContextPresentation<T extends RenderingContext = RenderingContext> = Readonly<{
+    /** Gets display information for the rendering context node. */
+    getDisplayInfo?: () => ExplorerDisplayInfo;
+    /** Overrides the icon rendered for the node. The icon receives the Rendering Context subtype matched by the provider. */
+    icon?: ComponentType<{ entity: T }>;
+}>;
+
+/**
+ * Contributes presentation for a compatible Babylon Lite rendering context.
+ * @experimental
+ */
+export type RenderingContextPresentationProvider<T extends RenderingContext> = Readonly<{
+    /** Returns whether this provider supports the rendering context. */
+    predicate: (context: RenderingContext) => context is T;
+    /** Gets partial presentation that overrides the built-in rendering context presentation. */
+    getPresentation: (context: T) => RenderingContextPresentation<T>;
+}>;
+
+/**
  * Allows product-specific services to contribute hierarchy beneath Babylon Lite rendering contexts.
+ * @experimental
  */
 export interface IEngineExplorerService extends IService<typeof EngineExplorerServiceIdentity> {
+    /**
+     * Adds a provider that contributes child nodes beneath compatible rendering contexts.
+     * @param provider The node provider to add.
+     * @returns A disposable that removes the provider.
+     */
     addRenderingContextNodeProvider<T extends RenderingContext>(provider: RenderingContextNodeProvider<T>): IDisposable;
+
+    /**
+     * Adds a provider that controls how compatible rendering context nodes are presented.
+     * The last registered matching provider takes precedence.
+     * @param provider The presentation provider to add.
+     * @returns A disposable that removes the provider.
+     */
+    addRenderingContextPresentationProvider<T extends RenderingContext>(provider: RenderingContextPresentationProvider<T>): IDisposable;
 }
 
 type UntypedRenderingContextNodeProvider = RenderingContextNodeProvider<RenderingContext>;
+type UntypedRenderingContextPresentationProvider = Readonly<{
+    predicate: (context: RenderingContext) => boolean;
+    getPresentation: (context: RenderingContext) => Partial<Pick<ExplorerNodeDescription, "getDisplayInfo" | "icon">>;
+}>;
 
 function UntypeRenderingContextNodeProvider<T extends RenderingContext>(provider: RenderingContextNodeProvider<T>): UntypedRenderingContextNodeProvider {
     return {
@@ -51,6 +94,26 @@ function UntypeRenderingContextNodeProvider<T extends RenderingContext>(provider
         predicate: (context): context is RenderingContext => provider.predicate(context),
         getNodes: (context) => (provider.predicate(context) ? provider.getNodes(context) : []),
         getSnapshot: (context) => (provider.predicate(context) ? provider.getSnapshot(context) : []),
+    };
+}
+
+// The predicate validates the subtype before the presentation is requested. Wrapping the icon then
+// preserves its typed context without casting it to the generic Explorer icon contract, which accepts any object.
+function UntypeRenderingContextPresentationProvider<T extends RenderingContext>(provider: RenderingContextPresentationProvider<T>): UntypedRenderingContextPresentationProvider {
+    return {
+        predicate: provider.predicate,
+        getPresentation: (context) => {
+            if (!provider.predicate(context)) {
+                return {};
+            }
+
+            const presentation = provider.getPresentation(context);
+            const iconComponent = presentation.icon;
+            return {
+                ...(presentation.getDisplayInfo ? { getDisplayInfo: presentation.getDisplayInfo } : {}),
+                ...("icon" in presentation ? { icon: iconComponent ? () => createElement(iconComponent, { entity: context }) : undefined } : {}),
+            };
+        },
     };
 }
 
@@ -135,7 +198,7 @@ function AreTopologySnapshotsEqual(left: TopologySnapshot, right: TopologySnapsh
     return true;
 }
 
-function GetRenderingContextDisplayName(context: RenderingContext): string {
+function GetBuiltInRenderingContextDisplayName(context: RenderingContext): string {
     const kind = getRenderingContextKind(context);
     if (kind === "scene") {
         return (context as SceneContext).name || "Scene";
@@ -143,7 +206,7 @@ function GetRenderingContextDisplayName(context: RenderingContext): string {
     return RenderingContextDisplayNames.get(kind) ?? kind;
 }
 
-function GetRenderingContextIcon(context: RenderingContext): FunctionComponent | undefined {
+function GetBuiltInRenderingContextIcon(context: RenderingContext): FunctionComponent | undefined {
     switch (getRenderingContextKind(context)) {
         case "scene":
             return SceneIcon;
@@ -160,30 +223,59 @@ function GetApplicableProviders(context: RenderingContext, providers: readonly U
     return providers.filter((provider) => provider.predicate(context)).sort((left, right) => (left.order ?? 0) - (right.order ?? 0));
 }
 
+// Presentation resolution is runtime behavior rather than type adaptation: start with a generic fallback,
+// apply the known built-in presentation, then let the last registered matching provider partially override it.
+function GetRenderingContextPresentation(
+    context: RenderingContext,
+    watcherService: IWatcherService,
+    providers: readonly UntypedRenderingContextPresentationProvider[]
+): Required<Pick<ExplorerNodeDescription, "getDisplayInfo">> & Pick<ExplorerNodeDescription, "icon"> {
+    const isScene = getRenderingContextKind(context) === "scene";
+    const fallbackPresentation = {
+        getDisplayInfo: () => ({ name: getRenderingContextKind(context) }),
+        icon: undefined,
+    };
+    const builtInPresentation = {
+        getDisplayInfo: () =>
+            isScene
+                ? CreateWatchedNameDisplayInfo(watcherService, context as SceneContext, () => GetBuiltInRenderingContextDisplayName(context))
+                : { name: GetBuiltInRenderingContextDisplayName(context) },
+        icon: GetBuiltInRenderingContextIcon(context),
+    };
+    let provider: UntypedRenderingContextPresentationProvider | undefined;
+    for (let index = providers.length - 1; index >= 0; index--) {
+        if (providers[index].predicate(context)) {
+            provider = providers[index];
+            break;
+        }
+    }
+
+    return {
+        ...fallbackPresentation,
+        ...builtInPresentation,
+        ...provider?.getPresentation(context),
+    };
+}
+
 function CreateRenderingContextNode(
     context: RenderingContext,
-    providers: readonly UntypedRenderingContextNodeProvider[],
-    watcherService: IWatcherService
+    watcherService: IWatcherService,
+    presentationProviders: readonly UntypedRenderingContextPresentationProvider[]
 ): ExplorerNodeDescription {
-    const isScene = getRenderingContextKind(context) === "scene";
+    const presentation = GetRenderingContextPresentation(context, watcherService, presentationProviders);
     return {
         id: `rendering-context-${GetNodeId(context)}`,
         kind: "item",
         entity: context,
-        icon: GetRenderingContextIcon(context),
-        getDisplayInfo: () =>
-            isScene
-                ? CreateWatchedNameDisplayInfo(watcherService, context as SceneContext, () => GetRenderingContextDisplayName(context))
-                : { name: GetRenderingContextDisplayName(context) },
-        getChildren: () => GetApplicableProviders(context, providers).flatMap((provider) => provider.getNodes(context)),
+        ...presentation,
     };
 }
 
 function CreateSurfaceNode(
     engine: EngineContext,
     surface: SurfaceContext,
-    providers: readonly UntypedRenderingContextNodeProvider[],
-    watcherService: IWatcherService
+    watcherService: IWatcherService,
+    presentationProviders: readonly UntypedRenderingContextPresentationProvider[]
 ): ExplorerNodeDescription {
     return {
         id: `surface-${GetNodeId(surface)}`,
@@ -191,21 +283,25 @@ function CreateSurfaceNode(
         entity: surface,
         icon: SurfaceIcon,
         getDisplayInfo: () => ({ name: `Surface ${engine.surfaces.indexOf(surface) + 1}` }),
-        getChildren: () => getRenderingContexts(surface).map((context) => CreateRenderingContextNode(context, providers, watcherService)),
+        getChildren: () => getRenderingContexts(surface).map((context) => CreateRenderingContextNode(context, watcherService, presentationProviders)),
     };
 }
 
-function CreateEngineNodes(engine: EngineContext, providers: readonly UntypedRenderingContextNodeProvider[], watcherService: IWatcherService): readonly ExplorerNodeDescription[] {
+function CreateEngineNodes(
+    engine: EngineContext,
+    watcherService: IWatcherService,
+    presentationProviders: readonly UntypedRenderingContextPresentationProvider[]
+): readonly ExplorerNodeDescription[] {
     // The engine itself is the primary surface, and it is already represented by the Explorer root node,
     // so its rendering contexts are contributed as children of the root.
-    const nodes: ExplorerNodeDescription[] = getRenderingContexts(engine).map((context) => CreateRenderingContextNode(context, providers, watcherService));
+    const nodes: ExplorerNodeDescription[] = getRenderingContexts(engine).map((context) => CreateRenderingContextNode(context, watcherService, presentationProviders));
 
     if (engine.surfaces.length > 1) {
         nodes.push({
             id: "auxiliary-surfaces",
             kind: "group",
             getDisplayInfo: () => ({ name: "Auxiliary Surfaces" }),
-            getChildren: () => engine.surfaces.slice(1).map((surface) => CreateSurfaceNode(engine, surface, providers, watcherService)),
+            getChildren: () => engine.surfaces.slice(1).map((surface) => CreateSurfaceNode(engine, surface, watcherService, presentationProviders)),
         });
     }
 
@@ -216,13 +312,17 @@ function CreateEngineNodes(engine: EngineContext, providers: readonly UntypedRen
  * Owns the "Explorer" pane of the Babylon Lite Inspector, which displays the engine hierarchy
  * (rendering contexts of the primary surface, and any auxiliary surfaces and their contexts).
  */
-export const EngineExplorerServiceDefinition: ServiceDefinition<[IEngineExplorerService], [IEngineContext, IShellService, ISelectionService, IWatcherService]> = {
+export const EngineExplorerServiceDefinition: ServiceDefinition<[IEngineExplorerService, IExplorerService], [IEngineContext, IShellService, ISelectionService, IWatcherService]> = {
     friendlyName: "Babylon Lite Engine Explorer",
-    produces: [EngineExplorerServiceIdentity],
+    produces: [EngineExplorerServiceIdentity, ExplorerServiceIdentity],
     consumes: [EngineContextIdentity, ShellServiceIdentity, SelectionServiceIdentity, WatcherServiceIdentity],
     factory: (engineContext, shellService, selectionService, watcherService) => {
         const engine = engineContext.engine;
         const nodeProviders = new ObservableCollection<UntypedRenderingContextNodeProvider>();
+        const presentationProviders = new ObservableCollection<UntypedRenderingContextPresentationProvider>();
+        const explorerService = CreateExplorerService();
+        const isRenderingContext = (entity: object): entity is RenderingContext =>
+            engine.surfaces.some((surface) => getRenderingContexts(surface).includes(entity as RenderingContext));
         const getTopologySnapshot = (): TopologySnapshot =>
             engine.surfaces.map((surface) => ({
                 surface,
@@ -242,19 +342,54 @@ export const EngineExplorerServiceDefinition: ServiceDefinition<[IEngineExplorer
             getRoot: () => engine,
             rootLabel: "Engine",
             rootIcon: EngineIcon,
-            getNodes: () => CreateEngineNodes(engine, nodeProviders.items, watcherService),
+            getNodes: () => CreateEngineNodes(engine, watcherService, presentationProviders.items),
             onNodesChanged,
+            nodeProviders: explorerService.nodeProviders,
+            itemCommandProviders: explorerService.itemCommandProviders,
+            groupCommandProviders: explorerService.groupCommandProviders,
         });
 
         const topologyWatcher = watcherService.watchValue(getTopologySnapshot, () => onNodesChanged.notifyObservers(), AreTopologySnapshotsEqual);
-        const providersObserver = nodeProviders.observable.add(() => onNodesChanged.notifyObservers());
+        const nodeProvidersObserver = nodeProviders.observable.add(() => onNodesChanged.notifyObservers());
+        const presentationProvidersObserver = presentationProviders.observable.add(() => onNodesChanged.notifyObservers());
 
+        // Lite keeps its rendering-context vocabulary while adapting hierarchy and commands onto the generic
+        // entity-attached service. Structural groups such as "Auxiliary Surfaces" remain adapter-owned Explorer groups.
         return {
-            addRenderingContextNodeProvider: (provider) => nodeProviders.add(UntypeRenderingContextNodeProvider(provider)),
+            addRenderingContextNodeProvider: (provider) => {
+                const untypedProvider = UntypeRenderingContextNodeProvider(provider);
+                const topologyRegistration = nodeProviders.add(untypedProvider);
+                const explorerRegistration = explorerService.addNodeProvider({
+                    order: provider.order,
+                    predicate: (parent): parent is RenderingContext =>
+                        typeof parent === "object" && parent !== null && isRenderingContext(parent) && untypedProvider.predicate(parent),
+                    getNodes: untypedProvider.getNodes,
+                });
+                let isRegistered = true;
+                return {
+                    dispose: () => {
+                        if (!isRegistered) {
+                            return;
+                        }
+
+                        isRegistered = false;
+                        topologyRegistration.dispose();
+                        explorerRegistration.dispose();
+                    },
+                };
+            },
+            addRenderingContextPresentationProvider: (provider) => presentationProviders.add(UntypeRenderingContextPresentationProvider(provider)),
+            addNodeProvider: explorerService.addNodeProvider,
+            addItemCommand: explorerService.addItemCommand,
+            addGroupCommand: explorerService.addGroupCommand,
             dispose: () => {
-                providersObserver.remove();
+                nodeProvidersObserver.remove();
+                presentationProvidersObserver.remove();
                 topologyWatcher.dispose();
                 paneRegistration.dispose();
+                nodeProviders.dispose();
+                presentationProviders.dispose();
+                explorerService.dispose();
                 onNodesChanged.clear();
             },
         };

--- a/packages/dev/inspector-v2/src/lite/index.ts
+++ b/packages/dev/inspector-v2/src/lite/index.ts
@@ -2,5 +2,5 @@ export * from "../index.common";
 export { ShowInspector } from "./inspector";
 export type { IEngineContext } from "./engineContext";
 export { EngineContextIdentity } from "./engineContext";
-export type { IEngineExplorerService, RenderingContextNodeProvider } from "./engineExplorerService";
+export type { IEngineExplorerService, RenderingContextNodeProvider, RenderingContextPresentation, RenderingContextPresentationProvider } from "./engineExplorerService";
 export { EngineExplorerServiceIdentity } from "./engineExplorerService";

--- a/packages/dev/inspector-v2/src/services/panes/explorer/explorerPane.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/explorer/explorerPane.tsx
@@ -10,7 +10,7 @@ import { type IShellService } from "shared-ui-components/modularTool/services/sh
 
 import { CubeTreeRegular } from "@fluentui/react-icons";
 
-import { useObservableState, useOrderedObservableCollection } from "shared-ui-components/modularTool/hooks/observableHooks";
+import { useObservableCollection, useObservableState, useOrderedObservableCollection } from "shared-ui-components/modularTool/hooks/observableHooks";
 import { type IReadonlyObservableCollection, ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
 
 /**
@@ -135,7 +135,7 @@ type ExplorerPaneProps = Readonly<{
 const ExplorerPane: FunctionComponent<ExplorerPaneProps> = (props) => {
     const { selectionService, getRoot, rootLabel, rootIcon, onRootChanged, getNodes, onNodesChanged, nodeProviders, itemCommandProviders, groupCommandProviders } = props;
 
-    const orderedNodeProviders = useOrderedObservableCollection(nodeProviders);
+    const currentNodeProviders = useObservableCollection(nodeProviders);
     const itemCommands = useOrderedObservableCollection(itemCommandProviders);
     const groupCommands = useOrderedObservableCollection(groupCommandProviders);
     const nodesVersion = useNodesVersion(onNodesChanged);
@@ -158,11 +158,11 @@ const ExplorerPane: FunctionComponent<ExplorerPaneProps> = (props) => {
             entity: root,
             icon: rootIcon,
             getDisplayInfo: () => ({ name: rootLabel }),
-            getChildren: () => GetExplorerNodeChildren(root, getNodes(), orderedNodeProviders),
+            getChildren: () => GetExplorerNodeChildren(root, getNodes(), currentNodeProviders),
         };
 
         return [rootNode];
-    }, [rootLabel, rootIcon, getNodes, nodesVersion, nodeProvidersVersion, orderedNodeProviders, root]);
+    }, [rootLabel, rootIcon, getNodes, nodesVersion, nodeProvidersVersion, currentNodeProviders, root]);
 
     return (
         <>

--- a/packages/dev/inspector-v2/src/services/panes/explorer/explorerPane.tsx
+++ b/packages/dev/inspector-v2/src/services/panes/explorer/explorerPane.tsx
@@ -4,13 +4,14 @@ import { type ComponentType, type FunctionComponent, useCallback, useEffect, use
 
 import { type ExplorerCommandProvider, type ExplorerNodeDescription } from "../../../components/explorer/explorerModel";
 import { Explorer } from "../../../components/explorer/explorer";
+import { GetExplorerNodeChildren, type ExplorerNodeProvider } from "./explorerService";
 import { type ISelectionService } from "../../selectionService";
 import { type IShellService } from "shared-ui-components/modularTool/services/shellService";
 
 import { CubeTreeRegular } from "@fluentui/react-icons";
 
 import { useObservableState, useOrderedObservableCollection } from "shared-ui-components/modularTool/hooks/observableHooks";
-import { ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
+import { type IReadonlyObservableCollection, ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
 
 /**
  * Describes an Explorer side pane, including the services it needs and the hierarchy it displays.
@@ -69,14 +70,19 @@ export type ExplorerPaneOptions = Readonly<{
     onNodesChanged?: IReadonlyObservable<void>;
 
     /**
+     * Optional providers that contribute nodes beneath compatible entity-backed nodes.
+     */
+    nodeProviders?: IReadonlyObservableCollection<ExplorerNodeProvider<object>>;
+
+    /**
      * Optional command providers for nodes that represent an entity.
      */
-    itemCommandProviders?: ObservableCollection<ExplorerCommandProvider<object>>;
+    itemCommandProviders?: IReadonlyObservableCollection<ExplorerCommandProvider<object>>;
 
     /**
      * Optional command providers for group nodes (the command context is the group's display name).
      */
-    groupCommandProviders?: ObservableCollection<ExplorerCommandProvider<string, "contextMenu">>;
+    groupCommandProviders?: IReadonlyObservableCollection<ExplorerCommandProvider<string, "contextMenu">>;
 }>;
 
 // Rebuilds the tree when the owner reports that its set of top level nodes changed.
@@ -94,6 +100,25 @@ function useNodesVersion(onNodesChanged: IReadonlyObservable<void> | undefined):
     return version;
 }
 
+function useNodeProvidersVersion(providers: IReadonlyObservableCollection<ExplorerNodeProvider<object>>): number {
+    const [version, setVersion] = useState(0);
+
+    useEffect(() => {
+        let providerObservers = providers.items.map((provider) => provider.onChanged?.add(() => setVersion((version) => version + 1)));
+        const collectionObserver = providers.observable.add(() => {
+            providerObservers.forEach((observer) => observer?.remove());
+            providerObservers = providers.items.map((provider) => provider.onChanged?.add(() => setVersion((version) => version + 1)));
+        });
+
+        return () => {
+            collectionObserver.remove();
+            providerObservers.forEach((observer) => observer?.remove());
+        };
+    }, [providers]);
+
+    return version;
+}
+
 type ExplorerPaneProps = Readonly<{
     selectionService: ISelectionService;
     getRoot: () => Nullable<object>;
@@ -102,16 +127,19 @@ type ExplorerPaneProps = Readonly<{
     onRootChanged?: IReadonlyObservable<unknown>;
     getNodes: () => readonly ExplorerNodeDescription[];
     onNodesChanged?: IReadonlyObservable<void>;
-    itemCommandProviders: ObservableCollection<ExplorerCommandProvider<object>>;
-    groupCommandProviders: ObservableCollection<ExplorerCommandProvider<string, "contextMenu">>;
+    nodeProviders: IReadonlyObservableCollection<ExplorerNodeProvider<object>>;
+    itemCommandProviders: IReadonlyObservableCollection<ExplorerCommandProvider<object>>;
+    groupCommandProviders: IReadonlyObservableCollection<ExplorerCommandProvider<string, "contextMenu">>;
 }>;
 
 const ExplorerPane: FunctionComponent<ExplorerPaneProps> = (props) => {
-    const { selectionService, getRoot, rootLabel, rootIcon, onRootChanged, getNodes, onNodesChanged, itemCommandProviders, groupCommandProviders } = props;
+    const { selectionService, getRoot, rootLabel, rootIcon, onRootChanged, getNodes, onNodesChanged, nodeProviders, itemCommandProviders, groupCommandProviders } = props;
 
+    const orderedNodeProviders = useOrderedObservableCollection(nodeProviders);
     const itemCommands = useOrderedObservableCollection(itemCommandProviders);
     const groupCommands = useOrderedObservableCollection(groupCommandProviders);
     const nodesVersion = useNodesVersion(onNodesChanged);
+    const nodeProvidersVersion = useNodeProvidersVersion(nodeProviders);
     const root = useObservableState(
         useCallback(() => getRoot(), [getRoot]),
         onRootChanged
@@ -130,11 +158,11 @@ const ExplorerPane: FunctionComponent<ExplorerPaneProps> = (props) => {
             entity: root,
             icon: rootIcon,
             getDisplayInfo: () => ({ name: rootLabel }),
-            getChildren: getNodes,
+            getChildren: () => GetExplorerNodeChildren(root, getNodes(), orderedNodeProviders),
         };
 
         return [rootNode];
-    }, [rootLabel, rootIcon, getNodes, nodesVersion, root]);
+    }, [rootLabel, rootIcon, getNodes, nodesVersion, nodeProvidersVersion, orderedNodeProviders, root]);
 
     return (
         <>
@@ -163,6 +191,7 @@ export function CreateExplorerPaneRegistration(shellService: IShellService, sele
     const { key, title, getRoot, rootLabel, rootIcon, onRootChanged, getNodes, onNodesChanged } = options;
 
     // These are created once per pane so the identities passed to the hooks below are stable.
+    const nodeProviders = options.nodeProviders ?? new ObservableCollection<ExplorerNodeProvider<object>>();
     const itemCommandProviders = options.itemCommandProviders ?? new ObservableCollection<ExplorerCommandProvider<object>>();
     const groupCommandProviders = options.groupCommandProviders ?? new ObservableCollection<ExplorerCommandProvider<string, "contextMenu">>();
 
@@ -183,6 +212,7 @@ export function CreateExplorerPaneRegistration(shellService: IShellService, sele
                 onRootChanged={onRootChanged}
                 getNodes={getNodes}
                 onNodesChanged={onNodesChanged}
+                nodeProviders={nodeProviders}
                 itemCommandProviders={itemCommandProviders}
                 groupCommandProviders={groupCommandProviders}
             />

--- a/packages/dev/inspector-v2/src/services/panes/explorer/explorerService.ts
+++ b/packages/dev/inspector-v2/src/services/panes/explorer/explorerService.ts
@@ -1,0 +1,133 @@
+import { type IDisposable, type IReadonlyObservable } from "core/index";
+
+import { type ExplorerCommandProvider, type ExplorerNodeDescription } from "../../../components/explorer/explorerModel";
+import { type IReadonlyObservableCollection, ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
+import { type IService } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+/**
+ * The unique identity symbol for the product-neutral Explorer service.
+ * @experimental
+ */
+export const ExplorerServiceIdentity = Symbol("Explorer");
+
+/**
+ * Contributes Explorer nodes beneath compatible entity-backed parent nodes.
+ *
+ * Providers return ordinary {@link ExplorerNodeDescription}s, so each contribution may contain arbitrary
+ * nested groups and items. Providers attach by parent entity rather than node id because structural groups
+ * are presentation details owned by product adapters.
+ * @experimental
+ */
+export type ExplorerNodeProvider<T extends object> = Readonly<{
+    /** Controls this provider's position relative to other providers attached to the same parent. */
+    order?: number;
+    /** Returns whether this provider supports the parent entity. */
+    predicate: (parent: unknown) => parent is T;
+    /** Gets the Explorer nodes contributed beneath the parent entity. */
+    getNodes: (parent: T) => readonly ExplorerNodeDescription[];
+    /** Optionally notifies when the nodes returned by this provider may have changed. */
+    onChanged?: IReadonlyObservable<unknown>;
+}>;
+
+/**
+ * Allows hierarchy and commands to be contributed to an Explorer without depending on a product-specific API.
+ *
+ * The item/group terminology intentionally matches `ExplorerNodeKind`. Product adapters may expose
+ * domain-specific aliases (such as entity/section), but a generic Explorer group is not necessarily a scene section.
+ * @experimental
+ */
+export interface IExplorerService extends IService<typeof ExplorerServiceIdentity> {
+    /**
+     * Adds a provider that contributes nodes beneath compatible entity-backed Explorer nodes.
+     * @param provider The node provider to add.
+     * @returns A disposable that removes the node provider.
+     */
+    addNodeProvider<T extends object>(provider: ExplorerNodeProvider<T>): IDisposable;
+
+    /**
+     * Adds a command that can be executed on Explorer item nodes.
+     * @param command The command provider to add.
+     * @returns A disposable that removes the command provider.
+     */
+    addItemCommand<T extends object>(command: ExplorerCommandProvider<T>): IDisposable;
+
+    /**
+     * Adds a context-menu command that can be executed on Explorer group nodes.
+     * @param command The command provider to add.
+     * @returns A disposable that removes the command provider.
+     */
+    addGroupCommand<T extends string>(command: ExplorerCommandProvider<T, "contextMenu">): IDisposable;
+}
+
+/**
+ * The shared Explorer service implementation and the command collections consumed by an Explorer pane.
+ * @internal
+ */
+export type ExplorerServiceState = IExplorerService &
+    Readonly<{
+        nodeProviders: IReadonlyObservableCollection<ExplorerNodeProvider<object>>;
+        itemCommandProviders: IReadonlyObservableCollection<ExplorerCommandProvider<object>>;
+        groupCommandProviders: IReadonlyObservableCollection<ExplorerCommandProvider<string, "contextMenu">>;
+        dispose: () => void;
+    }>;
+
+/**
+ * Creates the product-neutral Explorer contribution service.
+ * @returns The service implementation and its observable contribution collections.
+ * @internal
+ */
+export function CreateExplorerService(): ExplorerServiceState {
+    const nodeProviders = new ObservableCollection<ExplorerNodeProvider<object>>();
+    const itemCommands = new ObservableCollection<ExplorerCommandProvider<object>>();
+    const groupCommands = new ObservableCollection<ExplorerCommandProvider<string, "contextMenu">>();
+
+    return {
+        nodeProviders,
+        itemCommandProviders: itemCommands,
+        groupCommandProviders: groupCommands,
+        addNodeProvider: (provider) => nodeProviders.add(provider as unknown as ExplorerNodeProvider<object>),
+        addItemCommand: (command) => itemCommands.add(command as unknown as ExplorerCommandProvider<object>),
+        addGroupCommand: (command) => groupCommands.add(command as unknown as ExplorerCommandProvider<string, "contextMenu">),
+        dispose: () => {
+            nodeProviders.dispose();
+            itemCommands.dispose();
+            groupCommands.dispose();
+        },
+    };
+}
+
+function ExtendNodeDescription(description: ExplorerNodeDescription, providers: readonly ExplorerNodeProvider<object>[]): ExplorerNodeDescription {
+    const getChildren = description.getChildren;
+    if (!getChildren && !description.entity) {
+        return description;
+    }
+
+    return {
+        ...description,
+        getChildren: () => GetExplorerNodeChildren(description.entity, getChildren?.() ?? [], providers),
+    };
+}
+
+/**
+ * Combines product-owned children with shared provider contributions and recursively enables contributions
+ * beneath every entity-backed descendant.
+ * @param parent The entity represented by the parent node, if any.
+ * @param children The children owned by the product adapter.
+ * @param providers The shared node providers registered with the Explorer.
+ * @returns The combined child node descriptions.
+ * @internal
+ */
+export function GetExplorerNodeChildren(
+    parent: object | undefined,
+    children: readonly ExplorerNodeDescription[],
+    providers: readonly ExplorerNodeProvider<object>[]
+): readonly ExplorerNodeDescription[] {
+    const contributedChildren = parent
+        ? providers
+              .filter((provider) => provider.predicate(parent))
+              .sort((left, right) => (left.order ?? 0) - (right.order ?? 0))
+              .flatMap((provider) => provider.getNodes(parent))
+        : [];
+
+    return [...children, ...contributedChildren].map((description) => ExtendNodeDescription(description, providers));
+}

--- a/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.ts
+++ b/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.ts
@@ -1,6 +1,6 @@
 import { type IDisposable } from "core/index";
 
-import { type ExplorerCommandProvider, type ExplorerNodeDescription, GetEntityId } from "../../../components/explorer/explorerModel";
+import { type ExplorerNodeDescription, GetEntityId } from "../../../components/explorer/explorerModel";
 import { type SceneExplorerCommandProvider, type SceneExplorerSection } from "../../../components/scene/sceneExplorer";
 import { type IService, type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
 import { type ISceneContext, SceneContextIdentity } from "../../sceneContext";
@@ -8,7 +8,7 @@ import { type ISelectionService, SelectionServiceIdentity } from "../../selectio
 import { type IShellService, ShellServiceIdentity } from "shared-ui-components/modularTool/services/shellService";
 
 import { CreateExplorerPaneRegistration } from "../explorer/explorerPane";
-import { ObservableCollection } from "shared-ui-components/modularTool/misc/observableCollection";
+import { CreateExplorerService, type IExplorerService, ExplorerServiceIdentity } from "../explorer/explorerService";
 
 /**
  * The unique identity symbol for the scene explorer service.
@@ -17,6 +17,9 @@ export const SceneExplorerServiceIdentity = Symbol("SceneExplorer");
 
 /**
  * Allows new sections or commands to be added to the scene explorer pane.
+ *
+ * Entity and section commands are Full Inspector conveniences over the product-neutral item and group command APIs.
+ * They remain scene-specific so other Explorer products do not have to model their groups as scene sections.
  */
 export interface ISceneExplorerService extends IService<typeof SceneExplorerServiceIdentity> {
     /**
@@ -88,14 +91,12 @@ function CreateSectionNode(section: SceneExplorerSection<object>): ExplorerNodeD
  * Adapts the Babylon.js scene section/entity model onto the generic Explorer, and owns the "Scene Explorer"
  * pane that enables browsing the scene graph and executing commands on entities.
  */
-export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerService], [ISceneContext, IShellService, ISelectionService]> = {
+export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerService, IExplorerService], [ISceneContext, IShellService, ISelectionService]> = {
     friendlyName: "Scene Explorer",
-    produces: [SceneExplorerServiceIdentity],
+    produces: [SceneExplorerServiceIdentity, ExplorerServiceIdentity],
     consumes: [SceneContextIdentity, ShellServiceIdentity, SelectionServiceIdentity],
     factory: (sceneContext, shellService, selectionService) => {
-        const sectionsCollection = new ObservableCollection<SceneExplorerSection<object>>();
-        const entityCommandsCollection = new ObservableCollection<ExplorerCommandProvider<object>>();
-        const sectionCommandsCollection = new ObservableCollection<ExplorerCommandProvider<string, "contextMenu">>();
+        const explorerService = CreateExplorerService();
 
         const paneRegistration = CreateExplorerPaneRegistration(shellService, selectionService, {
             key: "Scene Explorer",
@@ -103,17 +104,32 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
             getRoot: () => sceneContext.currentScene,
             rootLabel: "Scene",
             onRootChanged: sceneContext.currentSceneObservable,
-            getNodes: () => [...sectionsCollection.items].sort((left, right) => (left.order ?? 0) - (right.order ?? 0)).map(CreateSectionNode),
-            onNodesChanged: sectionsCollection.observable,
-            itemCommandProviders: entityCommandsCollection,
-            groupCommandProviders: sectionCommandsCollection,
+            getNodes: () => [],
+            nodeProviders: explorerService.nodeProviders,
+            itemCommandProviders: explorerService.itemCommandProviders,
+            groupCommandProviders: explorerService.groupCommandProviders,
         });
 
+        // Preserve the Full Inspector's entity/section vocabulary while adapting its sections and commands
+        // onto the product-neutral service consumed by extensions that support Full and Lite.
         return {
-            addSection: (section) => sectionsCollection.add(section as unknown as SceneExplorerSection<object>),
-            addEntityCommand: (command) => entityCommandsCollection.add(command as unknown as ExplorerCommandProvider<object>),
-            addSectionCommand: (command) => sectionCommandsCollection.add(command as unknown as ExplorerCommandProvider<string, "contextMenu">),
-            dispose: () => paneRegistration.dispose(),
+            addSection: (section) => {
+                const untypedSection = section as unknown as SceneExplorerSection<object>;
+                return explorerService.addNodeProvider({
+                    order: section.order,
+                    predicate: (parent): parent is object => parent === sceneContext.currentScene,
+                    getNodes: () => [CreateSectionNode(untypedSection)],
+                });
+            },
+            addEntityCommand: explorerService.addItemCommand,
+            addSectionCommand: explorerService.addGroupCommand,
+            addNodeProvider: explorerService.addNodeProvider,
+            addItemCommand: explorerService.addItemCommand,
+            addGroupCommand: explorerService.addGroupCommand,
+            dispose: () => {
+                explorerService.dispose();
+                paneRegistration.dispose();
+            },
         };
     },
 };

--- a/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.ts
+++ b/packages/dev/inspector-v2/src/services/panes/scene/sceneExplorerService.ts
@@ -127,8 +127,8 @@ export const SceneExplorerServiceDefinition: ServiceDefinition<[ISceneExplorerSe
             addItemCommand: explorerService.addItemCommand,
             addGroupCommand: explorerService.addGroupCommand,
             dispose: () => {
-                explorerService.dispose();
                 paneRegistration.dispose();
+                explorerService.dispose();
             },
         };
     },

--- a/packages/dev/inspector-v2/test/unit/explorer.test.tsx
+++ b/packages/dev/inspector-v2/test/unit/explorer.test.tsx
@@ -1,6 +1,4 @@
-/**
- * @vitest-environment jsdom
- */
+// @vitest-environment jsdom
 
 import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 import { act, type FunctionComponent, type ReactElement } from "react";
@@ -8,7 +6,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Explorer } from "../../src/components/explorer/explorer";
-import { type ExplorerNodeDescription } from "../../src/components/explorer/explorerModel";
+import { type ExplorerCommandProvider, type ExplorerNodeDescription } from "../../src/components/explorer/explorerModel";
 
 vi.hoisted(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
@@ -207,5 +205,70 @@ describe("Explorer root node", () => {
         RenderSelectionExplorer(root, [], customSelection, setSelectedEntity);
 
         expect(setSelectedEntity).not.toHaveBeenCalled();
+    });
+
+    it("disposes display metadata when topology rebuilds", () => {
+        const firstDispose = vi.fn();
+        const firstEntity = {};
+        const secondEntity = {};
+
+        RenderSelectionExplorer(root, [{ id: "first", entity: firstEntity, getDisplayInfo: () => ({ name: "First", dispose: firstDispose }) }], firstEntity, vi.fn());
+        expect(firstDispose).not.toHaveBeenCalled();
+
+        RenderSelectionExplorer(root, [{ id: "second", entity: secondEntity, getDisplayInfo: () => ({ name: "Second" }) }], secondEntity, vi.fn());
+        expect(firstDispose).toHaveBeenCalledOnce();
+    });
+
+    it("disposes item and group commands when their providers are removed", () => {
+        const itemDispose = vi.fn();
+        const groupDispose = vi.fn();
+        const itemEntity = {};
+        const childEntity = {};
+        const nodes: readonly ExplorerNodeDescription[] = [
+            { id: "item", entity: itemEntity, getDisplayInfo: () => ({ name: "Item" }) },
+            {
+                id: "group",
+                kind: "group",
+                getDisplayInfo: () => ({ name: "Group" }),
+                getChildren: () => [{ id: "child", entity: childEntity, getDisplayInfo: () => ({ name: "Child" }) }],
+            },
+        ];
+        const itemCommandProvider = {
+            predicate: (context: unknown): context is object => context === itemEntity,
+            getCommand: () => ({
+                type: "action",
+                displayName: "Inspect",
+                icon: () => null,
+                execute: () => {},
+                dispose: itemDispose,
+            }),
+        } satisfies ExplorerCommandProvider<object>;
+        const groupCommandProvider = {
+            predicate: (context: unknown): context is "Group" => context === "Group",
+            getCommand: () => ({
+                type: "action",
+                mode: "contextMenu",
+                displayName: "Create",
+                execute: () => {},
+                dispose: groupDispose,
+            }),
+        } satisfies ExplorerCommandProvider<"Group", "contextMenu">;
+        const render = (itemCommandProviders: readonly ExplorerCommandProvider<object>[], groupCommandProviders: readonly ExplorerCommandProvider<string, "contextMenu">[]) => {
+            act(() =>
+                root.render(
+                    <FluentProvider theme={webLightTheme}>
+                        <Explorer getNodes={() => nodes} itemCommandProviders={itemCommandProviders} groupCommandProviders={groupCommandProviders} />
+                    </FluentProvider>
+                )
+            );
+        };
+
+        render([itemCommandProvider], [groupCommandProvider]);
+        expect(itemDispose).not.toHaveBeenCalled();
+        expect(groupDispose).not.toHaveBeenCalled();
+
+        render([], []);
+        expect(itemDispose).toHaveBeenCalledOnce();
+        expect(groupDispose).toHaveBeenCalledOnce();
     });
 });

--- a/packages/dev/inspector-v2/test/unit/explorerPane.test.tsx
+++ b/packages/dev/inspector-v2/test/unit/explorerPane.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act, type ComponentType } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Observable } from "core/Misc/observable";
+
+import { type ExplorerNodeDescription } from "../../src/components/explorer/explorerModel";
+import { CreateExplorerPaneRegistration } from "../../src/services/panes/explorer/explorerPane";
+import { CreateExplorerService } from "../../src/services/panes/explorer/explorerService";
+import { type ISelectionService } from "../../src/services/selectionService";
+import { type IShellService, type SidePaneDefinition } from "shared-ui-components/modularTool/services/shellService";
+
+vi.hoisted(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+});
+
+vi.mock("../../src/components/explorer/explorer", () => ({
+    Explorer: ({ getNodes }: { getNodes: () => readonly ExplorerNodeDescription[] }) => {
+        const children = getNodes()[0]?.getChildren?.() ?? [];
+        return (
+            <>
+                {children.map((node) => (
+                    <span key={node.id}>{node.getDisplayInfo().name}</span>
+                ))}
+            </>
+        );
+    },
+}));
+
+describe("Explorer pane", () => {
+    const containers: HTMLElement[] = [];
+
+    afterEach(() => {
+        containers.forEach((container) => container.remove());
+        containers.length = 0;
+    });
+
+    it("refreshes and cleans up node provider change observations", async () => {
+        const providerChanged = new Observable<void>();
+        const explorerService = CreateExplorerService();
+        const parent = {};
+        let childName = "First";
+        const providerRegistration = explorerService.addNodeProvider({
+            predicate: (entity): entity is object => entity === parent,
+            getNodes: () => [{ id: "child", entity: {}, getDisplayInfo: () => ({ name: childName }) }],
+            onChanged: providerChanged,
+        });
+        let PaneContent: ComponentType | undefined;
+        const shellService = {
+            addSidePane: (pane: SidePaneDefinition) => {
+                PaneContent = pane.content;
+                return { dispose: vi.fn() };
+            },
+        } as unknown as IShellService;
+        const selectionChanged = new Observable<object>();
+        const selectionService = {
+            selectedEntity: null,
+            onSelectedEntityChanged: selectionChanged,
+        } as unknown as ISelectionService;
+
+        CreateExplorerPaneRegistration(shellService, selectionService, {
+            key: "Explorer",
+            title: "Explorer",
+            getRoot: () => parent,
+            rootLabel: "Root",
+            getNodes: () => [],
+            nodeProviders: explorerService.nodeProviders,
+        });
+        if (!PaneContent) {
+            throw new Error("Expected the Explorer pane to be registered.");
+        }
+
+        const container = document.createElement("div");
+        containers.push(container);
+        const root = createRoot(container);
+        await act(async () => root.render(<PaneContent />));
+        expect(container.textContent).toBe("First");
+        expect(providerChanged.hasObservers()).toBe(true);
+        expect(providerChanged.observers).toHaveLength(1);
+
+        childName = "Second";
+        await act(async () => providerChanged.notifyObservers());
+        expect(container.textContent).toBe("Second");
+        expect(providerChanged.observers).toHaveLength(1);
+
+        await act(async () => providerRegistration.dispose());
+        expect(container.textContent).toBe("");
+        expect(providerChanged.observers).toHaveLength(0);
+
+        await act(async () => root.unmount());
+        explorerService.dispose();
+    });
+});

--- a/packages/dev/inspector-v2/test/unit/explorerService.test.ts
+++ b/packages/dev/inspector-v2/test/unit/explorerService.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { BuildExplorerTree, type ExplorerCommandProvider } from "../../src/components/explorer/explorerModel";
+import { CreateExplorerService, GetExplorerNodeChildren } from "../../src/services/panes/explorer/explorerService";
+
+type TestEntity = {
+    name: string;
+};
+
+const ItemCommand = {
+    predicate: (context: unknown): context is TestEntity => typeof context === "object" && context !== null && "name" in context,
+    getCommand: () => ({
+        type: "action",
+        displayName: "Inspect",
+        icon: () => null,
+        execute: () => {},
+    }),
+} satisfies ExplorerCommandProvider<TestEntity>;
+
+const GroupCommand = {
+    predicate: (context: unknown): context is "Resources" => context === "Resources",
+    getCommand: () => ({
+        type: "action",
+        mode: "contextMenu",
+        displayName: "Create",
+        execute: () => {},
+    }),
+} satisfies ExplorerCommandProvider<"Resources", "contextMenu">;
+
+describe("Explorer service", () => {
+    it("attaches nested node contributions beneath compatible parent entities", () => {
+        const service = CreateExplorerService();
+        const root = {};
+        const branch = {};
+        const leaf = {};
+        const later = {};
+
+        const laterRegistration = service.addNodeProvider({
+            order: 10,
+            predicate: (parent): parent is object => parent === root,
+            getNodes: () => [{ id: "later", entity: later, getDisplayInfo: () => ({ name: "Later" }) }],
+        });
+        service.addNodeProvider({
+            predicate: (parent): parent is object => parent === root,
+            getNodes: () => [
+                {
+                    id: "group",
+                    kind: "group",
+                    getDisplayInfo: () => ({ name: "Group" }),
+                    getChildren: () => [{ id: "branch", entity: branch, getDisplayInfo: () => ({ name: "Branch" }) }],
+                },
+            ],
+        });
+        service.addNodeProvider({
+            predicate: (parent): parent is object => parent === branch,
+            getNodes: () => [{ id: "leaf", entity: leaf, getDisplayInfo: () => ({ name: "Leaf" }) }],
+        });
+
+        const tree = BuildExplorerTree(GetExplorerNodeChildren(root, [], service.nodeProviders.items));
+        expect(tree.nodes.map((node) => node.getDisplayInfo().name)).toEqual(["Group", "Later"]);
+        expect(tree.nodes[0].kind).toBe("group");
+        expect(tree.nodes[0].children[0].entity).toBe(branch);
+        expect(tree.nodes[0].children[0].children[0].entity).toBe(leaf);
+
+        laterRegistration.dispose();
+        laterRegistration.dispose();
+        expect(BuildExplorerTree(GetExplorerNodeChildren(root, [], service.nodeProviders.items)).nodes.map((node) => node.getDisplayInfo().name)).toEqual(["Group"]);
+    });
+
+    it("registers and unregisters item and group commands idempotently", () => {
+        const service = CreateExplorerService();
+        const itemRegistration = service.addItemCommand(ItemCommand);
+        const groupRegistration = service.addGroupCommand(GroupCommand);
+
+        expect(service.itemCommandProviders.items).toEqual([ItemCommand]);
+        expect(service.groupCommandProviders.items).toEqual([GroupCommand]);
+
+        itemRegistration.dispose();
+        itemRegistration.dispose();
+        groupRegistration.dispose();
+        groupRegistration.dispose();
+
+        expect(service.itemCommandProviders.items).toEqual([]);
+        expect(service.groupCommandProviders.items).toEqual([]);
+    });
+
+    it("owns outstanding registrations and rejects additions after disposal", () => {
+        const service = CreateExplorerService();
+        const nodeProvider = { predicate: (parent: unknown): parent is object => true, getNodes: () => [] };
+        const nodeRegistration = service.addNodeProvider(nodeProvider);
+        const itemRegistration = service.addItemCommand(ItemCommand);
+        const groupRegistration = service.addGroupCommand(GroupCommand);
+
+        service.dispose();
+        service.dispose();
+        nodeRegistration.dispose();
+        itemRegistration.dispose();
+        groupRegistration.dispose();
+
+        expect(service.nodeProviders.items).toEqual([]);
+        expect(service.itemCommandProviders.items).toEqual([]);
+        expect(service.groupCommandProviders.items).toEqual([]);
+        expect(() => service.addNodeProvider(nodeProvider)).toThrow("Observable collection is disposed.");
+        expect(() => service.addItemCommand(ItemCommand)).toThrow("Observable collection is disposed.");
+        expect(() => service.addGroupCommand(GroupCommand)).toThrow("Observable collection is disposed.");
+    });
+});

--- a/packages/dev/inspector-v2/test/unit/liteExplorerServices.test.ts
+++ b/packages/dev/inspector-v2/test/unit/liteExplorerServices.test.ts
@@ -9,6 +9,8 @@ import {
     type TextRenderer,
     type Texture2D,
 } from "@babylonjs/lite";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 vi.hoisted(() => {
@@ -38,6 +40,7 @@ import {
     EngineExplorerServiceDefinition,
     EngineExplorerServiceIdentity,
     type RenderingContextNodeProvider,
+    type RenderingContextPresentationProvider,
 } from "../../src/lite/engineExplorerService";
 import { MaterialExplorerServiceDefinition } from "../../src/lite/services/panes/scene/materialExplorerService";
 import { MeshExplorerServiceDefinition } from "../../src/lite/services/panes/scene/meshExplorerService";
@@ -45,6 +48,7 @@ import { TextLayerExplorerServiceDefinition } from "../../src/lite/services/pane
 import { TextureExplorerServiceDefinition } from "../../src/lite/services/panes/scene/textureExplorerService";
 import { type IWatcherService, WatcherServiceIdentity } from "../../src/services/watcherService";
 import { type ISelectionService } from "../../src/services/selectionService";
+import { GetExplorerNodeChildren, type IExplorerService, ExplorerServiceIdentity } from "../../src/services/panes/explorer/explorerService";
 import { type IShellService } from "shared-ui-components/modularTool/services/shellService";
 
 function CreateMaterial(family: string, name: string, texture?: Texture2D): Material {
@@ -152,23 +156,31 @@ describe("Babylon Lite engine explorer service", () => {
 
         let getTopologySnapshot: (() => readonly object[]) | undefined;
         let areTopologySnapshotsEqual: ((left: readonly object[], right: readonly object[]) => boolean) | undefined;
+        let notifyTopologyChanged: (() => void) | undefined;
         const watcherService = {
             watchValue: vi.fn(
-                (getValue: () => readonly object[], _onChanged: (value: readonly object[]) => void, equals: (left: readonly object[], right: readonly object[]) => boolean) => {
+                (getValue: () => readonly object[], onChanged: (value: readonly object[]) => void, equals: (left: readonly object[], right: readonly object[]) => boolean) => {
                     getTopologySnapshot = getValue;
                     areTopologySnapshotsEqual = equals;
+                    notifyTopologyChanged = () => onChanged(getValue());
                     return { dispose: vi.fn() };
                 }
             ),
         } as unknown as IWatcherService;
         const service = EngineExplorerServiceDefinition.factory({ engine } as IEngineContext, {} as IShellService, {} as ISelectionService, watcherService)!;
+        const onNodesChanged = vi.fn();
+        PaneRegistrations.at(-1)!.options.onNodesChanged?.add(onNodesChanged);
         const providerRegistration = service.addRenderingContextNodeProvider({
             predicate: (context): context is SceneContext => context === firstScene || context === secondScene,
-            getNodes: () => [],
+            getNodes: (scene) => scene.meshes.map((entity) => ({ id: "mesh", entity, getDisplayInfo: () => ({ name: "Mesh" }) })),
             getSnapshot: (scene) => scene.meshes,
         });
+        const paneNodeProviders = PaneRegistrations.at(-1)!.options.nodeProviders?.items ?? [];
 
-        if (!getTopologySnapshot || !areTopologySnapshotsEqual) {
+        expect(GetExplorerNodeChildren(firstScene, [], paneNodeProviders)[0].entity).toBe(mesh);
+        expect(GetExplorerNodeChildren(secondScene, [], paneNodeProviders)).toEqual([]);
+
+        if (!getTopologySnapshot || !areTopologySnapshotsEqual || !notifyTopologyChanged) {
             throw new Error("Expected the topology watcher to be registered.");
         }
 
@@ -178,15 +190,127 @@ describe("Babylon Lite engine explorer service", () => {
         const afterTransfer = getTopologySnapshot();
 
         expect(areTopologySnapshotsEqual(beforeTransfer, afterTransfer)).toBe(false);
+        expect(onNodesChanged).toHaveBeenCalledOnce();
+        notifyTopologyChanged();
+        expect(onNodesChanged).toHaveBeenCalledTimes(2);
+        expect(GetExplorerNodeChildren(firstScene, [], paneNodeProviders)).toEqual([]);
+        expect(GetExplorerNodeChildren(secondScene, [], paneNodeProviders)[0].entity).toBe(mesh);
 
         providerRegistration.dispose();
+        providerRegistration.dispose();
+        expect(onNodesChanged).toHaveBeenCalledTimes(3);
+        expect(GetExplorerNodeChildren(secondScene, [], paneNodeProviders)).toEqual([]);
         service.dispose?.();
+    });
+
+    it("keeps rendering context presentation separate from contributed children", () => {
+        PaneRegistrations.length = 0;
+        type CustomRenderingContext = RenderingContext & { iconLabel: string };
+        const context = { _kind: "custom-rendering-context", iconLabel: "Custom context" } as unknown as CustomRenderingContext;
+        const child = {};
+        const engine = {
+            surfaces: [] as unknown as EngineContext["surfaces"],
+            _renderingContexts: [context],
+        } as unknown as EngineContext;
+        (engine as { surfaces: readonly SurfaceContext[] }).surfaces = [engine];
+        const watcherService = {
+            watchValue: vi.fn(() => ({ dispose: vi.fn() })),
+        } as unknown as IWatcherService;
+        const service = EngineExplorerServiceDefinition.factory({ engine } as IEngineContext, {} as IShellService, {} as ISelectionService, watcherService)!;
+        const paneOptions = PaneRegistrations.at(-1)!.options;
+        const onNodesChanged = vi.fn();
+        paneOptions.onNodesChanged?.add(onNodesChanged);
+        const CustomIcon = ({ entity }: { entity: CustomRenderingContext }) => createElement("span", null, entity.iconLabel);
+
+        const getContextNode = () => paneOptions.getNodes()[0];
+        expect(getContextNode().getDisplayInfo().name).toBe("custom-rendering-context");
+        expect(getContextNode().icon).toBeUndefined();
+
+        const childRegistration = service.addRenderingContextNodeProvider({
+            predicate: (candidate): candidate is RenderingContext => candidate === context,
+            getNodes: () => [{ id: "child", entity: child, getDisplayInfo: () => ({ name: "Child" }) }],
+            getSnapshot: () => [child],
+        });
+        const earlierPresentationRegistration = service.addRenderingContextPresentationProvider({
+            predicate: (candidate): candidate is RenderingContext => candidate === context,
+            getPresentation: () => ({ getDisplayInfo: () => ({ name: "Earlier presentation" }) }),
+        });
+        const preferredPresentationRegistration = service.addRenderingContextPresentationProvider({
+            predicate: (candidate): candidate is CustomRenderingContext => candidate === context,
+            getPresentation: () => ({ icon: CustomIcon }),
+        });
+
+        const preferredNode = getContextNode();
+        expect(preferredNode.getDisplayInfo().name).toBe("custom-rendering-context");
+        expect(renderToStaticMarkup(createElement(preferredNode.icon!, { entity: {} }))).toBe("<span>Custom context</span>");
+        expect(GetExplorerNodeChildren(context, [], paneOptions.nodeProviders?.items ?? [])[0].entity).toBe(child);
+        expect(onNodesChanged).toHaveBeenCalledTimes(3);
+
+        preferredPresentationRegistration.dispose();
+        preferredPresentationRegistration.dispose();
+        expect(getContextNode().getDisplayInfo().name).toBe("Earlier presentation");
+        expect(getContextNode().icon).toBeUndefined();
+
+        earlierPresentationRegistration.dispose();
+        expect(getContextNode().getDisplayInfo().name).toBe("custom-rendering-context");
+
+        childRegistration.dispose();
+        childRegistration.dispose();
+        expect(GetExplorerNodeChildren(context, [], paneOptions.nodeProviders?.items ?? [])).toEqual([]);
+        expect(onNodesChanged).toHaveBeenCalledTimes(6);
+
+        const ownedProvider = {
+            predicate: (candidate: RenderingContext): candidate is RenderingContext => candidate === context,
+            getPresentation: () => ({ icon: CustomIcon }),
+        } satisfies RenderingContextPresentationProvider<RenderingContext>;
+        const ownedRegistration = service.addRenderingContextPresentationProvider(ownedProvider);
+        expect(onNodesChanged).toHaveBeenCalledTimes(7);
+
+        service.dispose?.();
+        ownedRegistration.dispose();
+        ownedRegistration.dispose();
+        expect(() => service.addRenderingContextPresentationProvider(ownedProvider)).toThrow("Observable collection is disposed.");
+        expect(onNodesChanged).toHaveBeenCalledTimes(7);
+    });
+
+    it("routes shared commands to the Explorer and cleans them up", () => {
+        PaneRegistrations.length = 0;
+        const engine = {
+            surfaces: [] as unknown as EngineContext["surfaces"],
+            _renderingContexts: [],
+        } as unknown as EngineContext;
+        (engine as { surfaces: readonly SurfaceContext[] }).surfaces = [engine];
+        const watcherService = {
+            watchValue: vi.fn(() => ({ dispose: vi.fn() })),
+        } as unknown as IWatcherService;
+
+        const service = EngineExplorerServiceDefinition.factory({ engine } as IEngineContext, {} as IShellService, {} as ISelectionService, watcherService)!;
+        const sharedService: IExplorerService = service;
+        const itemCommand = { predicate: (context: unknown): context is Mesh => true, getCommand: () => ({}) };
+        const groupCommand = { predicate: (context: unknown): context is "Resources" => context === "Resources", getCommand: () => ({}) };
+        const itemRegistration = sharedService.addItemCommand(itemCommand as never);
+        const groupRegistration = sharedService.addGroupCommand(groupCommand as never);
+        const paneOptions = PaneRegistrations.at(-1)!.options;
+
+        expect(paneOptions.itemCommandProviders?.items).toEqual([itemCommand]);
+        expect(paneOptions.groupCommandProviders?.items).toEqual([groupCommand]);
+
+        itemRegistration.dispose();
+        groupRegistration.dispose();
+        expect(paneOptions.itemCommandProviders?.items).toEqual([]);
+        expect(paneOptions.groupCommandProviders?.items).toEqual([]);
+
+        sharedService.addItemCommand(itemCommand as never);
+        sharedService.addGroupCommand(groupCommand as never);
+        service.dispose?.();
+        expect(paneOptions.itemCommandProviders?.items).toEqual([]);
+        expect(paneOptions.groupCommandProviders?.items).toEqual([]);
     });
 });
 
 describe("Babylon Lite scene resource explorer services", () => {
     it("registers product-specific providers with the engine explorer", () => {
-        expect(EngineExplorerServiceDefinition.produces).toEqual([EngineExplorerServiceIdentity]);
+        expect(EngineExplorerServiceDefinition.produces).toEqual([EngineExplorerServiceIdentity, ExplorerServiceIdentity]);
         expect(MeshExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity, WatcherServiceIdentity]);
         expect(MaterialExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity, WatcherServiceIdentity]);
         expect(TextureExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity]);

--- a/packages/dev/inspector-v2/test/unit/sceneExplorerSection.test.ts
+++ b/packages/dev/inspector-v2/test/unit/sceneExplorerSection.test.ts
@@ -8,6 +8,7 @@ import { type ExplorerPaneOptions } from "../../src/services/panes/explorer/expl
 import { type ISceneContext, SceneContextIdentity } from "../../src/services/sceneContext";
 import { type ISelectionService } from "../../src/services/selectionService";
 import { SceneExplorerServiceDefinition } from "../../src/services/panes/scene/sceneExplorerService";
+import { GetExplorerNodeChildren, type IExplorerService, ExplorerServiceIdentity } from "../../src/services/panes/explorer/explorerService";
 import { type IShellService } from "shared-ui-components/modularTool/services/shellService";
 
 vi.hoisted(() => {
@@ -58,10 +59,10 @@ function CreateTestSceneExplorerService() {
         get groupCommands() {
             return [...(registration.options.groupCommandProviders?.items ?? [])];
         },
-        getNodes: () => registration.options.getNodes(),
-        get onNodesChanged() {
-            return registration.options.onNodesChanged;
+        get nodeProviders() {
+            return [...(registration.options.nodeProviders?.items ?? [])];
         },
+        getNodes: () => GetExplorerNodeChildren(scene, registration.options.getNodes(), registration.options.nodeProviders?.items ?? []),
     };
 }
 
@@ -106,6 +107,9 @@ describe("SceneExplorerService", () => {
 
     it("owns a single side pane titled Scene Explorer", () => {
         const service = CreateTestSceneExplorerService();
+        service.sceneExplorerService.addSection(CreateTestSection("Nodes", [{ name: "Mesh" }]));
+        service.sceneExplorerService.addItemCommand({ predicate: (context): context is TestEntity => true, getCommand: () => ({}) } as never);
+        service.sceneExplorerService.addGroupCommand({ predicate: (context): context is "Nodes" => context === "Nodes", getCommand: () => ({}) } as never);
 
         expect(PaneRegistrations).toHaveLength(1);
         expect(service.registration.options.title).toBe("Scene Explorer");
@@ -113,6 +117,10 @@ describe("SceneExplorerService", () => {
 
         service.sceneExplorerService.dispose?.();
         expect(service.registration.isDisposed).toBe(true);
+        expect(service.getNodes()).toEqual([]);
+        expect(service.nodeProviders).toEqual([]);
+        expect(service.itemCommands).toEqual([]);
+        expect(service.groupCommands).toEqual([]);
     });
 
     it("supplies the current scene and the Scene label as the explorer root", () => {
@@ -126,6 +134,7 @@ describe("SceneExplorerService", () => {
     it("consumes the scene context (and not a generic target context)", () => {
         expect(SceneExplorerServiceDefinition.consumes?.[0]).toBe(SceneContextIdentity);
         expect(SceneExplorerServiceDefinition.consumes).toHaveLength(3);
+        expect(SceneExplorerServiceDefinition.produces).toContain(ExplorerServiceIdentity);
     });
 
     it("adapts sections into explorer nodes ordered by section order", () => {
@@ -193,7 +202,7 @@ describe("SceneExplorerService", () => {
     it("notifies the explorer when sections are added or removed", () => {
         const service = CreateTestSceneExplorerService();
         let notifications = 0;
-        service.onNodesChanged?.add(() => notifications++);
+        service.registration.options.nodeProviders?.observable.add(() => notifications++);
 
         const registration = service.sceneExplorerService.addSection(CreateTestSection("Nodes", [{ name: "Mesh" }]));
         expect(notifications).toBe(1);
@@ -207,11 +216,39 @@ describe("SceneExplorerService", () => {
         const service = CreateTestSceneExplorerService();
         const entityCommand = { predicate: (context: unknown): context is TestEntity => true, getCommand: () => ({}) };
         const sectionCommand = { predicate: (context: unknown): context is "Nodes" => context === "Nodes", getCommand: () => ({}) };
+        const sharedService: IExplorerService = service.sceneExplorerService;
 
-        service.sceneExplorerService.addEntityCommand(entityCommand as never);
-        service.sceneExplorerService.addSectionCommand(sectionCommand as never);
+        const entityRegistration = service.sceneExplorerService.addEntityCommand(entityCommand as never);
+        const sectionRegistration = service.sceneExplorerService.addSectionCommand(sectionCommand as never);
 
         expect(service.itemCommands).toEqual([entityCommand]);
         expect(service.groupCommands).toEqual([sectionCommand]);
+
+        entityRegistration.dispose();
+        sectionRegistration.dispose();
+        expect(service.itemCommands).toEqual([]);
+        expect(service.groupCommands).toEqual([]);
+
+        sharedService.addItemCommand(entityCommand as never);
+        sharedService.addGroupCommand(sectionCommand as never);
+        expect(service.itemCommands).toEqual([entityCommand]);
+        expect(service.groupCommands).toEqual([sectionCommand]);
+    });
+
+    it("routes shared hierarchy providers through the same Explorer pane", () => {
+        const service = CreateTestSceneExplorerService();
+        const customEntity = {};
+        const sharedService: IExplorerService = service.sceneExplorerService;
+        const registration = sharedService.addNodeProvider({
+            predicate: (parent): parent is object => parent === service.scene,
+            getNodes: () => [{ id: "custom", entity: customEntity, getDisplayInfo: () => ({ name: "Custom" }) }],
+        });
+
+        expect(service.nodeProviders).toHaveLength(1);
+        expect(service.getNodes()[0].entity).toBe(customEntity);
+
+        registration.dispose();
+        registration.dispose();
+        expect(service.getNodes()).toEqual([]);
     });
 });

--- a/packages/dev/sharedUiComponents/src/modularTool/hooks/observableHooks.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/hooks/observableHooks.ts
@@ -1,6 +1,6 @@
 import { type IReadonlyObservable } from "core/index";
 
-import { type ObservableCollection } from "../misc/observableCollection";
+import { type IReadonlyObservableCollection } from "../misc/observableCollection";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -84,7 +84,7 @@ export function useObservableState<T>(accessor: () => T, ...observables: Array<I
  * @param collection The collection to observe.
  * @returns A copy of the items in the collection.
  */
-export function useObservableCollection<T>(collection: ObservableCollection<T>) {
+export function useObservableCollection<T>(collection: IReadonlyObservableCollection<T>) {
     const itemsRef = useRef([...collection.items]);
     return useObservableState(
         useCallback(() => {
@@ -102,7 +102,7 @@ export function useObservableCollection<T>(collection: ObservableCollection<T>) 
  * @param collection The collection to observe.
  * @returns A copy of the items in the collection sorted by the order property.
  */
-export function useOrderedObservableCollection<T extends Readonly<{ order?: number }>>(collection: ObservableCollection<T>) {
+export function useOrderedObservableCollection<T extends Readonly<{ order?: number }>>(collection: IReadonlyObservableCollection<T>) {
     const items = useObservableCollection(collection);
     const sortedItems = useMemo(() => items.sort((a, b) => (a.order ?? 0) - (b.order ?? 0)), [items]);
     return sortedItems;

--- a/packages/dev/sharedUiComponents/src/modularTool/misc/observableCollection.ts
+++ b/packages/dev/sharedUiComponents/src/modularTool/misc/observableCollection.ts
@@ -3,12 +3,28 @@ import { type IDisposable, type IReadonlyObservable } from "core/index";
 import { Observable } from "core/Misc/observable";
 
 /**
+ * A read-only view of a collection whose changes can be observed.
+ */
+export interface IReadonlyObservableCollection<T> {
+    /**
+     * An observable that notifies observers when the collection changes.
+     */
+    readonly observable: IReadonlyObservable<void>;
+
+    /**
+     * The items in the collection.
+     */
+    readonly items: readonly T[];
+}
+
+/**
  * A collection of items that can be observed for changes.
  */
-export class ObservableCollection<T> {
+export class ObservableCollection<T> implements IReadonlyObservableCollection<T>, IDisposable {
     private readonly _items: T[] = [];
     private readonly _keys: symbol[] = [];
     private readonly _observable = new Observable<void>();
+    private _isDisposed = false;
 
     /**
      * An observable that notifies observers when the collection changes.
@@ -30,6 +46,10 @@ export class ObservableCollection<T> {
      * @returns A disposable that removes the item from the collection when disposed.
      */
     public add(item: T): IDisposable {
+        if (this._isDisposed) {
+            throw new Error("Observable collection is disposed.");
+        }
+
         const key = Symbol();
         this._items.push(item);
         this._keys.push(key);
@@ -38,10 +58,29 @@ export class ObservableCollection<T> {
         return {
             dispose: () => {
                 const index = this._keys.indexOf(key);
+                if (index === -1) {
+                    return;
+                }
+
                 this._items.splice(index, 1);
                 this._keys.splice(index, 1);
                 this._observable.notifyObservers();
             },
         };
+    }
+
+    /**
+     * Removes all items and observers and rejects subsequent additions.
+     */
+    public dispose(): void {
+        if (this._isDisposed) {
+            return;
+        }
+
+        this._isDisposed = true;
+        this._items.length = 0;
+        this._keys.length = 0;
+        this._observable.notifyObservers();
+        this._observable.clear();
     }
 }

--- a/packages/dev/sharedUiComponents/test/unit/modularTool/observableCollection.test.ts
+++ b/packages/dev/sharedUiComponents/test/unit/modularTool/observableCollection.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ObservableCollection } from "../../../src/modularTool/misc/observableCollection";
+
+describe("ObservableCollection", () => {
+    it("owns its registrations and rejects additions after disposal", () => {
+        const collection = new ObservableCollection<object>();
+        const onChanged = vi.fn();
+        collection.observable.add(onChanged);
+        const first = {};
+        const second = {};
+        const firstRegistration = collection.add(first);
+        const secondRegistration = collection.add(second);
+
+        firstRegistration.dispose();
+        firstRegistration.dispose();
+        expect(collection.items).toEqual([second]);
+
+        collection.dispose();
+        collection.dispose();
+        secondRegistration.dispose();
+        expect(collection.items).toEqual([]);
+        expect(onChanged).toHaveBeenCalledTimes(4);
+        expect(() => collection.add({})).toThrow("Observable collection is disposed.");
+    });
+});


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

Completes P1 of the Inspector Lite parity roadmap by introducing runtime-neutral Explorer contribution and lifecycle APIs shared by the Full and Lite Inspectors.

- Adds experimental `IExplorerService` APIs for recursive entity-attached node providers and generic item/group commands.
- Adapts the Full Scene Explorer to the shared layer while preserving `ISceneExplorerService`, scene sections, and entity/section command compatibility.
- Preserves the Lite Engine → Surface → Rendering Context hierarchy, including auxiliary surfaces and non-Scene rendering contexts.
- Adds Lite rendering-context child and presentation providers without exposing Full-only Scene Explorer section APIs through `@babylonjs/inspector/lite`.
- Centralizes registration ownership in `ObservableCollection` with idempotent removal, collection disposal, read-only views, and rejection after disposal.
- Cleans up provider observers, commands, display metadata, topology snapshots, and registrations when contributions are removed or Inspector services close.

## Behavior

- All matching hierarchy providers contribute nodes and are ordered for display.
- Rendering-context presentation is exclusive; the last registered matching provider wins, and unregistering it reveals the prior match.
- Topology updates detect resource transfer between rendering contexts and preserve selection while an entity remains represented elsewhere in the Explorer.

## Validation

- Shared UI Components and Inspector v2 TypeScript compilation
- 30 focused unit tests covering shared Explorer contracts, Full/Lite adapters, topology, selection, commands, presentation, observers, and disposal
- Targeted ESLint, Prettier, TypeDoc, and whitespace checks

## Related

Follows #18889, which introduced the Inspector Lite entry point and P0 hierarchy/resources support.