### PR TITLE
Add Babylon Lite scene entities to Inspector v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23096,6 +23096,7 @@
             "name": "@dev/shared-ui-components",
             "version": "1.0.0",
             "devDependencies": {
+                "@babylonjs/lite": "1.27.0",
                 "@dev/core": "^1.0.0",
                 "@dev/gui": "^1.0.0",
                 "@fluentui-contrib/react-resize-handle": "^0.8.4",
@@ -23451,16 +23452,23 @@
             "version": "9.26.0",
             "license": "Apache-2.0",
             "devDependencies": {
+                "@babylonjs/lite": "1.27.0",
                 "@dev/build-tools": "^1.0.0",
                 "@dev/shared-ui-components": "^1.0.0"
             },
             "peerDependencies": {
+                "@babylonjs/lite": "^1.27.0",
                 "@types/dagre": "^0.7.47",
                 "dagre": "^0.8.5",
                 "react": "^18.2.0",
                 "react-dnd": "15.0.1",
                 "react-dnd-touch-backend": "15.0.1",
                 "react-dom": "^18.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@babylonjs/lite": {
+                    "optional": true
+                }
             }
         },
         "packages/public/@babylonjs/smart-filters": {

--- a/packages/dev/inspector-v2/src/components/properties/boundProperty.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/boundProperty.tsx
@@ -190,6 +190,36 @@ export function ComputedProperty<TargetT extends object, ComponentT extends Comp
     return <Component {...({ ...rest, value } as ComponentProps<ComponentT>)} />;
 }
 
+export type DerivedPropertyProps<TargetT extends object, ComponentT extends ComponentType<any>> = Omit<ComponentProps<ComponentT>, "value" | "onChange"> & {
+    component: ComponentT;
+    target: TargetT;
+    getValue: (target: TargetT) => ComponentValue<ComponentT>;
+    setValue: (target: TargetT, value: ComponentValue<ComponentT>) => void;
+};
+
+/**
+ * Renders an editable property-line component for a value derived from a target.
+ *
+ * This is useful for method-backed values, readonly object references, or values whose UI
+ * representation differs from their stored representation. The getter follows the Preferred
+ * Watch Mode, while the setter owns the runtime-specific write-back.
+ * @param props The target, derived getter, write-back function, and property-line component props.
+ * @returns The editable derived property-line component.
+ */
+export function DerivedProperty<TargetT extends object, ComponentT extends ComponentType<any>>(props: DerivedPropertyProps<TargetT, ComponentT>) {
+    const {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        component: Component,
+        target,
+        getValue,
+        setValue,
+        ...rest
+    } = props;
+    const value = useWatchedValue(target, getValue);
+
+    return <Component {...({ ...rest, value, onChange: (changedValue: ComponentValue<ComponentT>) => setValue(target, changedValue) } as ComponentProps<ComponentT>)} />;
+}
+
 /**
  * Mutually exclusive propertyPath or functionPath - one required
  */

--- a/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
+++ b/packages/dev/inspector-v2/src/components/properties/metadataProperties.tsx
@@ -135,8 +135,12 @@ function SaveMetadata(entity: IMetadataContainer, metadata: string) {
     }
 }
 
+/**
+ * An inspected entity that can carry user-defined metadata.
+ */
 export interface IMetadataContainer {
-    metadata: unknown;
+    /** User-defined metadata associated with the inspected entity. */
+    metadata?: unknown;
 }
 
 const useStyles = makeStyles({

--- a/packages/dev/inspector-v2/src/lite/components/properties/cameraProperties.tsx
+++ b/packages/dev/inspector-v2/src/lite/components/properties/cameraProperties.tsx
@@ -1,0 +1,95 @@
+import { type ArcRotateCamera, type Camera, type FreeCamera, type Vec3 } from "@babylonjs/lite";
+import { type FunctionComponent } from "react";
+
+import { NumberInputPropertyLine, TextInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
+import { SyncedSliderPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/syncedSliderPropertyLine";
+
+import { BoundProperty, DerivedProperty } from "../../../components/properties/boundProperty";
+import { useAngleConverters } from "../../../hooks/settingsHooks";
+import { SetVector3Value } from "../../sceneEntityUtils";
+import { Vector3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/vectorPropertyLine";
+
+function GetPosition(camera: FreeCamera): readonly [number, number, number] {
+    return [camera.position.x, camera.position.y, camera.position.z];
+}
+
+function GetTarget(camera: ArcRotateCamera | FreeCamera): readonly [number, number, number] {
+    return [camera.target.x, camera.target.y, camera.target.z];
+}
+
+function SetFreeCameraPosition(camera: FreeCamera, value: Vec3 | readonly [number, number, number]): void {
+    SetVector3Value(camera.position, value);
+}
+
+function SetCameraTarget(camera: ArcRotateCamera | FreeCamera, value: Vec3 | readonly [number, number, number]): void {
+    SetVector3Value(camera.target, value);
+}
+
+export const CameraGeneralProperties: FunctionComponent<{ camera: Camera }> = (props) => {
+    const { camera } = props;
+    const [toDisplayAngle, fromDisplayAngle, useDegrees] = useAngleConverters();
+
+    return (
+        <>
+            <BoundProperty component={TextInputPropertyLine} label="Name" target={camera} propertyKey="name" ignoreNullable defaultValue="" />
+            <BoundProperty component={NumberInputPropertyLine} label="Near Plane" target={camera} propertyKey="nearPlane" />
+            <BoundProperty component={NumberInputPropertyLine} label="Far Plane" target={camera} propertyKey="farPlane" />
+            <BoundProperty
+                component={SyncedSliderPropertyLine}
+                label="FOV"
+                target={camera}
+                propertyKey="fov"
+                min={toDisplayAngle(0.1)}
+                max={toDisplayAngle(Math.PI)}
+                step={toDisplayAngle(0.01)}
+                unit={useDegrees ? "°" : "rad"}
+                convertTo={toDisplayAngle}
+                convertFrom={fromDisplayAngle}
+            />
+        </>
+    );
+};
+
+export const FreeCameraTransformProperties: FunctionComponent<{ camera: FreeCamera }> = (props) => {
+    const { camera } = props;
+
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Position" target={camera} getValue={GetPosition} setValue={SetFreeCameraPosition} />
+            <DerivedProperty component={Vector3PropertyLine} label="Target" target={camera} getValue={GetTarget} setValue={SetCameraTarget} />
+            <BoundProperty component={NumberInputPropertyLine} label="Speed" target={camera} propertyKey="speed" />
+            <BoundProperty component={NumberInputPropertyLine} label="Inertia" target={camera} propertyKey="inertia" min={0} max={1} />
+        </>
+    );
+};
+
+export const ArcRotateCameraTransformProperties: FunctionComponent<{ camera: ArcRotateCamera }> = (props) => {
+    const { camera } = props;
+    const [toDisplayAngle, fromDisplayAngle, useDegrees] = useAngleConverters();
+
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Target" target={camera} getValue={GetTarget} setValue={SetCameraTarget} />
+            <BoundProperty
+                component={NumberInputPropertyLine}
+                label="Alpha"
+                target={camera}
+                propertyKey="alpha"
+                unit={useDegrees ? "°" : "rad"}
+                convertTo={toDisplayAngle}
+                convertFrom={fromDisplayAngle}
+            />
+            <BoundProperty
+                component={NumberInputPropertyLine}
+                label="Beta"
+                target={camera}
+                propertyKey="beta"
+                unit={useDegrees ? "°" : "rad"}
+                convertTo={toDisplayAngle}
+                convertFrom={fromDisplayAngle}
+            />
+            <BoundProperty component={NumberInputPropertyLine} label="Radius" target={camera} propertyKey="radius" min={0} />
+            <BoundProperty component={NumberInputPropertyLine} label="Inertia" target={camera} propertyKey="inertia" min={0} max={1} />
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/lite/components/properties/lightProperties.tsx
+++ b/packages/dev/inspector-v2/src/lite/components/properties/lightProperties.tsx
@@ -1,0 +1,74 @@
+import { type DirectionalLight, type HemisphericLight, type LightBase, type PointLight, type SpotLight, type Vec3 } from "@babylonjs/lite";
+import { type FunctionComponent } from "react";
+
+import { NumberInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
+import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
+
+import { BoundProperty, DerivedProperty } from "../../../components/properties/boundProperty";
+import { SetVector3Value } from "../../sceneEntityUtils";
+import { Color3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/colorPropertyLine";
+import { Vector3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/vectorPropertyLine";
+
+function GetVector3(value: Vec3): readonly [number, number, number] {
+    return [value.x, value.y, value.z];
+}
+
+export const LightGeneralProperties: FunctionComponent<{ light: LightBase }> = (props) => {
+    const { light } = props;
+    return <TextPropertyLine label="Type" value={light.lightType} />;
+};
+
+export const DirectionalLightSetupProperties: FunctionComponent<{ light: DirectionalLight }> = (props) => {
+    const { light } = props;
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Position" target={light.position} getValue={GetVector3} setValue={SetVector3Value} />
+            <DerivedProperty component={Vector3PropertyLine} label="Direction" target={light.direction} getValue={GetVector3} setValue={SetVector3Value} />
+            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuse" isLinearMode />
+            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specular" isLinearMode />
+            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
+        </>
+    );
+};
+
+export const PointLightSetupProperties: FunctionComponent<{ light: PointLight }> = (props) => {
+    const { light } = props;
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Position" target={light.position} getValue={GetVector3} setValue={SetVector3Value} />
+            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuse" isLinearMode />
+            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specular" isLinearMode />
+            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
+            <BoundProperty component={NumberInputPropertyLine} label="Range" target={light} propertyKey="range" />
+        </>
+    );
+};
+
+export const SpotLightSetupProperties: FunctionComponent<{ light: SpotLight }> = (props) => {
+    const { light } = props;
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Position" target={light.position} getValue={GetVector3} setValue={SetVector3Value} />
+            <DerivedProperty component={Vector3PropertyLine} label="Direction" target={light.direction} getValue={GetVector3} setValue={SetVector3Value} />
+            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuse" isLinearMode />
+            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specular" isLinearMode />
+            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
+            <BoundProperty component={NumberInputPropertyLine} label="Range" target={light} propertyKey="range" />
+            <BoundProperty component={NumberInputPropertyLine} label="Angle" target={light} propertyKey="angle" unit="rad" min={0} max={Math.PI} />
+            <BoundProperty component={NumberInputPropertyLine} label="Exponent" target={light} propertyKey="exponent" min={0} />
+        </>
+    );
+};
+
+export const HemisphericLightSetupProperties: FunctionComponent<{ light: HemisphericLight }> = (props) => {
+    const { light } = props;
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Direction" target={light.direction} getValue={GetVector3} setValue={SetVector3Value} />
+            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuseColor" isLinearMode />
+            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specularColor" isLinearMode />
+            <BoundProperty component={Color3PropertyLine} label="Ground" target={light} propertyKey="groundColor" isLinearMode />
+            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/lite/components/properties/lightProperties.tsx
+++ b/packages/dev/inspector-v2/src/lite/components/properties/lightProperties.tsx
@@ -6,11 +6,97 @@ import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/
 
 import { BoundProperty, DerivedProperty } from "../../../components/properties/boundProperty";
 import { SetVector3Value } from "../../sceneEntityUtils";
-import { Color3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/colorPropertyLine";
+import { Color3PropertyLine, type Color3Value } from "shared-ui-components/lite/fluent/hoc/propertyLines/colorPropertyLine";
 import { Vector3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/vectorPropertyLine";
+
+type DirtyVector = Vec3 & { set(x: number, y: number, z: number): void };
+type LightPropertyTarget = ({ direction: DirtyVector } | { position: DirtyVector }) & object;
+type ColoredLight = DirectionalLight | PointLight | SpotLight;
+type EditableLight = ColoredLight | HemisphericLight;
+type RangedLight = PointLight | SpotLight;
 
 function GetVector3(value: Vec3): readonly [number, number, number] {
     return [value.x, value.y, value.z];
+}
+
+/**
+ * Updates a plain Babylon Lite light property and marks its GPU light data dirty through a public observable transform.
+ * @param light The light to update.
+ * @param propertyKey The property to update.
+ * @param value The new property value.
+ */
+export function SetLightProperty<T extends LightPropertyTarget, K extends keyof T>(light: T, propertyKey: K, value: T[K]): void {
+    light[propertyKey] = value;
+    const dirtyVector = "direction" in light ? light.direction : light.position;
+    dirtyVector.set(dirtyVector.x, dirtyVector.y, dirtyVector.z);
+}
+
+function GetDiffuse(light: ColoredLight): ColoredLight["diffuse"] {
+    return light.diffuse;
+}
+
+function ToColorTuple(value: Color3Value): [number, number, number] {
+    return "r" in value ? [value.r, value.g, value.b] : [value[0], value[1], value[2]];
+}
+
+function SetDiffuse(light: ColoredLight, value: Color3Value): void {
+    SetLightProperty(light, "diffuse", ToColorTuple(value));
+}
+
+function GetSpecular(light: ColoredLight): ColoredLight["specular"] {
+    return light.specular;
+}
+
+function SetSpecular(light: ColoredLight, value: Color3Value): void {
+    SetLightProperty(light, "specular", ToColorTuple(value));
+}
+
+function GetIntensity(light: EditableLight): number {
+    return light.intensity;
+}
+
+function SetIntensity(light: EditableLight, value: number): void {
+    SetLightProperty(light, "intensity", value);
+}
+
+function GetRange(light: RangedLight): number {
+    return light.range;
+}
+
+function SetRange(light: RangedLight, value: number): void {
+    SetLightProperty(light, "range", value);
+}
+
+function GetExponent(light: SpotLight): number {
+    return light.exponent;
+}
+
+function SetExponent(light: SpotLight, value: number): void {
+    SetLightProperty(light, "exponent", value);
+}
+
+function GetDiffuseColor(light: HemisphericLight): HemisphericLight["diffuseColor"] {
+    return light.diffuseColor;
+}
+
+function SetDiffuseColor(light: HemisphericLight, value: Color3Value): void {
+    SetLightProperty(light, "diffuseColor", ToColorTuple(value));
+}
+
+function GetSpecularColor(light: HemisphericLight): HemisphericLight["specularColor"] {
+    return light.specularColor;
+}
+
+function SetSpecularColor(light: HemisphericLight, value: Color3Value): void {
+    SetLightProperty(light, "specularColor", ToColorTuple(value));
+}
+
+function GetGroundColor(light: HemisphericLight): HemisphericLight["groundColor"] {
+    return light.groundColor;
+}
+
+function SetGroundColor(light: HemisphericLight, value: Color3Value): void {
+    SetLightProperty(light, "groundColor", ToColorTuple(value));
 }
 
 export const LightGeneralProperties: FunctionComponent<{ light: LightBase }> = (props) => {
@@ -24,9 +110,9 @@ export const DirectionalLightSetupProperties: FunctionComponent<{ light: Directi
         <>
             <DerivedProperty component={Vector3PropertyLine} label="Position" target={light.position} getValue={GetVector3} setValue={SetVector3Value} />
             <DerivedProperty component={Vector3PropertyLine} label="Direction" target={light.direction} getValue={GetVector3} setValue={SetVector3Value} />
-            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuse" isLinearMode />
-            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specular" isLinearMode />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
+            <DerivedProperty component={Color3PropertyLine} label="Diffuse" target={light} getValue={GetDiffuse} setValue={SetDiffuse} isLinearMode />
+            <DerivedProperty component={Color3PropertyLine} label="Specular" target={light} getValue={GetSpecular} setValue={SetSpecular} isLinearMode />
+            <DerivedProperty component={NumberInputPropertyLine} label="Intensity" target={light} getValue={GetIntensity} setValue={SetIntensity} />
         </>
     );
 };
@@ -36,10 +122,10 @@ export const PointLightSetupProperties: FunctionComponent<{ light: PointLight }>
     return (
         <>
             <DerivedProperty component={Vector3PropertyLine} label="Position" target={light.position} getValue={GetVector3} setValue={SetVector3Value} />
-            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuse" isLinearMode />
-            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specular" isLinearMode />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
-            <BoundProperty component={NumberInputPropertyLine} label="Range" target={light} propertyKey="range" />
+            <DerivedProperty component={Color3PropertyLine} label="Diffuse" target={light} getValue={GetDiffuse} setValue={SetDiffuse} isLinearMode />
+            <DerivedProperty component={Color3PropertyLine} label="Specular" target={light} getValue={GetSpecular} setValue={SetSpecular} isLinearMode />
+            <DerivedProperty component={NumberInputPropertyLine} label="Intensity" target={light} getValue={GetIntensity} setValue={SetIntensity} />
+            <DerivedProperty component={NumberInputPropertyLine} label="Range" target={light} getValue={GetRange} setValue={SetRange} />
         </>
     );
 };
@@ -50,12 +136,12 @@ export const SpotLightSetupProperties: FunctionComponent<{ light: SpotLight }> =
         <>
             <DerivedProperty component={Vector3PropertyLine} label="Position" target={light.position} getValue={GetVector3} setValue={SetVector3Value} />
             <DerivedProperty component={Vector3PropertyLine} label="Direction" target={light.direction} getValue={GetVector3} setValue={SetVector3Value} />
-            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuse" isLinearMode />
-            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specular" isLinearMode />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
-            <BoundProperty component={NumberInputPropertyLine} label="Range" target={light} propertyKey="range" />
+            <DerivedProperty component={Color3PropertyLine} label="Diffuse" target={light} getValue={GetDiffuse} setValue={SetDiffuse} isLinearMode />
+            <DerivedProperty component={Color3PropertyLine} label="Specular" target={light} getValue={GetSpecular} setValue={SetSpecular} isLinearMode />
+            <DerivedProperty component={NumberInputPropertyLine} label="Intensity" target={light} getValue={GetIntensity} setValue={SetIntensity} />
+            <DerivedProperty component={NumberInputPropertyLine} label="Range" target={light} getValue={GetRange} setValue={SetRange} />
             <BoundProperty component={NumberInputPropertyLine} label="Angle" target={light} propertyKey="angle" unit="rad" min={0} max={Math.PI} />
-            <BoundProperty component={NumberInputPropertyLine} label="Exponent" target={light} propertyKey="exponent" min={0} />
+            <DerivedProperty component={NumberInputPropertyLine} label="Exponent" target={light} getValue={GetExponent} setValue={SetExponent} min={0} />
         </>
     );
 };
@@ -65,10 +151,10 @@ export const HemisphericLightSetupProperties: FunctionComponent<{ light: Hemisph
     return (
         <>
             <DerivedProperty component={Vector3PropertyLine} label="Direction" target={light.direction} getValue={GetVector3} setValue={SetVector3Value} />
-            <BoundProperty component={Color3PropertyLine} label="Diffuse" target={light} propertyKey="diffuseColor" isLinearMode />
-            <BoundProperty component={Color3PropertyLine} label="Specular" target={light} propertyKey="specularColor" isLinearMode />
-            <BoundProperty component={Color3PropertyLine} label="Ground" target={light} propertyKey="groundColor" isLinearMode />
-            <BoundProperty component={NumberInputPropertyLine} label="Intensity" target={light} propertyKey="intensity" />
+            <DerivedProperty component={Color3PropertyLine} label="Diffuse" target={light} getValue={GetDiffuseColor} setValue={SetDiffuseColor} isLinearMode />
+            <DerivedProperty component={Color3PropertyLine} label="Specular" target={light} getValue={GetSpecularColor} setValue={SetSpecularColor} isLinearMode />
+            <DerivedProperty component={Color3PropertyLine} label="Ground" target={light} getValue={GetGroundColor} setValue={SetGroundColor} isLinearMode />
+            <DerivedProperty component={NumberInputPropertyLine} label="Intensity" target={light} getValue={GetIntensity} setValue={SetIntensity} />
         </>
     );
 };

--- a/packages/dev/inspector-v2/src/lite/components/properties/sceneNodeProperties.tsx
+++ b/packages/dev/inspector-v2/src/lite/components/properties/sceneNodeProperties.tsx
@@ -1,0 +1,76 @@
+import { setSubtreeVisible, type SceneNode } from "@babylonjs/lite";
+import { type FunctionComponent } from "react";
+
+import { TextInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
+import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
+import { useSetting } from "shared-ui-components/modularTool/hooks/settingsHooks";
+
+import { BoundProperty, DerivedProperty } from "../../../components/properties/boundProperty";
+import { UseDegreesSettingDescriptor, UseEulerSettingDescriptor } from "../../../services/globalSettings";
+import { SetQuaternionValue, SetVector3Value } from "../../sceneEntityUtils";
+import { QuaternionPropertyLine, Vector3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/vectorPropertyLine";
+
+function GetPosition(node: SceneNode): readonly [number, number, number] {
+    return [node.position.x, node.position.y, node.position.z];
+}
+
+function GetRotation(node: SceneNode): readonly [number, number, number, number] {
+    return [node.rotationQuaternion.x, node.rotationQuaternion.y, node.rotationQuaternion.z, node.rotationQuaternion.w];
+}
+
+function GetScaling(node: SceneNode): readonly [number, number, number] {
+    return [node.scaling.x, node.scaling.y, node.scaling.z];
+}
+
+function GetVisibility(node: SceneNode): boolean {
+    return node.visible !== false;
+}
+
+function SetVisibility(node: SceneNode, visible: boolean): void {
+    setSubtreeVisible(node, visible);
+}
+
+function SetPosition(node: SceneNode, value: Parameters<typeof SetVector3Value>[1]): void {
+    SetVector3Value(node.position, value);
+}
+
+function SetRotation(node: SceneNode, value: Parameters<typeof SetQuaternionValue>[1]): void {
+    SetQuaternionValue(node.rotationQuaternion, value);
+}
+
+function SetScaling(node: SceneNode, value: Parameters<typeof SetVector3Value>[1]): void {
+    SetVector3Value(node.scaling, value);
+}
+
+export const SceneNodeGeneralProperties: FunctionComponent<{ node: SceneNode }> = (props) => {
+    const { node } = props;
+
+    return (
+        <>
+            <BoundProperty component={TextInputPropertyLine} label="Name" target={node} propertyKey="name" />
+            <DerivedProperty component={SwitchPropertyLine} label="Visible" target={node} getValue={GetVisibility} setValue={SetVisibility} />
+        </>
+    );
+};
+
+export const SceneNodeTransformProperties: FunctionComponent<{ node: SceneNode }> = (props) => {
+    const { node } = props;
+    const [useDegrees] = useSetting(UseDegreesSettingDescriptor);
+    const [useEuler] = useSetting(UseEulerSettingDescriptor);
+
+    return (
+        <>
+            <DerivedProperty component={Vector3PropertyLine} label="Position" target={node} getValue={GetPosition} setValue={SetPosition} />
+            <DerivedProperty
+                component={QuaternionPropertyLine}
+                label="Rotation"
+                target={node}
+                getValue={GetRotation}
+                setValue={SetRotation}
+                useDegrees={useDegrees}
+                useEuler={useEuler}
+            />
+            <DerivedProperty component={Vector3PropertyLine} label="Scaling" target={node} getValue={GetScaling} setValue={SetScaling} step={0.1} />
+        </>
+    );
+};

--- a/packages/dev/inspector-v2/src/lite/inspector.tsx
+++ b/packages/dev/inspector-v2/src/lite/inspector.tsx
@@ -13,13 +13,20 @@ import { type IEngineContext, EngineContextIdentity } from "./engineContext";
 import { EngineExplorerServiceDefinition } from "./engineExplorerService";
 import { EngineSelectionServiceDefinition } from "./engineSelectionService";
 import { EnginePropertiesServiceDefinition } from "./services/panes/properties/enginePropertiesService";
+import { CameraPropertiesServiceDefinition } from "./services/panes/properties/cameraPropertiesService";
+import { LightPropertiesServiceDefinition } from "./services/panes/properties/lightPropertiesService";
 import { MaterialPropertiesServiceDefinition } from "./services/panes/properties/materialPropertiesService";
 import { MeshPropertiesServiceDefinition } from "./services/panes/properties/meshPropertiesService";
 import { RenderingContextPropertiesServiceDefinition } from "./services/panes/properties/renderingContextPropertiesService";
+import { SceneNodePropertiesServiceDefinition } from "./services/panes/properties/sceneNodePropertiesService";
+import { ShadowGeneratorPropertiesServiceDefinition } from "./services/panes/properties/shadowGeneratorPropertiesService";
 import { TextLayerPropertiesServiceDefinition } from "./services/panes/properties/textLayerPropertiesService";
 import { TexturePropertiesServiceDefinition } from "./services/panes/properties/texturePropertiesService";
+import { CameraExplorerServiceDefinition } from "./services/panes/scene/cameraExplorerService";
+import { LightExplorerServiceDefinition } from "./services/panes/scene/lightExplorerService";
 import { MaterialExplorerServiceDefinition } from "./services/panes/scene/materialExplorerService";
 import { MeshExplorerServiceDefinition } from "./services/panes/scene/meshExplorerService";
+import { ShadowGeneratorExplorerServiceDefinition } from "./services/panes/scene/shadowGeneratorExplorerService";
 import { TextLayerExplorerServiceDefinition } from "./services/panes/scene/textLayerExplorerService";
 import { TextureExplorerServiceDefinition } from "./services/panes/scene/textureExplorerService";
 
@@ -63,13 +70,20 @@ export function ShowInspector(engine: EngineContext, options: Partial<InspectorO
                 watcherServiceDefinition,
                 EngineExplorerServiceDefinition,
                 MeshExplorerServiceDefinition,
+                CameraExplorerServiceDefinition,
+                LightExplorerServiceDefinition,
+                ShadowGeneratorExplorerServiceDefinition,
                 MaterialExplorerServiceDefinition,
                 TextureExplorerServiceDefinition,
                 TextLayerExplorerServiceDefinition,
                 PropertiesServiceDefinition,
                 EnginePropertiesServiceDefinition,
                 RenderingContextPropertiesServiceDefinition,
+                SceneNodePropertiesServiceDefinition,
                 MeshPropertiesServiceDefinition,
+                CameraPropertiesServiceDefinition,
+                LightPropertiesServiceDefinition,
+                ShadowGeneratorPropertiesServiceDefinition,
                 MaterialPropertiesServiceDefinition,
                 TexturePropertiesServiceDefinition,
                 TextLayerPropertiesServiceDefinition,

--- a/packages/dev/inspector-v2/src/lite/sceneEntityUtils.ts
+++ b/packages/dev/inspector-v2/src/lite/sceneEntityUtils.ts
@@ -1,0 +1,157 @@
+import {
+    getRenderingContextKind,
+    getRenderingContexts,
+    type ArcRotateCamera,
+    type Camera,
+    type DirectionalLight,
+    type EngineContext,
+    type FreeCamera,
+    type HemisphericLight,
+    type LightBase,
+    type Mesh,
+    type ObservableQuat,
+    type ObservableVec3,
+    type PointLight,
+    type Quat,
+    type SceneContext,
+    type SceneNode,
+    type ShadowGenerator,
+    type SpotLight,
+    type Vec3,
+} from "@babylonjs/lite";
+
+export function GetSceneContexts(engine: EngineContext): readonly SceneContext[] {
+    return engine.surfaces.flatMap((surface) => getRenderingContexts(surface).filter((context): context is SceneContext => getRenderingContextKind(context) === "scene"));
+}
+
+export function IsSceneNode(entity: unknown): entity is SceneNode {
+    return (
+        typeof entity === "object" &&
+        entity !== null &&
+        "name" in entity &&
+        "children" in entity &&
+        "position" in entity &&
+        "rotationQuaternion" in entity &&
+        "scaling" in entity &&
+        "parent" in entity
+    );
+}
+
+export function IsMesh(entity: unknown): entity is Mesh {
+    return IsSceneNode(entity) && "material" in entity && "receiveShadows" in entity;
+}
+
+export function IsCamera(entity: unknown): entity is Camera {
+    return typeof entity === "object" && entity !== null && "fov" in entity && "nearPlane" in entity && "farPlane" in entity && "children" in entity && "worldMatrix" in entity;
+}
+
+export function IsArcRotateCamera(entity: unknown): entity is ArcRotateCamera {
+    return IsCamera(entity) && "alpha" in entity && "beta" in entity && "radius" in entity && "target" in entity;
+}
+
+export function IsFreeCamera(entity: unknown): entity is FreeCamera {
+    return IsCamera(entity) && "position" in entity && "target" in entity && "speed" in entity;
+}
+
+export function IsLight(entity: unknown): entity is LightBase {
+    return typeof entity === "object" && entity !== null && "lightType" in entity && "children" in entity && "parent" in entity && "worldMatrix" in entity;
+}
+
+export function IsDirectionalLight(entity: unknown): entity is DirectionalLight {
+    return IsLight(entity) && entity.lightType === "directional";
+}
+
+export function IsPointLight(entity: unknown): entity is PointLight {
+    return IsLight(entity) && entity.lightType === "point";
+}
+
+export function IsSpotLight(entity: unknown): entity is SpotLight {
+    return IsLight(entity) && entity.lightType === "spot";
+}
+
+export function IsHemisphericLight(entity: unknown): entity is HemisphericLight {
+    return IsLight(entity) && entity.lightType === "hemispheric";
+}
+
+export function GetSceneNodes(scene: SceneContext): readonly SceneNode[] {
+    const nodes = new Set<SceneNode>();
+    const addNode = (node: SceneNode) => {
+        if (nodes.has(node)) {
+            return;
+        }
+
+        nodes.add(node);
+        for (const child of node.children) {
+            addNode(child);
+        }
+    };
+
+    for (const mesh of scene.meshes) {
+        let root: SceneNode = mesh;
+        while (IsSceneNode(root.parent)) {
+            root = root.parent;
+        }
+        addNode(root);
+    }
+
+    return [...nodes];
+}
+
+export function GetSceneNodeRoots(scene: SceneContext): readonly SceneNode[] {
+    const nodes = GetSceneNodes(scene);
+    const nodeSet = new Set(nodes);
+    return nodes.filter((node) => !IsSceneNode(node.parent) || !nodeSet.has(node.parent));
+}
+
+export function IsSceneNodeDescendantOf(node: SceneNode, ancestor: SceneNode): boolean {
+    let parent = node.parent;
+    while (IsSceneNode(parent)) {
+        if (parent === ancestor) {
+            return true;
+        }
+        parent = parent.parent;
+    }
+    return false;
+}
+
+export function SetVector3Value(target: Vec3, value: Vec3 | readonly [number, number, number]): void {
+    const x = "x" in value ? value.x : value[0];
+    const y = "x" in value ? value.y : value[1];
+    const z = "x" in value ? value.z : value[2];
+    const observableTarget = target as Partial<ObservableVec3>;
+
+    if (typeof observableTarget.set === "function") {
+        observableTarget.set(x, y, z);
+    } else {
+        target.x = x;
+        target.y = y;
+        target.z = z;
+    }
+}
+
+export function SetQuaternionValue(target: Quat, value: Quat | readonly [number, number, number, number]): void {
+    const x = "x" in value ? value.x : value[0];
+    const y = "x" in value ? value.y : value[1];
+    const z = "x" in value ? value.z : value[2];
+    const w = "x" in value ? value.w : value[3];
+    const observableTarget = target as Partial<ObservableQuat>;
+
+    if (typeof observableTarget.set === "function") {
+        observableTarget.set(x, y, z, w);
+    } else {
+        target.x = x;
+        target.y = y;
+        target.z = z;
+        target.w = w;
+    }
+}
+
+export function GetLightDisplayName(light: LightBase, index: number): string {
+    const typeName = `${light.lightType.charAt(0).toUpperCase()}${light.lightType.slice(1)}`;
+    return `${typeName} Light ${index + 1}`;
+}
+
+export function GetShadowGeneratorDisplayName(scene: SceneContext, shadowGenerator: ShadowGenerator): string {
+    const lightIndex = scene.lights.findIndex((light) => light.shadowGenerator === shadowGenerator);
+    return lightIndex === -1 ? `Shadow Generator ${scene.shadowGenerators.indexOf(shadowGenerator) + 1}` : `${GetLightDisplayName(scene.lights[lightIndex], lightIndex)} Shadows`;
+}

--- a/packages/dev/inspector-v2/src/lite/sceneEntityUtils.ts
+++ b/packages/dev/inspector-v2/src/lite/sceneEntityUtils.ts
@@ -103,11 +103,14 @@ export function GetSceneNodeRoots(scene: SceneContext): readonly SceneNode[] {
     return nodes.filter((node) => !IsSceneNode(node.parent) || !nodeSet.has(node.parent));
 }
 
-export function IsSceneNodeDescendantOf(node: SceneNode, ancestor: SceneNode): boolean {
+export function IsSceneNodeDescendantOf(node: SceneNode, ancestor: object): boolean {
     let parent = node.parent;
-    while (IsSceneNode(parent)) {
+    while (typeof parent === "object" && parent !== null) {
         if (parent === ancestor) {
             return true;
+        }
+        if (!IsSceneNode(parent)) {
+            return false;
         }
         parent = parent.parent;
     }

--- a/packages/dev/inspector-v2/src/lite/services/panes/properties/cameraPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/properties/cameraPropertiesService.tsx
@@ -1,0 +1,50 @@
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import { ArcRotateCameraTransformProperties, CameraGeneralProperties, FreeCameraTransformProperties } from "../../../components/properties/cameraProperties";
+import { IsArcRotateCamera, IsCamera, IsFreeCamera } from "../../../sceneEntityUtils";
+import { type IPropertiesService, PropertiesServiceIdentity } from "../../../../services/panes/properties/propertiesService";
+
+export const CameraPropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService]> = {
+    friendlyName: "Babylon Lite Camera Properties",
+    consumes: [PropertiesServiceIdentity],
+    factory: (propertiesService) => {
+        const cameraRegistration = propertiesService.addSectionContent({
+            key: "Babylon Lite Camera Properties",
+            predicate: IsCamera,
+            content: [
+                {
+                    section: "General",
+                    component: ({ context }) => <CameraGeneralProperties camera={context} />,
+                },
+            ],
+        });
+        const freeCameraRegistration = propertiesService.addSectionContent({
+            key: "Babylon Lite Free Camera Properties",
+            predicate: IsFreeCamera,
+            content: [
+                {
+                    section: "Transform",
+                    component: ({ context }) => <FreeCameraTransformProperties camera={context} />,
+                },
+            ],
+        });
+        const arcRotateCameraRegistration = propertiesService.addSectionContent({
+            key: "Babylon Lite Arc Rotate Camera Properties",
+            predicate: IsArcRotateCamera,
+            content: [
+                {
+                    section: "Transform",
+                    component: ({ context }) => <ArcRotateCameraTransformProperties camera={context} />,
+                },
+            ],
+        });
+
+        return {
+            dispose: () => {
+                arcRotateCameraRegistration.dispose();
+                freeCameraRegistration.dispose();
+                cameraRegistration.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/lite/services/panes/properties/lightPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/properties/lightPropertiesService.tsx
@@ -1,0 +1,49 @@
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import {
+    DirectionalLightSetupProperties,
+    HemisphericLightSetupProperties,
+    LightGeneralProperties,
+    PointLightSetupProperties,
+    SpotLightSetupProperties,
+} from "../../../components/properties/lightProperties";
+import { IsDirectionalLight, IsHemisphericLight, IsLight, IsPointLight, IsSpotLight } from "../../../sceneEntityUtils";
+import { type IPropertiesService, PropertiesServiceIdentity } from "../../../../services/panes/properties/propertiesService";
+
+export const LightPropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService]> = {
+    friendlyName: "Babylon Lite Light Properties",
+    consumes: [PropertiesServiceIdentity],
+    factory: (propertiesService) => {
+        const registrations = [
+            propertiesService.addSectionContent({
+                key: "Babylon Lite Light Properties",
+                predicate: IsLight,
+                content: [{ section: "General", component: ({ context }) => <LightGeneralProperties light={context} /> }],
+            }),
+            propertiesService.addSectionContent({
+                key: "Babylon Lite Directional Light Properties",
+                predicate: IsDirectionalLight,
+                content: [{ section: "Setup", component: ({ context }) => <DirectionalLightSetupProperties light={context} /> }],
+            }),
+            propertiesService.addSectionContent({
+                key: "Babylon Lite Point Light Properties",
+                predicate: IsPointLight,
+                content: [{ section: "Setup", component: ({ context }) => <PointLightSetupProperties light={context} /> }],
+            }),
+            propertiesService.addSectionContent({
+                key: "Babylon Lite Spot Light Properties",
+                predicate: IsSpotLight,
+                content: [{ section: "Setup", component: ({ context }) => <SpotLightSetupProperties light={context} /> }],
+            }),
+            propertiesService.addSectionContent({
+                key: "Babylon Lite Hemispheric Light Properties",
+                predicate: IsHemisphericLight,
+                content: [{ section: "Setup", component: ({ context }) => <HemisphericLightSetupProperties light={context} /> }],
+            }),
+        ];
+
+        return {
+            dispose: () => registrations.forEach((registration) => registration.dispose()),
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/lite/services/panes/properties/meshPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/properties/meshPropertiesService.tsx
@@ -1,26 +1,17 @@
 import { type Mesh } from "@babylonjs/lite";
 import { type FunctionComponent } from "react";
 
-import { TextInputPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/inputPropertyLine";
 import { SwitchPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/switchPropertyLine";
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
 
 import { BoundProperty } from "../../../../components/properties/boundProperty";
 import { type IPropertiesService, PropertiesServiceIdentity } from "../../../../services/panes/properties/propertiesService";
-
-function IsMesh(entity: unknown): entity is Mesh {
-    return typeof entity === "object" && entity !== null && "_gpu" in entity && "material" in entity;
-}
+import { IsMesh } from "../../../sceneEntityUtils";
 
 const MeshGeneralProperties: FunctionComponent<{ mesh: Mesh }> = (props) => {
     const { mesh } = props;
 
-    return (
-        <>
-            <BoundProperty component={TextInputPropertyLine} label="Name" target={mesh} propertyKey="name" />
-            <BoundProperty component={SwitchPropertyLine} label="Receive Shadows" target={mesh} propertyKey="receiveShadows" />
-        </>
-    );
+    return <BoundProperty component={SwitchPropertyLine} label="Receive Shadows" target={mesh} propertyKey="receiveShadows" />;
 };
 
 export const MeshPropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService]> = {
@@ -32,7 +23,7 @@ export const MeshPropertiesServiceDefinition: ServiceDefinition<[], [IProperties
             predicate: IsMesh,
             content: [
                 {
-                    section: "General",
+                    section: "Rendering",
                     component: ({ context }) => <MeshGeneralProperties mesh={context} />,
                 },
             ],

--- a/packages/dev/inspector-v2/src/lite/services/panes/properties/sceneNodePropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/properties/sceneNodePropertiesService.tsx
@@ -1,0 +1,30 @@
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import { MetadataProperties } from "../../../../components/properties/metadataProperties";
+import { type IPropertiesService, PropertiesServiceIdentity } from "../../../../services/panes/properties/propertiesService";
+import { IsSceneNode } from "../../../sceneEntityUtils";
+import { SceneNodeGeneralProperties, SceneNodeTransformProperties } from "../../../components/properties/sceneNodeProperties";
+
+export const SceneNodePropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService]> = {
+    friendlyName: "Babylon Lite Scene Node Properties",
+    consumes: [PropertiesServiceIdentity],
+    factory: (propertiesService) =>
+        propertiesService.addSectionContent({
+            key: "Babylon Lite Scene Node Properties",
+            predicate: IsSceneNode,
+            content: [
+                {
+                    section: "General",
+                    component: ({ context }) => <SceneNodeGeneralProperties node={context} />,
+                },
+                {
+                    section: "Transform",
+                    component: ({ context }) => <SceneNodeTransformProperties node={context} />,
+                },
+                {
+                    section: "Metadata",
+                    component: ({ context }) => <MetadataProperties entity={context} />,
+                },
+            ],
+        }),
+};

--- a/packages/dev/inspector-v2/src/lite/services/panes/properties/shadowGeneratorPropertiesService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/properties/shadowGeneratorPropertiesService.tsx
@@ -1,0 +1,33 @@
+import { getRenderingContexts, type SceneContext, type ShadowGenerator } from "@babylonjs/lite";
+
+import { TextPropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/textPropertyLine";
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
+import { GetShadowGeneratorDisplayName } from "../../../sceneEntityUtils";
+import { type IPropertiesService, PropertiesServiceIdentity } from "../../../../services/panes/properties/propertiesService";
+import { IsSceneContext } from "../scene/sceneExplorerSection";
+
+function GetScenes(engineContext: IEngineContext): readonly SceneContext[] {
+    return engineContext.engine.surfaces.flatMap((surface) => getRenderingContexts(surface).filter(IsSceneContext));
+}
+
+export const ShadowGeneratorPropertiesServiceDefinition: ServiceDefinition<[], [IPropertiesService, IEngineContext]> = {
+    friendlyName: "Babylon Lite Shadow Generator Properties",
+    consumes: [PropertiesServiceIdentity, EngineContextIdentity],
+    factory: (propertiesService, engineContext) =>
+        propertiesService.addSectionContent({
+            key: "Babylon Lite Shadow Generator Properties",
+            predicate: (entity: unknown): entity is ShadowGenerator =>
+                typeof entity === "object" && entity !== null && GetScenes(engineContext).some((scene) => scene.shadowGenerators.includes(entity)),
+            content: [
+                {
+                    section: "General",
+                    component: ({ context }) => {
+                        const scene = GetScenes(engineContext).find((candidate) => candidate.shadowGenerators.includes(context));
+                        return <TextPropertyLine label="Identity" value={scene ? GetShadowGeneratorDisplayName(scene, context) : "Shadow Generator"} />;
+                    },
+                },
+            ],
+        }),
+};

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/cameraExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/cameraExplorerService.tsx
@@ -1,0 +1,65 @@
+import { removeFromScene, type Camera } from "@babylonjs/lite";
+import { CameraRegular, DeleteRegular } from "@fluentui/react-icons";
+
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import { EngineExplorerServiceIdentity, type IEngineExplorerService } from "../../../engineExplorerService";
+import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
+import { CreateWatchedNameDisplayInfo } from "../../../explorerDisplayInfo";
+import { GetSceneContexts, IsCamera } from "../../../sceneEntityUtils";
+import { ExplorerServiceIdentity, type IExplorerService } from "../../../../services/panes/explorer/explorerService";
+import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
+import { WatcherServiceIdentity, type IWatcherService } from "../../../../services/watcherService";
+import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
+
+const CameraIcon = () => <CameraRegular />;
+
+export const CameraExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, IWatcherService, ISelectionService, IEngineContext]> = {
+    friendlyName: "Babylon Lite Camera Explorer",
+    consumes: [EngineExplorerServiceIdentity, ExplorerServiceIdentity, WatcherServiceIdentity, SelectionServiceIdentity, EngineContextIdentity],
+    factory: (engineExplorerService, explorerService, watcherService, selectionService, engineContext) => {
+        const providerRegistration = engineExplorerService.addRenderingContextNodeProvider({
+            order: 10,
+            predicate: IsSceneContext,
+            getNodes: (scene) => {
+                return [
+                    CreateSceneExplorerSectionNode(
+                        "cameras",
+                        "Cameras",
+                        scene.camera ? [scene.camera] : [],
+                        (camera: Camera) => CreateWatchedNameDisplayInfo(watcherService, camera, () => camera.name || "Camera"),
+                        CameraIcon
+                    ),
+                ];
+            },
+            getSnapshot: (scene) => (scene.camera ? [scene.camera] : []),
+        });
+        const removeRegistration = explorerService.addItemCommand({
+            predicate: (entity): entity is Camera => IsCamera(entity) && GetSceneContexts(engineContext.engine).filter((scene) => scene.camera === entity).length === 1,
+            order: 10000,
+            getCommand: (camera) => ({
+                type: "action",
+                mode: "contextMenu",
+                displayName: "Remove from Scene",
+                icon: DeleteRegular,
+                hotKey: { keyCode: "Delete" },
+                execute: () => {
+                    const owningScenes = GetSceneContexts(engineContext.engine).filter((candidate) => candidate.camera === camera);
+                    if (owningScenes.length === 1) {
+                        if (selectionService.selectedEntity === camera) {
+                            selectionService.selectedEntity = null;
+                        }
+                        removeFromScene(owningScenes[0], camera);
+                    }
+                },
+            }),
+        });
+
+        return {
+            dispose: () => {
+                removeRegistration.dispose();
+                providerRegistration.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/cameraExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/cameraExplorerService.tsx
@@ -1,4 +1,5 @@
 import { removeFromScene, type Camera } from "@babylonjs/lite";
+import { tokens } from "@fluentui/react-components";
 import { CameraRegular, DeleteRegular } from "@fluentui/react-icons";
 
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
@@ -12,7 +13,7 @@ import { SelectionServiceIdentity, type ISelectionService } from "../../../../se
 import { WatcherServiceIdentity, type IWatcherService } from "../../../../services/watcherService";
 import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
 
-const CameraIcon = () => <CameraRegular />;
+const CameraIcon = () => <CameraRegular color={tokens.colorPaletteGreenForeground2} />;
 
 export const CameraExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, IWatcherService, ISelectionService, IEngineContext]> = {
     friendlyName: "Babylon Lite Camera Explorer",

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/cameraExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/cameraExplorerService.tsx
@@ -7,11 +7,12 @@ import { type ServiceDefinition } from "shared-ui-components/modularTool/modular
 import { EngineExplorerServiceIdentity, type IEngineExplorerService } from "../../../engineExplorerService";
 import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
 import { CreateWatchedNameDisplayInfo } from "../../../explorerDisplayInfo";
-import { GetSceneContexts, IsCamera } from "../../../sceneEntityUtils";
+import { GetSceneContexts, IsCamera, IsSceneNode, IsSceneNodeDescendantOf } from "../../../sceneEntityUtils";
 import { ExplorerServiceIdentity, type IExplorerService } from "../../../../services/panes/explorer/explorerService";
 import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
 import { WatcherServiceIdentity, type IWatcherService } from "../../../../services/watcherService";
 import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
+import { ClearRemovedSelection } from "./sceneSelectionUtils";
 
 const CameraIcon = () => <CameraRegular color={tokens.colorPaletteGreenForeground2} />;
 
@@ -47,10 +48,10 @@ export const CameraExplorerServiceDefinition: ServiceDefinition<[], [IEngineExpl
                 execute: () => {
                     const owningScenes = GetSceneContexts(engineContext.engine).filter((candidate) => candidate.camera === camera);
                     if (owningScenes.length === 1) {
-                        if (selectionService.selectedEntity === camera) {
-                            selectionService.selectedEntity = null;
-                        }
+                        const selectedEntity = selectionService.selectedEntity;
+                        const selectionWasRemoved = selectedEntity === camera || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, camera));
                         removeFromScene(owningScenes[0], camera);
+                        ClearRemovedSelection(selectionService, engineContext, selectionWasRemoved);
                     }
                 },
             }),

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/lightExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/lightExplorerService.tsx
@@ -1,0 +1,55 @@
+import { removeFromScene, type LightBase } from "@babylonjs/lite";
+import { DeleteRegular, LightbulbRegular } from "@fluentui/react-icons";
+
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import { EngineExplorerServiceIdentity, type IEngineExplorerService } from "../../../engineExplorerService";
+import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
+import { GetLightDisplayName, GetSceneContexts, IsLight } from "../../../sceneEntityUtils";
+import { ExplorerServiceIdentity, type IExplorerService } from "../../../../services/panes/explorer/explorerService";
+import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
+import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
+
+const LightIcon = () => <LightbulbRegular />;
+
+export const LightExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, ISelectionService, IEngineContext]> = {
+    friendlyName: "Babylon Lite Light Explorer",
+    consumes: [EngineExplorerServiceIdentity, ExplorerServiceIdentity, SelectionServiceIdentity, EngineContextIdentity],
+    factory: (engineExplorerService, explorerService, selectionService, engineContext) => {
+        const providerRegistration = engineExplorerService.addRenderingContextNodeProvider({
+            order: 20,
+            predicate: IsSceneContext,
+            getNodes: (scene) => {
+                return [CreateSceneExplorerSectionNode("lights", "Lights", scene.lights, (light: LightBase, index) => ({ name: GetLightDisplayName(light, index) }), LightIcon)];
+            },
+            getSnapshot: (scene) => scene.lights,
+        });
+        const removeRegistration = explorerService.addItemCommand({
+            predicate: (entity): entity is LightBase => IsLight(entity) && GetSceneContexts(engineContext.engine).filter((scene) => scene.lights.includes(entity)).length === 1,
+            order: 10000,
+            getCommand: (light) => ({
+                type: "action",
+                mode: "contextMenu",
+                displayName: "Remove from Scene",
+                icon: DeleteRegular,
+                hotKey: { keyCode: "Delete" },
+                execute: () => {
+                    const owningScenes = GetSceneContexts(engineContext.engine).filter((candidate) => candidate.lights.includes(light));
+                    if (owningScenes.length === 1) {
+                        if (selectionService.selectedEntity === light || selectionService.selectedEntity === light.shadowGenerator) {
+                            selectionService.selectedEntity = null;
+                        }
+                        removeFromScene(owningScenes[0], light);
+                    }
+                },
+            }),
+        });
+
+        return {
+            dispose: () => {
+                removeRegistration.dispose();
+                providerRegistration.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/lightExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/lightExplorerService.tsx
@@ -6,10 +6,11 @@ import { type ServiceDefinition } from "shared-ui-components/modularTool/modular
 
 import { EngineExplorerServiceIdentity, type IEngineExplorerService } from "../../../engineExplorerService";
 import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
-import { GetLightDisplayName, GetSceneContexts, IsLight } from "../../../sceneEntityUtils";
+import { GetLightDisplayName, GetSceneContexts, IsLight, IsSceneNode, IsSceneNodeDescendantOf } from "../../../sceneEntityUtils";
 import { ExplorerServiceIdentity, type IExplorerService } from "../../../../services/panes/explorer/explorerService";
 import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
 import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
+import { ClearRemovedSelection } from "./sceneSelectionUtils";
 
 const LightIcon = () => <LightbulbRegular color={tokens.colorPaletteYellowForeground2} />;
 
@@ -37,10 +38,11 @@ export const LightExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplo
                 execute: () => {
                     const owningScenes = GetSceneContexts(engineContext.engine).filter((candidate) => candidate.lights.includes(light));
                     if (owningScenes.length === 1) {
-                        if (selectionService.selectedEntity === light || selectionService.selectedEntity === light.shadowGenerator) {
-                            selectionService.selectedEntity = null;
-                        }
+                        const selectedEntity = selectionService.selectedEntity;
+                        const selectionWasRemoved =
+                            selectedEntity === light || selectedEntity === light.shadowGenerator || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, light));
                         removeFromScene(owningScenes[0], light);
+                        ClearRemovedSelection(selectionService, engineContext, selectionWasRemoved);
                     }
                 },
             }),

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/lightExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/lightExplorerService.tsx
@@ -1,4 +1,5 @@
 import { removeFromScene, type LightBase } from "@babylonjs/lite";
+import { tokens } from "@fluentui/react-components";
 import { DeleteRegular, LightbulbRegular } from "@fluentui/react-icons";
 
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
@@ -10,7 +11,7 @@ import { ExplorerServiceIdentity, type IExplorerService } from "../../../../serv
 import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
 import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
 
-const LightIcon = () => <LightbulbRegular />;
+const LightIcon = () => <LightbulbRegular color={tokens.colorPaletteYellowForeground2} />;
 
 export const LightExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, ISelectionService, IEngineContext]> = {
     friendlyName: "Babylon Lite Light Explorer",

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
@@ -1,29 +1,164 @@
-import { type Mesh } from "@babylonjs/lite";
+import { removeFromScene, setParent, setSubtreeVisible, type SceneContext, type SceneNode } from "@babylonjs/lite";
 import { tokens } from "@fluentui/react-components";
+import { DeleteRegular, EyeOffRegular, EyeRegular, MyLocationRegular } from "@fluentui/react-icons";
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
 import { MeshIcon } from "shared-ui-components/fluent/icons";
 
+import { Observable } from "core/Misc/observable";
+import { type ExplorerNodeDescription, GetEntityId } from "../../../../components/explorer/explorerModel";
 import { type IEngineExplorerService, EngineExplorerServiceIdentity } from "../../../engineExplorerService";
+import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
 import { CreateWatchedNameDisplayInfo } from "../../../explorerDisplayInfo";
+import { GetSceneContexts, GetSceneNodeRoots, IsMesh, IsSceneNode, IsSceneNodeDescendantOf } from "../../../sceneEntityUtils";
+import { ExplorerServiceIdentity, type IExplorerService } from "../../../../services/panes/explorer/explorerService";
+import { type ISelectionService, SelectionServiceIdentity } from "../../../../services/selectionService";
 import { type IWatcherService, WatcherServiceIdentity } from "../../../../services/watcherService";
-import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
+import { IsSceneContext } from "./sceneExplorerSection";
 
-export const MeshExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IWatcherService]> = {
-    friendlyName: "Babylon Lite Mesh Explorer",
-    consumes: [EngineExplorerServiceIdentity, WatcherServiceIdentity],
-    factory: (engineExplorerService, watcherService) =>
-        engineExplorerService.addRenderingContextNodeProvider({
+type NodeTopologyMarker = {
+    parent: object | null;
+    marker: object;
+};
+
+const NodeTopologyMarkers = new WeakMap<SceneNode, NodeTopologyMarker>();
+
+function GetNodeTopologyMarker(node: SceneNode): object {
+    const parent = IsSceneNode(node.parent) ? node.parent : null;
+    const existing = NodeTopologyMarkers.get(node);
+    if (existing?.parent === parent) {
+        return existing.marker;
+    }
+
+    const marker = {};
+    NodeTopologyMarkers.set(node, { parent, marker });
+    return marker;
+}
+
+function CreateNodeDescription(node: SceneNode, watcherService: IWatcherService): ExplorerNodeDescription {
+    return {
+        id: GetEntityId(node).toString(),
+        kind: "item",
+        entity: node,
+        icon: () => (IsMesh(node) ? <MeshIcon color={tokens.colorPaletteBlueForeground2} /> : <MyLocationRegular color={tokens.colorPaletteBlueForeground2} />),
+        getDisplayInfo: () => CreateWatchedNameDisplayInfo(watcherService, node, () => node.name || (IsMesh(node) ? "Unnamed Mesh" : "Unnamed Transform Node")),
+        getChildren: () => node.children.filter(IsSceneNode).map((child) => CreateNodeDescription(child, watcherService)),
+    };
+}
+
+function ClearRemovedSelection(selectionService: ISelectionService, engineContext: IEngineContext, selectionWasRemoved: boolean): void {
+    const selectedEntity = selectionService.selectedEntity;
+    if (
+        selectionWasRemoved &&
+        !GetSceneContexts(engineContext.engine).some((scene) =>
+            GetSceneNodeRoots(scene).some((root) => root === selectedEntity || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, root)))
+        )
+    ) {
+        selectionService.selectedEntity = null;
+    }
+}
+
+export const MeshExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, IWatcherService, ISelectionService, IEngineContext]> = {
+    friendlyName: "Babylon Lite Scene Node Explorer",
+    consumes: [EngineExplorerServiceIdentity, ExplorerServiceIdentity, WatcherServiceIdentity, SelectionServiceIdentity, EngineContextIdentity],
+    factory: (engineExplorerService, explorerService, watcherService, selectionService, engineContext) => {
+        const providerRegistration = engineExplorerService.addRenderingContextNodeProvider({
             order: 0,
             predicate: IsSceneContext,
-            getNodes: (scene) => [
-                CreateSceneExplorerSectionNode(
-                    "meshes",
-                    "Meshes",
-                    scene.meshes,
-                    (mesh: Mesh) => CreateWatchedNameDisplayInfo(watcherService, mesh, () => mesh.name),
-                    () => <MeshIcon color={tokens.colorPaletteBlueForeground2} />
-                ),
-            ],
-            getSnapshot: (scene) => scene.meshes,
-        }),
+            getNodes: (scene) => {
+                return [
+                    {
+                        id: "nodes",
+                        kind: "group",
+                        getDisplayInfo: () => ({ name: "Nodes" }),
+                        getChildren: () => GetSceneNodeRoots(scene).map((node) => CreateNodeDescription(node, watcherService)),
+                        dragDropConfig: {
+                            canDrag: IsSceneNode,
+                            canDrop: (draggedEntity, targetEntity) =>
+                                IsSceneNode(draggedEntity) &&
+                                (targetEntity === null || (IsSceneNode(targetEntity) && draggedEntity !== targetEntity && !IsSceneNodeDescendantOf(targetEntity, draggedEntity))) &&
+                                draggedEntity.parent !== targetEntity,
+                            onDrop: (draggedEntity, targetEntity) => {
+                                if (IsSceneNode(draggedEntity) && (targetEntity === null || IsSceneNode(targetEntity))) {
+                                    setParent(draggedEntity, targetEntity);
+                                }
+                            },
+                        },
+                    },
+                ];
+            },
+            getSnapshot: (scene) =>
+                GetSceneNodeRoots(scene)
+                    .flatMap((root) => [root, ...GetNodeDescendants(root)])
+                    .flatMap((node) => [node, GetNodeTopologyMarker(node)]),
+        });
+
+        const visibilityRegistration = explorerService.addItemCommand({
+            predicate: (entity): entity is SceneNode => IsSceneNode(entity) && GetOwningScenes(engineContext, entity).length > 0,
+            order: 1100,
+            getCommand: (node) => {
+                const onChange = new Observable<void>();
+                const visibilityWatcher = watcherService.watchValue(
+                    () => node.visible !== false,
+                    () => onChange.notifyObservers()
+                );
+
+                return {
+                    type: "toggle",
+                    mode: "contextMenu",
+                    get displayName() {
+                        return node.visible === false ? "Show Node" : "Hide Node";
+                    },
+                    icon: () => (node.visible === false ? <EyeOffRegular /> : <EyeRegular />),
+                    get isEnabled() {
+                        return node.visible !== false;
+                    },
+                    set isEnabled(visible: boolean) {
+                        setSubtreeVisible(node, visible);
+                    },
+                    onChange,
+                    dispose: () => {
+                        visibilityWatcher.dispose();
+                        onChange.clear();
+                    },
+                };
+            },
+        });
+
+        const removeRegistration = explorerService.addItemCommand({
+            predicate: (entity): entity is SceneNode => IsSceneNode(entity) && GetOwningScenes(engineContext, entity).length === 1,
+            order: 10000,
+            getCommand: (node) => ({
+                type: "action",
+                mode: "contextMenu",
+                displayName: "Remove from Scene",
+                icon: DeleteRegular,
+                hotKey: { keyCode: "Delete" },
+                execute: () => {
+                    const [scene] = GetOwningScenes(engineContext, node);
+                    if (scene && GetOwningScenes(engineContext, node).length === 1) {
+                        const selectedEntity = selectionService.selectedEntity;
+                        const selectionWasRemoved = selectedEntity === node || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, node));
+                        removeFromScene(scene, node);
+                        ClearRemovedSelection(selectionService, engineContext, selectionWasRemoved);
+                    }
+                },
+            }),
+        });
+
+        return {
+            dispose: () => {
+                removeRegistration.dispose();
+                visibilityRegistration.dispose();
+                providerRegistration.dispose();
+            },
+        };
+    },
 };
+
+function GetNodeDescendants(node: SceneNode): readonly SceneNode[] {
+    return node.children.filter(IsSceneNode).flatMap((child) => [child, ...GetNodeDescendants(child)]);
+}
+
+function GetOwningScenes(engineContext: IEngineContext, node: SceneNode): readonly SceneContext[] {
+    return GetSceneContexts(engineContext.engine).filter((scene) => GetSceneNodeRoots(scene).some((root) => root === node || IsSceneNodeDescendantOf(node, root)));
+}

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
@@ -57,6 +57,10 @@ function ClearRemovedSelection(selectionService: ISelectionService, engineContex
     }
 }
 
+function IsNodeInScene(scene: SceneContext, node: SceneNode): boolean {
+    return GetSceneNodeRoots(scene).some((root) => root === node || IsSceneNodeDescendantOf(node, root));
+}
+
 export const MeshExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, IWatcherService, ISelectionService, IEngineContext]> = {
     friendlyName: "Babylon Lite Scene Node Explorer",
     consumes: [EngineExplorerServiceIdentity, ExplorerServiceIdentity, WatcherServiceIdentity, SelectionServiceIdentity, EngineContextIdentity],
@@ -72,10 +76,15 @@ export const MeshExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplor
                         getDisplayInfo: () => ({ name: "Nodes" }),
                         getChildren: () => GetSceneNodeRoots(scene).map((node) => CreateNodeDescription(node, watcherService)),
                         dragDropConfig: {
-                            canDrag: IsSceneNode,
+                            canDrag: (entity) => IsSceneNode(entity) && IsNodeInScene(scene, entity),
                             canDrop: (draggedEntity, targetEntity) =>
                                 IsSceneNode(draggedEntity) &&
-                                (targetEntity === null || (IsSceneNode(targetEntity) && draggedEntity !== targetEntity && !IsSceneNodeDescendantOf(targetEntity, draggedEntity))) &&
+                                IsNodeInScene(scene, draggedEntity) &&
+                                (targetEntity === null ||
+                                    (IsSceneNode(targetEntity) &&
+                                        IsNodeInScene(scene, targetEntity) &&
+                                        draggedEntity !== targetEntity &&
+                                        !IsSceneNodeDescendantOf(targetEntity, draggedEntity))) &&
                                 draggedEntity.parent !== targetEntity,
                             onDrop: (draggedEntity, targetEntity) => {
                                 if (IsSceneNode(draggedEntity) && (targetEntity === null || IsSceneNode(targetEntity))) {
@@ -138,6 +147,9 @@ export const MeshExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplor
                     if (scene && GetOwningScenes(engineContext, node).length === 1) {
                         const selectedEntity = selectionService.selectedEntity;
                         const selectionWasRemoved = selectedEntity === node || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, node));
+                        if (node.parent) {
+                            setParent(node, null);
+                        }
                         removeFromScene(scene, node);
                         ClearRemovedSelection(selectionService, engineContext, selectionWasRemoved);
                     }

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
@@ -14,6 +14,7 @@ import { ExplorerServiceIdentity, type IExplorerService } from "../../../../serv
 import { type ISelectionService, SelectionServiceIdentity } from "../../../../services/selectionService";
 import { type IWatcherService, WatcherServiceIdentity } from "../../../../services/watcherService";
 import { IsSceneContext } from "./sceneExplorerSection";
+import { ClearRemovedSelection } from "./sceneSelectionUtils";
 
 type NodeTopologyMarker = {
     parent: object | null;
@@ -43,18 +44,6 @@ function CreateNodeDescription(node: SceneNode, watcherService: IWatcherService)
         getDisplayInfo: () => CreateWatchedNameDisplayInfo(watcherService, node, () => node.name || (IsMesh(node) ? "Unnamed Mesh" : "Unnamed Transform Node")),
         getChildren: () => node.children.filter(IsSceneNode).map((child) => CreateNodeDescription(child, watcherService)),
     };
-}
-
-function ClearRemovedSelection(selectionService: ISelectionService, engineContext: IEngineContext, selectionWasRemoved: boolean): void {
-    const selectedEntity = selectionService.selectedEntity;
-    if (
-        selectionWasRemoved &&
-        !GetSceneContexts(engineContext.engine).some((scene) =>
-            GetSceneNodeRoots(scene).some((root) => root === selectedEntity || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, root)))
-        )
-    ) {
-        selectionService.selectedEntity = null;
-    }
 }
 
 function IsNodeInScene(scene: SceneContext, node: SceneNode): boolean {

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/meshExplorerService.tsx
@@ -143,8 +143,9 @@ export const MeshExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplor
                 icon: DeleteRegular,
                 hotKey: { keyCode: "Delete" },
                 execute: () => {
-                    const [scene] = GetOwningScenes(engineContext, node);
-                    if (scene && GetOwningScenes(engineContext, node).length === 1) {
+                    const owningScenes = GetOwningScenes(engineContext, node);
+                    const [scene] = owningScenes;
+                    if (scene && owningScenes.length === 1) {
                         const selectedEntity = selectionService.selectedEntity;
                         const selectionWasRemoved = selectedEntity === node || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, node));
                         if (node.parent) {

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/sceneSelectionUtils.ts
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/sceneSelectionUtils.ts
@@ -1,0 +1,15 @@
+import { GetSceneContexts, GetSceneNodeRoots, IsSceneNode, IsSceneNodeDescendantOf } from "../../../sceneEntityUtils";
+import { type IEngineContext } from "../../../engineContext";
+import { type ISelectionService } from "../../../../services/selectionService";
+
+export function ClearRemovedSelection(selectionService: ISelectionService, engineContext: IEngineContext, selectionWasRemoved: boolean): void {
+    const selectedEntity = selectionService.selectedEntity;
+    if (
+        selectionWasRemoved &&
+        !GetSceneContexts(engineContext.engine).some((scene) =>
+            GetSceneNodeRoots(scene).some((root) => root === selectedEntity || (IsSceneNode(selectedEntity) && IsSceneNodeDescendantOf(selectedEntity, root)))
+        )
+    ) {
+        selectionService.selectedEntity = null;
+    }
+}

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/shadowGeneratorExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/shadowGeneratorExplorerService.tsx
@@ -1,4 +1,5 @@
 import { removeFromScene, type ShadowGenerator } from "@babylonjs/lite";
+import { tokens } from "@fluentui/react-components";
 import { DeleteRegular, WeatherMoonRegular } from "@fluentui/react-icons";
 
 import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
@@ -10,7 +11,7 @@ import { ExplorerServiceIdentity, type IExplorerService } from "../../../../serv
 import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
 import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
 
-const ShadowGeneratorIcon = () => <WeatherMoonRegular />;
+const ShadowGeneratorIcon = () => <WeatherMoonRegular color={tokens.colorPaletteYellowForeground2} />;
 
 export const ShadowGeneratorExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, ISelectionService, IEngineContext]> = {
     friendlyName: "Babylon Lite Shadow Generator Explorer",

--- a/packages/dev/inspector-v2/src/lite/services/panes/scene/shadowGeneratorExplorerService.tsx
+++ b/packages/dev/inspector-v2/src/lite/services/panes/scene/shadowGeneratorExplorerService.tsx
@@ -1,0 +1,66 @@
+import { removeFromScene, type ShadowGenerator } from "@babylonjs/lite";
+import { DeleteRegular, WeatherMoonRegular } from "@fluentui/react-icons";
+
+import { type ServiceDefinition } from "shared-ui-components/modularTool/modularity/serviceDefinition";
+
+import { EngineExplorerServiceIdentity, type IEngineExplorerService } from "../../../engineExplorerService";
+import { EngineContextIdentity, type IEngineContext } from "../../../engineContext";
+import { GetSceneContexts, GetShadowGeneratorDisplayName } from "../../../sceneEntityUtils";
+import { ExplorerServiceIdentity, type IExplorerService } from "../../../../services/panes/explorer/explorerService";
+import { SelectionServiceIdentity, type ISelectionService } from "../../../../services/selectionService";
+import { CreateSceneExplorerSectionNode, IsSceneContext } from "./sceneExplorerSection";
+
+const ShadowGeneratorIcon = () => <WeatherMoonRegular />;
+
+export const ShadowGeneratorExplorerServiceDefinition: ServiceDefinition<[], [IEngineExplorerService, IExplorerService, ISelectionService, IEngineContext]> = {
+    friendlyName: "Babylon Lite Shadow Generator Explorer",
+    consumes: [EngineExplorerServiceIdentity, ExplorerServiceIdentity, SelectionServiceIdentity, EngineContextIdentity],
+    factory: (engineExplorerService, explorerService, selectionService, engineContext) => {
+        const providerRegistration = engineExplorerService.addRenderingContextNodeProvider({
+            order: 30,
+            predicate: IsSceneContext,
+            getNodes: (scene) => {
+                return [
+                    CreateSceneExplorerSectionNode(
+                        "shadow-generators",
+                        "Shadow Generators",
+                        scene.shadowGenerators,
+                        (shadowGenerator: ShadowGenerator) => ({ name: GetShadowGeneratorDisplayName(scene, shadowGenerator) }),
+                        ShadowGeneratorIcon
+                    ),
+                ];
+            },
+            getSnapshot: (scene) => scene.shadowGenerators,
+        });
+        const removeRegistration = explorerService.addItemCommand({
+            predicate: (entity): entity is ShadowGenerator =>
+                typeof entity === "object" &&
+                entity !== null &&
+                GetSceneContexts(engineContext.engine).filter((scene) => scene.shadowGenerators.some((shadowGenerator) => shadowGenerator === entity)).length === 1,
+            order: 10000,
+            getCommand: (shadowGenerator) => ({
+                type: "action",
+                mode: "contextMenu",
+                displayName: "Remove from Scene",
+                icon: DeleteRegular,
+                hotKey: { keyCode: "Delete" },
+                execute: () => {
+                    const owningScenes = GetSceneContexts(engineContext.engine).filter((candidate) => candidate.shadowGenerators.includes(shadowGenerator));
+                    if (owningScenes.length === 1) {
+                        if (selectionService.selectedEntity === shadowGenerator) {
+                            selectionService.selectedEntity = null;
+                        }
+                        removeFromScene(owningScenes[0], shadowGenerator);
+                    }
+                },
+            }),
+        });
+
+        return {
+            dispose: () => {
+                removeRegistration.dispose();
+                providerRegistration.dispose();
+            },
+        };
+    },
+};

--- a/packages/dev/inspector-v2/test/app/lite.ts
+++ b/packages/dev/inspector-v2/test/app/lite.ts
@@ -102,7 +102,6 @@ const shadowGenerator = createPcfDirectionalShadowGenerator(engine, directionalL
 directionalLight.shadowGenerator = shadowGenerator;
 primaryScene.shadowGenerators.push(shadowGenerator);
 setShadowTaskCasterMeshes(shadowGenerator, [box, sphere, smallBox]);
-sphere.receiveShadows = true;
 
 const camera = createDefaultCamera(primaryScene);
 camera.name = "Main Camera";

--- a/packages/dev/inspector-v2/test/app/lite.ts
+++ b/packages/dev/inspector-v2/test/app/lite.ts
@@ -4,19 +4,24 @@ import {
     createBox,
     createDefaultTextData,
     createDefaultCamera,
+    createDirectionalLight,
     createEngine,
     createGridSpriteAtlas,
     createHemisphericLight,
+    createPcfDirectionalShadowGenerator,
     createPbrMaterial,
+    createPointLight,
     createSceneContext,
     createSolidTexture2D,
     createSphere,
     createSprite2DLayer,
     createSpriteRenderer,
     createStandardMaterial,
+    createSpotLight,
     createSurface,
     createTextLayer,
     createTextRenderer,
+    createTransformNode,
     disposeDefaultTextData,
     disposeEngine,
     disposeScene,
@@ -27,6 +32,7 @@ import {
     registerScene,
     registerSpriteRenderer,
     registerTextRenderer,
+    setShadowTaskCasterMeshes,
     startEngine,
     stopEngine,
 } from "@babylonjs/lite";
@@ -73,13 +79,33 @@ sphere.position.x = 0.75;
 const smallBox = createBox(engine, 0.5);
 smallBox.name = "Small Red Box";
 smallBox.material = standardMaterial;
-smallBox.position.set(-0.75, 1, 0);
+smallBox.position.set(0, 1, 0);
 
 addToScene(primaryScene, box);
 addToScene(primaryScene, sphere);
-addToScene(primaryScene, smallBox);
-addToScene(primaryScene, createHemisphericLight([0, 1, 0], 0.9));
-createDefaultCamera(primaryScene);
+const boxGroup = createTransformNode("Box Group", -0.75);
+boxGroup.children.push(smallBox);
+smallBox.parent = boxGroup;
+addToScene(primaryScene, boxGroup);
+
+const hemisphericLight = createHemisphericLight([0, 1, 0], 0.55);
+const directionalLight = createDirectionalLight([-0.5, -1, 0.25], 0.45);
+directionalLight.position.set(4, 6, -3);
+const pointLight = createPointLight([0, 2, -2], 0.15);
+const spotLight = createSpotLight([0, 4, -4], [0, -0.5, 1], Math.PI / 3, 2, 0.15);
+addToScene(primaryScene, hemisphericLight);
+addToScene(primaryScene, directionalLight);
+addToScene(primaryScene, pointLight);
+addToScene(primaryScene, spotLight);
+
+const shadowGenerator = createPcfDirectionalShadowGenerator(engine, directionalLight, { mapSize: 512 });
+directionalLight.shadowGenerator = shadowGenerator;
+primaryScene.shadowGenerators.push(shadowGenerator);
+setShadowTaskCasterMeshes(shadowGenerator, [box, sphere, smallBox]);
+sphere.receiveShadows = true;
+
+const camera = createDefaultCamera(primaryScene);
+camera.name = "Main Camera";
 
 await registerScene(primaryScene);
 
@@ -129,6 +155,7 @@ Object.assign(globalThis, {
     liteEngine: engine,
     liteMaterials: [standardMaterial, pbrMaterial],
     liteMeshes: [box, sphere, smallBox],
+    liteLights: [hemisphericLight, directionalLight, pointLight, spotLight],
     litePrimaryScene: primaryScene,
     liteRegisterScene: registerScene,
     liteSecondarySurface: secondarySurface,
@@ -137,6 +164,8 @@ Object.assign(globalThis, {
     liteTextRenderer: textRenderer,
     liteTextRendererLayer: overlayTextLayer,
     liteTextures: [redTexture, blueTexture],
+    liteTransformNode: boxGroup,
+    liteShadowGenerator: shadowGenerator,
 });
 
 window.addEventListener(

--- a/packages/dev/inspector-v2/test/app/lite.ts
+++ b/packages/dev/inspector-v2/test/app/lite.ts
@@ -1,6 +1,7 @@
 import {
     addSprite2DIndex,
     addToScene,
+    attachControl,
     createBox,
     createDefaultTextData,
     createDefaultCamera,
@@ -105,6 +106,7 @@ setShadowTaskCasterMeshes(shadowGenerator, [box, sphere, smallBox]);
 
 const camera = createDefaultCamera(primaryScene);
 camera.name = "Main Camera";
+const detachCameraControl = attachControl(camera, canvas, primaryScene);
 
 await registerScene(primaryScene);
 
@@ -171,6 +173,7 @@ window.addEventListener(
     "beforeunload",
     () => {
         void inspectorToken.dispose();
+        detachCameraControl();
         stopEngine(engine);
         disposeTextRenderer(textRenderer);
         disposeDefaultTextData(overlayTextData);

--- a/packages/dev/inspector-v2/test/unit/liteExplorerServices.test.ts
+++ b/packages/dev/inspector-v2/test/unit/liteExplorerServices.test.ts
@@ -3,6 +3,7 @@ import {
     type Material,
     type Mesh,
     type RenderingContext,
+    type SceneNode,
     type SceneContext,
     type SurfaceContext,
     type TextLayer,
@@ -34,7 +35,7 @@ vi.mock("../../src/services/panes/explorer/explorerPane", () => ({
 }));
 
 import { BuildExplorerTree, type ExplorerNode } from "../../src/components/explorer/explorerModel";
-import { type IEngineContext } from "../../src/lite/engineContext";
+import { EngineContextIdentity, type IEngineContext } from "../../src/lite/engineContext";
 import {
     type IEngineExplorerService,
     EngineExplorerServiceDefinition,
@@ -47,7 +48,7 @@ import { MeshExplorerServiceDefinition } from "../../src/lite/services/panes/sce
 import { TextLayerExplorerServiceDefinition } from "../../src/lite/services/panes/scene/textLayerExplorerService";
 import { TextureExplorerServiceDefinition } from "../../src/lite/services/panes/scene/textureExplorerService";
 import { type IWatcherService, WatcherServiceIdentity } from "../../src/services/watcherService";
-import { type ISelectionService } from "../../src/services/selectionService";
+import { type ISelectionService, SelectionServiceIdentity } from "../../src/services/selectionService";
 import { GetExplorerNodeChildren, type IExplorerService, ExplorerServiceIdentity } from "../../src/services/panes/explorer/explorerService";
 import { type IShellService } from "shared-ui-components/modularTool/services/shellService";
 
@@ -65,7 +66,19 @@ function CreateMaterial(family: string, name: string, texture?: Texture2D): Mate
 }
 
 function CreateMesh(name: string, material: Material): Mesh {
-    return { name, material } as Mesh;
+    return {
+        name,
+        material,
+        receiveShadows: false,
+        children: [],
+        parent: null,
+        position: { x: 0, y: 0, z: 0 },
+        rotationQuaternion: { x: 0, y: 0, z: 0, w: 1 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scaling: { x: 1, y: 1, z: 1 },
+        worldMatrix: new Float32Array(16),
+        worldMatrixVersion: 0,
+    } as Mesh;
 }
 
 function GetNames(nodes: readonly ExplorerNode[]): string[] {
@@ -311,7 +324,13 @@ describe("Babylon Lite engine explorer service", () => {
 describe("Babylon Lite scene resource explorer services", () => {
     it("registers product-specific providers with the engine explorer", () => {
         expect(EngineExplorerServiceDefinition.produces).toEqual([EngineExplorerServiceIdentity, ExplorerServiceIdentity]);
-        expect(MeshExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity, WatcherServiceIdentity]);
+        expect(MeshExplorerServiceDefinition.consumes).toEqual([
+            EngineExplorerServiceIdentity,
+            ExplorerServiceIdentity,
+            WatcherServiceIdentity,
+            SelectionServiceIdentity,
+            EngineContextIdentity,
+        ]);
         expect(MaterialExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity, WatcherServiceIdentity]);
         expect(TextureExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity]);
         expect(TextLayerExplorerServiceDefinition.consumes).toEqual([EngineExplorerServiceIdentity]);
@@ -336,14 +355,17 @@ describe("Babylon Lite scene resource explorer services", () => {
                 watcherDisposals.set(entity, dispose);
                 return { dispose };
             }),
+            watchValue: vi.fn(() => ({ dispose: vi.fn() })),
         } as unknown as IWatcherService;
-
-        const registrations = [
-            MeshExplorerServiceDefinition.factory(engineExplorerService, watcherService),
-            MaterialExplorerServiceDefinition.factory(engineExplorerService, watcherService),
-            TextureExplorerServiceDefinition.factory(engineExplorerService),
-            TextLayerExplorerServiceDefinition.factory(engineExplorerService),
-        ];
+        const commandDisposals: ReturnType<typeof vi.fn>[] = [];
+        const explorerService = {
+            addItemCommand: vi.fn(() => {
+                const commandDispose = vi.fn();
+                commandDisposals.push(commandDispose);
+                return { dispose: commandDispose };
+            }),
+        } as unknown as IExplorerService;
+        const selectionService = { selectedEntity: null } as ISelectionService;
 
         const redTexture = { width: 1, height: 1 } as Texture2D;
         const blueTexture = { width: 2, height: 2 } as Texture2D;
@@ -354,7 +376,21 @@ describe("Babylon Lite scene resource explorer services", () => {
         const scene = {
             _kind: "scene",
             meshes: [redMesh, blueMesh, CreateMesh("Small Red Box", standardMaterial)],
+            camera: null,
+            lights: [],
+            shadowGenerators: [],
         } as SceneContext;
+        const engine = {
+            surfaces: [] as unknown as EngineContext["surfaces"],
+            _renderingContexts: [scene],
+        } as unknown as EngineContext;
+        (engine as { surfaces: readonly SurfaceContext[] }).surfaces = [engine];
+        const registrations = [
+            MeshExplorerServiceDefinition.factory(engineExplorerService, explorerService, watcherService, selectionService, { engine } as IEngineContext),
+            MaterialExplorerServiceDefinition.factory(engineExplorerService, watcherService),
+            TextureExplorerServiceDefinition.factory(engineExplorerService),
+            TextLayerExplorerServiceDefinition.factory(engineExplorerService),
+        ];
 
         const descriptions = providers
             .filter((provider) => provider.predicate(scene))
@@ -362,7 +398,7 @@ describe("Babylon Lite scene resource explorer services", () => {
             .flatMap((provider) => provider.getNodes(scene));
         const tree = BuildExplorerTree(descriptions);
 
-        expect(GetNames(tree.nodes)).toEqual(["Meshes", "Materials", "Textures"]);
+        expect(GetNames(tree.nodes)).toEqual(["Nodes", "Materials", "Textures"]);
         expect(GetNames(tree.nodes[0].children)).toEqual(["Red Box", "Blue Sphere", "Small Red Box"]);
         expect(GetNames(tree.nodes[1].children)).toEqual(["Red Material", "Blue Material"]);
         expect(GetNames(tree.nodes[2].children)).toEqual(["Texture 1 (1 x 1)", "Texture 2 (2 x 2)"]);
@@ -398,6 +434,7 @@ describe("Babylon Lite scene resource explorer services", () => {
 
         registrations.forEach((registration) => registration?.dispose?.());
         expect(dispose).toHaveBeenCalledTimes(4);
+        commandDisposals.forEach((commandDispose) => expect(commandDispose).toHaveBeenCalledOnce());
     });
 
     it("contributes stable text layer children and snapshots beneath text renderers", () => {
@@ -447,10 +484,24 @@ describe("Babylon Lite scene resource explorer services", () => {
         } as IEngineExplorerService;
         const watcherService = {
             watchProperty: vi.fn(() => ({ dispose: vi.fn() })),
+            watchValue: vi.fn(() => ({ dispose: vi.fn() })),
         } as unknown as IWatcherService;
-
-        MeshExplorerServiceDefinition.factory(engineExplorerService, watcherService);
         const effectRenderer = { _kind: "effect-renderer" } as RenderingContext;
+        const engine = {
+            surfaces: [] as unknown as EngineContext["surfaces"],
+            _renderingContexts: [effectRenderer],
+        } as unknown as EngineContext;
+        (engine as { surfaces: readonly SurfaceContext[] }).surfaces = [engine];
+
+        MeshExplorerServiceDefinition.factory(
+            engineExplorerService,
+            { addItemCommand: vi.fn(() => ({ dispose: vi.fn() })) } as unknown as IExplorerService,
+            watcherService,
+            {
+                selectedEntity: null,
+            } as ISelectionService,
+            { engine } as IEngineContext
+        );
 
         expect(providers[0].predicate(effectRenderer)).toBe(false);
     });

--- a/packages/dev/inspector-v2/test/unit/liteMeshPropertiesService.test.tsx
+++ b/packages/dev/inspector-v2/test/unit/liteMeshPropertiesService.test.tsx
@@ -12,22 +12,26 @@ import { MeshPropertiesServiceDefinition } from "../../src/lite/services/panes/p
 import { type IPropertiesService, PropertiesServiceIdentity } from "../../src/services/panes/properties/propertiesService";
 
 describe("Babylon Lite mesh properties service", () => {
-    it("registers General properties only for Babylon Lite meshes", () => {
+    it("registers rendering properties only for Babylon Lite meshes", () => {
         const dispose = vi.fn();
         const addSectionContent = vi.fn(() => ({ dispose }));
         const registration = MeshPropertiesServiceDefinition.factory({ addSectionContent } as unknown as IPropertiesService);
         const sectionContent = addSectionContent.mock.calls[0][0];
         const mesh = {
             name: "Box",
+            children: [],
+            position: {},
+            rotationQuaternion: {},
+            scaling: {},
+            parent: null,
             material: {},
             receiveShadows: false,
-            _gpu: {},
         } as Mesh;
 
         expect(MeshPropertiesServiceDefinition.consumes).toEqual([PropertiesServiceIdentity]);
         expect(sectionContent.key).toBe("Babylon Lite Mesh Properties");
         expect(sectionContent.content).toHaveLength(1);
-        expect(sectionContent.content[0].section).toBe("General");
+        expect(sectionContent.content[0].section).toBe("Rendering");
         expect(sectionContent.predicate(mesh)).toBe(true);
         expect(sectionContent.predicate({ name: "Not a mesh" })).toBe(false);
 

--- a/packages/dev/inspector-v2/test/unit/liteSceneEntities.test.ts
+++ b/packages/dev/inspector-v2/test/unit/liteSceneEntities.test.ts
@@ -1,0 +1,319 @@
+import { type Camera, type DirectionalLight, type Mesh, type SceneContext, type SceneNode, type ShadowGenerator } from "@babylonjs/lite";
+import { describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+    vi.stubGlobal("window", globalThis);
+    vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({ matches: false }))
+    );
+});
+
+vi.mock("@babylonjs/lite", async (importOriginal) => {
+    const original = await importOriginal<typeof import("@babylonjs/lite")>();
+    return {
+        ...original,
+        removeFromScene: vi.fn((scene: SceneContext, entity: object) => {
+            if (scene.camera === entity) {
+                scene.camera = null;
+            }
+            if ("children" in entity && Array.isArray(entity.children)) {
+                const removedNodes = new Set<object>([entity]);
+                const addChildren = (node: { children: SceneNode[] }) => {
+                    node.children.forEach((child) => {
+                        removedNodes.add(child);
+                        addChildren(child);
+                    });
+                };
+                addChildren(entity as { children: SceneNode[] });
+                for (let index = scene.meshes.length - 1; index >= 0; index--) {
+                    if (removedNodes.has(scene.meshes[index])) {
+                        scene.meshes.splice(index, 1);
+                    }
+                }
+            }
+            const lightIndex = scene.lights.indexOf(entity as DirectionalLight);
+            if (lightIndex !== -1) {
+                scene.lights.splice(lightIndex, 1);
+            }
+            const shadowIndex = scene.shadowGenerators.indexOf(entity as ShadowGenerator);
+            if (shadowIndex !== -1) {
+                scene.shadowGenerators.splice(shadowIndex, 1);
+            }
+        }),
+        setParent: vi.fn((node: SceneNode, parent: SceneNode | null) => {
+            if (node.parent && "children" in node.parent) {
+                const index = node.parent.children.indexOf(node);
+                if (index !== -1) {
+                    node.parent.children.splice(index, 1);
+                }
+            }
+            node.parent = parent;
+            parent?.children.push(node);
+        }),
+        setSubtreeVisible: vi.fn((node: SceneNode, visible: boolean) => {
+            node.visible = visible;
+            node.children.forEach((child) => (child.visible = visible));
+        }),
+    };
+});
+
+import { BuildExplorerTree, type ExplorerCommandProvider } from "../../src/components/explorer/explorerModel";
+import { type IEngineExplorerService, type RenderingContextNodeProvider } from "../../src/lite/engineExplorerService";
+import { type IEngineContext } from "../../src/lite/engineContext";
+import { GetSceneNodeRoots, SetQuaternionValue, SetVector3Value } from "../../src/lite/sceneEntityUtils";
+import { CameraPropertiesServiceDefinition } from "../../src/lite/services/panes/properties/cameraPropertiesService";
+import { LightPropertiesServiceDefinition } from "../../src/lite/services/panes/properties/lightPropertiesService";
+import { SceneNodePropertiesServiceDefinition } from "../../src/lite/services/panes/properties/sceneNodePropertiesService";
+import { ShadowGeneratorPropertiesServiceDefinition } from "../../src/lite/services/panes/properties/shadowGeneratorPropertiesService";
+import { CameraExplorerServiceDefinition } from "../../src/lite/services/panes/scene/cameraExplorerService";
+import { LightExplorerServiceDefinition } from "../../src/lite/services/panes/scene/lightExplorerService";
+import { MeshExplorerServiceDefinition } from "../../src/lite/services/panes/scene/meshExplorerService";
+import { ShadowGeneratorExplorerServiceDefinition } from "../../src/lite/services/panes/scene/shadowGeneratorExplorerService";
+import { type IExplorerService } from "../../src/services/panes/explorer/explorerService";
+import { type IPropertiesService } from "../../src/services/panes/properties/propertiesService";
+import { type ISelectionService } from "../../src/services/selectionService";
+import { type IWatcherService } from "../../src/services/watcherService";
+
+function CreateNode(name: string): SceneNode {
+    const position = { x: 0, y: 0, z: 0, set: vi.fn(), copyFrom: vi.fn(), toArray: vi.fn() };
+    const rotationQuaternion = { x: 0, y: 0, z: 0, w: 1, set: vi.fn(), copyFrom: vi.fn(), toArray: vi.fn() };
+    const scaling = { x: 1, y: 1, z: 1, set: vi.fn(), copyFrom: vi.fn(), toArray: vi.fn() };
+    return {
+        name,
+        children: [],
+        position,
+        rotationQuaternion,
+        rotation: { x: 0, y: 0, z: 0, set: vi.fn() },
+        scaling,
+        parent: null,
+        worldMatrix: new Float32Array(16),
+        worldMatrixVersion: 0,
+    };
+}
+
+function CreateMesh(name: string): Mesh {
+    return {
+        ...CreateNode(name),
+        material: {},
+        receiveShadows: false,
+    } as Mesh;
+}
+
+function CreateScene(root: Mesh, camera: Camera, light: DirectionalLight, shadowGenerator: ShadowGenerator): SceneContext {
+    return {
+        _kind: "scene",
+        meshes: [root, ...root.children.filter((child): child is Mesh => "material" in child)],
+        camera,
+        lights: [light],
+        shadowGenerators: [shadowGenerator],
+    } as SceneContext;
+}
+
+describe("Babylon Lite scene entities", () => {
+    it("builds a hierarchy from public parent and children links", () => {
+        const root = CreateMesh("Root");
+        const child = CreateMesh("Child");
+        const transform = CreateNode("Transform");
+        root.children.push(transform);
+        transform.parent = root;
+        transform.children.push(child);
+        child.parent = transform;
+        const scene = { meshes: [root, child] } as SceneContext;
+
+        expect(GetSceneNodeRoots(scene)).toEqual([root]);
+    });
+
+    it("mutates readonly transform references through public bulk setters", () => {
+        const node = CreateNode("Node");
+
+        SetVector3Value(node.position, [1, 2, 3]);
+        SetQuaternionValue(node.rotationQuaternion, [0.1, 0.2, 0.3, 0.9]);
+
+        expect(node.position.set).toHaveBeenCalledWith(1, 2, 3);
+        expect(node.rotationQuaternion.set).toHaveBeenCalledWith(0.1, 0.2, 0.3, 0.9);
+    });
+
+    it("contributes nodes, cameras, lights, shadows, commands, and cleans up", () => {
+        const providers: RenderingContextNodeProvider<SceneContext>[] = [];
+        const providerDisposals: ReturnType<typeof vi.fn>[] = [];
+        const commandProviders: ExplorerCommandProvider<object>[] = [];
+        const commandDisposals: ReturnType<typeof vi.fn>[] = [];
+        const engineExplorerService = {
+            addRenderingContextNodeProvider: (provider: RenderingContextNodeProvider<SceneContext>) => {
+                providers.push(provider);
+                const dispose = vi.fn();
+                providerDisposals.push(dispose);
+                return { dispose };
+            },
+        } as IEngineExplorerService;
+        const explorerService = {
+            addItemCommand: (provider: ExplorerCommandProvider<object>) => {
+                commandProviders.push(provider);
+                const dispose = vi.fn();
+                commandDisposals.push(dispose);
+                return { dispose };
+            },
+        } as unknown as IExplorerService;
+        const watcherService = {
+            watchProperty: vi.fn(() => ({ dispose: vi.fn() })),
+            watchValue: vi.fn(() => ({ dispose: vi.fn() })),
+        } as unknown as IWatcherService;
+        const selectionService = { selectedEntity: null } as ISelectionService;
+        const root = CreateMesh("Root");
+        const child = CreateMesh("Child");
+        root.children.push(child);
+        child.parent = root;
+        const camera = {
+            name: "Camera",
+            fov: 1,
+            nearPlane: 0.1,
+            farPlane: 100,
+            children: [],
+            worldMatrix: new Float32Array(16),
+            worldMatrixVersion: 0,
+        } as Camera;
+        const shadowGenerator = {};
+        const light = {
+            lightType: "directional",
+            children: [],
+            parent: null,
+            worldMatrix: new Float32Array(16),
+            worldMatrixVersion: 0,
+            direction: { x: 0, y: -1, z: 0 },
+            position: { x: 0, y: 1, z: 0 },
+            diffuse: [1, 1, 1],
+            specular: [1, 1, 1],
+            intensity: 1,
+            shadowGenerator,
+        } as DirectionalLight;
+        const scene = CreateScene(root, camera, light, shadowGenerator);
+        const engine = {
+            surfaces: [] as unknown[],
+            _renderingContexts: [scene],
+        };
+        engine.surfaces.push(engine);
+        const engineContext = { engine } as unknown as IEngineContext;
+
+        const registrations = [
+            MeshExplorerServiceDefinition.factory(engineExplorerService, explorerService, watcherService, selectionService, engineContext),
+            CameraExplorerServiceDefinition.factory(engineExplorerService, explorerService, watcherService, selectionService, engineContext),
+            LightExplorerServiceDefinition.factory(engineExplorerService, explorerService, selectionService, engineContext),
+            ShadowGeneratorExplorerServiceDefinition.factory(engineExplorerService, explorerService, selectionService, engineContext),
+        ];
+        const descriptions = providers.flatMap((provider) => provider.getNodes(scene));
+        const tree = BuildExplorerTree(descriptions);
+
+        expect(tree.nodes.map((node) => node.getDisplayInfo().name)).toEqual(["Nodes", "Cameras", "Lights", "Shadow Generators"]);
+        expect(tree.nodes[0].children[0].children[0].entity).toBe(child);
+        expect(commandProviders).toHaveLength(5);
+
+        const nodeProvider = providers[0];
+        const beforeReparent = nodeProvider.getSnapshot(scene);
+        const dragDropConfig = descriptions[0].dragDropConfig;
+        dragDropConfig?.onDrop(child, null);
+        const afterReparent = nodeProvider.getSnapshot(scene);
+        expect(child.parent).toBeNull();
+        expect(afterReparent.at(-1)).not.toBe(beforeReparent.at(-1));
+        dragDropConfig?.onDrop(child, root);
+
+        const visibilityProvider = commandProviders.find((provider) => provider.getCommand(root).type === "toggle");
+        const visibilityCommand = visibilityProvider?.getCommand(root);
+        if (visibilityCommand?.type !== "toggle") {
+            throw new Error("Expected a visibility toggle command.");
+        }
+        visibilityCommand.isEnabled = false;
+        expect(root.visible).toBe(false);
+        expect(child.visible).toBe(false);
+
+        selectionService.selectedEntity = child;
+        const nodeRemoveProvider = commandProviders.find((provider) => provider.getCommand(root).displayName === "Remove from Scene");
+        const secondScene = { ...scene, meshes: [root], camera: null, lights: [], shadowGenerators: [] } as SceneContext;
+        engine._renderingContexts.push(secondScene);
+        expect(nodeRemoveProvider?.predicate(root)).toBe(false);
+        engine._renderingContexts.pop();
+        expect(nodeRemoveProvider?.predicate(root)).toBe(true);
+        const nodeRemoveCommand = nodeRemoveProvider?.getCommand(root);
+        if (nodeRemoveCommand?.type !== "action") {
+            throw new Error("Expected a remove command.");
+        }
+        nodeRemoveCommand.execute();
+        expect(selectionService.selectedEntity).toBeNull();
+        expect(scene.meshes).not.toContain(root);
+
+        registrations.forEach((registration) => registration?.dispose?.());
+        providerDisposals.forEach((dispose) => expect(dispose).toHaveBeenCalledOnce());
+        commandDisposals.forEach((dispose) => expect(dispose).toHaveBeenCalledOnce());
+    });
+
+    it("registers scene node, camera, light, and identity-only shadow properties", () => {
+        const root = CreateMesh("Root");
+        const camera = {
+            name: "Camera",
+            fov: 1,
+            nearPlane: 0.1,
+            farPlane: 100,
+            children: [],
+            worldMatrix: new Float32Array(16),
+            worldMatrixVersion: 0,
+        } as Camera;
+        const shadowGenerator = {};
+        const light = {
+            lightType: "directional",
+            children: [],
+            parent: null,
+            worldMatrix: new Float32Array(16),
+            worldMatrixVersion: 0,
+            direction: { x: 0, y: -1, z: 0 },
+            position: { x: 0, y: 1, z: 0 },
+            diffuse: [1, 1, 1],
+            specular: [1, 1, 1],
+            intensity: 1,
+            shadowGenerator,
+        } as DirectionalLight;
+        const scene = CreateScene(root, camera, light, shadowGenerator);
+        const engine = {
+            surfaces: [] as unknown[],
+            _renderingContexts: [scene],
+        };
+        engine.surfaces.push(engine);
+        const contents: Parameters<IPropertiesService["addSectionContent"]>[0][] = [];
+        const disposals: ReturnType<typeof vi.fn>[] = [];
+        const propertiesService = {
+            addSectionContent: (content: Parameters<IPropertiesService["addSectionContent"]>[0]) => {
+                contents.push(content);
+                const dispose = vi.fn();
+                disposals.push(dispose);
+                return { dispose };
+            },
+        } as IPropertiesService;
+
+        const registrations = [
+            SceneNodePropertiesServiceDefinition.factory(propertiesService),
+            CameraPropertiesServiceDefinition.factory(propertiesService),
+            LightPropertiesServiceDefinition.factory(propertiesService),
+            ShadowGeneratorPropertiesServiceDefinition.factory(propertiesService, { engine } as unknown as IEngineContext),
+        ];
+
+        expect(contents.map((content) => content.key)).toEqual([
+            "Babylon Lite Scene Node Properties",
+            "Babylon Lite Camera Properties",
+            "Babylon Lite Free Camera Properties",
+            "Babylon Lite Arc Rotate Camera Properties",
+            "Babylon Lite Light Properties",
+            "Babylon Lite Directional Light Properties",
+            "Babylon Lite Point Light Properties",
+            "Babylon Lite Spot Light Properties",
+            "Babylon Lite Hemispheric Light Properties",
+            "Babylon Lite Shadow Generator Properties",
+        ]);
+        expect(contents[0].predicate(root)).toBe(true);
+        expect(contents[1].predicate(camera)).toBe(true);
+        expect(contents[5].predicate(light)).toBe(true);
+        expect(contents[9].predicate(shadowGenerator)).toBe(true);
+        expect(contents[9].content[0].section).toBe("General");
+
+        registrations.forEach((registration) => registration?.dispose?.());
+        disposals.forEach((dispose) => expect(dispose).toHaveBeenCalledOnce());
+    });
+});

--- a/packages/dev/inspector-v2/test/unit/liteSceneEntities.test.ts
+++ b/packages/dev/inspector-v2/test/unit/liteSceneEntities.test.ts
@@ -262,6 +262,36 @@ describe("Babylon Lite scene entities", () => {
         expect(camera.children).not.toContain(cameraChild);
         expect(scene.meshes).not.toContain(cameraChild);
 
+        const removedCameraChild = CreateMesh("Removed Camera Child");
+        camera.children.push(removedCameraChild);
+        removedCameraChild.parent = camera;
+        scene.meshes.push(removedCameraChild);
+        selectionService.selectedEntity = removedCameraChild;
+        const cameraRemoveProvider = commandProviders.find((provider) => provider.predicate(camera));
+        const cameraRemoveCommand = cameraRemoveProvider?.getCommand(camera);
+        if (cameraRemoveCommand?.type !== "action") {
+            throw new Error("Expected a camera remove command.");
+        }
+        cameraRemoveCommand.execute();
+        expect(scene.camera).toBeNull();
+        expect(scene.meshes).not.toContain(removedCameraChild);
+        expect(selectionService.selectedEntity).toBeNull();
+
+        const removedLightChild = CreateMesh("Removed Light Child");
+        light.children.push(removedLightChild);
+        removedLightChild.parent = light;
+        scene.meshes.push(removedLightChild);
+        selectionService.selectedEntity = removedLightChild;
+        const lightRemoveProvider = commandProviders.find((provider) => provider.predicate(light));
+        const lightRemoveCommand = lightRemoveProvider?.getCommand(light);
+        if (lightRemoveCommand?.type !== "action") {
+            throw new Error("Expected a light remove command.");
+        }
+        lightRemoveCommand.execute();
+        expect(scene.lights).not.toContain(light);
+        expect(scene.meshes).not.toContain(removedLightChild);
+        expect(selectionService.selectedEntity).toBeNull();
+
         const secondScene = { ...scene, meshes: [root], camera: null, lights: [], shadowGenerators: [] } as SceneContext;
         engine._renderingContexts.push(secondScene);
         expect(nodeRemoveProvider?.predicate(root)).toBe(false);

--- a/packages/dev/inspector-v2/test/unit/liteSceneEntities.test.ts
+++ b/packages/dev/inspector-v2/test/unit/liteSceneEntities.test.ts
@@ -1,4 +1,7 @@
 import { type Camera, type DirectionalLight, type Mesh, type SceneContext, type SceneNode, type ShadowGenerator } from "@babylonjs/lite";
+import { tokens } from "@fluentui/react-components";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 vi.hoisted(() => {
@@ -206,6 +209,10 @@ describe("Babylon Lite scene entities", () => {
 
         expect(tree.nodes.map((node) => node.getDisplayInfo().name)).toEqual(["Nodes", "Cameras", "Lights", "Shadow Generators"]);
         expect(tree.nodes[0].children[0].children[0].entity).toBe(child);
+        expect(renderToStaticMarkup(createElement(tree.nodes[0].children[0].icon!, { entity: root }))).toContain(tokens.colorPaletteBlueForeground2);
+        expect(renderToStaticMarkup(createElement(tree.nodes[1].children[0].icon!, { entity: camera }))).toContain(tokens.colorPaletteGreenForeground2);
+        expect(renderToStaticMarkup(createElement(tree.nodes[2].children[0].icon!, { entity: light }))).toContain(tokens.colorPaletteYellowForeground2);
+        expect(renderToStaticMarkup(createElement(tree.nodes[3].children[0].icon!, { entity: shadowGenerator }))).toContain(tokens.colorPaletteYellowForeground2);
         expect(commandProviders).toHaveLength(5);
 
         const nodeProvider = providers[0];
@@ -217,6 +224,12 @@ describe("Babylon Lite scene entities", () => {
         expect(afterReparent.at(-1)).not.toBe(beforeReparent.at(-1));
         dragDropConfig?.onDrop(child, root);
 
+        const foreignRoot = CreateMesh("Foreign Root");
+        const foreignScene = { ...scene, meshes: [foreignRoot], camera: null, lights: [], shadowGenerators: [] } as SceneContext;
+        engine._renderingContexts.push(foreignScene);
+        expect(dragDropConfig?.canDrop(child, foreignRoot)).toBe(false);
+        engine._renderingContexts.pop();
+
         const visibilityProvider = commandProviders.find((provider) => provider.getCommand(root).type === "toggle");
         const visibilityCommand = visibilityProvider?.getCommand(root);
         if (visibilityCommand?.type !== "toggle") {
@@ -226,8 +239,29 @@ describe("Babylon Lite scene entities", () => {
         expect(root.visible).toBe(false);
         expect(child.visible).toBe(false);
 
-        selectionService.selectedEntity = child;
         const nodeRemoveProvider = commandProviders.find((provider) => provider.getCommand(root).displayName === "Remove from Scene");
+        selectionService.selectedEntity = child;
+        const childRemoveCommand = nodeRemoveProvider?.getCommand(child);
+        if (childRemoveCommand?.type !== "action") {
+            throw new Error("Expected a nested remove command.");
+        }
+        childRemoveCommand.execute();
+        expect(root.children).not.toContain(child);
+        expect(scene.meshes).not.toContain(child);
+        expect(selectionService.selectedEntity).toBeNull();
+
+        const cameraChild = CreateMesh("Camera Child");
+        camera.children.push(cameraChild);
+        cameraChild.parent = camera;
+        scene.meshes.push(cameraChild);
+        const cameraChildRemoveCommand = nodeRemoveProvider?.getCommand(cameraChild);
+        if (cameraChildRemoveCommand?.type !== "action") {
+            throw new Error("Expected a camera-child remove command.");
+        }
+        cameraChildRemoveCommand.execute();
+        expect(camera.children).not.toContain(cameraChild);
+        expect(scene.meshes).not.toContain(cameraChild);
+
         const secondScene = { ...scene, meshes: [root], camera: null, lights: [], shadowGenerators: [] } as SceneContext;
         engine._renderingContexts.push(secondScene);
         expect(nodeRemoveProvider?.predicate(root)).toBe(false);
@@ -237,6 +271,7 @@ describe("Babylon Lite scene entities", () => {
         if (nodeRemoveCommand?.type !== "action") {
             throw new Error("Expected a remove command.");
         }
+        selectionService.selectedEntity = root;
         nodeRemoveCommand.execute();
         expect(selectionService.selectedEntity).toBeNull();
         expect(scene.meshes).not.toContain(root);

--- a/packages/dev/inspector-v2/test/unit/runtimeNeutralPropertyLines.test.tsx
+++ b/packages/dev/inspector-v2/test/unit/runtimeNeutralPropertyLines.test.tsx
@@ -30,7 +30,7 @@ import {
     Vector3PropertyLine as LiteVector3PropertyLine,
 } from "shared-ui-components/lite/fluent/hoc/propertyLines/vectorPropertyLine";
 import { DerivedProperty } from "../../src/components/properties/boundProperty";
-import { DirectionalLightSetupProperties } from "../../src/lite/components/properties/lightProperties";
+import { DirectionalLightSetupProperties, SetLightProperty } from "../../src/lite/components/properties/lightProperties";
 
 vi.stubGlobal("NodeFilter", window.NodeFilter);
 
@@ -109,6 +109,25 @@ describe("runtime-neutral property-line wrappers", () => {
 
         expect(container.textContent).toContain("[4.00, 6.00, -3.00]");
         expect(container.textContent).toContain("[-0.50, -1.00, 0.25]");
+    });
+
+    it("invalidates Lite light rendering after plain color and intensity writes", () => {
+        const directionSet = vi.fn();
+        const light = {
+            direction: { x: -0.5, y: -1, z: 0.25, set: directionSet },
+            position: { x: 4, y: 6, z: -3, set: vi.fn() },
+            diffuse: [1, 1, 1] as [number, number, number],
+            specular: [1, 1, 1] as [number, number, number],
+            intensity: 0.5,
+        };
+
+        SetLightProperty(light, "diffuse", [0.2, 0.4, 0.6]);
+        expect(light.diffuse).toEqual([0.2, 0.4, 0.6]);
+        expect(directionSet).toHaveBeenLastCalledWith(-0.5, -1, 0.25);
+
+        SetLightProperty(light, "intensity", 0.25);
+        expect(light.intensity).toBe(0.25);
+        expect(directionSet).toHaveBeenCalledTimes(2);
     });
 
     it("supports reusable watched projections with custom write-back", () => {

--- a/packages/dev/inspector-v2/test/unit/runtimeNeutralPropertyLines.test.tsx
+++ b/packages/dev/inspector-v2/test/unit/runtimeNeutralPropertyLines.test.tsx
@@ -93,8 +93,14 @@ describe("runtime-neutral property-line wrappers", () => {
 
         expect(container.textContent).toContain("[1.00, 2.00, 3.00]");
         expect(container.textContent).toContain("[4.00, 5.00, 6.00]");
-        expect(container.textContent).toContain("[0, 0, 0]");
+        expect(container.textContent).toContain("[0.0, 0.0, 0.0]");
         expect(container.querySelectorAll("button").length).toBeGreaterThan(0);
+    });
+
+    it("uses explicit precision in the collapsed tensor summary", () => {
+        const container = Render(<LiteVector3PropertyLine label="Precise" value={[1.24, 2.25, 3.26]} onChange={vi.fn()} precision={1} />);
+
+        expect(container.textContent).toContain("[1.2, 2.3, 3.3]");
     });
 
     it("renders watched Lite light vectors without a render loop", () => {

--- a/packages/dev/inspector-v2/test/unit/runtimeNeutralPropertyLines.test.tsx
+++ b/packages/dev/inspector-v2/test/unit/runtimeNeutralPropertyLines.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { Color3 } from "core/Maths/math.color";
+import { Vector3 } from "core/Maths/math.vector";
+import { FluentProvider, webLightTheme } from "@fluentui/react-components";
+import { act, createRef, type ComponentProps, type ForwardRefExoticComponent, type FunctionComponent, type ReactNode, type RefAttributes } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.hoisted(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal(
+        "matchMedia",
+        vi.fn(() => ({
+            matches: false,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        }))
+    );
+});
+
+import { Color3PropertyLine as FullColor3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLine";
+import { Vector3PropertyLine as FullVector3PropertyLine } from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLine";
+import { Color3PropertyLine as LiteColor3PropertyLine } from "shared-ui-components/lite/fluent/hoc/propertyLines/colorPropertyLine";
+import {
+    CreateQuaternionFromEuler,
+    QuaternionPropertyLine as LiteQuaternionPropertyLine,
+    Vector3PropertyLine as LiteVector3PropertyLine,
+} from "shared-ui-components/lite/fluent/hoc/propertyLines/vectorPropertyLine";
+import { DerivedProperty } from "../../src/components/properties/boundProperty";
+import { DirectionalLightSetupProperties } from "../../src/lite/components/properties/lightProperties";
+
+vi.stubGlobal("NodeFilter", window.NodeFilter);
+
+describe("runtime-neutral property-line wrappers", () => {
+    const containers: HTMLElement[] = [];
+    const roots: Root[] = [];
+
+    afterEach(() => {
+        roots.splice(0).forEach((root) => act(() => root.unmount()));
+        containers.splice(0).forEach((container) => container.remove());
+    });
+
+    function Render(content: ReactNode): HTMLElement {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+        containers.push(container);
+        const root = createRoot(container);
+        roots.push(root);
+        act(() => root.render(<FluentProvider theme={webLightTheme}>{content}</FluentProvider>));
+        return container;
+    }
+
+    it("preserves Full Babylon class-facing values", () => {
+        const vector = new Vector3(1, 2, 3);
+        const color = new Color3(0.25, 0.5, 0.75);
+        const container = Render(
+            <>
+                <FullVector3PropertyLine label="Vector" value={vector} onChange={vi.fn()} />
+                <FullColor3PropertyLine label="Color" value={color} onChange={vi.fn()} />
+            </>
+        );
+
+        expect(container.textContent).toContain("[1.00, 2.00, 3.00]");
+        expect(container.querySelectorAll("button").length).toBeGreaterThan(0);
+    });
+
+    it("preserves Full color refs and forwards disabled state to Full and Lite pickers", () => {
+        const ref = createRef<HTMLDivElement>();
+        const RefColorPropertyLine = FullColor3PropertyLine as ForwardRefExoticComponent<ComponentProps<typeof FullColor3PropertyLine> & RefAttributes<HTMLDivElement>>;
+        const container = Render(
+            <>
+                <RefColorPropertyLine ref={ref} label="Full Color" value={new Color3(1, 0, 0)} onChange={vi.fn()} disabled />
+                <LiteColor3PropertyLine label="Lite Color" value={[0, 1, 0]} onChange={vi.fn()} disabled />
+            </>
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLDivElement);
+        expect(container.querySelectorAll("button[disabled]")).toHaveLength(2);
+    });
+
+    it("accepts Lite tuple and structural values without constructing Full classes", () => {
+        const container = Render(
+            <>
+                <LiteVector3PropertyLine label="Tuple" value={[1, 2, 3]} onChange={vi.fn()} />
+                <LiteVector3PropertyLine label="Object" value={{ x: 4, y: 5, z: 6 }} onChange={vi.fn()} />
+                <LiteQuaternionPropertyLine label="Rotation" value={[0, 0, 0, 1]} onChange={vi.fn()} useEuler useDegrees />
+                <LiteColor3PropertyLine label="Color" value={[1, 0.5, 0]} onChange={vi.fn()} />
+            </>
+        );
+
+        expect(container.textContent).toContain("[1.00, 2.00, 3.00]");
+        expect(container.textContent).toContain("[4.00, 5.00, 6.00]");
+        expect(container.textContent).toContain("[0, 0, 0]");
+        expect(container.querySelectorAll("button").length).toBeGreaterThan(0);
+    });
+
+    it("renders watched Lite light vectors without a render loop", () => {
+        const light = {
+            direction: { x: -0.5, y: -1, z: 0.25 },
+            position: { x: 4, y: 6, z: -3 },
+            diffuse: [1, 1, 1],
+            specular: [1, 1, 1],
+            intensity: 0.5,
+        } as Parameters<typeof DirectionalLightSetupProperties>[0]["light"];
+        const container = Render(<DirectionalLightSetupProperties light={light} />);
+
+        expect(container.textContent).toContain("[4.00, 6.00, -3.00]");
+        expect(container.textContent).toContain("[-0.50, -1.00, 0.25]");
+    });
+
+    it("supports reusable watched projections with custom write-back", () => {
+        const target = { storedValue: 2 };
+        const NumberProperty: FunctionComponent<{ label: string; value: number; onChange: (value: number) => void }> = (props) => {
+            const { label, value, onChange } = props;
+            return <button onClick={() => onChange(value + 2)}>{`${label}: ${value}`}</button>;
+        };
+        const container = Render(
+            <DerivedProperty
+                component={NumberProperty}
+                label="Derived"
+                target={target}
+                getValue={(value) => value.storedValue * 2}
+                setValue={(value, changedValue) => (value.storedValue = changedValue / 2)}
+            />
+        );
+
+        expect(container.textContent).toBe("Derived: 4");
+        act(() => container.querySelector("button")?.click());
+        expect(target.storedValue).toBe(3);
+    });
+
+    it("preserves Lite quaternion representation during Euler conversion", () => {
+        expect(CreateQuaternionFromEuler([0, 0, 0], [0, 0, 0, 1])).toEqual([0, 0, 0, 1]);
+        expect(CreateQuaternionFromEuler({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: 0, w: 1 })).toEqual({ x: 0, y: 0, z: 0, w: 1 });
+    });
+});

--- a/packages/dev/sharedUiComponents/package.json
+++ b/packages/dev/sharedUiComponents/package.json
@@ -37,6 +37,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
+        "@babylonjs/lite": "1.27.0",
         "@dev/core": "^1.0.0",
         "@dev/gui": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^7.3.1",

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -29,8 +29,13 @@ export function copyCommandToClipboard(strCommand: string) {
 // Return the class name of the considered target
 // babylonNamespace is either "" (ES6) or "BABYLON."
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function getClassNameWithNamespace(obj: { getClassName?: () => string; constructor?: { name?: string } }): { className: string; babylonNamespace: string } {
-    let className = obj.getClassName?.() ?? obj.constructor?.name ?? "Unknown";
+export function getClassNameWithNamespace(obj: unknown): { className: string; babylonNamespace: string } {
+    if ((typeof obj !== "object" && typeof obj !== "function") || obj === null) {
+        return { className: "Unknown", babylonNamespace: "" };
+    }
+
+    const candidate = obj as { getClassName?: () => string; constructor?: { name?: string } };
+    let className = candidate.getClassName?.() ?? candidate.constructor?.name ?? "Unknown";
     if (className.includes("BABYLON.")) {
         className = className.split("BABYLON.")[1];
     }

--- a/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
+++ b/packages/dev/sharedUiComponents/src/copyCommandToClipboard.ts
@@ -1,5 +1,3 @@
-import { GetClassName } from "core/Misc/typeStore";
-
 // Check if BABYLON namespace exists
 let BabylonNamespace = "";
 const GlobalObject = typeof global !== "undefined" ? global : typeof window !== "undefined" ? window : undefined;
@@ -31,8 +29,8 @@ export function copyCommandToClipboard(strCommand: string) {
 // Return the class name of the considered target
 // babylonNamespace is either "" (ES6) or "BABYLON."
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export function getClassNameWithNamespace(obj: any): { className: string; babylonNamespace: string } {
-    let className = GetClassName(obj);
+export function getClassNameWithNamespace(obj: { getClassName?: () => string; constructor?: { name?: string } }): { className: string; babylonNamespace: string } {
+    let className = obj.getClassName?.() ?? obj.constructor?.name ?? "Unknown";
     if (className.includes("BABYLON.")) {
         className = className.split("BABYLON.")[1];
     }

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/colorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/colorPropertyLine.tsx
@@ -1,65 +1,37 @@
-import { type FunctionComponent, forwardRef, useEffect, useState } from "react";
+import { type FunctionComponent, forwardRef } from "react";
 
-import { type PropertyLineProps, PropertyLine } from "./propertyLine";
-import { SyncedSliderPropertyLine } from "./syncedSliderPropertyLine";
+import { type PropertyLineProps } from "./propertyLine";
 
 import { type Color3, Color4 } from "core/Maths/math.color";
 import { ColorPickerPopup, type ColorPickerProps } from "../../primitives/colorPicker";
+import { ControlledColorPropertyLine, type ColorPropertyLineAdapter } from "./colorPropertyLineCore";
 
 export type ColorPropertyLineProps = ColorPickerProps<Color3 | Color4> & PropertyLineProps<Color3 | Color4>;
 
-/**
- * Reusable component which renders a color property line containing a label, colorPicker popout, and expandable RGBA values
- * The expandable RGBA values are synced sliders that allow the user to modify the color's RGBA values directly
- * @param props - PropertyLine props, replacing children with a color object so that we can properly display the color
- * @returns Component wrapping a colorPicker component with a property line
- */
-const ColorPropertyLine = forwardRef<HTMLDivElement, ColorPropertyLineProps>((props, ref) => {
-    ColorPropertyLine.displayName = "ColorPropertyLine";
-    const [color, setColor] = useState(props.value);
-
-    useEffect(() => {
-        setColor(props.value);
-    }, [props.value]);
-
-    const onSliderChange = (value: number, key: "r" | "g" | "b" | "a") => {
-        let newColor: Color3 | Color4;
-        if (key === "a") {
-            newColor = Color4.FromColor3(color, value);
-        } else {
-            newColor = color.clone();
-            newColor[key] = value / 255;
+const Picker: FunctionComponent<ColorPickerProps<Color3 | Color4>> = (props) => <ColorPickerPopup {...props} />;
+const Adapter: ColorPropertyLineAdapter<Color3 | Color4> = {
+    picker: Picker,
+    getColor: (value) => value,
+    createColor: (color, source) => {
+        if (source instanceof Color4) {
+            return new Color4(color.r, color.g, color.b, color.a ?? source.a);
         }
-
-        setColor(newColor); // Create a new object to trigger re-render
-        props.onChange(newColor);
-    };
-
-    const onColorPickerChange = (newColor: Color3 | Color4) => {
-        setColor(newColor);
-        props.onChange(newColor);
-    };
-
-    return (
-        <PropertyLine ref={ref} {...props} expandedContent={color ? <ColorSliders color={color} onSliderChange={onSliderChange} /> : undefined}>
-            <ColorPickerPopup {...props} onChange={onColorPickerChange} value={color} />
-        </PropertyLine>
-    );
-});
-
-type ColorSlidersProps = {
-    color: Color3 | Color4;
-    onSliderChange: (value: number, key: "r" | "g" | "b" | "a") => void;
+        return source.clone().set(color.r, color.g, color.b);
+    },
 };
 
-const ColorSliders: FunctionComponent<ColorSlidersProps> = ({ color, onSliderChange }) => (
-    <>
-        <SyncedSliderPropertyLine label="R" value={color.r * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "r")} />
-        <SyncedSliderPropertyLine label="G" value={color.g * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "g")} />
-        <SyncedSliderPropertyLine label="B" value={color.b * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "b")} />
-        {color instanceof Color4 && <SyncedSliderPropertyLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onSliderChange(value, "a")} />}
-    </>
-);
+const ColorPropertyLine = forwardRef<HTMLDivElement, ColorPropertyLineProps>((props, ref) => <ControlledColorPropertyLine {...props} adapter={Adapter} propertyLineRef={ref} />);
+ColorPropertyLine.displayName = "ColorPropertyLine";
 
+/**
+ * Edits a Babylon.js Color3 value.
+ * @param props The controlled color and property-line presentation.
+ * @returns The Color3 property line.
+ */
 export const Color3PropertyLine = ColorPropertyLine as FunctionComponent<ColorPickerProps<Color3> & PropertyLineProps<Color3>>;
+/**
+ * Edits a Babylon.js Color4 value.
+ * @param props The controlled color and property-line presentation.
+ * @returns The Color4 property line.
+ */
 export const Color4PropertyLine = ColorPropertyLine as FunctionComponent<ColorPickerProps<Color4> & PropertyLineProps<Color4>>;

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/colorPropertyLineCore.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/colorPropertyLineCore.tsx
@@ -1,0 +1,86 @@
+import { createElement, type ComponentType, type FunctionComponent, type Ref, useEffect, useState } from "react";
+
+import { type StructuralColor, type StructuralColorAdapter } from "../../primitives/structuralColorPicker";
+import { type PrimitiveProps } from "../../primitives/primitive";
+import { type PropertyLineProps, PropertyLine } from "./propertyLine";
+import { SyncedSliderPropertyLine } from "./syncedSliderPropertyLine";
+
+export type ColorPropertyLineAdapter<ValueT> = StructuralColorAdapter<ValueT> &
+    Readonly<{
+        picker: ComponentType<PrimitiveProps<ValueT> & { isLinearMode?: boolean }>;
+    }>;
+
+export type ControlledColorPropertyLineProps<ValueT> = PrimitiveProps<ValueT> &
+    PropertyLineProps<ValueT> &
+    Readonly<{
+        adapter: ColorPropertyLineAdapter<ValueT>;
+        isLinearMode?: boolean;
+        propertyLineRef?: Ref<HTMLDivElement>;
+    }>;
+
+/**
+ * Runtime-neutral controlled color editor with RGB or RGBA sliders and an injected picker.
+ * @param props The controlled color, runtime adapter, and property-line presentation.
+ * @returns The color property line.
+ */
+export const ControlledColorPropertyLine = <ValueT,>(props: ControlledColorPropertyLineProps<ValueT>) => {
+    const { adapter, value, onChange, propertyLineRef } = props;
+    const [currentValue, setCurrentValue] = useState(value);
+
+    useEffect(() => {
+        setCurrentValue(value);
+    }, [value]);
+
+    const handleChange = (newValue: ValueT) => {
+        setCurrentValue(newValue);
+        onChange(newValue);
+    };
+
+    const onSliderChange = (componentValue: number, component: keyof StructuralColor) => {
+        const color = adapter.getColor(currentValue);
+        handleChange(
+            adapter.createColor(
+                {
+                    ...color,
+                    [component]: component === "a" ? componentValue : componentValue / 255,
+                },
+                currentValue
+            )
+        );
+    };
+
+    const color = adapter.getColor(currentValue);
+    return (
+        <PropertyLine ref={propertyLineRef} {...props} expandedContent={<ColorSliders color={color} onSliderChange={onSliderChange} />}>
+            {createElement(adapter.picker, {
+                value: currentValue,
+                onChange: handleChange,
+                isLinearMode: props.isLinearMode,
+                disabled: props.disabled,
+                className: props.className,
+                style: props.style,
+                title: props.title,
+            })}
+        </PropertyLine>
+    );
+};
+
+type ColorSlidersProps = Readonly<{
+    color: StructuralColor;
+    onSliderChange: (value: number, component: keyof StructuralColor) => void;
+}>;
+
+const ColorSliders: FunctionComponent<ColorSlidersProps> = (props) => {
+    const { color, onSliderChange } = props;
+
+    return (
+        <>
+            <SyncedSliderPropertyLine label="R" value={color.r * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "r")} />
+            <SyncedSliderPropertyLine label="G" value={color.g * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "g")} />
+            <SyncedSliderPropertyLine label="B" value={color.b * 255} min={0} max={255} onChange={(value) => onSliderChange(value, "b")} />
+            {color.a === undefined ? undefined : (
+                <SyncedSliderPropertyLine label="A" value={color.a} min={0} max={1} step={0.01} onChange={(value) => onSliderChange(value, "a")} />
+            )}
+        </>
+    );
+};

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/vectorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/vectorPropertyLine.tsx
@@ -1,223 +1,107 @@
-import { type FunctionComponent, useEffect, useState } from "react";
+import { type FunctionComponent } from "react";
 
-import { type Vector3, Quaternion, Vector2, Vector4 } from "core/Maths/math.vector";
-import { type PrimitiveProps } from "../../primitives/primitive";
-import { type PropertyLineProps, PropertyLine } from "./propertyLine";
+import { Quaternion, type Vector2, type Vector3, type Vector4 } from "core/Maths/math.vector";
+import {
+    ControlledQuaternionPropertyLine,
+    ControlledRotationVectorPropertyLine,
+    ControlledTensorPropertyLine,
+    type QuaternionValueAdapter,
+    type TensorComponent,
+    type TensorPropertyLineProps as RuntimeNeutralTensorPropertyLineProps,
+    type TensorValueAdapter,
+} from "./vectorPropertyLineCore";
 
-import { Body1 } from "@fluentui/react-components";
+export type TensorPropertyLineProps<ValueT extends Vector2 | Vector3 | Vector4 | Quaternion> = RuntimeNeutralTensorPropertyLineProps<ValueT>;
 
-import { Tools } from "core/Misc/tools";
-import { CalculatePrecision } from "../../primitives/utils";
-import { NumberInputPropertyLine } from "./inputPropertyLine";
-import { TextPropertyLine } from "./textPropertyLine";
-
-export type TensorPropertyLineProps<V extends Vector2 | Vector3 | Vector4 | Quaternion> = PropertyLineProps<V> &
-    PrimitiveProps<V> & {
-        /**
-         * If passed, all sliders will use this for the min value
-         */
-        min?: number;
-        /**
-         * If passed, all sliders will use this for the max value
-         */
-        max?: number;
-        /**
-         * Will be displayed in the input UI to indicate the unit of measurement
-         */
-        unit?: string;
-        /**
-         * Internal spinbutton's step
-         */
-        step?: number;
-        /** Optional fixed precision (number of decimal digits). Overrides the automatically computed display precision. */
-        precision?: number;
-        /**
-         * If passed, the UX will use the conversion functions to display/update values
-         */
-        valueConverter?: {
-            /**
-             * Will call from(val) before displaying in the UX
-             */
-            from: (val: number) => number;
-            /**
-             * Will call to(val) before calling onChange
-             */
-            to: (val: number) => number;
-        };
-    };
-
-const HasZ = (vector: Vector2 | Vector3 | Vector4 | Quaternion): vector is Vector3 => !(vector instanceof Vector2);
-const HasW = (vector: Vector2 | Vector3 | Vector4 | Quaternion): vector is Vector4 => vector instanceof Vector4 || vector instanceof Quaternion;
-
-/**
- * Reusable component which renders a vector property line containing a label, vector value, and expandable XYZW values
- * The expanded section contains a slider/input box for each component of the vector (x, y, z, w)
- * @param props
- * @returns
- */
-const TensorPropertyLine: FunctionComponent<TensorPropertyLineProps<Vector2 | Vector3 | Vector4 | Quaternion>> = (props) => {
-    TensorPropertyLine.displayName = "TensorPropertyLine";
-    const converted = (val: number) => (props.valueConverter ? props.valueConverter.from(val) : val);
-    const formatted = (val: number) => converted(val).toFixed(props.step !== undefined ? Math.max(0, CalculatePrecision(props.step)) : 2);
-
-    const [vector, setVector] = useState(props.value);
-    const { min, max } = props;
-
-    const onChange = (val: number, key: "x" | "y" | "z" | "w") => {
-        const value = props.valueConverter ? props.valueConverter.to(val) : val;
-        const newVector = vector.clone();
-        (newVector as Vector4)[key] = value; // The syncedSlider for 'w' is only rendered when vector is a Vector4, so this is safe
-
-        setVector(newVector);
-        props.onChange(newVector);
-    };
-
-    useEffect(() => {
-        setVector(props.value);
-    }, [props.value, props.expandedContent]);
-
-    return (
-        <PropertyLine
-            {...props}
-            expandedContent={
-                <>
-                    {props.expandedContent}
-                    {vector ? (
-                        <VectorSliders
-                            vector={vector}
-                            min={min}
-                            max={max}
-                            unit={props.unit}
-                            step={props.step}
-                            precision={props.precision}
-                            converted={converted}
-                            onChange={onChange}
-                        />
-                    ) : undefined}
-                </>
+function CreateCoreTensorAdapter<ValueT extends Vector2 | Vector3 | Vector4 | Quaternion>(components: readonly TensorComponent[]): TensorValueAdapter<ValueT> {
+    return {
+        components,
+        getComponent: (value, component) => {
+            switch (component) {
+                case "x":
+                    return value.x;
+                case "y":
+                    return value.y;
+                case "z":
+                    return "z" in value ? value.z : 0;
+                case "w":
+                    return "w" in value ? value.w : 0;
             }
-        >
-            <Body1>{`[${formatted(props.value.x)}, ${formatted(props.value.y)}${HasZ(props.value) ? `, ${formatted(props.value.z)}` : ""}${HasW(props.value) ? `, ${formatted(props.value.w)}` : ""}]`}</Body1>
-        </PropertyLine>
-    );
-};
+        },
+        withComponent: (value, component, componentValue) => {
+            const result = value.clone() as ValueT;
+            switch (component) {
+                case "x":
+                    result.x = componentValue;
+                    break;
+                case "y":
+                    result.y = componentValue;
+                    break;
+                case "z":
+                    if ("z" in result) {
+                        result.z = componentValue;
+                    }
+                    break;
+                case "w":
+                    if ("w" in result) {
+                        result.w = componentValue;
+                    }
+                    break;
+            }
+            return result;
+        },
+    };
+}
 
-type VectorSlidersProps<V extends Vector2 | Vector3 | Vector4 | Quaternion> = {
-    vector: V;
-    min?: number;
-    max?: number;
-    unit?: string;
-    step?: number;
-    precision?: number;
-    converted: (val: number) => number;
-    onChange: (val: number, key: "x" | "y" | "z" | "w") => void;
+const Vector2Adapter = CreateCoreTensorAdapter<Vector2>(["x", "y"]);
+const Vector3Adapter = CreateCoreTensorAdapter<Vector3>(["x", "y", "z"]);
+const Vector4Adapter = CreateCoreTensorAdapter<Vector4>(["x", "y", "z", "w"]);
+const QuaternionTensorAdapter = CreateCoreTensorAdapter<Quaternion>(["x", "y", "z", "w"]);
+const QuaternionAdapter: QuaternionValueAdapter<Quaternion, Vector3> = {
+    quaternion: QuaternionTensorAdapter,
+    euler: Vector3Adapter,
+    fromEuler: (value) => Quaternion.FromEulerAngles(value.x, value.y, value.z),
+    toEuler: (value) => value.toEulerAngles(),
 };
-
-const VectorSliders = <V extends Vector2 | Vector3 | Vector4 | Quaternion>({ vector, min, max, unit, step, precision, converted, onChange }: VectorSlidersProps<V>) => (
-    <>
-        <NumberInputPropertyLine label="X" value={converted(vector.x)} min={min} max={max} onChange={(val) => onChange(val, "x")} unit={unit} step={step} precision={precision} />
-        <NumberInputPropertyLine label="Y" value={converted(vector.y)} min={min} max={max} onChange={(val) => onChange(val, "y")} unit={unit} step={step} precision={precision} />
-        {HasZ(vector) && (
-            <NumberInputPropertyLine
-                label="Z"
-                value={converted(vector.z)}
-                min={min}
-                max={max}
-                onChange={(val) => onChange(val, "z")}
-                unit={unit}
-                step={step}
-                precision={precision}
-            />
-        )}
-        {HasW(vector) && (
-            <NumberInputPropertyLine
-                label="W"
-                value={converted(vector.w)}
-                min={min}
-                max={max}
-                onChange={(val) => onChange(val, "w")}
-                unit={unit}
-                step={step}
-                precision={precision}
-            />
-        )}
-    </>
-);
 
 type RotationVectorPropertyLineProps = TensorPropertyLineProps<Vector3> & {
-    /**
-     * Display angles as degrees instead of radians
-     */
     useDegrees?: boolean;
-};
-
-const ToDegreesConverter = { from: Tools.ToDegrees, to: Tools.ToRadians };
-export const RotationVectorPropertyLine: FunctionComponent<RotationVectorPropertyLineProps> = (props) => {
-    RotationVectorPropertyLine.displayName = "RotationVectorPropertyLine";
-    const step = props.useDegrees ? 1 : 0.01;
-    const precision = props.useDegrees ? 1 : 2;
-    return (
-        <Vector3PropertyLine
-            {...props}
-            unit={props.useDegrees ? "°" : "rad"}
-            valueConverter={props.useDegrees ? ToDegreesConverter : undefined}
-            step={step}
-            precision={precision}
-        />
-    );
 };
 
 type QuaternionPropertyLineProps = TensorPropertyLineProps<Quaternion> & {
-    /**
-     * Display angles as degrees instead of radians
-     */
     useDegrees?: boolean;
-    /**
-     * Display angles as Euler angles instead of quaternions
-     */
     useEuler?: boolean;
 };
-const QuaternionPropertyLineInternal = TensorPropertyLine as FunctionComponent<TensorPropertyLineProps<Quaternion>>;
-export const QuaternionPropertyLine: FunctionComponent<QuaternionPropertyLineProps> = (props) => {
-    QuaternionPropertyLine.displayName = "QuaternionPropertyLine";
-    const step = props.useDegrees ? 1 : 0.01;
-    const precision = props.useDegrees ? 1 : 2;
-    const [quat, setQuat] = useState(props.value);
 
-    useEffect(() => {
-        setQuat(props.value);
-    }, [props.value]);
-
-    // Extract only the properties that exist on QuaternionPropertyLineProps
-    const { useEuler, ...restProps } = props;
-
-    const onQuatChange = (val: Quaternion) => {
-        setQuat(val);
-        props.onChange(val);
-    };
-
-    const onEulerChange = (val: Vector3) => {
-        const quat = Quaternion.FromEulerAngles(val.x, val.y, val.z);
-        onQuatChange(quat);
-    };
-
-    return useEuler ? (
-        <Vector3PropertyLine
-            {...restProps}
-            nullable={false}
-            ignoreNullable={false}
-            value={quat.toEulerAngles()}
-            valueConverter={ToDegreesConverter}
-            onChange={onEulerChange}
-            unit={props.useDegrees ? "°" : "rad"}
-            step={step}
-            precision={precision}
-            expandedContent={<TextPropertyLine label="Quaternion" value={`[${quat.x.toFixed(4)}, ${quat.y.toFixed(4)}, ${quat.z.toFixed(4)}, ${quat.w.toFixed(4)}]`} />}
-        />
-    ) : (
-        <QuaternionPropertyLineInternal {...props} nullable={false} value={quat} onChange={onQuatChange} unit={props.useDegrees ? "°" : "rad"} step={step} precision={precision} />
-    );
-};
-export const Vector2PropertyLine = TensorPropertyLine as FunctionComponent<TensorPropertyLineProps<Vector2>>;
-export const Vector3PropertyLine = TensorPropertyLine as FunctionComponent<TensorPropertyLineProps<Vector3>>;
-export const Vector4PropertyLine = TensorPropertyLine as FunctionComponent<TensorPropertyLineProps<Vector4>>;
+/**
+ * Edits a Babylon.js Vector2 value.
+ * @param props The controlled vector and property-line presentation.
+ * @returns The Vector2 property line.
+ */
+export const Vector2PropertyLine: FunctionComponent<TensorPropertyLineProps<Vector2>> = (props) => <ControlledTensorPropertyLine {...props} adapter={Vector2Adapter} />;
+/**
+ * Edits a Babylon.js Vector3 value.
+ * @param props The controlled vector and property-line presentation.
+ * @returns The Vector3 property line.
+ */
+export const Vector3PropertyLine: FunctionComponent<TensorPropertyLineProps<Vector3>> = (props) => <ControlledTensorPropertyLine {...props} adapter={Vector3Adapter} />;
+/**
+ * Edits a Babylon.js Vector4 value.
+ * @param props The controlled vector and property-line presentation.
+ * @returns The Vector4 property line.
+ */
+export const Vector4PropertyLine: FunctionComponent<TensorPropertyLineProps<Vector4>> = (props) => <ControlledTensorPropertyLine {...props} adapter={Vector4Adapter} />;
+/**
+ * Edits a Babylon.js Euler rotation value.
+ * @param props The controlled rotation and property-line presentation.
+ * @returns The Euler rotation property line.
+ */
+export const RotationVectorPropertyLine: FunctionComponent<RotationVectorPropertyLineProps> = (props) => (
+    <ControlledRotationVectorPropertyLine {...props} adapter={Vector3Adapter} />
+);
+/**
+ * Edits a Babylon.js Quaternion value with optional Euler presentation.
+ * @param props The controlled quaternion and property-line presentation.
+ * @returns The quaternion property line.
+ */
+export const QuaternionPropertyLine: FunctionComponent<QuaternionPropertyLineProps> = (props) => <ControlledQuaternionPropertyLine {...props} adapter={QuaternionAdapter} />;

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/vectorPropertyLineCore.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/vectorPropertyLineCore.tsx
@@ -45,7 +45,7 @@ type ControlledTensorPropertyLineProps<ValueT> = TensorPropertyLineProps<ValueT>
 export const ControlledTensorPropertyLine = <ValueT,>(props: ControlledTensorPropertyLineProps<ValueT>) => {
     const { adapter, min, max, unit, step, precision, valueConverter } = props;
     const converted = (value: number) => (valueConverter ? valueConverter.from(value) : value);
-    const formatted = (value: number) => converted(value).toFixed(step !== undefined ? Math.max(0, CalculatePrecision(step)) : 2);
+    const formatted = (value: number) => converted(value).toFixed(precision ?? (step !== undefined ? Math.max(0, CalculatePrecision(step)) : 2));
     const [value, setValue] = useState(props.value);
 
     useEffect(() => {
@@ -204,7 +204,7 @@ export const ControlledQuaternionPropertyLine = <QuaternionT, EulerT>(props: Con
 
     return (
         <ControlledTensorPropertyLine
-            {...props}
+            {...rest}
             nullable={false}
             value={quaternion}
             adapter={adapter.quaternion}

--- a/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/vectorPropertyLineCore.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/hoc/propertyLines/vectorPropertyLineCore.tsx
@@ -1,0 +1,217 @@
+import { Body1 } from "@fluentui/react-components";
+import { useEffect, useState } from "react";
+
+import { type PrimitiveProps } from "../../primitives/primitive";
+import { CalculatePrecision } from "../../primitives/utils";
+import { NumberInputPropertyLine } from "./inputPropertyLine";
+import { type PropertyLineProps, PropertyLine } from "./propertyLine";
+import { TextPropertyLine } from "./textPropertyLine";
+
+export type TensorComponent = "x" | "y" | "z" | "w";
+
+export type TensorValue2 = Readonly<{ x: number; y: number }>;
+export type TensorValue3 = TensorValue2 & Readonly<{ z: number }>;
+export type TensorValue4 = TensorValue3 & Readonly<{ w: number }>;
+
+export type TensorPropertyLineProps<ValueT> = PropertyLineProps<ValueT> &
+    PrimitiveProps<ValueT> & {
+        min?: number;
+        max?: number;
+        unit?: string;
+        step?: number;
+        precision?: number;
+        valueConverter?: {
+            from: (value: number) => number;
+            to: (value: number) => number;
+        };
+    };
+
+export type TensorValueAdapter<ValueT> = Readonly<{
+    components: readonly TensorComponent[];
+    getComponent: (value: ValueT, component: TensorComponent) => number;
+    withComponent: (value: ValueT, component: TensorComponent, componentValue: number) => ValueT;
+}>;
+
+type ControlledTensorPropertyLineProps<ValueT> = TensorPropertyLineProps<ValueT> &
+    Readonly<{
+        adapter: TensorValueAdapter<ValueT>;
+    }>;
+
+/**
+ * Runtime-neutral controlled editor for two-, three-, and four-component numeric values.
+ * @param props The value, change callback, component adapter, and property-line presentation.
+ * @returns The tensor property line.
+ */
+export const ControlledTensorPropertyLine = <ValueT,>(props: ControlledTensorPropertyLineProps<ValueT>) => {
+    const { adapter, min, max, unit, step, precision, valueConverter } = props;
+    const converted = (value: number) => (valueConverter ? valueConverter.from(value) : value);
+    const formatted = (value: number) => converted(value).toFixed(step !== undefined ? Math.max(0, CalculatePrecision(step)) : 2);
+    const [value, setValue] = useState(props.value);
+
+    useEffect(() => {
+        setValue(props.value);
+    }, [props.value, props.expandedContent]);
+
+    const onComponentChange = (componentValue: number, component: TensorComponent) => {
+        const storedValue = valueConverter ? valueConverter.to(componentValue) : componentValue;
+        const newValue = adapter.withComponent(value, component, storedValue);
+        setValue(newValue);
+        props.onChange(newValue);
+    };
+
+    const summary = adapter.components.map((component) => formatted(adapter.getComponent(props.value, component))).join(", ");
+
+    return (
+        <PropertyLine
+            {...props}
+            expandedContent={
+                <>
+                    {props.expandedContent}
+                    <TensorSliders
+                        value={value}
+                        adapter={adapter}
+                        min={min}
+                        max={max}
+                        unit={unit}
+                        step={step}
+                        precision={precision}
+                        converted={converted}
+                        onChange={onComponentChange}
+                    />
+                </>
+            }
+        >
+            <Body1>{`[${summary}]`}</Body1>
+        </PropertyLine>
+    );
+};
+
+type TensorSlidersProps<ValueT> = Readonly<{
+    value: ValueT;
+    adapter: TensorValueAdapter<ValueT>;
+    min?: number;
+    max?: number;
+    unit?: string;
+    step?: number;
+    precision?: number;
+    converted: (value: number) => number;
+    onChange: (value: number, component: TensorComponent) => void;
+}>;
+
+const TensorSliders = <ValueT,>(props: TensorSlidersProps<ValueT>) => {
+    const { value, adapter, min, max, unit, step, precision, converted, onChange } = props;
+
+    return (
+        <>
+            {adapter.components.map((component) => (
+                <NumberInputPropertyLine
+                    key={component}
+                    label={component.toUpperCase()}
+                    value={converted(adapter.getComponent(value, component))}
+                    min={min}
+                    max={max}
+                    onChange={(componentValue) => onChange(componentValue, component)}
+                    unit={unit}
+                    step={step}
+                    precision={precision}
+                />
+            ))}
+        </>
+    );
+};
+
+export const RadiansToDegreesConverter = {
+    from: (value: number) => (value * 180) / Math.PI,
+    to: (value: number) => (value * Math.PI) / 180,
+};
+
+type ControlledRotationVectorPropertyLineProps<ValueT> = TensorPropertyLineProps<ValueT> &
+    Readonly<{
+        adapter: TensorValueAdapter<ValueT>;
+        useDegrees?: boolean;
+    }>;
+
+/**
+ * Runtime-neutral controlled Euler rotation editor.
+ * @param props The rotation value, runtime adapter, and display options.
+ * @returns The rotation property line.
+ */
+export const ControlledRotationVectorPropertyLine = <ValueT,>(props: ControlledRotationVectorPropertyLineProps<ValueT>) => {
+    const { useDegrees, ...rest } = props;
+
+    return (
+        <ControlledTensorPropertyLine
+            {...rest}
+            unit={useDegrees ? "°" : "rad"}
+            valueConverter={useDegrees ? RadiansToDegreesConverter : undefined}
+            step={useDegrees ? 1 : 0.01}
+            precision={useDegrees ? 1 : 2}
+        />
+    );
+};
+
+export type QuaternionValueAdapter<QuaternionT, EulerT> = Readonly<{
+    quaternion: TensorValueAdapter<QuaternionT>;
+    euler: TensorValueAdapter<EulerT>;
+    fromEuler: (value: EulerT, source: QuaternionT) => QuaternionT;
+    toEuler: (value: QuaternionT) => EulerT;
+}>;
+
+type ControlledQuaternionPropertyLineProps<QuaternionT, EulerT> = TensorPropertyLineProps<QuaternionT> &
+    Readonly<{
+        adapter: QuaternionValueAdapter<QuaternionT, EulerT>;
+        useDegrees?: boolean;
+        useEuler?: boolean;
+    }>;
+
+/**
+ * Runtime-neutral controlled quaternion editor with optional Euler presentation.
+ * @param props The quaternion value, runtime conversion adapter, and display options.
+ * @returns The quaternion or Euler property line.
+ */
+export const ControlledQuaternionPropertyLine = <QuaternionT, EulerT>(props: ControlledQuaternionPropertyLineProps<QuaternionT, EulerT>) => {
+    const { adapter, useEuler, useDegrees, ...rest } = props;
+    const [quaternion, setQuaternion] = useState(props.value);
+
+    useEffect(() => {
+        setQuaternion(props.value);
+    }, [props.value]);
+
+    const onQuaternionChange = (value: QuaternionT) => {
+        setQuaternion(value);
+        props.onChange(value);
+    };
+
+    if (useEuler) {
+        const quaternionSummary = adapter.quaternion.components.map((component) => adapter.quaternion.getComponent(quaternion, component).toFixed(4)).join(", ");
+
+        return (
+            <ControlledTensorPropertyLine
+                {...rest}
+                nullable={false}
+                ignoreNullable={false}
+                value={adapter.toEuler(quaternion)}
+                adapter={adapter.euler}
+                valueConverter={useDegrees ? RadiansToDegreesConverter : undefined}
+                onChange={(value) => onQuaternionChange(adapter.fromEuler(value, quaternion))}
+                unit={useDegrees ? "°" : "rad"}
+                step={useDegrees ? 1 : 0.01}
+                precision={useDegrees ? 1 : 2}
+                expandedContent={<TextPropertyLine label="Quaternion" value={`[${quaternionSummary}]`} />}
+            />
+        );
+    }
+
+    return (
+        <ControlledTensorPropertyLine
+            {...props}
+            nullable={false}
+            value={quaternion}
+            adapter={adapter.quaternion}
+            onChange={onQuaternionChange}
+            unit={useDegrees ? "°" : "rad"}
+            step={useDegrees ? 1 : 0.01}
+            precision={useDegrees ? 1 : 2}
+        />
+    );
+};

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.contexts.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.contexts.tsx
@@ -8,7 +8,7 @@ import { type AccordionProps, type AccordionSectionBlockProps, type AccordionSec
 const STORAGE_KEY_ROOT = "Babylon/Accordion";
 const InMemoryStorage = new Map<string, string>();
 // eslint-disable-next-line no-console
-const Warn = (message: string): void => globalThis.console.warn(message);
+const Warn = (message: string): void => globalThis.console?.warn?.(message);
 
 const ReadStoredString = (key: string): string => {
     try {

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.contexts.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/accordion.contexts.tsx
@@ -1,17 +1,38 @@
 import { type RefObject, createContext, useContext, useEffect, useMemo, useReducer, useRef } from "react";
 import { type AccordionProps, type AccordionSectionBlockProps, type AccordionSectionItemProps } from "./accordion";
-import { DataStorage } from "core/Misc/dataStorage";
-import { Logger } from "core/Misc/logger";
 
 // ============================================================================
 // Storage Helpers
 // ============================================================================
 
 const STORAGE_KEY_ROOT = "Babylon/Accordion";
+const InMemoryStorage = new Map<string, string>();
+// eslint-disable-next-line no-console
+const Warn = (message: string): void => globalThis.console.warn(message);
+
+const ReadStoredString = (key: string): string => {
+    try {
+        return globalThis.localStorage?.getItem(key) ?? InMemoryStorage.get(key) ?? "";
+    } catch {
+        return InMemoryStorage.get(key) ?? "";
+    }
+};
+
+const WriteStoredString = (key: string, value: string): void => {
+    try {
+        if (globalThis.localStorage) {
+            globalThis.localStorage.setItem(key, value);
+            return;
+        }
+    } catch {
+        // Fall through to in-memory persistence when localStorage is unavailable.
+    }
+    InMemoryStorage.set(key, value);
+};
 
 const ReadFromStorage = <T,>(path: string, initial: T): T => {
     try {
-        const stored = DataStorage.ReadString(`${STORAGE_KEY_ROOT}/${path}`, "");
+        const stored = ReadStoredString(`${STORAGE_KEY_ROOT}/${path}`);
         return stored ? JSON.parse(stored) : initial;
     } catch {
         return initial;
@@ -19,7 +40,7 @@ const ReadFromStorage = <T,>(path: string, initial: T): T => {
 };
 
 const WriteToStorage = (path: string, data: unknown): void => {
-    DataStorage.WriteString(`${STORAGE_KEY_ROOT}/${path}`, JSON.stringify(data));
+    WriteStoredString(`${STORAGE_KEY_ROOT}/${path}`, JSON.stringify(data));
 };
 
 // ============================================================================
@@ -323,7 +344,7 @@ export function useAccordionSectionItemState(props: AccordionSectionItemProps): 
     const prevItemIdRef = useRef(itemId);
     useEffect(() => {
         if (accordionCtx && prevItemIdRef.current !== itemId) {
-            Logger.Warn(
+            Warn(
                 `Accordion: The uniqueId "${itemId}" in section "${sectionCtx?.sectionId}" has changed from "${prevItemIdRef.current}". ` +
                     `Each item must have a unique, stable ID for pin/hide persistence to work correctly.`
             );
@@ -338,7 +359,7 @@ export function useAccordionSectionItemState(props: AccordionSectionItemProps): 
         }
         const { registeredItemIds } = accordionCtx;
         if (registeredItemIds.has(itemUniqueId)) {
-            Logger.Warn(
+            Warn(
                 `Accordion: Duplicate uniqueId "${itemId}" detected in section "${sectionCtx?.sectionId}". ` +
                     `Each item must have a unique ID within its section for pin/hide persistence to work correctly.`
             );

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/spinButton.tsx
@@ -5,7 +5,6 @@ import { type PrimitiveProps } from "./primitive";
 import { Input, makeStyles, mergeClasses, tokens, useId, useMergedRefs } from "@fluentui/react-components";
 import { ArrowBidirectionalUpDownFilled } from "@fluentui/react-icons";
 
-import { Clamp } from "core/Maths/math.scalar.functions";
 import { ToolContext } from "../hoc/fluentToolWrapper";
 import { useKeyState } from "../hooks/keyboardHooks";
 import { InfoLabel } from "./infoLabel";
@@ -148,7 +147,7 @@ export const SpinButton = forwardRef<HTMLInputElement, SpinButtonProps>((props, 
     );
 
     // Constrain a value to the valid range by clamping to [min, max].
-    const constrainValue = useCallback((v: number) => Clamp(v, min ?? -Infinity, max ?? Infinity), [min, max]);
+    const constrainValue = useCallback((v: number) => Math.min(max ?? Infinity, Math.max(min ?? -Infinity, v)), [min, max]);
 
     const tryCommitValue = useCallback(
         (currVal: number) => {

--- a/packages/dev/sharedUiComponents/src/fluent/primitives/structuralColorPicker.tsx
+++ b/packages/dev/sharedUiComponents/src/fluent/primitives/structuralColorPicker.tsx
@@ -1,0 +1,177 @@
+import {
+    AlphaSlider,
+    ColorArea,
+    ColorPicker as FluentColorPicker,
+    type ColorPickerProps as FluentColorPickerProps,
+    ColorSlider,
+    ColorSwatch,
+    makeStyles,
+    tokens,
+} from "@fluentui/react-components";
+import { useContext, useEffect, useMemo, useState } from "react";
+
+import { ToolContext } from "../hoc/fluentToolWrapper";
+import { Popover } from "./popover";
+import { type PrimitiveProps } from "./primitive";
+
+export type StructuralColor = Readonly<{ r: number; g: number; b: number; a?: number }>;
+
+export type StructuralColorAdapter<ValueT> = Readonly<{
+    getColor: (value: ValueT) => StructuralColor;
+    createColor: (color: StructuralColor, source: ValueT) => ValueT;
+}>;
+
+export type StructuralColorPickerProps<ValueT> = PrimitiveProps<ValueT> &
+    Readonly<{
+        adapter: StructuralColorAdapter<ValueT>;
+        isLinearMode?: boolean;
+    }>;
+
+const useStyles = makeStyles({
+    picker: {
+        width: "350px",
+        height: "350px",
+    },
+    trigger: {
+        display: "flex",
+        alignItems: "center",
+    },
+});
+
+function LinearChannelToGamma(value: number): number {
+    return value <= 0.0031308 ? value * 12.92 : 1.055 * value ** (1 / 2.4) - 0.055;
+}
+
+function GammaChannelToLinear(value: number): number {
+    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function ConvertColorSpace(color: StructuralColor, convertChannel: (value: number) => number): StructuralColor {
+    return {
+        r: convertChannel(color.r),
+        g: convertChannel(color.g),
+        b: convertChannel(color.b),
+        ...("a" in color ? { a: color.a } : {}),
+    };
+}
+
+function RgbToHsv(color: StructuralColor): { h: number; s: number; v: number; a?: number } {
+    const max = Math.max(color.r, color.g, color.b);
+    const min = Math.min(color.r, color.g, color.b);
+    const delta = max - min;
+    let hue = 0;
+
+    if (delta !== 0) {
+        if (max === color.r) {
+            hue = 60 * (((color.g - color.b) / delta) % 6);
+        } else if (max === color.g) {
+            hue = 60 * ((color.b - color.r) / delta + 2);
+        } else {
+            hue = 60 * ((color.r - color.g) / delta + 4);
+        }
+    }
+
+    return {
+        h: hue < 0 ? hue + 360 : hue,
+        s: max === 0 ? 0 : delta / max,
+        v: max,
+        ...("a" in color ? { a: color.a } : {}),
+    };
+}
+
+function HsvToRgb(hue: number, saturation: number, value: number, alpha?: number): StructuralColor {
+    const chroma = value * saturation;
+    const hueSector = hue / 60;
+    const intermediate = chroma * (1 - Math.abs((hueSector % 2) - 1));
+    const offset = value - chroma;
+    let red = 0;
+    let green = 0;
+    let blue = 0;
+
+    if (hueSector < 1) {
+        red = chroma;
+        green = intermediate;
+    } else if (hueSector < 2) {
+        red = intermediate;
+        green = chroma;
+    } else if (hueSector < 3) {
+        green = chroma;
+        blue = intermediate;
+    } else if (hueSector < 4) {
+        green = intermediate;
+        blue = chroma;
+    } else if (hueSector < 5) {
+        red = intermediate;
+        blue = chroma;
+    } else {
+        red = chroma;
+        blue = intermediate;
+    }
+
+    return {
+        r: red + offset,
+        g: green + offset,
+        b: blue + offset,
+        ...(alpha !== undefined ? { a: alpha } : {}),
+    };
+}
+
+function ColorToHex(color: StructuralColor): string {
+    const channelToHex = (value: number) =>
+        Math.round(Math.min(1, Math.max(0, value)) * 255)
+            .toString(16)
+            .padStart(2, "0");
+    return `#${channelToHex(color.r)}${channelToHex(color.g)}${channelToHex(color.b)}${color.a === undefined ? "" : channelToHex(color.a)}`;
+}
+
+/**
+ * Runtime-neutral color picker for structural RGB and RGBA values.
+ * @param props The controlled value, adapter, color-space mode, and change callback.
+ * @returns A color swatch that opens the Fluent color picker.
+ */
+export const StructuralColorPickerPopup = <ValueT,>(props: StructuralColorPickerProps<ValueT>) => {
+    const { value, onChange, adapter, isLinearMode, ...rest } = props;
+    const classes = useStyles();
+    const { size } = useContext(ToolContext);
+    const [currentValue, setCurrentValue] = useState(value);
+
+    useEffect(() => {
+        setCurrentValue(value);
+    }, [value]);
+
+    const storedColor = adapter.getColor(currentValue);
+    const gammaColor = useMemo(() => (isLinearMode ? ConvertColorSpace(storedColor, LinearChannelToGamma) : storedColor), [storedColor, isLinearMode]);
+    const hexColor = ColorToHex(gammaColor);
+
+    const handleColorPickerChange: FluentColorPickerProps["onColorChange"] = (_event, data) => {
+        const changedGammaColor = HsvToRgb(data.color.h, data.color.s, data.color.v, storedColor.a === undefined ? undefined : (data.color.a ?? storedColor.a));
+        const changedStoredColor = isLinearMode ? ConvertColorSpace(changedGammaColor, GammaChannelToLinear) : changedGammaColor;
+        const changedValue = adapter.createColor(changedStoredColor, currentValue);
+        setCurrentValue(changedValue);
+        onChange(changedValue);
+    };
+
+    return (
+        <Popover
+            trigger={
+                <ColorSwatch
+                    {...rest}
+                    className={classes.trigger}
+                    borderColor={tokens.colorNeutralShadowKeyDarker}
+                    size={size === "small" ? "extra-small" : "small"}
+                    shape="rounded"
+                    color={hexColor}
+                    value={hexColor.slice(1)}
+                />
+            }
+        >
+            <FluentColorPicker className={classes.picker} color={RgbToHsv(gammaColor)} onColorChange={handleColorPickerChange}>
+                {/* Fluent's API requires the native ARIA attribute spelling. */}
+                {/* eslint-disable-next-line @typescript-eslint/naming-convention */}
+                <ColorArea inputX={{ "aria-label": "Saturation" }} inputY={{ "aria-label": "Brightness" }} />
+                <ColorSlider aria-label="Hue" />
+                {storedColor.a !== undefined ? <AlphaSlider aria-label="Alpha" /> : undefined}
+            </FluentColorPicker>
+        </Popover>
+    );
+};

--- a/packages/dev/sharedUiComponents/src/lite/fluent/hoc/propertyLines/colorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/lite/fluent/hoc/propertyLines/colorPropertyLine.tsx
@@ -1,0 +1,74 @@
+import { type Color3, type Color4 } from "@babylonjs/lite";
+import { type FunctionComponent } from "react";
+
+import { ControlledColorPropertyLine, type ColorPropertyLineAdapter } from "shared-ui-components/fluent/hoc/propertyLines/colorPropertyLineCore";
+import { type PropertyLineProps } from "shared-ui-components/fluent/hoc/propertyLines/propertyLine";
+import { StructuralColorPickerPopup, type StructuralColorPickerProps, type StructuralColor } from "shared-ui-components/fluent/primitives/structuralColorPicker";
+
+export type Color3Value = Color3 | readonly [number, number, number];
+export type Color4Value = Color4 | readonly [number, number, number, number];
+
+export type ColorPickerProps<ValueT extends Color3Value | Color4Value> = Omit<StructuralColorPickerProps<ValueT>, "adapter">;
+export type ColorPropertyLineProps<ValueT extends Color3Value | Color4Value> = ColorPickerProps<ValueT> & PropertyLineProps<ValueT>;
+
+function IsColor4Value(value: Color3Value | Color4Value): value is Color4Value {
+    return "r" in value ? "a" in value : value.length === 4;
+}
+
+function GetStructuralColor(value: Color3Value | Color4Value): StructuralColor {
+    if (!("r" in value)) {
+        return {
+            r: value[0],
+            g: value[1],
+            b: value[2],
+            ...(value.length === 4 ? { a: value[3] } : {}),
+        };
+    }
+    return value;
+}
+
+function CreateColor3Value(color: StructuralColor, source: Color3Value): Color3Value {
+    if (!("r" in source)) {
+        return [color.r, color.g, color.b];
+    }
+    return {
+        r: color.r,
+        g: color.g,
+        b: color.b,
+    };
+}
+
+function CreateColor4Value(color: StructuralColor, source: Color4Value): Color4Value {
+    if (!("r" in source)) {
+        return [color.r, color.g, color.b, color.a ?? source[3]];
+    }
+    return {
+        r: color.r,
+        g: color.g,
+        b: color.b,
+        a: color.a ?? source.a,
+    };
+}
+
+const Picker: FunctionComponent<ColorPickerProps<Color3Value | Color4Value>> = (props) => (
+    <StructuralColorPickerPopup
+        {...props}
+        adapter={{
+            getColor: GetStructuralColor,
+            createColor: (color, source) => (IsColor4Value(source) ? CreateColor4Value(color, source) : CreateColor3Value(color, source)),
+        }}
+    />
+);
+
+const Adapter: ColorPropertyLineAdapter<Color3Value | Color4Value> = {
+    picker: Picker,
+    getColor: GetStructuralColor,
+    createColor: (color, source) => (IsColor4Value(source) ? CreateColor4Value(color, source) : CreateColor3Value(color, source)),
+};
+
+export const Color3PropertyLine: FunctionComponent<ColorPropertyLineProps<Color3Value>> = (props) => (
+    <ControlledColorPropertyLine {...props} adapter={Adapter as ColorPropertyLineAdapter<Color3Value>} />
+);
+export const Color4PropertyLine: FunctionComponent<ColorPropertyLineProps<Color4Value>> = (props) => (
+    <ControlledColorPropertyLine {...props} adapter={Adapter as ColorPropertyLineAdapter<Color4Value>} />
+);

--- a/packages/dev/sharedUiComponents/src/lite/fluent/hoc/propertyLines/vectorPropertyLine.tsx
+++ b/packages/dev/sharedUiComponents/src/lite/fluent/hoc/propertyLines/vectorPropertyLine.tsx
@@ -1,0 +1,128 @@
+import { eulerToQuat, quatToEulerXYZ, type Quat, type Vec2, type Vec3, type Vec4 } from "@babylonjs/lite";
+import { type FunctionComponent } from "react";
+
+import {
+    ControlledQuaternionPropertyLine,
+    ControlledRotationVectorPropertyLine,
+    ControlledTensorPropertyLine,
+    type QuaternionValueAdapter,
+    type TensorComponent,
+    type TensorPropertyLineProps as RuntimeNeutralTensorPropertyLineProps,
+    type TensorValueAdapter,
+} from "shared-ui-components/fluent/hoc/propertyLines/vectorPropertyLineCore";
+
+export type Vector2Value = Vec2 | readonly [number, number];
+export type Vector3Value = Vec3 | readonly [number, number, number];
+export type Vector4Value = Vec4 | readonly [number, number, number, number];
+export type QuaternionValue = Quat | readonly [number, number, number, number];
+
+export type TensorPropertyLineProps<ValueT extends Vector2Value | Vector3Value | Vector4Value | QuaternionValue> = RuntimeNeutralTensorPropertyLineProps<ValueT>;
+
+const ComponentIndices: Readonly<Record<TensorComponent, number>> = {
+    x: 0,
+    y: 1,
+    z: 2,
+    w: 3,
+};
+
+type TupleValue = readonly [number, number] | readonly [number, number, number] | readonly [number, number, number, number];
+
+function IsNumberTuple(value: Vector2Value | Vector3Value | Vector4Value | QuaternionValue): value is TupleValue {
+    return Array.isArray(value);
+}
+
+function GetComponent(value: Vector2Value | Vector3Value | Vector4Value | QuaternionValue, component: TensorComponent): number {
+    if (IsNumberTuple(value)) {
+        return value[ComponentIndices[component]];
+    }
+    switch (component) {
+        case "x":
+            return value.x;
+        case "y":
+            return value.y;
+        case "z":
+            return "z" in value ? value.z : 0;
+        case "w":
+            return "w" in value ? value.w : 0;
+    }
+}
+
+const Vector2Adapter: TensorValueAdapter<Vector2Value> = {
+    components: ["x", "y"],
+    getComponent: GetComponent,
+    withComponent: (value, component, componentValue) =>
+        IsNumberTuple(value) ? [component === "x" ? componentValue : value[0], component === "y" ? componentValue : value[1]] : { ...value, [component]: componentValue },
+};
+const Vector3Adapter: TensorValueAdapter<Vector3Value> = {
+    components: ["x", "y", "z"],
+    getComponent: GetComponent,
+    withComponent: (value, component, componentValue) =>
+        IsNumberTuple(value)
+            ? [component === "x" ? componentValue : value[0], component === "y" ? componentValue : value[1], component === "z" ? componentValue : value[2]]
+            : { ...value, [component]: componentValue },
+};
+const Vector4Adapter: TensorValueAdapter<Vector4Value> = {
+    components: ["x", "y", "z", "w"],
+    getComponent: GetComponent,
+    withComponent: (value, component, componentValue) =>
+        IsNumberTuple(value)
+            ? [
+                  component === "x" ? componentValue : value[0],
+                  component === "y" ? componentValue : value[1],
+                  component === "z" ? componentValue : value[2],
+                  component === "w" ? componentValue : value[3],
+              ]
+            : { ...value, [component]: componentValue },
+};
+const QuaternionTensorAdapter: TensorValueAdapter<QuaternionValue> = {
+    components: ["x", "y", "z", "w"],
+    getComponent: GetComponent,
+    withComponent: (value, component, componentValue) =>
+        IsNumberTuple(value)
+            ? [
+                  component === "x" ? componentValue : value[0],
+                  component === "y" ? componentValue : value[1],
+                  component === "z" ? componentValue : value[2],
+                  component === "w" ? componentValue : value[3],
+              ]
+            : { ...value, [component]: componentValue },
+};
+
+/**
+ * Converts a Lite Euler value to a quaternion while preserving tuple versus structural representation.
+ * @param value The Euler value in radians.
+ * @param source The source quaternion whose representation should be preserved.
+ * @returns The converted quaternion.
+ */
+export function CreateQuaternionFromEuler(value: Vector3Value, source: QuaternionValue): QuaternionValue {
+    const [x, y, z] = "x" in value ? [value.x, value.y, value.z] : value;
+    const quaternion = eulerToQuat(x, y, z);
+    return "x" in source ? { x: quaternion[0], y: quaternion[1], z: quaternion[2], w: quaternion[3] } : quaternion;
+}
+
+const QuaternionAdapter: QuaternionValueAdapter<QuaternionValue, Vector3Value> = {
+    quaternion: QuaternionTensorAdapter,
+    euler: Vector3Adapter,
+    fromEuler: CreateQuaternionFromEuler,
+    toEuler: (value) => {
+        const [x, y, z, w] = "x" in value ? [value.x, value.y, value.z, value.w] : value;
+        return quatToEulerXYZ(x, y, z, w);
+    },
+};
+
+type RotationVectorPropertyLineProps = TensorPropertyLineProps<Vector3Value> & {
+    useDegrees?: boolean;
+};
+
+type QuaternionPropertyLineProps = TensorPropertyLineProps<QuaternionValue> & {
+    useDegrees?: boolean;
+    useEuler?: boolean;
+};
+
+export const Vector2PropertyLine: FunctionComponent<TensorPropertyLineProps<Vector2Value>> = (props) => <ControlledTensorPropertyLine {...props} adapter={Vector2Adapter} />;
+export const Vector3PropertyLine: FunctionComponent<TensorPropertyLineProps<Vector3Value>> = (props) => <ControlledTensorPropertyLine {...props} adapter={Vector3Adapter} />;
+export const Vector4PropertyLine: FunctionComponent<TensorPropertyLineProps<Vector4Value>> = (props) => <ControlledTensorPropertyLine {...props} adapter={Vector4Adapter} />;
+export const RotationVectorPropertyLine: FunctionComponent<RotationVectorPropertyLineProps> = (props) => (
+    <ControlledRotationVectorPropertyLine {...props} adapter={Vector3Adapter} />
+);
+export const QuaternionPropertyLine: FunctionComponent<QuaternionPropertyLineProps> = (props) => <ControlledQuaternionPropertyLine {...props} adapter={QuaternionAdapter} />;

--- a/packages/dev/sharedUiComponents/src/lite/index.ts
+++ b/packages/dev/sharedUiComponents/src/lite/index.ts
@@ -1,0 +1,2 @@
+export * from "./fluent/hoc/propertyLines/colorPropertyLine";
+export * from "./fluent/hoc/propertyLines/vectorPropertyLine";

--- a/packages/dev/sharedUiComponents/test/unit/copyCommandToClipboard.test.ts
+++ b/packages/dev/sharedUiComponents/test/unit/copyCommandToClipboard.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { getClassNameWithNamespace } from "../../src/copyCommandToClipboard";
+
+describe("getClassNameWithNamespace", () => {
+    it("returns Unknown for nullish and primitive inputs", () => {
+        expect(getClassNameWithNamespace(null)).toEqual({ className: "Unknown", babylonNamespace: "" });
+        expect(getClassNameWithNamespace(undefined)).toEqual({ className: "Unknown", babylonNamespace: "" });
+        expect(getClassNameWithNamespace(42)).toEqual({ className: "Unknown", babylonNamespace: "" });
+    });
+
+    it("prefers getClassName and falls back to the constructor name", () => {
+        expect(getClassNameWithNamespace({ getClassName: () => "BABYLON.CustomType" }).className).toBe("CustomType");
+        expect(getClassNameWithNamespace(new (class CustomType {})()).className).toBe("CustomType");
+    });
+});

--- a/packages/dev/sharedUiComponents/test/unit/liteEntryPoint.test.ts
+++ b/packages/dev/sharedUiComponents/test/unit/liteEntryPoint.test.ts
@@ -1,0 +1,62 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { build, type Plugin } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+const SourceRoot = path.resolve("packages/dev/sharedUiComponents/src");
+const PublicPackagePath = path.resolve("packages/public/@babylonjs/shared-ui-components/package.json");
+
+const SourceAliasPlugin: Plugin = {
+    name: "shared-ui-source-alias",
+    setup: (buildContext) => {
+        buildContext.onResolve({ filter: /^shared-ui-components\// }, (args) => {
+            const sourcePath = path.join(SourceRoot, args.path.slice("shared-ui-components/".length));
+            const resolvedPath = [sourcePath, `${sourcePath}.ts`, `${sourcePath}.tsx`].find(existsSync);
+            return resolvedPath ? { path: resolvedPath } : { errors: [{ text: `Unable to resolve shared UI source: ${args.path}` }] };
+        });
+        buildContext.onResolve({ filter: /^core\// }, (args) => ({
+            errors: [{ text: `Lite entry imports Babylon Core: ${args.path}` }],
+        }));
+    },
+};
+
+describe("@babylonjs/shared-ui-components/lite", () => {
+    it("bundles without importing Babylon Core", async () => {
+        await expect(
+            build({
+                entryPoints: [path.join(SourceRoot, "lite/index.ts")],
+                bundle: true,
+                write: false,
+                platform: "browser",
+                external: ["react", "react-dom", "@fluentui/*", "@babylonjs/lite"],
+                plugins: [SourceAliasPlugin],
+            })
+        ).resolves.toBeDefined();
+    });
+
+    it("preserves existing package subpaths while exporting the Lite entry", async () => {
+        const packageJson = JSON.parse(await readFile(PublicPackagePath, "utf8"));
+
+        expect(packageJson.exports).toMatchObject({
+            ".": {
+                types: "./index.d.ts",
+                default: "./index.js",
+            },
+            "./lite": {
+                types: "./lite/index.d.ts",
+                default: "./lite/index.js",
+            },
+            "./*.js": "./*.js",
+            "./*.d.ts": "./*.d.ts",
+            "./*.map": "./*.map",
+            "./*.svg": "./*.svg",
+            "./*.scss": "./*.scss",
+            "./*": {
+                types: "./*.d.ts",
+                default: "./*.js",
+            },
+        });
+    });
+});

--- a/packages/public/@babylonjs/shared-ui-components/package.json
+++ b/packages/public/@babylonjs/shared-ui-components/package.json
@@ -4,6 +4,17 @@
     "main": "index.js",
     "module": "index.js",
     "types": "index.d.ts",
+    "exports": {
+        "./lite": {
+            "types": "./lite/index.d.ts",
+            "default": "./lite/index.js"
+        },
+        "./*": {
+            "types": "./*.d.ts",
+            "default": "./*.js"
+        },
+        "./package.json": "./package.json"
+    },
     "files": [
         "**/*.js",
         "**/*.d.ts",
@@ -21,16 +32,23 @@
         "postcompile": "build-tools -c add-js-to-es6"
     },
     "devDependencies": {
+        "@babylonjs/lite": "1.27.0",
         "@dev/build-tools": "^1.0.0",
         "@dev/shared-ui-components": "^1.0.0"
     },
     "peerDependencies": {
+        "@babylonjs/lite": "^1.27.0",
         "@types/dagre": "^0.7.47",
         "dagre": "^0.8.5",
         "react": "^18.2.0",
         "react-dnd": "15.0.1",
         "react-dnd-touch-backend": "15.0.1",
         "react-dom": "^18.2.0"
+    },
+    "peerDependenciesMeta": {
+        "@babylonjs/lite": {
+            "optional": true
+        }
     },
     "keywords": [
         "3D",

--- a/packages/public/@babylonjs/shared-ui-components/package.json
+++ b/packages/public/@babylonjs/shared-ui-components/package.json
@@ -5,10 +5,19 @@
     "module": "index.js",
     "types": "index.d.ts",
     "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "default": "./index.js"
+        },
         "./lite": {
             "types": "./lite/index.d.ts",
             "default": "./lite/index.js"
         },
+        "./*.js": "./*.js",
+        "./*.d.ts": "./*.d.ts",
+        "./*.map": "./*.map",
+        "./*.svg": "./*.svg",
+        "./*.scss": "./*.scss",
         "./*": {
             "types": "./*.d.ts",
             "default": "./*.js"


### PR DESCRIPTION
> 🤖 *This PR was created by the create-pr skill.*

## Summary

- refactor Fluent vector, quaternion, and color editors around runtime-neutral controlled primitives
- add reusable Babylon Lite property editors through `@babylonjs/shared-ui-components/lite` while preserving existing Full APIs
- add hierarchical Lite scene nodes with transforms, metadata, visibility, reparenting, removal, and topology/selection reconciliation
- add Lite cameras, directional/point/spot/hemispheric lights, and identity-only shadow generators to Explorer and Properties
- make Lite light color, intensity, range, and exponent edits refresh GPU light data immediately
- expand the Lite Inspector test app and focused unit coverage

## Behavior

The Lite Inspector now exposes the primary P2 scene-entity workflows with Full-equivalent outcomes where Babylon Lite has public support. Shadow generators remain identity/display-only because Babylon Lite does not expose editable internals. Bounding boxes/gizmos and editor hand-offs remain deferred to later parity milestones.

## Review follow-up

- addressed all six automated inline recommendations in `80fc942561`
- added regression coverage for input compatibility and explicit precision formatting
- prevented quaternion-only props from leaking into the shared tensor property line
- guarded persistence warnings in console-less environments
- removed redundant scene ownership traversal
- attached Lite test-app camera controls with teardown cleanup in `4989d98e4e`
- resolved all six review threads

## Visual changes

The Lite Explorer now presents the scene hierarchy, cameras, lights, shadow generators, materials, and textures with Full Inspector color conventions. Light properties support live vector, color, and intensity editing.

![Babylon Lite Inspector Explorer and directional light properties](https://github.com/user-attachments/assets/abfb8337-b423-4204-94ca-dbcf1b86d3e5)

## Validation

- `npm run format:check`
- `npm run lint:check`
- focused shared UI and Inspector Lite unit tests: 24 passing
- published shared UI Lite entry bundle smoke test verifies no Babylon Core runtime dependency
- shared UI package and Inspector TypeScript compilation
- visible Microsoft Edge validation of hierarchy, properties, icon colors, PBR rendering, live light color/intensity updates, and camera controls
- Azure Unit CI executed 5,006 passing tests; its red result is caused by 16 asynchronous shader-import `EnvironmentTeardownError`s after Vitest teardown, with the aggregate Monorepo check reflecting that same flake